### PR TITLE
l10n_br_crm_zip view adjust

### DIFF
--- a/l10n_br_crm/views/crm_lead_view.xml
+++ b/l10n_br_crm/views/crm_lead_view.xml
@@ -8,17 +8,28 @@
             <field name="model">crm.lead</field>
             <field name="inherit_id" ref="crm.crm_case_form_view_leads"/>
             <field name="arch" type="xml">
-                <field name="city" position="replace">
-                    <field name="city" invisible="1"/>
-                </field>
-                <field name="state_id" position="replace">
-                    <field name="state_id" placeholder="Estado"/>
-                    <field name="l10n_br_city_id" placeholder="Município"/>
-                </field>
-                <field name="street2" position="replace">
-                    <field name="district" placeholder="Bairro"/>
+                <field name="street2" position="replace"/>
+                <field name="zip" position="replace"/>
+                <field name="street" position="replace">
+                    <field name="zip" placeholder="CEP" style="width:50%" />
+                    <field name="street" placeholder="Logradouro" />
                     <field name="number" placeholder="Número"/>
                     <field name="street2" placeholder="Complemento"/>
+                    <field name="district" placeholder="Bairro"/>
+                </field>
+                <field name="state_id" position="attributes">
+                    <attribute name="domain">[('country_id','=',country_id)]</attribute>
+                    <attribute name="style">width:100%</attribute>
+                </field>
+                <field name="country_id" position="replace"/>
+                <field name="state_id" position="before">
+                    <field name="country_id" placeholder="País" />
+                </field>
+                <field name="state_id" position="after">
+                    <field name="l10n_br_city_id" placeholder="Cidade"/>
+                </field>
+                <field name="city" position="replace">
+                    <field name="city" invisible="1" />
                 </field>
                 <field name="partner_name" position="after">
                     <field name="legal_name"/>
@@ -36,6 +47,6 @@
                 </field>
             </field>
         </record>
-    
+
     </data>
 </openerp>

--- a/l10n_br_crm/views/crm_opportunity_view.xml
+++ b/l10n_br_crm/views/crm_opportunity_view.xml
@@ -8,17 +8,28 @@
             <field name="model">crm.lead</field>
             <field name="inherit_id" ref="crm.crm_case_form_view_oppor"/>
             <field name="arch" type="xml">
-                <field name="city" position="replace">
-                    <field name="city" invisible="1"/>
-                </field>
-                <field name="state_id" position="replace">
-                    <field name="state_id" placeholder="Estado"/>
-                    <field name="l10n_br_city_id" placeholder="Município"/>
-                </field>
-                <field name="street2" position="replace">
-                    <field name="district" placeholder="Bairro"/>
+                <field name="street2" position="replace"/>
+                <field name="zip" position="replace"/>
+                <field name="street" position="replace">
+                    <field name="zip" placeholder="CEP" style="width:50%" />
+                    <field name="street" placeholder="Logradouro" />
                     <field name="number" placeholder="Número"/>
                     <field name="street2" placeholder="Complemento"/>
+                    <field name="district" placeholder="Bairro"/>
+                </field>
+                <field name="state_id" position="attributes">
+                    <attribute name="domain">[('country_id','=',country_id)]</attribute>
+                    <attribute name="style">width:100%</attribute>
+                </field>
+                <field name="country_id" position="replace"/>
+                <field name="state_id" position="before">
+                    <field name="country_id" placeholder="País" />
+                </field>
+                <field name="state_id" position="after">
+                    <field name="l10n_br_city_id" placeholder="Cidade"/>
+                </field>
+                <field name="city" position="replace">
+                    <field name="city" invisible="1" />
                 </field>
                 <field name="partner_name" position="after">
                     <field name="legal_name"/>

--- a/l10n_br_zip/models/l10n_br_zip.py
+++ b/l10n_br_zip/models/l10n_br_zip.py
@@ -20,7 +20,7 @@ class L10nBrZip(models.Model):
     street_type = fields.Char('Tipo', size=26)
     street = fields.Char('Logradouro', size=72)
     district = fields.Char('Bairro', size=72)
-    country_id = fields.Many2one('res.country', 'Country')
+    country_id = fields.Many2one('res.country', u'País')
     state_id = fields.Many2one(
         'res.country.state', 'Estado',
         domain="[('country_id','=',country_id)]")
@@ -39,7 +39,7 @@ class L10nBrZip(models.Model):
             if not state_id or not l10n_br_city_id or \
                     len(street or '') == 0:
                 raise except_orm(
-                    u'Parametros insuficientes',
+                    u'Parâmetros insuficientes',
                     u'Necessário informar Estado, município e logradouro')
 
             if country_id:


### PR DESCRIPTION
- Ajustes na posição dos campos de endereço da view de Prospectos
  ![prospectos](https://cloud.githubusercontent.com/assets/8174740/10777266/a13c4820-7d00-11e5-9868-0e421f5f8791.png)

e de Oportunidade.
![oportunidades](https://cloud.githubusercontent.com/assets/8174740/10777272/b12969ac-7d00-11e5-87c1-7b71f08b2a14.png)

O objetivo é que os campos de endereço fiquem padronizados, iguais aos das views de Cliente e de Empresa.
- Tradução da string do campo _country_id_ da tela de cadastro de CEP's (módulo _l10n_br_zip_) para português.
