### PR TITLE
[12.0] Atualizar endereço no onchange do campo zip

### DIFF
--- a/l10n_br_zip/models/__init__.py
+++ b/l10n_br_zip/models/__init__.py
@@ -4,3 +4,5 @@
 from . import res_config_settings
 from . import l10n_br_zip
 from . import format_address_mixin
+from . import res_company
+from . import res_partner

--- a/l10n_br_zip/models/res_company.py
+++ b/l10n_br_zip/models/res_company.py
@@ -1,0 +1,12 @@
+# Copyright (C) 2020  Gabriel Cardoso de Faria - Kmee
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import models, api
+
+class Company(models.Model):
+    _inherit = "res.company"
+
+    @api.onchange("zip")
+    def _onchange_zip(self):
+        super()._onchange_zip()
+        return self.zip_search()

--- a/l10n_br_zip/models/res_company.py
+++ b/l10n_br_zip/models/res_company.py
@@ -3,6 +3,7 @@
 
 from odoo import models, api
 
+
 class Company(models.Model):
     _inherit = "res.company"
 

--- a/l10n_br_zip/models/res_company.py
+++ b/l10n_br_zip/models/res_company.py
@@ -8,5 +8,10 @@ class Company(models.Model):
 
     @api.onchange("zip")
     def _onchange_zip(self):
-        super()._onchange_zip()
-        return self.zip_search()
+        res = super()._onchange_zip() or {}
+        try:
+            zip_search = self.zip_search()
+            res.update(zip_search)
+        except Exception as e:
+            pass
+        return res

--- a/l10n_br_zip/models/res_partner.py
+++ b/l10n_br_zip/models/res_partner.py
@@ -1,0 +1,12 @@
+# Copyright (C) 2020  Gabriel Cardoso de Faria - Kmee
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import models, api
+
+class Partner(models.Model):
+    _inherit = "res.partner"
+
+    @api.onchange("zip")
+    def _onchange_zip(self):
+        super()._onchange_zip()
+        return self.zip_search()

--- a/l10n_br_zip/models/res_partner.py
+++ b/l10n_br_zip/models/res_partner.py
@@ -3,6 +3,7 @@
 
 from odoo import models, api
 
+
 class Partner(models.Model):
     _inherit = "res.partner"
 

--- a/l10n_br_zip/models/res_partner.py
+++ b/l10n_br_zip/models/res_partner.py
@@ -8,5 +8,10 @@ class Partner(models.Model):
 
     @api.onchange("zip")
     def _onchange_zip(self):
-        super()._onchange_zip()
-        return self.zip_search()
+        res = super()._onchange_zip() or {}
+        try:
+            zip_search = self.zip_search()
+            res.update(zip_search)
+        except Exception as e:
+            pass
+        return res


### PR DESCRIPTION
Percebemos que o botão pesquisar cep não estava sendo adicionado em todos os formulários dos parceiros e empresas. Após várias tentativas, constatei que resolver isso para todos os casos não seria tão simples, visto que a única solução plausível seria mexer no _fields_view_get para colocar o botão dinamicamente. Uma solução mais simples é a implementada nesse PR, em que o endereço é pesquisado e atualizado sempre que se muda o campo CEP.