### PR TITLE
[12.0][FIX] Function _generate_key

### DIFF
--- a/l10n_br_nfse/models/document.py
+++ b/l10n_br_nfse/models/document.py
@@ -95,7 +95,7 @@ class Document(models.Model):
     def _generate_key(self):
         remaining = self - self.filtered(fiter_processador_edoc_nfse)
         if remaining:
-            super(Document, remaining)._generate_key()
+            return super(Document, remaining)._generate_key()
 
     def _processador_erpbrasil_nfse(self):
         certificado = cert.Certificado(


### PR DESCRIPTION
When installed both the l10n_br_nfse and l10n_br_nfe modules, the key generation stops working. This happens because the _generate_key function doesn't return the value of super like it's supposed to. This Pull Request fix this problem.