### PR TITLE
[12.0] rename tables only if they exist

### DIFF
--- a/l10n_br_fiscal/migrations/12.0.12.0.0/pre-migration.py
+++ b/l10n_br_fiscal/migrations/12.0.12.0.0/pre-migration.py
@@ -46,6 +46,7 @@ _field_renames = [
 
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
-    openupgrade.rename_models(env.cr, _model_renames)
-    openupgrade.rename_tables(env.cr, _table_renames)
-    openupgrade.rename_fields(env, _field_renames)
+    if openupgrade.table_exists(env.cr, 'l10n_br_fiscal_document_invalidate_number'):
+        openupgrade.rename_models(env.cr, _model_renames)
+        openupgrade.rename_tables(env.cr, _table_renames)
+        openupgrade.rename_fields(env, _field_renames)


### PR DESCRIPTION
fix bug with recent fiscal event migration when migrating an old database with no such tables

cc @renatonlima  @mileo 