### PR TITLE
[12.0] avoids failure when migrating from v10

### DIFF
--- a/l10n_br_fiscal/migrations/12.0.3.0.0/pre-migration.py
+++ b/l10n_br_fiscal/migrations/12.0.3.0.0/pre-migration.py
@@ -15,4 +15,5 @@ _column_renames = {
 
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
-    openupgrade.rename_columns(env.cr, _column_renames)
+    if openupgrade.table_exists(env.cr, 'l10n_br_fiscal_document'):
+        openupgrade.rename_columns(env.cr, _column_renames)


### PR DESCRIPTION
quando se migra um banco a partir da v10 com OpenUpgrade, a tabela l10n_br_fiscal_document pode ainda não existir no script pre-migration.py, eu tive que fazer essa correçao pro script rodar...