### PR TITLE
[12.0] [l10n_br_base] remove useless default @api.multi

### DIFF
--- a/l10n_br_base/models/res_company.py
+++ b/l10n_br_base/models/res_company.py
@@ -130,7 +130,6 @@ class Company(models.Model):
             res["arch"] = self._fields_view_get_address(res["arch"])
         return res
 
-    @api.multi
     def write(self, values):
         try:
             result = super(Company, self).write(values)

--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -34,7 +34,6 @@ class Partner(models.Model):
 
     union_entity_code = fields.Char(string="Union Entity code")
 
-    @api.multi
     @api.constrains("cnpj_cpf", "inscr_est")
     def _check_cnpj_inscr_est(self):
         for record in self:
@@ -83,7 +82,6 @@ class Partner(models.Model):
                         _("There is already a partner record with this CPF/RG!")
                     )
 
-    @api.multi
     @api.constrains("cnpj_cpf", "country_id")
     def _check_cnpj_cpf(self):
         result = True
@@ -108,7 +106,6 @@ class Partner(models.Model):
                 if not result:
                     raise ValidationError(_("{} Invalid!").format(document))
 
-    @api.multi
     @api.constrains("inscr_est", "state_id")
     def _check_ie(self):
         """Checks if company register number in field insc_est is valid,
@@ -134,7 +131,6 @@ class Partner(models.Model):
                 if not result:
                     raise ValidationError(_("Estadual Inscription Invalid !"))
 
-    @api.multi
     @api.constrains("state_tax_number_ids")
     def _check_state_tax_number_ids(self):
         """Checks if field other insc_est is valid,
@@ -177,7 +173,6 @@ class Partner(models.Model):
         Overwrite this function if you want to add your own fields."""
         return super().get_street_fields() + ["street"]
 
-    @api.multi
     def _set_street(self):
         company_country = self.env.user.company_id.country_id
         if company_country.code:

--- a/l10n_br_base/models/res_partner_bank.py
+++ b/l10n_br_base/models/res_partner_bank.py
@@ -54,7 +54,6 @@ class ResPartnerBank(models.Model):
         help="Last part of BIC/Swift Code.",
     )
 
-    @api.multi
     @api.constrains('bra_number')
     def _check_bra_number(self):
         for b in self:


### PR DESCRIPTION
Ola, seguindo a filisofia de alguns PRs recentes como https://github.com/OCA/l10n-brazil/pull/1392 a ideia é fazer a mudanças transparentes necessarias na v12 para facilitar a manutençao quando teremos foco na v14.

Para isso queremos aplicar a mesma estrategia que ja aplicamos com successo no Shopinvader ou que a Acsone aplica para manter OCA/mis-builder.

Ou seja, ja que na v12 os metodos do recordsets sao todos @api.multi por padrao, esse decorador ja virou inutil (agora pelo contrario estava faltando uns self.ensure_one() que acertei nesse outro PR https://github.com/OCA/l10n-brazil/pull/1392 ), o @api.multi na v12 entao teria como o unico efeito de aumentar artificialmente os diff na hora dos back-e front-ports. Por isso queremos  remove-los pelo menos nos principais modulos que a gente mantem. A gente suggere para KMEE ou ESCODOO de adotar a mesma estrategia nos modulos que lideram, porem entendemos que as pessoas devem escolher pelo trabalho dela e nao dos outros entao esta tranquilo se outros modulos fazem diferente.

Esse PR é menor para ser mais digesto para revisores, mas vou subir outros em seguida, aplicando a mesma logica em outros modulos.