### PR TITLE
Use float_is_zero method in compute_taxes

### DIFF
--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -3,6 +3,7 @@
 
 from odoo import api, fields, models
 from odoo.addons import decimal_precision as dp
+from odoo.tools import float_is_zero
 
 from ..constants.fiscal import (
     FISCAL_IN,
@@ -284,7 +285,7 @@ class Tax(models.Model):
         })
 
         # TODO futuramente levar em consideração outros tipos de base de calculo
-        if tax_dict.get("base", 0.00) == 0.00:
+        if float_is_zero(tax_dict.get("base", 0.00), precision):
             tax_dict = self._compute_tax_base(tax, tax_dict, **kwargs)
 
         fiscal_operation_type = (operation_line.fiscal_operation_type


### PR DESCRIPTION
Como comparar se um float é zero, existe funções para no odoo.tools para fazer isso, e este PR adiciona o método float_is_zero para comprar se um valor realmente é zero e evitar problemas com os floats.