### PR TITLE
[ADD] added field financial_move_line_ids on invoice object

### DIFF
--- a/l10n_br_account/views/account_invoice_view.xml
+++ b/l10n_br_account/views/account_invoice_view.xml
@@ -38,6 +38,11 @@
                     <field name="document_serie" invisible="1"/>
                 </group>
             </xpath>
+            <notebook position="inside">
+                <page string="Receivable" name="financial_move_line_ids">
+                    <field name="financial_move_line_ids"/>
+                </page>
+            </notebook>
         </field>
     </record>
 
@@ -79,6 +84,11 @@
                     <field name="document_serie" invisible="1"/>
                 </group>
             </xpath>
+            <notebook position="inside">
+                <page string="Payable" name="financial_move_line_ids">
+                    <field name="financial_move_line_ids"/>
+                </page>
+            </notebook>
         </field>
     </record>
 


### PR DESCRIPTION
Adiciona o campo financial_move_line_ids para visualizar os vencimentos/pagamentos e adiciona uma aba na fatura para visualização dos vencimentos a receber do caso de faturas de clientes e a pagar no caso de faturas de fornecedores.

![image](https://user-images.githubusercontent.com/211005/109017016-87792400-7695-11eb-8f0b-90a73b4d4995.png)
