### PR TITLE
[12.0] [l10n_br_purchase][l10n_br_purchase_stock] remove useless default @api.multi

### DIFF
--- a/l10n_br_purchase/models/purchase_order.py
+++ b/l10n_br_purchase/models/purchase_order.py
@@ -79,7 +79,6 @@ class PurchaseOrder(models.Model):
     # TODO open by default Invoice view with Fiscal Details Button
     # You can add a group to select default view Fiscal Invoice or
     # Account invoice.
-    # @api.multi
     # def action_view_invoice(self):
     #     result = super().action_view_invoice()
     #     fiscal_dict = self._prepare_br_fiscal_dict(default=True)
@@ -113,7 +112,6 @@ class PurchaseOrder(models.Model):
     def _onchange_fiscal_operation_id(self):
         self.fiscal_position_id = self.fiscal_operation_id.fiscal_position_id
 
-    @api.multi
     def _get_amount_lines(self):
         """Get object lines instaces used to compute fields"""
         return self.mapped('order_line')

--- a/l10n_br_purchase/models/purchase_order_line.py
+++ b/l10n_br_purchase/models/purchase_order_line.py
@@ -96,7 +96,6 @@ class PurchaseOrderLine(models.Model):
         super()._onchange_quantity()
         self._onchange_commercial_quantity()
 
-    @api.multi
     def _compute_tax_id(self):
         super()._compute_tax_id()
         for line in self:

--- a/l10n_br_purchase_stock/models/purchase_order_line.py
+++ b/l10n_br_purchase_stock/models/purchase_order_line.py
@@ -2,13 +2,12 @@
 # Copyright (C) 2012  Raphaël Valyi - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import api, models
+from odoo import models
 
 
 class PurchaseOrderLine(models.Model):
     _inherit = 'purchase.order.line'
 
-    @api.multi
     def _prepare_stock_moves(self, picking):
         """Prepare the stock moves data for one order line.
         This function returns a list of

--- a/l10n_br_purchase_stock/models/stock_move.py
+++ b/l10n_br_purchase_stock/models/stock_move.py
@@ -2,13 +2,12 @@
 #   Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, models
+from odoo import models
 
 
 class StockMove(models.Model):
     _inherit = 'stock.move'
 
-    @api.multi
     def _get_price_unit_invoice(self, inv_type, partner, qty=1):
         result = super()._get_price_unit_invoice(inv_type, partner, qty)
         # Caso tenha Purchase Line já vem desagrupado aqui devido ao KEY

--- a/l10n_br_purchase_stock/models/stock_rule.py
+++ b/l10n_br_purchase_stock/models/stock_rule.py
@@ -1,13 +1,12 @@
 # Copyright (C) 2020  Renato Lima - Akretion
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, models
+from odoo import models
 
 
 class StockRule(models.Model):
     _inherit = 'stock.rule'
 
-    @api.multi
     def _run_buy(self, product_id, product_qty, product_uom,
                  location_id, name, origin, values):
         super()._run_buy(
@@ -20,7 +19,6 @@ class StockRule(models.Model):
                 line._onchange_fiscal_operation_id()
                 line._onchange_fiscal_operation_line_id()
 
-    @api.multi
     def _prepare_purchase_order_line(self, product_id, product_qty,
                                      product_uom, values, po, partner):
         values = super()._prepare_purchase_order_line(

--- a/l10n_br_purchase_stock/wizards/stock_invocing_onshipping.py
+++ b/l10n_br_purchase_stock/wizards/stock_invocing_onshipping.py
@@ -2,14 +2,12 @@
 #   Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class StockInvoiceOnshipping(models.TransientModel):
-
     _inherit = 'stock.invoice.onshipping'
 
-    @api.multi
     def _build_invoice_values_from_pickings(self, pickings):
         """
         Build dict to create a new invoice from given pickings
@@ -28,7 +26,6 @@ class StockInvoiceOnshipping(models.TransientModel):
 
         return invoice, values
 
-    @api.multi
     def _get_move_key(self, move):
         """
         Get the key based on the given move


### PR DESCRIPTION
mesma coisa do que #1399

Dessa vez, como os modulos sao "glue-modules" menores, eu junto os modulos l10n_br_purchase e l10n_br_purchase _stock no mesmo PR (mas em commits diferentes) para aliviar um pouco o Travis agora e na hora dos merges depois.