### PR TITLE
[IMP] l10n_br_fiscal: Adiciona o campo Issuer na Operação Fiscal

### DIFF
--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -866,6 +866,11 @@ class Document(models.Model):
             }))
         self.document_subsequent_ids = subsequent_documents
 
+    @api.onchange('issuer')
+    def _onchange_issuer(self):
+        if self.issuer == DOCUMENT_ISSUER_COMPANY:
+            self.document_type_id = self.company_id.document_type_id
+
     @api.onchange('document_type_id')
     def _onchange_document_type_id(self):
         if self.document_type_id and self.issuer == DOCUMENT_ISSUER_COMPANY:

--- a/l10n_br_fiscal/models/document_fiscal_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin_methods.py
@@ -30,4 +30,5 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
     def _onchange_fiscal_operation_id(self):
         if self.fiscal_operation_id:
             self.operation_name = self.fiscal_operation_id.name
+            self.issuer = self.fiscal_operation_id.issuer
             self.comment_ids = self.fiscal_operation_id.comment_ids

--- a/l10n_br_fiscal/models/operation.py
+++ b/l10n_br_fiscal/models/operation.py
@@ -13,6 +13,8 @@ from ..constants.fiscal import (
     OPERATION_STATE_DEFAULT,
     OPERATION_STATE,
     FISCAL_COMMENT_DOCUMENT,
+    DOCUMENT_ISSUER,
+    DOCUMENT_ISSUER_COMPANY,
 )
 
 
@@ -122,6 +124,13 @@ class Operation(models.Model):
         comodel_name='l10n_br_fiscal.subsequent.operation',
         inverse_name='fiscal_operation_id',
         string='Subsequent Operation')
+
+    issuer = fields.Selection(
+        selection=DOCUMENT_ISSUER,
+        default=DOCUMENT_ISSUER_COMPANY,
+        required=True,
+        string='Issuer',
+    )
 
     _sql_constraints = [(
         "fiscal_operation_code_uniq",

--- a/l10n_br_fiscal/views/operation_view.xml
+++ b/l10n_br_fiscal/views/operation_view.xml
@@ -47,6 +47,7 @@
                             <field name="fiscal_operation_type"/>
                             <field name="fiscal_type"/>
                             <field name="ind_final"/>
+                            <field name="issuer"/>
                             <field name="company_id"/>
                         </group>
                         <group>


### PR DESCRIPTION
Adiciona o campo Issuer na Operação Fiscal e campo Issuer do Documento Fiscal foi alterado para se relacionar com o valor da Operação Fiscal.

cc @renatonlima @mileo @jpcarassato 