### PR TITLE
[FIX] Fiscal document number check constraint

### DIFF
--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -710,7 +710,7 @@ class Document(models.Model):
                 ('document_serie', '=', record.document_serie),
                 ('number', '=', record.number)]
 
-            if not record.issuer == DOCUMENT_ISSUER_PARTNER:
+            if record.issuer == DOCUMENT_ISSUER_PARTNER:
                 domain.append(('partner_id', '=', record.partner_id.id))
 
             if record.env["l10n_br_fiscal.document"].search(domain):


### PR DESCRIPTION
É gerado um erro no método de validação do numero do document fiscal, esse PR corrige o método de validação do numero do documento fiscal para permitir notas com a mesma serie e numero mas emitida por fornecedores diferentes.