### PR TITLE
[12.0][FIX] NFS-e document number

### DIFF
--- a/l10n_br_nfse/models/document.py
+++ b/l10n_br_nfse/models/document.py
@@ -90,6 +90,7 @@ class Document(models.Model):
                     if not record.rps_number and record.date:
                         record.rps_number = record.document_serie_id.\
                             next_seq_number()
+                        record.number = record.rps_number
         super(Document, self - self.filtered(fiter_processador_edoc_nfse)
               ).document_number()
 

--- a/l10n_br_nfse/models/document.py
+++ b/l10n_br_nfse/models/document.py
@@ -90,7 +90,8 @@ class Document(models.Model):
                     if not record.rps_number and record.date:
                         record.rps_number = record.document_serie_id.\
                             next_seq_number()
-        super(Document, self).document_number()
+        super(Document, self - self.filtered(fiter_processador_edoc_nfse)
+              ).document_number()
 
     def _generate_key(self):
         remaining = self - self.filtered(fiter_processador_edoc_nfse)

--- a/l10n_br_nfse_ginfes/tests/test_fiscal_document_nfse_ginfes.py
+++ b/l10n_br_nfse_ginfes/tests/test_fiscal_document_nfse_ginfes.py
@@ -34,7 +34,8 @@ class TestFiscalDocumentNFSeGinfes(TestFiscalDocumentNFSeCommon):
         self.nfse_same_state._onchange_document_serie_id()
         self.nfse_same_state._onchange_fiscal_operation_id()
         self.nfse_same_state._onchange_company_id()
-        self.nfse_same_state.rps_number = 50
+        self.nfse_same_state.rps_number = '50'
+        self.nfse_same_state.number = '50'
 
         for line in self.nfse_same_state.line_ids:
             line._onchange_product_id_fiscal()

--- a/l10n_br_nfse_issnet/tests/test_fiscal_document_nfse_issnet.py
+++ b/l10n_br_nfse_issnet/tests/test_fiscal_document_nfse_issnet.py
@@ -33,7 +33,8 @@ class TestFiscalDocumentNFSeIssnet(TestFiscalDocumentNFSeCommon):
         self.nfse_same_state._onchange_document_serie_id()
         self.nfse_same_state._onchange_fiscal_operation_id()
         self.nfse_same_state._onchange_company_id()
-        self.nfse_same_state.rps_number = 50
+        self.nfse_same_state.rps_number = '50'
+        self.nfse_same_state.number = '50'
 
         for line in self.nfse_same_state.line_ids:
             line._onchange_product_id_fiscal()


### PR DESCRIPTION
In the NFS-e documents, both the fields `rps_number` and `number` got their values from the document_serie_id sequence, causing this document number to advance two by two. This Pull Request solves it.