### PR TITLE
[NEW] VAT and Vat label

### DIFF
--- a/l10n_br_base/data/res_country_data.xml
+++ b/l10n_br_base/data/res_country_data.xml
@@ -120,6 +120,7 @@
         <field name="name_position">before</field>
         <field name="address_format" eval="'%(street)s, %(street_number)s %(street2)s\n%(district)s\n%(zip)s - %(city)s-%(state_code)s\n%(country_name)s'"/>
         <field name="address_view_id" ref="l10n_br_base_res_partner_address"/>
+        <field name="vat_label">CNPJ/CPF</field>
     </record>
 
     <record id="base.bs" model="res.country">

--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -60,6 +60,7 @@ class Partner(models.Model):
             return address_format % args
 
     cnpj_cpf = fields.Char(string="CNPJ/CPF", size=18)
+    vat = fields.Char(related='cnpj_cpf')
 
     inscr_est = fields.Char(string="State Tax Number/RG", size=16)
 


### PR DESCRIPTION
Relaciona o campo cnpj_cpf com o VAT e também adiciona o label para que o cnpj seja exibido por padrão nos relatórios de vendas, compras, estoque e etc.