### PR TITLE
[12.0][REF] change compute to create and write methods to sync fields

### DIFF
--- a/l10n_br_fiscal/models/data_abstract.py
+++ b/l10n_br_fiscal/models/data_abstract.py
@@ -26,15 +26,21 @@ class DataAbstract(models.AbstractModel):
 
     code_unmasked = fields.Char(
         string='Unmasked Code',
-        compute='_compute_code_unmasked',
-        store=True,
         index=True)
 
-    @api.depends('code')
-    def _compute_code_unmasked(self):
-        for r in self:
-            # TODO mask code and unmasck
-            r.code_unmasked = misc.punctuation_rm(r.code)
+    @api.model
+    def create(self, values):
+        if 'code' in values:
+            values['code_unmasked'] = misc.punctuation_rm(values.get(code))
+        return super().create(values)
+
+    @api.multi
+    def write(self, values):
+        if 'code_unmasked':
+            values.pop('code_unmasked')
+        if 'code' in values:
+            values['code_unmasked'] = misc.punctuation_rm(values.get(code))
+        return super().write(values)
 
     @api.model
     def fields_view_get(self, view_id=None, view_type="form",


### PR DESCRIPTION
Para melhorar a performace da carga de dados fiscais na instalação do módulo l10n_br_fiscal foi substituído o método compute do campo unmasked_code e criados os métodos write e create.