### PR TITLE
[12.0][l10n_br_fiscal] pis_wh_cst_id and cofins_wh_cst_id do not exist

### DIFF
--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -713,7 +713,6 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
 
     def _set_fields_pis_wh(self, tax_dict):
         if tax_dict:
-            self.pis_wh_cst_id = tax_dict.get("cst_id")
             self.pis_wh_base_type = tax_dict.get("base_type")
             self.pis_wh_base = tax_dict.get("base", 0.00)
             self.pis_wh_percent = tax_dict.get("percent_amount", 0.00)
@@ -767,7 +766,6 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
 
     def _set_fields_cofins_wh(self, tax_dict):
         if tax_dict:
-            self.cofins_wh_cst_id = tax_dict.get("cst_id")
             self.cofins_wh_base_type = tax_dict.get("base_type")
             self.cofins_wh_base = tax_dict.get("base", 0.00)
             self.cofins_wh_percent = tax_dict.get("percent_amount", 0.00)


### PR DESCRIPTION
agora que umas urgencias passaram tou revisando bastante o codigo para evitar erros despercebidos na prod. Esse é um. Esses campos nao existem, nao sei como a gente nao pegou erro com isso mas a gente nao pegou mesmo.