### PR TITLE
[8.0][FIX] allow group "Faturamento & Pagamento" create and cancel invoice

### DIFF
--- a/l10n_br_account/security/ir.model.access.csv
+++ b/l10n_br_account/security/ir.model.access.csv
@@ -29,7 +29,7 @@
 "account_tax_computation_manager","account.tax.computation","model_account_tax_computation","account.group_account_manager",1,1,1,1
 "l10n_br_account_invoice_cancel_user","l10n_br_account_invoice.cancel","model_l10n_br_account_invoice_cancel","account.group_account_invoice",1,0,0,0
 "l10n_br_account_invoice_cancel_manager","l10n_br_account_invoice.cancel","model_l10n_br_account_invoice_cancel","account.group_account_manager",1,1,1,1
-"l10n_br_account_document_event_user","l10n_br_account.document_event","model_l10n_br_account_document_event","account.group_account_invoice",1,0,0,0
+"l10n_br_account_document_event_user","l10n_br_account.document_event","model_l10n_br_account_document_event","account.group_account_invoice",1,1,1,0
 "l10n_br_account_document_event_manager","l10n_br_account.document_event","model_l10n_br_account_document_event","account.group_account_manager",1,1,1,1
 "l10n_br_account_invoice_cce_manager","l10n_br_account_invoice_cce","model_l10n_br_account_invoice_cce","account.group_account_manager",1,1,1,1
 "access_account_tax_code_user","access_account_tax_code_user","account.model_account_tax_code","base.group_user",1,0,0,0

--- a/l10n_br_account/security/ir.model.access.csv
+++ b/l10n_br_account/security/ir.model.access.csv
@@ -27,7 +27,7 @@
 "l10n_br_account_invoice_invalid_number_user","l10n_br_account.invoice.invalid.number","model_l10n_br_account_invoice_invalid_number","account.group_account_invoice",1,0,0,0
 "account_tax_computation_user","account.tax.computation","model_account_tax_computation","account.group_account_invoice",1,0,0,0
 "account_tax_computation_manager","account.tax.computation","model_account_tax_computation","account.group_account_manager",1,1,1,1
-"l10n_br_account_invoice_cancel_user","l10n_br_account_invoice.cancel","model_l10n_br_account_invoice_cancel","account.group_account_invoice",1,0,0,0
+"l10n_br_account_invoice_cancel_user","l10n_br_account_invoice.cancel","model_l10n_br_account_invoice_cancel","account.group_account_invoice",1,1,1,0
 "l10n_br_account_invoice_cancel_manager","l10n_br_account_invoice.cancel","model_l10n_br_account_invoice_cancel","account.group_account_manager",1,1,1,1
 "l10n_br_account_document_event_user","l10n_br_account.document_event","model_l10n_br_account_document_event","account.group_account_invoice",1,1,1,0
 "l10n_br_account_document_event_manager","l10n_br_account.document_event","model_l10n_br_account_document_event","account.group_account_manager",1,1,1,1

--- a/l10n_br_account/security/ir.model.access.csv
+++ b/l10n_br_account/security/ir.model.access.csv
@@ -32,5 +32,6 @@
 "l10n_br_account_document_event_user","l10n_br_account.document_event","model_l10n_br_account_document_event","account.group_account_invoice",1,1,1,0
 "l10n_br_account_document_event_manager","l10n_br_account.document_event","model_l10n_br_account_document_event","account.group_account_manager",1,1,1,1
 "l10n_br_account_invoice_cce_manager","l10n_br_account_invoice_cce","model_l10n_br_account_invoice_cce","account.group_account_manager",1,1,1,1
+"l10n_br_account_invoice_cce_user","l10n_br_account_invoice_cce_user","model_l10n_br_account_invoice_cce","account.group_account_invoice",1,1,1,0
 "access_account_tax_code_user","access_account_tax_code_user","account.model_account_tax_code","base.group_user",1,0,0,0
 "l10n_br_account_partner_fiscal_type_user","l10n_br_account_partner_fiscal_type_user","model_l10n_br_account_partner_fiscal_type","base.group_user",1,0,0,0


### PR DESCRIPTION
Descrição do problema/nova funcionalidade deste Pull Resquest(PR):
------------------------------------------------------------------

- Usuários que pertencem ao grupo "Faturamento & Pagamento" por falta de permissão de acesso não conseguem criar ou cancelar Faturas
- Users who belong to group "Faturamento & Pagamento"  by lack of access can't create and cancel Invoice

Comportamento esperado depois do PR:
------------------------------------

- Permitir usuários do grupo "Faturamento & Pagamento" criar e cancelar Faturas
- Allow users belong to group "Faturamento & Pagamento" create and cancel Invoices


--
Eu confirmo que eu assinei a CLA e li as recomendações de como contribuir:
- https://odoo-community.org/page/cla
- https://odoo-community.org/page/Contribute