### PR TITLE
[12.0] Adapt Multi company sale orders

### DIFF
--- a/l10n_br_sale/__init__.py
+++ b/l10n_br_sale/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2009  Renato Lima - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+from .hooks import post_init_hook
+
 from . import models
 from . import report
 from . import tests

--- a/l10n_br_sale/__manifest__.py
+++ b/l10n_br_sale/__manifest__.py
@@ -35,7 +35,7 @@
     ],
     "installable": True,
     "auto_install": True,
+    "post_init_hook": "post_init_hook",
     "development_status": "Production/Stable",
     "maintainers": ["renatonlima"],
-    "external_dependencies": {"python": ["erpbrasil.base"]},
 }

--- a/l10n_br_sale/demo/l10n_br_sale.xml
+++ b/l10n_br_sale/demo/l10n_br_sale.xml
@@ -174,7 +174,7 @@
         <field name="partner_id" ref="l10n_br_base.res_partner_akretion"/>
         <field name="partner_invoice_id" ref="l10n_br_base.res_partner_akretion"/>
         <field name="partner_shipping_id" ref="l10n_br_base.res_partner_akretion"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="user_id" ref="l10n_br_base.user_demo_simples"/>
         <field name="pricelist_id" ref="product.list0"/>
         <field name="team_id" ref="sales_team.crm_team_1"/>
         <field name="state">draft</field>
@@ -229,7 +229,7 @@
         <field name="partner_id" ref="l10n_br_base.res_partner_akretion"/>
         <field name="partner_invoice_id" ref="l10n_br_base.res_partner_akretion"/>
         <field name="partner_shipping_id" ref="l10n_br_base.res_partner_akretion"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="user_id" ref="l10n_br_base.user_demo_simples"/>
         <field name="pricelist_id" ref="product.list0"/>
         <field name="team_id" ref="sales_team.crm_team_1"/>
         <field name="state">draft</field>
@@ -284,7 +284,7 @@
         <field name="partner_id" ref="l10n_br_base.res_partner_akretion"/>
         <field name="partner_invoice_id" ref="l10n_br_base.res_partner_akretion"/>
         <field name="partner_shipping_id" ref="l10n_br_base.res_partner_akretion"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="user_id" ref="l10n_br_base.user_demo_simples"/>
         <field name="pricelist_id" ref="product.list0"/>
         <field name="team_id" ref="sales_team.crm_team_1"/>
         <field name="state">draft</field>
@@ -340,7 +340,7 @@
         <field name="partner_id" ref="l10n_br_base.res_partner_akretion"/>
         <field name="partner_invoice_id" ref="l10n_br_base.res_partner_akretion"/>
         <field name="partner_shipping_id" ref="l10n_br_base.res_partner_akretion"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="user_id" ref="l10n_br_base.user_demo_presumido"/>
         <field name="pricelist_id" ref="product.list0"/>
         <field name="team_id" ref="sales_team.crm_team_1"/>
         <field name="state">draft</field>
@@ -395,7 +395,7 @@
         <field name="partner_id" ref="l10n_br_base.res_partner_akretion"/>
         <field name="partner_invoice_id" ref="l10n_br_base.res_partner_akretion"/>
         <field name="partner_shipping_id" ref="l10n_br_base.res_partner_akretion"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="user_id" ref="l10n_br_base.user_demo_presumido"/>
         <field name="pricelist_id" ref="product.list0"/>
         <field name="team_id" ref="sales_team.crm_team_1"/>
         <field name="state">draft</field>
@@ -450,7 +450,7 @@
         <field name="partner_id" ref="l10n_br_base.res_partner_akretion"/>
         <field name="partner_invoice_id" ref="l10n_br_base.res_partner_akretion"/>
         <field name="partner_shipping_id" ref="l10n_br_base.res_partner_akretion"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="user_id" ref="l10n_br_base.user_demo_presumido"/>
         <field name="pricelist_id" ref="product.list0"/>
         <field name="team_id" ref="sales_team.crm_team_1"/>
         <field name="state">draft</field>

--- a/l10n_br_sale/hooks.py
+++ b/l10n_br_sale/hooks.py
@@ -1,0 +1,21 @@
+# Copyright (C) 2020  Renato Lima - Akretion <renato.lima@akretion.com.br>
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import api, tools, SUPERUSER_ID
+
+
+def post_init_hook(cr, registry):
+
+    if not tools.config['without_demo']:
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        sale_orders = env['sale.order'].search(
+            [('company_id', '!=', env.ref('base.main_company').id)])
+
+        for order in sale_orders:
+            defaults = order.sudo(
+                user=order.user_id.id).default_get(order._fields)
+            defaults.update({
+                'name': order.name,
+                'fiscal_operation_id': order.fiscal_operation_id.id
+            })
+            order.write(defaults)


### PR DESCRIPTION
Com o merge do l10n_br_stock_account, agora no travis esta sendo instalado o módulo sale_stock, que por padrão esta atribuindo o campo warehouse_id com o armazem da empresa principal, este PR implementa um hook no módulo l10n_br_sale para carregar os valores default corretamente nas sale orders de demo das outras empresas.