### PR TITLE
[FIX] Error in saving company

### DIFF
--- a/l10n_br_fiscal/models/res_company.py
+++ b/l10n_br_fiscal/models/res_company.py
@@ -273,7 +273,7 @@ class ResCompany(models.Model):
         if tax_def:
             tax_def.update(tax_def_values)
         else:
-            self.tax_definition_ids.create(tax_def_values)
+            self.tax_definition_ids |= self.tax_definition_ids.create(tax_def_values)
 
     @api.onchange("cnae_main_id")
     def _onchange_cnae_main_id(self):

--- a/l10n_br_fiscal/models/res_company.py
+++ b/l10n_br_fiscal/models/res_company.py
@@ -267,22 +267,13 @@ class ResCompany(models.Model):
             "custom_tax": True,
             "tax_id": tax.id,
             "cst_id": tax.cst_out_id.id,
+            "company_id": self._origin.id,
         }
-
-        tax_def_ids = self.tax_definition_ids.ids
-        if not (self.env.context.get('params') and
-                self.env.context['params'].get('id')):
-            return
-        tax_def_id = self.tax_definition_ids.search([
-            ('company_id', '=', self.env.context['params']['id']),
-            ('tax_group_id', '=', tax.tax_group_id.id),
-            ('tax_id', '=', tax.id)]).id or \
-            self.tax_definition_ids.create(tax_def_values).id
 
         if tax_def:
             tax_def.update(tax_def_values)
         else:
-            self.tax_definition_ids = [(6, 0, tax_def_ids + [tax_def_id])]
+            self.tax_definition_ids.create(tax_def_values)
 
     @api.onchange("cnae_main_id")
     def _onchange_cnae_main_id(self):

--- a/l10n_br_fiscal/models/res_company.py
+++ b/l10n_br_fiscal/models/res_company.py
@@ -269,10 +269,20 @@ class ResCompany(models.Model):
             "cst_id": tax.cst_out_id.id,
         }
 
+        tax_def_ids = self.tax_definition_ids.ids
+        if not (self.env.context.get('params') and
+                self.env.context['params'].get('id')):
+            return
+        tax_def_id = self.tax_definition_ids.search([
+            ('company_id', '=', self.env.context['params']['id']),
+            ('tax_group_id', '=', tax.tax_group_id.id),
+            ('tax_id', '=', tax.id)]).id or \
+            self.tax_definition_ids.create(tax_def_values).id
+
         if tax_def:
             tax_def.update(tax_def_values)
         else:
-            self.tax_definition_ids = [(0, None, tax_def_values)]
+            self.tax_definition_ids = [(6, 0, tax_def_ids + [tax_def_id])]
 
     @api.onchange("cnae_main_id")
     def _onchange_cnae_main_id(self):


### PR DESCRIPTION
Não estava sendo possível salvar o cadastro da empresa. O motivo era a escrita do campo one2many tax_definition_ids, que funcionava no onchange, mas na hora de salvar (execução da função write) o valor do campo é passado com um dicionário vazio. Para corrigir o problema, foi feita a criação dos registros do one2many tax_definition_ids no método onchange e os registros foram passados para o campo via uma estrutura [(6, 0, [ids])].