### PR TITLE
[12.0][FIX] Chamadas de compute_all sem o argumento product

### DIFF
--- a/l10n_br_account/models/account_tax.py
+++ b/l10n_br_account/models/account_tax.py
@@ -64,6 +64,8 @@ class AccountTax(models.Model):
         if not fiscal_taxes:
             fiscal_taxes = self.env['l10n_br_fiscal.tax']
 
+        product = product or self.env['product.product']
+
         # FIXME Should get company from document?
         fiscal_taxes_results = fiscal_taxes.compute_taxes(
             company=self.env.user.company_id,


### PR DESCRIPTION
No core a função compute_all do modelo account.tax é chamada sem todos os argumentos que usamos na localização brasileira. Essa pequena alteração permite que a função seja executada sem erros.