### PR TITLE
Corrige o valor do vProd nas linhas da NFe

### DIFF
--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -71,7 +71,7 @@ class NFeLine(spec_models.StackedModel):
     )
 
     nfe40_vProd = fields.Monetary(
-        related='amount_untaxed',
+        related='price_gross',
     )
 
     nfe40_choice9 = fields.Selection([


### PR DESCRIPTION
Quando uma NF-e tem descontos o valor do vProd (total de mercadorias esta incorreto).