### PR TITLE
[FIX] city fields is not set in zip search

### DIFF
--- a/l10n_br_zip/models/l10n_br_zip.py
+++ b/l10n_br_zip/models/l10n_br_zip.py
@@ -66,6 +66,7 @@ class L10nBrZip(models.Model):
                 'country_id': zip_obj.country_id.id,
                 'state_id': zip_obj.state_id.id,
                 'l10n_br_city_id': zip_obj.l10n_br_city_id.id,
+                'city': zip_obj.l10n_br_city_id.name,
                 'district': zip_obj.district,
                 'street': ((zip_obj.street_type or '') +
                            ' ' + (zip_obj.street or '')) if


### PR DESCRIPTION
Quando realizo a busca de CEP utilizando o módulo *l10n_br_zip_correios* e *l10n_br_zip*, o campo `city` (do *core* do Odoo) do `res_partner` não é setado.

Normalmente ele é setado pelo *onchange* do campo *l10n_br_city_id*, porém atribuindo uma cidade para o *l10n_br_city_id* através do método *zip_search*, o campo *city* permanece com seu valor inalterado.

Para simular o erro:

* Base 8.0 com dados demo.
* l10n_br_brazil da OCA
* Instalar o módulo *l10n_br_zip_correios*
* Entrar em Vendas->Vendas->Clientes, colocar no modo de visão **Kanban** e procurar o cliente * AMD do Brasil*. Verificar que logo abaixo do nome da empresa, está mostrando apenas o valor do campo *country_id*, que no caso é "Brasil". Isto ocorre pois o campo *city* está vazio (ele fica logo antes do nome do País).

![captura de tela de 2016-11-10 10-28-39](https://cloud.githubusercontent.com/assets/8174740/20176845/d55a886e-a730-11e6-8603-ba36c9d08a66.png)

Com este PR, após realizamos a busca do CEP (mesmo que seja com o mesmo CEP), podemos visualizar que o campo *city* foi setado corretamente (não está mais vazio).

![captura de tela de 2016-11-10 10-29-03](https://cloud.githubusercontent.com/assets/8174740/20176902/25decb4c-a731-11e6-9f06-54cbe179cdc2.png)
