### PR TITLE
Remove invisible attr in IE fields

### DIFF
--- a/l10n_br_fiscal/views/res_partner_view.xml
+++ b/l10n_br_fiscal/views/res_partner_view.xml
@@ -14,15 +14,6 @@
                     <field name="cnae_main_id"/>
                 </group>
             </group>
-            <field name="state_tax_number_ids" position="attributes">
-                <attribute name="attrs">{'invisible': [('ind_ie_dest','=', '9')]}</attribute>
-            </field>
-            <field name="inscr_est" position="attributes">
-                <attribute name="attrs">{'invisible': [('ind_ie_dest','=', '9')]}</attribute>
-            </field>
-            <div name="inscr_est" position="attributes">
-                <attribute name="attrs">{'invisible': [('ind_ie_dest','=', '9')]}</attribute>
-            </div>
         </field>
     </record>
 


### PR DESCRIPTION
Existe parceiros que o não são contribuintes do ICMS (id_ie_dest == 9) mas tem inscrição estadual, um exemplo que vi recentemente é de "Institutos de Pesquisas" que tem inscrição estadual mas não é contribuinte, essa alteração mantém os campos de IE visíveis para cadastrar parceiros nestes casos.

Porque se você tentar emitir uma NF-e para um destinatário que tem IE e não informa-la no XML você vai ter o retorno da Sefaz com o erro número [232 - IE do destinatário não informada](https://www.oobj.com.br/bc/article/rejei%C3%A7%C3%A3o-232-ie-do-destinat%C3%A1rio-n%C3%A3o-informada-como-resolver-122.html#:~:text=Quando%20o%20for%20emitida%20uma,IE%20do%20destinat%C3%A1rio%20n%C3%A3o%20informada%22.)