### PR TITLE
[FIX] Method map_tax was missing Replacement Tax Code in Invoice

### DIFF
--- a/l10n_br_account_product/models/res_partner.py
+++ b/l10n_br_account_product/models/res_partner.py
@@ -130,8 +130,9 @@ class AccountFiscalPosition(models.Model):
         map_taxes_ncm = self.env['account.fiscal.position.tax'].browse()
         for tax in taxes:
             for map in self.tax_ids:
-                if map.tax_src_id.id == tax.id or \
-                        map.tax_code_src_id.id == tax.tax_code_id.id:
+                if (map.tax_src_id.id == tax.id or
+                        map.tax_dest_id == tax or
+                        map.tax_code_src_id.id == tax.tax_code_id.id):
                     if map.tax_dest_id.id or tax.tax_code_id.id:
                         if map.fiscal_classification_id.id == \
                                 product.fiscal_classification_id.id:


### PR DESCRIPTION
Method map_tax was missing Replacement Tax Code when we use Source Tax to configure Fiscal Position.

Se a Posição Fiscal estivesse configurada usando o campo Origem do Imposto com um imposto "coringa" por exemplo ICMS Externo o campo Replacement Tax Code, no caso a CST do ICMS, era ignorado no mapeamento ficando o campo em branco 
