### PR TITLE
[FIX] do not remove discount field from view

### DIFF
--- a/l10n_br_account/views/account_invoice_line_view.xml
+++ b/l10n_br_account/views/account_invoice_line_view.xml
@@ -16,7 +16,10 @@
                 </div>
                 <field name="fiscal_price" attrs="{'invisible': [('document_type_id', '=', False)]}"/>
             </field>
-            <field name="discount" position="replace">
+            <field name="discount" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+            <field name="discount" position="before">
                 <field name="discount_value"/>
             </field>
             <field name="analytic_tag_ids" position="after">


### PR DESCRIPTION
Removendo o campo discount da visão form do account.invoice.line, se for instalado o l10n_br_account antes do módulo sale vai gerar um erro, para evitar isso, esta sendo deixado o campo discount como invisible=True. e adicionado o campo discount_value.