### PR TITLE
[12.0][FIX] fiscal document return

### DIFF
--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -801,7 +801,7 @@ class Document(models.Model):
         return_docs = self._create_return()
 
         if return_docs:
-            action['domain'] = literal_eval(action['domain'])
+            action['domain'] = literal_eval(action['domain'] or '[]')
             action['domain'].append(('id', 'in', return_docs.ids))
 
             return action

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -776,8 +776,8 @@ class Document(models.Model):
             fsc_op = record.fiscal_operation_id.return_fiscal_operation_id
             if not fsc_op:
                 raise ValidationError(_(
-                    "The fiscal operation {} there is no Return Fiscal "
-                    "Operation definied".format(record.fiscal_operation_id)))
+                    "The fiscal operation {} has no return Fiscal "
+                    "Operation defined".format(record.fiscal_operation_id)))
 
             new_doc = record.copy()
             new_doc.fiscal_operation_id = fsc_op
@@ -787,10 +787,11 @@ class Document(models.Model):
                 fsc_op_line = l.fiscal_operation_id.return_fiscal_operation_id
                 if not fsc_op_line:
                     raise ValidationError(_(
-                        "The fiscal operation {} there is no Return Fiscal "
-                        "Operation definied".format(l.fiscal_operation_id)))
+                        "The fiscal operation {} has no return Fiscal "
+                        "Operation defined".format(l.fiscal_operation_id)))
                 l.fiscal_operation_id = fsc_op_line
                 l._onchange_fiscal_operation_id()
+                l._onchange_fiscal_operation_line_id()
 
             return_docs |= new_doc
         return return_docs
@@ -804,7 +805,7 @@ class Document(models.Model):
             action['domain'] = literal_eval(action['domain'] or '[]')
             action['domain'].append(('id', 'in', return_docs.ids))
 
-            return action
+        return action
 
     def _document_comment_vals(self):
         return {

--- a/l10n_br_fiscal/tests/test_fiscal_document_generic.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_generic.py
@@ -10,7 +10,7 @@ from ..constants.icms import ICMS_ORIGIN_TAX_IMPORTED
 class TestFiscalDocumentGeneric(TransactionCase):
 
     def setUp(self):
-        super(TestFiscalDocumentGeneric, self).setUp()
+        super().setUp()
         # Contribuinte
         self.nfe_same_state = self.env.ref(
             'l10n_br_fiscal.demo_nfe_same_state'
@@ -775,10 +775,9 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
     def test_nfe_return(self):
         """ Test Fiscal Document Return """
-
         action = self.nfe_same_state.action_create_return()
         return_id = self.nfe_same_state.browse(
-            [i[2] for i in action['domain'] if i[0] == 'id'])
+            [i[2][0] for i in action['domain'] if i[0] == 'id'])
 
         self.assertEquals(
             return_id.fiscal_operation_id.id,

--- a/l10n_br_fiscal/views/l10n_br_fiscal_action.xml
+++ b/l10n_br_fiscal/views/l10n_br_fiscal_action.xml
@@ -579,6 +579,24 @@
         </field>
     </record>
 
+    <record id="document_action" model="ir.actions.act_window">
+        <field name="name">Fiscal Document</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">l10n_br_fiscal.document</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">kanban,tree,form</field>
+        <field name="search_view_id" ref="document_search"/>
+        <field name="view_id" ref="document_tree"/>
+        <field name="help" type="html">
+          <p class="o_view_nocontent_smiling_face">
+            Create a new Document
+          </p><p>
+            Odoo helps you easily track all activities
+            related to a fiscal operation.
+          </p>
+        </field>
+    </record>
+
     <!-- Fiscal Document In -->
     <record id="document_nfe_in_action" model="ir.actions.act_window">
         <field name="name">NF-e Receivement</field>


### PR DESCRIPTION
- [x] Não deve chamar o onchange do product_id na linha ao fazer as linhas de devolução (porque deve pegar os dados fiscais exatamente como da nota original);
- [x] O _create_return espera vários registros, mas é chamdo pelo método action_create_return tem um ensure_one();
- [x] Implementado uma validação caso a operação fiscal não tenha a operação de retorno definida
- [x] Não deveria gravar a operação fiscal do cabeçalho da NF-e em todas as linhas, pois cada linha pode ter operações fiscais diferentes e consequentemente operações fiscais de retorno diferentes.
