### PR TITLE
l10n_br_currency_rate_update faster CI: 14239 queries down to 9816

### DIFF
--- a/l10n_br_currency_rate_update/tests/test_currency_rate_update_bcb.py
+++ b/l10n_br_currency_rate_update/tests/test_currency_rate_update_bcb.py
@@ -3,13 +3,14 @@
 
 from dateutil.relativedelta import relativedelta
 from odoo import fields
-from odoo.tests import common
+from odoo.tests import SavepointCase
 
 
-class TestCurrencyRateUpdateBCB(common.TransactionCase):
-    def setUp(self):
-        super().setUp()
+class TestCurrencyRateUpdateBCB(SavepointCase):
 
+    @classmethod
+    def setUpClass(self):
+        super().setUpClass()
         self.Company = self.env["res.company"]
         self.CurrencyRate = self.env["res.currency.rate"]
         self.CurrencyRateProvider = self.env["res.currency.rate.provider"]


### PR DESCRIPTION
antes:
![2021-03-10_00-46](https://user-images.githubusercontent.com/16926/110573612-53443f80-813a-11eb-8c07-1afc356ccb9c.png)

depois:
![2021-03-10_00-47](https://user-images.githubusercontent.com/16926/110573621-563f3000-813a-11eb-9dab-e0a9299d6a3a.png)

Infelizmente nao tem nehnum ganho magico para ganhar muito tempo nessa nossa serie de teste. Aqui estamos ganhando 6 segundos, 5000 queries e salvando duas focas por ano. Ja eh isso.
