### PR TITLE
[12.0] l10n_br_base: flake8 B902 'cls' used for instance method

### DIFF
--- a/l10n_br_base/tests/test_base_onchange.py
+++ b/l10n_br_base/tests/test_base_onchange.py
@@ -30,38 +30,38 @@ class L10nBrBaseOnchangeTest(SavepointCase):
                 {"name": "Partner Test 01", "zip": "29161-695"}
             )
 
-    def test_onchange(cls):
+    def test_onchange(self):
         """
         Call all the onchange methods in l10n_br_base
         """
-        cls.company_01._onchange_cnpj_cpf()
-        cls.company_01._onchange_city_id()
-        cls.company_01._onchange_zip()
-        cls.company_01._onchange_state()
+        self.company_01._onchange_cnpj_cpf()
+        self.company_01._onchange_city_id()
+        self.company_01._onchange_zip()
+        self.company_01._onchange_state()
 
-        cls.partner_01._onchange_cnpj_cpf()
-        cls.partner_01._onchange_city_id()
-        cls.partner_01._onchange_zip()
+        self.partner_01._onchange_cnpj_cpf()
+        self.partner_01._onchange_city_id()
+        self.partner_01._onchange_zip()
 
-    def test_inverse_fields(cls):
-        cls.company_01.inscr_mun = "692015742119"
-        cls.assertEquals(
-            cls.company_01.partner_id.inscr_mun,
+    def test_inverse_fields(self):
+        self.company_01.inscr_mun = "692015742119"
+        self.assertEquals(
+            self.company_01.partner_id.inscr_mun,
             "692015742119",
             "The inverse function to field inscr_mun failed.",
         )
-        cls.company_01.suframa = "1234"
-        cls.assertEquals(
-            cls.company_01.partner_id.suframa,
+        self.company_01.suframa = "1234"
+        self.assertEquals(
+            self.company_01.partner_id.suframa,
             "1234",
             "The inverse function to field suframa failed.",
         )
 
-    def test_display_address(cls):
-        partner = cls.env.ref("l10n_br_base.res_partner_akretion")
+    def test_display_address(self):
+        partner = self.env.ref("l10n_br_base.res_partner_akretion")
         partner._onchange_city_id()
         display_address = partner._display_address()
-        cls.assertEquals(
+        self.assertEquals(
             display_address,
             "Akretion Sao Paulo\n"
             "Avenida Paulista, 807 CJ 2315\nCentro"
@@ -69,11 +69,11 @@ class L10nBrBaseOnchangeTest(SavepointCase):
             "The function _display_address failed.",
         )
 
-    def test_display_address_parent_id(cls):
-        partner = cls.env.ref("l10n_br_base.res_partner_address_ak2")
+    def test_display_address_parent_id(self):
+        partner = self.env.ref("l10n_br_base.res_partner_address_ak2")
         partner._onchange_city_id()
         display_address = partner._display_address()
-        cls.assertEquals(
+        self.assertEquals(
             display_address,
             "Akretion Rio de Janeiro\n"
             "Rua Acre, 47 sala 1310\nCentro"
@@ -81,10 +81,10 @@ class L10nBrBaseOnchangeTest(SavepointCase):
             "The function _display_address with parent_id failed.",
         )
 
-    def test_other_country_display_address(cls):
-        partner = cls.env.ref("l10n_br_base.res_partner_exterior")
+    def test_other_country_display_address(self):
+        partner = self.env.ref("l10n_br_base.res_partner_exterior")
         display_address = partner._display_address()
-        cls.assertEquals(
+        self.assertEquals(
             display_address,
             "Cliente Exterior\n3404  Edgewood"
             " Road\n\nJonesboro"
@@ -92,11 +92,11 @@ class L10nBrBaseOnchangeTest(SavepointCase):
             "The function _display_address for other country failed.",
         )
 
-    def test_display_address_without_company(cls):
-        partner = cls.env.ref("l10n_br_base.res_partner_akretion")
+    def test_display_address_without_company(self):
+        partner = self.env.ref("l10n_br_base.res_partner_akretion")
         partner._onchange_city_id()
         display_address = partner._display_address(without_company=True)
-        cls.assertEquals(
+        self.assertEquals(
             display_address,
             "Avenida Paulista, 807 CJ 2315\nCentro"
             "\n01311-915 - São Paulo-SP\nBrazil",

--- a/l10n_br_base/tests/test_other_ie.py
+++ b/l10n_br_base/tests/test_other_ie.py
@@ -38,37 +38,37 @@ class OtherIETest(SavepointCase):
         )
 
     @mute_logger("odoo.sql_db")
-    def test_included_valid_ie_in_company(cls):
-        result = cls.company.write(
+    def test_included_valid_ie_in_company(self):
+        result = self.company.write(
             {
                 "state_tax_number_ids": [
                     (
                         0,
                         0,
                         {
-                            "state_id": cls.env.ref("base.state_br_ba").id,
+                            "state_id": self.env.ref("base.state_br_ba").id,
                             "inscr_est": 41902653,
                         },
                     )
                 ]
             }
         )
-        cls.assertTrue(result, "Error to included valid IE.")
-        for line in cls.company.partner_id.state_tax_number_ids:
+        self.assertTrue(result, "Error to included valid IE.")
+        for line in self.company.partner_id.state_tax_number_ids:
             result = False
             if line.inscr_est == "41902653":
                 result = True
-            cls.assertTrue(result, "Error in method to update other IE(s) on partner.")
+            self.assertTrue(result, "Error in method to update other IE(s) on partner.")
 
         try:
-            result = cls.company.write(
+            result = self.company.write(
                 {
                     "state_tax_number_ids": [
                         (
                             0,
                             0,
                             {
-                                "state_id": cls.env.ref("base.state_br_ba").id,
+                                "state_id": self.env.ref("base.state_br_ba").id,
                                 "inscr_est": 67729139,
                             },
                         )
@@ -78,20 +78,20 @@ class OtherIETest(SavepointCase):
         except Exception:
             result = False
 
-        cls.assertFalse(
+        self.assertFalse(
             result, "Error to check included other" " IE to State already informed."
         )
 
-    def test_included_invalid_ie(cls):
+    def test_included_invalid_ie(self):
         try:
-            result = cls.company.write(
+            result = self.company.write(
                 {
                     "state_tax_number_ids": [
                         (
                             0,
                             0,
                             {
-                                "state_id": cls.env.ref("base.state_br_am").id,
+                                "state_id": self.env.ref("base.state_br_am").id,
                                 "inscr_est": "042933681",
                             },
                         )
@@ -100,18 +100,18 @@ class OtherIETest(SavepointCase):
             )
         except Exception:
             result = False
-        cls.assertFalse(result, "Error to check included invalid IE.")
+        self.assertFalse(result, "Error to check included invalid IE.")
 
-    def test_included_other_valid_ie_to_same_state_of_company(cls):
+    def test_included_other_valid_ie_to_same_state_of_company(self):
         try:
-            result = cls.company.write(
+            result = self.company.write(
                 {
                     "state_tax_number_ids": [
                         (
                             0,
                             0,
                             {
-                                "state_id": cls.env.ref("base.state_br_sp").id,
+                                "state_id": self.env.ref("base.state_br_sp").id,
                                 "inscr_est": 692015742119,
                             },
                         )
@@ -120,29 +120,29 @@ class OtherIETest(SavepointCase):
             )
         except Exception:
             result = False
-        cls.assertFalse(
+        self.assertFalse(
             result,
             "Error to check included other valid IE " " in to same state of Company.",
         )
 
-    def test_included_valid_ie_on_partner(cls):
-        result = cls.company.partner_id.write(
+    def test_included_valid_ie_on_partner(self):
+        result = self.company.partner_id.write(
             {
                 "state_tax_number_ids": [
                     (
                         0,
                         0,
                         {
-                            "state_id": cls.env.ref("base.state_br_ba").id,
+                            "state_id": self.env.ref("base.state_br_ba").id,
                             "inscr_est": 41902653,
                         },
                     )
                 ]
             }
         )
-        cls.assertTrue(result, "Error to included valid IE.")
-        for line in cls.company.state_tax_number_ids:
+        self.assertTrue(result, "Error to included valid IE.")
+        for line in self.company.state_tax_number_ids:
             result = False
             if line.inscr_est == "41902653":
                 result = True
-            cls.assertTrue(result, "Error in method to update other IE(s) on Company.")
+            self.assertTrue(result, "Error in method to update other IE(s) on Company.")

--- a/l10n_br_base/tests/test_valid_createid.py
+++ b/l10n_br_base/tests/test_valid_createid.py
@@ -110,50 +110,50 @@ class ValidCreateIdTest(SavepointCase):
 
     # Tests on companies
 
-    def test_comp_valid(cls):
+    def test_comp_valid(self):
         """Try do create id with correct CNPJ and correct Inscricao Estadual"""
         try:
-            company = cls.env["res.company"].with_context(
-                tracking_disable=True).create(cls.company_valid)
+            company = self.env["res.company"].with_context(
+                tracking_disable=True).create(self.company_valid)
         except Exception:
             assert (
                 company
             ), "Error when using .create() even with valid \
                              and Inscricao Estadual"
 
-    def test_comp_invalid_cnpj(cls):
+    def test_comp_invalid_cnpj(self):
         """Test if ValidationError raised during .create() with invalid CNPJ
             and correct Inscricao Estadual"""
-        with cls.assertRaises(ValidationError):
-            cls.env["res.company"].with_context(
-                tracking_disable=True).create(cls.company_invalid_cnpj)
+        with self.assertRaises(ValidationError):
+            self.env["res.company"].with_context(
+                tracking_disable=True).create(self.company_invalid_cnpj)
 
-    def test_comp_invalid_inscr_est(cls):
+    def test_comp_invalid_inscr_est(self):
         """Test if ValidationError raised with correct CNPJ
             and invalid Inscricao Estadual"""
-        with cls.assertRaises(ValidationError):
-            cls.env["res.company"].with_context(
-                tracking_disable=True).create(cls.company_invalid_inscr_est)
+        with self.assertRaises(ValidationError):
+            self.env["res.company"].with_context(
+                tracking_disable=True).create(self.company_invalid_inscr_est)
 
     # Tests on partners
 
-    def test_part_valid(cls):
+    def test_part_valid(self):
         """Try do create id with correct CPF and correct Inscricao Estadual"""
         try:
-            partner = cls.env["res.partner"].with_context(
-                tracking_disable=True).create(cls.partner_valid)
+            partner = self.env["res.partner"].with_context(
+                tracking_disable=True).create(self.partner_valid)
         except Exception:
             assert (
                 partner
             ), "Error when using .create() even with valid CPF \
                          and Inscricao Estadual"
 
-    def test_part_invalid_cpf(cls):
+    def test_part_invalid_cpf(self):
         """Test if ValidationError raised during .create() with invalid CPF
             and correct Inscricao Estadual"""
-        with cls.assertRaises(ValidationError):
-            cls.env["res.partner"].with_context(
-                tracking_disable=True).create(cls.partner_invalid_cpf)
+        with self.assertRaises(ValidationError):
+            self.env["res.partner"].with_context(
+                tracking_disable=True).create(self.partner_invalid_cpf)
 
 
 # No test on Inscricao Estadual for partners with CPF


### PR DESCRIPTION
foi mal nesse PR https://github.com/OCA/l10n-brazil/pull/1360 eu errei a medida da troca self -> cls nos tests para tirar os warning do flake8. Criou outros. Agora corrigi.