### PR TITLE
[FIX] Suds ImportError: cannot import name TransportError

### DIFF
--- a/l10n_br_zip_correios/models/webservice_client.py
+++ b/l10n_br_zip_correios/models/webservice_client.py
@@ -14,6 +14,13 @@ try:
 except ImportError:
     raise UserError(_(u'Erro!'), _(u"Biblioteca Suds não instalada!"))
 
+try:
+    # to pip install suds (version: 0.4)
+    from suds.client import TransportError
+except ImportError as ex:
+    # to apt-get install python-suds (version: 0.7~git20150727.94664dd-3)
+    from suds.transport import TransportError
+
 _logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Erro de _import_ ao instalar o módulo _l10n_br_zip_correios_ causada pela lib _suds_

FIX #421

Obs.: O erro no TravisCI causado pelo Pylint foi corrigido aqui: https://github.com/OCA/l10n-brazil/pull/414
