### PR TITLE
Configure access to allow users of account can change Sequence of Invoices (NFe) in case of errors

### DIFF
--- a/l10n_br_account_product/security/ir.model.access.csv
+++ b/l10n_br_account_product/security/ir.model.access.csv
@@ -31,3 +31,4 @@
 "l10n_br_account_product_ipi_guideline","l10n_br_account_product.ipi_guideline","model_l10n_br_account_product_ipi_guideline","account.group_account_invoice",1,1,1,1
 "l10n_br_account_product_ipi_guideline_user","l10n_br_account_product.ipi_guideline","model_l10n_br_account_product_ipi_guideline","account.group_account_invoice",1,0,0,0
 "l10n_br_account_product_ipi_guideline_invoice","l10n_br_account_product.ipi_guideline","model_l10n_br_account_product_ipi_guideline","account.group_account_invoice",1,0,0,0
+"ir_sequence_account_invoice","ir_sequence account_invoice","base.model_ir_sequence","account.group_account_invoice",1,1,1,0


### PR DESCRIPTION
Quando na transmissão de uma NFe ocorre um erro e é necessário edita-lá para corrigi-lá  é preciso Cancelar e Voltar para Provisória porém a sequencia na NFe não volta automaticamente sendo necessário que o usuário faça isso manualmente, se não fizer esse número da NFe cancelada será perdido, para fazer isso o usuário não deveria precisar ter permissão de Configurações por isso apenas adicionei a permissão ao grupo Faturamentos/Pagamentos.
