### PR TITLE
[FIX] Fix Unidade de medida CENTO

### DIFF
--- a/l10n_br_fiscal/data/uom_data.xml
+++ b/l10n_br_fiscal/data/uom_data.xml
@@ -179,7 +179,7 @@
         <field name="category_id" ref="uom.product_uom_categ_unit"/>
         <field name="code">CENTO</field>
         <field name="name">CENTO</field>
-        <field name="factor" eval="1000"/>
+        <field name="factor_inv" eval="100"/>
         <field name="uom_type">bigger</field>
     </record>
 


### PR DESCRIPTION
When `uom_type` is "bigger", needs to use `factor_inv` instead of `factor`.