### PR TITLE
[ADD] fiscal document message alerts

### DIFF
--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -62,6 +62,15 @@
 <!--            -->
             <field name="state" widget="statusbar" statusbar_visible="em_digitacao,autorizada"/>
         </header>
+        <div class="alert alert-danger" role="alert" attrs="{'invisible': [('state_edoc','not in',('rejeitada', 'denegada'))]}">
+            Fiscal Document: <field name="document_type_id"/> is <strong><field name="state_edoc"/></strong>: <field name="codigo_motivo_situacao"/>
+        </div>
+        <div class="alert alert-success" role="alert" attrs="{'invisible': [('state_edoc','!=','autorizada')]}">
+            Fiscal Document: <field name="document_type_id"/> is <strong>Authorized</strong>
+        </div>
+        <div class="alert alert-warning" role="alert" attrs="{'invisible': [('state_edoc','!=','cancelada')]}">
+            Fiscal Document: <field name="document_type_id"/> is <strong>Cancelled</strong>
+        </div>
         <sheet string="Fiscal Document">
           <div class="oe_title">
             <h1>
@@ -89,7 +98,6 @@
             <group>
               <field name="document_serie_id" attrs="{'invisible': [('issuer', '!=', 'company')], 'required': [('issuer', '=', 'company')]}" context="{'default_document_type_id': document_type_id}"/>
               <field name="document_serie" attrs="{'invisible': [('issuer', '!=', 'partner')], 'required': [('issuer', '=', 'partner')]}"/>
-              <field name="codigo_motivo_situacao" attrs="{'invisible': [('document_electronic', '=', '0')]}"/>
             </group>
             <group>
               <field name="number" force_save="1" attrs="{'readonly': [('issuer', '=', 'company')], 'required': [('issuer', '=', 'partner')]}"/>
@@ -199,6 +207,7 @@
             <page name="others" string="Others">
                 <group>
                     <field name="operation_name"/>
+                    <field name="codigo_motivo_situacao" attrs="{'invisible': [('document_electronic', '=', '0')]}"/>
                 </group>
                 <group>
                     <group name="autorizacao" string="Autorização" colspan="4">


### PR DESCRIPTION
Adiciona as informações dos status da NF-e de forma mais amigável

Nota Fiscal rejeitada ou denegada
----------------------------------
<img width="1435" alt="Captura de Tela 2021-03-03 às 18 42 49" src="https://user-images.githubusercontent.com/211005/109876859-0ac7e600-7c51-11eb-90b2-76de5fb290cc.png">

Nota Fiscal cancelada
----------------------
<img width="1440" alt="Captura de Tela 2021-03-03 às 18 44 08" src="https://user-images.githubusercontent.com/211005/109876872-0dc2d680-7c51-11eb-81ed-7987760ad1cf.png">

Nota Fiscal autorizada
----------------------
<img width="1440" alt="Captura de Tela 2021-03-03 às 18 44 56" src="https://user-images.githubusercontent.com/211005/109877068-537f9f00-7c51-11eb-888f-9bf0cde81690.png">

