### PR TITLE
[12.0][FIX] Purchase data in invoice created from Picking

### DIFF
--- a/l10n_br_purchase_stock/__init__.py
+++ b/l10n_br_purchase_stock/__init__.py
@@ -3,3 +3,4 @@
 
 from . import models
 from . import tests
+from . import wizards

--- a/l10n_br_purchase_stock/__manifest__.py
+++ b/l10n_br_purchase_stock/__manifest__.py
@@ -17,6 +17,9 @@
         'views/purchase_order.xml',
         'views/res_config_settings.xml',
     ],
+    'demo': [
+        'demo/purchase_order.xml',
+    ],
     'installable': True,
     'auto_install': True,
 }

--- a/l10n_br_purchase_stock/demo/purchase_order.xml
+++ b/l10n_br_purchase_stock/demo/purchase_order.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+    <!-- Criação da Invoice baseada no Picking.
+     Com isso os Picking são criados com o invoice_state 2binvoiced -->
+    <record id="purchase_create_invoice_policy_settings" model="res.config.settings">
+        <field name="purchase_create_invoice_policy">stock_picking</field>
+    </record>
+
+    <function model="res.config.settings" name="execute">
+        <value model="res.config.settings"
+               search="[('id', '=',
+                ref('purchase_create_invoice_policy_settings'))]"/>
+    </function>
+
+    <!-- Testar quando o Cliente possui o Termo de Pagamento diferente do Pedido de Venda -->
+    <record id="l10n_br_base.res_partner_akretion" model="res.partner">
+        <field name="property_payment_term_id" ref="account.account_payment_term_15days"/>
+    </record>
+
+    <!-- Main Company Simples Nacional -->
+    <!-- Purchase Order with only products test -->
+    <record id="main_po_only_products_1" model="purchase.order">
+        <field name="name">Main l10n_br_purchase_stock</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_akretion"/>
+        <field name="payment_term_id" ref="account.account_payment_term_advance"/>
+        <field name="state">draft</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="company_id" ref="base.main_company"/>
+        <field name="notes">TESTE - TERMOS E CONDIÇÕES</field>
+        <field name="customer_additional_data">TESTE - CUSTOMER ADDITIONAL DATA</field>
+        <field name="fiscal_additional_data">TESTE - FISCAL ADDITIONAL DATA</field>
+    </record>
+
+    <function model="purchase.order" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('main_po_only_products_1')]"/>
+    </function>
+
+    <record id="main_pl_only_products_1_1" model="purchase.order.line">
+        <field name="order_id" ref="main_po_only_products_1"/>
+        <field name="name">Office Chair Black</field>
+        <field name="product_id" ref="product.product_product_12"/>
+        <field name="product_qty">4</field>
+        <field name="product_uom" ref="uom.product_uom_unit"/>
+        <field name="price_unit">250</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras"/>
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_compras_compras"/>
+        <field name="date_planned" eval="time.strftime('%Y-%m-%d')"/>
+        <field name="partner_order">999999</field>
+        <field name="partner_order_line">001</field>
+        <field name="additional_data">Teste - Additional Data</field>
+        <field name="insurance_value">10</field>
+        <field name="other_costs_value">10</field>
+        <field name="freight_value">10</field>
+    </record>
+
+    <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('main_pl_only_products_1_1')]"/>
+    </function>
+
+    <function model="purchase.order.line" name="_onchange_fiscal_operation_line_id">
+        <value eval="[ref('main_pl_only_products_1_1')]"/>
+    </function>
+
+    <record id="main_pl_only_products_1_2" model="purchase.order.line">
+        <field name="order_id" ref="main_po_only_products_1"/>
+        <field name="name">Laptop Customized</field>
+        <field name="product_id" ref="product.product_product_27"/>
+        <field name="product_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit"/>
+        <field name="price_unit">500</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras"/>
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_compras_compras"/>
+        <field name="date_planned" eval="time.strftime('%Y-%m-%d')"/>
+        <field name="partner_order">999999</field>
+        <field name="partner_order_line">002</field>
+        <field name="additional_data">Teste - Additional Data</field>
+        <field name="insurance_value">10</field>
+        <field name="other_costs_value">10</field>
+        <field name="freight_value">10</field>
+    </record>
+
+    <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('main_pl_only_products_1_2')]"/>
+    </function>
+
+    <function model="purchase.order.line" name="_onchange_fiscal_operation_line_id">
+        <value eval="[ref('main_pl_only_products_1_2')]"/>
+    </function>
+
+    <!-- Purchase Order with only products test 2 - Teste Agrupamento -->
+    <record id="main_po_only_products_2" model="purchase.order">
+        <field name="name">Main l10n_br_purchase_stock - teste agrupamento</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_akretion"/>
+        <field name="payment_term_id" ref="account.account_payment_term_advance"/>
+        <field name="state">draft</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="company_id" ref="base.main_company"/>
+        <field name="notes">TESTE - TERMOS E CONDIÇÕES</field>
+        <field name="customer_additional_data">TESTE - CUSTOMER ADDITIONAL DATA</field>
+        <field name="fiscal_additional_data">TESTE - FISCAL ADDITIONAL DATA</field>
+    </record>
+
+    <function model="purchase.order" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('main_po_only_products_2')]"/>
+    </function>
+
+    <record id="main_pl_only_products_2_1" model="purchase.order.line">
+        <field name="order_id" ref="main_po_only_products_2"/>
+        <field name="name">Office Chair Black</field>
+        <field name="product_id" ref="product.product_product_12"/>
+        <field name="product_qty">4</field>
+        <field name="product_uom" ref="uom.product_uom_unit"/>
+        <field name="price_unit">250</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras"/>
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_compras_compras"/>
+        <field name="date_planned" eval="time.strftime('%Y-%m-%d')"/>
+        <field name="partner_order">0000001</field>
+        <field name="partner_order_line">001</field>
+        <field name="additional_data">Teste - Additional Data</field>
+        <field name="insurance_value">10</field>
+        <field name="other_costs_value">10</field>
+        <field name="freight_value">10</field>
+    </record>
+
+    <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('main_pl_only_products_2_1')]"/>
+    </function>
+
+    <function model="purchase.order.line" name="_onchange_fiscal_operation_line_id">
+        <value eval="[ref('main_pl_only_products_2_1')]"/>
+    </function>
+
+    <record id="main_pl_only_products_2_2" model="purchase.order.line">
+        <field name="order_id" ref="main_po_only_products_2"/>
+        <field name="name">Laptop Customized</field>
+        <field name="product_id" ref="product.product_product_27"/>
+        <field name="product_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit"/>
+        <field name="price_unit">500</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras"/>
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_compras_compras"/>
+        <field name="date_planned" eval="time.strftime('%Y-%m-%d')"/>
+        <field name="partner_order">0000001</field>
+        <field name="partner_order_line">002</field>
+        <field name="additional_data">Teste - Additional Data</field>
+        <field name="insurance_value">10</field>
+        <field name="other_costs_value">10</field>
+        <field name="freight_value">10</field>
+    </record>
+
+    <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('main_pl_only_products_2_2')]"/>
+    </function>
+
+    <function model="purchase.order.line" name="_onchange_fiscal_operation_line_id">
+        <value eval="[ref('main_pl_only_products_2_2')]"/>
+    </function>
+
+</odoo>

--- a/l10n_br_purchase_stock/models/__init__.py
+++ b/l10n_br_purchase_stock/models/__init__.py
@@ -6,3 +6,4 @@ from . import purchase_order
 from . import purchase_order_line
 from . import stock_rule
 from . import res_config_settings
+from . import stock_move

--- a/l10n_br_purchase_stock/models/purchase_order.py
+++ b/l10n_br_purchase_stock/models/purchase_order.py
@@ -19,4 +19,8 @@ class PurchaseOrder(models.Model):
     def _prepare_picking(self):
         values = super()._prepare_picking()
         values.update(self._prepare_br_fiscal_dict())
+        if (self.company_id.purchase_create_invoice_policy
+                == 'stock_picking'):
+            values['invoice_state'] = '2binvoiced'
+
         return values

--- a/l10n_br_purchase_stock/models/stock_move.py
+++ b/l10n_br_purchase_stock/models/stock_move.py
@@ -1,0 +1,22 @@
+# @ 2021 Akretion - www.akretion.com.br -
+#   Magno Costa <magno.costa@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class StockMove(models.Model):
+    _inherit = 'stock.move'
+
+    @api.multi
+    def _get_price_unit_invoice(self, inv_type, partner, qty=1):
+        result = super()._get_price_unit_invoice(inv_type, partner, qty)
+        # Caso tenha Purchase Line já vem desagrupado aqui devido ao KEY
+        if len(self) == 1:
+            # Caso venha apenas uma linha porem sem
+            # purchase_line_id é preciso ignora-la
+            if self.purchase_line_id and \
+                    self.purchase_line_id.price_unit != result:
+                result = self.purchase_line_id.price_unit
+
+        return result

--- a/l10n_br_purchase_stock/readme/CONTRIBUTORS.rst
+++ b/l10n_br_purchase_stock/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Renato Lima <renato.lima@akretion.com.br>
+* Magno Costa <magno.costa@akretion.com.br>

--- a/l10n_br_purchase_stock/tests/test_l10n_br_purchase_stock.py
+++ b/l10n_br_purchase_stock/tests/test_l10n_br_purchase_stock.py
@@ -8,6 +8,11 @@ from odoo.addons.l10n_br_purchase.tests import test_l10n_br_purchase
 
 class L10nBrPurchaseStockBase(test_l10n_br_purchase.L10nBrPurchaseBaseTest):
 
+    def setUp(self):
+        super().setUp()
+        self.invoice_model = self.env['account.invoice']
+        self.invoice_wizard = self.env['stock.invoice.onshipping']
+
     def _picking_purchase_order(self, order):
         self.assertEqual(
             order.picking_count, 1,
@@ -25,3 +30,76 @@ class L10nBrPurchaseStockBase(test_l10n_br_purchase.L10nBrPurchaseBaseTest):
     def test_l10n_br_purchase_products(self):
         super().test_l10n_br_purchase_products()
         self._picking_purchase_order(self.po_products)
+
+    def test_grouping_pickings(self):
+        """
+        Test the invoice generation grouped by partner/product with 2
+        picking and 2 moves per picking.
+        """
+        purchase_1 = self.env.ref(
+            'l10n_br_purchase_stock.main_po_only_products_1')
+        purchase_1.button_confirm()
+        picking_1 = purchase_1.picking_ids
+        self.assertEqual(picking_1.invoice_state, '2binvoiced',
+                         'Error to inform Invoice State.')
+
+        picking_1.action_confirm()
+        picking_1.action_assign()
+        # Force product availability
+        for move in picking_1.move_ids_without_package:
+            move.quantity_done = move.product_uom_qty
+        picking_1.button_validate()
+        self.assertEqual(picking_1.state, 'done')
+
+        self.assertEquals(
+            purchase_1.invoice_status, 'to invoice',
+            "Error in compute field invoice_status,"
+            " before create invoice by Picking."
+        )
+
+        purchase_2 = self.env.ref(
+            'l10n_br_purchase_stock.main_po_only_products_2')
+        purchase_2.button_confirm()
+        picking_2 = purchase_2.picking_ids
+        picking_2.action_confirm()
+        picking_2.action_assign()
+        # Force product availability
+        for move in picking_2.move_ids_without_package:
+            move.quantity_done = move.product_uom_qty
+        picking_2.button_validate()
+
+        pickings = picking_1 | picking_2
+        wizard_obj = self.invoice_wizard.with_context(
+            active_ids=pickings.ids,
+            active_model=pickings._name,
+        )
+        fields_list = wizard_obj.fields_get().keys()
+        wizard_values = wizard_obj.default_get(fields_list)
+        # One invoice per partner but group products
+        wizard_values.update({
+            'group': 'partner_product',
+        })
+        wizard = wizard_obj.create(wizard_values)
+        wizard.onchange_group()
+        wizard.action_generate()
+        domain = [('picking_ids', 'in', (picking_1.id, picking_2.id))]
+        invoice = self.invoice_model.search(domain)
+        # Fatura Agrupada
+        self.assertEquals(len(invoice), 1)
+        self.assertEqual(picking_1.invoice_state, 'invoiced')
+        self.assertEqual(picking_2.invoice_state, 'invoiced')
+
+        self.assertIn(invoice, picking_1.invoice_ids)
+        self.assertIn(picking_1, invoice.picking_ids)
+        self.assertIn(invoice, picking_2.invoice_ids)
+        self.assertIn(picking_2, invoice.picking_ids)
+
+        # Validar o price_unit usado
+        for inv_line in invoice.invoice_line_ids:
+            self.assertTrue(
+                inv_line.invoice_line_tax_ids,
+                'Error to map Purchase Tax in invoice.line.')
+            # Preço usado na Linha da Invoice deve ser o mesmo
+            # informado no Pedido de Compra
+            self.assertEqual(inv_line.price_unit,
+                             inv_line.purchase_line_id.price_unit)

--- a/l10n_br_purchase_stock/wizards/__init__.py
+++ b/l10n_br_purchase_stock/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_invocing_onshipping

--- a/l10n_br_purchase_stock/wizards/stock_invocing_onshipping.py
+++ b/l10n_br_purchase_stock/wizards/stock_invocing_onshipping.py
@@ -1,0 +1,69 @@
+# @ 2021 Akretion - www.akretion.com.br -
+#   Magno Costa <magno.costa@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, fields, models
+
+
+class StockInvoiceOnshipping(models.TransientModel):
+
+    _inherit = 'stock.invoice.onshipping'
+
+    @api.multi
+    def _build_invoice_values_from_pickings(self, pickings):
+        """
+        Build dict to create a new invoice from given pickings
+        :param pickings: stock.picking recordset
+        :return: dict
+        """
+        invoice, values = super()._build_invoice_values_from_pickings(pickings)
+
+        pick = fields.first(pickings)
+        if pick.purchase_id:
+            values['purchase_id'] = pick.purchase_id.id
+            if pick.purchase_id.payment_term_id.id != values['payment_term_id']:
+                values.update({
+                    'payment_term_id': pick.purchase_id.payment_term_id.id
+                })
+
+        return invoice, values
+
+    @api.multi
+    def _get_move_key(self, move):
+        """
+        Get the key based on the given move
+        :param move: stock.move recordset
+        :return: key
+        """
+        key = super()._get_move_key(move)
+        if move.purchase_line_id:
+            # TODO: deveria permitir agrupar as linhas ?
+            #  Deveria permitir agrupar Pedidos de Compras ?
+            if type(key) is tuple:
+                key = key + (move.purchase_line_id,)
+            else:
+                # TODO - seria melhor identificar o TYPE para saber se
+                #  o KEY realmente é um objeto nesse caso
+                key = (key, move.purchase_line_id)
+
+        return key
+
+    def _get_invoice_line_values(self, moves, invoice_values, invoice):
+        """
+        Create invoice line values from given moves
+        :param moves: stock.move
+        :param invoice: account.invoice
+        :return: dict
+        """
+
+        values = super()._get_invoice_line_values(
+            moves, invoice_values, invoice)
+        # Devido ao KEY com purchase_line_id aqui
+        # vem somente um registro
+        if len(moves) == 1:
+            # Caso venha apenas uma linha porem sem
+            # purchase_line_id é preciso ignora-la
+            if moves.purchase_line_id:
+                values['purchase_line_id'] = moves.purchase_line_id.id
+
+        return values


### PR DESCRIPTION
Fix Purchase data in invoice created from Picking.

* Informando o invoice_state do picking
* Não agrupando as linhas quando forem de compras
* O preço unitário dos itens na Fatura criada deve ser o mesmo do informado no Pedido de Compra

Adicionado dados de demo e testes para validar essas questões.

 cc @renatonlima @rvalyi 