### PR TITLE
[FIX] l10n_br_base demo dados de demo

### DIFF
--- a/l10n_br_base/demo/res_users_demo.xml
+++ b/l10n_br_base/demo/res_users_demo.xml
@@ -3,11 +3,11 @@
 
     <!-- Configure Users -->
     <record id="base.user_admin" model="res.users">
-        <field name="company_ids" eval="[(6, 0, [ref('base.main_company'), ref('l10n_br_base.empresa_simples_nacional'), ref('l10n_br_base.empresa_lucro_presumido')])]"/>
+	<field name="company_ids" eval="[(4, ref('base.main_company')), (4, ref('l10n_br_base.empresa_simples_nacional')), (4, ref('l10n_br_base.empresa_lucro_presumido'))]"/>
     </record>
 
     <record id="base.user_demo" model="res.users">
-        <field name="company_ids" eval="[(6, 0, [ref('base.main_company'), ref('l10n_br_base.empresa_simples_nacional'), ref('l10n_br_base.empresa_lucro_presumido')])]"/>
+	<field name="company_ids" eval="[(4, ref('base.main_company')), (4, ref('l10n_br_base.empresa_simples_nacional')), (4, ref('l10n_br_base.empresa_lucro_presumido'))]"/>
     </record>
 
     <record id="partner_demo_simples" model="res.partner">


### PR DESCRIPTION
Nos dados de demonstração do l10n_br_base os usuarios admin e demo estão com o campo company_ids esta sendo populado com "[(6, 0, [ref('" o que apaga as empresas anteriores e adiciona as empresas do l10n_br_base, na verdade deve ser populado com "[(4, ref('" para manter as empresas populadas no company_ids anteriormente.