### PR TITLE
[12.0][ADD] Button to recompute document line taxes and values

### DIFF
--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -802,4 +802,5 @@ class Document(models.Model):
         }
 
     def recompute_lines_taxes(self):
+        self.document_comment()
         self.mapped('line_ids').recompute_taxes()

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -800,3 +800,6 @@ class Document(models.Model):
             'target': 'new',
             'context': ctx,
         }
+
+    def recompute_lines_taxes(self):
+        self.mapped('line_ids').recompute_taxes()

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -167,3 +167,14 @@ class DocumentLine(models.Model):
             raise UserError(
                 _("You cannot unlink Fiscal Document Line Dummy !"))
         return super().unlink()
+
+    def recompute_taxes(self):
+        for line in self:
+            price_unit = line.price_unit
+            line._onchange_product_id_fiscal()
+            line._onchange_ncm_id()
+            line._onchange_fiscal_operation_id()
+            line._onchange_fiscal_operation_line_id()
+            line.price_unit = price_unit
+            line._onchange_commercial_quantity()
+            line._onchange_fiscal_taxes()

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -178,3 +178,5 @@ class DocumentLine(models.Model):
             line.price_unit = price_unit
             line._onchange_commercial_quantity()
             line._onchange_fiscal_taxes()
+            line._compute_amount()
+            line.document_comment()

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -57,7 +57,7 @@
             <button name="action_document_correction" type="object" string="Carta de correção" groups="l10n_br_fiscal.group_user" states="autorizada"/>
             <button name="action_create_return" type="object" string="Devolver" groups="l10n_br_fiscal.group_user" states="autorizada"/>
             <button name="action_send_email" type="object" string="Send Email" attrs="{'invisible': [('state', 'not in', ('autorizada', 'cancelada', 'denegada'))]}"/>
-            <button name="recompute_lines_taxes" icon="fa-repeat" type="object" string="Recompute Lines Taxes"/>
+            <button name="recompute_lines_taxes" icon="fa-repeat" type="object" string="Recompute Lines Taxes" groups="l10n_br_fiscal.group_data_maintenance"/>
 <!--                <button name="action_edoc_check" type="object"-->
 <!--                        string="Consultar no sefaz"-->
 <!--                        groups="base.group_no_one"/>-->

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -57,6 +57,7 @@
             <button name="action_document_correction" type="object" string="Carta de correção" groups="l10n_br_fiscal.group_user" states="autorizada"/>
             <button name="action_create_return" type="object" string="Devolver" groups="l10n_br_fiscal.group_user" states="autorizada"/>
             <button name="action_send_email" type="object" string="Send Email" attrs="{'invisible': [('state', 'not in', ('autorizada', 'cancelada', 'denegada'))]}"/>
+            <button name="recompute_lines_taxes" icon="fa-repeat" type="object" string="Recompute Lines Taxes"/>
 <!--                <button name="action_edoc_check" type="object"-->
 <!--                        string="Consultar no sefaz"-->
 <!--                        groups="base.group_no_one"/>-->


### PR DESCRIPTION
We often need to recalculate the taxes in a document and there's no practical way to do it with the current code. This Pull Request adds a button to do it, visible to the group Fiscal Data Maitenance.