### PR TITLE
Feature/fiscal tax adjustments

### DIFF
--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -112,6 +112,16 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         if view_type == 'form':
             model_view["arch"] = self.fiscal_form_view(model_view["arch"])
 
+        View = self.env['ir.ui.view']
+        # Override context for postprocessing
+        if view_id and model_view.get('base_model', self._name) != self._name:
+            View = View.with_context(base_model_name=model_view['base_model'])
+
+        # Apply post processing, groups and modifiers etc...
+        xarch, xfields = View.postprocess_and_fields(
+            self._name, etree.fromstring(model_view['arch']), view_id)
+        model_view['arch'] = xarch
+        model_view['fields'] = xfields
         return model_view
 
     def _compute_taxes(self, taxes, cst=None):

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -317,6 +317,8 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 partner=self.partner_id,
                 product=self.product_id)
 
+            self._onchange_fiscal_operation_line_id()
+
     @api.onchange("fiscal_operation_line_id")
     def _onchange_fiscal_operation_line_id(self):
 

--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -333,6 +333,9 @@ class Tax(models.Model):
         taxes_dict[tax.tax_domain].update(self._compute_tax(
             tax, taxes_dict, **kwargs))
 
+        taxes_dict[tax.tax_domain].update({
+            'icms_base_type': tax.icms_base_type})
+
         # DIFAL
         if (company.state_id != partner.state_id
                 and operation_line.fiscal_operation_type == FISCAL_OUT


### PR DESCRIPTION
- [x] Atualizar o tipo da base do ICMS quando a taxa é recomputada;

- [x] Chamar o onchange da linha da operação após uma mudança no produto ou na operação, para carregar impostos não carregados em chamadas anteriores pela falta do produto;

- [x] Corrige a sobrescrita do fields_view_get na linha do documento, pois os campos adicionais não estavam sendo carregados corretamente e por isso os onchanges respectivos não estavam sendo chamados.