### PR TITLE
Change field Fiscal Category to be required in Fiscal Rule

### DIFF
--- a/l10n_br_account/views/account_fiscal_position_rule_view.xml
+++ b/l10n_br_account/views/account_fiscal_position_rule_view.xml
@@ -40,7 +40,7 @@
                     <separator colspan="4" />
                     <field name="parent_id" />
                     <field name="fiscal_type" />
-                    <field name="fiscal_category_id" attrs="{'required': [('parent_id', '=', True)]}"/>
+                    <field name="fiscal_category_id" required="True"/>
                     <newline />
                     <group colspan="4" attrs="{'invisible': [('fiscal_type', '=', '3')]}">
                         <separator string="Faixa de Faturamento" colspan="4" />
@@ -67,7 +67,7 @@
                     <separator colspan="4" />
                     <field name="parent_id" />
                     <field name="fiscal_type" />
-                    <field name="fiscal_category_id" attrs="{'required': [('parent_id', '=', True)]}"/>
+                    <field name="fiscal_category_id" required="True"/>
                     <newline />
                     <group colspan="4" attrs="{'invisible': [('fiscal_type', '=', '3')]}">
                         <separator string="Faixa de Faturamento" colspan="4" />


### PR DESCRIPTION
Because there is no reason to create Fiscal Rule with Fiscal Position null and consequently Fiscal Category too. https://github.com/OCA/account-fiscal-rule/pull/53#issuecomment-243926277 
