### PR TITLE
[ADD] Disable allow cnpj multi ie via context for importing data

### DIFF
--- a/l10n_br_base/models/res_config_settings.py
+++ b/l10n_br_base/models/res_config_settings.py
@@ -9,7 +9,7 @@ class ResConfigSettings(models.TransientModel):
 
     allow_cnpj_multi_ie = fields.Boolean(
         string="Multiple partners with the same CNPJ",
-        config_parameter="l10n_br_base_allow_cnpj_multi_ie",
+        config_parameter="l10n_br_base.allow_cnpj_multi_ie",
         default=False,
     )
 

--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -44,8 +44,11 @@ class Partner(models.Model):
             if not record.cnpj_cpf:
                 return
 
+            if self.env.context.get('disable_allow_cnpj_multi_ie'):
+                return
+
             allow_cnpj_multi_ie = record.env["ir.config_parameter"].sudo().get_param(
-                "l10n_br_base_allow_cnpj_multi_ie", default=True
+                "l10n_br_base.allow_cnpj_multi_ie", default=True
             )
 
             if record.parent_id:


### PR DESCRIPTION
This PR allows disabling cpnj/ie duplicate validation via context. When importing data, pass context flags to turn off validation.