### PR TITLE
[12.0] [l10n_br_sale][l10n_br_sale_stock] remove useless default @api.multi 

### DIFF
--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -74,7 +74,6 @@ class SaleOrder(models.Model):
         string='Comments',
     )
 
-    @api.multi
     def _get_amount_lines(self):
         """Get object lines instaces used to compute fields"""
         return self.mapped('order_line')
@@ -140,7 +139,6 @@ class SaleOrder(models.Model):
         super()._onchange_fiscal_operation_id()
         self.fiscal_position_id = self.fiscal_operation_id.fiscal_position_id
 
-    @api.multi
     def _prepare_invoice(self):
         self.ensure_one()
         result = super()._prepare_invoice()
@@ -168,7 +166,6 @@ class SaleOrder(models.Model):
 
         return result
 
-    @api.multi
     def action_invoice_create(self, grouped=False, final=False):
 
         inv_ids = super().action_invoice_create(grouped=grouped, final=final)
@@ -251,7 +248,6 @@ class SaleOrder(models.Model):
     # TODO open by default Invoice view with Fiscal Details Button
     # You can add a group to select default view Fiscal Invoice or
     # Account invoice.
-    # @api.multi
     # def action_view_invoice(self):
     #     action = super().action_view_invoice()
     #     invoices = self.mapped('invoice_ids')

--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -124,7 +124,6 @@ class SaleOrderLine(models.Model):
                 'price_total': l.amount_total,
             })
 
-    @api.multi
     def _prepare_invoice_line(self, qty):
         self.ensure_one()
         result = self._prepare_br_fiscal_dict()
@@ -139,7 +138,6 @@ class SaleOrderLine(models.Model):
         the price and fiscal quantity."""
         self._onchange_commercial_quantity()
 
-    @api.multi
     @api.depends(
         'qty_delivered_method',
         'qty_delivered_manual',

--- a/l10n_br_sale_stock/models/sale_order_line.py
+++ b/l10n_br_sale_stock/models/sale_order_line.py
@@ -9,7 +9,6 @@ from odoo import api, models
 class SaleOrderLine(models.Model):
     _inherit = 'sale.order.line'
 
-    @api.multi
     def _prepare_procurement_values(self, group_id=False):
         values = self._prepare_br_fiscal_dict()
         values.update(super()._prepare_procurement_values(group_id))

--- a/l10n_br_sale_stock/models/stock_move.py
+++ b/l10n_br_sale_stock/models/stock_move.py
@@ -2,13 +2,12 @@
 # Copyright (C) 2021  Magno Costa - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import api, models
+from odoo import models
 
 
 class StockMove(models.Model):
     _inherit = 'stock.move'
 
-    @api.multi
     def _get_price_unit_invoice(self, inv_type, partner, qty=1):
         result = super()._get_price_unit_invoice(inv_type, partner, qty)
         # Caso tenha Sale Line já vem desagrupado aqui devido ao KEY

--- a/l10n_br_sale_stock/models/stock_picking.py
+++ b/l10n_br_sale_stock/models/stock_picking.py
@@ -1,13 +1,12 @@
 # Copyright (C) 2021  Magno Costa - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import api, models
+from odoo import models
 
 
 class StockPicking(models.Model):
     _inherit = 'stock.picking'
 
-    @api.multi
     def _get_partner_to_invoice(self):
         self.ensure_one()
         partner = self.partner_id

--- a/l10n_br_sale_stock/wizards/stock_invoice_onshipping.py
+++ b/l10n_br_sale_stock/wizards/stock_invoice_onshipping.py
@@ -1,14 +1,13 @@
 # Copyright 2020 KMEE
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class StockInvoiceOnshipping(models.TransientModel):
 
     _inherit = 'stock.invoice.onshipping'
 
-    @api.multi
     def _build_invoice_values_from_pickings(self, pickings):
         """
         Build dict to create a new invoice from given pickings
@@ -35,7 +34,6 @@ class StockInvoiceOnshipping(models.TransientModel):
 
         return invoice, values
 
-    @api.multi
     def _get_move_key(self, move):
         """
         Get the key based on the given move


### PR DESCRIPTION
mesma coisa do que #1399 

Dessa vez, como os modulos sao "glue-modules" menores, eu junto os modulos l10n_br_sale e l10n_br_sale_stock no mesmo PR (mas em commits diferentes) para aliviar um pouco o Travis agora e na hora dos merges depois.