### PR TITLE
force unique NFe schema stacked field labels

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -217,8 +217,10 @@ class NFe(spec_models.StackedModel):
     nfe40_vTotTrib = fields.Monetary(
         related='amount_estimate_tax'
     )
+
     nfe40_vBC = fields.Monetary(
-        related='amount_icms_base'
+        string='BC do ICMS',
+        related='amount_icms_base',
     )
 
     nfe40_vICMS = fields.Monetary(
@@ -226,6 +228,7 @@ class NFe(spec_models.StackedModel):
     )
 
     nfe40_vPIS = fields.Monetary(
+        string='Valor do PIS (NFe)',
         related='amount_pis_value'
     )
 
@@ -234,6 +237,7 @@ class NFe(spec_models.StackedModel):
     )
 
     nfe40_vCOFINS = fields.Monetary(
+        string='valor do COFINS (NFe)',
         related='amount_cofins_value'
     )
 

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -140,10 +140,12 @@ class NFeLine(spec_models.StackedModel):
     )
 
     nfe40_vPIS = fields.Monetary(
+        string='Valor do PIS (NFe)',
         related='pis_value',
     )
 
     nfe40_vCOFINS = fields.Monetary(
+        string='Valor do COFINS (NFe)',
         related='cofins_value',
     )
 
@@ -213,6 +215,10 @@ class NFeLine(spec_models.StackedModel):
     nfe40_vDesc = fields.Monetary(
         related='discount_value'
     )
+
+    # TODO toxic field from several tags, should not even be injected!
+    # meanwhile forcing a string on it avoids .pot issues.
+    nfe40_vBC = fields.Monetary(string='FIXME Não usar esse campo!')
 
     nfe40_vBCST = fields.Monetary(
         related='icmsst_base'


### PR DESCRIPTION
outra tentativa para resolver https://github.com/OCA/l10n-brazil/issues/1291

basicamente quando varias tags da NFe definem o mesmo campo como nfe40_vPIS ou nfe40_vCOFINS
(ver https://github.com/OCA/l10n-brazil/blob/12.0/l10n_br_nfe_spec/models/v4_00/leiauteNFe.py ), a ordem na qual essas tags sao colectadas pelo StackedModel é aleatoria e a cada run pode sair um label de campo diferente o que cria um loop na geraçao do arquivo .pot pelo bot da OCA.
O que eu faço aqui é impor um label unico de forma determinista.

o caso do campo vBC no caso da linha de documento fiscal é diferente ainda. Ele é usado em varias tags de impostos que podem ser usadas na mesma linha de documento fisca! Por isso esse campo Nao deve nem ser usado! Eu deixei isso de forma explicita aqui (tb resolvendo a questao do lable) e porem dei um override para impor um label tb ate eventualmente a gente botar um suporte no spec_driven_model para conseguir pular a injeçao de algum campo problematico como esse.