### PR TITLE
[REF] 8.0 refactoring ipbt

### DIFF
--- a/l10n_br_account/models/res_config.py
+++ b/l10n_br_account/models/res_config.py
@@ -29,3 +29,4 @@ class ResConfig(models.Model):
         string='IPBT Token',
         related='company_id.ipbt_token'
     )
+    number_days_update = fields.Integer('Quantidade de dias para Atualizar')

--- a/l10n_br_account/views/res_config_view.xml
+++ b/l10n_br_account/views/res_config_view.xml
@@ -1,28 +1,35 @@
 <?xml version="1.0"?>
 <openerp>
-    <data>
-        <record id="view_account_config_settings_l10n_br_account" model="ir.ui.view">
-            <field name="name">account.config.settings.l10n_br_account</field>
-            <field name="model">account.config.settings</field>
-            <field name="inherit_id" ref="account.view_account_config_settings" />
-            <field name="arch" type="xml">
-                <data>
-                    <xpath expr="//group[@name='bank_cash']" position="after">
-                        <group name="l10n_br_account" string="Contabilidade Brasil">
-                            <label for="id" string="Configuration"/>
-                            <div>
-                                <div>
-                                    <label string="IPBT Token:"/>
-                                </div>
-                                <div>
-                                   <field name="ipbt_token" class="oe_inline" />
-                                </div>
-                            </div>
-                        </group>
-                    </xpath>
-                </data>
-            </field>
-        </record>
+	<data>
 
-    </data>
+		<record id="view_account_config_settings_l10n_br_account" model="ir.ui.view">
+			<field name="name">account.config.settings.l10n_br_account</field>
+			<field name="model">account.config.settings</field>
+			<field name="inherit_id" ref="account.view_account_config_settings" />
+			<field name="arch" type="xml">
+				<data>
+					<xpath expr="//group[@name='bank_cash']" position="after">
+						<group name="l10n_br_account" string="Contabilidade Brasil">
+							<label for="id" string="Configuration"/>
+							<div>
+								<div>
+									<label string="IPBT Token:"/>
+								</div>
+								<div>
+								   <field name="ipbt_token" class="oe_inline" />
+								</div>
+								<div>
+									<label string="Quantidade de dias para Atualizar:"/>
+								</div>
+								<div>
+									<field name="number_days_update"/>
+								</div>
+							</div>
+						</group>
+					</xpath>
+				</data>
+			</field>
+		</record>
+
+	</data>
 </openerp>

--- a/l10n_br_account_product/models/account_product_fiscal_classification.py
+++ b/l10n_br_account_product/models/account_product_fiscal_classification.py
@@ -144,9 +144,8 @@ class L10nBrTaxEstimateModel(models.AbstractModel):
         'Impostos Municipais Nacional', default=0.00,
         digits_compute=dp.get_precision('Account'))
 
-    date_start = fields.Date('Data Inicial')
-
-    date_end = fields.Date('Data Final')
+    create_date = fields.Datetime(
+        u'Data de Criação', readonly=True)
 
     key = fields.Char('Chave', size=32)
 
@@ -217,7 +216,7 @@ class AccountProductFiscalClassification(models.Model):
     tax_estimate_ids = fields.One2many(
         comodel_name='l10n_br_tax.estimate',
         inverse_name='fiscal_classification_id',
-        string=u'Impostos Estimados')
+        string=u'Impostos Estimados', readonly=True)
 
     _sql_constraints = [
         ('account_fiscal_classfication_code_uniq', 'unique (code)',
@@ -226,23 +225,22 @@ class AccountProductFiscalClassification(models.Model):
     @api.multi
     def get_ibpt(self):
         for item in self:
+
             brazil = item.env['res.country'].search([('code', '=', 'BR')])
             states = item.env['res.country.state'].search([('country_id', '=',
                                                             brazil.id)])
             company = item.company_id or item.env.user.company_id
-            config = DeOlhoNoImposto(company.ipbt_token,
-                                     punctuation_rm(company.cnpj_cpf),
-                                     company.state_id.code)
+            config = DeOlhoNoImposto(
+                company.ipbt_token, punctuation_rm(company.cnpj_cpf),
+                company.state_id.code)
             tax_estimate = item.env['l10n_br_tax.estimate']
             for state in states:
+
                 result = get_ibpt_product(
                     config,
                     punctuation_rm(item.code or ''),
                     ex='0')
-                update = tax_estimate.search([('state_id', '=', state.id),
-                                              ('origin', '=', 'IBPT-WS'),
-                                              ('fiscal_classification_id',
-                                               '=', item.id)])
+
                 vals = {
                     'fiscal_classification_id': item.id,
                     'origin': 'IBPT-WS',
@@ -251,10 +249,10 @@ class AccountProductFiscalClassification(models.Model):
                     'federal_taxes_national': result.nacional,
                     'federal_taxes_import': result.importado,
                     }
-                if update:
-                    update.write(vals)
-                else:
+
+                if item.env.user.company_id.state_id.id == state.id:
                     tax_estimate.create(vals)
+
         return True
 
 

--- a/l10n_br_account_product/models/account_product_fiscal_classification.py
+++ b/l10n_br_account_product/models/account_product_fiscal_classification.py
@@ -224,34 +224,34 @@ class AccountProductFiscalClassification(models.Model):
 
     @api.multi
     def get_ibpt(self):
-        for item in self:
 
-            brazil = item.env['res.country'].search([('code', '=', 'BR')])
-            states = item.env['res.country.state'].search([('country_id', '=',
-                                                            brazil.id)])
-            company = item.company_id or item.env.user.company_id
+        for fiscal_classification in self:
+
+            company = (
+                fiscal_classification.env.user.company_id or
+                fiscal_classification.company_id)
+
             config = DeOlhoNoImposto(
                 company.ipbt_token, punctuation_rm(company.cnpj_cpf),
                 company.state_id.code)
-            tax_estimate = item.env['l10n_br_tax.estimate']
-            for state in states:
 
-                result = get_ibpt_product(
-                    config,
-                    punctuation_rm(item.code or ''),
-                    ex='0')
+            result = get_ibpt_product(
+                config,
+                punctuation_rm(fiscal_classification.code or ''), ex='0')
 
-                vals = {
-                    'fiscal_classification_id': item.id,
-                    'origin': 'IBPT-WS',
-                    'state_id': state.id,
-                    'state_taxes': result.estadual,
-                    'federal_taxes_national': result.nacional,
-                    'federal_taxes_import': result.importado,
-                    }
+            vals = {
+                'fiscal_classification_id': fiscal_classification.id,
+                'origin': 'IBPT-WS',
+                'state_id': company.state_id.id,
+                'state_taxes': result.estadual,
+                'federal_taxes_national': result.nacional,
+                'federal_taxes_import': result.importado,
+                }
 
-                if item.env.user.company_id.state_id.id == state.id:
-                    tax_estimate.create(vals)
+            tax_estimate = fiscal_classification.env[
+                'l10n_br_tax.estimate']
+
+            tax_estimate.create(vals)
 
         return True
 

--- a/l10n_br_account_product/views/account_product_fiscal_classification_view.xml
+++ b/l10n_br_account_product/views/account_product_fiscal_classification_view.xml
@@ -92,6 +92,7 @@
 									<field name="state_taxes"/>
 									<field name="municipal_taxes"/>
 									<field name="origin"/>
+									<field name="create_date"/>
 								</tree>
 								<form>
 									<group>
@@ -100,8 +101,7 @@
 											<field name="origin"/>
 											<field name="version"/>
 											<field name="state_id"/>
-											<field name="date_start"/>
-											<field name="date_end"/>
+											<field name="create_date"/>
 										</group>
 										<group>
 											<field name="active"/>
@@ -210,6 +210,7 @@
 									<field name="state_taxes"/>
 									<field name="municipal_taxes"/>
 									<field name="origin"/>
+									<field name="create_date"/>
 								</tree>
 								<form>
 									<group>
@@ -218,8 +219,7 @@
 											<field name="origin"/>
 											<field name="version"/>
 											<field name="state_id"/>
-											<field name="date_start"/>
-											<field name="date_end"/>
+											<field name="create_date"/>
 										</group>
 										<group>
 											<field name="active"/>


### PR DESCRIPTION
Alterei os seguintes pontos:
- Removi os campos da Data Inicial e Final e coloquei o de Data da Criação
- Inclui um parâmetro na Configuração da Contabilidade de quantidade de dias que o programa deverá consultar o webservice, isso é chamado automaticamente pelo método compute_all
- Antes estava sendo gravado os Impostos Estimados de todos os Estados agora somente do estado da empresa do usuário
- A linha de Impostos Estimados agora é Somente Leitura e não apaga as linhas já cadastradas  apenas adiciona novas e na consulta pega a de Data mais recente
- Ao clicar no botão de Consulta na tela de Classificação Fiscal o parâmetro de dias é ignorado e uma nova consulta e um nova linha será cadastrada 

Se for testar ou implementar em uma base dados que já tem linhas de Impostos Estimados cadastrados é preciso que você apague esses dados antes.
