### PR TITLE
[FIX] nfe40_NFref comodel_name attribute

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -131,6 +131,7 @@ class NFe(spec_models.StackedModel):
     )
 
     nfe40_NFref = fields.One2many(
+        comodel_name='l10n_br_fiscal.document.related',
         related='document_related_ids',
         inverse_name='document_id',
     )


### PR DESCRIPTION
Os campos relacionais que são definidos no l10n_br_nfe_spec alterado no l10n_br_nfe para related devem ter o atributo comodel_name para evitar esse erro, normalmente um novo campo related já pega o atributo comodel_name do campo usado no related, porem quando o campo é herdado, como esse campo herdado já tinha o comodel_name, deve ser redefindo este atributo.