### PR TITLE
[12.0][IMP] l10n_br_nfe: add field nfe40_xEnder

### DIFF
--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -58,6 +58,7 @@ class ResPartner(spec_models.SpecModel):
     nfe40_IE = fields.Char(related='inscr_est')
     nfe40_ISUF = fields.Char(related='suframa')
     nfe40_email = fields.Char(related='email')
+    nfe40_xEnder = fields.Char(compute='_compute_nfe40_xEnder')
 
     # nfe.40.infresptec
     nfe40_xContato = fields.Char(related='legal_name')
@@ -66,6 +67,13 @@ class ResPartner(spec_models.SpecModel):
         ('nfe40_CNPJ', 'CNPJ'),
         ('nfe40_CPF', 'CPF')],
         "CNPJ/CPF do Parceiro")
+
+    @api.multi
+    def _compute_nfe40_xEnder(self):
+        for rec in self:
+            rec.nfe40_xEnder = rec.street + ', ' + rec.street_number
+            if rec.street2:
+                rec.nfe40_xEnder = rec.nfe40_xEnder + ' - ' + rec.street2
 
     @api.multi
     def _compute_nfe40_enderDest(self):


### PR DESCRIPTION
O valor xEnder não é preenchido nos dados da transportadora. Sendo assim, adicionei no modelo res_partner e coloquei um método simples para definição do mesmo. Qualquer dúvida, critica ou sugestão é bem vinda :)