### PR TITLE
[12.0][IMP] Suporte à nota de entrada no módulo fiscal

### DIFF
--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -181,7 +181,7 @@ class DocumentLine(models.Model):
         comodel_name='uom.uom',
         string="Unit",
     )
-    billed_cfop_id = fields.Many2one(
+    entry_cfop_id = fields.Many2one(
         comodel_name='l10n_br_fiscal.cfop',
         string='In CFOP',
     )

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -158,3 +158,22 @@ class DocumentLine(models.Model):
         compute='_compute_amount',
         default=0.00,
     )
+
+    # Entry fields
+    product_name = fields.Char(
+        string='Vendor Product Name',
+    )
+    product_code = fields.Char(
+        string='Vendor Product Code',
+    )
+    qty_received = fields.Float(
+        string='Received',
+    )
+    entry_uom_id = fields.Many2one(
+        comodel_name='uom.uom',
+        string="Unit",
+    )
+    billed_cfop_id = fields.Many2one(
+        comodel_name='l10n_br_fiscal.cfop',
+        string='In CFOP',
+    )

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -71,6 +71,39 @@ class DocumentLine(models.Model):
             elif record.fiscal_operation_type == 'in':
                 record.tax_framework = record.partner_id.tax_framework
 
+    @api.depends(
+        'exclude_icms',
+        'exclude_icms_st',
+        'exclude_ipi',
+        'exclude_insurance',
+        'exclude_pis',
+        'exclude_cofins',
+        'exclude_freight',
+        'exclude_other_costs',
+        'amount_total')
+    def _compute_amount_total_cost(self):
+        for record in self:
+            record.amount_total_cost = record.amount_total
+
+            if record.exclude_icms:
+                record.amount_total_cost -= record.icms_value
+            if record.exclude_icms_st:
+                record.amount_total_cost -= record.icmsst_value
+            if record.exclude_ipi:
+                record.amount_total_cost -= record.ipi_value
+            if record.exclude_insurance:
+                record.amount_total_cost -= record.insurance_value
+            if record.exclude_pis:
+                record.amount_total_cost -= record.pis_value
+            if record.exclude_cofins:
+                record.amount_total_cost -= record.cofins_value
+            if record.exclude_freight:
+                record.amount_total_cost -= record.freight_value
+            if record.exclude_other_costs:
+                record.amount_total_cost -= record.other_costs_value
+
+            record.amount_total_cost /= record.quantity
+
     @api.model
     def _operation_domain(self):
         domain = [('state', '=', 'approved')]
@@ -184,4 +217,35 @@ class DocumentLine(models.Model):
     entry_cfop_id = fields.Many2one(
         comodel_name='l10n_br_fiscal.cfop',
         string='In CFOP',
+    )
+
+    # CMC
+    exclude_icms = fields.Boolean(
+        string='Exclude ICMS'
+    )
+    exclude_icms_st = fields.Boolean(
+        string='Exclude ICMS ST'
+    )
+    exclude_ipi = fields.Boolean(
+        string='Exclude IPI'
+    )
+    exclude_insurance = fields.Boolean(
+        string='Exclude Insurance'
+    )
+    exclude_pis = fields.Boolean(
+        string='Exclude PIS'
+    )
+    exclude_cofins = fields.Boolean(
+        string='Exclude COFINS'
+    )
+    exclude_freight = fields.Boolean(
+        string='Exclude Freight'
+    )
+    exclude_other_costs = fields.Boolean(
+        string='Exclude Other Costs'
+    )
+    amount_total_cost = fields.Monetary(
+        string='Entry Cost',
+        compute='_compute_amount_total_cost',
+        default=0.00,
     )

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -63,6 +63,14 @@ class DocumentLine(models.Model):
                 record.amount_tax_withholding
             )
 
+    @api.depends('fiscal_operation_type')
+    def _compute_tax_framework(self):
+        for record in self:
+            if record.fiscal_operation_type == 'out':
+                record.tax_framework = record.company_id.tax_framework
+            elif record.fiscal_operation_type == 'in':
+                record.tax_framework = record.partner_id.tax_framework
+
     @api.model
     def _operation_domain(self):
         domain = [('state', '=', 'approved')]
@@ -97,8 +105,8 @@ class DocumentLine(models.Model):
 
     tax_framework = fields.Selection(
         selection=TAX_FRAMEWORK,
-        related='company_id.tax_framework',
         string='Tax Framework',
+        compute='_compute_tax_framework',
     )
 
     partner_id = fields.Many2one(

--- a/l10n_br_fiscal/views/document_line_view.xml
+++ b/l10n_br_fiscal/views/document_line_view.xml
@@ -102,6 +102,38 @@
             </group>
           </page>
           <page name="fiscal_line_extra_info" string="Extra Info"/>
+          <page name="inventory_cost" string="Inventory Cost">
+              <group>
+                <group>
+                  <field name="exclude_icms"/>
+                  <field name="exclude_icms_st"/>
+                  <field name="exclude_ipi"/>
+                  <field name="exclude_insurance"/>
+                </group>
+                <group>
+                  <field name="exclude_pis"/>
+                  <field name="exclude_cofins"/>
+                  <field name="exclude_freight"/>
+                  <field name="exclude_other_costs"/>
+                </group>
+              </group>
+              <group>
+                  <label for="amount_total_cost"/>
+                  <div>
+                      <field name="amount_total_cost"/>
+                  </div>
+              </group>
+          </page>
+          <page name="extra_info" string="Extra Info">
+            <group>
+                <field name="partner_order"/>
+                <field name="partner_order_line"/>
+            </group>
+            <group>
+                <field name="comment_ids" widget="many2many_tags" domain="[('object','=','l10n_br_fiscal.document.line')]"/>
+                <field name="additional_data"/>
+            </group>
+          </page>
         </notebook>
       </form>
     </field>

--- a/l10n_br_fiscal/views/document_line_view.xml
+++ b/l10n_br_fiscal/views/document_line_view.xml
@@ -39,8 +39,8 @@
                     <field name="entry_uom_id" groups="uom.group_uom" class="oe_inline"/>
                 </div>
                 <div class="col-4 oe_inline">
-                    <label for="billed_cfop_id" class="col-4 col-lg-4 o_light_label oe_inline"/>
-                    <field name="billed_cfop_id" class="oe_inline"/>
+                    <label for="entry_cfop_id" class="col-4 col-lg-4 o_light_label oe_inline"/>
+                    <field name="entry_cfop_id" class="oe_inline"/>
                 </div>
             </h3>
         </div>

--- a/l10n_br_fiscal/views/document_line_view.xml
+++ b/l10n_br_fiscal/views/document_line_view.xml
@@ -19,6 +19,31 @@
           <field name="product_id" context="{'tree_view_ref': 'product_template_tree', 'form_view_ref': 'product.product_template_only_form_view'}"/>
           <field name="name" required="1"/>
         </group>
+        <group attrs="{'invisible': [('fiscal_operation_type', '!=', 'in')]}">
+          <group>
+              <field name="product_code"/>
+          </group>
+          <group>
+              <field name="product_name"/>
+          </group>
+        </group>
+        <div class="oe_slogan" style="background-color:#FFB6C1;" attrs="{'invisible': [('fiscal_operation_type', '!=', 'in')]}">
+            <h2>Entry data</h2>
+            <h3 class="content-group mt16 row">
+                <div class="col-4 oe_inline">
+                    <label for="qty_received" class="col-4 col-lg-4 o_light_label oe_inline"/>
+                    <field name="qty_received" class="oe_inline"/>
+                </div>
+                <div class="col-4 oe_inline">
+                    <label for="entry_uom_id" groups="uom.group_uom" class="col-4 col-lg-4 o_light_label oe_inline"/>
+                    <field name="entry_uom_id" groups="uom.group_uom" class="oe_inline"/>
+                </div>
+                <div class="col-4 oe_inline">
+                    <label for="billed_cfop_id" class="col-4 col-lg-4 o_light_label oe_inline"/>
+                    <field name="billed_cfop_id" class="oe_inline"/>
+                </div>
+            </h3>
+        </div>
         <notebook>
           <page name="general" string="General">
             <group>


### PR DESCRIPTION
Esse Pull Request busca adaptar o módulo fiscal para lidar com documentos fiscais de entrada. Mapeamos as seguintes atividades até o momento:

- [x] Adicionar campos para registrar as diferenças entre a nota fiscal do fornecedor e a nota de entrada em quantidades e unidades;

- [x] Adicionar campos para registrar o código e o nome do produto na nota fiscal do fornecedor;

- [x] Remover o related do campo tax_framework na linha do documento e preenchê-lo com base na empresa em notas de saída e com base no parceiro em notas de entrada;

- [x] Calcular o custo da mercadoria comprada, sendo possível selecionar que impostos compõem ou não o custo.