### PR TITLE
[12.0] Remove compute_reduction validation

### DIFF
--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -364,8 +364,6 @@ class Tax(models.Model):
             add_to_base.append(tax_dict_ipi.get("tax_value", 0.00))
 
         compute_reduction = True
-        if company.state_id != partner.state_id and not partner.is_company:
-            compute_reduction = False
 
         kwargs.update({
             'add_to_base': sum(add_to_base),

--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -46,6 +46,7 @@ TAX_DICT_VALUES = {
     "value_amount": 0.00,
     "uot_id": False,
     "tax_value": 0.00,
+    "compute_reduction": True,
 }
 
 
@@ -363,12 +364,9 @@ class Tax(models.Model):
             # Add IPI in ICMS Base
             add_to_base.append(tax_dict_ipi.get("tax_value", 0.00))
 
-        compute_reduction = True
-
         kwargs.update({
             'add_to_base': sum(add_to_base),
             'remove_from_base': sum(remove_from_base),
-            'compute_reduction': compute_reduction,
             'icms_base_type': tax.icms_base_type
         })
 
@@ -536,14 +534,9 @@ class Tax(models.Model):
                 tax_dict["percent_amount"] = icms_sn_percent
                 tax_dict["value_amount"] = icms_sn_percent
 
-        compute_reduction = True
-        if company.state_id != partner.state_id and not partner.is_company:
-            compute_reduction = False
-
         kwargs.update({
             'add_to_base': sum(add_to_base),
             'remove_from_base': sum(remove_from_base),
-            'compute_reduction': compute_reduction
         })
 
         taxes_dict.update(self._compute_tax_base(


### PR DESCRIPTION
Hello guys, I'm opening this PR more with a character of doubt. 

We recently came across the following situation with a customer. In one of the tests he was reproducing a sale to the final consumer of a product that had a reduction in the ICMS calculation base. However, it fell in the validation that is being the target of this PR (It was a sale to another state and to a partner that was not a company). 

From the research we have done, we have not found a reason for the reduction to be calculated just in case it is a sale to a company in the same state. I would like to confirm with you if we are missing any legislation that requires this validation.