### PR TITLE
l10n_br_base faster tests: tracking_disable + SavepointCase

### DIFF
--- a/l10n_br_base/tests/test_amount_to_text.py
+++ b/l10n_br_base/tests/test_amount_to_text.py
@@ -2,10 +2,9 @@
 #   Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-
 import logging
 
-from odoo.tests.common import TransactionCase
+from odoo.tests import SavepointCase
 
 _logger = logging.getLogger(__name__)
 
@@ -15,9 +14,11 @@ except ImportError:
     _logger.info("Biblioteca Num2Words não instalada")
 
 
-class Num2WordsPTBRTest(TransactionCase):
-    def setUp(self):
-        super(Num2WordsPTBRTest, self).setUp()
+class Num2WordsPTBRTest(SavepointCase):
+
+    @classmethod
+    def setUpClass(self):
+        super().setUpClass()
         self.n2w = Num2Word_PT_BR()
 
     def test_01_amount_to_text(self):

--- a/l10n_br_base/tests/test_base_onchange.py
+++ b/l10n_br_base/tests/test_base_onchange.py
@@ -2,29 +2,33 @@
 #   Clément Mombereau <clement.mombereau@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo.tests.common import TransactionCase
+from odoo.tests import SavepointCase
 
 
-class L10nBrBaseOnchangeTest(TransactionCase):
-    def setUp(self):
-        super(L10nBrBaseOnchangeTest, self).setUp()
+class L10nBrBaseOnchangeTest(SavepointCase):
 
-        self.company_01 = self.env["res.company"].create(
-            {
-                "name": "Company Test 1",
-                "cnpj_cpf": "02.960.895/0001-31",
-                "city_id": self.env.ref("l10n_br_base.city_3205002").id,
-                "zip": "29161-695",
-            }
-        )
+    @classmethod
+    def setUpClass(self):
+        super().setUpClass()
+
+        self.company_01 = self.env["res.company"].with_context(
+            tracking_disable=True).create(
+                {
+                    "name": "Company Test 1",
+                    "cnpj_cpf": "02.960.895/0001-31",
+                    "city_id": self.env.ref("l10n_br_base.city_3205002").id,
+                    "zip": "29161-695",
+                }
+            )
 
         self.bank_01 = self.env["res.bank"].create(
             {"name": "Bank Test 1", "zip": "29161-695"}
         )
 
-        self.partner_01 = self.env["res.partner"].create(
-            {"name": "Partner Test 01", "zip": "29161-695"}
-        )
+        self.partner_01 = self.env["res.partner"].with_context(
+            tracking_disable=True).create(
+                {"name": "Partner Test 01", "zip": "29161-695"}
+            )
 
     def test_onchange(self):
         """
@@ -93,5 +97,6 @@ class L10nBrBaseOnchangeTest(TransactionCase):
         self.assertEquals(
             display_address,
             "Rua Paulo Dias, 586 \nCentro" "\n18125-000 - Alumínio-SP\nBrazil",
-            "The function _display_address with parameter" " without_company failed.",
+            "The function _display_address with parameter"
+            " without_company failed.",
         )

--- a/l10n_br_base/tests/test_other_ie.py
+++ b/l10n_br_base/tests/test_other_ie.py
@@ -2,20 +2,22 @@
 #   Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-
 import logging
 
-from odoo.tests.common import TransactionCase
+from odoo.tests import SavepointCase
 from odoo.tools import mute_logger
 
 _logger = logging.getLogger(__name__)
 
 
-class OtherIETest(TransactionCase):
-    def setUp(self):
-        super(OtherIETest, self).setUp()
+class OtherIETest(SavepointCase):
+
+    @classmethod
+    def setUpClass(self):
+        super().setUpClass()
         self.company_model = self.env["res.company"]
-        self.company = self.company_model.create(
+        self.company = self.company_model.with_context(
+            tracking_disable=True).create(
             {
                 "name": "Akretion Sao Paulo",
                 "legal_name": "Akretion Sao Paulo",
@@ -24,9 +26,9 @@ class OtherIETest(TransactionCase):
                 "street": "Rua Paulo Dias",
                 "street_number": "586",
                 "district": "Alumínio",
-                "state_id": self.ref("base.state_br_sp"),
-                "city_id": self.ref("l10n_br_base.city_3501152"),
-                "country_id": self.ref("base.br"),
+                "state_id": self.env.ref("base.state_br_sp"),
+                "city_id": self.env.ref("l10n_br_base.city_3501152"),
+                "country_id": self.env.ref("base.br"),
                 "city": "Alumínio",
                 "zip": "18125-000",
                 "phone": "+55 (21) 3010 9965",
@@ -44,7 +46,7 @@ class OtherIETest(TransactionCase):
                         0,
                         0,
                         {
-                            "state_id": self.ref("base.state_br_ba"),
+                            "state_id": self.env.ref("base.state_br_ba").id,
                             "inscr_est": 41902653,
                         },
                     )
@@ -66,7 +68,7 @@ class OtherIETest(TransactionCase):
                             0,
                             0,
                             {
-                                "state_id": self.ref("base.state_br_ba"),
+                                "state_id": self.env.ref("base.state_br_ba").id,
                                 "inscr_est": 67729139,
                             },
                         )
@@ -89,7 +91,7 @@ class OtherIETest(TransactionCase):
                             0,
                             0,
                             {
-                                "state_id": self.ref("base.state_br_am"),
+                                "state_id": self.env.ref("base.state_br_am").id,
                                 "inscr_est": "042933681",
                             },
                         )
@@ -109,7 +111,7 @@ class OtherIETest(TransactionCase):
                             0,
                             0,
                             {
-                                "state_id": self.ref("base.state_br_sp"),
+                                "state_id": self.env.ref("base.state_br_sp").id,
                                 "inscr_est": 692015742119,
                             },
                         )
@@ -131,7 +133,7 @@ class OtherIETest(TransactionCase):
                         0,
                         0,
                         {
-                            "state_id": self.ref("base.state_br_ba"),
+                            "state_id": self.env.ref("base.state_br_ba").id,
                             "inscr_est": 41902653,
                         },
                     )

--- a/l10n_br_base/tests/test_valid_createid.py
+++ b/l10n_br_base/tests/test_valid_createid.py
@@ -3,14 +3,15 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo.exceptions import ValidationError
-from odoo.tests.common import TransactionCase
+from odoo.tests import SavepointCase
 
 
-class ValidCreateIdTest(TransactionCase):
+class ValidCreateIdTest(SavepointCase):
     """Test if ValidationError is raised well during create({})"""
 
-    def setUp(self):
-        super(ValidCreateIdTest, self).setUp()
+    @classmethod
+    def setUpClass(self):
+        super().setUpClass()
 
         self.company_valid = {
             "name": "Company Test 1",
@@ -112,7 +113,8 @@ class ValidCreateIdTest(TransactionCase):
     def test_comp_valid(self):
         """Try do create id with correct CNPJ and correct Inscricao Estadual"""
         try:
-            company = self.env["res.company"].create(self.company_valid)
+            company = self.env["res.company"].with_context(
+                tracking_disable=True).create(self.company_valid)
         except:
             assert (
                 company
@@ -123,20 +125,23 @@ class ValidCreateIdTest(TransactionCase):
         """Test if ValidationError raised during .create() with invalid CNPJ
             and correct Inscricao Estadual"""
         with self.assertRaises(ValidationError):
-            self.env["res.company"].create(self.company_invalid_cnpj)
+            self.env["res.company"].with_context(
+                tracking_disable=True).create(self.company_invalid_cnpj)
 
     def test_comp_invalid_inscr_est(self):
         """Test if ValidationError raised with correct CNPJ
             and invalid Inscricao Estadual"""
         with self.assertRaises(ValidationError):
-            self.env["res.company"].create(self.company_invalid_inscr_est)
+            self.env["res.company"].with_context(
+                tracking_disable=True).create(self.company_invalid_inscr_est)
 
     # Tests on partners
 
     def test_part_valid(self):
         """Try do create id with correct CPF and correct Inscricao Estadual"""
         try:
-            partner = self.env["res.partner"].create(self.partner_valid)
+            partner = self.env["res.partner"].with_context(
+                tracking_disable=True).create(self.partner_valid)
         except:
             assert (
                 partner
@@ -147,7 +152,8 @@ class ValidCreateIdTest(TransactionCase):
         """Test if ValidationError raised during .create() with invalid CPF
             and correct Inscricao Estadual"""
         with self.assertRaises(ValidationError):
-            self.env["res.partner"].create(self.partner_invalid_cpf)
+            self.env["res.partner"].with_context(
+                tracking_disable=True).create(self.partner_invalid_cpf)
 
 
 # No test on Inscricao Estadual for partners with CPF


### PR DESCRIPTION
pessoal, vendo que com os novos modulos a CI leva uns 15 minutos e ate mais de 25 minutos no Runbot, comecei a ver onde a gente podia otimizar as coisas. Nesse modulo foi mais para começar ja que nao tinha tanto para ganhar. O ganho nesse modulo base foi de apenas 5 segundos no Travis. Mas bom ja que esta aqui tb nao faz mal. Salva umas dezenas de requests tb. o l10n_br_base nao depende do modulo mail (o lance do tracking_disable) mas o Travis instala ele antes de lançar os testes e entao tem impacto sim.

Pensei eu poderia ter ganhos maiores em outros modulos aplicando as mesmas tecnicas. Pelo que eu vi no l10n_br_fiscal nao tem tanta margem de ganho nao (porque os testes nao criam muita coisa, os registros ja vem do demo). Testei tb nos modulos purchase mas ainda nao terminei.