### PR TITLE
[FIX] Remove white space before street name if street_type is empty.

### DIFF
--- a/l10n_br_zip/models/l10n_br_zip.py
+++ b/l10n_br_zip/models/l10n_br_zip.py
@@ -81,7 +81,8 @@ class L10n_brZip(models.Model):
                 'l10n_br_city_id': zip_obj.l10n_br_city_id.id,
                 'district': zip_obj.district,
                 'street': ((zip_obj.street_type or '') +
-                           ' ' + (zip_obj.street or '')),
+                           ' ' + (zip_obj.street or '')) if
+                zip_obj.street_type else (zip_obj.street or ''),
                 'zip': zip_code,
             }
         else:


### PR DESCRIPTION
Remove white space before street name if street_type is empty in _l10n_br_zip_ module.
