### PR TITLE
[8.0] Included function amount_to_text for Brazilian Portuguese

### DIFF
--- a/l10n_br_base/__init__.py
+++ b/l10n_br_base/__init__.py
@@ -19,3 +19,4 @@
 
 from . import models
 from . import tools
+from . import tests

--- a/l10n_br_base/tests/__init__.py
+++ b/l10n_br_base/tests/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+# @ 2016 Akretion - www.akretion.com.br -
+#   Magno Costa <magno.costa@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+# NOTE we can remove this once this is merged
+# https://github.com/odoo/odoo/pull/11388
+
+from . import test_amount_to_text

--- a/l10n_br_base/tests/__init__.py
+++ b/l10n_br_base/tests/__init__.py
@@ -3,7 +3,5 @@
 #   Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-# NOTE we can remove this once this is merged
-# https://github.com/odoo/odoo/pull/11388
 
 from . import test_amount_to_text

--- a/l10n_br_base/tests/test_amount_to_text.py
+++ b/l10n_br_base/tests/test_amount_to_text.py
@@ -3,51 +3,49 @@
 #   Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-# NOTE we can remove this once this is merged
-# https://github.com/odoo/odoo/pull/11388
 
-from openerp.tools import amount_to_text_br
+from openerp.tools import amount_to_text_pt_BR
 from openerp.tests.common import TransactionCase
 
 
 class Tests(TransactionCase):
 
     def test_01_amount_to_text(self):
-        text_number = amount_to_text_br(99.99, 'REAIS')
+        text_number = amount_to_text_pt_BR(99.99, 'REAIS')
         self.assertEqual(
             text_number,
             'Noventa e Nove REAIS e  Noventa e Nove Centavos')
 
     def test_02_amount_to_text(self):
-        text_number = amount_to_text_br(1999.99, 'REAIS')
+        text_number = amount_to_text_pt_BR(1999.99, 'REAIS')
         self.assertEqual(
             text_number,
             'Um Mil, Novecentos e Noventa e Nove REAIS'
             ' e  Noventa e Nove Centavos')
 
     def test_03_amount_to_text(self):
-        text_number = amount_to_text_br(77777.0, 'REAIS')
+        text_number = amount_to_text_pt_BR(77777.0, 'REAIS')
         self.assertEqual(
             text_number,
             u'Setenta e Sete Mil, Setecentos e Setenta'
             u' e Sete REAIS e  Zero Centavo')
 
     def test_04_amount_to_text(self):
-        text_number = amount_to_text_br(1856333.0, 'REAIS')
+        text_number = amount_to_text_pt_BR(1856333.0, 'REAIS')
         self.assertEqual(
             text_number,
             u'Um Milhão, Oitocentos e Cinquenta e Seis Mil,'
             u' Trezentos e Trinta e Três REAIS e  Zero Centavo')
 
     def test_05_amount_to_text(self):
-        text_number = amount_to_text_br(9999999.0, 'REAIS')
+        text_number = amount_to_text_pt_BR(9999999.0, 'REAIS')
         self.assertEqual(
             text_number,
             u'Nove Milhões, Novecentos e Noventa e Nove Mil,'
             u' Novecentos e Noventa e Nove REAIS e  Zero Centavo')
 
     def test_06_amount_to_text(self):
-        text_number = amount_to_text_br(9999999999.0, 'REAIS')
+        text_number = amount_to_text_pt_BR(9999999999.0, 'REAIS')
         self.assertEqual(
             text_number,
             u'Nove Bilhões, Novecentos e Noventa e Nove Milhões,'

--- a/l10n_br_base/tests/test_amount_to_text.py
+++ b/l10n_br_base/tests/test_amount_to_text.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+# @ 2016 Akretion - www.akretion.com.br -
+#   Magno Costa <magno.costa@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+# NOTE we can remove this once this is merged
+# https://github.com/odoo/odoo/pull/11388
+
+from openerp.tools import amount_to_text_br
+from openerp.tests.common import TransactionCase
+
+
+class Tests(TransactionCase):
+
+    def test_01_amount_to_text(self):
+        text_number = amount_to_text_br(99.99, 'REAIS')
+        self.assertEqual(
+            text_number,
+            'Noventa e Nove REAIS e  Noventa e Nove Centavos')
+
+    def test_02_amount_to_text(self):
+        text_number = amount_to_text_br(1999.99, 'REAIS')
+        self.assertEqual(
+            text_number,
+            'Um Mil, Novecentos e Noventa e Nove REAIS'
+            ' e  Noventa e Nove Centavos')
+
+    def test_03_amount_to_text(self):
+        text_number = amount_to_text_br(77777.0, 'REAIS')
+        self.assertEqual(
+            text_number,
+            u'Setenta e Sete Mil, Setecentos e Setenta'
+            u' e Sete REAIS e  Zero Centavo')
+
+    def test_04_amount_to_text(self):
+        text_number = amount_to_text_br(1856333.0, 'REAIS')
+        self.assertEqual(
+            text_number,
+            u'Um Milhão, Oitocentos e Cinquenta e Seis Mil,'
+            u' Trezentos e Trinta e Três REAIS e  Zero Centavo')
+
+    def test_05_amount_to_text(self):
+        text_number = amount_to_text_br(9999999.0, 'REAIS')
+        self.assertEqual(
+            text_number,
+            u'Nove Milhões, Novecentos e Noventa e Nove Mil,'
+            u' Novecentos e Noventa e Nove REAIS e  Zero Centavo')
+
+    def test_06_amount_to_text(self):
+        text_number = amount_to_text_br(9999999999.0, 'REAIS')
+        self.assertEqual(
+            text_number,
+            u'Nove Bilhões, Novecentos e Noventa e Nove Milhões,'
+            u' Novecentos e Noventa e Nove Mil, Novecentos e'
+            u' Noventa e Nove REAIS e  Zero Centavo')

--- a/l10n_br_base/tools/__init__.py
+++ b/l10n_br_base/tools/__init__.py
@@ -19,3 +19,4 @@
 
 from . import fiscal
 from . import misc
+from . import amount_to_text

--- a/l10n_br_base/tools/amount_to_text.py
+++ b/l10n_br_base/tools/amount_to_text.py
@@ -25,6 +25,12 @@ denom_br = ('', 'Mil', u'Milhão', u'Bilhão', u'Trilhão', u'Quatrilhão',
             u'Tredecilhão', u'Quattuordecilhão', u'Quindecilhão',
             u'Sexdecilhão', u'Septendecillion', u'Octodecilhão',
             u'Novendecilhão', u'Vigintilhão')
+denoms_br = ('', 'Mil', u'Milhões', u'Bilhões', u'Trilhões', u'Quatrilhões',
+             u'Quintilhões', u'Sextilhões', u'Septilhões', u'Octilhões',
+             u'Nonilhões', u'Decilhões', u'Undecilhões', u'Duodecilhões',
+             u'Tredecilhões', u'Quattuordecilhões', u'Quindecilhões',
+             u'Sexdecilhões', u'Septendecilliões', u'Octodecilhões',
+             u'Novendecilhões', u'Vigintilhões')
 
 
 def _convert_nn_br(val):
@@ -71,9 +77,14 @@ def brazil_number(val):
             mod = 1000 ** didx
             l = val // mod
             r = val - (l * mod)
-            ret = _convert_nnn_br(l) + ' ' + denom_br[didx]
+            if mod > 99999 and l > 2:
+                ret = _convert_nnn_br(l) + ' ' + denoms_br[didx]
+            else:
+                ret = _convert_nnn_br(l) + ' ' + denom_br[didx]
+
             if r > 0:
                 ret = ret + ', ' + brazil_number(r)
+
             return ret
 
 

--- a/l10n_br_base/tools/amount_to_text.py
+++ b/l10n_br_base/tools/amount_to_text.py
@@ -12,50 +12,50 @@ import openerp
 # Brazilian Portuguese
 # -------------------------------------------------------------
 
-to_19_br = ('Zero',  'Um', 'Dois', u'Três', 'Quatro', 'Cinco', 'Seis', 'Sete',
-            'Oito', 'Nove', 'Dez', 'Onze', 'Doze', 'Treze', 'Quatorze',
-            'Quinze', 'Dezesseis', 'Dezessete', 'Dezoito', 'Dezenove')
-tens_br = ('Vinte', 'Trinta', 'Quarenta', 'Cinquenta',
-           'Sessenta', 'Setenta', 'Oitenta', 'Noventa')
-hundreds_br = ('Cem', 'Duzentos', 'Trezentos', 'Quatrocentos', 'Quinhentos',
-               'Seicentos', 'Setecentos', 'Oitocentos', 'Novecentos')
-denom_br = ('', 'Mil', u'Milhão', u'Bilhão', u'Trilhão', u'Quatrilhão',
-            u'Quintilhão',  u'Sextilhão', u'Septilhão', u'Octilhão',
-            u'Nonilhão', u'Decilhão', u'Undecilhão', u'Duodecilhão',
-            u'Tredecilhão', u'Quattuordecilhão', u'Quindecilhão',
-            u'Sexdecilhão', u'Septendecillion', u'Octodecilhão',
-            u'Novendecilhão', u'Vigintilhão')
-denoms_br = ('', 'Mil', u'Milhões', u'Bilhões', u'Trilhões', u'Quatrilhões',
-             u'Quintilhões', u'Sextilhões', u'Septilhões', u'Octilhões',
-             u'Nonilhões', u'Decilhões', u'Undecilhões', u'Duodecilhões',
-             u'Tredecilhões', u'Quattuordecilhões', u'Quindecilhões',
-             u'Sexdecilhões', u'Septendecilliões', u'Octodecilhões',
-             u'Novendecilhões', u'Vigintilhões')
+to_19_pt_BR = ('Zero', 'Um', 'Dois', u'Três', 'Quatro', 'Cinco', 'Seis',
+               'Sete', 'Oito', 'Nove', 'Dez', 'Onze', 'Doze', 'Treze',
+               'Quatorze', 'Quinze', 'Dezesseis', 'Dezessete', 'Dezoito',
+               'Dezenove')
+tens_pt_BR = ('Vinte', 'Trinta', 'Quarenta', 'Cinquenta',
+              'Sessenta', 'Setenta', 'Oitenta', 'Noventa')
+hundreds_pt_BR = ('Cem', 'Duzentos', 'Trezentos', 'Quatrocentos', 'Quinhentos',
+                  'Seicentos', 'Setecentos', 'Oitocentos', 'Novecentos')
+denom_pt_BR = ('', 'Mil', u'Milhão', u'Bilhão', u'Trilhão', u'Quatrilhão',
+               u'Quintilhão', u'Sextilhão', u'Septilhão', u'Octilhão',
+               u'Nonilhão', u'Decilhão', u'Undecilhão', u'Duodecilhão',
+               u'Tredecilhão', u'Quattuordecilhão', u'Quindecilhão',
+               u'Sexdecilhão', u'Septendecillion', u'Octodecilhão',
+               u'Novendecilhão', u'Vigintilhão')
+denoms_pt_BR = ('', 'Mil', u'Milhões', u'Bilhões', u'Trilhões', u'Quatrilhões',
+                u'Quintilhões', u'Sextilhões', u'Septilhões', u'Octilhões',
+                u'Nonilhões', u'Decilhões', u'Undecilhões', u'Duodecilhões',
+                u'Tredecilhões', u'Quattuordecilhões', u'Quindecilhões',
+                u'Sexdecilhões', u'Septendecilliões', u'Octodecilhões',
+                u'Novendecilhões', u'Vigintilhões')
 
 
-def _convert_nn_br(val):
+def _convert_nn_pt_BR(val):
     """ convert a value < 100 to Brazilian Portuguese
     """
     if val < 20:
-        return to_19_br[val]
-    for (dcap, dval) in ((k, 20 + (10 * v)) for (v, k) in enumerate(tens_br)):
+        return to_19_pt_BR[val]
+    for (dcap, dval) in (
+            (k, 20 + (10 * v)) for (v, k) in enumerate(tens_pt_BR)):
         if dval + 10 > val:
             if val % 10:
-                return dcap + ' e ' + to_19_br[val % 10]
+                return dcap + ' e ' + to_19_pt_BR[val % 10]
             return dcap
 
 
-def _convert_nnn_br(val):
+def _convert_nnn_pt_BR(val):
     """ convert a value < 1000 to Brazilian Portuguese
         special cased because it is the level that kicks
         off the < 100 special case.  The rest are more general.
-        This also allows you to get strings in the form of
-        'forty-five hundred' if called directly.
     """
     word = ''
     if val > 0:
         for (dcap, dval) in (
-                (k, 100 + (100 * v)) for (v, k) in enumerate(hundreds_br)):
+                (k, 100 + (100 * v)) for (v, k) in enumerate(hundreds_pt_BR)):
             if dval + 100 > val:
                 (mod, rem) = (val % 100, val // 100)
                 if rem > 0:
@@ -63,24 +63,24 @@ def _convert_nnn_br(val):
                     if mod > 0:
                         word += ' e '
                 if mod > 0:
-                    word += _convert_nn_br(mod)
+                    word += _convert_nn_pt_BR(mod)
                 return word
 
 
 def brazil_number(val):
     if val < 100:
-        return _convert_nn_br(val)
+        return _convert_nn_pt_BR(val)
     if val < 1000:
-        return _convert_nnn_br(val)
-    for (didx, dval) in ((v - 1, 1000 ** v) for v in range(len(denom_br))):
+        return _convert_nnn_pt_BR(val)
+    for (didx, dval) in ((v - 1, 1000 ** v) for v in range(len(denom_pt_BR))):
         if dval > val:
             mod = 1000 ** didx
             l = val // mod
             r = val - (l * mod)
             if mod > 99999 and l > 2:
-                ret = _convert_nnn_br(l) + ' ' + denoms_br[didx]
+                ret = _convert_nnn_pt_BR(l) + ' ' + denoms_pt_BR[didx]
             else:
-                ret = _convert_nnn_br(l) + ' ' + denom_br[didx]
+                ret = _convert_nnn_pt_BR(l) + ' ' + denom_pt_BR[didx]
 
             if r > 0:
                 ret = ret + ', ' + brazil_number(r)
@@ -88,7 +88,7 @@ def brazil_number(val):
             return ret
 
 
-def amount_to_text_br(number, currency):
+def amount_to_text_pt_BR(number, currency):
     number = '%.2f' % number
     units_name = currency
     list = str(number).split('.')
@@ -100,4 +100,4 @@ def amount_to_text_br(number, currency):
                     ' e ' + ' ' + end_word + ' ' + cents_name)
     return final_result
 
-openerp.tools.amount_to_text_br = amount_to_text_br
+openerp.tools.amount_to_text_pt_BR = amount_to_text_pt_BR

--- a/l10n_br_base/tools/amount_to_text.py
+++ b/l10n_br_base/tools/amount_to_text.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+# @ 2016 Akretion - www.akretion.com.br -
+#   Magno Costa <magno.costa@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+# NOTE we can remove this once this is merged
+# https://github.com/odoo/odoo/pull/11388
+
+import openerp
+
+# -------------------------------------------------------------
+# Brazilian Portuguese
+# -------------------------------------------------------------
+
+to_19_br = ('Zero',  'Um', 'Dois', u'Três', 'Quatro', 'Cinco', 'Seis', 'Sete',
+            'Oito', 'Nove', 'Dez', 'Onze', 'Doze', 'Treze', 'Quatorze',
+            'Quinze', 'Dezesseis', 'Dezessete', 'Dezoito', 'Dezenove')
+tens_br = ('Vinte', 'Trinta', 'Quarenta', 'Cinquenta',
+           'Sessenta', 'Setenta', 'Oitenta', 'Noventa')
+hundreds_br = ('Cem', 'Duzentos', 'Trezentos', 'Quatrocentos', 'Quinhentos',
+               'Seicentos', 'Setecentos', 'Oitocentos', 'Novecentos')
+denom_br = ('', 'Mil', u'Milhão', u'Bilhão', u'Trilhão', u'Quatrilhão',
+            u'Quintilhão',  u'Sextilhão', u'Septilhão', u'Octilhão',
+            u'Nonilhão', u'Decilhão', u'Undecilhão', u'Duodecilhão',
+            u'Tredecilhão', u'Quattuordecilhão', u'Quindecilhão',
+            u'Sexdecilhão', u'Septendecillion', u'Octodecilhão',
+            u'Novendecilhão', u'Vigintilhão')
+
+
+def _convert_nn_br(val):
+    """ convert a value < 100 to Brazilian Portuguese
+    """
+    if val < 20:
+        return to_19_br[val]
+    for (dcap, dval) in ((k, 20 + (10 * v)) for (v, k) in enumerate(tens_br)):
+        if dval + 10 > val:
+            if val % 10:
+                return dcap + ' e ' + to_19_br[val % 10]
+            return dcap
+
+
+def _convert_nnn_br(val):
+    """ convert a value < 1000 to Brazilian Portuguese
+        special cased because it is the level that kicks
+        off the < 100 special case.  The rest are more general.
+        This also allows you to get strings in the form of
+        'forty-five hundred' if called directly.
+    """
+    word = ''
+    if val > 0:
+        for (dcap, dval) in (
+                (k, 100 + (100 * v)) for (v, k) in enumerate(hundreds_br)):
+            if dval + 100 > val:
+                (mod, rem) = (val % 100, val // 100)
+                if rem > 0:
+                    word += dcap
+                    if mod > 0:
+                        word += ' e '
+                if mod > 0:
+                    word += _convert_nn_br(mod)
+                return word
+
+
+def brazil_number(val):
+    if val < 100:
+        return _convert_nn_br(val)
+    if val < 1000:
+        return _convert_nnn_br(val)
+    for (didx, dval) in ((v - 1, 1000 ** v) for v in range(len(denom_br))):
+        if dval > val:
+            mod = 1000 ** didx
+            l = val // mod
+            r = val - (l * mod)
+            ret = _convert_nnn_br(l) + ' ' + denom_br[didx]
+            if r > 0:
+                ret = ret + ', ' + brazil_number(r)
+            return ret
+
+
+def amount_to_text_br(number, currency):
+    number = '%.2f' % number
+    units_name = currency
+    list = str(number).split('.')
+    start_word = brazil_number(int(list[0]))
+    end_word = brazil_number(int(list[1]))
+    cents_number = int(list[1])
+    cents_name = (cents_number > 1) and 'Centavos' or 'Centavo'
+    final_result = (start_word + ' ' + units_name +
+                    ' e ' + ' ' + end_word + ' ' + cents_name)
+    return final_result
+
+openerp.tools.amount_to_text_br = amount_to_text_br


### PR DESCRIPTION
The right place to put this function is openerp/tools/amount_to_text.py and I make pull request https://github.com/odoo/odoo/pull/11388 , but Odoo take long time to analise and merged, so until we waiting we can put this on our localization.   
