### PR TITLE
[FIX] l10n_br_sale: Correção do Tipo de Documento Fiscal

### DIFF
--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -267,7 +267,9 @@ class SaleOrder(models.Model):
                     document_type_list.append(fiscal_document_type.id)
 
             # Check if there more than one Document Type
-            if len(document_type_list) > 1:
+            if ((fiscal_document_type !=
+                    invoice_created_by_super.document_type_id.id) or
+                    (len(document_type_list) > 1)):
 
                 # Remove the First Document Type,
                 # already has Invoice created


### PR DESCRIPTION
Atualmente quando no cadastro da empresa o tipo de documento fiscal é **Nota Fiscal Eletrônica** e a SO tem somente itens do tipo fiscal Serviço (identifiquei o problema quando a SO tem 2 linhas de serviços e sem nenhum produto)

cc @mbcosta @mileo @renatonlima 