### PR TITLE
Tipo fiscal Simples Nacional é contribuinte do ICMS

### DIFF
--- a/l10n_br_account_product/data/l10n_br_account_data.xml
+++ b/l10n_br_account_product/data/l10n_br_account_data.xml
@@ -15,7 +15,7 @@
 
         <!-- Simples Nacional -->
         <record id="l10n_br_account.partner_fiscal_type_3" model="l10n_br_account.partner.fiscal.type">
-            <field name="ind_ie_dest">9</field>
+            <field name="ind_ie_dest">1</field>
         </record>
 
         <!-- Não Contribuinte -->


### PR DESCRIPTION
Descrição do problema/nova funcionalidade deste Pull Resquest(PR):
------------------------------------------------------------------
Tipo fiscal "Simples Nacional" está sendo cadastrado como não contribuinte do ICMS, o que impede a emissão de transferências faturadas cujo destino é empresa sob Simples Nacional.

Comportamento atual antes do PR:
--------------------------------
Vide acima.

Comportamento esperado depois do PR:
------------------------------------
Poder emitir transferências faturadas para empresas sob Simples Nacional.




- [x] Esta mudança não altera a estrutura do banco de dados, portanto não precisa de script de migração.

--
Eu confirmo que eu assinei a CLA e li as recomendações de como contribuir:
- https://odoo-community.org/page/cla
- https://odoo-community.org/page/Contribute