### PR TITLE
[12.0] XML exports: skip non XSD spec fields like o2m foreign keys

### DIFF
--- a/spec_driven_model/models/spec_export.py
+++ b/spec_driven_model/models/spec_export.py
@@ -17,12 +17,16 @@ class AbstractSpecMixin(models.AbstractModel):
         return getattr(binding_module, class_obj._generateds_type)
 
     def _export_fields(self, xsd_fields, class_obj, export_dict):
-        # FIXME: Remove all references of nfe, make it generic!
         ds_class = self._get_ds_class(class_obj)
         ds_class_spec = {i.name: i for i in ds_class.member_data_items_}
 
         for xsd_field in xsd_fields:
+            if not xsd_field or not self._fields.get(xsd_field):
+                continue
             field_spec_name = xsd_field.replace(class_obj._field_prefix, '')
+            if not ds_class_spec.get(field_spec_name):
+                # this can happen with a o2m generated foreign key for instance
+                continue
             member_spec = ds_class_spec[field_spec_name]
             field_data = self._export_field(xsd_field, class_obj, member_spec)
 


### PR DESCRIPTION
replaces https://github.com/OCA/l10n-brazil/pull/1097

@marcelsavegnago when we merged the spec_model_driven module I said it was OK for me and at max there would be just 3 or 4 lines diff compared to what we are using in prod. Well, this is half of these diff lines!
 (we have also a 2 lines skip with `if attr.get_name() == 'hashCSRT':` in the import build_attr but it really looks more like a temporary hack leftover)

It is a bit normal that a few keys are not part of the XSD spec. This is especially the case when we have a One2many relationship like infnfe - det. In the xsd there is no infnfe_id field, but we generate an equivalent field (nfe40_det_infNFe_id) so it can work with the Odoo ORM (even if in this case the key is not used due to the concrete mapping with document/document.line). It is also normal that the abstract XSD mixins like from l10n_br_nfe_spec are agnostic from their specific concrete usage like in l10n_br_nfe and have the required fields like nfe40_det_infNFe_id for their abstract relational model at least.

But yeah at least no need to hardcode specific fields to skip.