### PR TITLE
[REF] Additional data for document and document line

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -9,7 +9,7 @@
     "author": "Akretion, Odoo Community Association (OCA)",
     "maintainers": ["renatonlima"],
     "website": "http://github.com/OCA/l10n-brazil",
-    "version": "12.0.3.10.0",
+    "version": "12.0.4.0.0",
     "depends": [
         "uom",
         "decimal_precision",

--- a/l10n_br_fiscal/constants/fiscal.py
+++ b/l10n_br_fiscal/constants/fiscal.py
@@ -27,10 +27,16 @@ OPERATION_FISCAL_TYPE = [
 OPERATION_FISCAL_TYPE_DEFAULT = 'other'
 
 
-COMMENT_TYPE = [("fiscal", "Fiscal"), ("commercial", "Commercial")]
+COMMENT_TYPE = [
+    ('fiscal', 'Fiscal'),
+    ('commercial', 'Commercial'),
+]
 
 
-COMMENT_TYPE_DEFAULT = "commercial"
+COMMENT_TYPE_FISCAL = 'fiscal'
+
+
+COMMENT_TYPE_COMMERCIAL = 'commercial'
 
 
 PRODUCT_FISCAL_TYPE = (

--- a/l10n_br_fiscal/migrations/12.0.4.0.0/pre-migration.py
+++ b/l10n_br_fiscal/migrations/12.0.4.0.0/pre-migration.py
@@ -1,0 +1,14 @@
+# Copyright (C) 2020 - TODAY Renato Lima - Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+_columns_rename = {
+    'l10n_br_fiscal_document': [
+        ('additional_data', 'fiscal_additional_data')],
+}
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    openupgrade.rename_columns(env.cr, _columns_rename)

--- a/l10n_br_fiscal/migrations/12.0.4.0.0/pre-migration.py
+++ b/l10n_br_fiscal/migrations/12.0.4.0.0/pre-migration.py
@@ -11,4 +11,5 @@ _columns_rename = {
 
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
-    openupgrade.rename_columns(env.cr, _columns_rename)
+    if openupgrade.column_exists(env.cr, 'l10n_br_fiscal_document', 'additional_data'):
+        openupgrade.rename_columns(env.cr, _columns_rename)

--- a/l10n_br_fiscal/models/comment.py
+++ b/l10n_br_fiscal/models/comment.py
@@ -10,7 +10,7 @@ from odoo.osv import expression
 
 from ..constants.fiscal import (
     COMMENT_TYPE,
-    COMMENT_TYPE_DEFAULT,
+    COMMENT_TYPE_COMMERCIAL,
     FISCAL_COMMENT_OBJECTS,
 )
 
@@ -43,7 +43,7 @@ class Comment(models.Model):
     comment_type = fields.Selection(
         selection=COMMENT_TYPE,
         string='Comment Type',
-        default=COMMENT_TYPE_DEFAULT,
+        default=COMMENT_TYPE_COMMERCIAL,
         required=True,
     )
 

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -678,21 +678,6 @@ class Document(models.Model):
         default=False,
     )
 
-    def _document_comment_vals(self):
-        return {
-            'user': self.env.user,
-            'ctx': self._context,
-            'doc': self,
-        }
-
-    def document_comment(self):
-        for record in self:
-            record.additional_data = \
-                record.additional_data and record.additional_data + ' - ' or ''
-            record.additional_data += record.comment_ids.compute_message(
-                record._document_comment_vals())
-            record.line_ids.document_comment()
-
     @api.multi
     @api.constrains('number')
     def _check_number(self):
@@ -803,21 +788,6 @@ class Document(models.Model):
             action['domain'].append(('id', 'in', return_docs.ids))
 
         return action
-
-    def _document_comment_vals(self):
-        return {
-            'user': self.env.user,
-            'ctx': self._context,
-            'doc': self,
-        }
-
-    def document_comment(self):
-        for record in self:
-            record.additional_data = \
-                record.additional_data and record.additional_data + ' - ' or ''
-            record.additional_data += record.comment_ids.compute_message(
-                record._document_comment_vals())
-            record.line_ids.document_comment()
 
     def _get_email_template(self, state):
         self.ensure_one()

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin.py
@@ -926,6 +926,6 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         domain=[('object', '=', FISCAL_COMMENT_LINE)],
     )
 
-    additional_data = fields.Text(
+    additional_data = fields.Char(
         string='Additional Data',
     )

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin.py
@@ -925,3 +925,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         string='Comments',
         domain=[('object', '=', FISCAL_COMMENT_LINE)],
     )
+
+    additional_data = fields.Text(
+        string='Additional Data',
+    )

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -290,6 +290,20 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         self.price_unit = price.get(
             self.fiscal_operation_id.default_price_unit, 0.00)
 
+    def _document_comment_vals(self):
+        return {
+            'user': self.env.user,
+            'ctx': self._context,
+            'doc': self.document_id,
+            'item': self,
+        }
+
+    def document_comment(self):
+        for d in self.filtered('comment_ids'):
+            d.additional_data = d.additional_data or ''
+            d.additional_data += d.comment_ids.compute_message(
+                d._document_comment_vals())
+
     @api.onchange('fiscal_operation_id')
     def _onchange_fiscal_operation_id(self):
         if self.fiscal_operation_id:

--- a/l10n_br_fiscal/models/document_fiscal_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin.py
@@ -74,8 +74,12 @@ class FiscalDocumentMixin(models.AbstractModel):
         domain=[('object', '=', FISCAL_COMMENT_DOCUMENT)],
     )
 
-    additional_data = fields.Text(
-        string='Additional Data',
+    fiscal_additional_data = fields.Text(
+        string='Fiscal Additional Data',
+    )
+
+    customer_additional_data = fields.Text(
+        string='Customer Additional Data',
     )
 
     ind_final = fields.Selection(

--- a/l10n_br_fiscal/models/document_fiscal_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin_methods.py
@@ -3,6 +3,11 @@
 
 from odoo import api, models
 
+from ..constants.fiscal import (
+    COMMENT_TYPE_FISCAL,
+    COMMENT_TYPE_COMMERCIAL,
+)
+
 
 class FiscalDocumentMixinMethods(models.AbstractModel):
     _name = 'l10n_br_fiscal.document.mixin.methods'
@@ -25,6 +30,26 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
         if default:  # in case you want to use new rather than write later
             return {"default_%s" % (k,): vals[k] for k in vals.keys()}
         return vals
+
+    def _document_comment_vals(self):
+        return {
+            'user': self.env.user,
+            'ctx': self._context,
+            'doc': self,
+        }
+
+    def document_comment(self):
+        for d in self:
+            fiscal_additional_data = d.fiscal_additional_data or ''
+            d.fiscal_additional_data += d.comment_ids.filtered(
+                lambda c: c.comment_type == COMMENT_TYPE_FISCAL
+                    ).compute_message(
+                d._document_comment_vals())
+            d.customer_additional_data += d.comment_ids.filtered(
+                lambda c: c.comment_type == COMMENT_TYPE_COMMERCIAL
+                    ).compute_message(
+                d._document_comment_vals())
+            d.line_ids.document_comment()
 
     @api.onchange('fiscal_operation_id')
     def _onchange_fiscal_operation_id(self):

--- a/l10n_br_fiscal/models/document_fiscal_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin_methods.py
@@ -40,15 +40,21 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
 
     def document_comment(self):
         for d in self:
-            fiscal_additional_data = d.fiscal_additional_data or ''
-            d.fiscal_additional_data += d.comment_ids.filtered(
+            # Fiscal Comments
+            fsc_comments = []
+            fsc_comments.append(d.fiscal_additional_data or '')
+            fsc_comments.append(d.comment_ids.filtered(
                 lambda c: c.comment_type == COMMENT_TYPE_FISCAL
-                    ).compute_message(
-                d._document_comment_vals())
-            d.customer_additional_data += d.comment_ids.filtered(
+                    ).compute_message(d._document_comment_vals()) or '')
+            d.fiscal_additional_data = fsc_comments.join(', ')
+
+            # Commercial Coments
+            com_comments = []
+            com_comments.append(d.customer_additional_data or '')
+            com_comments.append(d.comment_ids.filtered(
                 lambda c: c.comment_type == COMMENT_TYPE_COMMERCIAL
-                    ).compute_message(
-                d._document_comment_vals())
+                    ).compute_message(d._document_comment_vals()) or '')
+            d.customer_additional_data = com_comments.join(', ')
             d.line_ids.document_comment()
 
     @api.onchange('fiscal_operation_id')

--- a/l10n_br_fiscal/models/document_fiscal_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin_methods.py
@@ -45,7 +45,7 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
             fsc_comments.append(d.fiscal_additional_data or '')
             fsc_comments.append(d.comment_ids.filtered(
                 lambda c: c.comment_type == COMMENT_TYPE_FISCAL
-                    ).compute_message(d._document_comment_vals()) or '')
+                ).compute_message(d._document_comment_vals()) or '')
             d.fiscal_additional_data = fsc_comments.join(', ')
 
             # Commercial Coments
@@ -53,7 +53,7 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
             com_comments.append(d.customer_additional_data or '')
             com_comments.append(d.comment_ids.filtered(
                 lambda c: c.comment_type == COMMENT_TYPE_COMMERCIAL
-                    ).compute_message(d._document_comment_vals()) or '')
+                ).compute_message(d._document_comment_vals()) or '')
             d.customer_additional_data = com_comments.join(', ')
             d.line_ids.document_comment()
 

--- a/l10n_br_fiscal/models/document_fiscal_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin_methods.py
@@ -46,7 +46,8 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
             fsc_comments.append(d.comment_ids.filtered(
                 lambda c: c.comment_type == COMMENT_TYPE_FISCAL
                 ).compute_message(d._document_comment_vals()) or '')
-            d.fiscal_additional_data = fsc_comments.join(', ')
+            d.fiscal_additional_data = ', '.join(
+                [c for c in fsc_comments if c])
 
             # Commercial Coments
             com_comments = []
@@ -54,7 +55,8 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
             com_comments.append(d.comment_ids.filtered(
                 lambda c: c.comment_type == COMMENT_TYPE_COMMERCIAL
                 ).compute_message(d._document_comment_vals()) or '')
-            d.customer_additional_data = com_comments.join(', ')
+            d.customer_additional_data = ', '.join(
+                [c for c in com_comments if c])
             d.line_ids.document_comment()
 
     @api.onchange('fiscal_operation_id')

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -116,10 +116,6 @@ class DocumentLine(models.Model):
         string='Product',
     )
 
-    additional_data = fields.Text(
-        string='Additional Data',
-    )
-
     # Amount Fields
     amount_estimate_tax = fields.Monetary(
         string='Amount Estimate Total',
@@ -168,18 +164,3 @@ class DocumentLine(models.Model):
         compute='_compute_amount',
         default=0.00,
     )
-
-    def _document_comment_vals(self):
-        return {
-            'user': self.env.user,
-            'ctx': self._context,
-            'doc': self.document_id,
-            'item': self,
-        }
-
-    def document_comment(self):
-        for record in self.filtered('comment_ids'):
-            record.additional_data = \
-                record.additional_data and record.additional_data + ' - ' or ''
-            record.additional_data += record.comment_ids.compute_message(
-                record._document_comment_vals())

--- a/l10n_br_fiscal/views/document_fiscal_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_fiscal_mixin_view.xml
@@ -9,6 +9,10 @@
         <group name="l10n_br_fiscal">
             <field name="fiscal_operation_id" required="1"/>
         </group>
+        <group name="l10n_br_fiscal_comment">
+            <field name="fiscal_additional_data"/>
+            <field name="customer_additional_data"/>
+        </group>
       </form>
     </field>
   </record>

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -286,7 +286,8 @@
             <page name="extra_info" string="Extra Info">
                 <group>
                     <field name="comment_ids" widget="many2many_tags" domain="[('object','=','l10n_br_fiscal.document')]"/>
-                    <field name="additional_data"/>
+                    <field name="fiscal_additional_data"/>
+                    <field name="customer_additional_data"/>
                 </group>
             </page>
           </notebook>


### PR DESCRIPTION
- [x] Alterado o campo additional_data no l10n_br_fiscal.document para fiscal_additional_data (dados adicionais para o fisco);
- [x] Criado o campo customer_additional_data para os dados adicionais para o contribuinte;
- [x] Movido os campos fiscal_additional_data e customer_additional_data no mixin do documento fiscal;
- [x] Corrigido metodos dupllicados document_comment e _document_comment_vals
- [x] Movido os metodos document_comment e _document_comment_vals para o mixin