### PR TITLE
[12.0][FIX]  Creation Invoice from Sale Order with Product and Service

### DIFF
--- a/l10n_br_sale_stock/demo/sale_order_demo.xml
+++ b/l10n_br_sale_stock/demo/sale_order_demo.xml
@@ -143,11 +143,11 @@
 
     <record id="main_sl_l10n_br_sale_stock_2_2" model="sale.order.line">
         <field name="order_id" ref="main_so_l10n_br_sale_stock_2"/>
-        <field name="name">Virtual Home Staging</field>
-        <field name="product_id" ref="product.product_product_2"/>
-        <field name="product_uom_qty">20</field>
+        <field name="name">Customized Odoo Development</field>
+        <field name="product_id" ref="l10n_br_fiscal.customized_development_sale"/>
+        <field name="product_uom_qty">10</field>
         <field name="product_uom" ref="uom.product_uom_hour"/>
-        <field name="price_unit">38.25</field>
+        <field name="price_unit">100</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
         <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_servico_ind"/>

--- a/l10n_br_sale_stock/models/sale_order.py
+++ b/l10n_br_sale_stock/models/sale_order.py
@@ -1,13 +1,39 @@
 # Copyright (C) 2020  Magno Costa - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import fields, models
+from odoo import fields, models, api
 
 
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
     # Make Invisible Invoice Button
-    sale_create_invoice_policy = fields.Selection(
-        related='company_id.sale_create_invoice_policy',
+    button_create_invoice_invisible = fields.Boolean(
+        compute='_get_button_create_invoice_invisible'
     )
+
+    @api.depends('state', 'order_line.invoice_status')
+    def _get_button_create_invoice_invisible(self):
+
+        button_create_invoice_invisible = False
+
+        if self.company_id.sale_create_invoice_policy == 'stock_picking':
+            has_services_to_invoice = self.order_line.filtered(
+                lambda x: x.product_id.type == 'service' and
+                          x.invoice_status == 'to invoice'
+            )
+            # A criação de Fatura de Serviços deve ser possível via Pedido
+            if not has_services_to_invoice:
+                button_create_invoice_invisible = True
+        else:
+            # No caso da Politica de criação baseada no Pedido de Venda
+            # qdo acionado o Botão irá criar as Faturas automaticamente
+            # mesmo no caso de ter Produtos e Serviços
+            if self.invoice_count > 0:
+                button_create_invoice_invisible = True
+
+        # Somente depois do Pedido confirmado o botão pode aparecer
+        if self.state != 'sale':
+            button_create_invoice_invisible = True
+
+        self.button_create_invoice_invisible = button_create_invoice_invisible

--- a/l10n_br_sale_stock/models/sale_order.py
+++ b/l10n_br_sale_stock/models/sale_order.py
@@ -19,8 +19,9 @@ class SaleOrder(models.Model):
 
         if self.company_id.sale_create_invoice_policy == 'stock_picking':
             has_services_to_invoice = self.order_line.filtered(
-                lambda x: x.product_id.type == 'service' and
-                          x.invoice_status == 'to invoice'
+                lambda x:
+                x.product_id.type == 'service' and
+                x.invoice_status == 'to invoice'
             )
             # A criação de Fatura de Serviços deve ser possível via Pedido
             if not has_services_to_invoice:

--- a/l10n_br_sale_stock/models/sale_order_line.py
+++ b/l10n_br_sale_stock/models/sale_order_line.py
@@ -14,8 +14,43 @@ class SaleOrderLine(models.Model):
         values = self._prepare_br_fiscal_dict()
         values.update(super()._prepare_procurement_values(group_id))
         # Incluir o invoice_state
-        if self.order_id.company_id.sale_create_invoice_policy \
+        if self.order_id.company_id.sale_create_invoice_policy\
                 == 'stock_picking':
             values['invoice_state'] = '2binvoiced'
 
         return values
+
+    # no trigger product_id.invoice_policy to avoid retroactively changing SO
+    @api.depends(
+        'qty_invoiced', 'qty_delivered', 'product_uom_qty', 'order_id.state')
+    def _get_to_invoice_qty(self):
+        """
+        Compute the quantity to invoice. If the invoice policy is order,
+        the quantity to invoice is calculated from the ordered quantity.
+        Otherwise, the quantity delivered is used.
+        """
+        super()._get_to_invoice_qty()
+
+        for line in self:
+            if line.order_id.state in ['sale', 'done']:
+                if line.product_id.invoice_policy == 'order':
+                    if line.order_id.company_id.sale_create_invoice_policy ==\
+                            'stock_picking' and\
+                            line.product_id.type == 'product':
+                        # O correto seria que ao selecionar
+                        # sale_create_invoice_policy 'stock_picking' os
+                        # produtos tenham o campo invoice_policy definidos para
+                        # 'delivery', porém para evitar que seja criada uma
+                        # Fatura a partir do Pedido de Venda estamos
+                        # alterando isso mesmo para os produtos definidos com
+                        # 'order', já que a Politica de Criação da Fatura no
+                        # caso do Tipo Produto está definida para ser a
+                        # partir do stock.picking .
+                        # TODO: Essa seria a melhor opção ? Por enquanto pelo
+                        #  que vi para ter o mesmo resultado, que é no caso
+                        #  sale_create_invoice_policy 'stock_picking' só ser
+                        #  possível criar a partir do sale.order Faturas das
+                        #  linhas que sejam type service sim, a outra opção
+                        #  seria sobre escrever o metodo action_invoice_create
+                        #  sem ser possível chamar o super.
+                        line.qty_to_invoice = 0

--- a/l10n_br_sale_stock/models/sale_order_line.py
+++ b/l10n_br_sale_stock/models/sale_order_line.py
@@ -14,7 +14,8 @@ class SaleOrderLine(models.Model):
         values = self._prepare_br_fiscal_dict()
         values.update(super()._prepare_procurement_values(group_id))
         # Incluir o invoice_state
-        if self.order_id.sale_create_invoice_policy == 'stock_picking':
+        if self.order_id.company_id.sale_create_invoice_policy \
+                == 'stock_picking':
             values['invoice_state'] = '2binvoiced'
 
         return values

--- a/l10n_br_sale_stock/views/sale_order_view.xml
+++ b/l10n_br_sale_stock/views/sale_order_view.xml
@@ -7,11 +7,11 @@
         <field name="inherit_id" ref="l10n_br_sale.l10n_br_sale_order_form"/>
         <field name="priority">99</field>
         <field name="arch" type="xml">
-            <field name="state" position="before">
-                <field name="sale_create_invoice_policy" invisible="1"/>
+            <field name="partner_id" position="before">
+                <field name="button_create_invoice_invisible" invisible="1"/>
             </field>
             <xpath expr="//button[@name='%(sale.action_view_sale_advance_payment_inv)d']" position="attributes">
-                <attribute name="attrs">{'invisible': [('sale_create_invoice_policy', '!=', 'sale_order')]}</attribute>
+                <attribute name="attrs">{'invisible': [('button_create_invoice_invisible', '=', True)]}</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Creation Invoice from Sale Order with Product and Service.

* Botão de Criar Faturas usando um campo compute porque isso é dinâmico e depende se existir uma linha de serviço
* Bloqueada a Criação de Fatura pela Ordem de Venda quando a Politica de Criação de Fatura de Vendas seja 'stock_picking' e o Produto tenha o campo 'type' definido com 'product' independente da 'invoice_policy' do produto, nesse caso apenas a Fatura de Serviço poderá ser criada a partir do Pedido de Venda ( A solução feita para isso é debatível e precisa ser revisada porém por enquanto é a única opção que encontrei, sem ser dessa forma seria sobre escrever o método action_invoice_create porém sem chamar o super, o que parece ser pior )
* Incluído teste para validar essas questões

cc @renatonlima @rvalyi 