### PR TITLE
[12.0] [FIX] simplifed tax range calculation

### DIFF
--- a/l10n_br_fiscal/models/res_company.py
+++ b/l10n_br_fiscal/models/res_company.py
@@ -92,7 +92,7 @@ class ResCompany(models.Model):
                         ((record.annual_revenue *
                           record.simplifed_tax_range_id.total_tax_percent / 100) -
                          record.simplifed_tax_range_id.amount_deduced) /
-                        record.annual_revenue) * 100, record.currency_id.decimal_places)
+                        record.simplifed_tax_range_id.final_revenue) * 100, record.currency_id.decimal_places)
 
     cnae_main_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.cnae",


### PR DESCRIPTION
Hello guys.

A correction was made for the simplified rate percentage where the progressive calculation was not using the correct values. In this case, the value used in the division was the annual income of the company and not the value determined in the table of the "Simples Nacional".