### PR TITLE
[12.0][FIX] Function _amount_by_group

### DIFF
--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -291,7 +291,7 @@ class SaleOrder(models.Model):
             for line in order.order_line:
                 # price_reduce = line.price_unit * (1.0 - line.discount / 100.0)
                 # taxes = line.tax_id.compute_all(price_reduce, quantity=line.product_uom_qty, product=line.product_id, partner=order.partner_shipping_>
-                taxes = line._compute_taxes(line.fiscal_tax_ids)
+                taxes = line._compute_taxes(line.fiscal_tax_ids)['taxes']
                 for tax in line.fiscal_tax_ids:
                     group = tax.tax_group_id
                     res.setdefault(group, {'amount': 0.0, 'base': 0.0})

--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -6,6 +6,7 @@ from lxml import etree
 from functools import partial
 
 from odoo import api, fields, models
+from odoo.tools import float_is_zero
 from odoo.tools.misc import formatLang
 
 
@@ -296,7 +297,9 @@ class SaleOrder(models.Model):
                 taxes = line._compute_taxes(line.fiscal_tax_ids)['taxes']
                 for tax in line.fiscal_tax_ids:
                     computed_tax = taxes.get(tax.tax_domain)
-                    if computed_tax and computed_tax.get('tax_value', 0.0):
+                    pr = order.currency_id.rounding
+                    if computed_tax and not float_is_zero(
+                            computed_tax.get('tax_value', 0.0), precision_rounding=pr):
                         group = tax.tax_group_id
                         res.setdefault(group, {'amount': 0.0, 'base': 0.0})
                         res[group]['amount'] += computed_tax.get('tax_value', 0.0)

--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -297,8 +297,8 @@ class SaleOrder(models.Model):
                     res.setdefault(group, {'amount': 0.0, 'base': 0.0})
                     computed_tax = taxes.get(tax.tax_domain)
                     if computed_tax:
-                        res[group]['amount'] = computed_tax.get('tax_value', 0.0)
-                        res[group]['base'] = computed_tax.get('base', 0.0)
+                        res[group]['amount'] += computed_tax.get('tax_value', 0.0)
+                        res[group]['base'] += computed_tax.get('base', 0.0)
             res = sorted(res.items(), key=lambda l: l[0].sequence)
             order.amount_by_group = [(
                 l[0].name, l[1]['amount'], l[1]['base'],

--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -3,8 +3,10 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from lxml import etree
+from functools import partial
 
 from odoo import api, fields, models
+from odoo.tools.misc import formatLang
 
 
 class SaleOrder(models.Model):
@@ -280,3 +282,26 @@ class SaleOrder(models.Model):
     #         else:
     #             action = {'type': 'ir.actions.act_window_close'}
     #     return action
+
+    def _amount_by_group(self):
+        for order in self:
+            currency = order.currency_id or order.company_id.currency_id
+            fmt = partial(formatLang, self.with_context(lang=order.partner_id.lang).env, currency_obj=currency)
+            res = {}
+            for line in order.order_line:
+                # price_reduce = line.price_unit * (1.0 - line.discount / 100.0)
+                # taxes = line.tax_id.compute_all(price_reduce, quantity=line.product_uom_qty, product=line.product_id, partner=order.partner_shipping_>
+                taxes = line._compute_taxes(line.fiscal_tax_ids)
+                for tax in line.fiscal_tax_ids:
+                    group = tax.tax_group_id
+                    res.setdefault(group, {'amount': 0.0, 'base': 0.0})
+                    computed_tax = taxes.get(tax.tax_domain)
+                    if computed_tax:
+                        res[group]['amount'] = computed_tax.get('tax_value', 0.0)
+                        res[group]['base'] = computed_tax.get('base', 0.0)
+            res = sorted(res.items(), key=lambda l: l[0].sequence)
+            order.amount_by_group = [(
+                l[0].name, l[1]['amount'], l[1]['base'],
+                fmt(l[1]['amount']), fmt(l[1]['base']),
+                len(res),
+            ) for l in res]

--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -295,10 +295,10 @@ class SaleOrder(models.Model):
             for line in order.order_line:
                 taxes = line._compute_taxes(line.fiscal_tax_ids)['taxes']
                 for tax in line.fiscal_tax_ids:
-                    group = tax.tax_group_id
-                    res.setdefault(group, {'amount': 0.0, 'base': 0.0})
                     computed_tax = taxes.get(tax.tax_domain)
-                    if computed_tax:
+                    if computed_tax and computed_tax.get('tax_value', 0.0):
+                        group = tax.tax_group_id
+                        res.setdefault(group, {'amount': 0.0, 'base': 0.0})
                         res[group]['amount'] += computed_tax.get('tax_value', 0.0)
                         res[group]['base'] += computed_tax.get('base', 0.0)
             res = sorted(res.items(), key=lambda l: l[0].sequence)

--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -286,11 +286,13 @@ class SaleOrder(models.Model):
     def _amount_by_group(self):
         for order in self:
             currency = order.currency_id or order.company_id.currency_id
-            fmt = partial(formatLang, self.with_context(lang=order.partner_id.lang).env, currency_obj=currency)
+            fmt = partial(
+                formatLang,
+                self.with_context(lang=order.partner_id.lang).env,
+                currency_obj=currency
+            )
             res = {}
             for line in order.order_line:
-                # price_reduce = line.price_unit * (1.0 - line.discount / 100.0)
-                # taxes = line.tax_id.compute_all(price_reduce, quantity=line.product_uom_qty, product=line.product_id, partner=order.partner_shipping_>
                 taxes = line._compute_taxes(line.fiscal_tax_ids)['taxes']
                 for tax in line.fiscal_tax_ids:
                     group = tax.tax_group_id


### PR DESCRIPTION
In the report, the taxes totals displayed are the core `account.tax` values grouped. 
![image](https://user-images.githubusercontent.com/9100543/111817772-312a8a00-88bd-11eb-99e6-6dc6329b6cd2.png)
This Pull Request uses the `l10n_br_fiscal.tax` values instead.
