### PR TITLE
[12.0] Rename fiscal operation and fiscal operation line fields

### DIFF
--- a/l10n_br_account/wizards/account_invoice_refund.py
+++ b/l10n_br_account/wizards/account_invoice_refund.py
@@ -88,7 +88,7 @@ class AccountInvoiceRefund(models.TransientModel):
 
                     line_values = {
                         "operation_id": line.operation_id.id,
-                        "operation_line_id": line.operation_line_id.id,
+                        "fiscal_operation_line_id": line.fiscal_operation_line_id.id,
                     }
                     line.write(line_values)
                 invoice.write(invoice_values)

--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -8,7 +8,7 @@
     "license": "AGPL-3",
     "author": "Akretion, Odoo Community Association (OCA)",
     "website": "http://github.com/OCA/l10n-brazil",
-    "version": "12.0.1.0.0",
+    "version": "12.0.2.0.0",
     "depends": [
         "uom",
         "decimal_precision",

--- a/l10n_br_fiscal/data/operation_data.xml
+++ b/l10n_br_fiscal/data/operation_data.xml
@@ -35,7 +35,7 @@
     </record>
 
     <record id="fo_venda_venda" model="l10n_br_fiscal.operation.line">
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
         <field name="name">Venda</field>
         <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5101"/>
         <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6101"/>
@@ -45,7 +45,7 @@
     </record>
 
     <record id="fo_venda_revenda" model="l10n_br_fiscal.operation.line">
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
         <field name="name">Revenda</field>
         <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5102"/>
         <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6102"/>
@@ -55,7 +55,7 @@
     </record>
 
     <record id="fo_venda_servico" model="l10n_br_fiscal.operation.line">
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
         <field name="name">Venda de Serviço</field>
         <field name="document_type_id" ref="l10n_br_fiscal.document_SE"/>
         <field name="state">approved</field>
@@ -63,7 +63,7 @@
     </record>
 
     <record id="fo_venda_revenda_ipi_nt" model="l10n_br_fiscal.tax.definition">
-        <field name="operation_line_id" ref="fo_venda_revenda"/>
+        <field name="fiscal_operation_line_id" ref="fo_venda_revenda"/>
         <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi"/>
         <field name="custom_tax">True</field>
         <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt"/>
@@ -72,7 +72,7 @@
     </record>
 
     <record id="fo_venda_55_serie_1" model="l10n_br_fiscal.operation.document.type">
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
         <field name="document_type_id" ref="l10n_br_fiscal.document_55"/>
         <field name="document_serie_id" ref="l10n_br_fiscal.document_55_serie_1"/>
         <field name="company_id" ref="base.main_company"/>
@@ -88,7 +88,7 @@
     </record>
 
     <record id="fo_bonificacao_bonificacao" model="l10n_br_fiscal.operation.line">
-        <field name="operation_id" ref="l10n_br_fiscal.fo_bonificacao"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_bonificacao"/>
         <field name="name">Bonificação</field>
         <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5910"/>
         <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6910"/>
@@ -96,7 +96,7 @@
     </record>
 
     <record id="fo_bonificacao_55_serie_1" model="l10n_br_fiscal.operation.document.type">
-        <field name="operation_id" ref="l10n_br_fiscal.fo_bonificacao"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_bonificacao"/>
         <field name="document_type_id" ref="l10n_br_fiscal.document_55"/>
         <field name="document_serie_id" ref="l10n_br_fiscal.document_55_serie_1"/>
     </record>
@@ -111,7 +111,7 @@
     </record>
 
     <record id="fo_devolucao_venda_devolucao_venda" model="l10n_br_fiscal.operation.line">
-        <field name="operation_id" ref="l10n_br_fiscal.fo_devolucao_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_devolucao_venda"/>
         <field name="name">Devolução de Venda</field>
         <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1201"/>
         <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2201"/>
@@ -120,7 +120,7 @@
     </record>
 
     <record id="fo_devolucao_revenda_devolucao_revenda" model="l10n_br_fiscal.operation.line">
-        <field name="operation_id" ref="l10n_br_fiscal.fo_devolucao_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_devolucao_venda"/>
         <field name="name">Devolução de Revenda</field>
         <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1202"/>
         <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2202"/>
@@ -129,7 +129,7 @@
     </record>
 
     <record id="fo_devolucao_venda_55_serie_1" model="l10n_br_fiscal.operation.document.type">
-        <field name="operation_id" ref="l10n_br_fiscal.fo_devolucao_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_devolucao_venda"/>
         <field name="document_type_id" ref="l10n_br_fiscal.document_55"/>
         <field name="document_serie_id" ref="l10n_br_fiscal.document_55_serie_1"/>
         <field name="company_id" ref="base.main_company"/>
@@ -145,7 +145,7 @@
     </record>
 
     <record id="fo_compras_compras" model="l10n_br_fiscal.operation.line">
-        <field name="operation_id" ref="l10n_br_fiscal.fo_compras"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras"/>
         <field name="name">Compras</field>
         <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1101"/>
         <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2101"/>
@@ -163,7 +163,7 @@
     </record>
 
     <record id="fo_devolucao_compras_devolucao_compras" model="l10n_br_fiscal.operation.line">
-        <field name="operation_id" ref="l10n_br_fiscal.fo_devolucao_compras"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_devolucao_compras"/>
         <field name="name">Devolução de Compras</field>
         <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5201"/>
         <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6201"/>
@@ -172,7 +172,7 @@
     </record>
 
     <record id="fo_devolucao_compras_55_serie_1" model="l10n_br_fiscal.operation.document.type">
-        <field name="operation_id" ref="l10n_br_fiscal.fo_devolucao_compras"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_devolucao_compras"/>
         <field name="document_type_id" ref="l10n_br_fiscal.document_55"/>
         <field name="document_serie_id" ref="l10n_br_fiscal.document_55_serie_1"/>
         <field name="company_id" ref="base.main_company"/>
@@ -188,7 +188,7 @@
     </record>
 
     <record id="fo_entrada_remessa_55_serie_1" model="l10n_br_fiscal.operation.document.type">
-        <field name="operation_id" ref="l10n_br_fiscal.fo_entrada_remessa"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_entrada_remessa"/>
         <field name="document_type_id" ref="l10n_br_fiscal.document_55"/>
         <field name="document_serie_id" ref="l10n_br_fiscal.document_55_serie_1"/>
         <field name="company_id" ref="base.main_company"/>
@@ -204,7 +204,7 @@
     </record>
 
     <record id="fo_simples_remessa_55_serie_1" model="l10n_br_fiscal.operation.document.type">
-        <field name="operation_id" ref="l10n_br_fiscal.fo_simples_remessa"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_simples_remessa"/>
         <field name="document_type_id" ref="l10n_br_fiscal.document_55"/>
         <field name="document_serie_id" ref="l10n_br_fiscal.document_55_serie_1"/>
         <field name="company_id" ref="base.main_company"/>
@@ -213,13 +213,13 @@
 
     <!-- l10n_br_fiscal.operation relations -->
     <record id="fo_venda" model="l10n_br_fiscal.operation">
-        <field name="return_operation_id" ref="fo_devolucao_venda"/>
-        <field name="inverse_operation_id" ref="fo_compras"/>
+        <field name="return_fiscal_operation_id" ref="fo_devolucao_venda"/>
+        <field name="inverse_fiscal_operation_id" ref="fo_compras"/>
     </record>
 
     <record id="fo_compras" model="l10n_br_fiscal.operation">
-        <field name="return_operation_id" ref="fo_devolucao_compras"/>
-        <field name="inverse_operation_id" ref="fo_venda"/>
+        <field name="return_fiscal_operation_id" ref="fo_devolucao_compras"/>
+        <field name="inverse_fiscal_operation_id" ref="fo_venda"/>
     </record>
 
     <!--

--- a/l10n_br_fiscal/demo/fiscal_document_demo.xml
+++ b/l10n_br_fiscal/demo/fiscal_document_demo.xml
@@ -9,7 +9,7 @@
 
     <!-- NFe Test - Empresa Contribuinte - Mesmo Estado -->
     <record id="demo_nfe_same_state" model="l10n_br_fiscal.document">
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
         <field name="document_type_id" ref="l10n_br_fiscal.document_55"/>
         <field name="document_serie_id" ref="l10n_br_fiscal.document_55_serie_1"/>
         <field name="document_serie">1</field>
@@ -35,8 +35,8 @@
         <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="operation_type">out</field>
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
-        <field name="operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
     </record>
 
     <record id="demo_nfe_line_same_state_1-2" model="l10n_br_fiscal.document.line">
@@ -47,13 +47,13 @@
         <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="operation_type">out</field>
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
-        <field name="operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
     </record>
 
     <!-- NFe Test - Empresa Contribuinte - Outro Estado -->
     <record id="demo_nfe_other_state" model="l10n_br_fiscal.document">
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
         <field name="document_type_id" ref="l10n_br_fiscal.document_55"/>
         <field name="document_serie_id" ref="l10n_br_fiscal.document_55_serie_1"/>
         <field name="document_serie">1</field>
@@ -77,8 +77,8 @@
         <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="operation_type">out</field>
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
-        <field name="operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
     </record>
 
     <record id="demo_nfe_line_same_state_2-3" model="l10n_br_fiscal.document.line">
@@ -89,8 +89,8 @@
         <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="operation_type">out</field>
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
-        <field name="operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
     </record>
 
     <record id="demo_nfe_line_same_state_3-3" model="l10n_br_fiscal.document.line">
@@ -101,13 +101,13 @@
         <field name="price_unit">2400</field>
         <field name="quantity">1</field>
         <field name="operation_type">out</field>
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
-        <field name="operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
     </record>
 
     <!-- NFe Test - Empresa Contribuinte - Exterior -->
     <record id="demo_nfe_export" model="l10n_br_fiscal.document">
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
         <field name="document_type_id" ref="l10n_br_fiscal.document_55"/>
         <field name="document_serie_id" ref="l10n_br_fiscal.document_55_serie_1"/>
         <field name="document_serie">13</field>
@@ -126,8 +126,8 @@
         <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="operation_type">out</field>
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
-        <field name="operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
     </record>
 
     <record id="demo_nfe_line_export_3-2" model="l10n_br_fiscal.document.line">
@@ -138,13 +138,13 @@
         <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="operation_type">out</field>
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
-        <field name="operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
     </record>
 
     <!-- NFe Test - Empresa Contribuinte - Nao Contribuinte PJ -->
     <record id="demo_nfe_nao_contribuinte" model="l10n_br_fiscal.document">
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
         <field name="document_type_id" ref="l10n_br_fiscal.document_55"/>
         <field name="document_serie_id" ref="l10n_br_fiscal.document_55_serie_1"/>
         <field name="document_serie">14</field>
@@ -167,8 +167,8 @@
         <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="operation_type">out</field>
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
-        <field name="operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
     </record>
 
     <record id="demo_nfe_line_nao_contribuinte_4-2" model="l10n_br_fiscal.document.line">
@@ -179,13 +179,13 @@
         <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="operation_type">out</field>
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
-        <field name="operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
     </record>
 
     <!-- NFe Test - Empresa Contribuinte - Nao Contribuinte PF -->
     <record id="demo_nfe_nao_contribuinte_pf" model="l10n_br_fiscal.document">
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
         <field name="document_type_id" ref="l10n_br_fiscal.document_55"/>
         <field name="document_serie_id" ref="l10n_br_fiscal.document_55_serie_1"/>
         <field name="document_serie">15</field>
@@ -208,8 +208,8 @@
         <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="operation_type">out</field>
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
-        <field name="operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
     </record>
 
     <record id="demo_nfe_nao_contribuinte_pf_2-2" model="l10n_br_fiscal.document.line">
@@ -220,14 +220,14 @@
         <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="operation_type">out</field>
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
-        <field name="operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
     </record>
 
     <!-- NFe Test - Empresa Simples Nacional - Mesmo Estado -->
     <record id="demo_nfe_sn_same_state" model="l10n_br_fiscal.document">
         <field name="company_id" ref="empresa_simples_nacional"/>
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
         <field name="document_type_id" ref="l10n_br_fiscal.document_55"/>
         <field name="document_serie_id" ref="l10n_br_fiscal.document_55_serie_1"/>
         <field name="document_serie">16</field>
@@ -251,8 +251,8 @@
         <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="operation_type">out</field>
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
-        <field name="operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
     </record>
 
     <record id="demo_nfe_line_sn_same_state_5-2" model="l10n_br_fiscal.document.line">
@@ -263,14 +263,14 @@
         <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="operation_type">out</field>
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
-        <field name="operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
     </record>
 
     <!-- NFe Test - Empresa Simples Nacional - Outro Estado -->
     <record id="demo_nfe_sn_other_state" model="l10n_br_fiscal.document">
         <field name="company_id" ref="empresa_simples_nacional"/>
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
         <field name="document_type_id" ref="l10n_br_fiscal.document_55"/>
         <field name="document_serie_id" ref="l10n_br_fiscal.document_55_serie_1"/>
         <field name="document_serie">17</field>
@@ -294,8 +294,8 @@
         <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="operation_type">out</field>
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
-        <field name="operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
     </record>
 
     <record id="demo_nfe_line_sn_other_state_6-2" model="l10n_br_fiscal.document.line">
@@ -306,14 +306,14 @@
         <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="operation_type">out</field>
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
-        <field name="operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
     </record>
 
     <!-- NFe Test - Empresa Simples Nacional - Exterior -->
     <record id="demo_nfe_sn_export" model="l10n_br_fiscal.document">
         <field name="company_id" ref="empresa_simples_nacional"/>
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
         <field name="document_type_id" ref="l10n_br_fiscal.document_55"/>
         <field name="document_serie_id" ref="l10n_br_fiscal.document_55_serie_1"/>
         <field name="document_serie">18</field>
@@ -332,8 +332,8 @@
         <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="operation_type">out</field>
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
-        <field name="operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
     </record>
 
     <record id="demo_nfe_line_sn_export_7-2" model="l10n_br_fiscal.document.line">
@@ -344,14 +344,14 @@
         <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="operation_type">out</field>
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
-        <field name="operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
     </record>
 
     <!-- NFe Test - Empresa Simples Nacional - Outro Estado -->
     <record id="demo_nfe_sn_nao_contribuinte" model="l10n_br_fiscal.document">
         <field name="company_id" ref="empresa_simples_nacional"/>
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
         <field name="document_type_id" ref="l10n_br_fiscal.document_55"/>
         <field name="document_serie_id" ref="l10n_br_fiscal.document_55_serie_1"/>
         <field name="document_serie">19</field>
@@ -374,8 +374,8 @@
         <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="operation_type">out</field>
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
-        <field name="operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
     </record>
 
     <record id="demo_nfe_line_sn_nao_contribuinte_7-2" model="l10n_br_fiscal.document.line">
@@ -386,8 +386,8 @@
         <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="operation_type">out</field>
-        <field name="operation_id" ref="l10n_br_fiscal.fo_venda"/>
-        <field name="operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
     </record>
 
 </odoo>

--- a/l10n_br_fiscal/i18n/l10n_br_fiscal.pot
+++ b/l10n_br_fiscal/i18n/l10n_br_fiscal.pot
@@ -4537,7 +4537,7 @@ msgid "Inverse CFOP"
 msgstr ""
 
 #. module: l10n_br_fiscal
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_operation__inverse_operation_id
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_operation__inverse_fiscal_operation_id
 msgid "Inverse Operation"
 msgstr ""
 
@@ -5598,12 +5598,12 @@ msgstr ""
 
 #. module: l10n_br_fiscal
 #: model:ir.actions.act_window,name:l10n_br_fiscal.operation_action
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document__operation_id
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line__operation_id
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line_mixin__operation_id
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_mixin__operation_id
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_operation_document_type__operation_id
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_operation_line__operation_id
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document__fiscal_operation_id
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line__fiscal_operation_id
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line_mixin__fiscal_operation_id
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_mixin__fiscal_operation_id
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_operation_document_type__fiscal_operation_id
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_operation_line__fiscal_operation_id
 #: model:ir.ui.menu,name:l10n_br_fiscal.operation_menu
 #: model_terms:ir.ui.view,arch_db:l10n_br_fiscal.document_line_form
 msgid "Operation"
@@ -5615,10 +5615,10 @@ msgid "Operation Document Types"
 msgstr ""
 
 #. module: l10n_br_fiscal
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line__operation_line_id
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line_mixin__operation_line_id
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line__fiscal_operation_line_id
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line_mixin__fiscal_operation_line_id
 #: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_operation__line_ids
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_tax_definition__operation_line_id
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_tax_definition__fiscal_operation_line_id
 #: model_terms:ir.ui.view,arch_db:l10n_br_fiscal.operation_form
 msgid "Operation Line"
 msgstr ""
@@ -6601,7 +6601,7 @@ msgid "Return CFOP"
 msgstr ""
 
 #. module: l10n_br_fiscal
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_operation__return_operation_id
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_operation__return_fiscal_operation_id
 msgid "Return Operation"
 msgstr ""
 

--- a/l10n_br_fiscal/i18n/pt_BR.po
+++ b/l10n_br_fiscal/i18n/pt_BR.po
@@ -4588,7 +4588,7 @@ msgid "Inverse CFOP"
 msgstr "CFOP Inverso"
 
 #. module: l10n_br_fiscal
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_operation__inverse_operation_id
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_operation__inverse_fiscal_operation_id
 msgid "Inverse Operation"
 msgstr ""
 
@@ -5662,12 +5662,12 @@ msgstr "Aberto"
 
 #. module: l10n_br_fiscal
 #: model:ir.actions.act_window,name:l10n_br_fiscal.operation_action
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document__operation_id
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line__operation_id
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line_mixin__operation_id
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_mixin__operation_id
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_operation_document_type__operation_id
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_operation_line__operation_id
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document__fiscal_operation_id
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line__fiscal_operation_id
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line_mixin__fiscal_operation_id
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_mixin__fiscal_operation_id
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_operation_document_type__fiscal_operation_id
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_operation_line__fiscal_operation_id
 #: model:ir.ui.menu,name:l10n_br_fiscal.operation_menu
 #: model_terms:ir.ui.view,arch_db:l10n_br_fiscal.document_line_form
 msgid "Operation"
@@ -5679,10 +5679,10 @@ msgid "Operation Document Types"
 msgstr ""
 
 #. module: l10n_br_fiscal
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line__operation_line_id
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line_mixin__operation_line_id
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line__fiscal_operation_line_id
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line_mixin__fiscal_operation_line_id
 #: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_operation__line_ids
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_tax_definition__operation_line_id
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_tax_definition__fiscal_operation_line_id
 #: model_terms:ir.ui.view,arch_db:l10n_br_fiscal.operation_form
 msgid "Operation Line"
 msgstr "Linha da Operação Fiscal"
@@ -6669,7 +6669,7 @@ msgid "Return CFOP"
 msgstr "CFOP de Retorno"
 
 #. module: l10n_br_fiscal
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_operation__return_operation_id
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_operation__return_fiscal_operation_id
 msgid "Return Operation"
 msgstr ""
 

--- a/l10n_br_fiscal/migrations/12.0.2.0.0/pre-migration.py
+++ b/l10n_br_fiscal/migrations/12.0.2.0.0/pre-migration.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2020 - TODAY Renato Lima - Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+_column_renames = {
+    'l10n_br_fiscal_operation_line': [
+        ('operation_id', 'fiscal_operation_id')],
+    'l10n_br_fiscal_tax_definition': [
+        ('operation_line_id', 'fiscal_operation_line_id')],
+    'l10n_br_fiscal_operation_document_type': [
+        ('operation_id', 'fiscal_operation_id')],
+    'l10n_br_fiscal_operation_comment_rel': [
+        ('operation_id', 'fiscal_operation_id')],
+    'l10n_br_fiscal_operation_line_comment_rel': [
+        ('operation_id', 'fiscal_operation_line_id')],
+    'l10n_br_fiscal_document': [
+        ('operation_id', 'fiscal_operation_line_id')],
+    'l10n_br_fiscal_document_line': [
+        ('operation_id', 'fiscal_operation_line_id')],
+    'l10n_br_fiscal_document_line': [
+        ('operation_line_id', 'fiscal_operation_line_id')],
+}
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    openupgrade.rename_columns(env.cr, _column_renames)

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -123,7 +123,7 @@ class Document(models.Model):
         default=True,
     )
 
-    operation_id = fields.Many2one(
+    fiscal_operation_id = fields.Many2one(
         domain="[('state', '=', 'approved'), "
                "'|', ('operation_type', '=', operation_type),"
                " ('operation_type', '=', 'all')]",
@@ -718,18 +718,19 @@ class Document(models.Model):
     def _create_return(self):
         return_ids = self.env[self._name]
         for record in self:
-            if record.operation_id.return_operation_id:
+            if record.fiscal_operation_id.return_fiscal_operation_id:
                 new = record.copy()
-                new.operation_id = record.operation_id.return_operation_id
+                new.fiscal_operation_id = (
+                    record.fiscal_operation_id.return_fiscal_operation_id)
                 if record.operation_type == 'out':
                     new.operation_type = 'in'
                 else:
                     new.operation_type = 'out'
-                new._onchange_operation_id()
-                new.line_ids.write({'operation_id': new.operation_id.id})
+                new._onchange_fiscal_operation_id()
+                new.line_ids.write({'fiscal_operation_id': new.fiscal_operation_id.id})
 
                 for item in new.line_ids:
-                    item._onchange_operation_id()
+                    item._onchange_fiscal_operation_id()
 
                 return_ids |= new
         return return_ids
@@ -793,12 +794,12 @@ class Document(models.Model):
             self.partner_cnae_main_id = self.partner_id.cnae_main_id
             self.partner_tax_framework = self.partner_id.tax_framework
 
-    @api.onchange('operation_id')
-    def _onchange_operation_id(self):
-        if self.operation_id:
-            self.operation_name = self.operation_id.name
+    @api.onchange('fiscal_operation_id')
+    def _onchange_fiscal_operation_id(self):
+        if self.fiscal_operation_id:
+            self.operation_name = self.fiscal_operation_id.name
 
-        for comment_id in self.operation_id.comment_ids:
+        for comment_id in self.fiscal_operation_id.comment_ids:
             self.comment_ids += comment_id
 
     @api.onchange('document_serie_id')

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin.py
@@ -125,7 +125,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         index=True,
         string="NBS")
 
-    operation_id = fields.Many2one(
+    fiscal_operation_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.operation",
         string="Operation",
         domain=lambda self: self._operation_domain(),
@@ -133,14 +133,14 @@ class FiscalDocumentLineMixin(models.AbstractModel):
 
     operation_type = fields.Selection(
         selection=FISCAL_IN_OUT,
-        related="operation_id.operation_type",
-        string="Operation Type",
+        related="fiscal_operation_id.operation_type",
+        string="Fiscal Operation Type",
         readonly=True)
 
-    operation_line_id = fields.Many2one(
+    fiscal_operation_line_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.operation.line",
         string="Operation Line",
-        domain="[('operation_id', '=', operation_id), "
+        domain="[('fiscal_operation_id', '=', fiscal_operation_id), "
                "('state', '=', 'approved')]")
 
     cfop_id = fields.Many2one(

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -126,7 +126,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             ncm=self.ncm_id,
             nbm=self.nbm_id,
             cest=self.cest_id,
-            operation_line=self.operation_line_id,
+            operation_line=self.fiscal_operation_line_id,
             icmssn_range=self.icmssn_range_id)
 
     @api.multi
@@ -272,30 +272,30 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                     l.inss_wh_tax_id = tax
                     self._set_fields_inss_wh(computed_tax)
 
-    @api.onchange("operation_id")
-    def _onchange_operation_id(self):
-        if self.operation_id:
+    @api.onchange("fiscal_operation_id")
+    def _onchange_fiscal_operation_id(self):
+        if self.fiscal_operation_id:
             price = {
                 "sale_price": self.product_id.list_price,
                 "cost_price": self.product_id.standard_price,
             }
 
-            self.price_unit = price.get(self.operation_id.default_price_unit,
+            self.price_unit = price.get(self.fiscal_operation_id.default_price_unit,
                                         0.00)
 
-            self.operation_line_id = self.operation_id.line_definition(
+            self.fiscal_operation_line_id = self.fiscal_operation_id.line_definition(
                 company=self.company_id,
                 partner=self.partner_id,
                 product=self.product_id)
 
-    @api.onchange("operation_line_id")
-    def _onchange_operation_line_id(self):
+    @api.onchange("fiscal_operation_line_id")
+    def _onchange_fiscal_operation_line_id(self):
 
         # Reset Taxes
         self._remove_all_fiscal_tax_ids()
-        if self.operation_line_id:
+        if self.fiscal_operation_line_id:
 
-            mapping_result = self.operation_line_id.map_fiscal_taxes(
+            mapping_result = self.fiscal_operation_line_id.map_fiscal_taxes(
                 company=self.company_id,
                 partner=self.partner_id,
                 product=self.product_id,
@@ -311,7 +311,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             self.fiscal_tax_ids = taxes
             self._update_taxes()
 
-        if not self.operation_line_id:
+        if not self.fiscal_operation_line_id:
             self.cfop_id = False
 
     @api.onchange("product_id")
@@ -339,7 +339,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             self.service_type_id = False
             self.uot_id = False
 
-        self._onchange_operation_id()
+        self._onchange_fiscal_operation_id()
 
     def _set_fields_issqn(self, tax_dict):
         if tax_dict:
@@ -737,4 +737,4 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
 
     @api.onchange("ncm_id", "nbs_id", "cest_id")
     def _onchange_ncm_id(self):
-        self._onchange_operation_id()
+        self._onchange_fiscal_operation_id()

--- a/l10n_br_fiscal/models/document_fiscal_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin.py
@@ -29,7 +29,7 @@ class FiscalDocumentMixin(models.AbstractModel):
                   ('company_id', '=', False)]
         return domain
 
-    operation_id = fields.Many2one(
+    fiscal_operation_id = fields.Many2one(
         comodel_name='l10n_br_fiscal.operation',
         string='Operation',
         domain=lambda self: self._operation_domain(),
@@ -37,7 +37,7 @@ class FiscalDocumentMixin(models.AbstractModel):
 
     operation_type = fields.Selection(
         selection=FISCAL_IN_OUT,
-        related='operation_id.operation_type',
+        related='fiscal_operation_id.operation_type',
         string='Operation Type',
         readonly=True)
 

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -68,7 +68,7 @@ class DocumentLine(models.Model):
         domain = [('state', '=', 'approved')]
         return domain
 
-    operation_id = fields.Many2one(
+    fiscal_operation_id = fields.Many2one(
         domain=lambda self: self._operation_domain(),
     )
 
@@ -197,8 +197,8 @@ class DocumentLine(models.Model):
             record.additional_data += record.comment_ids.compute_message(
                 record._document_comment_vals())
 
-    @api.onchange('operation_line_id')
-    def _onchange_operation_line_id(self):
-        super(DocumentLine, self)._onchange_operation_line_id()
-        for comment_id in self.operation_line_id.comment_ids:
+    @api.onchange('fiscal_operation_line_id')
+    def _onchange_fiscal_operation_line_id(self):
+        super(DocumentLine, self)._onchange_fiscal_operation_line_id()
+        for comment_id in self.fiscal_operation_line_id.comment_ids:
             self.comment_ids += comment_id

--- a/l10n_br_fiscal/models/operation.py
+++ b/l10n_br_fiscal/models/operation.py
@@ -53,7 +53,7 @@ class Operation(models.Model):
         readonly=True,
         states={'draft': [('readonly', False)]})
 
-    return_operation_id = fields.Many2one(
+    return_fiscal_operation_id = fields.Many2one(
         comodel_name='l10n_br_fiscal.operation',
         string='Return Operation',
         readonly=True,
@@ -63,7 +63,7 @@ class Operation(models.Model):
                "['purchase_refund'], 'other': ['return_in', 'return_out']}.get("
                "fiscal_type, []))]")
 
-    inverse_operation_id = fields.Many2one(
+    inverse_fiscal_operation_id = fields.Many2one(
         comodel_name='l10n_br_fiscal.operation',
         string='Inverse Operation',
         domain="[('operation_type', '!=', operation_type), "
@@ -88,14 +88,14 @@ class Operation(models.Model):
 
     document_type_ids = fields.One2many(
         comodel_name='l10n_br_fiscal.operation.document.type',
-        inverse_name='operation_id',
+        inverse_name='fiscal_operation_id',
         string='Operation Document Types',
         readonly=True,
         states={'draft': [('readonly', False)]})
 
     line_ids = fields.One2many(
         comodel_name='l10n_br_fiscal.operation.line',
-        inverse_name='operation_id',
+        inverse_name='fiscal_operation_id',
         string='Operation Line',
         readonly=True,
         states={'draft': [('readonly', False)]})
@@ -103,7 +103,7 @@ class Operation(models.Model):
     comment_ids = fields.Many2many(
         comodel_name='l10n_br_fiscal.comment',
         relation='l10n_br_fiscal_operation_comment_rel',
-        column1='operation_id',
+        column1='fiscal_operation_id',
         column2='comment_id',
         string='Comment')
 
@@ -141,7 +141,7 @@ class Operation(models.Model):
         serie = self.env['l10n_br_fiscal.document.serie']
         document_type_serie = self.env[
             'l10n_br_fiscal.operation.document.type'].search([
-                ('operation_id', '=', self.id),
+                ('fiscal_operation_id', '=', self.id),
                 ('company_id', '=', company.id),
                 ('document_type_id', '=', document_type.id)],
                 limit=1)
@@ -154,7 +154,7 @@ class Operation(models.Model):
     def _line_domain(self, company, partner, product):
 
         domain = [
-            ('operation_id', '=', self.id),
+            ('fiscal_operation_id', '=', self.id),
             ('operation_type', '=', self.operation_type),
             ('state', '=', 'approved'),
         ]

--- a/l10n_br_fiscal/models/operation_dashboard.py
+++ b/l10n_br_fiscal/models/operation_dashboard.py
@@ -70,22 +70,22 @@ class Operation(models.Model):
 
     def _get_number_2confirm_documents(self):
         return self.env['l10n_br_fiscal.document'].search_count([
-            ('operation_id.fiscal_type', '=', self.fiscal_type),
-            ('operation_id', '=', self.id),
+            ('fiscal_operation_id.fiscal_type', '=', self.fiscal_type),
+            ('fiscal_operation_id', '=', self.id),
             ('state_edoc', 'in', EDOC_2_CONFIRM)
         ])
 
     def _get_authorized_documents(self):
         return self.env['l10n_br_fiscal.document'].search_count([
-            ('operation_id.fiscal_type', '=', self.fiscal_type),
-            ('operation_id', '=', self.id),
+            ('fiscal_operation_id.fiscal_type', '=', self.fiscal_type),
+            ('fiscal_operation_id', '=', self.id),
             ('state_edoc', '=', SITUACAO_EDOC_AUTORIZADA)
         ])
 
     def _get_cancelled_documents(self):
         return self.env['l10n_br_fiscal.document'].search_count([
-            ('operation_id.fiscal_type', '=', self.fiscal_type),
-            ('operation_id', '=', self.id),
+            ('fiscal_operation_id.fiscal_type', '=', self.fiscal_type),
+            ('fiscal_operation_id', '=', self.id),
             ('state_edoc', 'in', EDOC_CANCELED)
         ])
 
@@ -95,10 +95,10 @@ class Operation(models.Model):
         model = 'l10n_br_fiscal.document'
         if self.fiscal_type == 'sale':
             ctx.update({'default_operation_type': 'out',
-                        'default_operation_id': self.id})
+                        'default_fiscal_operation_id': self.id})
         elif self.fiscal_type == 'purchase':
             ctx.update({'default_operation_type': 'in',
-                        'default_operation_id': self.id})
+                        'default_fiscal_operation_id': self.id})
         return {
             'name': _('Create invoice/bill'),
             'type': 'ir.actions.act_window',
@@ -140,8 +140,8 @@ class Operation(models.Model):
         action['context'] = ctx
         action['domain'] = self._context.get('use_domain', [])
         action['domain'] += [
-            ('operation_id.fiscal_type', '=', self.fiscal_type),
-            ('operation_id', '=', self.id)
+            ('fiscal_operation_id.fiscal_type', '=', self.fiscal_type),
+            ('fiscal_operation_id', '=', self.id)
         ]
         if ctx.get('search_default_cancel'):
             action['domain'] += [('state_edoc', 'in', EDOC_CANCELED)]

--- a/l10n_br_fiscal/models/operation_document_type.py
+++ b/l10n_br_fiscal/models/operation_document_type.py
@@ -8,7 +8,7 @@ class OperationDocumentType(models.Model):
     _name = "l10n_br_fiscal.operation.document.type"
     _description = "Fiscal Operation Document Type"
 
-    operation_id = fields.Many2one(
+    fiscal_operation_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.operation",
         string="Operation",
         ondelete="cascade",

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -24,7 +24,7 @@ class OperationLine(models.Model):
     _description = 'Fiscal Operation Line'
     _inherit = ['mail.thread', 'mail.activity.mixin']
 
-    operation_id = fields.Many2one(
+    fiscal_operation_id = fields.Many2one(
         comodel_name='l10n_br_fiscal.operation',
         string='Operation',
         ondelete='cascade',
@@ -60,14 +60,14 @@ class OperationLine(models.Model):
 
     operation_type = fields.Selection(
         selection=FISCAL_IN_OUT_ALL,
-        related='operation_id.operation_type',
+        related='fiscal_operation_id.operation_type',
         string='Operation Type',
         store=True,
         readonly=True)
 
     fiscal_type = fields.Selection(
         selection=OPERATION_FISCAL_TYPE,
-        related='operation_id.fiscal_type',
+        related='fiscal_operation_id.fiscal_type',
         string='Fiscal Type',
         store=True,
         readonly=True)
@@ -112,13 +112,13 @@ class OperationLine(models.Model):
 
     tax_definition_ids = fields.One2many(
         comodel_name='l10n_br_fiscal.tax.definition',
-        inverse_name='operation_line_id',
+        inverse_name='fiscal_operation_line_id',
         string='Tax Definition')
 
     comment_ids = fields.Many2many(
         comodel_name='l10n_br_fiscal.comment',
         relation='l10n_br_fiscal_operation_line_comment_rel',
-        column1='operation_id',
+        column1='fiscal_operation_line_id',
         column2='comment_id',
         string='Comment')
 
@@ -139,7 +139,7 @@ class OperationLine(models.Model):
 
     _sql_constraints = [(
         "fiscal_operation_name_uniq",
-        "unique (name, operation_id)",
+        "unique (name, fiscal_operation_id)",
         _("Fiscal Operation Line already exists with this name !"))]
 
     def get_document_type(self, company):
@@ -241,9 +241,9 @@ class OperationLine(models.Model):
         return super(OperationLine, self).unlink()
 
     @api.multi
-    @api.onchange('operation_id')
-    def _onchange_operation_id(self):
-        if not self.operation_id.operation_type:
+    @api.onchange('fiscal_operation_id')
+    def _onchange_fiscal_operation_id(self):
+        if not self.fiscal_operation_id.operation_type:
             warning = {
                 "title": _("Warning!"),
                 "message": _("You must first select a operation type."),

--- a/l10n_br_fiscal/models/tax_definition_operation_line.py
+++ b/l10n_br_fiscal/models/tax_definition_operation_line.py
@@ -8,18 +8,19 @@ from odoo.exceptions import ValidationError
 class TaxDefinitionOperationLine(models.Model):
     _inherit = 'l10n_br_fiscal.tax.definition'
 
-    operation_line_id = fields.Many2one(
+    fiscal_operation_line_id = fields.Many2one(
         comodel_name='l10n_br_fiscal.operation.line',
         string='Operation Line')
 
     @api.multi
-    @api.constrains('operation_line_id')
-    def _check_operation_line_id(self):
+    @api.constrains('fiscal_operation_line_id')
+    def _check_fiscal_operation_line_id(self):
         for record in self:
-            if record.operation_line_id:
+            if record.fiscal_operation_line_id:
                 domain = [
                     ('id', '!=', record.id),
-                    ('operation_line_id', '=', record.operation_line_id.id),
+                    ('fiscal_operation_line_id', '=',
+                        record.fiscal_operation_line_id.id),
                     ('tax_group_id', '=', record.tax_group_id.id),
                     ('tax_id', '=', record.tax_id.id)]
 

--- a/l10n_br_fiscal/tests/test_fiscal_document_generic.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_generic.py
@@ -49,17 +49,17 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         self.nfe_same_state._onchange_document_serie_id()
         self.nfe_same_state._onchange_partner_id()
-        self.nfe_same_state._onchange_operation_id()
+        self.nfe_same_state._onchange_fiscal_operation_id()
 
         for line in self.nfe_same_state.line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
             line._onchange_ncm_id()
-            line._onchange_operation_id()
-            line._onchange_operation_line_id()
+            line._onchange_fiscal_operation_id()
+            line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
 
-            if line.operation_line_id.name == 'Revenda':
+            if line.fiscal_operation_line_id.name == 'Revenda':
                 self.assertEquals(
                     line.cfop_id.code, '5102',
                     "Error to mappping CFOP 5102"
@@ -98,7 +98,7 @@ class TestFiscalDocumentGeneric(TransactionCase):
                 " for Venda de Contribuinte Dentro do Estado.")
 
             # IPI
-            if line.operation_line_id.name == 'Revenda':
+            if line.fiscal_operation_line_id.name == 'Revenda':
                 self.assertEquals(
                     line.ipi_tax_id.name, 'IPI NT',
                     "Error to mapping IPI NT"
@@ -144,17 +144,17 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         self.nfe_other_state._onchange_document_serie_id()
         self.nfe_other_state._onchange_partner_id()
-        self.nfe_other_state._onchange_operation_id()
+        self.nfe_other_state._onchange_fiscal_operation_id()
 
         for line in self.nfe_other_state.line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
             line._onchange_ncm_id()
-            line._onchange_operation_id()
-            line._onchange_operation_line_id()
+            line._onchange_fiscal_operation_id()
+            line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
 
-            if line.operation_line_id.name == 'Revenda':
+            if line.fiscal_operation_line_id.name == 'Revenda':
                 self.assertEquals(
                     line.cfop_id.code, '6102',
                     "Error to mapping CFOP 6102"
@@ -193,7 +193,7 @@ class TestFiscalDocumentGeneric(TransactionCase):
                 " for Venda de Contribuinte Dentro do Estado.")
 
             # IPI
-            if line.operation_line_id.name == 'Revenda':
+            if line.fiscal_operation_line_id.name == 'Revenda':
                 self.assertEquals(
                     line.ipi_tax_id.name, 'IPI NT',
                     "Error to mapping IPI NT"
@@ -239,17 +239,17 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         self.nfe_not_taxpayer._onchange_document_serie_id()
         self.nfe_not_taxpayer._onchange_partner_id()
-        self.nfe_not_taxpayer._onchange_operation_id()
+        self.nfe_not_taxpayer._onchange_fiscal_operation_id()
 
         for line in self.nfe_not_taxpayer.line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
             line._onchange_ncm_id()
-            line._onchange_operation_id()
-            line._onchange_operation_line_id()
+            line._onchange_fiscal_operation_id()
+            line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
 
-            if line.operation_line_id.name == 'Revenda':
+            if line.fiscal_operation_line_id.name == 'Revenda':
                 self.assertEquals(
                     line.cfop_id.code, '6102',
                     "Error to mapping CFOP 6102"
@@ -277,7 +277,7 @@ class TestFiscalDocumentGeneric(TransactionCase):
                 " for Venda de Contribuinte Dentro do Estado.")
 
             # IPI
-            if line.operation_line_id.name == 'Revenda':
+            if line.fiscal_operation_line_id.name == 'Revenda':
                 self.assertEquals(
                     line.ipi_tax_id.name, 'IPI NT',
                     "Error to mapping IPI NT"
@@ -323,17 +323,17 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         self.nfe_not_taxpayer_pf._onchange_document_serie_id()
         self.nfe_not_taxpayer_pf._onchange_partner_id()
-        self.nfe_not_taxpayer_pf._onchange_operation_id()
+        self.nfe_not_taxpayer_pf._onchange_fiscal_operation_id()
 
         for line in self.nfe_not_taxpayer_pf.line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
             line._onchange_ncm_id()
-            line._onchange_operation_id()
-            line._onchange_operation_line_id()
+            line._onchange_fiscal_operation_id()
+            line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
 
-            if line.operation_line_id.name == 'Revenda':
+            if line.fiscal_operation_line_id.name == 'Revenda':
                 self.assertEquals(
                     line.cfop_id.code, '6102',
                     "Error to mapping CFOP 6102"
@@ -361,7 +361,7 @@ class TestFiscalDocumentGeneric(TransactionCase):
                 " para Venda de Contribuinte p/ Não Contribuinte.")
 
             # IPI
-            if line.operation_line_id.name == 'Revenda':
+            if line.fiscal_operation_line_id.name == 'Revenda':
                 self.assertEquals(
                     line.ipi_tax_id.name, 'IPI NT',
                     "Error to mapping IPI NT"
@@ -407,17 +407,17 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         self.nfe_export._onchange_document_serie_id()
         self.nfe_export._onchange_partner_id()
-        self.nfe_export._onchange_operation_id()
+        self.nfe_export._onchange_fiscal_operation_id()
 
         for line in self.nfe_export.line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
             line._onchange_ncm_id()
-            line._onchange_operation_id()
-            line._onchange_operation_line_id()
+            line._onchange_fiscal_operation_id()
+            line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
 
-            if line.operation_line_id.name == 'Revenda':
+            if line.fiscal_operation_line_id.name == 'Revenda':
                 self.assertEquals(
                     line.cfop_id.code, '7102',
                     "Error to mapping CFOP 7102"
@@ -445,7 +445,7 @@ class TestFiscalDocumentGeneric(TransactionCase):
             #    " para Venda de Contribuinte p/ o Exterior.")
 
             # IPI
-            if line.operation_line_id.name == 'Revenda':
+            if line.fiscal_operation_line_id.name == 'Revenda':
                 self.assertEquals(
                     line.ipi_tax_id.name, 'IPI NT',
                     "Error to mapping IPI NT"
@@ -491,17 +491,17 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         self.nfe_sn_same_state._onchange_document_serie_id()
         self.nfe_sn_same_state._onchange_partner_id()
-        self.nfe_sn_same_state._onchange_operation_id()
+        self.nfe_sn_same_state._onchange_fiscal_operation_id()
 
         for line in self.nfe_sn_same_state.line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
             line._onchange_ncm_id()
-            line._onchange_operation_id()
-            line._onchange_operation_line_id()
+            line._onchange_fiscal_operation_id()
+            line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
 
-            if line.operation_line_id.name == 'Revenda':
+            if line.fiscal_operation_line_id.name == 'Revenda':
                 self.assertEquals(
                     line.cfop_id.code, '5102',
                     "Error to mappping CFOP 5102"
@@ -565,17 +565,17 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         self.nfe_sn_other_state._onchange_document_serie_id()
         self.nfe_sn_other_state._onchange_partner_id()
-        self.nfe_sn_other_state._onchange_operation_id()
+        self.nfe_sn_other_state._onchange_fiscal_operation_id()
 
         for line in self.nfe_sn_other_state.line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
             line._onchange_ncm_id()
-            line._onchange_operation_id()
-            line._onchange_operation_line_id()
+            line._onchange_fiscal_operation_id()
+            line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
 
-            if line.operation_line_id.name == 'Revenda':
+            if line.fiscal_operation_line_id.name == 'Revenda':
                 self.assertEquals(
                     line.cfop_id.code, '6102',
                     "Error to mappping CFOP 6102"
@@ -639,17 +639,17 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         self.nfe_sn_not_taxpayer._onchange_document_serie_id()
         self.nfe_sn_not_taxpayer._onchange_partner_id()
-        self.nfe_sn_not_taxpayer._onchange_operation_id()
+        self.nfe_sn_not_taxpayer._onchange_fiscal_operation_id()
 
         for line in self.nfe_sn_not_taxpayer.line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
             line._onchange_ncm_id()
-            line._onchange_operation_id()
-            line._onchange_operation_line_id()
+            line._onchange_fiscal_operation_id()
+            line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
 
-            if line.operation_line_id.name == 'Revenda':
+            if line.fiscal_operation_line_id.name == 'Revenda':
                 self.assertEquals(
                     line.cfop_id.code, '5102',
                     "Error to mappping CFOP 5102"
@@ -713,17 +713,17 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         self.nfe_sn_export._onchange_document_serie_id()
         self.nfe_sn_export._onchange_partner_id()
-        self.nfe_sn_export._onchange_operation_id()
+        self.nfe_sn_export._onchange_fiscal_operation_id()
 
         for line in self.nfe_sn_export.line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
             line._onchange_ncm_id()
-            line._onchange_operation_id()
-            line._onchange_operation_line_id()
+            line._onchange_fiscal_operation_id()
+            line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
 
-            if line.operation_line_id.name == 'Revenda':
+            if line.fiscal_operation_line_id.name == 'Revenda':
                 self.assertEquals(
                     line.cfop_id.code, '7102',
                     "Error to mapping CFOP 7102"
@@ -790,7 +790,7 @@ class TestFiscalDocumentGeneric(TransactionCase):
             [i[2] for i in action['domain'] if i[0] == 'id'])
 
         self.assertEquals(
-            return_id.operation_id.id,
-            self.nfe_same_state.operation_id.return_operation_id.id,
+            return_id.fiscal_operation_id.id,
+            self.nfe_same_state.fiscal_operation_id.return_fiscal_operation_id.id,
             "Error on creation return"
         )

--- a/l10n_br_fiscal/views/document_fiscal_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_fiscal_mixin_view.xml
@@ -7,7 +7,7 @@
     <field name="arch" type="xml">
       <form>
         <group name="l10n_br_fiscal">
-            <field name="operation_id" required="1"/>
+            <field name="fiscal_operation_id" required="1"/>
         </group>
       </form>
     </field>

--- a/l10n_br_fiscal/views/document_line_view.xml
+++ b/l10n_br_fiscal/views/document_line_view.xml
@@ -49,8 +49,8 @@
               <group name="l10n_br_fiscal" string="Operation">
                 <field name="fiscal_tax_ids" force_save="1" invisible="1" readonly="1"/>
                 <field name="operation_type" invisible="1" readonly="1"/>
-                <field name="operation_id" required="1"/>
-                <field name="operation_line_id" required="1"/>
+                <field name="fiscal_operation_id" required="1"/>
+                <field name="fiscal_operation_line_id" required="1"/>
                 <field name="cfop_id" attrs="{'invisible': ['fiscal_type', '=', '00']}"/>
               </group>
             </group>

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -24,7 +24,7 @@
         <field name="document_type_id"/>
         <field name="number"/>
         <field name="date"/>
-        <field name="operation_id"/>
+        <field name="fiscal_operation_id"/>
         <field name="partner_id"/>
         <field name="amount_untaxed"/>
         <field name="amount_tax"/>
@@ -68,7 +68,7 @@
             </h1>
           </div>
           <group name="l10n_br_fiscal" colspan="4">
-            <field name="operation_id"/> <!-- USE MIXIN VIEW -->
+            <field name="fiscal_operation_id"/> <!-- USE MIXIN VIEW -->
             <field name="edoc_purpose"/>
             <field name="ind_final"/>
             <field name="ind_pres"/>
@@ -146,7 +146,7 @@
               </group>
             </page>
             <page name="products" string="Products and Services">
-              <field name="line_ids" context="{'form_view_ref': 'l10n_br_fiscal.document_line_form', 'default_document_id': id, 'default_company_id': company_id, 'default_partner_id': partner_id, 'default_operation_type': operation_type, 'default_operation_id': operation_id}">
+              <field name="line_ids" context="{'form_view_ref': 'l10n_br_fiscal.document_line_form', 'default_document_id': id, 'default_company_id': company_id, 'default_partner_id': partner_id, 'default_operation_type': operation_type, 'default_fiscal_operation_id': fiscal_operation_id}">
                 <tree>
                   <field name="product_id"/>
                   <field name="uom_id"/>

--- a/l10n_br_fiscal/views/operation_line_view.xml
+++ b/l10n_br_fiscal/views/operation_line_view.xml
@@ -48,7 +48,7 @@
                           </group>
                       </page>
                       <page name="tax_definitions" string="Tax Definitions">
-                          <field name="tax_definition_ids" nolabel="1" context="{'tree_view_ref': 'l10n_br_fiscal.tax_definition_tree','form_view_ref': 'l10n_br_fiscal.tax_definition_form', 'default_operation_line_id': id}"/>
+                          <field name="tax_definition_ids" nolabel="1" context="{'tree_view_ref': 'l10n_br_fiscal.tax_definition_tree','form_view_ref': 'l10n_br_fiscal.tax_definition_form', 'default_fiscal_operation_line_id': id}"/>
                       </page>
                       <page name="extra_info" string="Extra Info">
                         <group>

--- a/l10n_br_fiscal/views/operation_view.xml
+++ b/l10n_br_fiscal/views/operation_view.xml
@@ -50,13 +50,13 @@
                         </group>
                         <group>
                             <field name="default_price_unit"/>
-                            <field name="return_operation_id"/>
-                            <field name="inverse_operation_id"/>
+                            <field name="return_fiscal_operation_id"/>
+                            <field name="inverse_fiscal_operation_id"/>
                         </group>
                     </group>
                     <notebook>
                         <page name="operation_line" string="Operation Line">
-                            <field name="line_ids" context="{'default_operation_id': id, 'default_fiscal_type': fiscal_type, 'default_operation_type': operation_type, 'form_view_ref': 'l10n_br_fiscal.operation_line_form' , 'show_code_only': 1}">
+                            <field name="line_ids" context="{'default_fiscal_operation_id': id, 'default_fiscal_type': fiscal_type, 'default_operation_type': operation_type, 'form_view_ref': 'l10n_br_fiscal.operation_line_form' , 'show_code_only': 1}">
                                 <tree>
                                     <field name="name"/>
                                     <field name="cfop_internal_id"/>
@@ -68,7 +68,7 @@
                             </field>
                         </page>
                         <page name="operation_document_type" string="Fiscal Documents">
-                            <field name="document_type_ids" context="{'default_operation_id': id}">
+                            <field name="document_type_ids" context="{'default_fiscal_operation_id': id}">
                                 <tree>
                                     <field name="document_type_id"/>
                                     <field name="document_serie_id"/>


### PR DESCRIPTION
To avoid collision with some core fields like this:

https://github.com/odoo/odoo/blob/12.0/addons/mrp/models/stock_move.py#L60

I renamed operation_id to fiscal_operation_id and operation_line_id to fiscal_operation_line_id