### PR TITLE
[12.0] product fiscal fields should be fiscal user editable

### DIFF
--- a/l10n_br_fiscal/views/product_template_view.xml
+++ b/l10n_br_fiscal/views/product_template_view.xml
@@ -37,7 +37,7 @@
         <field name="inherit_id" ref="product.product_template_only_form_view"/>
         <field name="arch" type="xml">
             <xpath expr="//page[@name='variants']" position="after">
-                <page name="fiscal" string="Fiscal" groups="l10n_br_fiscal.group_manager">
+                <page name="fiscal" string="Fiscal" groups="l10n_br_fiscal.group_user">
                     <group>
                         <group>
                             <field name="fiscal_type" required="1"/>


### PR DESCRIPTION
trivial but required.
Otherwise a bare inventary user should also be fiscal manager to edit these required field when creating new products which is an abusive privilege. in v8 you didn't need to be a fiscal manager for such settings.

cc @renatonlima @mileo @marcelsavegnago @mbcosta 