### PR TITLE
[12.0] Bank usability

### DIFF
--- a/l10n_br_account/__manifest__.py
+++ b/l10n_br_account/__manifest__.py
@@ -16,6 +16,7 @@
         "data/account_tax_group.xml",
         "data/account_tax_template.xml",
         # Views
+        "views/res_partner_view.xml",
         "views/account_tax_view.xml",
         "views/account_tax_template_view.xml",
         "views/fiscal_operation_view.xml",

--- a/l10n_br_account/views/res_partner_view.xml
+++ b/l10n_br_account/views/res_partner_view.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2021 KMEE - Luis Felipe Mileo <mileo@kmee.com.br>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+  <record model="ir.ui.view" id="view_partner_property_form">
+    <field name="name">l10n_br_account.res.partner.form (in l10n_br_account)</field>
+    <field name="model">res.partner</field>
+    <field name="inherit_id" ref="account.view_partner_property_form"/>
+    <field name="arch" type="xml">
+      <xpath expr="//group/field[@name='bank_ids']/tree/field[@name='acc_number']"
+             position="before">
+        <field name="bra_number" string="Branch"/>
+        <field name="bra_number_dig" string="Dig"/>
+      </xpath>
+      <xpath expr="//group/field[@name='bank_ids']/tree/field[@name='acc_number']"
+             position="after">
+        <field name="acc_number_dig" string="Dig"/>
+      </xpath>
+    </field>
+  </record>
+
+</odoo>

--- a/l10n_br_account/views/res_partner_view.xml
+++ b/l10n_br_account/views/res_partner_view.xml
@@ -1,22 +1,25 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright 2021 KMEE - Luis Felipe Mileo <mileo@kmee.com.br>
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
-
 <odoo>
 
   <record model="ir.ui.view" id="view_partner_property_form">
     <field name="name">l10n_br_account.res.partner.form (in l10n_br_account)</field>
     <field name="model">res.partner</field>
-    <field name="inherit_id" ref="account.view_partner_property_form"/>
+    <field name="inherit_id" ref="account.view_partner_property_form" />
     <field name="arch" type="xml">
-      <xpath expr="//group/field[@name='bank_ids']/tree/field[@name='acc_number']"
-             position="before">
-        <field name="bra_number" string="Branch"/>
-        <field name="bra_number_dig" string="Dig"/>
+      <xpath
+                expr="//group/field[@name='bank_ids']/tree/field[@name='acc_number']"
+                position="before"
+            >
+        <field name="bra_number" string="Branch" />
+        <field name="bra_number_dig" string="Dig" />
       </xpath>
-      <xpath expr="//group/field[@name='bank_ids']/tree/field[@name='acc_number']"
-             position="after">
-        <field name="acc_number_dig" string="Dig"/>
+      <xpath
+                expr="//group/field[@name='bank_ids']/tree/field[@name='acc_number']"
+                position="after"
+            >
+        <field name="acc_number_dig" string="Dig" />
       </xpath>
     </field>
   </record>

--- a/l10n_br_base/models/res_bank.py
+++ b/l10n_br_base/models/res_bank.py
@@ -1,12 +1,15 @@
 #    Copyright (C) 2016 MultidadosTI (http://www.multidadosti.com.br)
 #    @author Michell Stuttgart <michellstut@gmail.com>
+#    Copyright (C) 2021 KMEE - Luis Felipe Mileo <mileo@kmee.com.br>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import fields, models
+from odoo import api, fields, models
+from odoo.osv import expression
 
 
 class ResBank(models.Model):
     _inherit = "res.bank"
+    _order = "code_bc, name"
 
     short_name = fields.Char(
         string="Short Name",
@@ -27,3 +30,38 @@ class ResBank(models.Model):
         string="COMPE Member",
         default=False,
     )
+
+    @api.multi
+    def name_get(self):
+        name_template = super().name_get()
+        name_dict = dict([(x[0], x[1]) for x in name_template])
+
+        result = []
+        for br_template in self:
+            if br_template.code_bc:
+                name = '[{}] {}'.format(
+                    br_template.code_bc,
+                    name_dict[br_template.id]
+                )
+            else:
+                name = name_dict[br_template.id]
+            result.append([br_template.id, name])
+        return result
+
+    @api.model
+    def _name_search(
+            self, name, args=None, operator='ilike', limit=100, name_get_uid=None):
+        args = args or []
+        domain = []
+        if name:
+            domain = ['|',
+                      ('code_bc', '=ilike', name + '%'),
+                      '|',
+                      ('bic', '=ilike', name + '%'),
+                      ('name', operator, name)
+                      ]
+            if operator in expression.NEGATIVE_TERM_OPERATORS:
+                domain = ['&'] + domain
+        bank_ids = self._search(
+            domain + args, limit=limit, access_rights_uid=name_get_uid)
+        return self.browse(bank_ids).name_get()

--- a/l10n_br_base/models/res_bank.py
+++ b/l10n_br_base/models/res_bank.py
@@ -34,15 +34,12 @@ class ResBank(models.Model):
     @api.multi
     def name_get(self):
         name_template = super().name_get()
-        name_dict = dict([(x[0], x[1]) for x in name_template])
+        name_dict = {x[0]: x[1] for x in name_template}
 
         result = []
         for br_template in self:
             if br_template.code_bc:
-                name = '[{}] {}'.format(
-                    br_template.code_bc,
-                    name_dict[br_template.id]
-                )
+                name = "[{}] {}".format(br_template.code_bc, name_dict[br_template.id])
             else:
                 name = name_dict[br_template.id]
             result.append([br_template.id, name])
@@ -50,18 +47,21 @@ class ResBank(models.Model):
 
     @api.model
     def _name_search(
-            self, name, args=None, operator='ilike', limit=100, name_get_uid=None):
+        self, name, args=None, operator="ilike", limit=100, name_get_uid=None
+    ):
         args = args or []
         domain = []
         if name:
-            domain = ['|',
-                      ('code_bc', '=ilike', name + '%'),
-                      '|',
-                      ('bic', '=ilike', name + '%'),
-                      ('name', operator, name)
-                      ]
+            domain = [
+                "|",
+                ("code_bc", "=ilike", name + "%"),
+                "|",
+                ("bic", "=ilike", name + "%"),
+                ("name", operator, name),
+            ]
             if operator in expression.NEGATIVE_TERM_OPERATORS:
-                domain = ['&'] + domain
+                domain = ["&"] + domain
         bank_ids = self._search(
-            domain + args, limit=limit, access_rights_uid=name_get_uid)
+            domain + args, limit=limit, access_rights_uid=name_get_uid
+        )
         return self.browse(bank_ids).name_get()


### PR DESCRIPTION
Corrige alguns detalhes da usabilidade das contas bancarias:

![image](https://user-images.githubusercontent.com/1975978/119007505-a96a0600-b967-11eb-8a12-4b3d1cf5fc87.png)

![image](https://user-images.githubusercontent.com/1975978/119007790-ee8e3800-b967-11eb-8f39-0404ec2b90b4.png)


- [x] Pesquisa por número banco (001 BB , 237 Bradesco e etc) ;
- [x] Inserção dos campos digito e agência na visão tree;

Tentei não sobrescrever 100% o _name_search, mas não teve jeito:

```
    @api.model
    def _name_search(
            self, name, args=None, operator='ilike', limit=100, name_get_uid=None):
        args = args or []
        if name:
            args += ['|', ('code_bc', '=ilike', name + '%')]
        return super(ResBank, self)._name_search(
            name, args, operator, limit, name_get_uid
        )
```

Se alguém tiver alguma sugestão sobre isso.