### PR TITLE
[12.0][FIX][BUG] In case of Grouping stock move Invoice lines was created with wrong quantity

### DIFF
--- a/l10n_br_stock_account/demo/l10n_br_stock_account_demo.xml
+++ b/l10n_br_stock_account/demo/l10n_br_stock_account_demo.xml
@@ -98,7 +98,7 @@
         <!-- sem o campo abaixo falha o mapeamento de CFOP, erro não acontece na tela -->
         <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp"/>
         <field name="product_id" ref="product.product_product_27"/>
-        <field name="product_uom_qty">1</field>
+        <field name="product_uom_qty">2</field>
         <field name="product_uom" ref="uom.product_uom_unit"/>
         <field name="picking_id" ref="demo_main_l10n_br_stock_account-picking-1"/>
         <field name="location_id" ref="stock.stock_location_stock"/>
@@ -204,7 +204,7 @@
         <!-- sem o campo abaixo falha o mapeamento de CFOP, erro não acontece na tela -->
         <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp"/>
         <field name="product_id" ref="product.product_product_27"/>
-        <field name="product_uom_qty">1</field>
+        <field name="product_uom_qty">2</field>
         <field name="product_uom" ref="uom.product_uom_unit"/>
         <field name="picking_id" ref="demo_main_l10n_br_stock_account-picking-2"/>
         <field name="location_id" ref="stock.stock_location_stock"/>
@@ -314,7 +314,7 @@
         <!-- sem o campo abaixo falha o mapeamento de CFOP, erro não acontece na tela -->
         <field name="partner_id" ref="l10n_br_base.res_partner_address_ak3"/>
         <field name="product_id" ref="product.product_product_27"/>
-        <field name="product_uom_qty">1</field>
+        <field name="product_uom_qty">2</field>
         <field name="product_uom" ref="uom.product_uom_unit"/>
         <field name="picking_id" ref="demo_main_l10n_br_stock_account-picking-3"/>
         <field name="location_id" ref="stock.stock_location_stock"/>
@@ -420,7 +420,7 @@
         <!-- sem o campo abaixo falha o mapeamento de CFOP, erro não acontece na tela -->
         <field name="partner_id" ref="l10n_br_base.res_partner_akretion"/>
         <field name="product_id" ref="product.product_product_27"/>
-        <field name="product_uom_qty">1</field>
+        <field name="product_uom_qty">2</field>
         <field name="product_uom" ref="uom.product_uom_unit"/>
         <field name="picking_id" ref="demo_main_l10n_br_stock_account-picking-4"/>
         <field name="location_id" ref="stock.stock_location_stock"/>

--- a/l10n_br_stock_account/tests/test_invoicing_picking.py
+++ b/l10n_br_stock_account/tests/test_invoicing_picking.py
@@ -235,8 +235,11 @@ class InvoicingPickingTest(SavepointCase):
         self.assertIn(picking, invoice.picking_ids)
         self.assertIn(picking2, invoice.picking_ids)
         for inv_line in invoice.invoice_line_ids:
-            # qty = 3 because 1 move + duplicate one + 1 new
-            self.assertAlmostEqual(inv_line.quantity, 3)
+            # qty = 4 because 2 for each stock.move
+            self.assertEqual(inv_line.quantity, 4)
+            # Price Unit e Fiscal Price devem ser positivos
+            self.assertEqual(inv_line.price_unit, 100.0)
+            self.assertEqual(inv_line.fiscal_price, 100.0)
             self.assertTrue(
                 inv_line.invoice_line_tax_ids,
                 'Error to map Sale Tax in invoice.line.')
@@ -248,7 +251,7 @@ class InvoicingPickingTest(SavepointCase):
         # Should be equals because we delete the invoice
         self.assertEquals(nb_invoice_before, nb_invoice_after)
 
-    def test_picking_invoicing_by_product2(self):
+    def test_picking_invoicing_by_product3(self):
         """
         Test the invoice generation grouped by partner/product with 2
         picking and 3 moves per picking, but 1 picking are the one

--- a/l10n_br_stock_account/tests/test_invoicing_picking.py
+++ b/l10n_br_stock_account/tests/test_invoicing_picking.py
@@ -9,16 +9,16 @@ class InvoicingPickingTest(SavepointCase):
     """Test invoicing picking"""
 
     @classmethod
-    def setUpClass(self):
+    def setUpClass(cls):
         super().setUpClass()
-        self.stock_picking = self.env['stock.picking']
-        self.invoice_model = self.env['account.invoice']
-        self.invoice_wizard = self.env['stock.invoice.onshipping']
-        self.stock_return_picking = self.env['stock.return.picking']
-        self.stock_picking_sp = self.env.ref(
+        cls.stock_picking = cls.env['stock.picking']
+        cls.invoice_model = cls.env['account.invoice']
+        cls.invoice_wizard = cls.env['stock.invoice.onshipping']
+        cls.stock_return_picking = cls.env['stock.return.picking']
+        cls.stock_picking_sp = cls.env.ref(
             'l10n_br_stock_account.demo_main_l10n_br_stock_account-picking-1')
-        self.partner = self.env.ref('l10n_br_base.res_partner_cliente1_sp')
-        self.company = self.env.ref('l10n_br_base.empresa_lucro_presumido')
+        cls.partner = cls.env.ref('l10n_br_base.res_partner_cliente1_sp')
+        cls.company = cls.env.ref('l10n_br_base.empresa_lucro_presumido')
 
     def _run_fiscal_onchanges(self, record):
         record._onchange_fiscal_operation_id()


### PR DESCRIPTION
In case of Grouping stock move Invoice lines was created with wrong quantity.

Replace https://github.com/OCA/l10n-brazil/pull/1372 to has more specific PR

Ao criar uma Fatura a partir do stock.picking com a opção de agrupar as stock.move a quantidade da linha da fatura criada estava indo errada, isso acontecia porque o metodo chamado para obter os dados fiscais usa apenas uma stock.move https://github.com/OCA/l10n-brazil/blob/12.0/l10n_br_stock_account/wizards/stock_invoice_onshipping.py#L86 e o dicionario retornado tem o valor quantity que acabava substituindo o valor que vem no dicionario do metodo do stock_picking_invoicing https://github.com/OCA/l10n-brazil/blob/12.0/l10n_br_stock_account/wizards/stock_invoice_onshipping.py#L84 que já tem o valor correto. 

Também foi corrigido o nome do teste duplicado, alteração do self para cls nos testes ( por isso o replace do outro PR )  incluída a validação se a quantidade nesse caso de agrupamento está correta e se os campos price_unit e fiscal_price estão positivos na invoice criada.

cc @rvalyi @renatonlima @marcelsavegnago @mileo @gabrielcardoso21 
