### PR TITLE
[12.0][FIX] New Document button

### DIFF
--- a/l10n_br_fiscal/models/operation_dashboard.py
+++ b/l10n_br_fiscal/models/operation_dashboard.py
@@ -93,10 +93,10 @@ class Operation(models.Model):
     def action_create_new(self):
         ctx = self._context.copy()
         model = 'l10n_br_fiscal.document'
-        if self.fiscal_type == 'sale':
+        if self.fiscal_operation_type == 'out':
             ctx.update({'default_fiscal_operation_type': 'out',
                         'default_fiscal_operation_id': self.id})
-        elif self.fiscal_type == 'purchase':
+        elif self.fiscal_operation_type == 'in':
             ctx.update({'default_fiscal_operation_type': 'in',
                         'default_fiscal_operation_id': self.id})
         return {


### PR DESCRIPTION
The button "New Document" in the fiscal dashboard was not setting the default operation in new documents if the operation `fiscal_type` was not `sale` or `purchase`. This Pull Request fixes that.