### PR TITLE
[12.0] Data Abstract _search_name e filter_domain

### DIFF
--- a/l10n_br_fiscal/models/data_abstract.py
+++ b/l10n_br_fiscal/models/data_abstract.py
@@ -2,8 +2,8 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from erpbrasil.base import misc
+
 from odoo import api, fields, models
-from odoo.osv import expression
 
 
 class DataAbstract(models.AbstractModel):
@@ -44,13 +44,10 @@ class DataAbstract(models.AbstractModel):
                 '|',
                 ('code', operator, name),
                 ('code_unmasked', 'ilike', name + '%'),
-                ('name', operator, name),
             ]
-        recs = self._search(expression.AND([domain, args]),
-                            limit=limit,
-                            access_rights_uid=name_get_uid)
 
-        return self.browse(recs).name_get()
+        return super()._name_search(name, domain + args,
+                                    operator, limit, name_get_uid)
 
     @api.multi
     def name_get(self):

--- a/l10n_br_fiscal/models/document_type.py
+++ b/l10n_br_fiscal/models/document_type.py
@@ -10,7 +10,7 @@ from ..constants.fiscal import DOCUMENT_TYPE
 class DocumentType(models.Model):
     _name = 'l10n_br_fiscal.document.type'
     _description = 'Fiscal Document Type'
-    _inheirt = 'l10n_br_fiscal.data.abstract'
+    _inherit = 'l10n_br_fiscal.data.abstract'
 
     code = fields.Char(
         size=8,


### PR DESCRIPTION
- [x] Corrigido erro de digitação no l10n_br_fiscal.document.type
- [x] Corrigido método _search_name para permitir buscar pelos campos code, code_unmasked e name.
- [x] Adicionado no campo name da visão search dos objetos que herdam o data abstract o atributo filter_domain via fields_view_get

![image](https://user-images.githubusercontent.com/211005/108779508-be402480-7545-11eb-9348-7a61af13a5f0.png)

![image](https://user-images.githubusercontent.com/211005/108779688-052e1a00-7546-11eb-840e-14d20ba88f62.png)
