### PR TITLE
[ADD] Restringir a exclusão dos documentos fiscais Dummy

### DIFF
--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -5,7 +5,7 @@
 from ast import literal_eval
 
 from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
+from odoo.exceptions import ValidationError, UserError
 
 from ..constants.fiscal import (
     TAX_FRAMEWORK,
@@ -740,6 +740,12 @@ class Document(models.Model):
         if not values.get('date'):
             values['date'] = self._date_server_format()
         return super().create(values)
+
+    @api.multi
+    def unlink(self):
+        if self.env.ref('l10n_br_fiscal.fiscal_document_dummy') in self:
+            raise UserError(_("You cannot unlink Fiscal Document Dummy !"))
+        return super().unlink()
 
     @api.onchange('company_id')
     def _onchange_company_id(self):

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -1,7 +1,8 @@
 # Copyright (C) 2013  Renato Lima - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 from ..constants.fiscal import (TAX_FRAMEWORK)
 
@@ -159,3 +160,10 @@ class DocumentLine(models.Model):
         compute='_compute_amount',
         default=0.00,
     )
+
+    @api.multi
+    def unlink(self):
+        if self.env.ref('l10n_br_fiscal.fiscal_document_line_dummy') in self:
+            raise UserError(
+                _("You cannot unlink Fiscal Document Line Dummy !"))
+        return super().unlink()

--- a/l10n_br_fiscal/tests/test_fiscal_document_generic.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_generic.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo.tests.common import TransactionCase
+from odoo.exceptions import UserError
 
 from ..constants.icms import ICMS_ORIGIN_TAX_IMPORTED
 
@@ -784,3 +785,15 @@ class TestFiscalDocumentGeneric(TransactionCase):
             self.nfe_same_state.fiscal_operation_id.return_fiscal_operation_id.id,
             "Error on creation return"
         )
+
+    def test_unlink_dummy_document(self):
+        """ Test Dummy Fiscal Document Unlink Restrictions """
+        dummy_document = self.env.ref('l10n_br_fiscal.fiscal_document_dummy')
+        with self.assertRaises(UserError):
+            dummy_document.unlink()
+
+    def test_unlink_dummy_document_line(self):
+        """ Test Dummy Fiscal Document Line Unlink Restrictions """
+        dummy_line = self.env.ref('l10n_br_fiscal.fiscal_document_line_dummy')
+        with self.assertRaises(UserError):
+            dummy_line.unlink()


### PR DESCRIPTION
Os documentos: documento fiscal e linha de documento fiscal tem registros dummy que servem para serem informados nas faturas e linhas das faturas quando a fatura não tem um documento fiscal. Esse PR não permite a exclusão destes documento que são importantes para o funcionamento correto da localização brasileira.