### PR TITLE
[12.0][ADD] Discount fixed

### DIFF
--- a/l10n_br_sale/demo/l10n_br_sale.xml
+++ b/l10n_br_sale/demo/l10n_br_sale.xml
@@ -47,6 +47,8 @@
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
         <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
+        <field name="discount_fixed">True</field>
+        <field name="discount_value">50.0</field>
     </record>
 
     <function model="sale.order.line" name="_onchange_fiscal_operation_id">

--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -129,6 +129,8 @@ class SaleOrder(models.Model):
     def onchange_discount_rate(self):
         for order in self:
             for line in order.order_line:
+                if line.discount_fixed:
+                    continue
                 if self.env.user.has_group(
                         'l10n_br_sale.group_discount_per_value'):
                     line.discount_value = (

--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -70,6 +70,10 @@ class SaleOrderLine(models.Model):
         string='Comments',
     )
 
+    discount_fixed = fields.Boolean(
+        string="Fixed Discount?"
+    )
+
     def _get_protected_fields(self):
         protected_fields = super()._get_protected_fields()
         return protected_fields + [

--- a/l10n_br_sale/security/l10n_br_sale_security.xml
+++ b/l10n_br_sale/security/l10n_br_sale_security.xml
@@ -15,4 +15,8 @@
 	    <field name="groups_id" eval="[(4, ref('l10n_br_sale.group_discount_per_value'))]"/>
     </record>
 
+    <record id="base.user_admin" model="res.users">
+	    <field name="groups_id" eval="[(4, ref('sale.group_discount_per_so_line'))]"/>
+    </record>
+
 </odoo>

--- a/l10n_br_sale/security/l10n_br_sale_security.xml
+++ b/l10n_br_sale/security/l10n_br_sale_security.xml
@@ -11,4 +11,8 @@
         <field name="category_id" ref="base.module_category_hidden"/>
     </record>
 
+    <record id="base.user_admin" model="res.users">
+	    <field name="groups_id" eval="[(4, ref('l10n_br_sale.group_discount_per_value'))]"/>
+    </record>
+
 </odoo>

--- a/l10n_br_sale/tests/test_l10n_br_sale.py
+++ b/l10n_br_sale/tests/test_l10n_br_sale.py
@@ -131,6 +131,7 @@ class L10nBrSaleBaseTest(SavepointCase):
         sale_order.onchange_partner_id()
         sale_order.onchange_partner_shipping_id()
         sale_order._onchange_fiscal_operation_id()
+        sale_order.onchange_discount_rate()
 
     def _run_sale_line_onchanges(self, sale_line):
         sale_line._onchange_product_id_fiscal()

--- a/l10n_br_sale/views/sale_view.xml
+++ b/l10n_br_sale/views/sale_view.xml
@@ -120,6 +120,7 @@
                 <attribute name="groups">!l10n_br_sale.group_discount_per_value</attribute>
             </xpath>
             <xpath expr="//field[@name='order_line']/form//div[@name='discount']" position="after">
+              <field name="discount_fixed" groups="l10n_br_sale.group_total_discount"/>
               <label for="discount_value" groups="l10n_br_sale.group_discount_per_value"/>
               <div name="discount_value" groups="l10n_br_sale.group_discount_per_value">
                   <field name="discount_value" class="oe_inline"/>


### PR DESCRIPTION
In the sale order, the `discount_rate` field apply a discount rate in every line. This becomes a problem when the user needs to adjust the discount of a line to a specific value and then adjust the discount of the whole sale order to get the final price to a specific value. It can be done with the current code, but demands the user to change the discount of the line every time a change in the sale order `discount_rate` is made. This Pull Request makes it possible to mark a line to be skipped in this discount rate general update.