### PR TITLE
UserError: proper number of arguments

### DIFF
--- a/l10n_br_zip_correios/models/webservice_client.py
+++ b/l10n_br_zip_correios/models/webservice_client.py
@@ -12,7 +12,7 @@ try:
     from zeep import Client
     from zeep.exceptions import TransportError, Error
 except ImportError:
-    raise UserError(_(u'Erro!'), _(u"Biblioteca Zeep não instalada!"))
+    raise UserError(_(u"Biblioteca Zeep não instalada!"))
 
 _logger = logging.getLogger(__name__)
 
@@ -76,10 +76,10 @@ class WebServiceClient(object):
 
             except TransportError as e:
                 _logger.error(e.message, exc_info=True)
-                raise UserError(_('Error!'), e.message)
+                raise UserError(e.message)
             except Error as e:
                 _logger.error(e.message, exc_info=True)
-                raise UserError(_('Error!'), e.message)
+                raise UserError(e.message)
 
         else:
             return None


### PR DESCRIPTION
It seems the number of arguments of UserError changed in v10. Before this fix you would have error such as:
```
2019-05-21 18:04:39,656 82 ERROR ? werkzeug: Error on request:
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/serving.py", line 193, in run_wsgi
    execute(self.server.app)
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/serving.py", line 181, in execute
    application_iter = app(environ, start_response)
  File "/odoo/src/odoo/service/wsgi_server.py", line 186, in application
    return application_unproxied(environ, start_response)
  File "/odoo/src/odoo/service/wsgi_server.py", line 172, in application_unproxied
    result = handler(environ, start_response)
  File "/odoo/src/odoo/http.py", line 1325, in __call__
    self.load_addons()
  File "/odoo/src/odoo/http.py", line 1346, in load_addons
    m = __import__('odoo.addons.' + module)
  File "/odoo/src/odoo/modules/module.py", line 81, in load_module
    execfile(modfile, new_mod.__dict__)
  File "/odoo/external-src/l10n-brazil/l10n_br_zip_correios/__init__.py", line 6, in <module>
    from . import models
  File "/odoo/external-src/l10n-brazil/l10n_br_zip_correios/models/__init__.py", line 6, in <module>
    from . import webservice_client
  File "/odoo/external-src/l10n-brazil/l10n_br_zip_correios/models/webservice_client.py", line 15, in <module>
    raise UserError(_(u'Erro!'), _(u"Biblioteca Zeep não instalada!"))
TypeError: __init__() takes exactly 2 arguments (3 given)
```

As it happens only when you have errors anyway this is probably the reason it wasn't detected yet...