### PR TITLE
[12.0][FIX] Field related should inform comodel_name to avoid errors.

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -256,6 +256,7 @@ class NFe(spec_models.StackedModel):
     )
 
     nfe40_infRespTec = fields.Many2one(
+        comodel_name='res.partner',
         related='company_id.technical_support_id'
     )
 


### PR DESCRIPTION
Field related should inform comodel_name to avoid errors.

Correção do erro que está ocorrendo ao rodar os testes do l10n_br_account_payment_order https://travis-ci.com/github/OCA/l10n-brazil/jobs/502100222#L4095, aparentemente o campo mesmo sendo um related precisa informar o comodel_name.

cc @renatonlima @rvalyi 