### PR TITLE
Changes related to NT 2015/003 concerning the IE

### DIFF
--- a/l10n_br_account_product/sped/nfe/document.py
+++ b/l10n_br_account_product/sped/nfe/document.py
@@ -308,9 +308,14 @@ class NFe200(FiscalDocument):
                     invoice.partner_id.cnpj_cpf)
                 self.nfe.infNFe.dest.IE.valor = punctuation_rm(
                     invoice.partner_id.inscr_est)
+                if inv.partner_id.inscr_est:
+                    self.nfe.infNFe.dest.indIEDest.valor = '1'
+                else:
+                    self.nfe.infNFe.dest.indIEDest.valor = '2'
             else:
                 self.nfe.infNFe.dest.CPF.valor = punctuation_rm(
                     invoice.partner_id.cnpj_cpf)
+                self.nfe.infNFe.dest.indIEDest.valor = '9'
 
         self.nfe.infNFe.dest.enderDest.xLgr.valor = (
             invoice.partner_id.street or '')

--- a/l10n_br_account_product/sped/nfe/document.py
+++ b/l10n_br_account_product/sped/nfe/document.py
@@ -308,7 +308,7 @@ class NFe200(FiscalDocument):
                     invoice.partner_id.cnpj_cpf)
                 self.nfe.infNFe.dest.IE.valor = punctuation_rm(
                     invoice.partner_id.inscr_est)
-                if inv.partner_id.inscr_est:
+                if invoice.partner_id.inscr_est:
                     self.nfe.infNFe.dest.indIEDest.valor = '1'
                 else:
                     self.nfe.infNFe.dest.indIEDest.valor = '2'


### PR DESCRIPTION
These changes should be integrated with the Danimar PR related to changes in PySPED.

These changes address the indIEDest tag Nfe, following the logic.

if the partner is a corporation (is_company = True) and have the IE indIEDest tag takes on the value 1 if you do not have IE will take value 2 and if the partner is not a company will take the value 9.
