### PR TITLE
Definir os tax.definition do ICMS como noupdate

### DIFF
--- a/l10n_br_fiscal/data/l10n_br_fiscal_icms_tax_definition_data.xml
+++ b/l10n_br_fiscal/data/l10n_br_fiscal_icms_tax_definition_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo noupdate="True">
 
   <!-- ICMS -->
   <!-- AC -->

--- a/l10n_br_fiscal/data/l10n_br_fiscal_tax_icms_data.xml
+++ b/l10n_br_fiscal/data/l10n_br_fiscal_tax_icms_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo noupdate="True">
 
   <record id="tax_icms_regulation" model="l10n_br_fiscal.icms.regulation">
     <field name="name">Regulamento do ICMS</field>


### PR DESCRIPTION
Ao configurar as definições dos impostos do ICMS e atualizar o módulo l10n_br_fiscal as definições são carregadas novamente apagando a configuração feita na base de dados, neste PR os dados são definidos com noupdate="True" para evitar esse problema.