### PR TITLE
[FIX] wrong ensure_one call

### DIFF
--- a/l10n_br_fiscal/models/document_event.py
+++ b/l10n_br_fiscal/models/document_event.py
@@ -159,9 +159,9 @@ class DocumentEvent(models.Model):
     @api.multi
     @api.depends("company_id.name", "origin")
     def _compute_display_name(self):
-        self.ensure_one()
-        names = ["Evento", self.company_id.name, self.origin]
-        self.display_name = " / ".join(filter(None, names))
+        for r in self:
+            names = ["Evento", r.company_id.name, r.origin]
+            r.display_name = " / ".join(filter(None, names))
 
     @staticmethod
     def monta_caminho(ambiente, company_id, chave):


### PR DESCRIPTION
Em NF-es com mais de um evento fiscal nos objetos ontem tem um m2o da invoice gera o seguinte erro:

File "/odoo/src/odoo/fields.py", line 1069, in __get__
    self.determine_value(record)
  File "/odoo/src/odoo/fields.py", line 1182, in determine_value
    self.compute_value(recs)
  File "/odoo/src/odoo/fields.py", line 1136, in compute_value
    self._compute_value(records)
  File "/odoo/src/odoo/fields.py", line 1127, in _compute_value
    getattr(records, self.compute)()
  File "/odoo/external-src/l10n-brazil/l10n_br_fiscal/models/document_event.py", line 162, in _compute_display_name
    self.ensure_one()
  File "/odoo/src/odoo/models.py", line 4768, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: l10n_br_fiscal.document.event(4094, 4093)

Isso é causado porque no método compute esta sendo chamado o self.ensure_one(), este PR remove a chamda do ensure_one e trata o compute no caso de multiplus registros.