### PR TITLE
[12.0][IMP] Adicionando tipo de documento não fiscal e vinculando ao documento dummy

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -194,10 +194,15 @@ class AccountInvoice(models.Model):
 
     @api.model
     def create(self, values):
-        if not values.get('document_type_id'):
+        document_not_fiscal_id = self.env.ref('l10n_br_fiscal.document_999').id
+        if not values.get('document_type_id') or \
+                values.get('document_type_id') == document_not_fiscal_id:
             values.update({
                 'fiscal_document_id': self.env.ref(
-                    'l10n_br_fiscal.fiscal_document_dummy').id
+                    'l10n_br_fiscal.fiscal_document_dummy').id,
+                'document_type_id': False,
+                'document_serie_id': False,
+                'fiscal_operation_id': False,
             })
         invoice = super().create(values)
         invoice._write_shadowed_fields()

--- a/l10n_br_account/views/account_invoice_view.xml
+++ b/l10n_br_account/views/account_invoice_view.xml
@@ -38,7 +38,7 @@
         <field name="inherit_id" ref="account.invoice_form"/>
         <field name="arch" type="xml">
             <div name="button_box" position="inside">
-                <button name="open_fiscal_document" type="object" class="oe_stat_button" icon="fa-pencil-square-o" attrs="{'invisible': [('document_type_id', '=', False)]}">
+                <button name="open_fiscal_document" type="object" class="oe_stat_button" icon="fa-pencil-square-o" attrs="{'invisible': ['|',('document_type_id', '=', False), ('document_type', '=', '999')]}">
                     <span>Fiscal Details</span>
                 </button>
             </div>
@@ -60,6 +60,7 @@
                     <field name="id" invisible="1"/>
                     <field name="document_electronic" invisible="1"/>
                     <field name="fiscal_operation_type" invisible="1"/>
+                    <field name="document_type" invisible="1"/>
                     <field name="document_section" invisible="1"/>
                     <field name="number" invisible="1"/>
                     <field name="edoc_purpose" invisible="1"/>

--- a/l10n_br_fiscal/data/l10n_br_fiscal.document.type.csv
+++ b/l10n_br_fiscal/data/l10n_br_fiscal.document.type.csv
@@ -38,3 +38,4 @@
 "document_66","66","Nota Fiscal de Energia Elétrica Eletrônica - NF3e","True","NF3e","nf3-e","icms"
 "document_67","67","Conhecimento de Transporte Eletrônico para Outros Serviços - CT-e OS","True",,,"icms"
 "document_SE","SE","Nota Fiscal de Serviço Eletrônica - NFS-e","True","NFSe","nfs-e","service"
+"document_999","999","Documento Não Fiscal","False","DNF","dnf","service"

--- a/l10n_br_fiscal/data/operation_data.xml
+++ b/l10n_br_fiscal/data/operation_data.xml
@@ -9,13 +9,21 @@
         <field name="active">True</field>
     </record>
 
+    <record id="document_999_serie_1" model="l10n_br_fiscal.document.serie">
+        <field name="code">1</field>
+        <field name="name">Série Não Fiscal 1</field>
+        <field name="document_type_id" ref="l10n_br_fiscal.document_999"/>
+        <field name="company_id" ref="base.main_company"/>
+        <field name="active">True</field>
+    </record>
+
     <record id="fiscal_document_dummy" model="l10n_br_fiscal.document">
         <field name="key">dummy</field>
         <field name="number">0</field>
         <field name="active">False</field>
         <field name="partner_id" ref="base.main_partner"/>
-        <field name="document_type_id" ref="l10n_br_fiscal.document_55"/>
-        <field name="document_serie_id" ref="l10n_br_fiscal.document_55_serie_1"/>
+        <field name="document_type_id" ref="l10n_br_fiscal.document_999"/>
+        <field name="document_serie_id" ref="l10n_br_fiscal.document_999_serie_1"/>
         <field name="fiscal_operation_type">out</field>
         <field name="company_id" eval="False"/>
     </record>

--- a/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
@@ -37,7 +37,7 @@
               <page name="issqn" string="ISSQN" attrs="{'invisible': [('tax_icms_or_issqn', '!=', 'issqn')]}">
                 <group>
                   <field name="issqn_tax_id"/>
-                  <field name="issqn_fg_city_id" attrs="{'required': [('tax_icms_or_issqn', '=', 'issqn')]}"/>
+                  <field name="issqn_fg_city_id" />
                   <field name="issqn_eligibility" attrs="{'required': [('tax_icms_or_issqn', '=', 'issqn')]}"/>
                   <field name="issqn_incentive" attrs="{'required': [('tax_icms_or_issqn', '=', 'issqn')]}"/>
                 </group>


### PR DESCRIPTION
@mileo conforme sugerido na PR #1336 implementei a criação de um documento nao fiscal. O que acha ?

Obs. Tirei o required do campo issqn_fg_city_id já que se você tentar fazer uma invoice sem um tipo de documento fiscal e for um item do tipo serviço o formulário vai exigir o preenchimento deste campo.