### PR TITLE
Falha ao consultar CEP

### DIFF
--- a/l10n_br_zip_correios/models/webservice_client.py
+++ b/l10n_br_zip_correios/models/webservice_client.py
@@ -68,7 +68,7 @@ class WebServiceClient(object):
                         res.bairro.encode('utf8')) if res.bairro
                     else '',
                     'street_type': str(
-                        res.complemento.encode('utf8')) if res.complemento
+                        res.complemento2.encode('utf8')) if res.complemento2
                     else '',
                     'l10n_br_city_id': city_ids.ids[
                         0] if city_ids else False,


### PR DESCRIPTION
Vejam no https://apps.correios.com.br/SigepMasterJPA/AtendeClienteService/AtendeCliente?wsdl

Que o retorno:

```
<xs:sequence>
<xs:element minOccurs="0" name="bairro" type="xs:string"/>
<xs:element minOccurs="0" name="cep" type="xs:string"/>
<xs:element minOccurs="0" name="cidade" type="xs:string"/>
<xs:element minOccurs="0" name="complemento2" type="xs:string"/>
<xs:element minOccurs="0" name="end" type="xs:string"/>
<xs:element minOccurs="0" name="uf" type="xs:string"/>
<xs:element maxOccurs="unbounded" minOccurs="0" name="unidadesPostagem" nillable="true" type="tns:unidadePostagemERP"/>
</xs:sequence>
```