### PR TITLE
[NEW] Purchase company tax definition

### DIFF
--- a/l10n_br_account_product/models/res_company.py
+++ b/l10n_br_account_product/models/res_company.py
@@ -43,6 +43,9 @@ class ResCompany(models.Model):
     product_tax_definition_line = fields.One2many(
         'l10n_br_tax.definition.company.product',
         'company_id', 'Taxes Definitions')
+    purchase_product_tax_definition_line = fields.One2many(
+        'l10n_br_tax.definition.company.purchase_product',
+        'company_id', 'Taxes Definitions')
     product_tax_ids = fields.Many2many(
         'account.tax', string='Product Taxes', compute='_compute_taxes',
         store=True)
@@ -83,6 +86,23 @@ class ResCompany(models.Model):
 
 class L10nBrTaxDefinitionCompanyProduct(L10nBrTaxDefinition, models.Model):
     _name = 'l10n_br_tax.definition.company.product'
+
+    company_id = fields.Many2one('res.company', 'Empresa')
+    tax_ipi_guideline_id = fields.Many2one(
+        'l10n_br_account_product.ipi_guideline', string=u'Enquadramento IPI')
+    tax_icms_relief_id = fields.Many2one(
+        'l10n_br_account_product.icms_relief', string=u'Desoneração ICMS')
+
+    _sql_constraints = [
+        ('l10n_br_tax_definition_tax_id_uniq',
+         'unique (tax_id, company_id)',
+         u'Imposto já existente nesta empresa!')
+    ]
+
+
+class L10nBrTaxDefinitionCompanyPurchaseProduct(L10nBrTaxDefinition,
+                                                models.Model):
+    _name = 'l10n_br_tax.definition.company.purchase_product'
 
     company_id = fields.Many2one('res.company', 'Empresa')
     tax_ipi_guideline_id = fields.Many2one(

--- a/l10n_br_account_product/models/res_partner.py
+++ b/l10n_br_account_product/models/res_partner.py
@@ -119,6 +119,19 @@ class AccountFiscalPosition(models.Model):
             product_ncm_tax_def = product_fc.sale_tax_definition_line
 
         else:
+            if self.env.context.get('fiscal_type', 'product') == 'product':
+                company_taxes = \
+                    self.company_id.purchase_product_tax_definition_line
+                for tax_def in company_taxes:
+                    if tax_def.tax_id:
+                        taxes |= tax_def.tax_id
+                        result[tax_def.tax_id.domain] = {
+                            'tax': tax_def.tax_id,
+                            'tax_code': tax_def.tax_code_id,
+                            'icms_relief': tax_def.tax_icms_relief_id,
+                            'ipi_guideline':  tax_def.tax_ipi_guideline_id,
+                        }
+
             # FIXME se tiver com o admin pegar impostos de outras empresas
             product_ncm_tax_def = product_fc.purchase_tax_definition_line
 

--- a/l10n_br_account_product/security/ir.model.access.csv
+++ b/l10n_br_account_product/security/ir.model.access.csv
@@ -38,3 +38,5 @@
 "l10n_br_tax_icms_partition_user","l10n_br_tax.icms_partition","model_l10n_br_tax_icms_partition","account.group_account_invoice",1,0,0,0
 "l10n_br_account_product_cest_user","l10n_br_account_product.cest","model_l10n_br_account_product_cest","base.group_user",1,0,0,0
 "l10n_br_account_product_cest_manager","l10n_br_account_product.cest","model_l10n_br_account_product_cest","account.group_account_manager",1,1,1,1
+"l10n_br_tax_definition_company_purchase_product_manager","l10n_br_tax.definition.company.purchase_product","model_l10n_br_tax_definition_company_purchase_product","account.group_account_manager",1,1,1,1
+"l10n_br_tax_definition_company_purchase_product_user","l10n_br_tax.definition.company.purchase_product","model_l10n_br_tax_definition_company_purchase_product","account.group_account_invoice",1,0,0,0

--- a/l10n_br_account_product/views/res_company_view.xml
+++ b/l10n_br_account_product/views/res_company_view.xml
@@ -36,8 +36,10 @@
                                 </group>
                             </page>
                             <page string="Impostos">
-                                <separator colspan="4" string="Impostos sobre Produtos" />
+                                <separator colspan="4" string="Impostos sobre Produtos na Venda" />
                                 <field colspan="2" nolabel="1" widget="one2many_list"   name="product_tax_definition_line" />
+                                <separator colspan="4" string="Impostos sobre Produtos na Compra" />
+                                <field colspan="2" nolabel="1" widget="one2many_list"   name="purchase_product_tax_definition_line" />
                             </page>
                             <page string="NFe">
                                 <group>
@@ -85,6 +87,34 @@
             <field name="arch" type="xml">
                 <tree string="Definição de Impostos" editable="bottom">
                     <field name="tax_id" domain="[('type_tax_use', 'in', ('sale', 'all'))]" select="1"/>
+                    <field name="tax_domain" invisible="1"/>
+                    <field name="tax_code_id" domain="[('domain', '=', tax_domain)]" select="1"/>
+                    <field name="tax_ipi_guideline_id"/>
+                    <field name="tax_icms_relief_id"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="l10n_br_tax_definition_company_purchase_product_form" model="ir.ui.view">
+            <field name="name">l10n_br_tax.definition.company.purchase_product.form</field>
+            <field name="model">l10n_br_tax.definition.company.purchase_product</field>
+            <field name="arch" type="xml">
+                <form string="Definição de Impostos">
+                    <field name="tax_id" domain="[('type_tax_use', 'in', ('purchase', 'all'))]" select="1"/>
+                    <field name="tax_domain" invisible="1"/>
+                    <field name="tax_code_id" domain="[('domain', '=', tax_domain)]" select="1"/>
+                    <field name="tax_ipi_guideline_id"/>
+                    <field name="tax_icms_relief_id"/>
+                </form>
+            </field>
+        </record>
+
+        <record id="l10n_br_tax_definition_company_purchase_product_tree" model="ir.ui.view">
+            <field name="name">l10n_br_tax.definition.company.purchase_product.tree</field>
+            <field name="model">l10n_br_tax.definition.company.purchase_product</field>
+            <field name="arch" type="xml">
+                <tree string="Definição de Impostos" editable="bottom">
+                    <field name="tax_id" domain="[('type_tax_use', 'in', ('purchase', 'all'))]" select="1"/>
                     <field name="tax_domain" invisible="1"/>
                     <field name="tax_code_id" domain="[('domain', '=', tax_domain)]" select="1"/>
                     <field name="tax_ipi_guideline_id"/>


### PR DESCRIPTION
Descrição do problema/nova funcionalidade deste Pull Resquest(PR):
------------------------------------------------------------------

- Permite a inclusão de impostos de compras na configuração das empresas

Comportamento atual antes do PR:
--------------------------------

Para as compras somente é possivel realizar o mapeamento fiscal por NCM + Posição Fiscal

Comportamento esperado depois do PR:
------------------------------------

Realizar o mapeamento por Empresa + NCM + Posição fiscal

Exemplo:

QUANDO configurado na empresa as taxas PIS 0,65% e Cofins 3% e ICMS Interno
E na NCM de um produto IPI 10%
E na posição fiscal troca-se ICMS por ICMS 7%
QUANDO adicionado um produto com esta ncm em uma ordem de compra
ENTÃO os impostos PIS 0,65% 
E COFINS 3%
E IPI 10%
E ICMS 7% são adicionados na venda




- [ ] Esta mudança não altera a estrutura do banco de dados, portanto não precisa de script de migração.

--
Eu confirmo que eu assinei a CLA e li as recomendações de como contribuir:
- https://odoo-community.org/page/cla
- https://odoo-community.org/page/Contribute