### PR TITLE
Criar o código de conduta para a l10n-brazil

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,78 @@
+Código de Conduta do Colaborador
+
+## Nosso compromisso
+
+No interesse de promover um ambiente aberto e acolhedor, nós, como
+colaboradores e mantenedores nos comprometemos a participar do nosso projeto *Localização Brasileira* e proporcionar a
+nossa comunidade uma experiência livre de assédio para todos, independentemente da idade, do corpo
+tamanho, deficiência, etnia, características sexuais, identidade e expressão de gênero,
+nível de experiência, educação, status socioeconômico, nacionalidade, pessoal
+aparência, raça, religião ou identidade e orientação sexual.
+
+## Nossos padrões
+
+Exemplos de comportamento que contribui para criar um ambiente positivo
+incluir:
+
+* Usando linguagem acolhedora e inclusiva
+* Ser respeitoso com diferentes pontos de vista e experiências
+* Aceitando graciosamente críticas construtivas
+* Focar no que é melhor para a comunidade
+* Mostrar empatia com outros membros da comunidade
+
+Exemplos de comportamento inaceitável pelos participantes incluem:
+
+* O uso de linguagem ou imagem sexualizada e atenção ou atenção sexual indesejada
+* Trolling, comentários ofensivos / depreciativos e ataques políticos ou pessoais
+* Assédio público ou privado
+* Publicação de informações privadas de terceiros, como informações físicas ou eletrônicas
+ endereço, sem permissão explícita dentro de um cenário profissional
+
+## Nossas Responsabilidades
+
+Os mantenedores do projeto são responsáveis ​​por esclarecer os padrões aceitáveis de
+comportamento e espera-se que adotem ações corretivas apropriadas e justas bem como
+resposta a quaisquer instâncias de comportamento inaceitável.
+
+Os mantenedores do projeto têm o direito e a responsabilidade de remover, editar ou
+rejeitar comentários, confirmações, códigos, edições wiki, problemas e outras contribuições
+que não estejam alinhados com este Código de Conduta ou que proíbam temporariamente ou
+permanentemente qualquer colaborador de outros comportamentos que considerem inapropriado,
+ameaçador, ofensivo ou prejudicial.
+
+## Escopo
+
+Este Código de Conduta se aplica aos espaços do projeto e aos espaços públicos de encontro e ou eventos da comunidade
+quando um indivíduo está representando o projeto ou sua comunidade. Exemplos de
+representação de um projeto ou comunidade incluem o uso de um email oficial do projeto
+endereço, publicação por meio de uma conta oficial de mídia social ou como representante designado
+representante em um evento online ou offline. A representação de um projeto pode ser
+definido e esclarecido pelos mantenedores do projeto.
+
+São definidos aqui também empresas ou pessoas jurídicas parceiras do projeto ou da qual os mantenedores como pessoas físicas
+fazem parte. Estas não poderão assumir a representação em nome da comunidade sobre questões não acordadas e registradas.
+
+## Execução
+
+Instâncias de comportamento abusivo, assediador ou inaceitável podem ser
+relatado entrando em contato com a equipe do projeto em. Todas as
+reclamações serão analisadas e investigadas e terão uma resposta que
+seja considerada necessária e adequada às circunstâncias. A equipe do projeto é
+obrigada a manter a confidencialidade em relação ao relator de um incidente.
+Detalhes adicionais de políticas específicas de imposição podem ser publicadas separadamente.
+
+Os mantenedores do projeto que não sigam ou apliquem o Código de Conduta em boas condições
+ao espirito ou boa fé do projeto poderá enfrentar repercussões temporárias ou permanentes, conforme determinado por outros
+membros da liderança do projeto.
+
+## Atribuição
+
+Este código de conduta se coloca em interssecção 
+
+Este Código de Conduta é adaptado e traduzido da [Aliança do Colaborador] [página inicial], versão 1.4,
+disponível em https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[página inicial]: https://www.contributor-covenant.org
+
+Para obter respostas a perguntas comuns sobre este código de conduta, consulte
+https://www.contributor-covenant.org/faq


### PR DESCRIPTION
Fiz algumas modificações no linguajar pra tirar um pouco o juridiques, também adaptei algumas linhas para a necessidade da OCA. Recomendo para o próximo commit colocar a intercecionalidade do código da OCA (que não achei)

Um código de conduta deve ser seguido e respeitado, até para que não haja desrrespeito entre contribuidores e a fim de preservar as relações de maneira objetiva pelos interesses da comunidade.