### PR TITLE
[12.0] Foreign Partner Address

### DIFF
--- a/l10n_br_base/__init__.py
+++ b/l10n_br_base/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2009  Renato Lima - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+from .hooks import pre_init_hook
+
 from . import models
 from . import tests
 

--- a/l10n_br_base/__manifest__.py
+++ b/l10n_br_base/__manifest__.py
@@ -33,6 +33,7 @@
         "demo/res_users_demo.xml",
     ],
     "installable": True,
+    'pre_init_hook': 'pre_init_hook',
     "development_status": "Mature",
     "external_dependencies": {"python": ["num2words", "erpbrasil.base"]},
 }

--- a/l10n_br_base/hooks.py
+++ b/l10n_br_base/hooks.py
@@ -1,0 +1,26 @@
+# Copyright (C) 2019-2020 - Raphael Valyi Akretion
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def pre_init_hook(cr):
+    """
+    The objective of this hook is to ensure the Brazil country is
+    translated as "Brasil" in pt_BR to get the NFe tests pass
+    even if the pt_BR language pack is not installed.
+    """
+    cr.execute("""SELECT id
+    FROM ir_translation
+    WHERE name='res.country,name' AND
+    lang='pt_BR'""")
+    if not cr.fetchone():
+        cr.execute(
+            """
+            INSERT INTO ir_translation
+            (name, res_id, lang, type, src, value, module, state)
+            VALUES ('res.country,name', 31, 'pt_BR', 'model',
+            'Brazil', 'Brasil', 'base', 'translated');
+            """)

--- a/l10n_br_base/hooks.py
+++ b/l10n_br_base/hooks.py
@@ -3,6 +3,8 @@
 
 import logging
 
+from odoo import SUPERUSER_ID, api
+
 _logger = logging.getLogger(__name__)
 
 
@@ -17,10 +19,26 @@ def pre_init_hook(cr):
     WHERE name='res.country,name' AND
     lang='pt_BR'""")
     if not cr.fetchone():
-        cr.execute(
-            """
-            INSERT INTO ir_translation
-            (name, res_id, lang, type, src, value, module, state)
-            VALUES ('res.country,name', 31, 'pt_BR', 'model',
-            'Brazil', 'Brasil', 'base', 'translated');
-            """)
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        brazil_country_id = env.ref("base.br").id
+        sql_query = """
+        INSERT INTO ir_translation (
+            name,
+            res_id,
+            lang,
+            type,
+            src,
+            value,
+            module,
+            state)
+        VALUES (
+            'res.country,name',
+            {0},
+            'pt_BR',
+            'model',
+            'Brazil',
+            'Brasil',
+            'base',
+            'translated');
+        """.format(brazil_country_id)
+        cr.execute(sql_query)

--- a/l10n_br_base/views/res_partner_address_view.xml
+++ b/l10n_br_base/views/res_partner_address_view.xml
@@ -14,8 +14,8 @@
                     <field name="street2" placeholder="Complement..." class="o_address_street"/>
                     <field name="district" placeholder="District..." class="o_address_street"/>
                     <field name="state_id" domain="[('country_id', '=', country_id)]" placeholder="State..." class="o_address_state" options='{"no_open": True, "no_create": True}'/>
-                    <field name="city_id" placeholder="City..." class="o_address_city" options='{"no_open": True, "no_create": True}'/>
-                    <field name="city" invisible="1"/>
+                    <field name="city_id" placeholder="City..." class="o_address_city" options='{"no_open": True, "no_create": True}' attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"/>
+                    <field name="city" placeholder="City..." class="o_address_city" force_save="True" attrs="{'invisible': [('country_id', '=', %(base.br)d)]}"/>
                     <field name="country_id" placeholder="Country..." class="o_address_country" options='{"no_open": True, "no_create": True}'/>
                 </div>
             </form>

--- a/l10n_br_zip/views/res_partner_address_view.xml
+++ b/l10n_br_zip/views/res_partner_address_view.xml
@@ -8,7 +8,7 @@
         <field name="priority">33</field>
         <field name="arch" type="xml">
             <field name="zip" position="after">
-                <button name="zip_search" type="object" class="btn-sm btn-link mb4 fa fa-search oe_edit_only" aria-label="Pesquisar CEP" title="Pesquisar CEP"/>
+                <button name="zip_search" type="object" attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}" class="btn-sm btn-link mb4 fa fa-search oe_edit_only" aria-label="Pesquisar CEP" title="Pesquisar CEP"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Algumas melhorias e consistencia relacionada ao Endereço, Idioma e País:

- [x] Adicionado um pre_init_hook para inserir a tradução do nome do Brazil para Brasil (Pensei em carregar a tradução pt_BR mas não seria bom porque iria impactar a instalação que iria demorar mais para carregar as traduções)
- [x] Ao cadastrar um parceiro com o país diferente do Brasil, o campo city_id deve ficar invisível e o campo city visível
- [x] Desabilitar o botão de pesquisa de CEP se o país do parceiro for diferente do Brasil