### PR TITLE
[12.0][ADD] Autoselect Final Consumption operation for sale

### DIFF
--- a/l10n_br_sale/models/res_company.py
+++ b/l10n_br_sale/models/res_company.py
@@ -2,6 +2,7 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from odoo import fields, models
+from odoo.addons.l10n_br_fiscal.constants.fiscal import FINAL_CUSTOMER_YES
 
 
 class Company(models.Model):
@@ -10,6 +11,12 @@ class Company(models.Model):
     sale_fiscal_operation_id = fields.Many2one(
         comodel_name='l10n_br_fiscal.operation',
         string='Operação Fiscal Padrão de Vendas',
+    )
+
+    sale_final_consumption_fiscal_operation_id = fields.Many2one(
+        comodel_name='l10n_br_fiscal.operation',
+        string='Operação Fiscal Padrão de Vendas para Consumo Final',
+        domain=[('ind_final', '=', FINAL_CUSTOMER_YES)],
     )
 
     copy_note = fields.Boolean(

--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -5,6 +5,7 @@
 from lxml import etree
 
 from odoo import api, fields, models
+from odoo.addons.l10n_br_fiscal.constants.fiscal import NFE_IND_IE_DEST_9
 
 
 class SaleOrder(models.Model):
@@ -144,6 +145,16 @@ class SaleOrder(models.Model):
     def _onchange_fiscal_operation_id(self):
         super()._onchange_fiscal_operation_id()
         self.fiscal_position_id = self.fiscal_operation_id.fiscal_position_id
+
+    @api.onchange('partner_id')
+    def onchange_partner_id(self):
+        super().onchange_partner_id()
+        if self.partner_id.ind_ie_dest == NFE_IND_IE_DEST_9:
+            company_id = self.env.user.company_id
+            final_consumption_operation_id = \
+                company_id.sale_final_consumption_fiscal_operation_id
+            if final_operation_id:
+                self.fiscal_operation_id = final_consumption_operation_id
 
     @api.multi
     def _prepare_invoice(self):

--- a/l10n_br_sale/views/res_company_view.xml
+++ b/l10n_br_sale/views/res_company_view.xml
@@ -11,6 +11,7 @@
                     <group>
                         <group>
                             <field name="sale_fiscal_operation_id"/>
+                            <field name="sale_final_consumption_fiscal_operation_id"/>
                             <field name="copy_note"/>
                         </group>
                     </group>


### PR DESCRIPTION
This Pull Request adds a way to autoselect final consumption operation in a sale_order. 

P.S.: Indirectly depends on https://github.com/OCA/l10n-brazil/pull/1224