### PR TITLE
[12.0][FIX] Tamanho do campo inscr_est de 16 para 17

### DIFF
--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -62,7 +62,7 @@ class Partner(models.Model):
     cnpj_cpf = fields.Char(string="CNPJ/CPF", size=18)
     vat = fields.Char(related="cnpj_cpf")
 
-    inscr_est = fields.Char(string="State Tax Number/RG", size=16)
+    inscr_est = fields.Char(string="State Tax Number/RG", size=17)
 
     state_tax_number_ids = fields.One2many(
         string="Others State Tax Number",


### PR DESCRIPTION
Alteração do campo **inscr_est** no modelo **res.partner** de 16 para 17.

No **Acre são 17 caracteres** ao todo -> 01.921.569/207-25

![image](https://user-images.githubusercontent.com/3595132/81770366-79676780-94b6-11ea-80f2-529e1e3b353b.png)
