### PR TITLE
[12.0][REF] l10n br fiscal Fiscal Document Mixin Amounts

### DIFF
--- a/l10n_br_fiscal/models/document_fiscal_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin.py
@@ -304,18 +304,15 @@ class FiscalDocumentMixin(models.AbstractModel):
 
     amount_insurance_value = fields.Monetary(
         string='Insurance Value',
-        default=0.00,
         compute='_compute_amount',
     )
 
     amount_other_value = fields.Monetary(
         string='Other Costs',
-        default=0.00,
         compute='_compute_amount',
     )
 
     amount_freight_value = fields.Monetary(
         string='Freight Value',
-        default=0.00,
         compute='_compute_amount',
     )

--- a/l10n_br_fiscal/models/document_fiscal_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin.py
@@ -106,213 +106,257 @@ class FiscalDocumentMixin(models.AbstractModel):
     amount_untaxed = fields.Monetary(
         string='Amount Untaxed',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_icms_base = fields.Monetary(
         string='ICMS Base',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_icms_value = fields.Monetary(
         string='ICMS Value',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_icmsst_base = fields.Monetary(
         string='ICMS ST Base',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_icmsst_value = fields.Monetary(
         string='ICMS ST Value',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_icmssn_value = fields.Monetary(
         string='ICMSSN Value',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_icmsfcp_base = fields.Monetary(
         string='ICMS FCP Base',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_icmsfcp_value = fields.Monetary(
         string='ICMS FCP Value',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_ipi_base = fields.Monetary(
         string='IPI Base',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_ipi_value = fields.Monetary(
         string='IPI Value',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_pis_base = fields.Monetary(
         string='PIS Base',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_pis_value = fields.Monetary(
         string='PIS Value',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_pis_ret_base = fields.Monetary(
         string='PIS Ret Base',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_pis_ret_value = fields.Monetary(
         string='PIS Ret Value',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_cofins_base = fields.Monetary(
         string='COFINS Base',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_cofins_value = fields.Monetary(
         string='COFINS Value',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_cofins_ret_base = fields.Monetary(
         string='COFINS Ret Base',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_cofins_ret_value = fields.Monetary(
         string='COFINS Ret Value',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_issqn_base = fields.Monetary(
         string='ISSQN Base',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_issqn_value = fields.Monetary(
         string='ISSQN Value',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_issqn_ret_base = fields.Monetary(
         string='ISSQN Ret Base',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_issqn_ret_value = fields.Monetary(
         string='ISSQN Ret Value',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_csll_base = fields.Monetary(
         string='CSLL Base',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_csll_value = fields.Monetary(
         string='CSLL Value',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_csll_ret_base = fields.Monetary(
         string='CSLL Ret Base',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_csll_ret_value = fields.Monetary(
         string='CSLL Ret Value',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_irpj_base = fields.Monetary(
         string='IRPJ Base',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_irpj_value = fields.Monetary(
         string='IRPJ Value',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_irpj_ret_base = fields.Monetary(
         string='IRPJ Ret Base',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_irpj_ret_value = fields.Monetary(
         string='IRPJ Ret Value',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_inss_base = fields.Monetary(
         string='INSS Base',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_inss_value = fields.Monetary(
         string='INSS Value',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_inss_wh_base = fields.Monetary(
         string='INSS Ret Base',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_inss_wh_value = fields.Monetary(
         string='INSS Ret Value',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_estimate_tax = fields.Monetary(
         string='Amount Estimate Tax',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_tax = fields.Monetary(
         string='Amount Tax',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_total = fields.Monetary(
         string='Amount Total',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_tax_withholding = fields.Monetary(
         string="Amount Tax Withholding",
-        compute='_compute_amount')
+        compute='_compute_amount',
+        store=True,
+    )
 
     amount_financial = fields.Monetary(
         string='Amount Financial',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_discount_value = fields.Monetary(
         string='Amount Discount',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_insurance_value = fields.Monetary(
         string='Insurance Value',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_other_value = fields.Monetary(
         string='Other Costs',
         compute='_compute_amount',
+        store=True,
     )
 
     amount_freight_value = fields.Monetary(
         string='Freight Value',
         compute='_compute_amount',
+        store=True,
     )


### PR DESCRIPTION
Pessoal,

Hoje os campos amounts dos mixin do documento fiscal não são armazenados store=False e eles são sempre calculados, eu não acho interessante esses campos serem sempre calculados por uma questão performática, pois uma vez o documento é salvo ele não precisa ser calculado quando é feito uma leitura, apenas quando for editado novamente.

Esses campos são injetados em documentos como sale.order, purchase.order, stock.picking e etc... para cada objeto esse método esta sendo adaptado para ser compatível com os computes nativos destes objetos.

Eu vou fazer mais alguns testes para verificar se o store=True não causa nenhum problema com os depends atuais e a performace. Quem puder testar também e dar alguns feedback agradeço! 