### PR TITLE
12.0 sale ref order line view

### DIFF
--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -139,4 +139,4 @@ class SaleOrderLine(models.Model):
     @api.onchange('fiscal_tax_ids')
     def _onchange_fiscal_tax_ids(self):
         super()._onchange_fiscal_tax_ids()
-        self.tax_id |= self.fiscal_tax_ids.account_taxes()
+        self.tax_id |= self.fiscal_tax_ids.account_taxes(user_type='sale')

--- a/l10n_br_sale/views/sale_view.xml
+++ b/l10n_br_sale/views/sale_view.xml
@@ -59,25 +59,24 @@
             <xpath expr="//field[@name='order_line']/tree/field[@name='price_unit']" position="after">
                 <field name="discount" groups="!l10n_br_sale.group_discount_per_value"/>
                 <field name="discount_value" groups="l10n_br_sale.group_discount_per_value"/>
-                <field name="fiscal_tax_ids" widget="many2many_tags"/>
+                <field name="fiscal_tax_ids" widget="many2many_tags" options="{'no_create': True}"/>
             </xpath>
             <xpath expr="//field[@name='order_line']/tree/field[@name='price_subtotal']" position="after">
                 <field name="price_total" invisible="1"/>
             </xpath>
-            <xpath expr="//field[@name='order_line']/form//field[@name='sequence']" position="after">
+            <xpath expr="//field[@name='order_line']/form" position="inside">
                 <group name="fiscal_fields" invisible="1">
                     <field name="fiscal_operation_type" invisible="1" readonly="1"/>
                     <field name="fiscal_genre_code" invisible="1"/>
                     <field name="tax_framework" invisible="1"/>
+                    <field name="tax_icms_or_issqn" invisible="1"/>
                 </group>
             </xpath>
             <xpath expr="//field[@name='order_line']/form//label[@for='customer_lead']" position="before">
-                <field name="fiscal_type" force_save="1" invisible="1" readonly="1"/>
-                <field name="fiscal_operation_id" required="1"/>
-                <field name="fiscal_operation_line_id" required="1"/>
-                <field name="cfop_id" attrs="{'invisible': [('fiscal_genre_code', '=', '00'), ('cfop_id', '!=', False)]}"/>
-                <field name="service_type_id" attrs="{'invisible': [('fiscal_genre_code', '!=', '00'), ('cfop_id', '=', False)]}"/>
-                <field name="cfop_destination" invisible="1"/>
+                <field name="fiscal_operation_id" required="1" options="{'no_create': True}"/>
+                <field name="fiscal_operation_line_id" required="1" options="{'no_create': True}"/>
+                <field name="cfop_id" options="{'no_create': True}" attrs="{'invisible': [('tax_icms_or_issqn', '=', 'issqn')]}"/>
+                <field name="service_type_id" options="{'no_create': True}" attrs="{'invisible': [('tax_icms_or_issqn', '=', 'icms')]}"/>
                 <field name="price_total" invisible="1"/>
                 <field name="price_subtotal" invisible="1"/>
             </xpath>

--- a/l10n_br_sale/views/sale_view.xml
+++ b/l10n_br_sale/views/sale_view.xml
@@ -73,12 +73,12 @@
                 </group>
             </xpath>
             <xpath expr="//field[@name='order_line']/form//label[@for='customer_lead']" position="before">
-                <field name="fiscal_operation_id" required="1" options="{'no_create': True}"/>
-                <field name="fiscal_operation_line_id" required="1" options="{'no_create': True}"/>
+                <field name="fiscal_operation_id" options="{'no_create': True}" attrs="{'readonly': [('state', 'in', ('sale', 'done', 'cancel'))], 'required': [('display_type', '=', False)]}"/>
+                <field name="fiscal_operation_line_id" options="{'no_create': True}" attrs="{'readonly': [('state', 'in', ('sale', 'done', 'cancel'))], 'required': [('display_type', '=', False)]}"/>
                 <field name="cfop_id" options="{'no_create': True}" attrs="{'invisible': [('tax_icms_or_issqn', '=', 'issqn')]}"/>
-                <field name="service_type_id" options="{'no_create': True}" attrs="{'invisible': [('tax_icms_or_issqn', '=', 'icms')]}"/>
                 <field name="price_total" invisible="1"/>
                 <field name="price_subtotal" invisible="1"/>
+                <field name="service_type_id" options="{'no_create': True}" attrs="{'invisible': [('tax_icms_or_issqn', '=', 'icms')]}"/>
             </xpath>
             <xpath expr="//field[@name='order_line']/form//field[@name='tax_id']" position="replace"/>
             <xpath expr="//field[@name='order_line']/form/div[@groups='base.group_no_one' and field/@name='invoice_lines']" position="replace"/>
@@ -91,10 +91,10 @@
                 <field name="fiscal_price"/>
             </xpath>
             <xpath expr="//field[@name='order_line']/form/field[@name='name']" position="after">
-                <notebook>
+                <notebook attrs="{'invisible': [('display_type', '!=', False)]}">
                   <page name="fiscal_taxes" string="Taxes"/>
-                  <page string="Invoice Lines" groups="base.group_no_one">
-                      <div attrs="{'invisible': [('display_type', '!=', False)]}">
+                  <page string="Invoice Lines" groups="base.group_no_one" attrs="{'invisible': [('display_type', '!=', False)]}">
+                      <div>
                           <label for="invoice_lines"/>
                           <field name="invoice_lines"/>
                       </div>


### PR DESCRIPTION
- [x] Move o group fiscal_fields para o inicio do formulario para não ter problemas na ordem dos campos
- [x] Colocado a options="{'no_create': True}" nos campos de operação fiscal, linha de operação, cfop e etc para evitar a criação acidental de registros.
- [x] Definido argumento user_type='sale' para trazer apenas os impostos de venda. 