### PR TITLE
[12.][FIX] Remove company from fiscal document dummy

### DIFF
--- a/l10n_br_fiscal/data/operation_data.xml
+++ b/l10n_br_fiscal/data/operation_data.xml
@@ -17,6 +17,7 @@
         <field name="document_type_id" ref="l10n_br_fiscal.document_55"/>
         <field name="document_serie_id" ref="l10n_br_fiscal.document_55_serie_1"/>
         <field name="operation_type">out</field>
+        <field name="company_id" eval="False"/>
     </record>
 
     <record id="fiscal_document_line_dummy" model="l10n_br_fiscal.document.line">

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -251,7 +251,6 @@ class Document(models.Model):
     company_id = fields.Many2one(
         comodel_name='res.company',
         string='Company',
-        required=True,
         default=lambda self: self.env['res.company']._company_default_get(
             'l10n_br_fiscal.document'),
     )

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -106,7 +106,7 @@
                 </group>
               </group>
               <group name="company_info" string="Company">
-                <field name="company_id" groups="base.group_multi_company"/>
+                <field name="company_id" required="1" groups="base.group_multi_company"/>
               </group>
               <group>
                 <group name="company_left">


### PR DESCRIPTION
No l10n_br_fiscal.document existe o campo company_id que na definição esta como requerido, nos dados do módulo l10n_br_fiscal é criado um documento fiscal dummy para ser relacionado a todas as account.invoice que não possuem um documento fiscal, mas esse documento dummy estava com o company 1 (base.main_company) por padrão o que gera um erro se tivermos mais de uma empresa porque e ao criar uma account.invoice de outra empresa e relacionar ao dummy, vai gerar um erro de permissão.