### PR TITLE
no more lint false positive SQL injection warning

### DIFF
--- a/l10n_br_base/hooks.py
+++ b/l10n_br_base/hooks.py
@@ -21,7 +21,7 @@ def pre_init_hook(cr):
     if not cr.fetchone():
         env = api.Environment(cr, SUPERUSER_ID, {})
         brazil_country_id = env.ref("base.br").id
-        sql_query = """
+        insert_query = """
         INSERT INTO ir_translation (
             name,
             res_id,
@@ -33,12 +33,12 @@ def pre_init_hook(cr):
             state)
         VALUES (
             'res.country,name',
-            {0},
+            %s,
             'pt_BR',
             'model',
             'Brazil',
             'Brasil',
             'base',
             'translated');
-        """.format(brazil_country_id)
-        cr.execute(sql_query)
+        """
+        cr.execute(insert_query, (brazil_country_id,))


### PR DESCRIPTION
Makes pylint happy. But note that
there were no possible SQL injection even in the previous
code as the brazil_country_id was a database id and not any
kind of user input.

before that:

![2021-03-14_12-31](https://user-images.githubusercontent.com/16926/111074358-56845600-84c1-11eb-995b-59c4ee9f5542.png)
