### PR TITLE
[12.0][FIX] Tamanho do campo discriminacao

### DIFF
--- a/l10n_br_nfse/models/document_line.py
+++ b/l10n_br_nfse/models/document_line.py
@@ -120,6 +120,6 @@ class DocumentLine(models.Model):
                 self.service_type_id.code.replace('.', ''),
             'codigo_tributacao_municipio':
                 self.city_taxation_code_id.code or '',
-            'discriminacao': str(self.name[:120] or ''),
+            'discriminacao': str(self.name[:2000] or ''),
             'codigo_cnae': misc.punctuation_rm(self.cnae_id.code) or None,
         }


### PR DESCRIPTION
O campo discriminação permite permite até 2000 caracteres (modelo abrasf)

![image](https://user-images.githubusercontent.com/3595132/103022006-df769b80-4529-11eb-922c-add8567bf8a7.png)

Obs. importante validar se os demais provedores tbm.

cc @mileo @gabrielcardoso21 @luismalta 