### PR TITLE
[FIX] Events without number and key

### DIFF
--- a/l10n_br_fiscal/models/document_eletronic.py
+++ b/l10n_br_fiscal/models/document_eletronic.py
@@ -151,7 +151,7 @@ class DocumentEletronic(models.AbstractModel):
         vals = {
             "type": event_type,
             "company_id": self.company_id.id,
-            "origin": self.document_type_id.code + "/" + self.number,
+            "origin": self.document_type_id.code + "-" + (self.number or 'N/A'),
             "create_date": fields.Datetime.now(),
             "fiscal_document_id": self.id,
         }

--- a/l10n_br_fiscal/models/document_event.py
+++ b/l10n_br_fiscal/models/document_event.py
@@ -10,7 +10,12 @@ from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 from odoo.tools import config
 
-CODIGO_NOME = {"55": "nf-e", "SE": "nfs-e", "65": "nfc-e"}
+CODIGO_NOME = {
+    "55": "nf-e",
+    "59": "cf-e",
+    "SE": "nfs-e",
+    "65": "nfc-e"
+}
 
 
 def caminho_empresa(company_id, document):
@@ -192,6 +197,7 @@ class DocumentEvent(models.Model):
             chave=(
                 self.fiscal_document_id.key
                 or self.fiscal_document_id.number
+                or str(self.fiscal_document_id.id)
             ),  # FIXME:
         )
         file_path = os.path.join(save_dir, file_name)
@@ -220,7 +226,9 @@ class DocumentEvent(models.Model):
 
         file_name = ""
         file_name += (
-            self.fiscal_document_id.key or self.fiscal_document_id.number
+            self.fiscal_document_id.key or
+            self.fiscal_document_id.number or
+            ('ID' + str(self.id))
         )  # FIXME:
         file_name += "-"
         if autorizacao:


### PR DESCRIPTION
Não esta perfeito, mas foi a forma + simples que encontrei.

Um opção seria criar uma pasta temporária para todos os XML, ou ainda não salvar no disco os XML não autorizados, inclusive para não confundir.