### PR TITLE
[12.0][all modules] test lint: assertEquals -> assertEqual

### DIFF
--- a/l10n_br_account/tests/test_customer_invoice_dummy.py
+++ b/l10n_br_account/tests/test_customer_invoice_dummy.py
@@ -209,22 +209,22 @@ class TestCustomerInvoice(SavepointCase):
         )
 
     def test_state(self):
-        self.assertEquals(
+        self.assertEqual(
             self.invoice_1.state, "draft", "Invoice should be in state Draft"
         )
         self.invoice_1.action_invoice_open()
-        self.assertEquals(
+        self.assertEqual(
             self.invoice_1.state, "open", "Invoice should be in state Open"
         )
 
     def test_tax(self):
         self.invoice_2.action_invoice_open()
-        self.assertEquals(
+        self.assertEqual(
             self.invoice_2.state, "open", "Invoice should be in state Open"
         )
         invoice_tax = self.invoice_2.tax_line_ids.sorted(key=lambda r: r.sequence)
-        self.assertEquals(invoice_tax.mapped("amount"), [50.0, 550.0, 220.0])
-        self.assertEquals(invoice_tax.mapped("base"), [500.0, 550.0, 1100.0])
+        self.assertEqual(invoice_tax.mapped("amount"), [50.0, 550.0, 220.0])
+        self.assertEqual(invoice_tax.mapped("base"), [500.0, 550.0, 1100.0])
         assert self.invoice_2.move_id, "Move not created for open invoice"
         self.invoice_2.pay_and_reconcile(
             self.env["account.journal"].search([("type", "=", "bank")], limit=1),
@@ -233,23 +233,23 @@ class TestCustomerInvoice(SavepointCase):
         assert (
             self.invoice_2.payment_move_line_ids
         ), "Paymente Move Line not created for Paid invoice"
-        self.assertEquals(
+        self.assertEqual(
             self.invoice_2.state, "paid", "Invoice should be in state Paid"
         )
 
     def test_invoice_other_currency(self):
-        self.assertEquals(
+        self.assertEqual(
             self.invoice_3.state, "draft", "Invoice should be in state Draft"
         )
         self.invoice_3.action_invoice_open()
         assert self.invoice_3.move_id, "Move Receivable not created for open invoice"
-        self.assertEquals(
+        self.assertEqual(
             self.invoice_3.state, "open", "Invoice should be in state Open")
 
     def test_invoice_line_ids_write(self):
         self.invoice_3.invoice_line_ids.write({'invoice_id': self.invoice_3.id})
         for line in self.invoice_3.invoice_line_ids:
-            self.assertEquals(
+            self.assertEqual(
                 line.document_id.id,
                 self.invoice_3.fiscal_document_id.id,
                 "line.document_id should be equal account.fiscal_document_id")

--- a/l10n_br_account/tests/test_supplier_invoice_dummy.py
+++ b/l10n_br_account/tests/test_supplier_invoice_dummy.py
@@ -67,11 +67,11 @@ class TestSupplierInvoice(TransactionCase):
         )
 
     def test_state(self):
-        self.assertEquals(
+        self.assertEqual(
             self.invoice_1.state, "draft", "Invoice should be in state Draft"
         )
         self.invoice_1.action_invoice_open()
         assert self.invoice_1.move_id, "Move Receivable not created for open invoice"
-        self.assertEquals(
+        self.assertEqual(
             self.invoice_1.state, "open", "Invoice should be in state Open"
         )

--- a/l10n_br_account_payment_order/tests/test_payment_order.py
+++ b/l10n_br_account_payment_order/tests/test_payment_order.py
@@ -32,13 +32,13 @@ class TestPaymentOrder(TransactionCase):
         self.invoice_customer_original.journal_id.update_posted = True
 
         # I check that Initially customer invoice is in the "Draft" state
-        self.assertEquals(self.invoice_customer_original.state, 'draft')
+        self.assertEqual(self.invoice_customer_original.state, 'draft')
 
         # I validate invoice by creating on
         self.invoice_customer_original.action_invoice_open()
 
         # I check that the invoice state is "Open"
-        self.assertEquals(self.invoice_customer_original.state, 'open')
+        self.assertEqual(self.invoice_customer_original.state, 'open')
 
         # I check that now there is a move attached to the invoice
         assert self.invoice_customer_original.move_id,\
@@ -56,7 +56,7 @@ class TestPaymentOrder(TransactionCase):
         for line in self.invoice_customer_original.move_id.line_ids.filtered(
                 lambda l: l.account_id.id ==
                 self.invoice_customer_original.account_id.id):
-            self.assertEquals(
+            self.assertEqual(
                 line.journal_entry_ref, line.invoice_id.name,
                 "Error with compute field journal_entry_ref")
             test_balance_value = line.get_balance()
@@ -67,12 +67,12 @@ class TestPaymentOrder(TransactionCase):
         for line in self.invoice_customer_original.move_id.line_ids.filtered(
                 lambda l: l.account_id.id ==
                 self.invoice_customer_original.account_id.id):
-            self.assertEquals(
+            self.assertEqual(
                 line.journal_entry_ref, line.invoice_id.name,
                 "Error with compute field journal_entry_ref")
             test_balance_value = line.get_balance()
 
-        self.assertEquals(
+        self.assertEqual(
             test_balance_value, 700.0,
             "Error with method get_balance()")
 
@@ -91,31 +91,31 @@ class TestPaymentOrder(TransactionCase):
             'journal_id': bank_journal.id
         })
 
-        self.assertEquals(len(payment_order.payment_line_ids), 2)
-        self.assertEquals(len(payment_order.bank_line_ids), 0)
+        self.assertEqual(len(payment_order.payment_line_ids), 2)
+        self.assertEqual(len(payment_order.bank_line_ids), 0)
 
         for line in payment_order.payment_line_ids:
             line.percent_interest = 1.5
-            self.assertEquals(line._get_info_partner(
+            self.assertEqual(line._get_info_partner(
                 self.invoice_customer_original.partner_id),
                 'AKRETION LTDA',
                 "Error with method _get_info_partner"
             )
             test_amount_interest = line.amount_interest
-        self.assertEquals(
+        self.assertEqual(
             test_amount_interest, 10.5,
             "Error with compute field amount_interest.")
 
         # Open payment order
         payment_order.draft2open()
 
-        self.assertEquals(len(payment_order.bank_line_ids), 2)
+        self.assertEqual(len(payment_order.bank_line_ids), 2)
 
         # Generate and upload
         payment_order.open2generated()
         payment_order.generated2uploaded()
 
-        self.assertEquals(payment_order.state, 'uploaded')
+        self.assertEqual(payment_order.state, 'uploaded')
         with self.assertRaises(UserError):
             payment_order.unlink()
 
@@ -125,10 +125,10 @@ class TestPaymentOrder(TransactionCase):
             bank_line.unlink()
 
         payment_order.action_done_cancel()
-        self.assertEquals(payment_order.state, 'cancel')
+        self.assertEqual(payment_order.state, 'cancel')
 
         payment_order.unlink()
-        self.assertEquals(len(self.env['account.payment.order'].search([])), 0)
+        self.assertEqual(len(self.env['account.payment.order'].search([])), 0)
 
     def test_bra_number_constrains(self):
         """ Test bra_number constrains. """

--- a/l10n_br_base/tests/test_amount_to_text.py
+++ b/l10n_br_base/tests/test_amount_to_text.py
@@ -22,7 +22,7 @@ class Num2WordsPTBRTest(SavepointCase):
         cls.n2w = Num2Word_PT_BR()
 
     def test_01_amount_to_text(self):
-        self.assertEquals(
+        self.assertEqual(
             self.n2w.to_currency(99.99),
             "noventa e nove reais e noventa e nove centavos",
         )

--- a/l10n_br_base/tests/test_base_onchange.py
+++ b/l10n_br_base/tests/test_base_onchange.py
@@ -45,13 +45,13 @@ class L10nBrBaseOnchangeTest(SavepointCase):
 
     def test_inverse_fields(self):
         self.company_01.inscr_mun = "692015742119"
-        self.assertEquals(
+        self.assertEqual(
             self.company_01.partner_id.inscr_mun,
             "692015742119",
             "The inverse function to field inscr_mun failed.",
         )
         self.company_01.suframa = "1234"
-        self.assertEquals(
+        self.assertEqual(
             self.company_01.partner_id.suframa,
             "1234",
             "The inverse function to field suframa failed.",
@@ -61,7 +61,7 @@ class L10nBrBaseOnchangeTest(SavepointCase):
         partner = self.env.ref("l10n_br_base.res_partner_akretion")
         partner._onchange_city_id()
         display_address = partner._display_address()
-        self.assertEquals(
+        self.assertEqual(
             display_address,
             "Akretion Sao Paulo\n"
             "Avenida Paulista, 807 CJ 2315\nCentro"
@@ -73,7 +73,7 @@ class L10nBrBaseOnchangeTest(SavepointCase):
         partner = self.env.ref("l10n_br_base.res_partner_address_ak2")
         partner._onchange_city_id()
         display_address = partner._display_address()
-        self.assertEquals(
+        self.assertEqual(
             display_address,
             "Akretion Rio de Janeiro\n"
             "Rua Acre, 47 sala 1310\nCentro"
@@ -84,7 +84,7 @@ class L10nBrBaseOnchangeTest(SavepointCase):
     def test_other_country_display_address(self):
         partner = self.env.ref("l10n_br_base.res_partner_exterior")
         display_address = partner._display_address()
-        self.assertEquals(
+        self.assertEqual(
             display_address,
             "Cliente Exterior\n3404  Edgewood"
             " Road\n\nJonesboro"
@@ -96,7 +96,7 @@ class L10nBrBaseOnchangeTest(SavepointCase):
         partner = self.env.ref("l10n_br_base.res_partner_akretion")
         partner._onchange_city_id()
         display_address = partner._display_address(without_company=True)
-        self.assertEquals(
+        self.assertEqual(
             display_address,
             "Avenida Paulista, 807 CJ 2315\nCentro"
             "\n01311-915 - São Paulo-SP\nBrazil",

--- a/l10n_br_coa_complete/tests/test_l10n_br_coa_complete.py
+++ b/l10n_br_coa_complete/tests/test_l10n_br_coa_complete.py
@@ -20,5 +20,5 @@ class L10nBrCoaComplete(TransactionCase):
         self.env.user.company_id = self.l10n_br_company
         self.l10n_br_coa_complete.try_loading_for_current_company()
 
-        self.assertEquals(
+        self.assertEqual(
             self.l10n_br_coa_complete, self.l10n_br_company.chart_template_id)

--- a/l10n_br_coa_generic/tests/test_l10n_br_coa_generic.py
+++ b/l10n_br_coa_generic/tests/test_l10n_br_coa_generic.py
@@ -20,5 +20,5 @@ class L10nBrCoaGeneric(TransactionCase):
         self.env.user.company_id = self.l10n_br_company
         self.l10n_br_coa_generic.try_loading_for_current_company()
 
-        self.assertEquals(
+        self.assertEqual(
             self.l10n_br_coa_generic, self.l10n_br_company.chart_template_id)

--- a/l10n_br_coa_simple/tests/test_l10n_br_coa_simple.py
+++ b/l10n_br_coa_simple/tests/test_l10n_br_coa_simple.py
@@ -20,5 +20,5 @@ class L10nBrSimpleCOA(TransactionCase):
         self.env.user.company_id = self.l10n_br_company
         self.l10n_br_coa_simple.try_loading_for_current_company()
 
-        self.assertEquals(
+        self.assertEqual(
             self.l10n_br_coa_simple, self.l10n_br_company.chart_template_id)

--- a/l10n_br_fiscal/tests/test_certificate.py
+++ b/l10n_br_fiscal/tests/test_certificate.py
@@ -72,13 +72,13 @@ class TestCertificate(common.TransactionCase):
             }
         )
 
-        self.assertEquals(cert.issuer_name, self.cert_issuer_a)
-        self.assertEquals(cert.owner_name, self.cert_subject_valid)
-        self.assertEquals(cert.date_expiration.year, self.cert_date_exp.year)
-        self.assertEquals(cert.date_expiration.month, self.cert_date_exp.month)
-        self.assertEquals(cert.date_expiration.day, self.cert_date_exp.day)
-        self.assertEquals(cert.name, self.cert_name)
-        self.assertEquals(cert.is_valid, True)
+        self.assertEqual(cert.issuer_name, self.cert_issuer_a)
+        self.assertEqual(cert.owner_name, self.cert_subject_valid)
+        self.assertEqual(cert.date_expiration.year, self.cert_date_exp.year)
+        self.assertEqual(cert.date_expiration.month, self.cert_date_exp.month)
+        self.assertEqual(cert.date_expiration.day, self.cert_date_exp.day)
+        self.assertEqual(cert.name, self.cert_name)
+        self.assertEqual(cert.is_valid, True)
 
     def test_certificate_wrong_password(self):
         """Write a valid certificate with wrong password"""

--- a/l10n_br_fiscal/tests/test_fiscal_document_generic.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_generic.py
@@ -61,12 +61,12 @@ class TestFiscalDocumentGeneric(SavepointCase):
             line._onchange_fiscal_taxes()
 
             if 'Revenda' in line.fiscal_operation_line_id.name:
-                self.assertEquals(
+                self.assertEqual(
                     line.cfop_id.code, '5102',
                     "Error to mappping CFOP 5102"
                     " for Revenda de Contribuinte Dentro do Estado.")
             else:
-                self.assertEquals(
+                self.assertEqual(
                     line.cfop_id.code, '5101',
                     "Error to mapping CFOP 5101"
                     " for Venda de Contribuinte Dentro do Estado.")
@@ -87,7 +87,7 @@ class TestFiscalDocumentGeneric(SavepointCase):
                 "Error to mapping ICMS Inernal for {0}"
                 " for Venda de Contribuinte Dentro do "
                 "Estado.".format(self.nfe_same_state.partner_id.state_id.name))
-            self.assertEquals(
+            self.assertEqual(
                 line.icms_cst_id.code, '00',
                 "Error to mapping CST 00 from ICMS 12%"
                 " for Venda de Contribuinte Dentro do Estado.")
@@ -100,40 +100,40 @@ class TestFiscalDocumentGeneric(SavepointCase):
 
             # IPI
             if 'Revenda' in line.fiscal_operation_line_id.name:
-                self.assertEquals(
+                self.assertEqual(
                     line.ipi_tax_id.name, 'IPI NT',
                     "Error to mapping IPI NT"
                     " for Revenda de Contribuinte Dentro do Estado.")
-                self.assertEquals(
+                self.assertEqual(
                     line.ipi_cst_id.code, '53',
                     "Error to mapping CST 53 from IPI NT"
                     " to Revenda de Contribuinte Dentro do Estado.")
             else:
-                self.assertEquals(
+                self.assertEqual(
                     line.ipi_tax_id.name, 'IPI 5%',
                     "Error to mapping IPI 5%"
                     " for Venda de Contribuinte Dentro do Estado.")
-                self.assertEquals(
+                self.assertEqual(
                     line.ipi_cst_id.code, '50',
                     "Error to mapping CST 50 from IPI 5%"
                     " to Venda de Contribuinte Dentro do Estado.")
 
             # PIS
-            self.assertEquals(
+            self.assertEqual(
                 line.pis_tax_id.name, 'PIS 0,65%',
                 "Error to mapping PIS 0,65%"
                 " for Venda de Contribuinte Dentro do Estado.")
-            self.assertEquals(
+            self.assertEqual(
                 line.pis_cst_id.code, '01',
                 "Error to mapping CST 01 - Operação Tributável com Alíquota"
                 " Básica from PIS 0,65% to Venda de Contribuinte Dentro do Estado.")
 
             # PIS
-            self.assertEquals(
+            self.assertEqual(
                 line.cofins_tax_id.name, 'COFINS 3%',
                 "Error to mapping COFINS 3%"
                 " for Venda de Contribuinte Dentro do Estado.")
-            self.assertEquals(
+            self.assertEqual(
                 line.cofins_cst_id.code, '01',
                 "Error to mapping CST 01 - Operação Tributável com Alíquota Básica"
                 " Básica to COFINS 3% de Venda de Contribuinte Dentro do Estado.")
@@ -155,33 +155,33 @@ class TestFiscalDocumentGeneric(SavepointCase):
             line._onchange_fiscal_taxes()
 
             if 'Revenda' in line.fiscal_operation_line_id.name:
-                self.assertEquals(
+                self.assertEqual(
                     line.cfop_id.code, '6102',
                     "Error to mapping CFOP 6102"
                     " for Revenda de Contribuinte p/ Fora do Estado.")
             else:
-                self.assertEquals(
+                self.assertEqual(
                     line.cfop_id.code, '6101',
                     "Error to mapping CFOP 6101"
                     " for Venda de Contribuinte p/ Fora do Estado.")
 
             # ICMS
             if line.product_id.icms_origin in ICMS_ORIGIN_TAX_IMPORTED:
-                self.assertEquals(
+                self.assertEqual(
                     line.icms_tax_id.name, 'ICMS 4%',
                     "Error to mapping ICMS 4%"
                     " for Venda de Contribuinte p/ Fora do Estado.")
-                self.assertEquals(
+                self.assertEqual(
                     line.icms_cst_id.code, '00',
                     "Error to mapping CST 00 from ICMS 4%"
                     " for Venda de Contribuinte p/ Fora do Estado.")
             else:
 
-                self.assertEquals(
+                self.assertEqual(
                     line.icms_tax_id.name, 'ICMS 7%',
                     "Error to mapping ICMS 7%"
                     " for Venda de Contribuinte p/ Fora do Estado.")
-                self.assertEquals(
+                self.assertEqual(
                     line.icms_cst_id.code, '00',
                     "Error to mapping CST 00 from ICMS 7%"
                     " for Venda de Contribuinte p/ Fora do Estado.")
@@ -194,41 +194,41 @@ class TestFiscalDocumentGeneric(SavepointCase):
 
             # IPI
             if 'Revenda' in line.fiscal_operation_line_id.name:
-                self.assertEquals(
+                self.assertEqual(
                     line.ipi_tax_id.name, 'IPI NT',
                     "Error to mapping IPI NT"
                     " for Revenda de Contribuinte Dentro do Estado.")
-                self.assertEquals(
+                self.assertEqual(
                     line.ipi_cst_id.code, '53',
                     "Error to mapping CST 53 from IPI NT"
                     " to Revenda de Contribuinte Dentro do Estado.")
             else:
-                self.assertEquals(
+                self.assertEqual(
                     line.ipi_tax_id.name, 'IPI 5%',
                     "Error to mapping IPI 5%"
                     " for Venda de Contribuinte Dentro do Estado.")
-                self.assertEquals(
+                self.assertEqual(
                     line.ipi_cst_id.code, '50',
                     "Error to mapping CST 50 from IPI 5%"
                     " to Venda de Contribuinte Dentro do Estado.")
 
             # PIS
-            self.assertEquals(
+            self.assertEqual(
                 line.pis_tax_id.name, 'PIS 0,65%',
                 "Error to mapping PIS 0,65%"
                 " for Venda de Contribuinte p/ Fora do Estado.")
-            self.assertEquals(
+            self.assertEqual(
                 line.pis_cst_id.code, '01',
                 "Error to mapping CST 01 - Operação Tributável com Alíquota"
                 " Básica from PIS 0,65% for"
                 " Venda de Contribuinte p/ Fora do Estado.")
 
             # PIS
-            self.assertEquals(
+            self.assertEqual(
                 line.cofins_tax_id.name, 'COFINS 3%',
                 "Error to mapping COFINS 3%"
                 " for Venda de Contribuinte p/ Fora do Estado.")
-            self.assertEquals(
+            self.assertEqual(
                 line.cofins_cst_id.code, '01',
                 "Error to mapping CST 01 -"
                 " Operação Tributável com Alíquota Básica"
@@ -249,22 +249,22 @@ class TestFiscalDocumentGeneric(SavepointCase):
             line._onchange_fiscal_taxes()
 
             if 'Revenda' in line.fiscal_operation_line_id.name:
-                self.assertEquals(
+                self.assertEqual(
                     line.cfop_id.code, '6108',
                     "Error to mapping CFOP 6108"
                     " for Revenda de Contribuinte p/ Não Contribuinte.")
             else:
-                self.assertEquals(
+                self.assertEqual(
                     line.cfop_id.code, '6107',
                     "Error to mapping CFOP 6107"
                     " for Venda de Contribuinte p/ Não Contribuinte.")
 
             # ICMS
-            self.assertEquals(
+            self.assertEqual(
                 line.icms_tax_id.name, 'ICMS 12%',
                 "Error to mapping ICMS 12%"
                 " for Venda de Contribuinte p/ Não Contribuinte.")
-            self.assertEquals(
+            self.assertEqual(
                 line.icms_cst_id.code, '00',
                 "Error to mapping CST 00 from ICMS 12%"
                 " for Venda de Contribuinte p/ Não Contribuinte.")
@@ -277,41 +277,41 @@ class TestFiscalDocumentGeneric(SavepointCase):
 
             # IPI
             if 'Revenda' in line.fiscal_operation_line_id.name:
-                self.assertEquals(
+                self.assertEqual(
                     line.ipi_tax_id.name, 'IPI NT',
                     "Error to mapping IPI NT"
                     " for Revenda de Contribuinte Dentro do Estado.")
-                self.assertEquals(
+                self.assertEqual(
                     line.ipi_cst_id.code, '53',
                     "Error to mapping CST 53 from IPI NT"
                     " to Revenda de Contribuinte Dentro do Estado.")
             else:
-                self.assertEquals(
+                self.assertEqual(
                     line.ipi_tax_id.name, 'IPI 5%',
                     "Error to mapping IPI 5%"
                     " for Venda de Contribuinte Dentro do Estado.")
-                self.assertEquals(
+                self.assertEqual(
                     line.ipi_cst_id.code, '50',
                     "Error to mapping CST 50 from IPI 5%"
                     " to Venda de Contribuinte Dentro do Estado.")
 
             # PIS
-            self.assertEquals(
+            self.assertEqual(
                 line.pis_tax_id.name, 'PIS 0,65%',
                 "Error to mapping PIS 0,65%"
                 " for Venda de Contribuinte p/ Não Contribuinte.")
-            self.assertEquals(
+            self.assertEqual(
                 line.pis_cst_id.code, '01',
                 "Error to mapping CST 01 - Operação Tributável com Alíquota"
                 " Básica from PIS 0,65% for"
                 " Venda de Contribuinte p/ Não Contribuinte.")
 
             # PIS
-            self.assertEquals(
+            self.assertEqual(
                 line.cofins_tax_id.name, 'COFINS 3%',
                 "Error to mapping COFINS 3%"
                 " for Venda de Contribuinte p/ Não Contribuinte.")
-            self.assertEquals(
+            self.assertEqual(
                 line.cofins_cst_id.code, '01',
                 "Error to mapping CST 01 -"
                 " Operação Tributável com Alíquota Básica"
@@ -332,69 +332,69 @@ class TestFiscalDocumentGeneric(SavepointCase):
             line._onchange_fiscal_taxes()
 
             if 'Revenda' in line.fiscal_operation_line_id.name:
-                self.assertEquals(
+                self.assertEqual(
                     line.cfop_id.code, '6108',
                     "Error to mapping CFOP 6108"
                     " for Revenda de Contribuinte p/ Não Contribuinte.")
             else:
-                self.assertEquals(
+                self.assertEqual(
                     line.cfop_id.code, '6107',
                     "Error to mapping CFOP 6107"
                     " for Venda de Contribuinte p/ Não Contribuinte.")
 
             # ICMS
-            self.assertEquals(
+            self.assertEqual(
                 line.icms_tax_id.name, 'ICMS 12%',
                 "Error to mapping ICMS 12%"
                 " for Venda de Contribuinte p/ Não Contribuinte.")
-            self.assertEquals(
+            self.assertEqual(
                 line.icms_cst_id.code, '00',
                 "Error to mapping CST 00 from ICMS 12%"
                 " for Venda de Contribuinte p/ Não Contribuinte.")
 
             # ICMS FCP
-            self.assertEquals(
+            self.assertEqual(
                 line.icmsfcp_tax_id.name, 'FCP 2%',
                 "Erro ao mapear ICMS FCP 2%"
                 " para Venda de Contribuinte p/ Não Contribuinte.")
 
             # IPI
             if 'Revenda' in line.fiscal_operation_line_id.name:
-                self.assertEquals(
+                self.assertEqual(
                     line.ipi_tax_id.name, 'IPI NT',
                     "Error to mapping IPI NT"
                     " for Revenda de Contribuinte Dentro do Estado.")
-                self.assertEquals(
+                self.assertEqual(
                     line.ipi_cst_id.code, '53',
                     "Error to mapping CST 53 from IPI NT"
                     " to Revenda de Contribuinte Dentro do Estado.")
             else:
-                self.assertEquals(
+                self.assertEqual(
                     line.ipi_tax_id.name, 'IPI 5%',
                     "Error to mapping IPI 5%"
                     " for Venda de Contribuinte Dentro do Estado.")
-                self.assertEquals(
+                self.assertEqual(
                     line.ipi_cst_id.code, '50',
                     "Error to mapping CST 50 from IPI 5%"
                     " to Venda de Contribuinte Dentro do Estado.")
 
             # PIS
-            self.assertEquals(
+            self.assertEqual(
                 line.pis_tax_id.name, 'PIS 0,65%',
                 "Error to mapping PIS 0,65%"
                 " for Venda de Contribuinte p/ Não Contribuinte.")
-            self.assertEquals(
+            self.assertEqual(
                 line.pis_cst_id.code, '01',
                 "Error to mapping CST 01 - Operação Tributável com Alíquota"
                 " Básica from PIS 0,65% for"
                 " Venda de Contribuinte p/ Não Contribuinte.")
 
             # PIS
-            self.assertEquals(
+            self.assertEqual(
                 line.cofins_tax_id.name, 'COFINS 3%',
                 "Error to mapping COFINS 3%"
                 " for Venda de Contribuinte p/ Não Contribuinte.")
-            self.assertEquals(
+            self.assertEqual(
                 line.cofins_cst_id.code, '01',
                 "Error to mapping CST 01 -"
                 " Operação Tributável com Alíquota Básica"
@@ -415,69 +415,69 @@ class TestFiscalDocumentGeneric(SavepointCase):
             line._onchange_fiscal_taxes()
 
             if 'Revenda' in line.fiscal_operation_line_id.name:
-                self.assertEquals(
+                self.assertEqual(
                     line.cfop_id.code, '7102',
                     "Error to mapping CFOP 7102"
                     " for Revenda de Contribuinte p/ o Exterior.")
             else:
-                self.assertEquals(
+                self.assertEqual(
                     line.cfop_id.code, '7101',
                     "Error to mapping CFOP 7101"
                     " for Venda de Contribuinte p/ o Exterior.")
 
             # ICMS - TODO field missing
-            # self.assertEquals(
+            # self.assertEqual(
             #    line.icms_tax_id.name, 'ICMS 7%',
             #    "Error to mapping ICMS 7%"
             #    " for Venda de Contribuinte p/ o Exterior.")
-            # self.assertEquals(
+            # self.assertEqual(
             #    line.icms_cst_id.code, '00',
             #    "Error to mapping CST 00 from ICMS 7%"
             #    " for Venda de Contribuinte p/ o Exterior.")
 
             # ICMS FCP
-            # self.assertEquals(
+            # self.assertEqual(
             #    line.icmsfcp_tax_id.name, 'FCP 2%',
             #    "Erro ao mapear ICMS FCP 2%"
             #    " para Venda de Contribuinte p/ o Exterior.")
 
             # IPI
             if 'Revenda' in line.fiscal_operation_line_id.name:
-                self.assertEquals(
+                self.assertEqual(
                     line.ipi_tax_id.name, 'IPI NT',
                     "Error to mapping IPI NT"
                     " for Revenda de Contribuinte Dentro do Estado.")
-                self.assertEquals(
+                self.assertEqual(
                     line.ipi_cst_id.code, '53',
                     "Error to mapping CST 53 from IPI NT"
                     " to Revenda de Contribuinte Dentro do Estado.")
             else:
-                self.assertEquals(
+                self.assertEqual(
                     line.ipi_tax_id.name, 'IPI 5%',
                     "Error to mapping IPI 5%"
                     " for Venda de Contribuinte Dentro do Estado.")
-                self.assertEquals(
+                self.assertEqual(
                     line.ipi_cst_id.code, '50',
                     "Error to mapping CST 50 from IPI 5%"
                     " to Venda de Contribuinte Dentro do Estado.")
 
             # PIS
-            self.assertEquals(
+            self.assertEqual(
                 line.pis_tax_id.name, 'PIS 0,65%',
                 "Error to mapping PIS 0,65%"
                 " for Venda de Contribuinte p/ o Exterior.")
-            self.assertEquals(
+            self.assertEqual(
                 line.pis_cst_id.code, '01',
                 "Error to mapping CST 01 - Operação Tributável com Alíquota"
                 " Básica from PIS 0,65% for"
                 " Venda de Contribuinte p/ o Exterior.")
 
             # PIS
-            self.assertEquals(
+            self.assertEqual(
                 line.cofins_tax_id.name, 'COFINS 3%',
                 "Error to mapping COFINS 3%"
                 " for Venda de Contribuinte p/ o Exterior.")
-            self.assertEquals(
+            self.assertEqual(
                 line.cofins_cst_id.code, '01',
                 "Error to mapping CST 01 -"
                 " Operação Tributável com Alíquota Básica"
@@ -498,59 +498,59 @@ class TestFiscalDocumentGeneric(SavepointCase):
             line._onchange_fiscal_taxes()
 
             if 'Revenda' in line.fiscal_operation_line_id.name:
-                self.assertEquals(
+                self.assertEqual(
                     line.cfop_id.code, '5102',
                     "Error to mappping CFOP 5102"
                     " for Revenda de Simples Nacional Dentro do Estado.")
             else:
-                self.assertEquals(
+                self.assertEqual(
                     line.cfop_id.code, '5101',
                     "Error to mapping CFOP 5101"
                     " for Venda de Simples Nacional Dentro do Estado.")
 
             # ICMS
-            self.assertEquals(
+            self.assertEqual(
                 line.icmssn_tax_id.name, 'ICMS SN Com Permissão de Crédito',
                 "Error to mapping ICMS SN Com Permissão de Crédito"
                 " for Venda de Simples Nacional Dentro do Estado.")
-            self.assertEquals(
+            self.assertEqual(
                 line.icms_cst_id.code, '101',
                 "Error to mapping CST 101 do ICMS SN Com Permissão de Crédito"
                 " for Venda de Simples Nacional Dentro do Estado.")
 
             # ICMS FCP - TODO mapping failed
-            # self.assertEquals(
+            # self.assertEqual(
             #    line.icmsfcp_tax_id.name, 'FCP 2%',
             #    "Erro ao mapear ICMS FCP 2%"
             #    " para Venda de Simples Nacional Dentro do Estado.")
 
             # IPI
-            self.assertEquals(
+            self.assertEqual(
                 line.ipi_tax_id.name, 'IPI Outros',
                 "Error to mapping IPI Simples Nacional"
                 " for Venda de Simples Nacional Fora do Estado.")
-            self.assertEquals(
+            self.assertEqual(
                 line.ipi_cst_id.code, '99',
                 "Error to mapping CST 99 from IPI Simples Nacional"
                 " for Venda de Simples Nacional Fora do Estado.")
 
             # PIS
-            self.assertEquals(
+            self.assertEqual(
                 line.pis_tax_id.name, 'PIS Outros',
                 "Error to mapping PIS Simples Nacional"
                 " for Venda de Simples Nacional Dentro do Estado.")
-            self.assertEquals(
+            self.assertEqual(
                 line.pis_cst_id.code, '49',
                 "Error to mapping CST 49 Outras Operações de Saída"
                 " from PIS Simples Nacional from Venda de"
                 " Simples Nacional Dentro do Estado.")
 
             # COFINS
-            self.assertEquals(
+            self.assertEqual(
                 line.cofins_tax_id.name, 'COFINS Outros',
                 "Error to mapping COFINS Simples Nacional"
                 " for Venda de Simples Nacional Dentro do Estado.")
-            self.assertEquals(
+            self.assertEqual(
                 line.cofins_cst_id.code, '49',
                 "Error to mapping CST 49 Outras Operações de Saída"
                 " from COFINS Simples Nacional for Venda de"
@@ -571,59 +571,59 @@ class TestFiscalDocumentGeneric(SavepointCase):
             line._onchange_fiscal_taxes()
 
             if 'Revenda' in line.fiscal_operation_line_id.name:
-                self.assertEquals(
+                self.assertEqual(
                     line.cfop_id.code, '6102',
                     "Error to mappping CFOP 6102"
                     " for Revenda de Simples Nacional Fora do Estado.")
             else:
-                self.assertEquals(
+                self.assertEqual(
                     line.cfop_id.code, '6101',
                     "Error to mapping CFOP 6101"
                     " for Venda de Simples Nacional Fora do Estado.")
 
             # ICMS
-            self.assertEquals(
+            self.assertEqual(
                 line.icmssn_tax_id.name, 'ICMS SN Com Permissão de Crédito',
                 "Error to mapping ICMS SN Com Permissão de Crédito"
                 " for Venda de Simples Nacional Dentro do Estado.")
-            self.assertEquals(
+            self.assertEqual(
                 line.icms_cst_id.code, '101',
                 "Erro ao mapear a CST 101 do ICMS SN Com Permissão de Crédito"
                 " para Venda de Simples Nacional Dentro do Estado.")
 
             # ICMS FCP - TODO mapping failed
-            # self.assertEquals(
+            # self.assertEqual(
             #    line.icmsfcp_tax_id.name, 'FCP 2%',
             #    "Erro ao mapear ICMS FCP 2%"
             #    " para Venda de Simples Nacional Fora do Estado.")
 
             # IPI
-            self.assertEquals(
+            self.assertEqual(
                 line.ipi_tax_id.name, 'IPI Outros',
                 "Error to mapping IPI Simples Nacional"
                 " for Venda de Simples Nacional Fora do Estado.")
-            self.assertEquals(
+            self.assertEqual(
                 line.ipi_cst_id.code, '99',
                 "Error to mapping CST 99 from IPI Simples Nacional"
                 " for Venda de Simples Nacional Fora do Estado.")
 
             # PIS
-            self.assertEquals(
+            self.assertEqual(
                 line.pis_tax_id.name, 'PIS Outros',
                 "Erro ao mapear PIS Simples Nacional"
                 " para Venda de Simples Nacional Fora do Estado.")
-            self.assertEquals(
+            self.assertEqual(
                 line.pis_cst_id.code, '49',
                 "Erro ao mapear a CST 49 Outras Operações de Saída"
                 " com Alíquota Básica do PIS Simples Nacional de Venda de"
                 " Simples Nacional Dentro do Estado.")
 
             # COFINS
-            self.assertEquals(
+            self.assertEqual(
                 line.cofins_tax_id.name, 'COFINS Outros',
                 "Error to mapping COFINS Simples Nacional"
                 " for Venda de Simples Nacional Dentro do Estado.")
-            self.assertEquals(
+            self.assertEqual(
                 line.cofins_cst_id.code, '49',
                 "Error to mapping CST 49 Outras Operações de Saída"
                 " from COFINS Simples Nacional for Venda de"
@@ -644,59 +644,59 @@ class TestFiscalDocumentGeneric(SavepointCase):
             line._onchange_fiscal_taxes()
 
             if 'Revenda' in line.fiscal_operation_line_id.name:
-                self.assertEquals(
+                self.assertEqual(
                     line.cfop_id.code, '5102',
                     "Error to mappping CFOP 5102"
                     " for Revenda de Simples Nacional Fora do Estado.")
             else:
-                self.assertEquals(
+                self.assertEqual(
                     line.cfop_id.code, '5101',
                     "Error to mapping CFOP 5101"
                     " for Venda de Simples Nacional Fora do Estado.")
 
             # ICMS
-            self.assertEquals(
+            self.assertEqual(
                 line.icms_tax_id.name, 'ICMS 18%',
                 "Error to mapping ICMS 18%"
                 " for Venda de Simples Nacional Fora do Estado.")
-            self.assertEquals(
+            self.assertEqual(
                 line.icms_cst_id.code, '00',
                 "Erro ao mapear a CST 00 do ICMS 18%"
                 " para Venda de Simples Nacional Fora do Estado.")
 
             # ICMS FCP
-            # self.assertEquals(
+            # self.assertEqual(
             #     line.icmsfcp_tax_id.name, 'FCP 2%',
             #     "Erro ao mapear ICMS FCP 2%"
             #     " para Venda de Simples Nacional Fora do Estado.")
 
             # IPI
-            self.assertEquals(
+            self.assertEqual(
                 line.ipi_tax_id.name, 'IPI 5%',
                 "Erro ao mapear IPI 5%"
                 " para Venda de Simples Nacional Fora do Estado.")
-            self.assertEquals(
+            self.assertEqual(
                 line.ipi_cst_id.code, '50',
                 "Erro ao mapear a CST 50 do IPI 5%"
                 " de Venda de Simples Nacional Fora do Estado.")
 
             # PIS
-            self.assertEquals(
+            self.assertEqual(
                 line.pis_tax_id.name, 'PIS 0,65%',
                 "Erro ao mapear PIS 0,65%"
                 " para Venda de Simples Nacional Fora do Estado.")
-            self.assertEquals(
+            self.assertEqual(
                 line.pis_cst_id.code, '01',
                 "Erro ao mapear a CST 01 - Operação Tributável"
                 " com Alíquota Básica do PIS 0,65% de Venda de"
                 " Simples Nacional Fora do Estado.")
 
             # PIS
-            self.assertEquals(
+            self.assertEqual(
                 line.cofins_tax_id.name, 'COFINS 3%',
                 "Erro ao mapear COFINS 3%"
                 " para Venda de Simples Nacional Dentro do Estado.")
-            self.assertEquals(
+            self.assertEqual(
                 line.cofins_cst_id.code, '01',
                 "Erro ao mapear a CST 01 - Operação Tributável"
                 " com Alíquota Básica do COFINS 3% de Venda de"
@@ -717,59 +717,59 @@ class TestFiscalDocumentGeneric(SavepointCase):
             line._onchange_fiscal_taxes()
 
             if 'Revenda' in line.fiscal_operation_line_id.name:
-                self.assertEquals(
+                self.assertEqual(
                     line.cfop_id.code, '7102',
                     "Error to mapping CFOP 7102"
                     " for Revenda de Contribuinte p/ o Exterior.")
             else:
-                self.assertEquals(
+                self.assertEqual(
                     line.cfop_id.code, '7101',
                     "Error to mapping CFOP 7101"
                     " for Venda de Contribuinte p/ o Exterior.")
 
             # ICMS
-            self.assertEquals(
+            self.assertEqual(
                 line.icmssn_tax_id.name, 'ICMS SN Com Permissão de Crédito',
                 "Error to mapping ICMS SN Com Permissão de Crédito"
                 " for Venda de Simples Nacional Dentro do Estado.")
-            self.assertEquals(
+            self.assertEqual(
                 line.icms_cst_id.code, '101',
                 "Erro ao mapear a CST 101 do ICMS SN Com Permissão de Crédito"
                 " para Venda de Simples Nacional Dentro do Estado.")
 
             # ICMS FCP
-            # self.assertEquals(
+            # self.assertEqual(
             #    line.icmsfcp_tax_id.name, 'FCP 2%',
             #    "Erro ao mapear ICMS FCP 2%"
             #    " para Venda de Contribuinte p/ o Exterior.")
 
             # IPI
-            self.assertEquals(
+            self.assertEqual(
                 line.ipi_tax_id.name, 'IPI Outros',
                 "Error to mapping IPI Simples Nacional"
                 " for Venda de Simples Nacional Fora do Estado.")
-            self.assertEquals(
+            self.assertEqual(
                 line.ipi_cst_id.code, '99',
                 "Error to mapping CST 99 from IPI Simples Nacional"
                 " for Venda de Simples Nacional Fora do Estado.")
 
             # PIS
-            self.assertEquals(
+            self.assertEqual(
                 line.pis_tax_id.name, 'PIS Outros',
                 "Erro ao mapear PIS Simples Nacional"
                 " para Venda de Simples Nacional Fora do Estado.")
-            self.assertEquals(
+            self.assertEqual(
                 line.pis_cst_id.code, '49',
                 "Erro ao mapear a CST 49 Outras Operações de Saída"
                 " com Alíquota Básica do PIS Simples Nacional de Venda de"
                 " Simples Nacional Dentro do Estado.")
 
             # COFINS
-            self.assertEquals(
+            self.assertEqual(
                 line.cofins_tax_id.name, 'COFINS Outros',
                 "Error to mapping COFINS Simples Nacional"
                 " for Venda de Simples Nacional Dentro do Estado.")
-            self.assertEquals(
+            self.assertEqual(
                 line.cofins_cst_id.code, '49',
                 "Error to mapping CST 49 Outras Operações de Saída"
                 " from COFINS Simples Nacional for Venda de"
@@ -781,7 +781,7 @@ class TestFiscalDocumentGeneric(SavepointCase):
         return_id = self.nfe_same_state.browse(
             [i[2][0] for i in action['domain'] if i[0] == 'id'])
 
-        self.assertEquals(
+        self.assertEqual(
             return_id.fiscal_operation_id.id,
             self.nfe_same_state.fiscal_operation_id.return_fiscal_operation_id.id,
             "Error on creation return"

--- a/l10n_br_fiscal/tests/test_fiscal_document_nfse.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_nfse.py
@@ -27,19 +27,19 @@ class TestFiscalDocumentNFSe(TransactionCase):
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
 
-            self.assertEquals(
+            self.assertEqual(
                 line.fiscal_operation_line_id.name, 'Prestação de Serviço',
                 "Error to mappping Prestação de Serviço"
                 " for Venda de Serviço de Contribuinte Dentro do Estado.")
 
             # Service Type
-            self.assertEquals(
+            self.assertEqual(
                 line.service_type_id.code, '1.05',
                 "Error to mapping Service Type Code 1.05"
                 " for Venda de Serviço de Contribuinte Dentro do Estado.")
 
             # ISSQN
-            self.assertEquals(
+            self.assertEqual(
                 line.issqn_tax_id.name, 'ISSQN 5%',
                 "Error to mapping ICMS CST Tributada com permissão de crédito"
                 " for Venda de Serviço de Contribuinte Dentro do Estado.")

--- a/l10n_br_fiscal/tests/test_ibpt_product.py
+++ b/l10n_br_fiscal/tests/test_ibpt_product.py
@@ -76,8 +76,8 @@ class TestIbptProduct(SavepointCase):
 
     def test_ncm_count_product_template(self):
         """Check product template relation with NCM"""
-        self.assertEquals(self.ncm_85030010.product_tmpl_qty, 2)
-        self.assertEquals(self.ncm_85014029.product_tmpl_qty, 1)
+        self.assertEqual(self.ncm_85030010.product_tmpl_qty, 2)
+        self.assertEqual(self.ncm_85014029.product_tmpl_qty, 1)
 
     def test_update_scheduled(self):
         """Check NCM update scheduled"""

--- a/l10n_br_fiscal/tests/test_ibpt_service.py
+++ b/l10n_br_fiscal/tests/test_ibpt_service.py
@@ -79,8 +79,8 @@ class TestIbptService(SavepointCase):
 
     def test_nbs_count_product_template(self):
         """Check product template relation with NBS"""
-        self.assertEquals(self.nbs_115069000.product_tmpl_qty, 2)
-        self.assertEquals(self.nbs_124043300.product_tmpl_qty, 1)
+        self.assertEqual(self.nbs_115069000.product_tmpl_qty, 2)
+        self.assertEqual(self.nbs_124043300.product_tmpl_qty, 1)
 
     def test_update_scheduled(self):
         """Check NBS update scheduled"""

--- a/l10n_br_fiscal/tests/test_subsequent_operation.py
+++ b/l10n_br_fiscal/tests/test_subsequent_operation.py
@@ -51,7 +51,7 @@ class TestSubsequentOperation(TransactionCase):
                             "Subsequent document was not created")
 
             # Subsequent Document operation
-            self.assertEquals(
+            self.assertEqual(
                 document.subsequent_document_id.fiscal_operation_id.id,
                 self.so_simples_faturamento.subsequent_operation_id.id,
                 "Operation of the generated document is incorrect")
@@ -60,19 +60,19 @@ class TestSubsequentOperation(TransactionCase):
             for product in document.subsequent_document_id.line_ids:
 
                 # Document Line ICMS tax
-                self.assertEquals(
+                self.assertEqual(
                     product.icms_tax_id.id,
                     self.tax_icms_12.id,
                     "ICMS tax value is not 12%")
 
                 # Document Line PIS tax
-                self.assertEquals(
+                self.assertEqual(
                     product.pis_tax_id.id,
                     self.pis_tax_0.id,
                     "PIS tax value is not 0%")
 
                 # Document Line COFINS tax
-                self.assertEquals(
+                self.assertEqual(
                     product.cofins_tax_id.id,
                     self.cofins_tax_0.id,
                     "COFINS tax value is not 0%")

--- a/l10n_br_nfe/tests/test_account_customer_invoice.py
+++ b/l10n_br_nfe/tests/test_account_customer_invoice.py
@@ -20,7 +20,7 @@ class TestCustomerInvoice(TransactionCase):
     def test_customer_invoice_original(self):
         """Test if account.invoice still work as original desing."""
         # I check that Initially customer invoice is in the "Draft" state
-        self.assertEquals(self.invoice_customer_original.state, "draft")
+        self.assertEqual(self.invoice_customer_original.state, "draft")
 
         self.invoice_customer_original._onchange_fiscal()
 
@@ -32,16 +32,16 @@ class TestCustomerInvoice(TransactionCase):
         self.invoice_customer_original.action_invoice_proforma2()
 
         # I check that the invoice state is now "Proforma2"
-        self.assertEquals(self.invoice_customer_original.state, "proforma2")
+        self.assertEqual(self.invoice_customer_original.state, "proforma2")
 
         # I check that there is no move attached to the invoice
-        self.assertEquals(len(self.invoice_customer_original.move_id), 0)
+        self.assertEqual(len(self.invoice_customer_original.move_id), 0)
 
         # I validate invoice by creating on
         self.invoice_customer_original.action_invoice_open()
 
         # I check that the invoice state is "Open"
-        self.assertEquals(self.invoice_customer_original.state, "open")
+        self.assertEqual(self.invoice_customer_original.state, "open")
 
         # I check that now there is a move attached to the invoice
         assert (

--- a/l10n_br_nfe/tests/test_account_customer_nfe.py
+++ b/l10n_br_nfe/tests/test_account_customer_nfe.py
@@ -29,7 +29,7 @@ class TestCustomerNFe(TransactionCase):
             "Error with _onchange_fiscal() method, field "
             "fiscal_position_id is not mapped."
         )
-        self.assertEquals(
+        self.assertEqual(
             self.invoice_same_state.state, "draft", "Invoice is not in Draft state."
         )
 
@@ -51,113 +51,113 @@ class TestCustomerNFe(TransactionCase):
                 " is not mapped."
             )
             # Check ICMS
-            self.assertEquals(line.icms_cst_id.code, "00", "ICMS CST is not 00")
-            self.assertEquals(line.icms_base, 1000.0, "ICMS Base is not 1000.0 ")
-            self.assertEquals(line.icms_base_other, 0.0, "Other ICMS Base is not 0.0 ")
-            self.assertEquals(line.icms_value, 180.0, "ICMS Value is not 180.0 ")
-            self.assertEquals(line.icms_percent, 18.0, "ICMS Percent is not 18")
-            self.assertEquals(
+            self.assertEqual(line.icms_cst_id.code, "00", "ICMS CST is not 00")
+            self.assertEqual(line.icms_base, 1000.0, "ICMS Base is not 1000.0 ")
+            self.assertEqual(line.icms_base_other, 0.0, "Other ICMS Base is not 0.0 ")
+            self.assertEqual(line.icms_value, 180.0, "ICMS Value is not 180.0 ")
+            self.assertEqual(line.icms_percent, 18.0, "ICMS Percent is not 18")
+            self.assertEqual(
                 line.icms_percent_reduction, 0.0, "ICMS Percent Reduction is not 0.0 "
             )
 
             # Check ICMS ST
-            self.assertEquals(line.icms_st_base, 0.0, "ICMS ST BASE is not 0.0")
-            self.assertEquals(
+            self.assertEqual(line.icms_st_base, 0.0, "ICMS ST BASE is not 0.0")
+            self.assertEqual(
                 line.icms_st_base_other, 0.0, "Other ICMS ST BASE is not 0.0"
             )
-            self.assertEquals(line.icms_st_value, 0.0, "ICMS ST Value is not 0.0")
-            self.assertEquals(line.icms_st_percent, 0.0, "ICMS ST Percent is not 0.0")
-            self.assertEquals(
+            self.assertEqual(line.icms_st_value, 0.0, "ICMS ST Value is not 0.0")
+            self.assertEqual(line.icms_st_percent, 0.0, "ICMS ST Percent is not 0.0")
+            self.assertEqual(
                 line.icms_st_percent_reduction,
                 0.0,
                 "ICMS ST Percent Reduction is not 0.0",
             )
 
             # Check IPI
-            self.assertEquals(line.ipi_cst_id.code, "50", "IPI CODE is not 50")
-            self.assertEquals(line.ipi_base, 1000.0, "ICMS ST Value is not 1000.0")
-            self.assertEquals(line.ipi_base_other, 0.0, "Other IPI Base is not 0.0 ")
-            self.assertEquals(line.ipi_value, 150.0, "ICMS Value is not 150.0 ")
-            self.assertEquals(line.ipi_percent, 15.0, "ICMS Percent is not 15 .")
+            self.assertEqual(line.ipi_cst_id.code, "50", "IPI CODE is not 50")
+            self.assertEqual(line.ipi_base, 1000.0, "ICMS ST Value is not 1000.0")
+            self.assertEqual(line.ipi_base_other, 0.0, "Other IPI Base is not 0.0 ")
+            self.assertEqual(line.ipi_value, 150.0, "ICMS Value is not 150.0 ")
+            self.assertEqual(line.ipi_percent, 15.0, "ICMS Percent is not 15 .")
 
             # Check PIS
-            self.assertEquals(line.pis_cst_id.code, "01", "PIS CODE is not 01")
-            self.assertEquals(line.pis_base, 1000.0, "PIS BASE is not 1000.0")
-            self.assertEquals(line.pis_value, 6.50, "PIS Value is not 6.50 ")
-            self.assertEquals(line.pis_percent, 0.65, "ICMS Percent is not 0.65 .")
+            self.assertEqual(line.pis_cst_id.code, "01", "PIS CODE is not 01")
+            self.assertEqual(line.pis_base, 1000.0, "PIS BASE is not 1000.0")
+            self.assertEqual(line.pis_value, 6.50, "PIS Value is not 6.50 ")
+            self.assertEqual(line.pis_percent, 0.65, "ICMS Percent is not 0.65 .")
 
             # Check COFINS
-            self.assertEquals(line.cofins_cst_id.code, "01", "COFINS CODE is not 01")
-            self.assertEquals(line.cofins_base, 1000.0, "COFINS BASE is not 1000.0")
-            self.assertEquals(line.cofins_value, 30.0, "COFINS Value is not 30.0 ")
-            self.assertEquals(line.cofins_percent, 3.0, "ICMS Percent is not 3.0 .")
+            self.assertEqual(line.cofins_cst_id.code, "01", "COFINS CODE is not 01")
+            self.assertEqual(line.cofins_base, 1000.0, "COFINS BASE is not 1000.0")
+            self.assertEqual(line.cofins_value, 30.0, "COFINS Value is not 30.0 ")
+            self.assertEqual(line.cofins_percent, 3.0, "ICMS Percent is not 3.0 .")
 
         self.invoice_same_state.with_context(
             {"fiscal_document_code": "55"}
         ).action_invoice_open()
-        self.assertEquals(
+        self.assertEqual(
             self.invoice_same_state.state,
             "sefaz_export",
             "Invoice should be in state SEFAZ EXPORT",
         )
 
-        self.assertEquals(
+        self.assertEqual(
             self.invoice_same_state.amount_gross, 2000.0, "Amount Gross is not 2000.0"
         )
-        self.assertEquals(
+        self.assertEqual(
             self.invoice_same_state.amount_discount, 0.0, "Amount Discount is not 0.0"
         )
-        self.assertEquals(
+        self.assertEqual(
             self.invoice_same_state.amount_untaxed,
             2000.0,
             "Amount Untaxed is not 2000.0",
         )
-        self.assertEquals(
+        self.assertEqual(
             self.invoice_same_state.amount_tax, 0.0, "Amount Untaxed is not 0.0"
         )
-        self.assertEquals(
+        self.assertEqual(
             self.invoice_same_state.amount_total, 2000.0, "Amount Total is not 2000.0"
         )
-        self.assertEquals(
+        self.assertEqual(
             self.invoice_same_state.residual, 2000.0, "Amount Residual is not 2000.0"
         )
 
         # Deveria existir algo ?
         for tax in self.invoice_same_state.tax_line_ids:
             if tax.base_code_id.domain == "ipi":
-                self.assertEquals(tax.base, 2000.0, "IPI BASE is not 2000.0")
+                self.assertEqual(tax.base, 2000.0, "IPI BASE is not 2000.0")
 
         # TOTAL IPI
-        self.assertEquals(
+        self.assertEqual(
             self.invoice_same_state.ipi_base, 2000.0, "IPI Total Base is not 1000.0"
         )
-        self.assertEquals(
+        self.assertEqual(
             self.invoice_same_state.ipi_value, 300.0, "ICMS Total Value is not 300.0 "
         )
 
         # TOTAL ICMS
-        self.assertEquals(
+        self.assertEqual(
             self.invoice_same_state.icms_base, 2000.0, "ICMS Total Base is not 1000.0 "
         )
-        self.assertEquals(
+        self.assertEqual(
             self.invoice_same_state.icms_value, 360.0, "ICMS Total Value is not 360.0 "
         )
 
         # Total PIS
-        self.assertEquals(
+        self.assertEqual(
             self.invoice_same_state.pis_base, 2000.0, "PIS Total BASE is not 1000.0"
         )
-        self.assertEquals(
+        self.assertEqual(
             self.invoice_same_state.pis_value, 13.0, "PIS Total Value is not 13.0 "
         )
 
         # Total COFINS
-        self.assertEquals(
+        self.assertEqual(
             self.invoice_same_state.cofins_base,
             2000.0,
             "COFINS Total Base is not 1000.0",
         )
-        self.assertEquals(
+        self.assertEqual(
             self.invoice_same_state.cofins_value,
             60.0,
             "COFINS Total Value is not 60.0 ",
@@ -169,27 +169,27 @@ class TestCustomerNFe(TransactionCase):
         self.invoice_other_costs._onchange_fiscal()
         for line in self.invoice_other_costs.invoice_line_ids:
             line._onchange_fiscal()
-            self.assertEquals(
+            self.assertEqual(
                 line.freight_value, 100.0, "Freight value is not 100.0")
-            self.assertEquals(
+            self.assertEqual(
                 line.insurance_value, 10.0, "Insurance value is not 10.0")
-            self.assertEquals(
+            self.assertEqual(
                 line.other_value, 10.0, "Other Costs value is not 10.0")
 
         self.invoice_other_costs.with_context(
             {"fiscal_document_code": "55"}
         ).action_invoice_open()
-        self.assertEquals(
+        self.assertEqual(
             self.invoice_other_costs.amount_freight_value,
             100.0,
             "Amount Freight is not 100.0",
         )
-        self.assertEquals(
+        self.assertEqual(
             self.invoice_other_costs.amount_insurance_value,
             10.0,
             "Amount Insurance is not 10.0",
         )
-        self.assertEquals(
+        self.assertEqual(
             self.invoice_other_costs.amount_other_value,
             10.0,
             "Amount Costs is not 10.0",
@@ -229,61 +229,61 @@ class TestCustomerNFe(TransactionCase):
             )
 
             # Check ICMS
-            self.assertEquals(line.icms_cst_id.code, "00", "ICMS CST is not 00")
-            self.assertEquals(line.icms_base, 1120.0, "ICMS Base is not 1120.0 ")
-            self.assertEquals(line.icms_base_other, 0.0, "Other ICMS Base is not 0.0 ")
-            self.assertEquals(line.icms_value, 134.4, "ICMS Value is not 134.4 ")
-            self.assertEquals(line.icms_percent, 12.0, "ICMS Percent is not 12")
-            self.assertEquals(
+            self.assertEqual(line.icms_cst_id.code, "00", "ICMS CST is not 00")
+            self.assertEqual(line.icms_base, 1120.0, "ICMS Base is not 1120.0 ")
+            self.assertEqual(line.icms_base_other, 0.0, "Other ICMS Base is not 0.0 ")
+            self.assertEqual(line.icms_value, 134.4, "ICMS Value is not 134.4 ")
+            self.assertEqual(line.icms_percent, 12.0, "ICMS Percent is not 12")
+            self.assertEqual(
                 line.icms_percent_reduction, 0.0, "ICMS Percent Reduction is not 0.0 "
             )
 
             # Check ICMS DIFAL
-            self.assertEquals(
+            self.assertEqual(
                 line.icms_dest_base, 1120.0, "ICMS Dest Base is not 1120.0 "
             )
-            self.assertEquals(
+            self.assertEqual(
                 line.icms_fcp_percent, 2.0, "ICMS FCP Percent is not 2.0% "
             )
-            self.assertEquals(
+            self.assertEqual(
                 line.icms_dest_percent, 0.18, "ICMS Dest Percent is not 0.18 "
             )
-            self.assertEquals(
+            self.assertEqual(
                 line.icms_origin_percent, 12.0, "ICMS Origin Percent is not 12.0% "
             )
-            self.assertEquals(
+            self.assertEqual(
                 line.icms_part_percent, 1, "ICMS Origin Percent is not 1.0% "
             )
-            self.assertEquals(line.icms_fcp_value, 22.4, "ICMS FCP Value is not 22.4 ")
-            self.assertEquals(
+            self.assertEqual(line.icms_fcp_value, 22.4, "ICMS FCP Value is not 22.4 ")
+            self.assertEqual(
                 line.icms_dest_value, 132.38, "ICMS Dest Value is not 132.38 "
             )
-            self.assertEquals(
+            self.assertEqual(
                 line.icms_origin_value, 0.0, "ICMS Origin Value is not 0.0"
             )
 
             # Check ICMS ST
-            self.assertEquals(line.icms_st_base, 0.0, "ICMS ST BASE is not 0.0")
-            self.assertEquals(
+            self.assertEqual(line.icms_st_base, 0.0, "ICMS ST BASE is not 0.0")
+            self.assertEqual(
                 line.icms_st_base_other, 0.0, "Other ICMS ST BASE is not 0.0"
             )
-            self.assertEquals(line.icms_st_value, 0.0, "ICMS ST Value is not 0.0")
-            self.assertEquals(line.icms_st_percent, 0.0, "ICMS ST Percent is not 0.0")
-            self.assertEquals(
+            self.assertEqual(line.icms_st_value, 0.0, "ICMS ST Value is not 0.0")
+            self.assertEqual(line.icms_st_percent, 0.0, "ICMS ST Percent is not 0.0")
+            self.assertEqual(
                 line.icms_st_percent_reduction,
                 0.0,
                 "ICMS ST Percent Reduction is not 0.0",
             )
 
             # Check IPI
-            self.assertEquals(line.ipi_cst_id.code, "50", "IPI CODE is not 50")
-            self.assertEquals(line.ipi_base, 1000.0, "ICMS ST Value is not 1000.0")
-            self.assertEquals(line.ipi_base_other, 0.0, "Other IPI Base is not 0.0 ")
-            self.assertEquals(line.ipi_value, 150.0, "ICMS Value is not 150.0 ")
-            self.assertEquals(line.ipi_percent, 15.0, "ICMS Percent is not 15 .")
+            self.assertEqual(line.ipi_cst_id.code, "50", "IPI CODE is not 50")
+            self.assertEqual(line.ipi_base, 1000.0, "ICMS ST Value is not 1000.0")
+            self.assertEqual(line.ipi_base_other, 0.0, "Other IPI Base is not 0.0 ")
+            self.assertEqual(line.ipi_value, 150.0, "ICMS Value is not 150.0 ")
+            self.assertEqual(line.ipi_percent, 15.0, "ICMS Percent is not 15 .")
 
             # Check COFINS
-            self.assertEquals(line.cofins_cst_id.code, "01", "COFINS CODE is not 01")
-            self.assertEquals(line.cofins_base, 1000.0, "COFINS BASE is not 1000.0")
-            self.assertEquals(line.cofins_value, 30.0, "COFINS Value is not 30.0 ")
-            self.assertEquals(line.cofins_percent, 3.0, "ICMS Percent is not 3.0 .")
+            self.assertEqual(line.cofins_cst_id.code, "01", "COFINS CODE is not 01")
+            self.assertEqual(line.cofins_base, 1000.0, "COFINS BASE is not 1000.0")
+            self.assertEqual(line.cofins_value, 30.0, "COFINS Value is not 30.0 ")
+            self.assertEqual(line.cofins_percent, 3.0, "ICMS Percent is not 3.0 .")

--- a/l10n_br_nfe/tests/test_account_supplier_nfe.py
+++ b/l10n_br_nfe/tests/test_account_supplier_nfe.py
@@ -25,7 +25,7 @@ class TestSupplierNFe(TransactionCase):
             "Error with _onchange_fiscal() method, field "
             "fiscal_position_id is not mapped."
         )
-        self.assertEquals(
+        self.assertEqual(
             self.invoice_same_state.state, "draft", "Invoice is not in Draft state."
         )
 
@@ -50,6 +50,6 @@ class TestSupplierNFe(TransactionCase):
         self.invoice_same_state.with_context(
             {"fiscal_document_code": "55"}
         ).action_invoice_open()
-        self.assertEquals(
+        self.assertEqual(
             self.invoice_same_state.state, "open", "Invoice should be in state Open"
         )

--- a/l10n_br_nfse/tests/test_fiscal_document_nfse_common.py
+++ b/l10n_br_nfse/tests/test_fiscal_document_nfse_common.py
@@ -38,25 +38,25 @@ class TestFiscalDocumentNFSeCommon(TransactionCase):
             self.nfse_same_state._onchange_fiscal_operation_id()
 
             # RPS Number
-            self.assertEquals(
+            self.assertEqual(
                 self.nfse_same_state.rps_number, '50',
                 "Error to mappping RPS Number 50"
                 " for Venda de Serviço de Contribuinte Dentro do Estado.")
 
             # RPS Type
-            self.assertEquals(
+            self.assertEqual(
                 self.nfse_same_state.rps_type, '1',
                 "Error to mappping RPS Type 1"
                 " for Venda de Serviço de Contribuinte Dentro do Estado.")
 
             # Operation Nature
-            self.assertEquals(
+            self.assertEqual(
                 self.nfse_same_state.operation_nature, '1',
                 "Error to mappping Operation Nature 1"
                 " for Venda de Serviço de Contribuinte Dentro do Estado.")
 
             # Taxation Special Regime
-            self.assertEquals(
+            self.assertEqual(
                 self.nfse_same_state.taxation_special_regime, '1',
                 "Error to mappping Taxation Special Regime 1"
                 " for Venda de Serviço de Contribuinte Dentro do Estado.")
@@ -70,13 +70,13 @@ class TestFiscalDocumentNFSeCommon(TransactionCase):
                 line._onchange_fiscal_taxes()
 
                 # Fiscal Deductions Value
-                self.assertEquals(
+                self.assertEqual(
                     line.fiscal_deductions_value, 0.0,
                     "Error to mappping Fiscal Deductions Value 0.0"
                     " for Venda de Serviço de Contribuinte Dentro do Estado.")
 
                 # City Taxation Code
-                self.assertEquals(
+                self.assertEqual(
                     line.city_taxation_code_id.code, '6311900',
                     "Error to mappping City Taxation Code 6311900"
                     " for Venda de Serviço de Contribuinte Dentro do Estado.")

--- a/l10n_br_purchase/tests/test_l10n_br_purchase.py
+++ b/l10n_br_purchase/tests/test_l10n_br_purchase.py
@@ -199,7 +199,7 @@ class L10nBrPurchaseBaseTest(SavepointCase):
             'Purchase: all products should be invoiced"'
         )
 
-        self.assertEquals(
+        self.assertEqual(
             order.state, 'purchase', 'Error to confirm Purchase Order.'
         )
 
@@ -238,7 +238,7 @@ class L10nBrPurchaseBaseTest(SavepointCase):
             'Error to mapping Operation on Purchase Order.',
         )
 
-        self.assertEquals(
+        self.assertEqual(
             self.po_products.fiscal_operation_id.name,
             self.fsc_op_purchase.name,
             "Error to mapping correct Operation on Purchase Order "
@@ -266,7 +266,7 @@ class L10nBrPurchaseBaseTest(SavepointCase):
                 line.fiscal_operation_line_id.name][
                     line.company_id.tax_framework]
 
-            self.assertEquals(
+            self.assertEqual(
                 line.cfop_id.code, cfop.code,
                 "Error to mapping CFOP {} for {}.".format(cfop.code, cfop.name)
             )
@@ -277,14 +277,14 @@ class L10nBrPurchaseBaseTest(SavepointCase):
                 icms_tax = line.icms_tax_id
 
             # ICMS
-            self.assertEquals(
+            self.assertEqual(
                 icms_tax.name, taxes['icms']['tax'].name,
                 "Error to mapping Tax {} for {}.".format(
                     taxes['icms']['tax'].name,
                     line.fiscal_operation_line_id.name)
             )
 
-            self.assertEquals(
+            self.assertEqual(
                 line.icms_cst_id.code, taxes['icms']['cst'].code,
                 "Error to mapping CST {} from {} for {}.".format(
                     taxes['icms']['cst'].code,
@@ -299,14 +299,14 @@ class L10nBrPurchaseBaseTest(SavepointCase):
                 " for Venda de Contribuinte Dentro do Estado.")
 
             # IPI
-            self.assertEquals(
+            self.assertEqual(
                 line.ipi_tax_id.name, taxes['ipi']['tax'].name,
                 "Error to mapping Tax {} for {}.".format(
                     taxes['ipi']['tax'].name,
                     line.fiscal_operation_line_id.name)
             )
 
-            self.assertEquals(
+            self.assertEqual(
                 line.ipi_cst_id.code, taxes['ipi']['cst'].code,
                 "Error to mapping CST {} from {} for {}.".format(
                     taxes['ipi']['cst'].code,
@@ -315,14 +315,14 @@ class L10nBrPurchaseBaseTest(SavepointCase):
             )
 
             # PIS
-            self.assertEquals(
+            self.assertEqual(
                 line.pis_tax_id.name, taxes['pis']['tax'].name,
                 "Error to mapping Tax {} for {}.".format(
                     taxes['pis']['tax'].name,
                     line.fiscal_operation_line_id.name)
             )
 
-            self.assertEquals(
+            self.assertEqual(
                 line.pis_cst_id.code, taxes['pis']['cst'].code,
                 "Error to mapping CST {} from {} for {}.".format(
                     taxes['pis']['cst'].code,
@@ -331,14 +331,14 @@ class L10nBrPurchaseBaseTest(SavepointCase):
             )
 
             # COFINS
-            self.assertEquals(
+            self.assertEqual(
                 line.cofins_tax_id.name, taxes['cofins']['tax'].name,
                 "Error to mapping Tax {} for {}.".format(
                     taxes['cofins']['tax'].name,
                     line.fiscal_operation_line_id.name)
             )
 
-            self.assertEquals(
+            self.assertEqual(
                 line.cofins_cst_id.code, taxes['cofins']['cst'].code,
                 "Error to mapping CST {} from {} for {}.".format(
                     taxes['cofins']['cst'].code,

--- a/l10n_br_purchase_stock/tests/test_l10n_br_purchase_stock.py
+++ b/l10n_br_purchase_stock/tests/test_l10n_br_purchase_stock.py
@@ -53,7 +53,7 @@ class L10nBrPurchaseStockBase(test_l10n_br_purchase.L10nBrPurchaseBaseTest):
         picking_1.button_validate()
         self.assertEqual(picking_1.state, 'done')
 
-        self.assertEquals(
+        self.assertEqual(
             purchase_1.invoice_status, 'to invoice',
             "Error in compute field invoice_status,"
             " before create invoice by Picking."
@@ -87,7 +87,7 @@ class L10nBrPurchaseStockBase(test_l10n_br_purchase.L10nBrPurchaseBaseTest):
         domain = [('picking_ids', 'in', (picking_1.id, picking_2.id))]
         invoice = self.invoice_model.search(domain)
         # Fatura Agrupada
-        self.assertEquals(len(invoice), 1)
+        self.assertEqual(len(invoice), 1)
         self.assertEqual(picking_1.invoice_state, 'invoiced')
         self.assertEqual(picking_2.invoice_state, 'invoiced')
 
@@ -116,7 +116,7 @@ class L10nBrPurchaseStockBase(test_l10n_br_purchase.L10nBrPurchaseBaseTest):
 
         # Confirmando a Fatura
         invoice.action_invoice_open()
-        self.assertEquals(
+        self.assertEqual(
             invoice.state, 'open', 'Invoice should be in state Open')
         # Validar Atualização da Quantidade Faturada
         for line in purchase_1.order_line:
@@ -155,7 +155,7 @@ class L10nBrPurchaseStockBase(test_l10n_br_purchase.L10nBrPurchaseBaseTest):
         for move in picking_devolution.move_ids_without_package:
             move.quantity_done = move.product_uom_qty
         picking_devolution.button_validate()
-        self.assertEquals(
+        self.assertEqual(
             picking_devolution.state, 'done',
             'Change state fail.'
         )
@@ -173,7 +173,7 @@ class L10nBrPurchaseStockBase(test_l10n_br_purchase.L10nBrPurchaseBaseTest):
         invoice_devolution = self.invoice_model.search(domain)
         # Confirmando a Fatura
         invoice_devolution.action_invoice_open()
-        self.assertEquals(
+        self.assertEqual(
             invoice_devolution.state, 'open', 'Invoice should be in state Open')
         # Validar Atualização da Quantidade Faturada
         for line in purchase_1.order_line:

--- a/l10n_br_repair/tests/test_l10n_br_repair.py
+++ b/l10n_br_repair/tests/test_l10n_br_repair.py
@@ -171,7 +171,7 @@ class L10nBrRepairBaseTest(TransactionCase):
         # Create and check invoice
         repair_order.action_invoice_create(group=False)
 
-        self.assertEquals(
+        self.assertEqual(
             repair_order.state, "2binvoiced", "Error to confirm Repair Order."
         )
 
@@ -203,13 +203,13 @@ class L10nBrRepairBaseTest(TransactionCase):
             "Error to mapping Operation on Repair Order.",
         )
 
-        self.assertEquals(
+        self.assertEqual(
             self.so_products.fiscal_operation_id.name,
             self.fsc_op_sale.name,
             "Error to mapping correct Operation on Repair Order "
             "after change fiscal category.",
         )
-        self.assertEquals(
+        self.assertEqual(
             self.so_products.amount_discount_value,
             0,
             "Error to discount value",
@@ -235,7 +235,7 @@ class L10nBrRepairBaseTest(TransactionCase):
                 line.fiscal_operation_line_id.name][
                     line.company_id.tax_framework]
 
-            self.assertEquals(
+            self.assertEqual(
                 line.cfop_id.code, cfop.code,
                 "Error to mapping CFOP {} for {}.".format(cfop.code, cfop.name)
             )
@@ -252,14 +252,14 @@ class L10nBrRepairBaseTest(TransactionCase):
                         'l10n_br_fiscal.cst_ipi_53')
 
             # ICMS
-            self.assertEquals(
+            self.assertEqual(
                 icms_tax.name, taxes['icms']['tax'].name,
                 "Error to mapping Tax {} for {}.".format(
                     taxes['icms']['tax'].name,
                     line.fiscal_operation_line_id.name)
             )
 
-            self.assertEquals(
+            self.assertEqual(
                 line.icms_cst_id.code, taxes['icms']['cst'].code,
                 "Error to mapping CST {} from {} for {}.".format(
                     taxes['icms']['cst'].code,
@@ -274,14 +274,14 @@ class L10nBrRepairBaseTest(TransactionCase):
                 " for Venda de Contribuinte Dentro do Estado.")
 
             # IPI
-            self.assertEquals(
+            self.assertEqual(
                 line.ipi_tax_id.name, taxes['ipi']['tax'].name,
                 "Error to mapping Tax {} for {}.".format(
                     taxes['ipi']['tax'].name,
                     line.fiscal_operation_line_id.name)
             )
 
-            self.assertEquals(
+            self.assertEqual(
                 line.ipi_cst_id.code, taxes['ipi']['cst'].code,
                 "Error to mapping CST {} from {} for {}.".format(
                     taxes['ipi']['cst'].code,
@@ -290,14 +290,14 @@ class L10nBrRepairBaseTest(TransactionCase):
             )
 
             # PIS
-            self.assertEquals(
+            self.assertEqual(
                 line.pis_tax_id.name, taxes['pis']['tax'].name,
                 "Error to mapping Tax {} for {}.".format(
                     taxes['pis']['tax'].name,
                     line.fiscal_operation_line_id.name)
             )
 
-            self.assertEquals(
+            self.assertEqual(
                 line.pis_cst_id.code, taxes['pis']['cst'].code,
                 "Error to mapping CST {} from {} for {}.".format(
                     taxes['pis']['cst'].code,
@@ -306,14 +306,14 @@ class L10nBrRepairBaseTest(TransactionCase):
             )
 
             # COFINS
-            self.assertEquals(
+            self.assertEqual(
                 line.cofins_tax_id.name, taxes['cofins']['tax'].name,
                 "Error to mapping Tax {} for {}.".format(
                     taxes['cofins']['tax'].name,
                     line.fiscal_operation_line_id.name)
             )
 
-            self.assertEquals(
+            self.assertEqual(
                 line.cofins_cst_id.code, taxes['cofins']['cst'].code,
                 "Error to mapping CST {} from {} for {}.".format(
                     taxes['cofins']['cst'].code,
@@ -324,18 +324,18 @@ class L10nBrRepairBaseTest(TransactionCase):
         self._invoice_repair_order(self.so_products)
 
         action_view_document = self.so_products.action_view_document()
-        self.assertEquals(
+        self.assertEqual(
             action_view_document['xml_id'],
             'l10n_br_fiscal.document_out_action')
-        self.assertEquals(action_view_document['type'], 'ir.actions.act_window')
-        self.assertEquals(action_view_document['view_type'], 'form')
+        self.assertEqual(action_view_document['type'], 'ir.actions.act_window')
+        self.assertEqual(action_view_document['view_type'], 'form')
 
         action_view_invoice = self.so_products.action_view_invoice()
-        self.assertEquals(
+        self.assertEqual(
             action_view_invoice['xml_id'],
             'account.action_invoice_tree1')
-        self.assertEquals(action_view_invoice['type'], 'ir.actions.act_window')
-        self.assertEquals(action_view_invoice['view_type'], 'form')
+        self.assertEqual(action_view_invoice['type'], 'ir.actions.act_window')
+        self.assertEqual(action_view_invoice['view_type'], 'form')
 
         self._change_user_company(self.main_company)
 
@@ -348,14 +348,14 @@ class L10nBrRepairBaseTest(TransactionCase):
             "Error to mapping Operation on Repair Order.",
         )
 
-        self.assertEquals(
+        self.assertEqual(
             self.so_services.fiscal_operation_id.name,
             self.fsc_op_sale.name,
             "Error to mapping correct Operation on Repair Order "
             "after change fiscal category.",
         )
 
-        self.assertEquals(
+        self.assertEqual(
             self.so_services.amount_discount_value,
             0,
             "Error to discount value",
@@ -387,14 +387,14 @@ class L10nBrRepairBaseTest(TransactionCase):
 
                 icms_cst = line.icms_cst_id
 
-                self.assertEquals(
+                self.assertEqual(
                     icms_tax.name, taxes['icms']['tax'].name,
                     "Error to mapping Tax {} for {}.".format(
                         taxes['icms']['tax'].name,
                         line.fiscal_operation_line_id.name)
                 )
 
-                self.assertEquals(
+                self.assertEqual(
                     icms_cst.code, taxes['icms']['cst'].code,
                     "Error to mapping CST {} from {} for {}.".format(
                         taxes['icms']['cst'].code,
@@ -409,7 +409,7 @@ class L10nBrRepairBaseTest(TransactionCase):
                     " for Venda de Contribuinte Dentro do Estado.")
 
             if line.tax_icms_or_issqn == TAX_DOMAIN_ISSQN:
-                self.assertEquals(
+                self.assertEqual(
                     line.issqn_tax_id.name, taxes['issqn']['tax'].name,
                     "Error to mapping Tax {} for {}.".format(
                         taxes['issqn']['tax'].name,
@@ -417,14 +417,14 @@ class L10nBrRepairBaseTest(TransactionCase):
                 )
 
             # PIS
-            self.assertEquals(
+            self.assertEqual(
                 line.pis_tax_id.name, taxes['pis']['tax'].name,
                 "Error to mapping Tax {} for {}.".format(
                     taxes['pis']['tax'].name,
                     line.fiscal_operation_line_id.name)
             )
 
-            self.assertEquals(
+            self.assertEqual(
                 line.pis_cst_id.code, taxes['pis']['cst'].code,
                 "Error to mapping CST {} from {} for {}.".format(
                     taxes['pis']['cst'].code,
@@ -433,14 +433,14 @@ class L10nBrRepairBaseTest(TransactionCase):
             )
 
             # COFINS
-            self.assertEquals(
+            self.assertEqual(
                 line.cofins_tax_id.name, taxes['cofins']['tax'].name,
                 "Error to mapping Tax {} for {}.".format(
                     taxes['cofins']['tax'].name,
                     line.fiscal_operation_line_id.name)
             )
 
-            self.assertEquals(
+            self.assertEqual(
                 line.cofins_cst_id.code, taxes['cofins']['cst'].code,
                 "Error to mapping CST {} from {} for {}.".format(
                     taxes['cofins']['cst'].code,
@@ -451,28 +451,28 @@ class L10nBrRepairBaseTest(TransactionCase):
         self._invoice_repair_order(self.so_services)
 
         action_view_document = self.so_services.action_view_document()
-        self.assertEquals(
+        self.assertEqual(
             action_view_document['xml_id'],
             'l10n_br_fiscal.document_out_action')
-        self.assertEquals(action_view_document['type'], 'ir.actions.act_window')
-        self.assertEquals(action_view_document['view_type'], 'form')
+        self.assertEqual(action_view_document['type'], 'ir.actions.act_window')
+        self.assertEqual(action_view_document['view_type'], 'form')
 
         action_view_invoice = self.so_services.action_view_invoice()
-        self.assertEquals(
+        self.assertEqual(
             action_view_invoice['xml_id'],
             'account.action_invoice_tree1')
-        self.assertEquals(action_view_invoice['type'], 'ir.actions.act_window')
-        self.assertEquals(action_view_invoice['view_type'], 'form')
+        self.assertEqual(action_view_invoice['type'], 'ir.actions.act_window')
+        self.assertEqual(action_view_invoice['view_type'], 'form')
 
         self._change_user_company(self.main_company)
 
     def test_action_views(self):
         act1 = self.so_services.action_view_document()
-        self.assertEquals(act1['type'], 'ir.actions.act_window_close')
+        self.assertEqual(act1['type'], 'ir.actions.act_window_close')
         self.assertTrue(act1)
 
         act2 = self.so_services.action_view_invoice()
-        self.assertEquals(act2['type'], 'ir.actions.act_window_close')
+        self.assertEqual(act2['type'], 'ir.actions.act_window_close')
         self.assertTrue(act2)
 
         act3 = self.so_services.fields_view_get()

--- a/l10n_br_sale/tests/test_l10n_br_sale.py
+++ b/l10n_br_sale/tests/test_l10n_br_sale.py
@@ -170,7 +170,7 @@ class L10nBrSaleBaseTest(SavepointCase):
         # Create and check invoice
         sale_order.action_invoice_create(final=True)
 
-        self.assertEquals(
+        self.assertEqual(
             sale_order.state, "sale", "Error to confirm Sale Order."
         )
 
@@ -202,7 +202,7 @@ class L10nBrSaleBaseTest(SavepointCase):
             "Error to mapping Operation on Sale Order.",
         )
 
-        self.assertEquals(
+        self.assertEqual(
             self.so_products.fiscal_operation_id.name,
             self.fsc_op_sale.name,
             "Error to mapping correct Operation on Sale Order "
@@ -229,7 +229,7 @@ class L10nBrSaleBaseTest(SavepointCase):
                 line.fiscal_operation_line_id.name][
                     line.company_id.tax_framework]
 
-            self.assertEquals(
+            self.assertEqual(
                 line.cfop_id.code, cfop.code,
                 "Error to mapping CFOP {} for {}.".format(cfop.code, cfop.name)
             )
@@ -246,14 +246,14 @@ class L10nBrSaleBaseTest(SavepointCase):
                         'l10n_br_fiscal.cst_ipi_53')
 
             # ICMS
-            self.assertEquals(
+            self.assertEqual(
                 icms_tax.name, taxes['icms']['tax'].name,
                 "Error to mapping Tax {} for {}.".format(
                     taxes['icms']['tax'].name,
                     line.fiscal_operation_line_id.name)
             )
 
-            self.assertEquals(
+            self.assertEqual(
                 line.icms_cst_id.code, taxes['icms']['cst'].code,
                 "Error to mapping CST {} from {} for {}.".format(
                     taxes['icms']['cst'].code,
@@ -268,14 +268,14 @@ class L10nBrSaleBaseTest(SavepointCase):
                 " for Venda de Contribuinte Dentro do Estado.")
 
             # IPI
-            self.assertEquals(
+            self.assertEqual(
                 line.ipi_tax_id.name, taxes['ipi']['tax'].name,
                 "Error to mapping Tax {} for {}.".format(
                     taxes['ipi']['tax'].name,
                     line.fiscal_operation_line_id.name)
             )
 
-            self.assertEquals(
+            self.assertEqual(
                 line.ipi_cst_id.code, taxes['ipi']['cst'].code,
                 "Error to mapping CST {} from {} for {}.".format(
                     taxes['ipi']['cst'].code,
@@ -284,14 +284,14 @@ class L10nBrSaleBaseTest(SavepointCase):
             )
 
             # PIS
-            self.assertEquals(
+            self.assertEqual(
                 line.pis_tax_id.name, taxes['pis']['tax'].name,
                 "Error to mapping Tax {} for {}.".format(
                     taxes['pis']['tax'].name,
                     line.fiscal_operation_line_id.name)
             )
 
-            self.assertEquals(
+            self.assertEqual(
                 line.pis_cst_id.code, taxes['pis']['cst'].code,
                 "Error to mapping CST {} from {} for {}.".format(
                     taxes['pis']['cst'].code,
@@ -300,14 +300,14 @@ class L10nBrSaleBaseTest(SavepointCase):
             )
 
             # COFINS
-            self.assertEquals(
+            self.assertEqual(
                 line.cofins_tax_id.name, taxes['cofins']['tax'].name,
                 "Error to mapping Tax {} for {}.".format(
                     taxes['cofins']['tax'].name,
                     line.fiscal_operation_line_id.name)
             )
 
-            self.assertEquals(
+            self.assertEqual(
                 line.cofins_cst_id.code, taxes['cofins']['cst'].code,
                 "Error to mapping CST {} from {} for {}.".format(
                     taxes['cofins']['cst'].code,
@@ -327,7 +327,7 @@ class L10nBrSaleBaseTest(SavepointCase):
             "Error to mapping Operation on Sale Order.",
         )
 
-        self.assertEquals(
+        self.assertEqual(
             self.so_services.fiscal_operation_id.name,
             self.fsc_op_sale.name,
             "Error to mapping correct Operation on Sale Order "
@@ -360,14 +360,14 @@ class L10nBrSaleBaseTest(SavepointCase):
 
                 icms_cst = line.icms_cst_id
 
-                self.assertEquals(
+                self.assertEqual(
                     icms_tax.name, taxes['icms']['tax'].name,
                     "Error to mapping Tax {} for {}.".format(
                         taxes['icms']['tax'].name,
                         line.fiscal_operation_line_id.name)
                 )
 
-                self.assertEquals(
+                self.assertEqual(
                     icms_cst.code, taxes['icms']['cst'].code,
                     "Error to mapping CST {} from {} for {}.".format(
                         taxes['icms']['cst'].code,
@@ -382,7 +382,7 @@ class L10nBrSaleBaseTest(SavepointCase):
                     " for Venda de Contribuinte Dentro do Estado.")
 
             if line.tax_icms_or_issqn == TAX_DOMAIN_ISSQN:
-                self.assertEquals(
+                self.assertEqual(
                     line.issqn_tax_id.name, taxes['issqn']['tax'].name,
                     "Error to mapping Tax {} for {}.".format(
                         taxes['issqn']['tax'].name,
@@ -390,14 +390,14 @@ class L10nBrSaleBaseTest(SavepointCase):
                 )
 
             # PIS
-            self.assertEquals(
+            self.assertEqual(
                 line.pis_tax_id.name, taxes['pis']['tax'].name,
                 "Error to mapping Tax {} for {}.".format(
                     taxes['pis']['tax'].name,
                     line.fiscal_operation_line_id.name)
             )
 
-            self.assertEquals(
+            self.assertEqual(
                 line.pis_cst_id.code, taxes['pis']['cst'].code,
                 "Error to mapping CST {} from {} for {}.".format(
                     taxes['pis']['cst'].code,
@@ -406,14 +406,14 @@ class L10nBrSaleBaseTest(SavepointCase):
             )
 
             # COFINS
-            self.assertEquals(
+            self.assertEqual(
                 line.cofins_tax_id.name, taxes['cofins']['tax'].name,
                 "Error to mapping Tax {} for {}.".format(
                     taxes['cofins']['tax'].name,
                     line.fiscal_operation_line_id.name)
             )
 
-            self.assertEquals(
+            self.assertEqual(
                 line.cofins_cst_id.code, taxes['cofins']['cst'].code,
                 "Error to mapping CST {} from {} for {}.".format(
                     taxes['cofins']['cst'].code,
@@ -434,4 +434,4 @@ class L10nBrSaleBaseTest(SavepointCase):
         # Create and check invoice
         self.so_product_service.action_invoice_create(final=True)
         # Devem existir duas Faturas/Documentos Fiscais
-        self.assertEquals(2, self.so_product_service.invoice_count)
+        self.assertEqual(2, self.so_product_service.invoice_count)

--- a/l10n_br_sale_stock/tests/test_sale_stock.py
+++ b/l10n_br_sale_stock/tests/test_sale_stock.py
@@ -122,13 +122,13 @@ class TestSaleStock(SavepointCase):
         # deve gerar apenas a linha de serviço
         sale_order_2.action_invoice_create(final=True)
         # Deve existir apenas a Fatura/Documento Fiscal de Serviço
-        self.assertEquals(1, sale_order_2.invoice_count)
+        self.assertEqual(1, sale_order_2.invoice_count)
         for invoice in sale_order_2.invoice_ids:
             for line in invoice.invoice_line_ids:
-                self.assertEquals(line.product_id.type, 'service')
+                self.assertEqual(line.product_id.type, 'service')
             # Confirmando a Fatura de Serviço
             invoice.action_invoice_open()
-            self.assertEquals(
+            self.assertEqual(
                 invoice.state, 'open', 'Invoice should be in state Open')
 
         picking = sale_order_2.picking_ids
@@ -173,11 +173,11 @@ class TestSaleStock(SavepointCase):
 
         # No Pedido de Venda devem existir duas Faturas/Documentos Fiscais
         # de Serviço e Produto
-        self.assertEquals(2, sale_order_2.invoice_count)
+        self.assertEqual(2, sale_order_2.invoice_count)
 
         # Confirmando a Fatura
         invoice.action_invoice_open()
-        self.assertEquals(
+        self.assertEqual(
             invoice.state, 'open', 'Invoice should be in state Open')
 
         # Validar Atualização da Quantidade Faturada
@@ -216,7 +216,7 @@ class TestSaleStock(SavepointCase):
         for move in picking_devolution.move_ids_without_package:
             move.quantity_done = move.product_uom_qty
         picking_devolution.button_validate()
-        self.assertEquals(
+        self.assertEqual(
             picking_devolution.state, 'done',
             'Change state fail.'
         )
@@ -234,7 +234,7 @@ class TestSaleStock(SavepointCase):
         invoice_devolution = self.invoice_model.search(domain)
         # Confirmando a Fatura
         invoice_devolution.action_invoice_open()
-        self.assertEquals(
+        self.assertEqual(
             invoice_devolution.state, 'open',
             'Invoice should be in state Open')
         # Validar Atualização da Quantidade Faturada
@@ -292,7 +292,7 @@ class TestSaleStock(SavepointCase):
         domain = [('picking_ids', 'in', (picking.id, picking2.id))]
         invoice = self.invoice_model.search(domain)
         # Fatura Agrupada
-        self.assertEquals(len(invoice), 1)
+        self.assertEqual(len(invoice), 1)
         self.assertEqual(picking.invoice_state, 'invoiced')
         self.assertEqual(picking2.invoice_state, 'invoiced')
         # Fatura deverá ser criada com o partner_invoice_id
@@ -308,7 +308,7 @@ class TestSaleStock(SavepointCase):
 
         # Not grouping products with different sale line,
         # 3 products from sale_order_1 and 1 product from sale_order_2
-        self.assertEquals(len(invoice.invoice_line_ids), 4)
+        self.assertEqual(len(invoice.invoice_line_ids), 4)
         for inv_line in invoice.invoice_line_ids:
             self.assertTrue(
                 inv_line.invoice_line_tax_ids,
@@ -385,7 +385,7 @@ class TestSaleStock(SavepointCase):
         invoices = self.invoice_model.search(domain)
         # Mesmo tendo o mesmo Partner Invoice se não tiver o
         # mesmo Partner Shipping não deve ser Agrupado
-        self.assertEquals(len(invoices), 2)
+        self.assertEqual(len(invoices), 2)
         self.assertEqual(picking.invoice_state, 'invoiced')
         self.assertEqual(picking3.invoice_state, 'invoiced')
         self.assertEqual(picking4.invoice_state, 'invoiced')

--- a/l10n_br_stock_account/tests/test_invoicing_picking.py
+++ b/l10n_br_stock_account/tests/test_invoicing_picking.py
@@ -46,7 +46,7 @@ class InvoicingPickingTest(SavepointCase):
         for move in self.stock_picking_sp.move_ids_without_package:
             move.quantity_done = move.product_uom_qty
         self.stock_picking_sp.button_validate()
-        self.assertEquals(
+        self.assertEqual(
             self.stock_picking_sp.state, 'done',
             'Change state fail.'
         )
@@ -88,10 +88,10 @@ class InvoicingPickingTest(SavepointCase):
         self.assertIn(invoice, self.stock_picking_sp.invoice_ids)
         self.assertIn(self.stock_picking_sp, invoice.picking_ids)
         nb_invoice_after = self.invoice_model.search_count([])
-        self.assertEquals(nb_invoice_before, nb_invoice_after - len(invoice))
+        self.assertEqual(nb_invoice_before, nb_invoice_after - len(invoice))
         assert invoice.invoice_line_ids, 'Error to create invoice line.'
         for line in invoice.picking_ids:
-            self.assertEquals(
+            self.assertEqual(
                 line.id, self.stock_picking_sp.id,
                 'Relation between invoice and picking are missing.')
         for line in invoice.invoice_line_ids:
@@ -149,7 +149,7 @@ class InvoicingPickingTest(SavepointCase):
         for move in picking_devolution.move_ids_without_package:
             move.quantity_done = move.product_uom_qty
         picking_devolution.button_validate()
-        self.assertEquals(
+        self.assertEqual(
             picking_devolution.state, 'done',
             'Change state fail.'
         )
@@ -176,7 +176,7 @@ class InvoicingPickingTest(SavepointCase):
             res_overprocessed_transfer.get('res_id'))
         stock_overprocessed_transfer.action_confirm()
 
-        self.assertEquals(
+        self.assertEqual(
             self.stock_picking_sp.state, 'done',
             'Change state fail.'
         )
@@ -226,7 +226,7 @@ class InvoicingPickingTest(SavepointCase):
         wizard.action_generate()
         domain = [('picking_ids', '=', picking.id)]
         invoice = self.invoice_model.search(domain)
-        self.assertEquals(len(invoice), 1)
+        self.assertEqual(len(invoice), 1)
         self.assertEqual(picking.invoice_state, 'invoiced')
         self.assertEqual(picking2.invoice_state, 'invoiced')
         self.assertEqual(invoice.partner_id, self.partner)
@@ -246,10 +246,10 @@ class InvoicingPickingTest(SavepointCase):
         # Now test behaviour if the invoice is delete
         invoice.unlink()
         for picking in pickings:
-            self.assertEquals(picking.invoice_state, '2binvoiced')
+            self.assertEqual(picking.invoice_state, '2binvoiced')
         nb_invoice_after = self.invoice_model.search_count([])
         # Should be equals because we delete the invoice
-        self.assertEquals(nb_invoice_before, nb_invoice_after)
+        self.assertEqual(nb_invoice_before, nb_invoice_after)
 
     def test_picking_invoicing_by_product3(self):
         """
@@ -296,7 +296,7 @@ class InvoicingPickingTest(SavepointCase):
         wizard.action_generate()
         domain = [('picking_ids', 'in', (picking.id, picking2.id))]
         invoicies = self.invoice_model.search(domain)
-        self.assertEquals(len(invoicies), 2)
+        self.assertEqual(len(invoicies), 2)
         self.assertEqual(picking.invoice_state, 'invoiced')
         self.assertEqual(picking2.invoice_state, 'invoiced')
         invoice_pick_1 = invoicies.filtered(
@@ -319,7 +319,7 @@ class InvoicingPickingTest(SavepointCase):
         self.assertIn(picking2, invoice_pick_2.picking_ids)
 
         # Not grouping products with different Operation Fiscal Line
-        self.assertEquals(len(invoice_pick_1.invoice_line_ids), 3)
+        self.assertEqual(len(invoice_pick_1.invoice_line_ids), 3)
         for inv_line in invoice_pick_1.invoice_line_ids:
             self.assertTrue(
                 inv_line.invoice_line_tax_ids,
@@ -328,10 +328,10 @@ class InvoicingPickingTest(SavepointCase):
         invoice_pick_1.unlink()
         invoice_pick_2.unlink()
         for picking in pickings:
-            self.assertEquals(picking.invoice_state, '2binvoiced')
+            self.assertEqual(picking.invoice_state, '2binvoiced')
         nb_invoice_after = self.invoice_model.search_count([])
         # Should be equals because we delete the invoice
-        self.assertEquals(nb_invoice_before, nb_invoice_after)
+        self.assertEqual(nb_invoice_before, nb_invoice_after)
 
     def test_picking_split(self):
         """Test Picking Split created with Fiscal Values."""

--- a/l10n_br_zip/tests/test_l10n_br_zip_res_company.py
+++ b/l10n_br_zip/tests/test_l10n_br_zip_res_company.py
@@ -79,17 +79,17 @@ class L10nBRZipTest(TransactionCase):
                 return_value=mocked_response,
         ):
             self.company.zip_search()
-        self.assertEquals(
+        self.assertEqual(
             self.company.district,
             "Bela Vista",
             "Error in method zip_search to mapping field district.",
         )
-        self.assertEquals(
+        self.assertEqual(
             self.company.street,
             "Avenida Avenida Paulista 1842",
             "Error in method zip_search to mapping field street.",
         )
-        self.assertEquals(
+        self.assertEqual(
             self.company.city_id.name,
             "São Paulo",
             "Error in method zip_search to mapping field city.",
@@ -99,7 +99,7 @@ class L10nBRZipTest(TransactionCase):
         """Test search by address."""
 
         self.company_1.zip_search()
-        self.assertEquals(
+        self.assertEqual(
             self.company_1.zip,
             "01310-923",
             "Error in method zip_search to mapping zip code from fields"
@@ -123,25 +123,25 @@ class L10nBRZipTest(TransactionCase):
         result = self.company_1.zip_search()
         obj_zip_search = self.env["l10n_br.zip.search"].browse(result.get("res_id"))
 
-        self.assertEquals(
+        self.assertEqual(
             result["type"],
             "ir.actions.act_window",
             "It should return a action when there are more than one result",
         )
-        self.assertEquals(
+        self.assertEqual(
             result["res_model"],
             "l10n_br.zip.search",
             "It should return the model zip.search",
         )
-        self.assertEquals(
+        self.assertEqual(
             obj_zip_search.street, "paulista", "It should return the correct street"
         )
-        self.assertEquals(
+        self.assertEqual(
             obj_zip_search.state_id.id,
             self.env.ref("base.state_br_sp").id,
             "It should return the correct state",
         )
-        self.assertEquals(
+        self.assertEqual(
             len(obj_zip_search.zip_ids), 2, "It should return two Zip Codes."
         )
 
@@ -150,7 +150,7 @@ class L10nBRZipTest(TransactionCase):
         obj_zip_search.street = "900"
         result = obj_zip_search.zip_search()
 
-        self.assertEquals(
+        self.assertEqual(
             len(obj_zip_search.zip_ids), 1, "It should return one Zip Codes."
         )
 
@@ -164,12 +164,12 @@ class L10nBRZipTest(TransactionCase):
 
         obj_zip_search.zip_ids.with_context(result.get("context")).zip_select()
 
-        self.assertEquals(
+        self.assertEqual(
             self.company_1.zip,
             "01310-940",
             "It should return the correct zip, failed method zip_select.",
         )
-        self.assertEquals(
+        self.assertEqual(
             self.company_1.street,
             "Avenida Avenida Paulista 900",
             "It should return the correct street, failed method zip_select.",
@@ -204,18 +204,18 @@ class L10nBRZipTest(TransactionCase):
                 return_value=mocked_response,
         ):
             self.company.zip_search()
-        self.assertEquals(
+        self.assertEqual(
             self.company.district,
             "Paraíso",
             "Error in method zip_search with PyCEP-Correios"
             "to mapping field district.",
         )
-        self.assertEquals(
+        self.assertEqual(
             self.company.street,
             "Rua Coronel Oscar Porto",
             "Error in method zip_search with PyCEP-Correios" "to mapping field street.",
         )
-        self.assertEquals(
+        self.assertEqual(
             self.company.city_id.name,
             "São Paulo",
             "Error in method zip_search with PyCEP-Correios" "to mapping field city.",

--- a/l10n_br_zip/tests/test_l10n_br_zip_res_partner.py
+++ b/l10n_br_zip/tests/test_l10n_br_zip_res_partner.py
@@ -59,17 +59,17 @@ class L10nBRZipTest(TransactionCase):
 
         self.res_partner.zip = "01310923"
         self.res_partner.zip_search()
-        self.assertEquals(
+        self.assertEqual(
             self.res_partner.district,
             "Bela Vista",
             "Error in method zip_search to mapping field district.",
         )
-        self.assertEquals(
+        self.assertEqual(
             self.res_partner.street,
             "Avenida Avenida Paulista 1842",
             "Error in method zip_search to mapping field street.",
         )
-        self.assertEquals(
+        self.assertEqual(
             self.res_partner.city_id.name,
             "São Paulo",
             "Error in method zip_search to mapping field city.",
@@ -89,7 +89,7 @@ class L10nBRZipTest(TransactionCase):
 
         self.res_partner_1.street = "paulista"
         self.res_partner_1.zip_search()
-        self.assertEquals(
+        self.assertEqual(
             self.res_partner_1.zip,
             "01310-923",
             "Error in method zip_search to mapping zip code from fields"
@@ -113,25 +113,25 @@ class L10nBRZipTest(TransactionCase):
         result = self.res_partner_1.zip_search()
         obj_zip_search = self.env["l10n_br.zip.search"].browse(result.get("res_id"))
 
-        self.assertEquals(
+        self.assertEqual(
             result["type"],
             "ir.actions.act_window",
             "It should return a action when there are more than one result",
         )
-        self.assertEquals(
+        self.assertEqual(
             result["res_model"],
             "l10n_br.zip.search",
             "It should return the model zip.search",
         )
-        self.assertEquals(
+        self.assertEqual(
             obj_zip_search.street, "paulista", "It should return the correct street"
         )
-        self.assertEquals(
+        self.assertEqual(
             obj_zip_search.state_id.id,
             self.env.ref("base.state_br_sp").id,
             "It should return the correct state",
         )
-        self.assertEquals(
+        self.assertEqual(
             len(obj_zip_search.zip_ids), 2, "It should return two Zip Codes."
         )
 
@@ -140,7 +140,7 @@ class L10nBRZipTest(TransactionCase):
         obj_zip_search.street = "900"
         result = obj_zip_search.zip_search()
 
-        self.assertEquals(
+        self.assertEqual(
             len(obj_zip_search.zip_ids), 1, "It should return one Zip Codes."
         )
 
@@ -154,12 +154,12 @@ class L10nBRZipTest(TransactionCase):
 
         obj_zip_search.zip_ids.with_context(result.get("context")).zip_select()
 
-        self.assertEquals(
+        self.assertEqual(
             self.res_partner_1.zip,
             "01310-940",
             "It should return the correct zip, failed method zip_select.",
         )
-        self.assertEquals(
+        self.assertEqual(
             self.res_partner_1.street,
             "Avenida Avenida Paulista 900",
             "It should return the correct street, failed method zip_select.",
@@ -194,18 +194,18 @@ class L10nBRZipTest(TransactionCase):
                 return_value=mocked_response,
         ):
             self.res_partner.zip_search()
-        self.assertEquals(
+        self.assertEqual(
             self.res_partner.district,
             "Bela Vista",
             "Error in method zip_search with PyCEP-Correios"
             "to mapping field district.",
         )
-        self.assertEquals(
+        self.assertEqual(
             self.res_partner.street,
             "Avenida Paulista, 2100",
             "Error in method zip_search with PyCEP-Correios" "to mapping field street.",
         )
-        self.assertEquals(
+        self.assertEqual(
             self.res_partner.city_id.name,
             "São Paulo",
             "Error in method zip_search with PyCEP-Correios" "to mapping field city.",


### PR DESCRIPTION
As per https://docs.python.org/3.3/library/unittest.html#deprecated-aliases, **assertEquals** is deprecated since Python 3.3 (even in Python 2.7 in fact) and replaced by **assertEqual**. So this a good anticipation of something that will need to be done in v14 later to maintain the codebase of the two branches as close as possible (it is possible! We do it with Shopinvader and Acsone does it with OCA/mis-builder) to make front and back ports much easier.

I just separated the commits per addon to avoid issues in the migration process later.

Don't worry these are the last miles of such code changes.