### PR TITLE
[FIX] l10n_br_account_payment_order xml files ordering

### DIFF
--- a/l10n_br_account_payment_order/__manifest__.py
+++ b/l10n_br_account_payment_order/__manifest__.py
@@ -17,9 +17,9 @@
         'account_cancel',
     ],
     'data': [
-        'views/account_payment_order_menu_views.xml',
         'views/account_due_list.xml',
         'views/account_payment_order.xml',
+        'views/account_payment_order_menu_views.xml',
         'views/account_payment_line.xml',
         'views/account_payment_mode.xml',
     ],


### PR DESCRIPTION
The menu view file was referencing a view that was loaded in account_payment_order.xml file.