### PR TITLE
make nfe/nfse* CI .pot gen deterministic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,10 @@ install:
   - pip install -q coverage==4.5.4
   - pip install -q QUnitSuite codecov coveralls
 
+before_script:
+  - if [[ "$MAKEPOT" == "1" ]]; then sed -i "s/'l10n_br_fiscal'/'l10n_br_fiscal', 'l10n_br_nfe'/g" l10n_br_nfse/__manifest__.py; fi
+  - cat l10n_br_nfse/__manifest__.py
+
 script:
   - travis_run_tests
 


### PR DESCRIPTION
attempt to fix https://github.com/OCA/l10n-brazil/issues/1291

rationale: l10n_br_nfe and l10n_br_nfse* modules get their fields impacted one another depending on the order they load because they extend the same l10n_br_fiscal objects. Here I pin the loading order by forcing l10n_br_nfe to install 1st when the MAKEPOT ENV VAR is set so I expect to break the .pot rebuild chain reaction between these modules.
As only 1 of the 2 CI builds has MAKEPOT=1, we still have a test with a random installation order.