### PR TITLE
Add "Compras para Comercialização" in default data

### DIFF
--- a/l10n_br_account_product/data/l10n_br_account_product_data.xml
+++ b/l10n_br_account_product/data/l10n_br_account_product_data.xml
@@ -73,10 +73,19 @@
 			<field name="journal_type">sale</field>
 			<field name="state">approved</field>
 		</record>
-
+                               
 		<record id="fc_b7aafa9c3056c3f020ceae63d7312504" model="l10n_br_account.fiscal.category">
 			<field name="code">Compras para Ind</field>
 			<field name="name">Compras para Industrialização</field>
+			<field name="type">input</field>
+			<field name="fiscal_type">product</field>
+			<field name="journal_type">purchase</field>
+			<field name="state">approved</field>
+		</record>
+
+		<record id="fc_compras_para_com" model="l10n_br_account.fiscal.category">
+			<field name="code">Compras para Com</field>
+			<field name="name">Compras para Comercialização</field>
 			<field name="type">input</field>
 			<field name="fiscal_type">product</field>
 			<field name="journal_type">purchase</field>


### PR DESCRIPTION
I'm trying to add all possible fiscal categories into the default data, this is my first attempt as I'm unsure how to create the record_id, please help me if I made anything stupid.
Thanks.
Wagner Pereira
