### PR TITLE
[8.0][FIX] Included Customer Sale Information when create Invoice from Picking

### DIFF
--- a/l10n_br_sale_stock/__openerp__.py
+++ b/l10n_br_sale_stock/__openerp__.py
@@ -17,6 +17,7 @@
     ],
     'data': [
         'views/sale_stock_view.xml',
+        'security/ir.model.access.csv',
     ],
     'demo': [
         'demo/l10n_br_sale_stock_demo.xml'

--- a/l10n_br_sale_stock/models/__init__.py
+++ b/l10n_br_sale_stock/models/__init__.py
@@ -4,3 +4,4 @@
 
 from . import procurement
 from . import sale
+from . import stock_account

--- a/l10n_br_sale_stock/models/stock_account.py
+++ b/l10n_br_sale_stock/models/stock_account.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2017  Magno Costa - Akretion
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openerp import models, api
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    @api.model
+    def _get_invoice_line_vals(self, move, partner, inv_type):
+        result = super(StockMove, self)._get_invoice_line_vals(
+            move, partner, inv_type)
+        if move.procurement_id and move.procurement_id.sale_line_id:
+            result['partner_order'] = \
+                move.procurement_id.sale_line_id.customer_order
+            result['partner_order_line'] = \
+                move.procurement_id.sale_line_id.customer_order_line
+
+        return result


### PR DESCRIPTION
Descrição do problema/nova funcionalidade deste Pull Resquest(PR):
------------------------------------------------------------------
- Ao criar uma Nota Fiscal a partir de uma Ordem de Entrega não estava sendo carregado as informações do Pedido do Cliente e Número da Linha do Pedido do Cliente que são Informadas no Pedido de Venda

Comportamento atual antes do PR:
--------------------------------


Comportamento esperado depois do PR:
------------------------------------





- [x] Esta mudança não altera a estrutura do banco de dados, portanto não precisa de script de migração.

--
Eu confirmo que eu assinei a CLA e li as recomendações de como contribuir:
- https://odoo-community.org/page/cla
- https://odoo-community.org/page/Contribute