### PR TITLE
[REF] document_type_id move required attribute from object to view

### DIFF
--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -178,7 +178,6 @@ class Document(models.Model):
 
     document_type_id = fields.Many2one(
         comodel_name='l10n_br_fiscal.document.type',
-        required=True,
     )
 
     operation_name = fields.Char(

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -76,7 +76,7 @@
           </group>
           <group>
             <field name="issuer"/>
-            <field name="document_type_id"/>
+            <field name="document_type_id" required="1"/>
             <label for="key" attrs="{'invisible': [('document_electronic', '=', False)]}"/>
             <div class="o_row" attrs="{'readonly': [('issuer', '=', 'company')], 'required': [('issuer', '=', 'partner'), ('document_electronic', '=', True)], 'invisible': [('document_electronic', '=', False)]}">
               <field name="key" force_save="1" class="oe_inline"/>


### PR DESCRIPTION
Movido o atributo requerido do campo document_type_id do objeto para a visão para não impactar a criação de faturas (account.invoice) sem um documento fiscal (apenas relacionada com o l10n_br_fiscal.fiscal_document_dummy).