### PR TITLE
[FIX] Sale Order create invoice button attr

### DIFF
--- a/l10n_br_sale_stock/models/sale_order.py
+++ b/l10n_br_sale_stock/models/sale_order.py
@@ -14,27 +14,24 @@ class SaleOrder(models.Model):
 
     @api.depends('state', 'order_line.invoice_status')
     def _get_button_create_invoice_invisible(self):
-
         button_create_invoice_invisible = False
 
-        if self.company_id.sale_create_invoice_policy == 'stock_picking':
-            has_services_to_invoice = self.order_line.filtered(
-                lambda x:
-                x.product_id.type == 'service' and
-                x.invoice_status == 'to invoice'
-            )
-            # A criação de Fatura de Serviços deve ser possível via Pedido
-            if not has_services_to_invoice:
-                button_create_invoice_invisible = True
-        else:
-            # No caso da Politica de criação baseada no Pedido de Venda
-            # qdo acionado o Botão irá criar as Faturas automaticamente
-            # mesmo no caso de ter Produtos e Serviços
-            if self.invoice_count > 0:
-                button_create_invoice_invisible = True
+        lines = self.order_line.filtered(
+            lambda l: l.invoice_status == 'to invoice')
 
         # Somente depois do Pedido confirmado o botão pode aparecer
         if self.state != 'sale':
             button_create_invoice_invisible = True
+        else:
+            if self.company_id.sale_create_invoice_policy == 'stock_picking':
+                # A criação de Fatura de Serviços deve ser possível via Pedido
+                if not any(l.product_id.type == 'service' for l in lines):
+                    button_create_invoice_invisible = True
+            else:
+                # No caso da Politica de criação baseada no Pedido de Venda
+                # qdo acionado o Botão irá criar as Faturas automaticamente
+                # mesmo no caso de ter Produtos e Serviços
+                if not lines:
+                    button_create_invoice_invisible = True
 
         self.button_create_invoice_invisible = button_create_invoice_invisible


### PR DESCRIPTION
Quando o faturamento esta baseado no pedido de venda não é possível fazer um faturamento parcial.

Este PR altera o método _get_button_create_invoice_invisible para corrigir o atributo indivisível da criação da fatura no pedido de venda. 