### PR TITLE
[12.0][FIX] l10n_br_nfse: is not possible select city_taxation_code on product_template form

### DIFF
--- a/l10n_br_nfse/__manifest__.py
+++ b/l10n_br_nfse/__manifest__.py
@@ -26,6 +26,7 @@
 
         'views/document_view.xml',
         'views/product_template_view.xml',
+        'views/product_product_view.xml',
         'views/document_line_view.xml',
         'views/res_company_view.xml',
 

--- a/l10n_br_nfse/views/product_product_view.xml
+++ b/l10n_br_nfse/views/product_product_view.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2020 - TODAY, Marcel Savegnago - Escodoo
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+        <record id="product_product_form" model="ir.ui.view">
+        <field name="name">l10n_br_fiscal.product.product.form</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_normal_form_view"/>
+        <field name="arch" type="xml">
+            <field name="nbs_id" position="after">
+                <field name="fiscal_deductions_value"/>
+            </field>
+            <field name="service_type_id" position="after">
+                <field name="city_taxation_code_id" context="{'default_service_type_id': service_type_id}">
+                    <tree editable="bottom">
+                        <field name="code" />
+                        <field name="name" />
+                        <field name="service_type_id" />
+                        <field name="state_id" />
+                        <field name="city_id" />
+                    </tree>
+                </field>
+            </field>
+        </field>
+    </record>
+
+
+</odoo>

--- a/l10n_br_nfse/views/product_template_view.xml
+++ b/l10n_br_nfse/views/product_template_view.xml
@@ -13,7 +13,7 @@
                 <field name="fiscal_deductions_value"/>
             </field>
             <field name="service_type_id" position="after">
-                <field name="city_taxation_code_id" widget="one2many_list" context="{'default_service_type_id': service_type_id}">
+                <field name="city_taxation_code_id" context="{'default_service_type_id': service_type_id}">
                     <tree editable="bottom">
                         <field name="code" />
                         <field name="name" />


### PR DESCRIPTION
I removed this widget because I was unable to select a city tax code. Honestly, I don't know if there is a better solution but I accept suggestions.