### PR TITLE
[12.0][FIX] Load sale_order_line price in generated fiscal document lines

### DIFF
--- a/l10n_br_account/models/__init__.py
+++ b/l10n_br_account/models/__init__.py
@@ -11,4 +11,5 @@ from . import fiscal_operation_line
 from . import account_invoice
 from . import account_invoice_line
 from . import fiscal_document
+from . import fiscal_document_line
 from . import account_move_line

--- a/l10n_br_account/models/fiscal_document_line.py
+++ b/l10n_br_account/models/fiscal_document_line.py
@@ -1,0 +1,14 @@
+# Copyright (C) 2020 - Gabriel Cardoso de Faria <gabriel.cardoso@kmee.com.br>
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import models
+
+
+class FiscalDocumentLine(models.Model):
+    _inherit = 'l10n_br_fiscal.document.line'
+
+    def _get_product_price(self):
+        if not self.price_unit or self.price_unit in (
+                self.product_id.list_price, self.product_id.standard_price):
+            return super()._get_product_price()
+        return self.price_unit


### PR DESCRIPTION
Percebi que quando era setado um preço na linha da venda, diferente do preço padrão de venda do produto, esse preço ia para a linha da fatura, mas era sobrescrito na linha do documento. Essa pequena correção no módulo l10n_br_account resolve esse problema.