### PR TITLE
[FIX] button_reset_tax() duplicando objetos account_invoice_tax 

### DIFF
--- a/l10n_br_account_product/models/account_invoice.py
+++ b/l10n_br_account_product/models/account_invoice.py
@@ -527,7 +527,7 @@ class AccountInvoice(models.Model):
             for tax, cost in costs:
                 ait_id = ait.search([
                     ('invoice_id', '=', invoice.id),
-                    ('tax_code_id', '=', tax.id),
+                    ('tax_code_id', '=', tax.tax_code_id.id),
                 ])
                 vals = {
                     'tax_amount': cost,


### PR DESCRIPTION
Para simular o erro:
Ao instalar somente o módulo l10n_br_account_product numa base nova.
1) Configurar as contas de frete na empresa.
2) Criar uma fatura com uma linha. 
3) Nessa linha adicionar um valor de frete.
4) Clicar no botão atualizar nos totais

Caso seja clicado novamente, ele irá duplicar o imposto criado para o frete.
![erro_frete](https://cloud.githubusercontent.com/assets/8259094/19967138/1eb3d6b2-a1b6-11e6-9ac1-a45e8bf35172.png)
