### PR TITLE
[REF] Campo natureza da operacao referente ao nome da categoria fiscal

### DIFF
--- a/l10n_br_account/models/l10n_br_account.py
+++ b/l10n_br_account/models/l10n_br_account.py
@@ -138,7 +138,10 @@ class L10nBrAccountFiscalCategory(models.Model):
     _description = 'Categoria Fiscal'
 
     code = fields.Char(u'Código', size=254, required=True)
-    name = fields.Char(u'Descrição', size=254)
+    name = fields.Char(
+        string=u'Descrição',
+        size=254,
+        help="Natureza da operação informada no XML")
     type = fields.Selection(TYPE, 'Tipo', default='output')
     fiscal_type = fields.Selection(
         PRODUCT_FISCAL_TYPE, 'Tipo Fiscal',

--- a/l10n_br_account_product/sped/nfe/document.py
+++ b/l10n_br_account_product/sped/nfe/document.py
@@ -115,7 +115,7 @@ class NFe200(FiscalDocument):
         self.nfe.infNFe.ide.cUF.valor = (company.state_id and
                                          company.state_id.ibge_code or '')
         self.nfe.infNFe.ide.cNF.valor = ''
-        self.nfe.infNFe.ide.natOp.valor = invoice.cfop_ids[0].small_name or ''
+        self.nfe.infNFe.ide.natOp.valor = invoice.fiscal_category_id.name or ''
         self.nfe.infNFe.ide.indPag.valor = (invoice.payment_term and
                                             invoice.payment_term.indPag or '0')
         self.nfe.infNFe.ide.mod.valor = invoice.fiscal_document_id.code or ''


### PR DESCRIPTION
Segundo o caso de uso:

A CFOP deve ser a mesma da NF a complementar e a natureza da operação "Complemento de ICMS".
