### PR TITLE
[12.0][REF] Update res.partner Akretion demo data.

### DIFF
--- a/l10n_br_base/demo/l10n_br_base_demo.xml
+++ b/l10n_br_base/demo/l10n_br_base_demo.xml
@@ -387,12 +387,13 @@
         <field name="legal_name">AKRETION LTDA</field>
         <field name="name">Akretion Sao Paulo</field>
         <field name="district">Centro</field>
-        <field name="zip">18125-000</field>
+        <field name="zip">01311-915</field>
         <field name="country_id" ref="base.br"/>
-        <field name="street_number">586</field>
-        <field name="phone">(21) 3010 9965</field>
-        <field name="street">Rua Paulo Dias</field>
-        <field name="city_id" ref="l10n_br_base.city_3501152"/>
+        <field name="street_number">807</field>
+        <field name="phone">(11) 9999-9999</field>
+        <field name="street">Avenida Paulista</field>
+        <field name="street2">CJ 2315</field>
+        <field name="city_id" ref="l10n_br_base.city_3550308"/>
         <field name="state_id" ref="base.state_br_sp"/>
         <field name="image" type="base64" file="l10n_br_base/static/img/res_partner_akretion-image.jpg"/>
     </record>
@@ -413,11 +414,36 @@
         <field name="type">other</field>
         <field name="country_id" ref="base.br"/>
         <field name="street_number">47</field>
-        <field name="phone">(21) 2516-2954</field>
+        <field name="phone">(21) 9999-9999</field>
         <field name="street">Rua Acre</field>
         <field name="street2">sala 1310</field>
         <field name="website">http://www.akretion.com</field>
         <field name="state_id" ref="base.state_br_rj"/>
+        <field name="image" type="base64" file="l10n_br_base/static/img/res_partner_akretion-image.jpg"/>
+    </record>
+
+    <record id="res_partner_address_ak3" model="res.partner">
+        <field name="title" ref="res_partner_title_pvt_ltd"/>
+        <field name="cnpj_cpf">11.034.414/0003-10</field>
+        <field name="inscr_mun">1448</field>
+        <field eval="0" name="employee"/>
+        <field eval="1" name="customer"/>
+        <field eval="1" name="supplier"/>
+        <field eval="1" name="active"/>
+        <field name="is_company" eval="1"/>
+        <field name="legal_name">AKRETION LTDA</field>
+        <field name="name">Akretion Aluminio - SP</field>
+        <field name="parent_id" ref="res_partner_akretion"/>
+        <field name="district">Centro</field>
+        <field name="city_id" ref="l10n_br_base.city_3501152"/>
+        <field name="zip">18125-000</field>
+        <field name="type">other</field>
+        <field name="country_id" ref="base.br"/>
+        <field name="street_number">586</field>
+        <field name="phone">(11) 9999-9999</field>
+        <field name="street">Rua Paulo Dias</field>
+        <field name="website">http://www.akretion.com</field>
+        <field name="state_id" ref="base.state_br_sp"/>
         <field name="image" type="base64" file="l10n_br_base/static/img/res_partner_akretion-image.jpg"/>
     </record>
 

--- a/l10n_br_base/tests/test_base_onchange.py
+++ b/l10n_br_base/tests/test_base_onchange.py
@@ -63,7 +63,8 @@ class L10nBrBaseOnchangeTest(SavepointCase):
         display_address = partner._display_address()
         self.assertEquals(
             display_address,
-            "Rua Paulo Dias, 586 \nCentro" "\n18125-000 - Alumínio-SP\nBrazil",
+            "Avenida Paulista, 807 CJ 2315\nCentro"
+            "\n01311-915 - São Paulo-SP\nBrazil",
             "The function _display_address failed.",
         )
 
@@ -96,7 +97,8 @@ class L10nBrBaseOnchangeTest(SavepointCase):
         display_address = partner._display_address(without_company=False)
         self.assertEquals(
             display_address,
-            "Rua Paulo Dias, 586 \nCentro" "\n18125-000 - Alumínio-SP\nBrazil",
+            "Avenida Paulista, 807 CJ 2315\nCentro"
+            "\n01311-915 - São Paulo-SP\nBrazil",
             "The function _display_address with parameter"
             " without_company failed.",
         )


### PR DESCRIPTION
Atualização dos dados de demo da Akretion e incluído um endereço extra para ser usado no l10n_br_sale_stock para testar o caso do Endereço de Entrega/partner_shipping_id diferente do Endereço de Faturamento/partner_invoice_id já que no Brasil isso só é permitido para endereços no mesmo estado.

cc @renatonlima @rvalyi  