### PR TITLE
[12.0] purchase: usability: warning if no company_id.document_type_id

### DIFF
--- a/l10n_br_purchase/models/purchase_order.py
+++ b/l10n_br_purchase/models/purchase_order.py
@@ -3,9 +3,10 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from lxml import etree
-from odoo import api, fields, models
+from odoo import api, fields, models, _
 from odoo.addons import decimal_precision as dp
 from odoo.addons.l10n_br_fiscal.constants.fiscal import DOCUMENT_ISSUER_PARTNER
+from odoo.exceptions import UserError
 
 
 class PurchaseOrder(models.Model):
@@ -139,12 +140,15 @@ class PurchaseOrder(models.Model):
         fiscal_dict = self._prepare_br_fiscal_dict(default=True)
 
         document_type_id = self._context.get('document_type_id')
-
         if document_type_id:
             document_type = self.env['l10n_br_fiscal.document.type'].browse(
                 document_type_id)
         else:
             document_type = self.company_id.document_type_id
+            if not document_type:
+                raise UserError(_("You should first set the default fiscal "
+                                  "document for the company %s")
+                                % (self.company_id.name,))
             document_type_id = self.company_id.document_type_id.id
 
         fiscal_dict['default_document_type_id'] = document_type_id


### PR DESCRIPTION
Antes desse fix, se vc tentar criar uma nota fiscal de compra sem ter parametrizado o documento fiscal padrao na empresa, vc recebe essa stack trace:

```
  File "/odoo/src/addons/web/controllers/main.py", line 967, in call_button
    action = self._call_kw(model, method, args, {})
  File "/odoo/src/addons/web/controllers/main.py", line 955, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/odoo/src/odoo/api.py", line 759, in call_kw
    return _call_kw_multi(method, model, args, kwargs)
  File "/odoo/src/odoo/api.py", line 746, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/odoo/external-src/l10n-brazil/l10n_br_purchase/models/purchase_order.py", line 156, in action_view_invoice
    self.company_id, self.fiscal_operation_id)
  File "/odoo/external-src/l10n-brazil/l10n_br_fiscal/models/document_type.py", line 65, in get_document_serie
    self.ensure_one()
  File "/odoo/src/odoo/models.py", line 4768, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: l10n_br_fiscal.document.type()
```

Depois vc do fix vc tem um aviso que explica o que fazer:
![2021-02-03_09-47](https://user-images.githubusercontent.com/16926/106760044-26b87780-6612-11eb-984e-93e6311ef68b.png)
