### PR TITLE
Solução temporaria para emissão de nota fiscal de empresa do simples nacional

### DIFF
--- a/l10n_br_account_product/sped/nfe/document.py
+++ b/l10n_br_account_product/sped/nfe/document.py
@@ -354,8 +354,8 @@ class NFe200(FiscalDocument):
             else:
                 icms_base = inv.icms_base
                 icms_value = inv.icms_value
-            nfe.infNFe.total.ICMSTot.vBC.valor     = str("%.2f" % inv.icms_base)
-            nfe.infNFe.total.ICMSTot.vICMS.valor   = str("%.2f" % inv.icms_value)
+            nfe.infNFe.total.ICMSTot.vBC.valor     = icms_base
+            nfe.infNFe.total.ICMSTot.vICMS.valor   = icms_value
             nfe.infNFe.total.ICMSTot.vBCST.valor   = str("%.2f" % inv.icms_st_base)
             nfe.infNFe.total.ICMSTot.vST.valor     = str("%.2f" % inv.icms_st_value)
             nfe.infNFe.total.ICMSTot.vProd.valor   = str("%.2f" % inv.amount_gross)

--- a/l10n_br_account_product/sped/nfe/document.py
+++ b/l10n_br_account_product/sped/nfe/document.py
@@ -348,6 +348,12 @@ class NFe200(FiscalDocument):
             #
             # Totais
             #
+            if inv.company_id.fiscal_type in ('1'):#FIXME
+                icms_base = 0.00
+                icms_value = 0.00
+            else:
+                icms_base = inv.icms_base
+                icms_value = inv.icms_value
             nfe.infNFe.total.ICMSTot.vBC.valor     = str("%.2f" % inv.icms_base)
             nfe.infNFe.total.ICMSTot.vICMS.valor   = str("%.2f" % inv.icms_value)
             nfe.infNFe.total.ICMSTot.vBCST.valor   = str("%.2f" % inv.icms_st_base)


### PR DESCRIPTION
@renatonlima Solução temporaria para emissão de nota fiscal de empresa do simples nacional, até a criação de calculo personalizado para simples nacional no account.tax e campos pCredSN, vCredICMSSN no OpenERP 
