### PR TITLE
[8.0][FIX] Fix import and field name of move line

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -119,21 +119,21 @@ class AccountInvoice(models.Model):
             :return: the (possibly updated) final move_lines to create for this
             invoice
         """
-        move_lines = super(
-            AccountInvoice, self).finalize_invoice_move_lines(move_lines)
-        count = 1
-        total = len([x for x in move_lines
-                     if x[2]['account_id'] == self.account_id.id])
-        number = self.name or self.number
-        result = []
-        for move_line in move_lines:
-            if move_line[2]['debit'] or move_line[2]['credit']:
-                if move_line[2]['account_id'] == self.account_id.id:
-                    move_line[2]['name'] = '%s/%s-%s' % \
-                        (number, count, total)
-                    count += 1
-                result.append(move_line)
-        return result
+        for record in self:
+            move_lines = super(
+                AccountInvoice, record).finalize_invoice_move_lines(move_lines)
+            count = 1
+            total = len([x for x in move_lines
+                         if x[2]['account_id'] == record.account_id.id])
+            result = []
+            for move_line in move_lines:
+                if move_line[2]['debit'] or move_line[2]['credit']:
+                    if move_line[2]['account_id'] == record.account_id.id:
+                        move_line[2]['name'] = '%s/%s-%s' % \
+                            (record.number, count, total)
+                        count += 1
+                    result.append(move_line)
+            return result
 
     @api.multi
     def open_fiscal_document(self):

--- a/l10n_br_account_product/models/account_invoice.py
+++ b/l10n_br_account_product/models/account_invoice.py
@@ -569,7 +569,7 @@ class AccountInvoice(models.Model):
                 else:
                     date_move = inv.date_hour_invoice
                 date_hour_invoice = fields.Datetime.context_timestamp(
-                    self, datetime.datetime.strptime(
+                    self, datetime.strptime(
                         date_move, tools.DEFAULT_SERVER_DATETIME_FORMAT
                     )
                 )


### PR DESCRIPTION
Fixed wrong import and field 'name' of account.move.line because it is used on implementation of "Boleto", before when the field 'Referência/Descrição' is filled this value was used in the name

