### PR TITLE
[FIX] remove date shadow field

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -38,7 +38,6 @@ FISCAL_TYPE_REFUND = {
 SHADOWED_FIELDS = [
     'partner_id',
     'company_id',
-    'date',
     'currency_id',
     'partner_shipping_id',
 ]


### PR DESCRIPTION
Como o PR #1300 o campo date no documento fiscal foi renomeado, e agora não é mais necessário atualia-lo através da constante SHADOWED_FIELDS, esse remove os warnings:

<img width="1037" alt="Captura de Tela 2021-05-19 às 15 23 21" src="https://user-images.githubusercontent.com/211005/118864307-3b193b00-b8b6-11eb-9210-34d71dd2c125.png">
