### PR TITLE
[12.0][FIX] Reports not finding field fiscal_operation_line_id

### DIFF
--- a/l10n_br_purchase/models/purchase_order_line.py
+++ b/l10n_br_purchase/models/purchase_order_line.py
@@ -31,6 +31,12 @@ class PurchaseOrderLine(models.Model):
         domain=lambda self: self._fiscal_operation_domain(),
     )
 
+    fiscal_operation_line_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.operation.line",
+        string="Operation Line",
+        domain="[('fiscal_operation_id', '=', fiscal_operation_id), "
+               "('state', '=', 'approved')]")
+
     fiscal_tax_ids = fields.Many2many(
         comodel_name='l10n_br_fiscal.tax',
         relation='fiscal_purchase_line_tax_rel',

--- a/l10n_br_purchase/models/purchase_order_line.py
+++ b/l10n_br_purchase/models/purchase_order_line.py
@@ -31,6 +31,7 @@ class PurchaseOrderLine(models.Model):
         domain=lambda self: self._fiscal_operation_domain(),
     )
 
+    # This redundancy is necessary for the system to be able to load the report
     fiscal_operation_line_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.operation.line",
         string="Operation Line",

--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -25,6 +25,7 @@ class SaleOrderLine(models.Model):
         default=_default_fiscal_operation,
         domain=lambda self: self._fiscal_operation_domain())
 
+    # This redundancy is necessary for the system to be able to load the report
     fiscal_operation_line_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.operation.line",
         string="Operation Line",

--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -25,6 +25,12 @@ class SaleOrderLine(models.Model):
         default=_default_fiscal_operation,
         domain=lambda self: self._fiscal_operation_domain())
 
+    fiscal_operation_line_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.operation.line",
+        string="Operation Line",
+        domain="[('fiscal_operation_id', '=', fiscal_operation_id), "
+               "('state', '=', 'approved')]")
+
     # Adapt Mixin's fields
     fiscal_tax_ids = fields.Many2many(
         comodel_name='l10n_br_fiscal.tax',


### PR DESCRIPTION
While updating an old database to the current version of OCA 12.0 branch, the system couldn't find the field fiscal_operation_line_id when loading the reports of l10n_br_sale and l10n_br_purchase. I had to copy the field from the mixin to the python file in the models sale.order.line and purchase.order.line in those modules to be able to update them. If anyone knows any better way of solving this, please tell us. If not, this pull request solves the problem.