### PR TITLE
[FIX] Partner/Company inverse method

### DIFF
--- a/l10n_br_base/models/res_company.py
+++ b/l10n_br_base/models/res_company.py
@@ -56,10 +56,12 @@ class Company(models.Model):
         for company in self:
             company.partner_id.cnpj_cpf = company.cnpj_cpf
 
-    def _inverse_inscr_est(self):
+    def _inverse_state(self):
         """ Write the l10n_br specific functional fields. """
         for company in self:
-            company.partner_id.inscr_est = company.inscr_est
+            company.partner_id.write({
+                'state_id': company.state_id.id,
+                'inscr_est': company.inscr_est})
 
     def _inverse_state_tax_number_ids(self):
         """ Write the l10n_br specific functional fields. """
@@ -118,7 +120,7 @@ class Company(models.Model):
     inscr_est = fields.Char(
         string="State Tax Number",
         compute="_compute_l10n_br_data",
-        inverse="_inverse_inscr_est",
+        inverse="_inverse_state",
         size=16,
     )
 


### PR DESCRIPTION
Quando é feita uma alteração mudando os campos estado ou inscrição estadual, ocorre um erro no método de validação da inscrição estadual. Para corrigir eu utilizo o mesmo método inverse do core que altera o estado para alterar também a inscrição estadual, desta forma a validação da inscrição estadual vai funcionar.