### PR TITLE
[12.][FIX] fiscal closing temp directory

### DIFF
--- a/l10n_br_fiscal/models/closing.py
+++ b/l10n_br_fiscal/models/closing.py
@@ -329,7 +329,7 @@ class FiscalClosing(models.Model):
                 ziph.writestr(os.path.join(zip_path, file), file)
 
     def action_export(self):
-        temp_dir = tempfile.TemporaryDirectory(dir=os.getcwd())
+        temp_dir = tempfile.TemporaryDirectory()
 
         files_dir = self._prepara_arquivos(temp_dir)
         order_file = io.BytesIO()


### PR DESCRIPTION
No fechamento fiscal ao exportar os arquivos XML dos documentos fiscais, é criado um diretório temporário, mas é informado o parâmetro dir com o caminho absoluto do arquivo l10n_br_fiscal/models/closing.py o que gera um erro, pois o usuário que executa o odoo não deve ter permissão de escrita nesta pasta (por motivo de segurança). Ao remover o parâmetro dir é criado o diretório temporário na pasta temp do sistema operacional.