### PR TITLE
[8.0] Permitir Empresa informar outras Inscrições Estaduais( por Estado )

### DIFF
--- a/l10n_br_account_product/sped/nfe/document.py
+++ b/l10n_br_account_product/sped/nfe/document.py
@@ -248,7 +248,13 @@ class NFe200(FiscalDocument):
             str(company.phone or '').replace(' ', ''))
         self.nfe.infNFe.emit.IE.valor = punctuation_rm(
             invoice.company_id.partner_id.inscr_est)
-        self.nfe.infNFe.emit.IEST.valor = ''
+        for inscr_est_line in\
+                invoice.company_id.partner_id.other_inscr_est_lines:
+            if inscr_est_line.state_id.id == invoice.partner_id.state_id.id:
+                self.nfe.infNFe.emit.IEST.valor = punctuation_rm(
+                    inscr_est_line.inscr_est)
+            else:
+                self.nfe.infNFe.emit.IEST.valor = ''
         self.nfe.infNFe.emit.IM.valor = punctuation_rm(
             invoice.company_id.partner_id.inscr_mun or '')
         self.nfe.infNFe.emit.CRT.valor = invoice.company_id.fiscal_type or ''

--- a/l10n_br_base/models/res_company.py
+++ b/l10n_br_base/models/res_company.py
@@ -158,4 +158,3 @@ class ResCompany(models.Model):
             val = re.sub('[^0-9]', '', self.zip)
             if len(val) == 8:
                 self.zip = "%s-%s" % (val[0:5], val[5:8])
-

--- a/l10n_br_base/models/res_company.py
+++ b/l10n_br_base/models/res_company.py
@@ -28,6 +28,10 @@ class ResCompany(models.Model):
             obj.inscr_est = obj.partner_id.inscr_est
             obj.inscr_mun = obj.partner_id.inscr_mun
             obj.suframa = obj.partner_id.suframa
+            other_inscr_est_lines = self.env['other.inscricoes.estaduais']
+            for inscr_est_line in obj.partner_id.other_inscr_est_lines:
+                other_inscr_est_lines |= inscr_est_line
+            obj.other_inscr_est_lines = other_inscr_est_lines
 
     @api.multi
     def _set_l10n_br_legal_name(self):
@@ -58,6 +62,15 @@ class ResCompany(models.Model):
         """ Write the l10n_br specific functional fields. """
         self.ensure_one()
         self.partner_id.inscr_est = self.inscr_est
+
+    @api.multi
+    def _set_l10n_br_other_inscr_est(self):
+        """ Write the l10n_br specific functional fields. """
+        for record in self:
+            other_inscr_est_lines = self.env['other.inscricoes.estaduais']
+            for inscr_est_line in record.other_inscr_est_lines:
+                other_inscr_est_lines |= inscr_est_line
+            record.partner_id.other_inscr_est_lines = other_inscr_est_lines
 
     @api.multi
     def _set_l10n_br_inscr_mun(self):
@@ -96,6 +109,12 @@ class ResCompany(models.Model):
     inscr_est = fields.Char(
         compute=_get_l10n_br_data, inverse=_set_l10n_br_inscr_est,
         size=16, string='Inscr. Estadual')
+
+    other_inscr_est_lines = fields.One2many(
+        'other.inscricoes.estaduais', 'partner_id',
+        compute=_get_l10n_br_data, inverse=_set_l10n_br_other_inscr_est,
+        string=u'Outras Inscrições Estaduais', ondelete='cascade'
+    )
 
     inscr_mun = fields.Char(
         compute=_get_l10n_br_data, inverse=_set_l10n_br_inscr_mun,
@@ -139,3 +158,4 @@ class ResCompany(models.Model):
             val = re.sub('[^0-9]', '', self.zip)
             if len(val) == 8:
                 self.zip = "%s-%s" % (val[0:5], val[5:8])
+

--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -204,7 +204,6 @@ class ResPartner(models.Model):
         """
         for record in self:
             for inscr_est_line in record.other_inscr_est_lines:
-                valid_ie = True
                 state_code = inscr_est_line.state_id.code or ''
                 uf = state_code.lower()
                 valid_ie = fiscal.validate_ie(uf, inscr_est_line.inscr_est)
@@ -279,6 +278,6 @@ class OtherInscricoesEstaduais(models.Model):
 
     _sql_constraints = [
         ('other_inscricoes_estaduais_id_uniq',
-         'unique (inscr_est, state_id)',
-         u'Inscrição Estadual já usada dentro do Estado!')
+         'unique (state_id, partner_id)',
+         u'O Parceiro já possui uma Inscrição Estadual para esse Estado!')
     ]

--- a/l10n_br_base/security/ir.model.access.csv
+++ b/l10n_br_base/security/ir.model.access.csv
@@ -1,3 +1,5 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
 "l10n_br_base_city_user","l10n_br_base.city","model_l10n_br_base_city","base.group_user",1,0,0,0
 "l10n_br_base_city_manager","l10n_br_base.city","model_l10n_br_base_city","base.group_system",1,1,1,1
+"l10n_br_base_other_ie_user","l10n_br_base_other_ie","model_other_inscricoes_estaduais","base.group_user",1,0,0,0
+"l10n_br_base_other_ie_manager","l10n_br_base_other_ie","model_other_inscricoes_estaduais","base.group_system",1,1,1,1

--- a/l10n_br_base/tests/__init__.py
+++ b/l10n_br_base/tests/__init__.py
@@ -7,3 +7,5 @@
 
 from . import test_amount_to_text
 from . import test_tools_fiscal
+from . import test_other_ie
+

--- a/l10n_br_base/tests/test_other_ie.py
+++ b/l10n_br_base/tests/test_other_ie.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+# @ 2018 Akretion - www.akretion.com.br -
+#   Magno Costa <magno.costa@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+import openerp.tests.common as common
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+class OtherIETest(common.TransactionCase):
+
+    def setUp(self):
+        super(OtherIETest, self).setUp()
+        self.company_model = self.env['res.company']
+        self.company = self.company_model.create({
+            'name': 'Akretion Sao Paulo',
+            'legal_name': 'Akretion Sao Paulo',
+            'cnpj_cpf': '26.905.703/0001-52',
+            'inscr_est': '932.446.119.086',
+            'street': 'Rua Paulo Dias',
+            'number': '586',
+            'district': 'Alumínio',
+            'state_id': self.ref('l10n_br_base.br_sp'),
+            'l10n_br_city_id': self.ref('l10n_br_base.city_3501152'),
+            'country_id': self.ref('base.br'),
+            'city': 'Alumínio',
+            'zip': '18125-000',
+            'phone': '+55 (21) 3010 9965',
+            'email': 'contact@companytest.com.br',
+            'website': 'www.companytest.com.br'
+        })
+
+    def test_included_valid_ie_in_company(self):
+        result = self.company.write({
+            'other_inscr_est_lines': [(0, 0, {
+                'state_id': self.ref('l10n_br_base.br_ba'),
+                'inscr_est': 41902653,
+            })]
+        })
+        self.assertTrue(result, "Error to included valid IE.")
+        for line in self.company.partner_id.other_inscr_est_lines:
+            result = False
+            if line.inscr_est == '41902653':
+                result = True
+            self.assertTrue(
+                result, "Error in method to update other IE(s) on partner.")
+        line_id = False
+        for line in self.company.partner_id.other_inscr_est_lines:
+            line_id = line.id
+        try:
+            result = self.company.write({
+                'other_inscr_est_lines': [(1, line_id, {
+                    'state_id': self.ref('l10n_br_base.br_ba'),
+                    'inscr_est': 67729139,
+                })]
+            })
+        except:
+            result = False
+        self.assertFalse(
+            result, "Error to check included other"
+                    " IE to State already informed.")
+
+    def test_included_invalid_ie(self):
+        try:
+            result = self.company.write({
+                'other_inscr_est_lines': [(0, 0, {
+                    'state_id': self.ref('l10n_br_base.br_ba'),
+                    'inscr_est': 41902652,
+                })]
+            })
+        except:
+            result = False
+        self.assertFalse(result, "Error to check included invalid IE.")
+
+    def test_included_other_valid_ie_to_same_state_of_company(self):
+        try:
+            result = self.company.write({
+                'other_inscr_est_lines': [(0, 0, {
+                    'state_id': self.ref('l10n_br_base.br_sp'),
+                    'inscr_est': 692015742119,
+                })]
+            })
+        except:
+            result = False
+        self.assertFalse(
+            result, "Error to check included other valid IE "
+                    " in to same state of Company.")
+
+    def test_included_valid_ie_on_partner(self):
+        result = self.company.partner_id.write({
+            'other_inscr_est_lines': [(0, 0, {
+                'state_id': self.ref('l10n_br_base.br_ba'),
+                'inscr_est': 41902653,
+            })]
+        })
+        self.assertTrue(result, "Error to included valid IE.")
+        for line in self.company.other_inscr_est_lines:
+            result = False
+            if line.inscr_est == '41902653':
+                result = True
+            self.assertTrue(
+                result, "Error in method to update other IE(s) on Company.")

--- a/l10n_br_base/views/res_company_view.xml
+++ b/l10n_br_base/views/res_company_view.xml
@@ -38,6 +38,13 @@
                     <field name="inscr_est" placeholder="Inscr. Estadual"/>
                     <field name="inscr_mun" placeholder="Inscr. Municipal"/>
                     <field name="suframa" placeholder="Suframa"/>
+                    <field name="other_inscr_est_lines">
+                        <tree editable="bottom">
+                            <field name="partner_id" invisible="1"/>
+                            <field name="inscr_est"/>
+                            <field name="state_id" domain="[('country_id.id', '=', %(base.br)d)]}" create="False" edit="False"/>
+                        </tree>
+                    </field>
                 </field>
             </field>
         </record>

--- a/l10n_br_base/views/res_partner_view.xml
+++ b/l10n_br_base/views/res_partner_view.xml
@@ -87,6 +87,16 @@
                             <group>
                                 <field name="suframa" attrs="{'invisible': [('is_company','!=', True)]}"/>
                             </group>
+                            <group string="Outras Inscrições Estaduais" attrs="{'invisible': [('is_company','!=', True)]}">
+                                <field name="other_inscr_est_lines" nolabel="1">
+                                    <tree editable="bottom">
+                                        <field name="partner_id" invisible="1"/>
+                                        <field name="inscr_est"/>
+                                        <field name="state_id" domain="[('country_id.id', '=', %(base.br)d)]}" create="False" edit="False"/>
+                                    </tree>
+                                </field>
+                            </group>
+
                         </group>
                     </page>
                 </notebook>


### PR DESCRIPTION
Existe uma situação que parece que não estava contemplada pelo código, um empresa pode ter outras Inscrições Estaduais em outros estados( um por cada estado ) isso é feito para permitir que não seja preciso pagar a Substituição Tributaria antecipadamente( GNRE ).

Incluí a possibilidade de se cadastrar outras Inscrições Estaduais mantendo o campo original e não permitindo que no novo campo seja incluída uma inscrição do mesmo estado do parceiro( essa informação continua no campo principal ) nem que seja incluída uma inscrição já existente, e na emissão da NFe caso exista uma inscrição para o estado do parceiro a tag IEST será preenchida.

cc @renatonlima @rvalyi @mileo 