### PR TITLE
[12.0][IMP] l10n_br_fiscal: add delivery page tag on document fiscal form

### DIFF
--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -193,6 +193,8 @@
             </page>
             <page name="finance" string="Finance">
             </page>
+            <page name="delivery" string="Delivery">
+            </page>
             <page name="others" string="Others">
                 <group>
                     <field name="operation_name"/>


### PR DESCRIPTION
@rvalyi acredito que esta página pode ser criada pelo módulo fiscal e o módulo NFe só inclui os campos dentro dela ao invés de criar uma uma aba transporte pelo módulo NFe. Farei a mudança e submeto uma PR para tua branch da NFe.

Obs. farei isso tbm para os dados de pagamento.