### PR TITLE
[12.0][ADD] Default fiscal operation type in out invoices

### DIFF
--- a/l10n_br_account/views/l10n_br_account_action.xml
+++ b/l10n_br_account/views/l10n_br_account_action.xml
@@ -55,6 +55,14 @@
         </field>
     </record>
 
+     <record id="account.action_invoice_tree1" model="ir.actions.act_window">
+        <field name="context">{'type':'out_invoice', 'journal_type': 'sale', 'default_fiscal_operation_type': 'out'}</field>
+     </record>
+
+    <record id="account.action_invoice_out_refund" model="ir.actions.act_window">
+        <field name="context">{'default_type': 'out_refund', 'type': 'out_refund', 'journal_type': 'sale', 'default_fiscal_operation_type':'out'}</field>
+    </record>
+
     <record id="fiscal_invoice_out_action_tree" model="ir.actions.act_window.view">
         <field eval="1" name="sequence"/>
         <field name="view_mode">tree</field>


### PR DESCRIPTION
This Pull Request adds the default value of `fiscal_operation_type` in two core actions without this default values.