### PR TITLE
[8.0] [FIX] The right group to put access of partner.special.fiscal.type model

### DIFF
--- a/l10n_br_account/security/ir.model.access.csv
+++ b/l10n_br_account/security/ir.model.access.csv
@@ -8,7 +8,7 @@
 "l10n_br_account_cnae","l10n_br_account.cnae","model_l10n_br_account_cnae","account.group_account_manager",1,1,1,1
 "l10n_br_account_service_type","l10n_br_account.service.type","model_l10n_br_account_service_type","account.group_account_manager",1,1,1,1
 "l10n_br_account_partner_fiscal_type_user","l10n_br_account.partner.fiscal.type","model_l10n_br_account_partner_fiscal_type","account.group_account_user",1,0,0,0
-"l10n_br_account_partner_special_fiscal_type_user","l10n_br_account.partner.special.fiscal.type","model_l10n_br_account_partner_special_fiscal_type","account.group_account_user",1,0,0,0
+"l10n_br_account_partner_special_fiscal_type_invoice","l10n_br_account.partner.special.fiscal.type","model_l10n_br_account_partner_special_fiscal_type","account.group_account_invoice",1,0,0,0
 "l10n_br_account_fiscal_document_user","l10n_br_account.fiscal.document","model_l10n_br_account_fiscal_document","account.group_account_user",1,0,0,0
 "l10n_br_account_fiscal_category_user","l10n_br_account.fiscal.category","model_l10n_br_account_fiscal_category","account.group_account_user",1,0,0,0
 "l10n_br_account_document_serie_user","l10n_br_account.document.serie","model_l10n_br_account_document_serie","account.group_account_user",1,0,0,0

--- a/l10n_br_account/security/ir.model.access.csv
+++ b/l10n_br_account/security/ir.model.access.csv
@@ -8,6 +8,7 @@
 "l10n_br_account_cnae","l10n_br_account.cnae","model_l10n_br_account_cnae","account.group_account_manager",1,1,1,1
 "l10n_br_account_service_type","l10n_br_account.service.type","model_l10n_br_account_service_type","account.group_account_manager",1,1,1,1
 "l10n_br_account_partner_fiscal_type_user","l10n_br_account.partner.fiscal.type","model_l10n_br_account_partner_fiscal_type","account.group_account_user",1,0,0,0
+"l10n_br_account_partner_special_fiscal_type_manager","l10n_br_account.partner.special.fiscal.type","model_l10n_br_account_partner_special_fiscal_type","account.group_account_manager",1,1,1,1
 "l10n_br_account_partner_special_fiscal_type_invoice","l10n_br_account.partner.special.fiscal.type","model_l10n_br_account_partner_special_fiscal_type","account.group_account_invoice",1,0,0,0
 "l10n_br_account_fiscal_document_user","l10n_br_account.fiscal.document","model_l10n_br_account_fiscal_document","account.group_account_user",1,0,0,0
 "l10n_br_account_fiscal_category_user","l10n_br_account.fiscal.category","model_l10n_br_account_fiscal_category","account.group_account_user",1,0,0,0

--- a/l10n_br_account/security/ir.model.access.csv
+++ b/l10n_br_account/security/ir.model.access.csv
@@ -9,7 +9,7 @@
 "l10n_br_account_service_type","l10n_br_account.service.type","model_l10n_br_account_service_type","account.group_account_manager",1,1,1,1
 "l10n_br_account_partner_fiscal_type_user","l10n_br_account.partner.fiscal.type","model_l10n_br_account_partner_fiscal_type","account.group_account_user",1,0,0,0
 "l10n_br_account_partner_special_fiscal_type_manager","l10n_br_account.partner.special.fiscal.type","model_l10n_br_account_partner_special_fiscal_type","account.group_account_manager",1,1,1,1
-"l10n_br_account_partner_special_fiscal_type_invoice","l10n_br_account.partner.special.fiscal.type","model_l10n_br_account_partner_special_fiscal_type","account.group_account_invoice",1,0,0,0
+"l10n_br_account_partner_special_fiscal_type_invoice","l10n_br_account.partner.special.fiscal.type","model_l10n_br_account_partner_special_fiscal_type","base.group_user",1,0,0,0
 "l10n_br_account_fiscal_document_user","l10n_br_account.fiscal.document","model_l10n_br_account_fiscal_document","account.group_account_user",1,0,0,0
 "l10n_br_account_fiscal_category_user","l10n_br_account.fiscal.category","model_l10n_br_account_fiscal_category","account.group_account_user",1,0,0,0
 "l10n_br_account_document_serie_user","l10n_br_account.document.serie","model_l10n_br_account_document_serie","account.group_account_user",1,0,0,0
@@ -33,3 +33,5 @@
 "l10n_br_account_document_event_manager","l10n_br_account.document_event","model_l10n_br_account_document_event","account.group_account_manager",1,1,1,1
 "l10n_br_account_invoice_cce_manager","l10n_br_account_invoice_cce","model_l10n_br_account_invoice_cce","account.group_account_manager",1,1,1,1
 "access_account_config_settings","access_account_config_settings","model_account_config_settings","base.group_system",1,1,1,1
+"access_account_tax_code_user","access_account_tax_code_user","account.model_account_tax_code","base.group_user",1,0,0,0
+"l10n_br_account_partner_fiscal_type_user","l10n_br_account_partner_fiscal_type_user","model_l10n_br_account_partner_fiscal_type","base.group_user",1,0,0,0

--- a/l10n_br_account_product/security/ir.model.access.csv
+++ b/l10n_br_account_product/security/ir.model.access.csv
@@ -8,8 +8,8 @@
 "l10n_br_tax_definition_purchase_manager","l10n_br_tax.definition.purchase","model_l10n_br_tax_definition_purchase","account.group_account_manager",1,1,1,1
 "l10n_br_tax_definition_sale_template_user","l10n_br_tax.definition.sale.template","model_l10n_br_tax_definition_sale_template","account.group_account_invoice",1,0,0,0
 "l10n_br_tax_definition_purchase_template_user","l10n_br_tax.definition.purchase.template","model_l10n_br_tax_definition_purchase_template","account.group_account_invoice",1,0,0,0
-"l10n_br_tax_definition_sale_user","l10n_br_tax.definition.sale","model_l10n_br_tax_definition_sale","account.group_account_invoice",1,0,0,0
-"l10n_br_tax_definition_purchase_user","l10n_br_tax.definition.purchase","model_l10n_br_tax_definition_purchase","account.group_account_invoice",1,0,0,0
+"l10n_br_tax_definition_purchase_user","l10n_br_tax_definition_purchase_user","model_l10n_br_tax_definition_purchase","base.group_user",1,0,0,0
+"l10n_br_tax_definition_sale_user","l10n_br_tax_definition_sale_user","model_l10n_br_tax_definition_sale","base.group_user",1,0,0,0
 "l10n_br_account_product_document_related_user","l10n_br_account_product.document.related","model_l10n_br_account_product_document_related","account.group_account_invoice",1,1,1,1
 "l10n_br_account_product_document_related_manager","l10n_br_account_product.document.related","model_l10n_br_account_product_document_related","account.group_account_manager",1,1,1,1
 "l10n_br_tax_definition_company_product_manager","l10n_br_tax.definition.company.product","model_l10n_br_tax_definition_company_product","account.group_account_manager",1,1,1,1


### PR DESCRIPTION
The right group to put access of partner.special.fiscal.type model is group_account_invoice because the others groups of Account inherit this, and for example when we configure access for user who just use Stock but need to create Pickings to be invoice their access in Account must be the basic access..
