### PR TITLE
[12.0][FIX] Invoice line created from Stock Picking without Fiscal Operation

### DIFF
--- a/l10n_br_purchase_stock/tests/test_l10n_br_purchase_stock.py
+++ b/l10n_br_purchase_stock/tests/test_l10n_br_purchase_stock.py
@@ -101,5 +101,13 @@ class L10nBrPurchaseStockBase(test_l10n_br_purchase.L10nBrPurchaseBaseTest):
                 'Error to map Purchase Tax in invoice.line.')
             # Preço usado na Linha da Invoice deve ser o mesmo
             # informado no Pedido de Compra
-            self.assertEqual(inv_line.price_unit,
-                             inv_line.purchase_line_id.price_unit)
+            self.assertEqual(
+                inv_line.price_unit,
+                inv_line.purchase_line_id.price_unit)
+            # Valida presença dos campos principais para o mapeamento Fiscal
+            self.assertTrue(
+                inv_line.fiscal_operation_id,
+                'Missing Fiscal Operation.')
+            self.assertTrue(
+                inv_line.fiscal_operation_line_id,
+                'Missing Fiscal Operation Line.')

--- a/l10n_br_sale_stock/tests/test_sale_stock.py
+++ b/l10n_br_sale_stock/tests/test_sale_stock.py
@@ -210,6 +210,13 @@ class TestSaleStock(SavepointCase):
             self.assertTrue(
                 inv_line.invoice_line_tax_ids,
                 'Error to map Sale Tax in invoice.line.')
+            # Valida presença dos campos principais para o mapeamento Fiscal
+            self.assertTrue(
+                inv_line.fiscal_operation_id,
+                'Missing Fiscal Operation.')
+            self.assertTrue(
+                inv_line.fiscal_operation_line_id,
+                'Missing Fiscal Operation Line.')
 
     def test_ungrouping_pickings_partner_shipping_different(self):
         """

--- a/l10n_br_stock_account/tests/test_invoicing_picking.py
+++ b/l10n_br_stock_account/tests/test_invoicing_picking.py
@@ -104,6 +104,12 @@ class InvoicingPickingTest(SavepointCase):
             # Venda, ex.: Simples Remessa, Remessa p/ Industrialiazação e etc.
             # Aqui o campo não pode ser negativo
             self.assertEqual(line.price_unit, line.product_id.standard_price)
+            # Valida presença dos campos principais para o mapeamento Fiscal
+            self.assertTrue(
+                line.fiscal_operation_id, 'Missing Fiscal Operation.')
+            self.assertTrue(
+                line.fiscal_operation_line_id,
+                'Missing Fiscal Operation Line.')
 
         self.assertTrue(
             invoice.fiscal_operation_id,

--- a/l10n_br_stock_account/wizards/stock_invoice_onshipping.py
+++ b/l10n_br_stock_account/wizards/stock_invoice_onshipping.py
@@ -85,11 +85,14 @@ class StockInvoiceOnshipping(models.TransientModel):
             moves, invoice_values, invoice)
         move = fields.first(moves)
         fiscal_values = move._prepare_br_fiscal_dict()
+
+        # A Fatura não pode ser criada com os campos price_unit e fiscal_price
+        # negativos, o dict values contem o valor vindo do metodo
+        # _get_price_unit_invoice por isso é necessario obter antes do update
+        price_unit = abs(values.get('price_unit'))
+
         values.update(fiscal_values)
 
-        # A Fatura não pode ser criada com os campos
-        # price_unit é fiscal_price negativos
-        price_unit = abs(values.get('price_unit'))
         values.update({
             'price_unit': price_unit,
             'fiscal_price': price_unit


### PR DESCRIPTION
Invoice line created from Stock Picking without Fiscal Operation https://github.com/OCA/l10n-brazil/issues/1202

Tentei resolver o problema do valor negativo pela sequencia de atualizações dos dicionários mas acabei criando outro, valeu @marcelsavegnago por reportar o BUG, adicionei nos testes dos módulos que usam essa funcionalidade a validação da presença dos campos tanto da Linha quanto da Operação Fiscal.

cc @renatonlima @rvalyi 