### PR TITLE
[FIX] Freight type does not depends on a selected carrier

### DIFF
--- a/l10n_br_account_product/sped/nfe/document.py
+++ b/l10n_br_account_product/sped/nfe/document.py
@@ -511,8 +511,8 @@ class NFe200(FiscalDocument):
         """Dados da Transportadora e veiculo"""
 
         self.nfe.infNFe.transp.modFrete.valor = (
-                invoice.incoterm and
-                invoice.incoterm.freight_responsibility or '9')
+            invoice.incoterm and
+            invoice.incoterm.freight_responsibility or '9')
 
         if invoice.carrier_id:
 

--- a/l10n_br_account_product/sped/nfe/document.py
+++ b/l10n_br_account_product/sped/nfe/document.py
@@ -510,11 +510,11 @@ class NFe200(FiscalDocument):
     def _carrier_data(self, invoice):
         """Dados da Transportadora e veiculo"""
 
-        if invoice.carrier_id:
-
-            self.nfe.infNFe.transp.modFrete.valor = (
+        self.nfe.infNFe.transp.modFrete.valor = (
                 invoice.incoterm and
                 invoice.incoterm.freight_responsibility or '9')
+
+        if invoice.carrier_id:
 
             if invoice.carrier_id.partner_id.is_company:
                 self.nfe.infNFe.transp.transporta.CNPJ.valor = \


### PR DESCRIPTION
Freight type does not depends on a selected carrier in the field 'carrier_id'.

Reference: [Odoo Brasil PR #44 ](https://github.com/odoo-brazil/l10n-brazil/pull/44)
