### PR TITLE
[FIX] compute_all arguments

### DIFF
--- a/l10n_br_account/models/account_tax.py
+++ b/l10n_br_account/models/account_tax.py
@@ -20,7 +20,7 @@ class AccountTax(models.Model):
         self,
         price_unit,
         currency=None,
-        quantity=None,
+        quantity=1.0,
         product=None,
         partner=None,
         fiscal_taxes=None,


### PR DESCRIPTION
O Método original compute_all o argumento quantity tem o valor padrão de 1.0 e na localização não tem um valor padrão na assinatura do método, esse PR deixa a assinatura dos argumentos do método original com o valor padrão para evitar problemas de compatibilidade com outros módulos que chamam o compute_all.