### PR TITLE
[12.0][FIX] fiscal tax mapping for product and service taxes

### DIFF
--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -16,7 +16,12 @@ from ..constants.fiscal import (
     OPERATION_FISCAL_TYPE,
     CFOP_DESTINATION_EXPORT,
     FISCAL_COMMENT_LINE,
+    PRODUCT_FISCAL_TYPE_SERVICE,
+    NCM_FOR_SERVICE,
+    TAX_DOMAIN_ISSQN,
+    TAX_DOMAIN_ICMS,
 )
+
 from ..constants.icms import ICMS_ORIGIN
 
 
@@ -227,6 +232,12 @@ class OperationLine(models.Model):
             # 6 From Partner Profile
             for tax in partner.fiscal_profile_id.tax_definition_ids.mapped('tax_id'):
                 mapping_result['taxes'][tax.tax_domain] = tax
+
+        if (product.fiscal_type == PRODUCT_FISCAL_TYPE_SERVICE and
+                ncm.code == NCM_FOR_SERVICE):
+            mapping_result['taxes'].pop(TAX_DOMAIN_ICMS, None)
+        else:
+            mapping_result['taxes'].pop(TAX_DOMAIN_ISSQN, None)
 
         return mapping_result
 


### PR DESCRIPTION
No mapeamento fiscal, caso o produto não tenha NCM (Usando o ncm 0000.00.00) e o genero fiscal for 00 (Serviço) ele não deve mapear o imposto ICMS e mapear apenas o ISSQN, e caso contrário, deve mapear o ICMS e não o ISSQN.