### PR TITLE
Corrigir Teste

### DIFF
--- a/l10n_br_fiscal/models/closing.py
+++ b/l10n_br_fiscal/models/closing.py
@@ -253,8 +253,8 @@ class FiscalClosing(models.Model):
 
     def _date_range(self):
         date_range = calendar.monthrange(int(self.year), int(self.month))
-        date_min = '-'.join((self.year, self.month, str(date_range[0])))
-        date_min = datetime.strptime(date_min, '%Y-%m-%d').replace(day=1)
+        date_min = '-'.join((self.year, self.month, '01'))
+        date_min = datetime.strptime(date_min, '%Y-%m-%d')
 
         date_max = '-'.join((self.year, self.month, str(date_range[1])))
         date_max = datetime.strptime(date_max, '%Y-%m-%d')

--- a/l10n_br_zip/models/l10n_br_zip.py
+++ b/l10n_br_zip/models/l10n_br_zip.py
@@ -124,7 +124,7 @@ class L10nBrZip(models.Model):
             raise UserError(_("Erro no PyCEP-Correios : ") + str(e))
 
         values = {}
-        if cep:
+        if cep and any(cep.values()):
             # Search Brazil id
             country = self.env["res.country"].search(
                 [("code", "=", "BR")], limit=1)

--- a/l10n_br_zip/tests/test_l10n_br_zip_res_company.py
+++ b/l10n_br_zip/tests/test_l10n_br_zip_res_company.py
@@ -155,7 +155,7 @@ class L10nBRZipTest(TransactionCase):
         )
 
     def test_error_pycep_correios(self):
-        """Test error with PyCEP CORREIOS ."""
+        """Test error with PyCEP CORREIOS in company."""
         self.company.zip = "00000000"
         try:
             result = self.company.zip_search()

--- a/l10n_br_zip/tests/test_l10n_br_zip_res_partner.py
+++ b/l10n_br_zip/tests/test_l10n_br_zip_res_partner.py
@@ -158,7 +158,7 @@ class L10nBRZipTest(TransactionCase):
         )
 
     def test_error_pycep_correios(self):
-        """Test error with PyCEP CORREIOS ."""
+        """Test error with PyCEP CORREIOS in partner."""
 
         self.res_partner.zip = "00000000"
         try:


### PR DESCRIPTION
o método calendar.monthrange retorna o primeiro dia da semana:

```
>>> calendar.monthrange(2020, 6)
(0, 30)
```
E estava montando data inválida:
https://travis-ci.org/github/OCA/l10n-brazil/jobs/695763324#L1800
```
2020-06-07 20:08:49,270 6815 INFO openerp_test odoo.addons.l10n_br_fiscal.tests.test_fiscal_closing: ` Test Fiscal Close Export
2020-06-07 20:08:49,446 6815 ERROR openerp_test odoo.addons.l10n_br_fiscal.tests.test_fiscal_closing: ERROR
2020-06-07 20:08:49,446 6815 INFO openerp_test odoo.addons.l10n_br_fiscal.tests.test_fiscal_closing: ======================================================================
2020-06-07 20:08:49,446 6815 ERROR openerp_test odoo.addons.l10n_br_fiscal.tests.test_fiscal_closing: ERROR: test_event_to_fiscal_close (odoo.addons.l10n_br_fiscal.tests.test_fiscal_closing.TestFiscalClosing)
2020-06-07 20:08:49,446 6815 ERROR openerp_test odoo.addons.l10n_br_fiscal.tests.test_fiscal_closing: ` Test Fiscal Close Export
2020-06-07 20:08:49,446 6815 ERROR openerp_test odoo.addons.l10n_br_fiscal.tests.test_fiscal_closing: Traceback (most recent call last):
2020-06-07 20:08:49,447 6815 ERROR openerp_test odoo.addons.l10n_br_fiscal.tests.test_fiscal_closing: `   File "/home/travis/build/OCA/l10n-brazil/l10n_br_fiscal/tests/test_fiscal_closing.py", line 41, in test_event_to_fiscal_close
2020-06-07 20:08:49,447 6815 ERROR openerp_test odoo.addons.l10n_br_fiscal.tests.test_fiscal_closing: `     self.closing_period.action_export()
2020-06-07 20:08:49,447 6815 ERROR openerp_test odoo.addons.l10n_br_fiscal.tests.test_fiscal_closing: `   File "/home/travis/build/OCA/l10n-brazil/l10n_br_fiscal/models/closing.py", line 334, in action_export
2020-06-07 20:08:49,447 6815 ERROR openerp_test odoo.addons.l10n_br_fiscal.tests.test_fiscal_closing: `     files_dir = self._prepara_arquivos(temp_dir)
2020-06-07 20:08:49,447 6815 ERROR openerp_test odoo.addons.l10n_br_fiscal.tests.test_fiscal_closing: `   File "/home/travis/build/OCA/l10n-brazil/l10n_br_fiscal/models/closing.py", line 294, in _prepara_arquivos
2020-06-07 20:08:49,447 6815 ERROR openerp_test odoo.addons.l10n_br_fiscal.tests.test_fiscal_closing: `     date_min, date_max = self._date_range()
2020-06-07 20:08:49,447 6815 ERROR openerp_test odoo.addons.l10n_br_fiscal.tests.test_fiscal_closing: `   File "/home/travis/build/OCA/l10n-brazil/l10n_br_fiscal/models/closing.py", line 257, in _date_range
2020-06-07 20:08:49,447 6815 ERROR openerp_test odoo.addons.l10n_br_fiscal.tests.test_fiscal_closing: `     date_min = datetime.strptime(date_min, '%Y-%m-%d').replace(day=1)
2020-06-07 20:08:49,447 6815 ERROR openerp_test odoo.addons.l10n_br_fiscal.tests.test_fiscal_closing: `   File "/opt/python/3.5.6/lib/python3.5/_strptime.py", line 510, in _strptime_datetime
2020-06-07 20:08:49,447 6815 ERROR openerp_test odoo.addons.l10n_br_fiscal.tests.test_fiscal_closing: `     tt, fraction = _strptime(data_string, format)
2020-06-07 20:08:49,447 6815 ERROR openerp_test odoo.addons.l10n_br_fiscal.tests.test_fiscal_closing: `   File "/opt/python/3.5.6/lib/python3.5/_strptime.py", line 343, in _strptime
2020-06-07 20:08:49,447 6815 ERROR openerp_test odoo.addons.l10n_br_fiscal.tests.test_fiscal_closing: `     (data_string, format))
2020-06-07 20:08:49,447 6815 ERROR openerp_test odoo.addons.l10n_br_fiscal.tests.test_fiscal_closing: ` **ValueError: time data '2020-6-0' does not match format '%Y-%m-%d'**
2020-06-07 20:08:49,448 6815 INFO openerp_test odoo.addons.l10n_br_fiscal.tests.test_fiscal_closing: Ran 1 test in 0.177s
2020-06-07 20:08:49,448 6815 ERROR openerp_test odoo.addons.l10n_br_fiscal.tests.test_fiscal_closing: FAILED
```

Como na instrução seguinte, estava ignoranda o dia da semana e setando sempre o primeiro dia, utilizei um hardcode para montar a "date_min" sempre no primeiro dia de cada mês.