### PR TITLE
[8.0][FIX] Difal test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ virtualenv:
 install:
   - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
+  - travis_install_nightly
   - pip install reportlab
   - pip install unidecode
   - pip install suds
@@ -32,7 +33,6 @@ install:
   - pip install https://github.com/odoo-brazil/pyxmlsec/archive/master.zip
   - pip install https://github.com/odoo-brazil/geraldo/archive/master.zip
   - pip install https://github.com/odoo-brazil/PySPED/archive/8.0.zip --allow-external PyXMLSec --allow-insecure PyXMLSec
-  - travis_install_nightly
 
 before_script:
   - chmod +x configure_locale.sh

--- a/l10n_br_account_product/test/account_customer_invoice.yml
+++ b/l10n_br_account_product/test/account_customer_invoice.yml
@@ -594,18 +594,18 @@
     - invoice_line[0].icms_fcp_percent == 2.00
     - invoice_line[0].icms_dest_percent == 18.00
     - invoice_line[0].icms_origin_percent == 12.00
-    - invoice_line[0].icms_part_percent == 40.00
+    - invoice_line[0].icms_part_percent == 60.00
     - invoice_line[0].icms_fcp_value == 48.00
-    - invoice_line[0].icms_dest_value == 57.60
-    - invoice_line[0].icms_origin_value == 86.40
+    - invoice_line[0].icms_dest_value == 86.40
+    - invoice_line[0].icms_origin_value == 57.60
     - invoice_line[1].icms_dest_base == 550.00
     - invoice_line[1].icms_fcp_percent == 2.00
     - invoice_line[1].icms_dest_percent == 18.00
     - invoice_line[1].icms_origin_percent == 12.00
-    - invoice_line[1].icms_part_percent == 40.00
+    - invoice_line[1].icms_part_percent == 60.00
     - invoice_line[1].icms_fcp_value == 11.00
-    - invoice_line[1].icms_dest_value == 13.20
-    - invoice_line[1].icms_origin_value == 19.80
+    - invoice_line[1].icms_dest_value == 19.80
+    - invoice_line[1].icms_origin_value == 13.20
 -
   I check tax values ICMS ST
 -


### PR DESCRIPTION

Descrição do problema/nova funcionalidade deste Pull Resquest(PR):
------------------------------------------------------------------
- FIX Difal test because this tax change progressively by year until reach one hundred percent in 2019.
- Erro no teste causado por alteração no Percentual do Difal, esse percentual é alterado progressivamente a cada ano até chegar em 100 % em 2019

Hi @rvalyi , the error is caused by this https://github.com/OCA/l10n-brazil/blob/8.0/l10n_br_account_product/data/l10n_br_tax.icms_partition.csv , as you can see the percent of tax change by year

Hi @renatonlima , to make the fix I need change other values icms_dest_value and icms_origin_value, based on results of this method https://github.com/OCA/l10n-brazil/blob/8.0/l10n_br_account_product/models/account.py#L231 , please if you can take a look if everything is alright 



- [ ] Esta mudança não altera a estrutura do banco de dados, portanto não precisa de script de migração.

--
Eu confirmo que eu assinei a CLA e li as recomendações de como contribuir:
- https://odoo-community.org/page/cla
- https://odoo-community.org/page/Contribute