### PR TITLE
[12.0] Demo Configurar cancelar lançamentos contábeis

### DIFF
--- a/l10n_br_coa_generic/demo/account_journal.xml
+++ b/l10n_br_coa_generic/demo/account_journal.xml
@@ -20,4 +20,16 @@
             },]"/>
     </function>
 
+    <record id="sale_journal_empresa_lp" model="account.journal">
+        <field name="update_posted" eval="True"/>
+    </record>
+
+    <record id="purchase_journal_empresa_lp" model="account.journal">
+        <field name="update_posted" eval="True"/>
+    </record>
+
+    <record id="general_journal_empresa_lp" model="account.journal">
+        <field name="update_posted" eval="True"/>
+    </record>
+
 </odoo>

--- a/l10n_br_coa_simple/demo/account_journal.xml
+++ b/l10n_br_coa_simple/demo/account_journal.xml
@@ -35,4 +35,28 @@
             },]"/>
     </function>
 
+    <record id="sale_journal_main_company" model="account.journal">
+        <field name="update_posted" eval="True"/>
+    </record>
+
+    <record id="sale_journal_empresa_sn" model="account.journal">
+        <field name="update_posted" eval="True"/>
+    </record>
+
+    <record id="purchase_journal_main_company" model="account.journal">
+        <field name="update_posted" eval="True"/>
+    </record>
+
+    <record id="purchase_journal_empresa_sn" model="account.journal">
+        <field name="update_posted" eval="True"/>
+    </record>
+
+    <record id="general_journal_main_company" model="account.journal">
+        <field name="update_posted" eval="True"/>
+    </record>
+
+    <record id="general_journal_empresa_sn" model="account.journal">
+        <field name="update_posted" eval="True"/>
+    </record>    
+
 </odoo>


### PR DESCRIPTION
Este PR define o campo "Permite Cancelar Lançamentos Contábeis" nos diários contábeis carregados nos dados de demo.