### PR TITLE
[12.0][FIX] Sale line discount

### DIFF
--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -132,7 +132,7 @@ class SaleOrderLine(models.Model):
         """Update discount percent"""
         if self.env.user.has_group('l10n_br_sale.group_discount_per_value'):
             self.discount = ((self.discount_value * 100) /
-                             (self.product_uom_qty * self.price_unit))
+                             (self.product_uom_qty * self.price_unit or 1))
 
     @api.onchange('fiscal_tax_ids')
     def _onchange_fiscal_tax_ids(self):

--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -122,19 +122,17 @@ class SaleOrderLine(models.Model):
     def _onchange_discount_percent(self):
         """Update discount value"""
         if not self.env.user.has_group('l10n_br_sale.group_discount_per_value'):
-            if self.discount:
-                self.discount_value = (
-                    (self.product_uom_qty * self.price_unit)
-                    * (self.discount / 100)
-                )
+            self.discount_value = (
+                (self.product_uom_qty * self.price_unit)
+                * (self.discount / 100)
+            )
 
     @api.onchange('discount_value')
     def _onchange_discount_value(self):
         """Update discount percent"""
         if self.env.user.has_group('l10n_br_sale.group_discount_per_value'):
-            if self.discount_value:
-                self.discount = ((self.discount_value * 100) /
-                                 (self.product_uom_qty * self.price_unit))
+            self.discount = ((self.discount_value * 100) /
+                             (self.product_uom_qty * self.price_unit))
 
     @api.onchange('fiscal_tax_ids')
     def _onchange_fiscal_tax_ids(self):

--- a/l10n_br_sale/security/l10n_br_sale_security.xml
+++ b/l10n_br_sale/security/l10n_br_sale_security.xml
@@ -11,4 +11,8 @@
         <field name="category_id" ref="base.module_category_hidden"/>
     </record>
 
+    <record id="base.user_admin" model="res.users">
+	    <field name="groups_id" eval="[(4, ref('l10n_br_sale.group_discount_per_value'))]"/>
+    </record>
+
 </odoo>

--- a/l10n_br_sale/tests/test_l10n_br_sale.py
+++ b/l10n_br_sale/tests/test_l10n_br_sale.py
@@ -137,6 +137,7 @@ class L10nBrSaleBaseTest(SavepointCase):
         sale_line._onchange_fiscal_operation_id()
         sale_line._onchange_fiscal_operation_line_id()
         sale_line._onchange_fiscal_taxes()
+        sale_line._onchange_discount_percent()
 
     def _invoice_sale_order(self, sale_order):
         sale_order.action_confirm()


### PR DESCRIPTION
In the sale order line, the onchange of the `discount` field doesn't work when the value changes from any value back to zero. This Pull Request fixes that.