### PR TITLE
[FIX] use tax base_total in account.invoice.tax

### DIFF
--- a/l10n_br_account_product/models/account_invoice.py
+++ b/l10n_br_account_product/models/account_invoice.py
@@ -1415,8 +1415,9 @@ class AccountInvoiceTax(models.Model):
                     'manual': False,
                     'sequence': tax['sequence'],
                     'base': currency.round(
-                        tax['price_unit'] *
-                        line['quantity']),
+                        tax.get('total_base',
+                                tax.get('price_unit', 0.00) *
+                                line['quantity'])),
                 }
                 if invoice.type in ('out_invoice', 'in_invoice'):
                     val['base_code_id'] = tax['base_code_id']


### PR DESCRIPTION
Como reproduzir o erro:

- Crie um fatura e clique no botão "(update)";
- Salve;
- Utilize o botão recalcular custos para adionar o frete

  File "/home/mileo/Projects/travis-bot/parts/odoo/openerp/http.py", line 410, in response_wrap
    response = f(*args, **kw)
  File "/home/mileo/Projects/travis-bot/parts/odoo/addons/web/controllers/main.py", line 948, in call_button
    action = self._call_kw(model, method, args, {})
  File "/home/mileo/Projects/travis-bot/parts/odoo/addons/web/controllers/main.py", line 936, in _call_kw
    return getattr(request.registry.get(model), method)(request.cr, request.uid, *args, **kwargs)
  File "/home/mileo/Projects/travis-bot/parts/odoo/openerp/api.py", line 268, in wrapper
    return old_api(self, *args, **kwargs)
  File "/home/mileo/Projects/travis-bot/parts/odoo/openerp/api.py", line 399, in old_api
    result = method(recs, *args, **kwargs)
  File "/home/mileo/Projects/travis-bot/parts/l10n-brazil/l10n_br_account_product/wizard/l10n_br_account_invoice_costs_ratio.py", line 44, in set_invoice_costs_ratio
    invoice.button_reset_taxes()
  File "/home/mileo/Projects/travis-bot/parts/odoo/openerp/api.py", line 266, in wrapper
    return new_api(self, *args, **kwargs)
  File "/home/mileo/Projects/travis-bot/parts/odoo/addons/account/account_invoice.py", line 647, in button_reset_taxes
    for taxe in account_invoice_tax.compute(invoice.with_context(ctx)).values():
  File "/home/mileo/Projects/travis-bot/parts/odoo/openerp/api.py", line 266, in wrapper
    return new_api(self, *args, **kwargs)
  File "/home/mileo/Projects/travis-bot/parts/l10n-brazil/l10n_br_account_product/models/account_invoice.py", line 1375, in compute
    tax['price_unit'] *
KeyError: 'price_unit'
