### PR TITLE
[12.0] [l10n_br_nfe_spec] spec currency_field is brl_currency_id

### DIFF
--- a/l10n_br_nfe_spec/models/spec_models.py
+++ b/l10n_br_nfe_spec/models/spec_models.py
@@ -24,4 +24,4 @@ class NfeSpecMixin(models.AbstractModel):
 
     def _compute_brl_currency_id(self):
         for item in self:
-            item.currency_id = self.env.ref('base.BRL').id
+            item.brl_currency_id = self.env.ref('base.BRL').id


### PR DESCRIPTION
Da serie, ja emitiu milhares de NFe em prod faz 10 meses mas a gente nao sabe como nao deu problema...
o fields.Monetary deve ter um fall back legal com os 2 digits que a gente gosta aqui...