### PR TITLE
[FIX] Error in create partner from crm lead

### DIFF
--- a/l10n_br_crm/models/crm_lead.py
+++ b/l10n_br_crm/models/crm_lead.py
@@ -151,10 +151,13 @@ class CrmLead(models.Model):
             value.update({
                 'legal_name': lead.legal_name,
                 'cnpj_cpf': lead.cnpj,
-                'inscr_est': lead.inscr_est,
                 'inscr_mun': lead.inscr_mun,
                 'suframa': lead.suframa,
             })
+
+            if not lead.state_id or lead.inscr_est:
+                value.update({'inscr_est': lead.inscr_est})
+
         else:
             value.update({
                 'legal_name': lead.name_surname,


### PR DESCRIPTION
O problema está nesta linha: [8.0/l10n_br_crm/models/crm_lead.py#L154](https://github.com/OCA/l10n-brazil/blob/8.0/l10n_br_crm/models/crm_lead.py#L154)

Quando o campo `state_id` está preenchido, o campo `inscr_est` não pode ser adicionado no _dict_ `values`, ao menos não se seu valor for `False`. Se `state_id`  for `False`, o erro não ocorre. 
Isso ocorre porque a inscrição estadual depende do estado.

O campo `inscr_est` é validado em [8.0/l10n_br_base/models/res_partner.py#L147](https://github.com/OCA/l10n-brazil/blob/8.0/l10n_br_base/models/res_partner.py#L147). 

FIX #412 
