### PR TITLE
[12.0] Definir o formato da rua de parceiros de outros paises

### DIFF
--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -192,7 +192,13 @@ class Partner(models.Model):
     def get_street_fields(self):
         """Returns the fields that can be used in a street format.
         Overwrite this function if you want to add your own fields."""
-        return super(Partner, self).get_street_fields() + ('street',)
+        return super(Partner, self).get_street_fields() + ['street']
+
+    @api.multi
+    def _set_street(self):
+        company_country = self.env.user.company_id.country_id
+        if company_country.code.upper() != 'BR':
+            return super(Partner, self)._set_street()
 
     @api.onchange('cnpj_cpf', 'country_id')
     def _onchange_cnpj_cpf(self):


### PR DESCRIPTION
Como reproduzir o erro?
Ao criar um parceiro com um país diferente do brasil, o campo Rua é apagado ao salvar o parceiro.

Por padrão ao instalar o módulo base_address_extended, é criado um campo street_format para todos os países com o formato de rua padrão %(street_number)s/%(street_number2)s %(street_name)s e esse formato é atribuido de acordo com o país do parceiro. Esta alteração visa definir o formato da rua de parceiros de outros países quando a empresa atual for do brasil.