### PR TITLE
[12.0] Opção de chamar ou não o motor de impostos

### DIFF
--- a/l10n_br_fiscal/constants/fiscal.py
+++ b/l10n_br_fiscal/constants/fiscal.py
@@ -489,12 +489,12 @@ EVENT_ENVIRONMENT = [
     (EVENT_ENV_PROD, "Production"),
     (EVENT_ENV_HML, "Homologation"),
 ]
-TAX_CALC_AUTO = 'tax_calc_auto'
-TAX_CALC_ONLY = 'tax_calc_only'
-TAX_CALC_MANUAL = 'tax_calc_manual'
+TAX_CALC_AUTO = "tax_calc_auto"
+TAX_CALC_ONLY = "tax_calc_only"
+TAX_CALC_MANUAL = "tax_calc_manual"
 
 TAX_CALC = [
-    (TAX_CALC_AUTO, 'Automático'),
-    (TAX_CALC_ONLY, 'Semi-Automático'),
-    (TAX_CALC_MANUAL, 'Manual'),
+    (TAX_CALC_AUTO, "Automático"),
+    (TAX_CALC_ONLY, "Semi-Automático"),
+    (TAX_CALC_MANUAL, "Manual"),
 ]

--- a/l10n_br_fiscal/constants/fiscal.py
+++ b/l10n_br_fiscal/constants/fiscal.py
@@ -489,3 +489,12 @@ EVENT_ENVIRONMENT = [
     (EVENT_ENV_PROD, "Production"),
     (EVENT_ENV_HML, "Homologation"),
 ]
+TAX_CALC_AUTO = 'tax_calc_auto'
+TAX_CALC_ONLY = 'tax_calc_only'
+TAX_CALC_MANUAL = 'tax_calc_manual'
+
+TAX_CALC = [
+    (TAX_CALC_AUTO, 'Automático'),
+    (TAX_CALC_ONLY, 'Semi-Automático'),
+    (TAX_CALC_MANUAL, 'Manual'),
+]

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -442,12 +442,13 @@ class Document(models.Model):
         if self.document_serie_id and self.issuer == DOCUMENT_ISSUER_COMPANY:
             self.document_serie = self.document_serie_id.code
 
-    def _prepare_referenced_subsequent(self):
+    def _prepare_referenced_subsequent(self, new_document_id):
         self.ensure_one()
         vals = {
-            "fiscal_document_id": self.id,
+            "fiscal_document_id": new_document_id.id,
+            "document_related_id": self.id,
             "partner_id": self.partner_id.id,
-            "document_type_id": self.document_type,
+            "document_type_id": self.document_type_id.id,
             "serie": self.document_serie,
             "document_number": self.document_number,
             "document_date": self.document_date,

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin.py
@@ -167,6 +167,8 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         string="CFOP Destination",
     )
 
+    rel_tax_calc = fields.Selection(related="fiscal_operation_id.tax_calc")
+
     fiscal_price = fields.Float(
         string="Fiscal Price", digits=dp.get_precision("Product Price")
     )

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -206,9 +206,9 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         return taxes
 
     def _remove_all_fiscal_tax_ids(self):
-        if (self.fiscal_operation_line_id.tax_calc in (
-                TAX_CALC_MANUAL, TAX_CALC_ONLY) or
-                self.env.context.get('TAX_CALC_MANUAL')):
+        tax_calc = self.env.context.get('TAX_CALC_OVERRIDE',
+                                        self.fiscal_operation_line_id.tax_calc)
+        if tax_calc in (TAX_CALC_MANUAL, TAX_CALC_ONLY):
             return
         for line in self:
             line.fiscal_tax_ids = False
@@ -306,8 +306,9 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
 
     @api.onchange("fiscal_operation_line_id")
     def _onchange_fiscal_operation_line_id(self):
-        if (self.fiscal_operation_line_id.tax_calc == TAX_CALC_MANUAL or
-                self.env.context.get('TAX_CALC_MANUAL')):
+        tax_calc = self.env.context.get('TAX_CALC_OVERRIDE',
+                                        self.fiscal_operation_line_id.tax_calc)
+        if tax_calc == TAX_CALC_MANUAL:
             return
 
         # Reset Taxes

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -6,13 +6,9 @@ from lxml import etree
 from odoo import api, models
 from odoo.osv.orm import setup_modifiers
 
+from ..constants.fiscal import TAX_CALC_MANUAL, TAX_CALC_ONLY
 from ..constants.icms import ICMS_BASE_TYPE_DEFAULT, ICMS_ST_BASE_TYPE_DEFAULT
 from .tax import TAX_DICT_VALUES
-
-from ..constants.fiscal import (
-    TAX_CALC_ONLY,
-    TAX_CALC_MANUAL,
-)
 
 FISCAL_TAX_ID_FIELDS = [
     "cofins_tax_id",
@@ -206,8 +202,9 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         return taxes
 
     def _remove_all_fiscal_tax_ids(self):
-        tax_calc = self.env.context.get('TAX_CALC_OVERRIDE',
-                                        self.fiscal_operation_line_id.tax_calc)
+        tax_calc = self.env.context.get(
+            "TAX_CALC_OVERRIDE", self.fiscal_operation_line_id.tax_calc
+        )
         if tax_calc in (TAX_CALC_MANUAL, TAX_CALC_ONLY):
             return
         for line in self:
@@ -306,8 +303,9 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
 
     @api.onchange("fiscal_operation_line_id")
     def _onchange_fiscal_operation_line_id(self):
-        tax_calc = self.env.context.get('TAX_CALC_OVERRIDE',
-                                        self.fiscal_operation_line_id.tax_calc)
+        tax_calc = self.env.context.get(
+            "TAX_CALC_OVERRIDE", self.fiscal_operation_line_id.tax_calc
+        )
         if tax_calc == TAX_CALC_MANUAL:
             return
 

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -306,8 +306,6 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         tax_calc = self.env.context.get(
             "TAX_CALC_OVERRIDE", self.fiscal_operation_line_id.tax_calc
         )
-        if tax_calc == TAX_CALC_MANUAL:
-            return
 
         # Reset Taxes
         self._remove_all_fiscal_tax_ids()
@@ -325,6 +323,9 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
 
             self.ipi_guideline_id = mapping_result["ipi_guideline"]
             self.cfop_id = mapping_result["cfop"]
+
+            if tax_calc == TAX_CALC_MANUAL:
+                return
 
             if mapping_result.get("taxes"):
                 taxes = self.env["l10n_br_fiscal.tax"]

--- a/l10n_br_fiscal/models/document_fiscal_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin.py
@@ -63,7 +63,7 @@ class FiscalDocumentMixin(models.AbstractModel):
     )
 
     fiscal_operation_tax_calc = fields.Selection(
-        related='fiscal_operation_id.tax_calc',
+        related="fiscal_operation_id.tax_calc",
         readonly=True,
     )
 

--- a/l10n_br_fiscal/models/document_fiscal_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin.py
@@ -62,6 +62,11 @@ class FiscalDocumentMixin(models.AbstractModel):
         readonly=True,
     )
 
+    fiscal_operation_tax_calc = fields.Selection(
+        related='fiscal_operation_id.tax_calc',
+        readonly=True,
+    )
+
     ind_pres = fields.Selection(
         selection=NFE_IND_PRES,
         string="Buyer Presence",

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -88,6 +88,8 @@ class DocumentLine(models.Model):
         compute="_compute_amounts",
     )
 
+    rel_tax_calc = fields.Selection(related="fiscal_operation_id.tax_calc")
+
     def unlink(self):
         if self.env.ref("l10n_br_fiscal.fiscal_document_line_dummy") in self:
             raise UserError(_("You cannot unlink Fiscal Document Line Dummy !"))

--- a/l10n_br_fiscal/models/operation.py
+++ b/l10n_br_fiscal/models/operation.py
@@ -137,7 +137,7 @@ class Operation(models.Model):
 
     tax_calc = fields.Selection(
         selection=TAX_CALC,
-        string='Calculo tributação',
+        string="Calculo tributação",
         help="""Determina se o calculo da tributação deve ser:\n
               - Automático: O sistema determina nas aliquotas, cfop e entre outros;\n
               - Semi-Automático: O usuário informa a cfop, aliquotas e o

--- a/l10n_br_fiscal/models/operation.py
+++ b/l10n_br_fiscal/models/operation.py
@@ -13,6 +13,8 @@ from ..constants.fiscal import (
     OPERATION_FISCAL_TYPE_DEFAULT,
     OPERATION_STATE,
     OPERATION_STATE_DEFAULT,
+    TAX_CALC,
+    TAX_CALC_AUTO,
 )
 
 
@@ -131,6 +133,20 @@ class Operation(models.Model):
         comodel_name="l10n_br_fiscal.subsequent.operation",
         inverse_name="fiscal_operation_id",
         string="Subsequent Operation",
+    )
+
+    tax_calc = fields.Selection(
+        selection=TAX_CALC,
+        string='Calculo tributação',
+        help="""Determina se o calculo da tributação deve ser:\n
+              - Automático: O sistema determina nas aliquotas, cfop e entre outros;\n
+              - Semi-Automático: O usuário informa a cfop, aliquotas e o
+             sistema calcula os impostos\n
+              - Manual: O usuário informa as aliquotas e realiza os cálculos
+               manualmente.
+             """,
+        default=TAX_CALC_AUTO,
+        required=True,
     )
 
     _sql_constraints = [

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -202,6 +202,9 @@ class OperationLine(models.Model):
         nbs=None,
         cest=None,
     ):
+        tax_calc = self.env.context.get(
+            "TAX_CALC_OVERRIDE", self.tax_calc
+        )
 
         mapping_result = {
             "taxes": {},
@@ -216,7 +219,7 @@ class OperationLine(models.Model):
         cfop = self._get_cfop(company, partner)
         mapping_result["cfop"] = cfop
 
-        if self.tax_calc == TAX_CALC_ONLY:
+        if tax_calc == TAX_CALC_ONLY:
             return mapping_result
 
         # 1 Get Tax Defs from Company

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -80,7 +80,7 @@ class OperationLine(models.Model):
     )
 
     tax_calc = fields.Selection(
-        related='fiscal_operation_id.tax_calc',
+        related="fiscal_operation_id.tax_calc",
         readonly=True,
     )
 
@@ -202,9 +202,7 @@ class OperationLine(models.Model):
         nbs=None,
         cest=None,
     ):
-        tax_calc = self.env.context.get(
-            "TAX_CALC_OVERRIDE", self.tax_calc
-        )
+        tax_calc = self.env.context.get("TAX_CALC_OVERRIDE", self.tax_calc)
 
         mapping_result = {
             "taxes": {},

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -13,6 +13,7 @@ from ..constants.fiscal import (
     OPERATION_STATE,
     OPERATION_STATE_DEFAULT,
     PRODUCT_FISCAL_TYPE,
+    TAX_CALC_ONLY,
     TAX_DOMAIN_ICMS,
     TAX_DOMAIN_ISSQN,
     TAX_FRAMEWORK,
@@ -75,6 +76,11 @@ class OperationLine(models.Model):
         related="fiscal_operation_id.fiscal_type",
         string="Fiscal Type",
         store=True,
+        readonly=True,
+    )
+
+    tax_calc = fields.Selection(
+        related='fiscal_operation_id.tax_calc',
         readonly=True,
     )
 
@@ -209,6 +215,9 @@ class OperationLine(models.Model):
         # Define CFOP
         cfop = self._get_cfop(company, partner)
         mapping_result["cfop"] = cfop
+
+        if self.tax_calc == TAX_CALC_ONLY:
+            return mapping_result
 
         # 1 Get Tax Defs from Company
         for tax_definition in company.tax_definition_ids.map_tax_definition(

--- a/l10n_br_fiscal/models/subsequent_document.py
+++ b/l10n_br_fiscal/models/subsequent_document.py
@@ -81,7 +81,7 @@ class SubsequentDocument(models.Model):
                 "referenciado_ids",
                 self.source_document_id._prepare_referenced_subsequent(
                     new_document_id=self.subsequent_document_id,
-                )
+                ),
             )
         return []
 

--- a/l10n_br_fiscal/models/subsequent_document.py
+++ b/l10n_br_fiscal/models/subsequent_document.py
@@ -79,7 +79,9 @@ class SubsequentDocument(models.Model):
         if self.subsequent_operation_id.reference_document:
             return self.env.context.get(
                 "referenciado_ids",
-                self.source_document_id._prepare_referenced_subsequent(),
+                self.source_document_id._prepare_referenced_subsequent(
+                    new_document_id=self.subsequent_document_id,
+                )
             )
         return []
 

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -12,3 +12,4 @@ from . import test_fiscal_closing
 from . import test_subsequent_operation
 from . import test_uom_uom
 from . import test_fiscal_document_nfse
+from . import test_tax_calc

--- a/l10n_br_fiscal/tests/test_tax_calc.py
+++ b/l10n_br_fiscal/tests/test_tax_calc.py
@@ -1,0 +1,278 @@
+# @ 2021 KMEE - www.kmee.com.br
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestTaxCalc(TransactionCase):
+    def setUp(self):
+        super(TestTaxCalc, self).setUp()
+
+        self.fiscal_document_demo_1 = self.env.ref("l10n_br_fiscal.demo_nfe_same_state")
+        self.fiscal_sale_operation = self.env.ref("l10n_br_fiscal.fo_venda")
+
+    def test_tax_engine_automatic(self):
+        """
+        In the test cases that have been added, it's only checked that the tax values
+            were loaded correctly based on the 'tax_calc' selected for that operation
+            and the module's demo data.
+
+        Standard behavior of the system, where as soon as a product is selected,
+            all taxes referring to it are already loaded - usually linked to the
+            NCM.
+        """
+        product = self.fiscal_document_demo_1.line_ids[0]
+        product._onchange_fiscal_operation_id()
+
+        self.assertEqual(
+            product.icms_percent,
+            12.0,
+            "The ICMS percent does not match the standard in product from Automatic "
+            "Tax Engine.",
+        )
+        self.assertEqual(
+            product.icms_value,
+            12.0,
+            "The ICMS value does not match the standard in product from Automatic Tax "
+            "Engine.",
+        )
+
+        self.assertEqual(
+            product.ipi_percent,
+            0.0,
+            "The IPI percent does not match the standard in product from Automatic Tax "
+            "Engine.",
+        )
+        self.assertEqual(
+            product.ipi_value,
+            0.0,
+            "The IPI value does not match the standard in product from Automatic Tax "
+            "Engine.",
+        )
+
+        self.assertEqual(
+            product.pis_percent,
+            0.65,
+            "The PIS percent does not match the standard in product from Automatic Tax "
+            "Engine.",
+        )
+        self.assertEqual(
+            product.pis_value,
+            0.65,
+            "The PIS value does not match the standard in product from Automatic Tax "
+            "Engine.",
+        )
+
+        self.assertEqual(
+            product.cofins_percent,
+            3.0,
+            "The Cofins percent does not match the standard in product from Automatic "
+            "Tax Engine.",
+        )
+        self.assertEqual(
+            product.cofins_value,
+            3.0,
+            "The Cofins value does not match the standard in product from Automatic "
+            "Tax Engine.",
+        )
+
+    def test_tax_engine_semi_automatic(self):
+        """
+        Unlike the default behavior of the system, when the 'tax_calc' is set to
+            semi-automatic, the user must select the rates that will be used on
+            that product and only then the system will calculate them.
+        """
+
+        self.fiscal_sale_operation["tax_calc"] = "tax_calc_only"
+
+        fiscal_document = self.env["l10n_br_fiscal.document"].create(
+            dict(
+                fiscal_operation_id=self.fiscal_sale_operation.id,
+                document_type_id=self.env.ref("l10n_br_fiscal.document_55").id,
+                document_serie_id=self.env.ref(
+                    "l10n_br_fiscal.empresa_lc_document_55_serie_1"
+                ).id,
+                company_id=self.env.ref("l10n_br_base.empresa_lucro_presumido").id,
+                document_serie=1,
+                partner_id=self.env.ref("l10n_br_base.res_partner_cliente1_sp").id,
+                user_id=self.env.ref("base.user_demo").id,
+                fiscal_operation_type="in",
+                line_ids=[
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "Teste - Cálculo Semi-Automático",
+                            "product_id": self.env.ref("product.product_product_6").id,
+                            "uom_id": self.env.ref("uom.product_uom_unit").id,
+                            "price_unit": 100,
+                            "quantity": 1,
+                            "fiscal_operation_type": "in",
+                            "fiscal_operation_id": self.fiscal_sale_operation.id,
+                            "fiscal_operation_line_id": self.env.ref(
+                                "l10n_br_fiscal.fo_venda_venda"
+                            ).id,
+                            "icms_tax_id": self.env.ref(
+                                "l10n_br_fiscal.tax_icms_12"
+                            ).id,
+                            "ipi_tax_id": self.env.ref("l10n_br_fiscal.tax_ipi_nt").id,
+                            "cofins_tax_id": self.env.ref(
+                                "l10n_br_fiscal.tax_cofins_3"
+                            ).id,
+                            "pis_tax_id": self.env.ref(
+                                "l10n_br_fiscal.tax_pis_0_65"
+                            ).id,
+                        },
+                    )
+                ],
+            )
+        )
+
+        product = fiscal_document.line_ids[0]
+        product._onchange_fiscal_taxes()
+        product._onchange_fiscal_operation_id()
+
+        self.assertEqual(
+            product.icms_percent,
+            12.0,
+            "The ICMS percent does not match the standard in product from "
+            "Semi-Automatic Tax Engine.",
+        )
+        self.assertEqual(
+            product.icms_value,
+            12.0,
+            "The ICMS value does not match the standard in product from Semi-Automatic "
+            "Tax Engine.",
+        )
+
+        self.assertEqual(
+            product.ipi_percent,
+            0.0,
+            "The IPI percent does not match the standard in product from "
+            "Semi-Automatic Tax Engine.",
+        )
+        self.assertEqual(
+            product.ipi_value,
+            0.0,
+            "The IPI value does not match the standard in product from Semi-Automatic "
+            "Tax Engine.",
+        )
+
+        self.assertEqual(
+            product.pis_percent,
+            0.65,
+            "The PIS percent does not match the standard in product from "
+            "Semi-Automatic Tax Engine.",
+        )
+        self.assertEqual(
+            product.pis_value,
+            0.65,
+            "The PIS value does not match the standard in product from Semi-Automatic "
+            "Tax Engine.",
+        )
+
+        self.assertEqual(
+            product.cofins_percent,
+            3.0,
+            "The Cofins percent does not match the standard in product from "
+            "Semi-Automatic Tax Engine.",
+        )
+        self.assertEqual(
+            product.cofins_value,
+            3.0,
+            "The Cofins value does not match the standard in product from "
+            "Semi-Automatic Tax Engine.",
+        )
+
+    def test_tax_engine_manual(self):
+        """
+        Unlike the other options, when 'tax_calc' is set to manual, it's the user's
+            responsibility to enter all tax information into the system. He can
+            register this option in any of the operations, not being restricted to
+            anything.
+        """
+        self.fiscal_sale_operation["tax_calc"] = "tax_calc_manual"
+
+        fiscal_document = self.env["l10n_br_fiscal.document"].create(
+            dict(
+                fiscal_operation_id=self.fiscal_sale_operation.id,
+                document_type_id=self.env.ref("l10n_br_fiscal.document_55").id,
+                document_serie_id=self.env.ref(
+                    "l10n_br_fiscal.empresa_lc_document_55_serie_1"
+                ).id,
+                company_id=self.env.ref("l10n_br_base.empresa_lucro_presumido").id,
+                document_serie=1,
+                partner_id=self.env.ref("l10n_br_base.res_partner_cliente1_sp").id,
+                user_id=self.env.ref("base.user_demo").id,
+                fiscal_operation_type="in",
+                line_ids=[
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "Teste - Cálculo Manual",
+                            "product_id": self.env.ref("product.product_product_6").id,
+                            "uom_id": self.env.ref("uom.product_uom_unit").id,
+                            "price_unit": 100,
+                            "quantity": 1,
+                            "fiscal_operation_type": "in",
+                            "fiscal_operation_id": self.fiscal_sale_operation.id,
+                            "fiscal_operation_line_id": self.env.ref(
+                                "l10n_br_fiscal.fo_venda_venda"
+                            ).id,
+                            "icms_cst_id": self.env.ref(
+                                "l10n_br_fiscal.cst_icms_00"
+                            ).id,
+                            "icms_base": 1000.0,
+                            "icms_percent": 15.0,
+                            "icms_value": 150.0,
+                            "ipi_cst_id": self.env.ref("l10n_br_fiscal.cst_ipi_49").id,
+                            "ipi_base": 1000.0,
+                            "ipi_percent": 20.0,
+                            "ipi_value": 200.0,
+                            "pis_cst_id": self.env.ref("l10n_br_fiscal.cst_pis_01").id,
+                            "pis_base": 1000.0,
+                            "pis_percent": 5.0,
+                            "pis_value": 50.0,
+                            "cofins_cst_id": self.env.ref(
+                                "l10n_br_fiscal.cst_cofins_01"
+                            ).id,
+                            "cofins_base": 1000.0,
+                            "cofins_percent": 2.0,
+                            "cofins_value": 20.0,
+                        },
+                    ),
+                ],
+            )
+        )
+
+        product = fiscal_document.line_ids[0]
+        product._onchange_fiscal_operation_id()
+
+        icms_value = product.icms_base * (product.icms_percent / 100)
+        self.assertEqual(
+            product.icms_value,
+            icms_value,
+            "The value of ICMS is not the same. Error in manual demo data entry.",
+        )
+
+        ipi_value = product.ipi_base * (product.ipi_percent / 100)
+        self.assertEqual(
+            product.ipi_value,
+            ipi_value,
+            "The value of IPI is not the same. Error in manual demo data entry.",
+        )
+
+        pis_value = product.pis_base * (product.pis_percent / 100)
+        self.assertEqual(
+            product.pis_value,
+            pis_value,
+            "The value of PIS is not the same. Error in manual demo data entry.",
+        )
+
+        cofins_value = product.cofins_base * (product.cofins_percent / 100)
+        self.assertEqual(
+            product.cofins_value,
+            cofins_value,
+            "The value of Cofins is not the same. Error in manual demo data entry.",
+        )

--- a/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
@@ -30,6 +30,7 @@
           <field name="fiscal_quantity" force_save="1" invisible="1" />
           <field name="tax_icms_or_issqn" force_save="1" invisible="1" />
           <field name="fiscal_tax_ids" force_save="1" invisible="1" readonly="1" />
+          <field name="rel_tax_calc" force_save="1" invisible="1" readonly="1" />
         </group>
         <notebook>
           <page name="fiscal_taxes" string="Taxes">
@@ -40,7 +41,10 @@
                                 attrs="{'invisible': [('tax_icms_or_issqn', '!=', 'issqn')]}"
                             >
                 <group>
-                  <field name="issqn_tax_id" />
+                  <field
+                                        name="issqn_tax_id"
+                                        attrs="{'readonly': [('rel_tax_calc', '=', 'tax_calc_manual')]}"
+                                    />
                   <field
                                         name="issqn_fg_city_id"
                                         attrs="{'required': [('tax_icms_or_issqn', '=', 'issqn')]}"
@@ -106,7 +110,10 @@
                   </group>
                 </group>
                   <group string="Retenções">
-                    <field name="issqn_wh_tax_id" />
+                    <field
+                                        name="issqn_wh_tax_id"
+                                        attrs="{'readonly': [('rel_tax_calc', '=', 'tax_calc_manual')]}"
+                                    />
                   </group>
                   <group>
                       <group>
@@ -143,7 +150,7 @@
                   <group name="icms" string="ICMS">
                     <field
                                         name="icms_tax_id"
-                                        attrs="{'invisible': [('tax_framework', 'in', ('1', '2'))]}"
+                                        attrs="{'invisible': [('tax_framework', 'in', ('1', '2'))], 'readonly': [('rel_tax_calc', '=', 'tax_calc_manual')]}"
                                     />
                     <field
                                         name="icmssn_tax_id"
@@ -241,7 +248,7 @@
                                     >
                         <field
                                             name="icmsst_tax_id"
-                                            attrs="{'invisible': [('icms_cst_code', 'in', ('60', '500'))]}"
+                                            attrs="{'invisible': [('icms_cst_code', 'in', ('60', '500'))], 'readonly': [('rel_tax_calc', '=', 'tax_calc_manual')]}"
                                         />
                         <field
                                             name="icmsst_base_type"
@@ -296,7 +303,7 @@
                                     >
                           <field
                                             name="icmsfcp_tax_id"
-                                            attrs="{'invisible': [('icms_cst_code', '=', '500')]}"
+                                            attrs="{'invisible': [('icms_cst_code', '=', '500')], 'readonly': [('rel_tax_calc', '=', 'tax_calc_manual')]}"
                                         />
                         <field
                                             name="icmsfcp_base"
@@ -404,7 +411,10 @@
                                 attrs="{'invisible': [('tax_icms_or_issqn', '=', 'issqn')]}"
                             >
                   <group string="IPI">
-                      <field name="ipi_tax_id" />
+                      <field
+                                        name="ipi_tax_id"
+                                        attrs="{'readonly': [('rel_tax_calc', '=', 'tax_calc_manual')]}"
+                                    />
                       <field
                                         name="ipi_cst_id"
                                         force_save="1"
@@ -455,7 +465,10 @@
                                 attrs="{'invisible': [('cfop_destination', '!=', '3')]}"
                             >
                 <group string="II">
-                    <field name="ii_tax_id" />
+                    <field
+                                        name="ii_tax_id"
+                                        attrs="{'readonly': [('rel_tax_calc', '=', 'tax_calc_manual')]}"
+                                    />
                 </group>
                 <group>
                   <group>
@@ -470,7 +483,10 @@
               </page>
               <page name="pis" string="PIS">
                   <group name="pis" string="PIS">
-                    <field name="pis_tax_id" />
+                    <field
+                                        name="pis_tax_id"
+                                        attrs="{'readonly': [('rel_tax_calc', '=', 'tax_calc_manual')]}"
+                                    />
                     <field
                                         name="pis_cst_id"
                                         force_save="1"
@@ -520,7 +536,10 @@
                     </group>
                   </group>
                   <group name="pis_st" string="PIS ST">
-                    <field name="pisst_tax_id" />
+                    <field
+                                        name="pisst_tax_id"
+                                        attrs="{'readonly': [('rel_tax_calc', '=', 'tax_calc_manual')]}"
+                                    />
                     <field
                                         name="pisst_cst_id"
                                         force_save="1"
@@ -560,7 +579,10 @@
                     </group>
                   </group>
                   <group string="Retenções">
-                      <field name="pis_wh_tax_id" />
+                      <field
+                                        name="pis_wh_tax_id"
+                                        attrs="{'readonly': [('rel_tax_calc', '=', 'tax_calc_manual')]}"
+                                    />
                   </group>
                   <group>
                       <group>
@@ -591,7 +613,10 @@
               </page>
               <page name="cofins" string="COFINS">
                 <group name="cofins" string="COFINS">
-                  <field name="cofins_tax_id" />
+                  <field
+                                        name="cofins_tax_id"
+                                        attrs="{'readonly': [('rel_tax_calc', '=', 'tax_calc_manual')]}"
+                                    />
                   <field
                                         name="cofins_cst_id"
                                         force_save="1"
@@ -641,7 +666,10 @@
                   </group>
                 </group>
                 <group name="cofins_st" string="COFINS ST">
-                  <field name="cofinsst_tax_id" />
+                  <field
+                                        name="cofinsst_tax_id"
+                                        attrs="{'readonly': [('rel_tax_calc', '=', 'tax_calc_manual')]}"
+                                    />
                   <field
                                         name="cofinsst_cst_id"
                                         force_save="1"
@@ -681,7 +709,10 @@
                   </group>
                 </group>
                   <group string="Retenções">
-                      <field name="cofins_wh_tax_id" />
+                      <field
+                                        name="cofins_wh_tax_id"
+                                        attrs="{'readonly': [('rel_tax_calc', '=', 'tax_calc_manual')]}"
+                                    />
                   </group>
                   <group>
                       <group>
@@ -716,7 +747,10 @@
                                 attrs="{'invisible': [('tax_icms_or_issqn', '=', 'icms')]}"
                             >
                     <group>
-                        <field name="csll_tax_id" />
+                        <field
+                                        name="csll_tax_id"
+                                        attrs="{'readonly': [('rel_tax_calc', '=', 'tax_calc_manual')]}"
+                                    />
                     </group>
                     <group>
                         <group>
@@ -745,7 +779,10 @@
                         </group>
                     </group>
                     <group string="Retenções">
-                        <field name="csll_wh_tax_id" />
+                        <field
+                                        name="csll_wh_tax_id"
+                                        attrs="{'readonly': [('rel_tax_calc', '=', 'tax_calc_manual')]}"
+                                    />
                     </group>
                     <group>
                         <group>
@@ -780,7 +817,10 @@
                                 attrs="{'invisible': [('fiscal_genre_code', '!=', '00')]}"
                             >
                     <group>
-                        <field name="irpj_tax_id" />
+                        <field
+                                        name="irpj_tax_id"
+                                        attrs="{'readonly': [('rel_tax_calc', '=', 'tax_calc_manual')]}"
+                                    />
                     </group>
                     <group>
                         <group>
@@ -809,7 +849,10 @@
                         </group>
                     </group>
                     <group string="Retenções">
-                        <field name="irpj_wh_tax_id" />
+                        <field
+                                        name="irpj_wh_tax_id"
+                                        attrs="{'readonly': [('rel_tax_calc', '=', 'tax_calc_manual')]}"
+                                    />
                     </group>
                     <group>
                         <group>
@@ -844,7 +887,10 @@
                                 attrs="{'invisible': [('fiscal_genre_code', '!=', '00')]}"
                             >
                     <group>
-                        <field name="inss_tax_id" />
+                        <field
+                                        name="inss_tax_id"
+                                        attrs="{'readonly': [('rel_tax_calc', '=', 'tax_calc_manual')]}"
+                                    />
                     </group>
                     <group>
                         <group>
@@ -873,7 +919,10 @@
                         </group>
                     </group>
                     <group string="Retenções">
-                        <field name="inss_wh_tax_id" />
+                        <field
+                                        name="inss_wh_tax_id"
+                                        attrs="{'readonly': [('rel_tax_calc', '=', 'tax_calc_manual')]}"
+                                    />
                     </group>
                     <group>
                         <group>

--- a/l10n_br_fiscal/views/document_line_view.xml
+++ b/l10n_br_fiscal/views/document_line_view.xml
@@ -14,6 +14,7 @@
             <field name="fiscal_genre_id" invisible="1" />
             <field name="fiscal_genre_code" invisible="1" />
             <field name="fiscal_type" invisible="1" />
+            <field name="rel_tax_calc" invisible="1" />
         </group>
         <group>
           <field
@@ -73,15 +74,36 @@
           <page name="amounts" string="Amounts">
             <group>
               <group>
-                <field name="amount_untaxed" />
-                <field name="amount_fiscal" />
-                <field name="amount_tax" />
-                <field name="amount_estimate_tax" />
+                <field
+                                    name="amount_untaxed"
+                                    attrs="{'readonly': [('rel_tax_calc', '!=', 'tax_calc_manual')]}"
+                                />
+                <field
+                                    name="amount_fiscal"
+                                    attrs="{'readonly': [('rel_tax_calc', '!=', 'tax_calc_manual')]}"
+                                />
+                <field
+                                    name="amount_tax"
+                                    attrs="{'readonly': [('rel_tax_calc', '!=', 'tax_calc_manual')]}"
+                                />
+                <field
+                                    name="amount_estimate_tax"
+                                    attrs="{'readonly': [('rel_tax_calc', '!=', 'tax_calc_manual')]}"
+                                />
               </group>
               <group>
-                <field name="amount_total" />
-                <field name="amount_tax_withholding" />
-                <field name="amount_taxed" />
+                <field
+                                    name="amount_total"
+                                    attrs="{'readonly': [('rel_tax_calc', '!=', 'tax_calc_manual')]}"
+                                />
+                <field
+                                    name="amount_tax_withholding"
+                                    attrs="{'readonly': [('rel_tax_calc', '!=', 'tax_calc_manual')]}"
+                                />
+                <field
+                                    name="amount_taxed"
+                                    attrs="{'readonly': [('rel_tax_calc', '!=', 'tax_calc_manual')]}"
+                                />
               </group>
             </group>
           </page>

--- a/l10n_br_fiscal/views/operation_view.xml
+++ b/l10n_br_fiscal/views/operation_view.xml
@@ -76,6 +76,7 @@
                             <field name="company_id" />
                         </group>
                         <group>
+                            <field name="tax_calc" />
                             <field name="default_price_unit" />
                             <field name="return_fiscal_operation_id" />
                             <field name="inverse_fiscal_operation_id" />


### PR DESCRIPTION
Opção de chamar ou não o motor de impostos, conforme:

- Automática: Comportamento Padrão;
- Semi-automático: O usuário carrega os dados e só é realizado o calculo (Usado na devolução, onde as taxas são as mesas da entrada/saída e só precisa ser feito o cálculo novamente)
- Manual: Sem cálculos (Usado nas operações de entrada, importação de XML de outros sistemas, operações que exijam calculo manual, notas de complemento e etc)

TODO:
- [ ] Adicionar testes;
- [ ] https://github.com/OCA/l10n-brazil/pull/1317#discussion_r640044659
- [ ] https://github.com/OCA/l10n-brazil/pull/1317#discussion_r640055196
- [ ] https://github.com/OCA/l10n-brazil/pull/1317#discussion_r640059894
- [ ] https://github.com/OCA/l10n-brazil/pull/1317#discussion_r640060547

Related with: #1317 