### PR TITLE
Valor de mercadoria sem desconto

### DIFF
--- a/l10n_br_delivery/tests/test_delivery_inverse_amount.py
+++ b/l10n_br_delivery/tests/test_delivery_inverse_amount.py
@@ -89,8 +89,8 @@ class TestDeliveryInverseAmount(SavepointCase):
     def test_sale_order_total_amounts(self):
         """Check sale order total amounts"""
         self.assertEqual(
-            self.sale_order_total_id.amount_gross, 110.0,
-            "Unexpected value for the field amount_gross from Sale Order")
+            self.sale_order_total_id.amount_price_gross, 110.0,
+            "Unexpected value for the field amount_price_gross from Sale Order")
         self.assertEqual(
             self.sale_order_total_id.amount_untaxed, 110.0,
             "Unexpected value for the field amount_untaxed from Sale Order")
@@ -110,8 +110,8 @@ class TestDeliveryInverseAmount(SavepointCase):
     def test_sale_order_line_amounts(self):
         """Check sale order line amounts"""
         self.assertEqual(
-            self.sale_order_line_id.amount_gross, 110.0,
-            "Unexpected value for the field amount_gross from Sale Order")
+            self.sale_order_line_id.amount_price_gross, 110.0,
+            "Unexpected value for the field amount_price_gross from Sale Order")
         self.assertEqual(
             self.sale_order_line_id.amount_untaxed, 110.0,
             "Unexpected value for the field amount_untaxed from Sale Order")

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin.py
@@ -202,6 +202,14 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         compute='_compute_amounts',
     )
 
+    price_gross = fields.Monetary(
+        compute='_compute_amounts',
+        string='Amount Gross',
+        store=True,
+        readonly=True,
+        help="Amount without discount.",
+    )
+
     amount_untaxed = fields.Monetary(
         string='Amount Untaxed',
         compute='_compute_amounts',

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -145,8 +145,11 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         for record in self:
             round_curr = record.currency_id.round
             # Valor dos produtos
-            record.amount_untaxed = (round_curr(
-                record.price_unit * record.quantity) - record.discount_value)
+            record.price_gross = round_curr(
+                record.price_unit * record.quantity)
+
+            record.amount_untaxed = (
+                record.price_gross - record.discount_value)
 
             record.amount_fiscal = (round_curr(
                 record.fiscal_price * record.fiscal_quantity) -

--- a/l10n_br_fiscal/models/document_fiscal_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin.py
@@ -95,6 +95,14 @@ class FiscalDocumentMixin(models.AbstractModel):
         readonly=True,
     )
 
+    amount_price_gross = fields.Monetary(
+        compute='_compute_amount',
+        string='Amount Gross',
+        store=True,
+        readonly=True,
+        help="Amount without discount.",
+    )
+
     amount_untaxed = fields.Monetary(
         string='Amount Untaxed',
         compute='_compute_amount',

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -293,7 +293,7 @@
                 </group>
                 <group>
                   <group string="Amounts">
-                    <field name="amount_untaxed"/>
+                    <field name="amount_price_gross"/>
                     <field name="amount_discount_value"/>
                     <field name="amount_insurance_value"/>
                     <field name="amount_other_value"/>

--- a/l10n_br_fiscal/wizards/l10n_br_account_invoice_costs_ratio.py
+++ b/l10n_br_fiscal/wizards/l10n_br_account_invoice_costs_ratio.py
@@ -30,17 +30,17 @@ class L10nBrAccountProductInvoiceCostsRatio(models.TransientModel):
                         "freight_value": calc_price_ratio(
                             line.price_gross,
                             delivery.amount_freight_value,
-                            invoice.amount_gross,
+                            invoice.amount_price_gross,
                         ),
                         "insurance_value": calc_price_ratio(
                             line.price_gross,
                             delivery.amount_insurance_value,
-                            invoice.amount_gross,
+                            invoice.amount_price_gross,
                         ),
                         "other_value": calc_price_ratio(
                             line.price_gross,
                             delivery.amount_other_value,
-                            invoice.amount_gross,
+                            invoice.amount_price_gross,
                         ),
                     }
                     line.write(vals)

--- a/l10n_br_repair/migrations/12.0.2.1.0/pre-migration.py
+++ b/l10n_br_repair/migrations/12.0.2.1.0/pre-migration.py
@@ -1,0 +1,18 @@
+# Copyright (C) 2021 - TODAY Renato Lima - Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+_columns_rename = {
+    'repair_order': [
+        ('amount_gross', 'amount_price_gross')],
+}
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    for table in _columns_rename.keys():
+        for rename_column in _columns_rename[table]:
+            if openupgrade.column_exists(env.cr, table, rename_column[0]):
+                openupgrade.rename_columns(
+                    env.cr, {table: [rename_column]})

--- a/l10n_br_repair/models/repair_order.py
+++ b/l10n_br_repair/models/repair_order.py
@@ -70,14 +70,6 @@ class RepairOrder(models.Model):
         states={'draft': [('readonly', False)]},
     )
 
-    amount_gross = fields.Monetary(
-        compute='_amount_all',
-        string='Amount Gross',
-        store=True,
-        readonly=True,
-        help="Amount without discount.",
-    )
-
     fiscal_document_count = fields.Integer(
         string='Fiscal Document Count',
         related='invoice_count',
@@ -121,10 +113,6 @@ class RepairOrder(models.Model):
     def _amount_all(self):
         """Compute the total amounts of the RO."""
         self._compute_amount()
-        for order in self:
-            order.amount_gross = \
-                sum(line.price_gross for line in order.operations) + \
-                sum(line.price_gross for line in order.fees_lines)
 
     @api.depends('state', 'operations.invoice_line_id', 'fees_lines.invoice_line_id')
     def _get_invoiced(self):

--- a/l10n_br_repair/views/repair_order.xml
+++ b/l10n_br_repair/views/repair_order.xml
@@ -19,7 +19,7 @@
                 </button>
             </button>
             <field name="amount_untaxed" position="before" >
-                <field name="amount_gross" widget='monetary' options="{'currency_field': 'currency_id'}"/>
+                <field name="amount_price_gross" widget='monetary' options="{'currency_field': 'currency_id'}"/>
                  <field name="amount_discount_value" groups="l10n_br_repair.group_discount_per_value" widget='monetary' options="{'currency_field': 'currency_id'}"/>
             </field>
             <field name="amount_untaxed" position="after" >

--- a/l10n_br_sale/migrations/12.0.4.1.0/pre-migration.py
+++ b/l10n_br_sale/migrations/12.0.4.1.0/pre-migration.py
@@ -1,0 +1,19 @@
+# Copyright (C) 2021 - TODAY Renato Lima - Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+_columns_rename = {
+    'sale_order': [
+        ('amount_gross', 'amount_price_gross'),
+    ],
+}
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    for table in _columns_rename.keys():
+        for rename_column in _columns_rename[table]:
+            if openupgrade.column_exists(env.cr, table, rename_column[0]):
+                openupgrade.rename_columns(
+                    env.cr, {table: [rename_column]})

--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -66,14 +66,6 @@ class SaleOrder(models.Model):
         states={'draft': [('readonly', False)], 'sent': [('readonly', False)]},
     )
 
-    amount_gross = fields.Monetary(
-        compute='_amount_all',
-        string='Amount Gross',
-        store=True,
-        readonly=True,
-        help="Amount without discount.",
-    )
-
     comment_ids = fields.Many2many(
         comodel_name='l10n_br_fiscal.comment',
         relation='sale_order_comment_rel',
@@ -96,8 +88,6 @@ class SaleOrder(models.Model):
         """Compute the total amounts of the SO."""
         for order in self:
             order._compute_amount()
-            order.amount_gross = sum(
-                line.price_gross for line in order.order_line)
 
     @api.model
     def fields_view_get(self, view_id=None, view_type="form",

--- a/l10n_br_sale/report/sale_report_templates.xml
+++ b/l10n_br_sale/report/sale_report_templates.xml
@@ -22,10 +22,10 @@
         <!-- Inclusão de outros Totais usados no Brasil -->
         <xpath expr="//div[@name='total']/div/table/tr[@style='']" position="replace">
             <!-- Replace foi necessário para colocar os Totais na ordem desejada. -->
-            <tr t-if="doc.amount_gross != doc.amount_untaxed" class="border-black o_subtotal" style="">
-                <td name="td_amount_gross_label"><strong>Amount Gross</strong></td>
-                <td name="td_amount_amount_gross" class="text-right">
-                    <span t-field="doc.amount_gross"/>
+            <tr t-if="doc.amount_price_gross != doc.amount_untaxed" class="border-black o_subtotal" style="">
+                <td name="td_amount_price_gross_label"><strong>Amount Gross</strong></td>
+                <td name="td_amount_price_gross" class="text-right">
+                    <span t-field="doc.amount_price_gross"/>
                 </td>
             </tr>
 

--- a/l10n_br_sale/views/sale_view.xml
+++ b/l10n_br_sale/views/sale_view.xml
@@ -22,7 +22,7 @@
         <field name="priority">99</field>
         <field name="arch" type="xml">
             <field name="amount_untaxed" position="before">
-                <field name="amount_gross" widget='monetary' options="{'currency_field': 'currency_id'}"/>
+                <field name="amount_price_gross" widget='monetary' options="{'currency_field': 'currency_id'}"/>
                 <field name="amount_discount_value" groups="l10n_br_sale.group_discount_per_value" widget='monetary' options="{'currency_field': 'currency_id'}"/>
             </field>
             <field name="amount_untaxed" position="after">


### PR DESCRIPTION
No core do Odoo o valor do desconto é abatido no total sem impostos, mas na localização é implementado o total de descontos e o total de mercadoria sem impostos deve conter o valor do desconto, e o desconto ser abatido no total do documento.
Existia um campo amount_gross no objeto sale.order, e nesse PR o campo foi movido para o mixin do documento fiscal.