### PR TITLE
[12.0][FIX] Crédito de ICMS para empresas do Simples Nacional

### DIFF
--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -251,7 +251,8 @@ class Tax(models.Model):
         tax_dict["fiscal_tax_id"] = tax.id
         tax_dict["tax_domain"] = tax.tax_domain
         tax_dict["percent_reduction"] = tax.percent_reduction
-        tax_dict["percent_amount"] = tax.percent_amount
+        tax_dict["percent_amount"] = tax_dict.get('percent_amount',
+                                                  tax.percent_amount)
 
         company = kwargs.get("company", tax.env.user.company_id)
         # partner = kwargs.get("partner")


### PR DESCRIPTION
Olá pessoal,
Durante a realização dos testes de emissão de NFe por empresas do Simples Nacional, foi identificado que apesar do percentual do credito do ICMS esta sendo calculado corretamente no método __compute_icmssn_,  quando o dict com essa informação é passado para o método __compute_tax_ ele não é usado e essa informação é perdida.

Para corrigir isso eu usei um get no dict para verificar se se essa informação já esta vindo antes de ser substituída pelo padrão do imposto. Não conseguir avaliar se essa alteração impacta algum outro fluxo, me avisem se for um problema.