### PR TITLE
Add xPed and nItemPed fields to NFe

### DIFF
--- a/l10n_br_account_product/models/account_invoice.py
+++ b/l10n_br_account_product/models/account_invoice.py
@@ -23,6 +23,7 @@ from lxml import etree
 from openerp import models, fields, api, _
 from openerp.addons import decimal_precision as dp
 from openerp.exceptions import RedirectWarning
+from openerp.exceptions import ValidationError
 
 from openerp.addons.l10n_br_account.models.account_invoice import (
     OPERATION_TYPE,
@@ -756,6 +757,21 @@ class AccountInvoiceLine(models.Model):
     freight_value = fields.Float(
         'Frete', digits=dp.get_precision('Account'), default=0.00)
     fiscal_comment = fields.Text(u'Observação Fiscal')
+    xped = fields.Char(
+        string=u"Código do Pedido (xPed)",
+        size=15,
+    )
+    nitemped = fields.Char(
+        string=u"Item do Pedido (nItemPed)",
+        size=6,
+    )
+
+    @api.onchange("nitemped")
+    def _check_nitemped(self):
+        if self.nitemped and not self.nitemped.isdigit():
+            raise ValidationError(
+                _(u"nItemPed must be a number with up to six digits")
+            )
 
     def _amount_tax_icms(self, tax=None):
         result = {

--- a/l10n_br_account_product/sped/nfe/document.py
+++ b/l10n_br_account_product/sped/nfe/document.py
@@ -132,6 +132,7 @@ class NFe200(FiscalDocument):
         self.nfe.infNFe.ide.finNFe.valor = invoice.nfe_purpose
         self.nfe.infNFe.ide.procEmi.valor = 0
         self.nfe.infNFe.ide.verProc.valor = 'OpenERP Brasil v8'
+        self.nfe.infNFe.compra.xPed.valor = invoice.name or ''
 
         if invoice.cfop_ids[0].type in ("input"):
             self.nfe.infNFe.ide.tpNF.valor = 0
@@ -356,6 +357,8 @@ class NFe200(FiscalDocument):
         self.det.prod.vDesc.valor = str("%.2f" % invoice_line.discount_value)
         self.det.prod.vOutro.valor = str(
             "%.2f" % invoice_line.other_costs_value)
+        self.det.prod.xPed.valor = invoice_line.xped or ''
+        self.det.prod.nItemPed.valor = invoice_line.nitemped or ''
         self.det.infAdProd.valor = invoice_line.fiscal_comment or ''
 
         #

--- a/l10n_br_account_product/views/account_invoice_view.xml
+++ b/l10n_br_account_product/views/account_invoice_view.xml
@@ -449,7 +449,15 @@
 								</notebook>
 							</page>
 							<page string="Informações Adicionais">
-								<group>
+								<group string="Informação de interesse do emissor para controle do B2B">
+									<group>
+										<field name="xped"/>
+									</group>
+									<group>
+										<field name="nitemped"/>
+									</group>
+								</group>
+								<group string="Observações Fiscais">
 									<field name="fiscal_comment" nolabel="1"/>
 								</group>
 							</page>

--- a/l10n_br_sale_product/models/sale.py
+++ b/l10n_br_sale_product/models/sale.py
@@ -18,6 +18,9 @@
 ###############################################################################
 
 from openerp import models, fields, api
+from openerp import _
+from openerp.exceptions import ValidationError
+
 from openerp.addons import decimal_precision as dp
 from openerp.addons.l10n_br_base.tools.misc import calc_price_ratio
 
@@ -255,6 +258,21 @@ class SaleOrderLine(models.Model):
     price_subtotal = fields.Float(compute='_amount_line',
                                   string='Subtotal',
                                   digits=dp.get_precision('Sale Price'))
+    xped = fields.Char(
+        string=u"Código do Pedido (xPed)",
+        size=15,
+    )
+    nitemped = fields.Char(
+        string=u"Item do Pedido (nItemPed)",
+        size=6,
+    )
+
+    @api.onchange("nitemped")
+    def _check_nitemped(self):
+        if self.nitemped and not self.nitemped.isdigit():
+            raise ValidationError(
+                _(u"nItemPed must be a number with up to six digits")
+            )
 
     def _prepare_order_line_invoice_line(self, cr, uid, line,
                                          account_id=False, context=None):
@@ -264,6 +282,8 @@ class SaleOrderLine(models.Model):
         result['insurance_value'] = line.insurance_value
         result['other_costs_value'] = line.other_costs_value
         result['freight_value'] = line.freight_value
+        result['xped'] = line.xped
+        result['nitemped'] = line.nitemped
 
         # FIXME
         # Necessário informar estes campos pois são related do

--- a/l10n_br_sale_product/views/sale_view.xml
+++ b/l10n_br_sale_product/views/sale_view.xml
@@ -16,6 +16,23 @@
                 		<field name="invoiced" position="before">
 					<field name="ind_pres"/>
 				</field>
+				<xpath expr="//field[@name='order_line']/form/div[@groups='base.group_no_one' and field/@name='invoice_lines']" position="replace">
+					<notebook>
+						<page string="Invoice Lines" groups="base.group_no_one">
+							<field name="invoice_lines"/>
+						</page>
+						<page string="Informações Fiscais">
+							<group string="Informação de interesse do emissor para controle do B2B">
+								<group>
+									<field name="xped"/>
+								</group>
+								<group>
+									<field name="nitemped"/>
+								</group>
+							</group>
+						</page>
+					</notebook>
+				</xpath>
 			</field>
 		</record>
 


### PR DESCRIPTION
Add optional `xPed` field to NFe invoice header with with information
from `accounting.invoice` field `name`.

Add optional `xped` and  `nitemped` fields to invoice lines and copy the
info to `xPed` and `nItemPed` product fields in the NFe.
