### PR TITLE
[8.0] Included number and District in Carrier Address when create NFe.

### DIFF
--- a/l10n_br_account_product/sped/nfe/document.py
+++ b/l10n_br_account_product/sped/nfe/document.py
@@ -557,7 +557,9 @@ class NFe200(FiscalDocument):
             self.nfe.infNFe.transp.transporta.IE.valor = punctuation_rm(
                 invoice.carrier_id.partner_id.inscr_est)
             self.nfe.infNFe.transp.transporta.xEnder.valor = (
-                invoice.carrier_id.partner_id.street or '')
+                (invoice.carrier_id.partner_id.street or '') + ', ' +
+                (invoice.carrier_id.partner_id.number or '') + ', ' +
+                (invoice.carrier_id.partner_id.district or ''))[:60]
             self.nfe.infNFe.transp.transporta.xMun.valor = (
                 invoice.carrier_id.partner_id.l10n_br_city_id.name or '')
             self.nfe.infNFe.transp.transporta.UF.valor = (


### PR DESCRIPTION
Descrição do problema/nova funcionalidade deste Pull Resquest(PR):
------------------------------------------------------------------
- Incluir os campos Número e Bairro no campo Endereço da Transportadora ao gerar uma NFe


Comportamento atual antes do PR:
--------------------------------
- O endereço da Transportadora na NFe mostrava apenas a Rua, porém em muitos casos o responsável pelo frete precisa saber também o Número e o Bairro.

Comportamento esperado depois do PR:
------------------------------------
- O endereço da Transportadora deverá aparecer da seguinte forma " Rua, Número, Bairro" nas NFe geradas a partir do programa.




- [ x] Esta mudança não altera a estrutura do banco de dados, portanto não precisa de script de migração.

--
Eu confirmo que eu assinei a CLA e li as recomendações de como contribuir:
- https://odoo-community.org/page/cla
- https://odoo-community.org/page/Contribute