### PR TITLE
[12.0] fix l10n_br_fiscal/migrations/12.0.2.0.0 (bad dict)

### DIFF
--- a/l10n_br_fiscal/migrations/12.0.2.0.0/pre-migration.py
+++ b/l10n_br_fiscal/migrations/12.0.2.0.0/pre-migration.py
@@ -15,14 +15,20 @@ _column_renames = {
     'l10n_br_fiscal_operation_line_comment_rel': [
         ('operation_id', 'fiscal_operation_line_id')],
     'l10n_br_fiscal_document': [
-        ('operation_id', 'fiscal_operation_line_id')],
+        ('operation_id', 'fiscal_operation_id')],
     'l10n_br_fiscal_document_line': [
-        ('operation_id', 'fiscal_operation_line_id')],
-    'l10n_br_fiscal_document_line': [
-        ('operation_line_id', 'fiscal_operation_line_id')],
+        ('operation_id', 'fiscal_operation_id'),
+        ('operation_line_id', 'fiscal_operation_line_id')
+    ],
 }
 
 
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
-    openupgrade.rename_columns(env.cr, _column_renames)
+    if (
+            openupgrade.column_exists(
+                env.cr,
+                'l10n_br_fiscal_operation_line',
+                'operation_id')
+            ):
+        openupgrade.rename_columns(env.cr, _column_renames)


### PR DESCRIPTION
Do jeito que tava o dicionario nessa migração, o rename da coluna operation_id podia não acontecer (apenas o rename operation_line_id ia acontecer). Isso pode ter sido o motivo de algumas dores de cabeça de vcs @marcos-mendez @marcelsavegnago @renatonlima 