### PR TITLE
[12.0][REF] refactoring mixin line fields_view_get to use in parent objects

### DIFF
--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -70,41 +70,47 @@ FISCAL_CST_ID_FIELDS = [
 
 
 class FiscalDocumentLineMixinMethods(models.AbstractModel):
-    _name = "l10n_br_fiscal.document.line.mixin.methods"
-    _description = "Document Fiscal Mixin Methods"
+    _name = 'l10n_br_fiscal.document.line.mixin.methods'
+    _description = 'Document Fiscal Mixin Methods'
+
+    @api.model
+    def fiscal_form_view(self, form_view_arch):
+        try:
+            fiscal_view = self.env.ref(
+                "l10n_br_fiscal.document_fiscal_line_mixin_form")
+
+            # Get template tags
+            fsc_doc = etree.fromstring(fiscal_view["arch"])
+            group_node = fsc_doc.xpath("//group[@name='fiscal_fields']")[0]
+            page_node = fsc_doc.xpath("//page[@name='fiscal_taxes']")[0]
+
+            doc = etree.fromstring(form_view_arch)
+
+            # Replace group
+            doc_group_node = doc.xpath("//group[@name='fiscal_fields']")[0]
+            setup_modifiers(group_node)
+            doc_group_node.getparent().replace(doc_group_node, group_node)
+
+            # Replace page
+            doc_page_node = doc.xpath("//page[@name='fiscal_taxes']")[0]
+            for n in page_node.getiterator():
+                setup_modifiers(n)
+            doc_page_node.getparent().replace(doc_page_node, page_node)
+
+            form_view_arch = etree.tostring(doc, encoding='unicode')
+        except Exception:
+            return form_view_arch
+
+        return form_view_arch
 
     @api.model
     def fields_view_get(self, view_id=None, view_type="form",
                         toolbar=False, submenu=False):
-        model_view = super(FiscalDocumentLineMixinMethods, self).fields_view_get(
-            view_id, view_type, toolbar, submenu)
+        model_view = super(FiscalDocumentLineMixinMethods,
+            self).fields_view_get(view_id, view_type, toolbar, submenu)
 
         if view_type == 'form':
-            try:
-                fiscal_view = self.env.ref(
-                    "l10n_br_fiscal.document_fiscal_line_mixin_form")
-
-                # Get template tags
-                fsc_doc = etree.fromstring(fiscal_view["arch"])
-                group_node = fsc_doc.xpath("//group[@name='fiscal_fields']")[0]
-                page_node = fsc_doc.xpath("//page[@name='fiscal_taxes']")[0]
-
-                doc = etree.fromstring(model_view.get('arch'))
-
-                # Replace group
-                doc_group_node = doc.xpath("//group[@name='fiscal_fields']")[0]
-                setup_modifiers(group_node)
-                doc_group_node.getparent().replace(doc_group_node, group_node)
-
-                # Replace page
-                doc_page_node = doc.xpath("//page[@name='fiscal_taxes']")[0]
-                for n in page_node.getiterator():
-                    setup_modifiers(n)
-                doc_page_node.getparent().replace(doc_page_node, page_node)
-
-                model_view["arch"] = etree.tostring(doc, encoding='unicode')
-            except Exception:
-                return model_view
+            model_view["arch"] = self.fiscal_form_view(model_view["arch"])
 
         return model_view
 

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -106,8 +106,8 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
     @api.model
     def fields_view_get(self, view_id=None, view_type="form",
                         toolbar=False, submenu=False):
-        model_view = super(FiscalDocumentLineMixinMethods,
-            self).fields_view_get(view_id, view_type, toolbar, submenu)
+        model_view = super().fields_view_get(
+            view_id, view_type, toolbar, submenu)
 
         if view_type == 'form':
             model_view["arch"] = self.fiscal_form_view(model_view["arch"])

--- a/l10n_br_fiscal/models/document_fiscal_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin.py
@@ -35,18 +35,21 @@ class FiscalDocumentMixin(models.AbstractModel):
         comodel_name='l10n_br_fiscal.operation',
         string='Operation',
         domain=lambda self: self._operation_domain(),
-        default=_default_operation)
+        default=_default_operation,
+    )
 
     operation_type = fields.Selection(
         selection=FISCAL_IN_OUT,
         related='fiscal_operation_id.operation_type',
         string='Operation Type',
-        readonly=True)
+        readonly=True,
+    )
 
     ind_pres = fields.Selection(
         selection=NFE_IND_PRES,
         string='Buyer Presence',
-        default=NFE_IND_PRES_DEFAULT)
+        default=NFE_IND_PRES_DEFAULT,
+    )
 
     comment_ids = fields.Many2many(
         comodel_name='l10n_br_fiscal.comment',


### PR DESCRIPTION
Eu dividi o método fields_view_get do mixin line em dois métodos, o método fiscal_form_view recebe uma string com a arch da view do document e injeta a view do mixin das linhas.

Foi necessário fazer essa mudança porque em alguns objetos do core como o sale order e purchase order a visão form das sale.order.line e purchase.order.line é uma subvisão do sale order e purchase order e só o fields_view_get destes objetos são chamado pelo framework.