### PR TITLE
[12.0][IMP] l10n br fiscal: move city_taxation_code_id (fields, methods and views) from l10n_br_nfse to l10n_br_fiscal

### DIFF
--- a/l10n_br_fiscal/models/document_fiscal_line_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin.py
@@ -212,6 +212,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         string="Service Type LC 166",
         domain="[('internal_type', '=', 'normal')]")
 
+    city_taxation_code_id = fields.Many2one(
+        comodel_name='l10n_br_fiscal.city.taxation.code',
+        string='City Taxation Code')
+
     partner_order = fields.Char(
         string='Partner Order (xPed)',
         size=15)

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -375,6 +375,12 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             self.fiscal_genre_id = self.product_id.fiscal_genre_id
             self.service_type_id = self.product_id.service_type_id
             self.uot_id = self.product_id.uot_id or self.product_id.uom_id
+            if self.product_id.city_taxation_code_id:
+                company_city_id = self.company_id.city_id
+                city_id = self.product_id.city_taxation_code_id.filtered(
+                    lambda r: r.city_id == company_city_id)
+                if city_id:
+                    self.city_taxation_code_id = city_id
         else:
             self.name = False
             self.fiscal_type = False
@@ -387,6 +393,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             self.nbs_id = False
             self.fiscal_genre_id = False
             self.service_type_id = False
+            self.city_taxation_code_id = False
             self.uot_id = False
 
         self._get_product_price()
@@ -797,3 +804,8 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
     @api.onchange('fiscal_tax_ids')
     def _onchange_fiscal_tax_ids(self):
         self._update_taxes()
+
+    @api.onchange("city_taxation_code_id")
+    def _onchange_city_taxation_code_id(self):
+        if self.city_taxation_code_id:
+            self.cnae_id = self.city_taxation_code_id.cnae_id

--- a/l10n_br_fiscal/models/product_template.py
+++ b/l10n_br_fiscal/models/product_template.py
@@ -58,6 +58,10 @@ class ProductTemplate(models.Model):
         string='Service Type LC 166',
         domain="[('internal_type', '=', 'normal')]")
 
+    city_taxation_code_id = fields.Many2many(
+        comodel_name='l10n_br_fiscal.city.taxation.code',
+        string='City Taxation Code')
+
     fiscal_genre_code = fields.Char(
         related='fiscal_genre_id.code',
         store=True,

--- a/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
@@ -24,6 +24,7 @@
           <field name="cest_id" force_save="1" invisible="1"/>
           <field name="nbs_id" force_save="1" invisible="1"/>
           <field name="service_type_id" force_save="1" invisible="1"/>
+          <field name="city_taxation_code_id" force_save="1" invisible="1"/>
           <field name="uot_id" force_save="1" invisible="1"/>
           <field name="fiscal_price" force_save="1" invisible="1"/>
           <field name="fiscal_quantity" force_save="1" invisible="1"/>

--- a/l10n_br_fiscal/views/document_line_view.xml
+++ b/l10n_br_fiscal/views/document_line_view.xml
@@ -47,6 +47,7 @@
                 <field name="cest_id"/>
                 <field name="nbs_id"/>
                 <field name="service_type_id" attrs="{'invisible': [('fiscal_genre_code', '!=', '00'), ('cfop_id', '!=', False)]}"/>
+                <field name="city_taxation_code_id" attrs="{'invisible': [('fiscal_genre_code', '!=', '00'), ('cfop_id', '!=', False)]}"/>
               </group>
               <group name="l10n_br_fiscal" string="Operation">
                 <field name="fiscal_operation_type" invisible="1" readonly="1"/>

--- a/l10n_br_fiscal/views/product_product_view.xml
+++ b/l10n_br_fiscal/views/product_product_view.xml
@@ -44,6 +44,15 @@
                             <field name="ncm_id" required="1"/>
                             <field name="tax_icms_or_issqn" required="1"/>
                             <field name="service_type_id" attrs="{'invisible': [('fiscal_type', '!=', '09')]}"/>
+                            <field name="city_taxation_code_id" attrs="{'invisible': [('fiscal_type', '!=', '09')]}" context="{'default_service_type_id': service_type_id}">
+                                <tree editable="bottom">
+                                    <field name="code" />
+                                    <field name="name" />
+                                    <field name="service_type_id" />
+                                    <field name="state_id" />
+                                    <field name="city_id" />
+                                </tree>
+                            </field>
                         </group>
                         <group>
                             <field name="fiscal_genre_id" required="1"/>

--- a/l10n_br_fiscal/views/product_template_view.xml
+++ b/l10n_br_fiscal/views/product_template_view.xml
@@ -45,6 +45,16 @@
                             <field name="ncm_id" required="1"/>
                             <field name="tax_icms_or_issqn" required="1"/>
                             <field name="service_type_id" attrs="{'invisible': [('fiscal_type', '!=', '09')]}"/>
+                            <field name="city_taxation_code_id" attrs="{'invisible': [('fiscal_type', '!=', '09')]}" context="{'default_service_type_id': service_type_id}">
+                                <tree editable="bottom">
+                                    <field name="code" />
+                                    <field name="name" />
+                                    <field name="service_type_id" />
+                                    <field name="state_id" />
+                                    <field name="city_id" />
+                                    <field name="cnae_id" />
+                                </tree>
+                            </field>
                         </group>
                         <group>
                             <field name="fiscal_genre_id" required="1"/>


### PR DESCRIPTION
Como o campo service_type_id já está no fiscal, optei em tomar a iniciativa de mover o city_taxation_code_id para o fiscal.

Ref. #1089 

cc @renatonlima @mileo @rvalyi @gabrielcardoso21 