### PR TITLE
[12.0] make XML export schema agnostic

### DIFF
--- a/spec_driven_model/models/spec_mixin.py
+++ b/spec_driven_model/models/spec_mixin.py
@@ -11,6 +11,7 @@ class SpecMixin(models.AbstractModel):
     _description = "root abstract model meant for xsd generated fiscal models"
     _name = 'spec.mixin'
     # _spec_module = 'override.with.your.python.module'
-    # _odoo_module = 'your Odoo module'
+    # _binding_module = 'your.pyhthon.binding.module'
+    # _odoo_module = 'your.odoo_module'
     # _field_prefix = 'your_field_prefix_'
     # _schema_name = 'your_schema_name'

--- a/spec_driven_model/models/spec_models.py
+++ b/spec_driven_model/models/spec_models.py
@@ -201,7 +201,7 @@ class StackedModel(SpecModel):
     stacked in a denormalized way inside these two tables only.
     Because StackedModel has its _build_method overriden to do some magic
     during module loading it should be inherited the Python way
-    with MyObject(spec_models.StackedModel).
+    with MyModel(spec_models.StackedModel).
     """
     _register = False  # forces you to inherit StackeModel properly
 


### PR DESCRIPTION
make XML export schema agnostic.

This is also required to get https://github.com/OCA/l10n-brazil/pull/1043 tests passing.

Warning you will also need these settings in your schema module:
https://github.com/akretion/l10n-brazil/blob/12.0-add-l10n_br_nfe_spec/l10n_br_nfe_spec/models/spec_models.py#L15