### PR TITLE
[12.0][FIX] Return Picking process and test

### DIFF
--- a/l10n_br_purchase_stock/__manifest__.py
+++ b/l10n_br_purchase_stock/__manifest__.py
@@ -16,6 +16,7 @@
         # Views
         'views/purchase_order.xml',
         'views/res_config_settings.xml',
+        'views/res_company_view.xml',
     ],
     'demo': [
         'demo/purchase_order.xml',

--- a/l10n_br_purchase_stock/models/res_config_settings.py
+++ b/l10n_br_purchase_stock/models/res_config_settings.py
@@ -1,17 +1,13 @@
 # Copyright (C) 2021  Renato Lima - Akretion <renato.lima@akretion.com.br>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import _, fields, models
+from odoo import fields, models
 
 
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
     purchase_create_invoice_policy = fields.Selection(
-        selection=[
-            ('purchase_order', _('Purchase Order')),
-            ('stock_picking', _('Stock Picking'))],
-        string='Purchase Create Invoice Policy',
         related='company_id.purchase_create_invoice_policy',
         readonly=False,
     )

--- a/l10n_br_purchase_stock/views/res_company_view.xml
+++ b/l10n_br_purchase_stock/views/res_company_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="purchase_inv_policy_res_company_form" model="ir.ui.view">
+        <field name="name">purchase.create.inv.policy.res.company.form</field>
+        <field name="model">res.company</field>
+        <field name="inherit_id" ref="base.view_company_form"/>
+        <field name="arch" type="xml">
+            <field name="purchase_fiscal_operation_id" position="before">
+                <field name="purchase_create_invoice_policy"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/l10n_br_sale_stock/models/res_company.py
+++ b/l10n_br_sale_stock/models/res_company.py
@@ -2,7 +2,7 @@
 # @author Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models, _
+from odoo import _, fields, models
 
 
 class ResCompany(models.Model):

--- a/l10n_br_sale_stock/models/res_company.py
+++ b/l10n_br_sale_stock/models/res_company.py
@@ -2,7 +2,7 @@
 # @author Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import fields, models, _
 
 
 class ResCompany(models.Model):
@@ -10,11 +10,11 @@ class ResCompany(models.Model):
 
     sale_create_invoice_policy = fields.Selection(
         selection=[
-            ('sale_order', 'Sale Order'),
-            ('stock_picking', 'Stock Picking')
+            ('sale_order', _('Sale Order')),
+            ('stock_picking', _('Stock Picking'))
         ],
         string='Sale Create Invoice Policy',
-        help='Define if Invoice should be create'
-             ' from Sale Order or Stock Picking.',
+        help='Define, when Product Type are not service, if Invoice'
+             ' should be create from Sale Order or Stock Picking.',
         default='stock_picking'
     )

--- a/l10n_br_sale_stock/tests/test_sale_stock.py
+++ b/l10n_br_sale_stock/tests/test_sale_stock.py
@@ -14,6 +14,8 @@ class TestSaleStock(SavepointCase):
         super().setUpClass()
         self.invoice_model = self.env['account.invoice']
         self.invoice_wizard = self.env['stock.invoice.onshipping']
+        self.stock_return_picking = self.env['stock.return.picking']
+        self.stock_picking = self.env['stock.picking']
 
     def test_02_sale_stock_return(self):
         """
@@ -49,8 +51,9 @@ class TestSaleStock(SavepointCase):
                         'delivery" storable products')
 
         # set stock.picking to be invoiced
-        self.assertTrue(len(self.so.picking_ids) == 1, 'More than one stock '
-                                                       'picking for sale.order')
+        self.assertTrue(
+            len(self.so.picking_ids) == 1, 'More than one stock '
+                                           'picking for sale.order')
         self.so.picking_ids.set_to_be_invoiced()
 
         # validate stock.picking
@@ -97,6 +100,10 @@ class TestSaleStock(SavepointCase):
         for invoice in sale_order_2.invoice_ids:
             for line in invoice.invoice_line_ids:
                 self.assertEquals(line.product_id.type, 'service')
+            # Confirmando a Fatura de Serviço
+            invoice.action_invoice_open()
+            self.assertEquals(
+                invoice.state, 'open', 'Invoice should be in state Open')
 
         picking = sale_order_2.picking_ids
         # Check product availability
@@ -141,6 +148,69 @@ class TestSaleStock(SavepointCase):
         # No Pedido de Venda devem existir duas Faturas/Documentos Fiscais
         # de Serviço e Produto
         self.assertEquals(2, sale_order_2.invoice_count)
+
+        # Confirmando a Fatura
+        invoice.action_invoice_open()
+        self.assertEquals(
+            invoice.state, 'open', 'Invoice should be in state Open')
+
+        # Teste de Retorno
+        self.return_wizard = self.stock_return_picking.with_context(
+            dict(active_id=picking.id)).create(
+            dict(invoice_state='2binvoiced'))
+
+        result_wizard = self.return_wizard.create_returns()
+        self.assertTrue(result_wizard, 'Create returns wizard fail.')
+        picking_devolution = self.stock_picking.browse(
+            result_wizard.get('res_id'))
+
+        self.assertEqual(picking_devolution.invoice_state, '2binvoiced')
+        self.assertTrue(picking_devolution.fiscal_operation_id,
+                        'Missing Fiscal Operation.')
+        for line in picking_devolution.move_lines:
+            self.assertEqual(line.invoice_state, '2binvoiced')
+            # Valida presença dos campos principais para o mapeamento Fiscal
+            self.assertTrue(
+                line.fiscal_operation_id,
+                'Missing Fiscal Operation.')
+            self.assertTrue(
+                line.fiscal_operation_line_id,
+                'Missing Fiscal Operation Line.')
+        picking_devolution.action_confirm()
+        picking_devolution.action_assign()
+        # Force product availability
+        for move in picking_devolution.move_ids_without_package:
+            move.quantity_done = move.product_uom_qty
+        picking_devolution.button_validate()
+        self.assertEquals(
+            picking_devolution.state, 'done',
+            'Change state fail.'
+        )
+        wizard_obj = self.invoice_wizard.with_context(
+            active_ids=picking_devolution.ids,
+            active_model=picking_devolution._name,
+            active_id=picking_devolution.id,
+        )
+        fields_list = wizard_obj.fields_get().keys()
+        wizard_values = wizard_obj.default_get(fields_list)
+        wizard = wizard_obj.create(wizard_values)
+        wizard.onchange_group()
+        wizard.action_generate()
+        domain = [('picking_ids', '=', picking_devolution.id)]
+        invoice_devolution = self.invoice_model.search(domain)
+        # Confirmando a Fatura
+        invoice_devolution.action_invoice_open()
+        self.assertEquals(
+            invoice_devolution.state, 'open',
+            'Invoice should be in state Open')
+        # Validar Atualização da Quantidade Faturada
+        for line in sale_order_2.order_line:
+            # Apenas a linha de Produto tem a qtd faturada dobrada
+            if line.product_id.type == 'product':
+                # A quantidade Faturada deve ser duas vezes
+                # a quantidade do Produto já que foram criadas
+                # duas Faturas a de Envio e a de Devolução
+                self.assertEqual((2 * line.product_uom_qty), line.qty_invoiced)
 
     def test_picking_invoicing_partner_shipping_invoiced(self):
         """

--- a/l10n_br_sale_stock/views/res_config_settings_view.xml
+++ b/l10n_br_sale_stock/views/res_config_settings_view.xml
@@ -17,7 +17,7 @@
                         </div>
                         <div class="content-group">
                             <div class="mt16">
-                                <field name="sale_create_invoice_policy" class="o_light_label"/>
+                                <field name="sale_create_invoice_policy" class="o_light_label" widget="radio"/>
                             </div>
                         </div>
                     </div>

--- a/l10n_br_stock_account/demo/l10n_br_stock_account_demo.xml
+++ b/l10n_br_stock_account/demo/l10n_br_stock_account_demo.xml
@@ -92,38 +92,6 @@
         <value eval="[ref('demo_main_l10n_br_stock_account-move_1_2')]"/>
     </function>
 
-    <!-- usado para o teste de não agrupar qdo operação fiscal for diferente -->
-    <record model="stock.move" id="demo_main_l10n_br_stock_account-move_1_3">
-        <field name="name">Test - l10n_br_stock_account - 1</field>
-        <!-- sem o campo abaixo falha o mapeamento de CFOP, erro não acontece na tela -->
-        <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp"/>
-        <field name="product_id" ref="product.product_product_27"/>
-        <field name="product_uom_qty">1</field>
-        <field name="product_uom" ref="uom.product_uom_unit"/>
-        <field name="picking_id" ref="demo_main_l10n_br_stock_account-picking-1"/>
-        <field name="location_id" ref="stock.stock_location_stock"/>
-        <field name="location_dest_id" ref="stock.stock_location_customers"/>
-        <field name="invoice_state">2binvoiced</field>
-        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_bonificacao"/>
-        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_bonificacao_bonificacao"/>
-        <field name="company_id" ref="base.main_company"/>
-        <field name="freight_value">100</field>
-        <field name="insurance_value">100</field>
-        <field name="other_costs_value">100</field>
-    </record>
-
-    <function model="stock.move" name="_onchange_product_id_fiscal">
-        <value eval="[ref('demo_main_l10n_br_stock_account-move_1_3')]"/>
-    </function>
-
-    <function model="stock.move" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('demo_main_l10n_br_stock_account-move_1_3')]"/>
-    </function>
-
-    <function model="stock.move" name="_onchange_fiscal_operation_line_id">
-        <value eval="[ref('demo_main_l10n_br_stock_account-move_1_3')]"/>
-    </function>
-
     <!-- Picking Duplicado para testar o Agrupamento -->
     <record model="stock.picking" id="demo_main_l10n_br_stock_account-picking-2">
         <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp"/>

--- a/l10n_br_stock_account/wizards/stock_return_picking.py
+++ b/l10n_br_stock_account/wizards/stock_return_picking.py
@@ -45,6 +45,7 @@ class StockReturnPicking(models.TransientModel):
 
             values = {
                 'fiscal_operation_id': refund_fiscal_operation.id,
+                'invoice_state': '2binvoiced',
             }
 
             picking.write(values)


### PR DESCRIPTION
Return Picking process and test.

Estava faltando preencher o "invoice_state" do stock.picking, inclui testes para validar a criação e se a quantidade faturada está sendo atualizada.

 cc @renatonlima @rvalyi 