### PR TITLE
[12.0][IMP] Ajustando DANFSE

### DIFF
--- a/l10n_br_nfse/report/danfse.xml
+++ b/l10n_br_nfse/report/danfse.xml
@@ -60,7 +60,7 @@
                     <br />
                     Secretaria Municipal da Fazenda
                     <br />
-                    NOTA FISCAL ELETRÔNICA DE SERVIÇO - <span style="text-transform:uppercase" t-field="doc.company_id.provedor_nfse" />
+                    NOTA FISCAL ELETRÔNICA DE SERVIÇO
                 </div>
                 <div class="col-3" style="padding:0px;">
                     <div style="padding: 3px; text-align:center;">
@@ -304,49 +304,39 @@
             </div>
 
             <div class="row completa">
-                <div class="col rotulo br">
+                <div class="col-2 rotulo br">
                     PIS
                 </div>
-                <div class="col linha br centro">
+                <div class="col-1 linha br centro">
                     <span t-field="doc.line_ids[0].pis_wh_value" />
                 </div>
-                <div class="col rotulo br">
+                <div class="col-1 rotulo br">
                     COFINS
                 </div>
-                <div class="col linha br centro">
+                <div class="col-1 linha br centro">
                     <span t-field="doc.line_ids[0].cofins_wh_value" />
                 </div>
-                <div class="col rotulo br">
-                    IR(R$)
+                <div class="col-1 rotulo br">
+                    CSLL
                 </div>
-                <div class="col linha br centro">
+                <div class="col-1 linha br centro">
+                    <span t-field="doc.line_ids[0].csll_wh_value" />
+                </div>
+                <div class="col-1 rotulo br">
+                    IR
+                </div>
+                <div class="col-1 linha br centro">
                     <span t-field="doc.line_ids[0].irpj_wh_value" />
                 </div>
-                <div class="col rotulo br">
-                    INSS(R$)
+                <div class="col-1 rotulo br">
+                    INSS
                 </div>
-                <div class="col linha br centro">
+                <div class="col-2 linha centro">
                     <span t-field="doc.line_ids[0].inss_wh_value" />
-                </div>
-                <div class="col rotulo br">
-                    CSLL(R$)
-                </div>
-                <div class="col linha br centro">
-                    <span t-field="doc.line_ids[0].csll_wh_value" />
                 </div>
             </div>
 
-            <div class="row completa">
-                <div class="col-5 rotulo-header br">
-                    Detalhamento de Valores - Prestador dos Serviços
-                </div>
-                <div class="col-2 rotulo-header br">
-                    Outras Retenções
-                </div>
-                <div class="col-5 rotulo-header">
-                    Cálculo do ISSQN devido no Município
-                </div>
-            </div>
+            <div class="row centro" style="border: 0px; padding: 2px;" />
 
             <div class="row completa">
                 <div class="col-3 rotulo esquerda br">


### PR DESCRIPTION
- [x] Remover do título da nfse o nome do provedor. (para ganhar mais espaço no documento. a principio não vejo necessidade de sair impresso o provedor.. mas qualquer sugestão é bem vinda)
- [x] Corrigir impressão dos impostos retidos

![image](https://user-images.githubusercontent.com/3595132/103016920-9b7f9880-4521-11eb-9de3-d00568ad53ba.png)

cc @mileo @gabrielcardoso21 @luismalta 