### PR TITLE
[12.0][IMP] Onchange Discount Rate

### DIFF
--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -177,8 +177,16 @@ class SaleOrder(models.Model):
     def onchange_discount_rate(self):
         for order in self:
             for line in order.order_line:
-                line.discount = order.discount_rate
-                line._onchange_discount_percent()
+                if self.env.user.has_group(
+                        'l10n_br_sale.group_discount_per_value'):
+                    line.discount_value = (
+                        (line.product_uom_qty * line.price_unit)
+                        * (order.discount_rate / 100)
+                    )
+                    line._onchange_discount_value()
+                else:
+                    line.discount = order.discount_rate
+                    line._onchange_discount_percent()
 
     @api.onchange('fiscal_operation_id')
     def _onchange_fiscal_operation_id(self):


### PR DESCRIPTION
The `discount_rate` onchange in sale_order was not working properly when the user was in the group `l10n_br_sale.group_discount_per_value` because the sale line discount onchanges had this group verification and the sale order onchange didn't. This Pull Request fixes this problem.