### PR TITLE
[12.0][FIX] Library vcrpy used in tests by payment_cielo module was missing.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ xmldiff==2.4
 lxml==4.6.2
 -e git://github.com/akretion/nfelib.git@master_gen_v4_00#egg=nfelib
 -e git+https://github.com/OCA/openupgradelib.git@master#egg=openupgradelib
+vcrpy


### PR DESCRIPTION
Library vcrpy used in tests by payment_cielo module was missing. https://github.com/OCA/l10n-brazil/blob/12.0/payment_cielo/tests/test_cielo.py#L8

cc @renatonlima @rvalyi 