### PR TITLE
[FIX] IPI base compute

### DIFF
--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -542,6 +542,22 @@ class Tax(models.Model):
         return self._compute_generic(tax, taxes_dict, **kwargs)
 
     def _compute_ipi(self, tax, taxes_dict, **kwargs):
+        discount_value = kwargs.get("discount_value", 0.00)
+        insurance_value = kwargs.get("insurance_value", 0.00)
+        freight_value = kwargs.get("freight_value", 0.00)
+        other_costs_value = kwargs.get("other_costs_value", 0.00)
+
+        add_to_base = [insurance_value, freight_value, other_costs_value]
+        remove_from_base = [discount_value]
+
+        kwargs.update({
+            'add_to_base': sum(add_to_base),
+            'remove_from_base': sum(remove_from_base),
+        })
+
+        taxes_dict[tax.tax_domain].update(self._compute_tax_base(
+            tax, taxes_dict.get(tax.tax_domain), **kwargs))
+
         return self._compute_generic(tax, taxes_dict, **kwargs)
 
     def _compute_ii(self, tax, taxes_dict, **kwargs):


### PR DESCRIPTION
Atualmente a base do IPI esta sendo considerada apenas o total de mercadorias, mas a base do IPI deve ser composta pelo total de mercadorias + (Frete, Seguro e Outras Depesas) - Valor do Desconto.