### PR TITLE
[12.0][IMP] Automation of IPI GuideLine

### DIFF
--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -393,6 +393,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 nbs=self.nbs_id,
                 cest=self.cest_id)
 
+            self.ipi_guideline_id = mapping_result['ipi_guideline']
             self.cfop_id = mapping_result['cfop']
             taxes = self.env['l10n_br_fiscal.tax']
             for tax in mapping_result['taxes'].values():

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -182,6 +182,7 @@ class OperationLine(models.Model):
         mapping_result = {
             'taxes': {},
             'cfop': False,
+            'ipi_guideline': False,
             'taxes_value': 0.00
         }
 
@@ -249,6 +250,16 @@ class OperationLine(models.Model):
         else:
             mapping_result['taxes'].pop(TAX_DOMAIN_ICMS, None)
             mapping_result['taxes'].pop(TAX_DOMAIN_ISSQN, None)
+
+        # Define IPI Guideline
+
+        if ncm.ipi_guideline_id:
+            mapping_result['ipi_guideline'] = ncm.ipi_guideline_id
+        else:
+            for tax in self.tax_definition_ids.map_tax_definition(
+                company, partner, product, ncm=ncm, nbm=nbm, nbs=nbs, cest=cest
+            ):
+                mapping_result['ipi_guideline'] = tax.ipi_guideline_id
 
         return mapping_result
 

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -198,11 +198,10 @@ class OperationLine(models.Model):
         mapping_result['cfop'] = cfop
 
         # 1 Get Tax Defs from Company
-        company_tax_defs = company.tax_definition_ids.map_tax_definition(
-            company, partner, product, ncm=ncm, nbm=nbm, nbs=nbs, cest=cest)
-
-        for tax in company_tax_defs.mapped('tax_id'):
-            mapping_result['taxes'][tax.tax_domain] = tax
+        for tax_definition in company.tax_definition_ids.map_tax_definition(
+                company, partner, product,
+                ncm=ncm, nbm=nbm, nbs=nbs, cest=cest):
+            self._build_mapping_result(mapping_result, tax_definition)
 
         # 2 From NCM
         if not ncm and product:
@@ -211,7 +210,6 @@ class OperationLine(models.Model):
         if company.tax_framework == TAX_FRAMEWORK_NORMAL:
             tax_ipi = ncm.tax_ipi_id
             tax_ii = ncm.tax_ii_id
-            mapping_result['ipi_guideline'] = ncm.ipi_guideline_id
             mapping_result['taxes'][tax_ipi.tax_domain] = tax_ipi
 
             if mapping_result['cfop'].destination == CFOP_DESTINATION_EXPORT:

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -244,9 +244,11 @@ class OperationLine(models.Model):
                 self._build_mapping_result(mapping_result, tax_definition)
 
             # 6 From Partner Profile
-            for tax_definition in partner.fiscal_profile_id.tax_definition_ids.map_tax_definition(
-                company, partner, product, ncm=ncm, nbm=nbm, nbs=nbs, cest=cest
-            ):
+            for tax_definition in partner.fiscal_profile_id.\
+                tax_definition_ids.map_tax_definition(company, partner,
+                                                      product, ncm=ncm,
+                                                      nbm=nbm, nbs=nbs,
+                                                      cest=cest):
                 self._build_mapping_result(mapping_result, tax_definition)
 
         if product.tax_icms_or_issqn == TAX_DOMAIN_ICMS:

--- a/l10n_br_fiscal/models/tax_definition.py
+++ b/l10n_br_fiscal/models/tax_definition.py
@@ -203,6 +203,13 @@ class TaxDefinition(models.Model):
         copy=False,
     )
 
+    ipi_guideline_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.tax.ipi.guideline",
+        string="IPI Guideline",
+        domain="['|', ('cst_in_id', '=', cst_id),"
+               "('cst_out_id', '=', cst_id)]",
+    )
+
     @api.multi
     def action_review(self):
         self.write({'state': 'review'})

--- a/l10n_br_fiscal/views/tax_definition_view.xml
+++ b/l10n_br_fiscal/views/tax_definition_view.xml
@@ -51,6 +51,7 @@
             <field name="custom_tax"/>
             <field name="tax_id" attrs="{'invisible': [('custom_tax', '=', False)], 'required': [('custom_tax', '=', True)]}"/>
             <field name="cst_id" attrs="{'invisible': ['|', ('custom_tax', '=', False), ('tax_domain', 'not in', ('icmssn', 'icms', 'ipi', 'pis', 'pisst', 'cofins', 'cofinsst'))], 'required': [('custom_tax', '=', True), ('tax_domain', 'in', ('icms', 'ipi', 'pis', 'pisst', 'cofins', 'cofinsst'))]}"/>
+            <field name="ipi_guideline_id" attrs="{'invisible': [('tax_domain', '!=', 'ipi')]}"/>
           </group>
           <group name="state" string="State" attrs="{'invisible': [('icms_regulation_id', '=', False)]}">
             <field name="state_from_id"/>


### PR DESCRIPTION
Olá pessoal,
Em alguns testes foi observado que o Enquadramento Legal do IPI não estava sendo preenchido automaticamente e ainda era necessário não ter um imposto de IPI definido para poder alterá-lo. 
Com esse PR foi feito uma estratégia para realizar o preenchimento automático, porém ele não contempla todas as situações de Enquadramento. 

Existem casos específicos como:

> 603 | Redução | Microcomputadores e outros de até R$11.000,00, unidades de disco, circuitos, etc, destinados a bens de informática ou automação. Centro-Oeste SUDAM SUDENE - Art. 142,I do Decreto 7.212/2010

Logo aproveito esse PR para abrir a discussão de como tratar esses casos. 

OBS: Em conversa com o @mileo  foi levantado a ideia de ter uma lógica, semelhante ao ICMS Tax Definition, construído em cima das modificações desse PR.




