### PR TITLE
[Fix] View de cancelar nota como somente leitura

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -115,6 +115,12 @@ class AccountInvoice(models.Model):
         string='Gera Financeiro'
     )
 
+    @api.multi
+    def name_get(self):
+        self.ensure_one()
+        name = 'Fatura ' + self.internal_number if self.internal_number else ''
+        return [(self.id, name)]
+
     @api.one
     @api.constrains('number')
     def _check_invoice_number(self):

--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -117,9 +117,11 @@ class AccountInvoice(models.Model):
 
     @api.multi
     def name_get(self):
-        self.ensure_one()
-        name = 'Fatura ' + self.internal_number if self.internal_number else ''
-        return [(self.id, name)]
+        lista = []
+        for obj in self:
+            name = obj.internal_number if obj.internal_number else ''
+            lista.append((obj.id, name))
+        return lista
 
     @api.one
     @api.constrains('number')

--- a/l10n_br_account/models/l10n_br_account.py
+++ b/l10n_br_account/models/l10n_br_account.py
@@ -38,15 +38,11 @@ class L10nBrAccountInvoiceCancel(models.Model):
     _description = u'Cancelar Documento Eletrônico no Sefaz'
 
     invoice_id = fields.Many2one('account.invoice', 'Fatura')
-    justificative = fields.Char(
-        'Justificativa', size=255, readonly=True, required=True,
-        states={'draft': [('readonly', False)]})
+    justificative = fields.Char(string='Justificativa', size=255,
+                                readonly=True, required=True)
     cancel_document_event_ids = fields.One2many(
         'l10n_br_account.document_event', 'cancel_document_event_id',
         u'Eventos')
-    state = fields.Selection(
-        [('draft', 'Rascunho'), ('cancel', 'Cancelado'),
-         ('done', u'Concluído')], 'Status', required=True, default='draft')
 
     def _check_justificative(self, cr, uid, ids):
         for invalid in self.browse(cr, uid, ids):
@@ -58,10 +54,6 @@ class L10nBrAccountInvoiceCancel(models.Model):
         _check_justificative,
         'Justificativa deve ter tamanho minimo de 15 caracteres.',
         ['justificative'])]
-
-    def action_draft_done(self):
-        self.write({'state': 'done'})
-        return True
 
 
 class L10nBrDocumentEvent(models.Model):

--- a/l10n_br_account/models/l10n_br_account.py
+++ b/l10n_br_account/models/l10n_br_account.py
@@ -22,13 +22,13 @@ PRODUCT_FISCAL_TYPE_DEFAULT = PRODUCT_FISCAL_TYPE[0][0]
 
 class L10nBrAccountCce(models.Model):
     _name = 'l10n_br_account.invoice.cce'
-    _description = u'Cartão de Correção no Sefaz'
+    _description = u'Carta de Correção no Sefaz'
 
     # TODO nome de campos devem ser em ingles
     invoice_id = fields.Many2one('account.invoice', 'Fatura')
     motivo = fields.Text('Motivo', readonly=True, required=True)
     sequencia = fields.Char(
-        'Sequencia', help=u"Indica a sequencia da carta de correcão")
+        'Sequencia', help=u"Indica a sequência da carta de correcão")
     cce_document_event_ids = fields.One2many(
         'l10n_br_account.document_event', 'document_event_ids', u'Eventos')
 
@@ -85,7 +85,7 @@ class L10nBrDocumentEvent(models.Model):
         help="Reference of the document that produced event.")
     file_sent = fields.Char('Envio', readonly=True)
     file_returned = fields.Char('Retorno', readonly=True)
-    status = fields.Char('Codigo', readonly=True)
+    status = fields.Char(u'Código', readonly=True)
     message = fields.Char('Mensagem', readonly=True)
     create_date = fields.Datetime(u'Data Criação', readonly=True)
     write_date = fields.Datetime(u'Data Alteração', readonly=True)
@@ -153,7 +153,7 @@ class L10nBrAccountFiscalCategory(models.Model):
 
     _sql_constraints = [
         ('l10n_br_account_fiscal_category_code_uniq', 'unique (code)',
-         u'Já existe uma categoria fiscal com esse código !')
+         u'Já existe uma categoria fiscal com esse código!')
     ]
 
     @api.multi
@@ -368,7 +368,7 @@ class L10nBrAccountPartnerFiscalType(models.Model):
 
     name = fields.Char(u'Descrição', size=64)
 
-    is_company = fields.Boolean('Pessoa Juridica?')
+    is_company = fields.Boolean(u'Pessoa Jurídica?')
 
     default = fields.Boolean(u'Tipo Fiscal Padrão', default=True)
 
@@ -385,7 +385,7 @@ class L10nBrAccountPartnerFiscalType(models.Model):
             ])) > 1:
                 raise UserError(
                     _(u'Mantenha apenas um tipo fiscal padrão'
-                      u' para Pessoa Fisíca ou para Pessoa Jurídica!'))
+                      u' para Pessoa Física ou para Pessoa Jurídica!'))
             return True
 
 
@@ -393,7 +393,7 @@ class L10nBrAccountPartnerSpecialFiscalType(models.Model):
     _name = 'l10n_br_account.partner.special.fiscal.type'
     _description = 'Regime especial do parceiro'
 
-    name = fields.Char(u'Name', size=20)
+    name = fields.Char(u'Nome', size=20)
 
 
 class L10nBrAccountCNAE(models.Model):

--- a/l10n_br_account/models/l10n_br_account.py
+++ b/l10n_br_account/models/l10n_br_account.py
@@ -50,6 +50,9 @@ class L10nBrAccountInvoiceCancel(models.Model):
     _description = u'Documento Eletrônico no Sefaz'
 
     invoice_id = fields.Many2one('account.invoice', 'Fatura')
+    partner_id = fields.Many2one('res.partner',
+                                 related='invoice_id.partner_id',
+                                 string='Cliente')
     justificative = fields.Char(string='Justificativa', size=255,
                                 readonly=True, required=True)
     cancel_document_event_ids = fields.One2many(

--- a/l10n_br_account/views/l10n_br_account_view.xml
+++ b/l10n_br_account/views/l10n_br_account_view.xml
@@ -11,7 +11,7 @@
             <field name="name">l10n_br_account.invoice.cancel.form</field>
             <field name="model">l10n_br_account.invoice.cancel</field>
             <field name="arch" type="xml">
-                <form string="Cancelar Documento Eletrônico" version="7.0">
+                <form string="Cancelar Documento Eletrônico" version="7.0" edit="false" create="false">
                     <header>
                         <button name="action_draft_done" states="draft" colspan="2" string="Confirmar" type="object" icon="gtk-convert"/>
                         <field name="state" widget="statusbar" statusbar_visible="draft,done"/>
@@ -44,7 +44,8 @@
             <field name="name">l10n_br_account.invoice.cancel.tree</field>
             <field name="model">l10n_br_account.invoice.cancel</field>
             <field name="arch" type="xml">
-                <tree string="Cancelar Documento Eletrônico">                                      
+                <tree string="Cancelar Documento Eletrônico" edit="false" create="false">
+
                     <field name="invoice_id"/>
                     <field name="justificative"/>
                     <field name="state"/>

--- a/l10n_br_account/views/l10n_br_account_view.xml
+++ b/l10n_br_account/views/l10n_br_account_view.xml
@@ -11,11 +11,7 @@
             <field name="name">l10n_br_account.invoice.cancel.form</field>
             <field name="model">l10n_br_account.invoice.cancel</field>
             <field name="arch" type="xml">
-                <form string="Cancelar Documento Eletrônico" version="7.0" edit="false" create="false">
-                    <header>
-                        <button name="action_draft_done" states="draft" colspan="2" string="Confirmar" type="object" icon="gtk-convert"/>
-                        <field name="state" widget="statusbar" statusbar_visible="draft,done"/>
-                    </header>
+                <form string="Cancelar Documento Eletrônico" edit="false" create="false">
                     <group>
                         <field name="invoice_id"/>
                         <field name="justificative"/>
@@ -45,10 +41,8 @@
             <field name="model">l10n_br_account.invoice.cancel</field>
             <field name="arch" type="xml">
                 <tree string="Cancelar Documento Eletrônico" edit="false" create="false">
-
                     <field name="invoice_id"/>
                     <field name="justificative"/>
-                    <field name="state"/>
                 </tree>
             </field>
         </record>

--- a/l10n_br_account/views/l10n_br_account_view.xml
+++ b/l10n_br_account/views/l10n_br_account_view.xml
@@ -14,9 +14,16 @@
                 <form string="NFs Canceladas" edit="false" create="false">
                     <group>
                         <field name="invoice_id"/>
+                        <field name="partner_id"/>
+                    </group>
+                    <group>
                         <field name="justificative"/>
                     </group>
-                    <field name="cancel_document_event_ids"/>   
+                    <notebook>
+                        <page string="Eventos">
+                            <field name="cancel_document_event_ids"/>
+                        </page>
+                    </notebook>
                 </form>
             </field>
         </record>
@@ -28,20 +35,27 @@
                 <form string="Carta de Correção" version="7.0" edit="false" create="false">
                     <group>
                         <field name="invoice_id"/>
-                        <field name="motivo"/>
-                        <field name="sequencia"/>                       
+                        <field name="sequencia"/>
                     </group>
-                    <field name="cce_document_event_ids"/>  
+                    <group>
+                         <field name="motivo"/>
+                    </group>
+                    <notebook>
+                        <page string="Eventos">
+                            <field name="cce_document_event_ids"/>
+                        </page>
+                    </notebook>
                 </form>
             </field>
-        </record>       
-            
+        </record>
+
         <record id="l10n_br_account_invoice_cancel_tree" model="ir.ui.view">
             <field name="name">l10n_br_account.invoice.cancel.tree</field>
             <field name="model">l10n_br_account.invoice.cancel</field>
             <field name="arch" type="xml">
                 <tree string="NFs Canceladas" edit="false" create="false">
-                    <field name="invoice_id"/>
+                    <field name="invoice_id" style="width: 100%" />
+                    <field name="partner_id" style="width: 100%" />
                     <field name="justificative"/>
                 </tree>
             </field>
@@ -51,14 +65,14 @@
             <field name="name">l10n_br_account.invoice.cce.tree</field>
             <field name="model">l10n_br_account.invoice.cce</field>
             <field name="arch" type="xml">
-                <tree string="Carta de Correção" edit="false" create="false">                                     
+                <tree string="Carta de Correção" edit="false" create="false">
                     <field name="invoice_id"/>
                     <field name="motivo"/>
-                    <field name="sequencia"/>                   
+                    <field name="sequencia"/>
                 </tree>
             </field>
-        </record>       
-        
+        </record>
+
         <record id="view_l10n_br_account_fiscal_document_form" model="ir.ui.view">
             <field name="name">l10n_br_account.fiscal.document</field>
             <field name="model">l10n_br_account.fiscal.document</field>
@@ -266,7 +280,7 @@
             <field name="name">l10n_br_account.document_event.form</field>
             <field name="model">l10n_br_account.document_event</field>
             <field name="arch" type="xml">
-                <form string="Eventos Eletronicos" version="7.0">
+                <form string="Eventos Eletronicos" version="7.0" edit="false" create="false">
                     <header>
                         <field name="state" widget="statusbar" statusbar_visible="draft,send,wait,done"/>
                     </header>
@@ -533,7 +547,7 @@
         </record>
 
         <record id="action_l10n_br_account_invoice_cancel" model="ir.actions.act_window">
-            <field name="name">Cancelar Documento Eletrônico</field>
+            <field name="name">Documentos Eletrônicos Cancelados</field>
             <field name="type">ir.actions.act_window</field>
             <field name="res_model">l10n_br_account.invoice.cancel</field>
             <field name="view_mode">tree,form</field>
@@ -569,14 +583,14 @@
         <menuitem id="menu_action_l10n_br_account_fiscal_document_form" name="Documento Fiscal" parent="menu_l10n_br_account_configuration_fiscal" action="action_l10n_br_account_fiscal_document_form"/>
 
         <menuitem id="menu_action_document_serie_form" name="Serie de Documento Fiscal" parent="menu_l10n_br_account_configuration_fiscal" action="action_l10n_br_account_document_serie_form"/>
-        
+
         <menuitem id="menu_l10n_br_account_document_event" name="Eventos Eletronicos" parent="menu_l10n_br_account_fiscal" action="action_l10n_br_account_document_event"/>
 
         <menuitem id="menu_l10n_br_account_invoice_invalid_number" name="Inutilizar Faixa de Numeracao" parent="menu_l10n_br_account_fiscal" action="action_l10n_br_account_invoice_invalid_number"/>
 
         <menuitem id="menu_l10n_br_account_invoice_cancel" name="NFs Canceladas" parent="menu_l10n_br_account_fiscal" action="action_l10n_br_account_invoice_cancel"/>
-        
-        <menuitem id="menu_l10n_br_account_cce" name="Carta de Correção" parent="menu_l10n_br_account_fiscal" action="action_l10n_br_account_cce"/>       
+
+        <menuitem id="menu_l10n_br_account_cce" name="Carta de Correção" parent="menu_l10n_br_account_fiscal" action="action_l10n_br_account_cce"/>
 
     </data>
 

--- a/l10n_br_account/views/l10n_br_account_view.xml
+++ b/l10n_br_account/views/l10n_br_account_view.xml
@@ -11,7 +11,7 @@
             <field name="name">l10n_br_account.invoice.cancel.form</field>
             <field name="model">l10n_br_account.invoice.cancel</field>
             <field name="arch" type="xml">
-                <form string="Cancelar Documento Eletrônico" edit="false" create="false">
+                <form string="NFs Canceladas" edit="false" create="false">
                     <group>
                         <field name="invoice_id"/>
                         <field name="justificative"/>
@@ -40,7 +40,7 @@
             <field name="name">l10n_br_account.invoice.cancel.tree</field>
             <field name="model">l10n_br_account.invoice.cancel</field>
             <field name="arch" type="xml">
-                <tree string="Cancelar Documento Eletrônico" edit="false" create="false">
+                <tree string="NFs Canceladas" edit="false" create="false">
                     <field name="invoice_id"/>
                     <field name="justificative"/>
                 </tree>
@@ -574,7 +574,7 @@
 
         <menuitem id="menu_l10n_br_account_invoice_invalid_number" name="Inutilizar Faixa de Numeracao" parent="menu_l10n_br_account_fiscal" action="action_l10n_br_account_invoice_invalid_number"/>
 
-        <menuitem id="menu_l10n_br_account_invoice_cancel" name="Cancelar Documento Eletrônico" parent="menu_l10n_br_account_fiscal" action="action_l10n_br_account_invoice_cancel"/>
+        <menuitem id="menu_l10n_br_account_invoice_cancel" name="NFs Canceladas" parent="menu_l10n_br_account_fiscal" action="action_l10n_br_account_invoice_cancel"/>
         
         <menuitem id="menu_l10n_br_account_cce" name="Carta de Correção" parent="menu_l10n_br_account_fiscal" action="action_l10n_br_account_cce"/>       
 


### PR DESCRIPTION
Este PR torna a _view_ em  `Localização Brasil->Cancelar Documento Eletrônico` como somente leitura, segundo o proposto em: https://github.com/odoo-brazil/odoo-brazil-eletronic-documents/issues/110
