### PR TITLE
[12.0] l10n_br_sale partial deliveries

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -331,6 +331,8 @@ class AccountInvoice(models.Model):
                 uot=line.uot_id,
                 icmssn_range=line.icmssn_range_id)['taxes']
 
+            line._update_taxes()
+
             for tax in taxes:
                 if tax.get('amount', 0.0) != 0.0:
                     val = self._prepare_tax_line_vals(line, tax)

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -836,19 +836,22 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         }
 
         if uom_id != uot_id:
-            if product_id:
+            if product_id and price and quantity:
                 product = self.env['product.product'].browse(product_id)
                 result['fiscal_price'] = (
-                    price / product.uot_factor)
+                    price / (product.uot_factor or 1.0))
                 result['fiscal_quantity'] = (
-                    quantity * product.uot_factor)
+                    quantity * (product.uot_factor or 1.0))
 
         return result
 
     @api.onchange("uot_id", "uom_id", "price_unit", "quantity")
     def _onchange_commercial_quantity(self):
+        product_id = False
+        if self.product_id:
+            product_id = self.product_id.id
         self.update(self._update_fiscal_quantity(
-            self.product_id, self.price_unit, self.quantity,
+            product_id, self.price_unit, self.quantity,
             self.uom_id, self.uot_id))
 
     @api.onchange("ncm_id", "nbs_id", "cest_id")

--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, fields, models
+from odoo.addons import decimal_precision as dp
 from ...l10n_br_fiscal.constants.fiscal import TAX_FRAMEWORK
 
 
@@ -37,6 +38,14 @@ class SaleOrderLine(models.Model):
         string='Product Uom Quantity',
         related='product_uom_qty',
         depends=['product_uom_qty'],
+    )
+
+    fiscal_qty_delivered = fields.Float(
+        string='Fiscal Utm Qty Delivered',
+        compute='_compute_qty_delivered',
+        compute_sudo=True,
+        store=True,
+        digits=dp.get_precision('Product Unit of Measure'),
     )
 
     uom_id = fields.Many2one(
@@ -108,6 +117,8 @@ class SaleOrderLine(models.Model):
     def _prepare_invoice_line(self, qty):
         self.ensure_one()
         result = self._prepare_br_fiscal_dict()
+        if self.product_id and self.product_id.invoice_policy == 'delivery':
+            result['fiscal_quantity'] = self.fiscal_qty_delivered
         result.update(super()._prepare_invoice_line(qty))
         return result
 
@@ -116,6 +127,25 @@ class SaleOrderLine(models.Model):
         """To call the method in the mixin to update
         the price and fiscal quantity."""
         self._onchange_commercial_quantity()
+
+    @api.multi
+    @api.depends(
+        'qty_delivered_method',
+        'qty_delivered_manual',
+        'analytic_line_ids.so_line',
+        'analytic_line_ids.unit_amount',
+        'analytic_line_ids.product_uom_id')
+    def _compute_qty_delivered(self):
+        super()._compute_qty_delivered()
+        for line in self:
+            line.fiscal_qty_delivered = 0.0
+            if line.product_id.invoice_policy == 'delivery':
+                if line.uom_id == line.uot_id:
+                    line.fiscal_qty_delivered = line.qty_delivered
+
+            if line.uom_id != line.uot_id:
+                line.fiscal_qty_delivered = (
+                    line.qty_delivered * line.product_id.uot_factor)
 
     @api.onchange('discount')
     def _onchange_discount_percent(self):


### PR DESCRIPTION
No módulo de vendas quando um pedido de vendas é faturado baseado nas quantidades entregues e esta é diferente da quantidade pedida, os valores dos impostos são copiados das linhas dos pedidos de vendas que ficam incorretos. Esse PR chama o método _update_taxes das linhas dos documentos fiscais para corrigir esses valores, e também adiciona um campo calculado na linha de vendas para calcular a quantidade tributada entregue.