### PR TITLE
[FIX] Invoice line context

### DIFF
--- a/l10n_br_account/views/account_invoice_view.xml
+++ b/l10n_br_account/views/account_invoice_view.xml
@@ -81,7 +81,7 @@
                 <attribute name="editable"/>
             </xpath>
             <xpath expr="//field[@name='invoice_line_ids']" position="attributes">
-                <attribute name="context">{'default_company_id': company_id, 'default_partner_id': partner_id, 'default_fiscal_operation_id': fiscal_operation_id, 'default_document_type_id': document_type_id}</attribute>
+                <attribute name="context">{'default_company_id': company_id, 'default_partner_id': partner_id, 'default_fiscal_operation_id': fiscal_operation_id, 'default_document_type_id': document_type_id, 'journal_id': journal_id, 'type': type}</attribute>
             </xpath>
             <xpath expr="//field[@name='invoice_line_ids']/tree/field[@name='invoice_line_tax_ids']" position="after">
                 <field name="document_type_id" invisible="1"/>
@@ -146,7 +146,7 @@
                 <attribute name="editable"/>
             </xpath>
             <xpath expr="//field[@name='invoice_line_ids']" position="attributes">
-                <attribute name="context">{'default_company_id': company_id, 'default_partner_id': partner_id, 'default_fiscal_operation_type': fiscal_operation_type, 'default_fiscal_operation_id': fiscal_operation_id, 'default_document_type_id': document_type_id}</attribute>
+                <attribute name="context">{'default_company_id': company_id, 'default_partner_id': partner_id, 'default_fiscal_operation_type': fiscal_operation_type, 'default_fiscal_operation_id': fiscal_operation_id, 'default_document_type_id': document_type_id, 'journal_id': journal_id, 'type': type}</attribute>
             </xpath>
             <xpath expr="//field[@name='invoice_line_ids']/tree/field[@name='invoice_line_tax_ids']" position="after">
                 <field name="document_type_id" invisible="1"/>


### PR DESCRIPTION
Adiciona o mesmo contexto padrão do core:

https://github.com/odoo/odoo/blob/12.0/addons/account/views/account_invoice_view.xml#L318

Caso contrário este fluxo nunca é considerado:

```
    @api.model
    def _default_account(self):
        journal_id = self._context.get('journal_id') or self._context.get('default_journal_id')
        if journal_id:
            journal = self.env['account.journal'].browse(journal_id)
            if self._context.get('type') in ('out_invoice', 'in_refund'):
                return journal.default_credit_account_id.id
            return journal.default_debit_account_id.id
```
https://github.com/odoo/odoo/blob/12.0/addons/account/models/account_invoice.py#L1712