### PR TITLE
[FIX] removed nfe_root_folder field

### DIFF
--- a/l10n_br_account_product/models/res_company.py
+++ b/l10n_br_account_product/models/res_company.py
@@ -46,7 +46,6 @@ class ResCompany(models.Model):
     nfe_version = fields.Selection(
         [('1.10', '1.10'), ('2.00', '2.00'), ('3.10', '3.10')], u'Versão NFe',
         required=True, default='3.10')
-    nfe_root_folder = fields.Char('Pasta Raiz', size=254)
     nfe_import_folder = fields.Char('Pasta de Importação', size=254)
     nfe_export_folder = fields.Char('Pasta de Exportação', size=254)
     nfe_backup_folder = fields.Char('Pasta de Backup', size=254)

--- a/l10n_br_account_product/views/res_company_view.xml
+++ b/l10n_br_account_product/views/res_company_view.xml
@@ -42,7 +42,6 @@
 							<page string="NFe">
 								<group>
 									<field name="nfe_version" required="1" />
-                                    <field name="nfe_root_folder"/>
 									<field name="nfe_import_folder"/>
 									<field name="nfe_export_folder"/>
 									<field name="nfe_backup_folder"/>


### PR DESCRIPTION
Removida este campo onde era definido o local onde era salvo os XMLs pelo PySPED,
Com a mudança no PR https://github.com/odoo-brazil/odoo-brazil-eletronic-documents/pull/96 que defini a pasta configurada no parametro data-dir para armazenar os documentos fiscais, este campo não é mais necessário.
