### PR TITLE
[12.0][NEW] Correct accounting

### DIFF
--- a/l10n_br_account/__manifest__.py
+++ b/l10n_br_account/__manifest__.py
@@ -26,6 +26,7 @@
         "views/document_view.xml",
         "views/fiscal_invoice_view.xml",
         "views/fiscal_invoice_line_view.xml",
+        "views/l10n_br_fiscal_cfop.xml",
         # Wizards
         "wizards/account_invoice_refund_view.xml",
         "wizards/wizard_document_status.xml",

--- a/l10n_br_account/models/__init__.py
+++ b/l10n_br_account/models/__init__.py
@@ -14,3 +14,4 @@ from . import fiscal_document
 from . import fiscal_document_line
 from . import account_move
 from . import account_move_line
+from . import l10n_br_fiscal_cfop

--- a/l10n_br_account/models/__init__.py
+++ b/l10n_br_account/models/__init__.py
@@ -15,3 +15,5 @@ from . import fiscal_document_line
 from . import account_move
 from . import account_move_line
 from . import l10n_br_fiscal_cfop
+from . import document_fiscal_mixin_methods
+from . import document_fiscal_line_mixin_methods

--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -111,6 +111,15 @@ class AccountInvoice(models.Model):
         """Get object lines instaces used to compute fields"""
         return self.mapped("invoice_line_ids")
 
+    def _get_onchange_create(self):
+        res = super()._get_onchange_create()
+        res["_onchange_fiscal_operation_id"] = [
+            "account_id",
+            "comment_ids",
+            "operation_name",
+        ]
+        return res
+
     @api.depends("move_id.line_ids", "move_id.state")
     def _compute_financial(self):
         for invoice in self:

--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -371,6 +371,8 @@ class AccountInvoice(models.Model):
         super()._onchange_fiscal_operation_id()
         if self.fiscal_operation_id and self.fiscal_operation_id.journal_id:
             self.journal_id = self.fiscal_operation_id.journal_id
+        if self.fiscal_operation_id and self.fiscal_operation_id.account_id:
+            self.account_id = self.fiscal_operation_id.account_id
 
     def open_fiscal_document(self):
         if self.env.context.get("type", "") == "out_invoice":

--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -371,7 +371,11 @@ class AccountInvoice(models.Model):
         super()._onchange_fiscal_operation_id()
         if self.fiscal_operation_id and self.fiscal_operation_id.journal_id:
             self.journal_id = self.fiscal_operation_id.journal_id
-        if self.fiscal_operation_id and self.fiscal_operation_id.account_id:
+
+    @api.onchange('fiscal_operation_id', 'account_id', 'partner_id')
+    def _onchange_account_id(self):
+        if (self.partner_id and self.fiscal_operation_id and
+                self.fiscal_operation_id.account_id):
             self.account_id = self.fiscal_operation_id.account_id
 
     def open_fiscal_document(self):

--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -372,10 +372,13 @@ class AccountInvoice(models.Model):
         if self.fiscal_operation_id and self.fiscal_operation_id.journal_id:
             self.journal_id = self.fiscal_operation_id.journal_id
 
-    @api.onchange('fiscal_operation_id', 'account_id', 'partner_id')
+    @api.onchange("fiscal_operation_id", "account_id", "partner_id")
     def _onchange_account_id(self):
-        if (self.partner_id and self.fiscal_operation_id and
-                self.fiscal_operation_id.account_id):
+        if (
+            self.partner_id
+            and self.fiscal_operation_id
+            and self.fiscal_operation_id.account_id
+        ):
             self.account_id = self.fiscal_operation_id.account_id
 
     def open_fiscal_document(self):

--- a/l10n_br_account/models/account_invoice_line.py
+++ b/l10n_br_account/models/account_invoice_line.py
@@ -256,14 +256,24 @@ class AccountInvoiceLine(models.Model):
             user_type=user_type
         )
 
-    @api.onchange('product_id', 'fiscal_operation_id',
-                  'fiscal_operation_line_id', 'cfop_id', 'account_id')
+    @api.onchange(
+        "product_id",
+        "fiscal_operation_id",
+        "fiscal_operation_line_id",
+        "cfop_id",
+        "account_id",
+    )
     def _onchange_fiscal_account_id(self):
-        if (self.account_id and self.product_id and self.fiscal_operation_id and
-                self.fiscal_operation_line_id and self.cfop_id):
+        if (
+            self.account_id
+            and self.product_id
+            and self.fiscal_operation_id
+            and self.fiscal_operation_line_id
+            and self.cfop_id
+        ):
             account_id = self.account_id
             self.account_id = (
-                self.cfop_id.account_id or
-                self.fiscal_operation_line_id.account_id or
-                account_id
+                self.cfop_id.account_id
+                or self.fiscal_operation_line_id.account_id
+                or account_id
             )

--- a/l10n_br_account/models/account_invoice_line.py
+++ b/l10n_br_account/models/account_invoice_line.py
@@ -257,13 +257,13 @@ class AccountInvoiceLine(models.Model):
         )
 
     @api.onchange('product_id', 'fiscal_operation_id',
-                  'fiscal_operation_line_id', 'cfop_id')
+                  'fiscal_operation_line_id', 'cfop_id', 'account_id')
     def _onchange_fiscal_account_id(self):
-        if (self.product_id and self.fiscal_operation_id and
+        if (self.account_id and self.product_id and self.fiscal_operation_id and
                 self.fiscal_operation_line_id and self.cfop_id):
             account_id = self.account_id
-        self.account_id = (
-            self.cfop_id.account_id or
-            self.fiscal_operation_line_id.account_id or
-            account_id
-        )
+            self.account_id = (
+                self.cfop_id.account_id or
+                self.fiscal_operation_line_id.account_id or
+                account_id
+            )

--- a/l10n_br_account/models/account_invoice_line.py
+++ b/l10n_br_account/models/account_invoice_line.py
@@ -255,3 +255,15 @@ class AccountInvoiceLine(models.Model):
         self.invoice_line_tax_ids |= self.fiscal_tax_ids.account_taxes(
             user_type=user_type
         )
+
+    @api.onchange('product_id', 'fiscal_operation_id',
+                  'fiscal_operation_line_id', 'cfop_id')
+    def _onchange_fiscal_account_id(self):
+        if (self.product_id and self.fiscal_operation_id and
+                self.fiscal_operation_line_id and self.cfop_id):
+            account_id = self.account_id
+        self.account_id = (
+            self.cfop_id.account_id or
+            self.fiscal_operation_line_id.account_id or
+            account_id
+        )

--- a/l10n_br_account/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_account/models/document_fiscal_line_mixin_methods.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2021  Luis Felipe Mileo <mileo@kmee.com.br>
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import models
+
+
+class FiscalDocumentLineMixinMethods(models.AbstractModel):
+    _inherit = "l10n_br_fiscal.document.line.mixin.methods"
+
+    def _prepare_fiscal_account_id(self):
+        vals = {}
+        account_id = (
+            self.cfop_id.account_id
+            or self.fiscal_operation_line_id.account_id
+            or self.account_id
+        )
+        if account_id:
+            vals["account_id"] = account_id.id
+
+    def _prepare_br_fiscal_dict(self, default=False):
+        vals = super()._prepare_br_fiscal_dict(default)
+
+        if self.fiscal_operation_id and self.fiscal_operation_line_id:
+            if self.fiscal_operation_line_id.account_id:
+                vals["account_id"] = self.fiscal_operation_line_id.account_id.id
+            if self.cfop_id.account_id:
+                vals["account_id"] = self.cfop_id.account_id.id
+        return vals

--- a/l10n_br_account/models/document_fiscal_mixin_methods.py
+++ b/l10n_br_account/models/document_fiscal_mixin_methods.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2021  Luis Felipe Mileo <mileo@kmee.com.br>
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import models
+
+
+class FiscalDocumentMixinMethods(models.AbstractModel):
+    _inherit = "l10n_br_fiscal.document.mixin.methods"
+
+    def _prepare_br_fiscal_dict(self, default=False):
+        vals = super()._prepare_br_fiscal_dict(default)
+
+        if self.fiscal_operation_id:
+            if self.fiscal_operation_id.journal_id:
+                vals["journal_id"] = self.fiscal_operation_id.journal_id.id
+
+            if self.fiscal_operation_id.account_id:
+                vals["account_id"] = self.fiscal_operation_id.account_id.id
+
+        return vals

--- a/l10n_br_account/models/fiscal_operation.py
+++ b/l10n_br_account/models/fiscal_operation.py
@@ -24,9 +24,6 @@ class Operation(models.Model):
         comodel_name="account.journal",
         string="Account Journal",
         company_dependent=True,
-        domain="[('type', 'in', {'out': ['sale', 'general'], 'in': "
-        "['purchase', 'general'], 'all': ['sale', 'purchase', "
-        "'general']}.get(fiscal_operation_type, []))]",
     )
 
     fiscal_position_id = fields.Many2one(

--- a/l10n_br_account/models/fiscal_operation.py
+++ b/l10n_br_account/models/fiscal_operation.py
@@ -35,6 +35,12 @@ class Operation(models.Model):
         company_dependent=True,
     )
 
+    account_id = fields.Many2one(
+        comodel_name='account.account',
+        string='Account',
+        company_dependent=True,
+    )
+
     def _change_action_view(self, action):
         fiscal_op_type = action.get("context")
         if fiscal_op_type == "out":

--- a/l10n_br_account/models/fiscal_operation.py
+++ b/l10n_br_account/models/fiscal_operation.py
@@ -33,8 +33,8 @@ class Operation(models.Model):
     )
 
     account_id = fields.Many2one(
-        comodel_name='account.account',
-        string='Account',
+        comodel_name="account.account",
+        string="Account",
         company_dependent=True,
     )
 

--- a/l10n_br_account/models/fiscal_operation_line.py
+++ b/l10n_br_account/models/fiscal_operation_line.py
@@ -15,7 +15,7 @@ class OperationLine(models.Model):
     )
 
     account_id = fields.Many2one(
-        comodel_name='account.account',
-        string='Account',
+        comodel_name="account.account",
+        string="Account",
         company_dependent=True,
     )

--- a/l10n_br_account/models/fiscal_operation_line.py
+++ b/l10n_br_account/models/fiscal_operation_line.py
@@ -13,3 +13,9 @@ class OperationLine(models.Model):
         string="Fiscal Position",
         company_dependent=True,
     )
+
+    account_id = fields.Many2one(
+        comodel_name='account.account',
+        string='Account',
+        company_dependent=True,
+    )

--- a/l10n_br_account/models/l10n_br_fiscal_cfop.py
+++ b/l10n_br_account/models/l10n_br_fiscal_cfop.py
@@ -6,10 +6,10 @@ from odoo import fields, models
 
 class Cfop(models.Model):
 
-    _inherit = 'l10n_br_fiscal.cfop'
+    _inherit = "l10n_br_fiscal.cfop"
 
     account_id = fields.Many2one(
-        comodel_name='account.account',
-        string='Account',
+        comodel_name="account.account",
+        string="Account",
         company_dependent=True,
     )

--- a/l10n_br_account/models/l10n_br_fiscal_cfop.py
+++ b/l10n_br_account/models/l10n_br_fiscal_cfop.py
@@ -1,0 +1,15 @@
+# Copyright 2021 KMEE - Luis Felipe Mileo <mileo@kmee.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class Cfop(models.Model):
+
+    _inherit = 'l10n_br_fiscal.cfop'
+
+    account_id = fields.Many2one(
+        comodel_name='account.account',
+        string='Account',
+        company_dependent=True,
+    )

--- a/l10n_br_account/views/fiscal_operation_line_view.xml
+++ b/l10n_br_account/views/fiscal_operation_line_view.xml
@@ -11,6 +11,7 @@
                     name="fiscal_position_id"
                     attrs="{'readonly': [('state', '!=', 'draft')]}"
                 />
+                <field name="account_id" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
             </field>
         </field>
     </record>

--- a/l10n_br_account/views/fiscal_operation_line_view.xml
+++ b/l10n_br_account/views/fiscal_operation_line_view.xml
@@ -11,7 +11,10 @@
                     name="fiscal_position_id"
                     attrs="{'readonly': [('state', '!=', 'draft')]}"
                 />
-                <field name="account_id" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
+                <field
+                    name="account_id"
+                    attrs="{'readonly': [('state', '!=', 'draft')]}"
+                />
             </field>
         </field>
     </record>

--- a/l10n_br_account/views/fiscal_operation_view.xml
+++ b/l10n_br_account/views/fiscal_operation_view.xml
@@ -41,6 +41,7 @@
                                 name="journal_id"
                                 attrs="{'readonly': [('state', '!=', 'draft')]}"
                             />
+                            <field name="account_id" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
                             <field
                                 name="fiscal_position_id"
                                 attrs="{'readonly': [('state', '!=', 'draft')]}"

--- a/l10n_br_account/views/fiscal_operation_view.xml
+++ b/l10n_br_account/views/fiscal_operation_view.xml
@@ -41,7 +41,10 @@
                                 name="journal_id"
                                 attrs="{'readonly': [('state', '!=', 'draft')]}"
                             />
-                            <field name="account_id" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
+                            <field
+                                name="account_id"
+                                attrs="{'readonly': [('state', '!=', 'draft')]}"
+                            />
                             <field
                                 name="fiscal_position_id"
                                 attrs="{'readonly': [('state', '!=', 'draft')]}"

--- a/l10n_br_account/views/l10n_br_fiscal_cfop.xml
+++ b/l10n_br_account/views/l10n_br_fiscal_cfop.xml
@@ -1,17 +1,16 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright 2021 KMEE - Luis Felipe Mileo <mileo@kmee.com.br>
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
-
 <odoo>
 
       <record model="ir.ui.view" id="l10n_br_fiscal_cfop_form_view">
         <field name="name">l10n_br_fiscal.cfop.form (in l10n_br_account)</field>
         <field name="model">l10n_br_fiscal.cfop</field>
-        <field name="inherit_id" ref="l10n_br_fiscal.cfop_form"/>
+        <field name="inherit_id" ref="l10n_br_fiscal.cfop_form" />
         <field name="arch" type="xml">
           <group name="move_settings" position="after">
             <group name="account_settings" string="Account Settings">
-              <field name="account_id"/>
+              <field name="account_id" />
             </group>
           </group>
 
@@ -21,10 +20,10 @@
       <record model="ir.ui.view" id="l10n_br_fiscal_cfop_search_view">
         <field name="name">l10n_br_fiscal.cfop.search (in l10n_br_account)</field>
         <field name="model">l10n_br_fiscal.cfop</field>
-        <field name="inherit_id" ref="l10n_br_fiscal.cfop_search"/>
+        <field name="inherit_id" ref="l10n_br_fiscal.cfop_search" />
         <field name="arch" type="xml">
           <field name="name">
-            <field name="account_id"/>
+            <field name="account_id" />
           </field>
         </field>
       </record>
@@ -32,10 +31,10 @@
       <record model="ir.ui.view" id="l10n_br_fiscal_cfop_tree_view">
         <field name="name">l10n_br_fiscal.cfop.tree (in l10n_br_account)</field>
         <field name="model">l10n_br_fiscal.cfop</field>
-        <field name="inherit_id" ref="l10n_br_fiscal.cfop_tree"/>
+        <field name="inherit_id" ref="l10n_br_fiscal.cfop_tree" />
         <field name="arch" type="xml">
           <field name="type_move">
-            <field name="account_id"/>
+            <field name="account_id" />
           </field>
         </field>
       </record>

--- a/l10n_br_account/views/l10n_br_fiscal_cfop.xml
+++ b/l10n_br_account/views/l10n_br_fiscal_cfop.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2021 KMEE - Luis Felipe Mileo <mileo@kmee.com.br>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+      <record model="ir.ui.view" id="l10n_br_fiscal_cfop_form_view">
+        <field name="name">l10n_br_fiscal.cfop.form (in l10n_br_account)</field>
+        <field name="model">l10n_br_fiscal.cfop</field>
+        <field name="inherit_id" ref="l10n_br_fiscal.cfop_form"/>
+        <field name="arch" type="xml">
+          <group name="move_settings" position="after">
+            <group name="account_settings" string="Account Settings">
+              <field name="account_id"/>
+            </group>
+          </group>
+
+        </field>
+      </record>
+
+      <record model="ir.ui.view" id="l10n_br_fiscal_cfop_search_view">
+        <field name="name">l10n_br_fiscal.cfop.search (in l10n_br_account)</field>
+        <field name="model">l10n_br_fiscal.cfop</field>
+        <field name="inherit_id" ref="l10n_br_fiscal.cfop_search"/>
+        <field name="arch" type="xml">
+          <field name="name">
+            <field name="account_id"/>
+          </field>
+        </field>
+      </record>
+
+      <record model="ir.ui.view" id="l10n_br_fiscal_cfop_tree_view">
+        <field name="name">l10n_br_fiscal.cfop.tree (in l10n_br_account)</field>
+        <field name="model">l10n_br_fiscal.cfop</field>
+        <field name="inherit_id" ref="l10n_br_fiscal.cfop_tree"/>
+        <field name="arch" type="xml">
+          <field name="type_move">
+            <field name="account_id"/>
+          </field>
+        </field>
+      </record>
+
+</odoo>

--- a/l10n_br_stock_account/wizards/stock_invoice_onshipping.py
+++ b/l10n_br_stock_account/wizards/stock_invoice_onshipping.py
@@ -55,8 +55,13 @@ class StockInvoiceOnshipping(models.TransientModel):
         if document_serie:
             fiscal_vals["document_serie_id"] = document_serie.id
 
-        if pick.fiscal_operation_id and pick.fiscal_operation_id.journal_id:
-            fiscal_vals["journal_id"] = pick.fiscal_operation_id.journal_id.id
+        if pick.fiscal_operation_id:
+
+            if pick.fiscal_operation_id.journal_id:
+                fiscal_vals["journal_id"] = pick.fiscal_operation_id.journal_id.id
+
+            if pick.fiscal_operation_id.journal_id:
+                fiscal_vals["account_id"] = pick.fiscal_operation_id.account_id.id
 
         # Endereço de Entrega diferente do Endereço de Faturamento
         # so informado quando é diferente
@@ -88,6 +93,14 @@ class StockInvoiceOnshipping(models.TransientModel):
         # price_unit
         del fiscal_values["price_unit"]
         fiscal_values["fiscal_price"] = abs(fiscal_values.get("fiscal_price"))
+
+        if move.fiscal_operation_id and move.fiscal_operation_line_id:
+            if move.fiscal_operation_line_id.account_id:
+                fiscal_values[
+                    "account_id"
+                ] = move.fiscal_operation_line_id.account_id.id
+            if move.cfop_id.account_id:
+                fiscal_values["account_id"] = move.cfop_id.account_id.id
 
         # Como é usada apenas uma move para chamar o _prepare_br_fiscal_dict
         # a quantidade/quantity do dicionario traz a quantidade referente a

--- a/l10n_br_stock_account/wizards/stock_invoice_onshipping.py
+++ b/l10n_br_stock_account/wizards/stock_invoice_onshipping.py
@@ -55,14 +55,6 @@ class StockInvoiceOnshipping(models.TransientModel):
         if document_serie:
             fiscal_vals["document_serie_id"] = document_serie.id
 
-        if pick.fiscal_operation_id:
-
-            if pick.fiscal_operation_id.journal_id:
-                fiscal_vals["journal_id"] = pick.fiscal_operation_id.journal_id.id
-
-            if pick.fiscal_operation_id.journal_id:
-                fiscal_vals["account_id"] = pick.fiscal_operation_id.account_id.id
-
         # Endereço de Entrega diferente do Endereço de Faturamento
         # so informado quando é diferente
         if fiscal_vals["partner_id"] != values["partner_id"]:
@@ -93,14 +85,6 @@ class StockInvoiceOnshipping(models.TransientModel):
         # price_unit
         del fiscal_values["price_unit"]
         fiscal_values["fiscal_price"] = abs(fiscal_values.get("fiscal_price"))
-
-        if move.fiscal_operation_id and move.fiscal_operation_line_id:
-            if move.fiscal_operation_line_id.account_id:
-                fiscal_values[
-                    "account_id"
-                ] = move.fiscal_operation_line_id.account_id.id
-            if move.cfop_id.account_id:
-                fiscal_values["account_id"] = move.cfop_id.account_id.id
 
         # Como é usada apenas uma move para chamar o _prepare_br_fiscal_dict
         # a quantidade/quantity do dicionario traz a quantidade referente a


### PR DESCRIPTION
No core o lançamento contábil gerado por uma fatura é realizado através de três pontos chaves, ou três contas:
==============================================================================

1. Conta definida no cabeçalho da fatura (account.invoice);
2. Conta definida na linha da fatura (account.invoice.line);
3. As taxas aplicadas na fatura e consequentemente as linhas criadas no objeto account.invoice.tax e suas contas;

**Guardem essas três contas, pois vamos precisar delas!**

O comportamento padrão do Odoo, sem modificações funciona da seguinte forma, para cada uma das três contas citadas acima:

**1. account.invoice:** 

É sempre carregada automaticamente a partir da conta definida no cadastro de parceiros, quando o parceiro é selecionado essa conta é automaticamente	 carregando a conta definida no cadastro do parceiro(não passa por nenhum dos métodos da posição fiscal de troca de contas);

**2. account.invoice.line:**

É sempre definida através da conta definida no cadastro ou na categoria do produto.

`**Parametrização**: Essa conta pode ser manipulada naturalmente pelo código do core através da configuração da posição fiscal, ao configurar as contas de origem e destino.`

**3. account.invoice.tax:** 

É sempre definida através das contas configuradas nos impostos calculados e lançados na fatura, se não tiver determinado imposto, ou seja o valor for zero, não tem lançamento.

`**Parametrização**: Esta conta também pode ser manipulada pelas contas de origem e destino da posição fiscal.
`

O propósito deste pull request é modificar este comportamento nos níveis 1 e 2 (cabeçalho e linha da fatura). 
===================================================================================

### Para que seja possível diferenciar o lançamento de forma automática para vários cenários. Para tanto foram criados três campos “account_id” em três modelos:


**Operação fiscal:**
--------------------------

 Serve para substituir a conta do cadastro de parceiros em casos específicos (Geralmente em operações que não geram financeiro);

**Linha da operação Fiscal:**
---------------------------------------

 Substitui a conta da categoria do produto ou do produto, se e somente se uma conta estiver definida na linha da operação fiscal ( Serve para facilitar a configuração das operações de venda, se observarmos os planos de contas mais elaborados será possível verificar que existem contas contábeis de receita para cada cenário tributado - Mercadoria / Produtos / Serviços / Produtos com ST e etc. 

E também para conta de contrapartida das operações que não geram financeiro.

**CFOP:**
--------------

Essa conta serve para sobrescrever a conta da linha da operação ou a conta do produto ou categoria. De forma a diferenciar os lançamentos fora do país e dentro do país (Veja que alguns planos de contas já têm essas contas por padrão), além disso permitindo configurações mais robustas do cenário citado acima.

### Para uma operação de Bens envidados a concerto, sem impostos:

account.invoice - A conta do cabeçalho da fatura, não deve ser sempre a conta de clientes/fornecedor, pois em uma operação de por exemplo Simples Remessa ou Bens enviados a concerto:

Seria lançado na conta de clientes, causaria um lançamento incorreto na mesma e consequentemente um saldo errado na dívida que o cliente tem com a empresa.
O Balanço Patrimonial estaria incorreto.

account.invoice.line - A conta de contrapartida, não pode ser uma conta de Receita, pois deixaria o DRE incorreto

account.invoice.tax - Seguem as definições dos impostos aplicados, ou seja, sem lançamentos.

Nesse exemplo a configuração seria da seguinte forma:

**Na operação de envio:**

Operação:  coa_generic_191102	1.9.1.1.02	Bens enviados Conserto		
Linha da operação: coa_generic_291103	2.9.1.1.03	NFS Bens envidados

Dessa forma: Ativo + Passivo = 0, o Balanço Patrimonial permanece inalterado e o DRE tb.

**Na operação de retorno** 

É realizado um lançamento ao contrário, com valor invertido nas mesmas contas, lembrando que o Odoo nas devoluções inverte o sinal do lançamento realizado a partir da conta definida no cabeçalho e tb no item. De forma que podemos manter as mesmas contas definidas na operação de envio.

E então podemos conciliar o lançamento da saída da conta 1.9.1.1.02 com o da entrada que também foi realizado na mesma conta: 1.9.1.1.02, fazendo com que ambas as faturas sejam consideradas “pagas”.

### No link abaixo uma análise detalhada do fluxo e do código do core:

https://docs.google.com/document/d/1snw9Avctt6nMeLpBTF3RltvaeS28yokJ8BfG-sIbir4/edit#