### PR TITLE
[12.0][l10n_br_fiscal] no 0.0 default for Floats and Monetary, no required for Floats

### DIFF
--- a/l10n_br_fiscal/models/document_fiscal_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin.py
@@ -304,18 +304,15 @@ class FiscalDocumentMixin(models.AbstractModel):
 
     amount_insurance_value = fields.Monetary(
         string='Insurance Value',
-        default=0.00,
         compute='_compute_amount',
     )
 
     amount_other_value = fields.Monetary(
         string='Other Costs',
-        default=0.00,
         compute='_compute_amount',
     )
 
     amount_freight_value = fields.Monetary(
         string='Freight Value',
-        default=0.00,
         compute='_compute_amount',
     )

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -71,31 +71,26 @@ class DocumentLine(models.Model):
     amount_untaxed = fields.Monetary(
         string='Amount Untaxed',
         compute='_compute_amounts',
-        default=0.00,
     )
 
     amount_tax = fields.Monetary(
         string='Amount Tax',
         compute='_compute_amounts',
-        default=0.00,
     )
 
     amount_fiscal = fields.Monetary(
         string='Amount Fiscal',
         compute='_compute_amounts',
-        default=0.00,
     )
 
     amount_financial = fields.Monetary(
         string='Amount Financial',
         compute='_compute_amounts',
-        default=0.00,
     )
 
     amount_total = fields.Monetary(
         string='Amount Total',
         compute='_compute_amounts',
-        default=0.00,
     )
 
     def unlink(self):

--- a/l10n_br_fiscal/models/product_template.py
+++ b/l10n_br_fiscal/models/product_template.py
@@ -100,6 +100,4 @@ class ProductTemplate(models.Model):
         comodel_name='uom.uom',
         string='Tax UoM')
 
-    uot_factor = fields.Float(
-        string='Tax UoM Factor',
-        default=0.00)
+    uot_factor = fields.Float(string='Tax UoM Factor')

--- a/l10n_br_fiscal/models/res_company.py
+++ b/l10n_br_fiscal/models/res_company.py
@@ -141,7 +141,6 @@ class ResCompany(models.Model):
     annual_revenue = fields.Monetary(
         string="Annual Revenue",
         currency_field="currency_id",
-        default=0.00,
         digits=dp.get_precision("Fiscal Documents"))
 
     simplifed_tax_id = fields.Many2one(
@@ -159,7 +158,6 @@ class ResCompany(models.Model):
 
     simplifed_tax_percent = fields.Float(
         string="Simplifed Tax Percent",
-        default=0.00,
         compute='_compute_simplifed_tax',
         store=True,
         digits=dp.get_precision("Fiscal Tax Percent"))
@@ -167,7 +165,6 @@ class ResCompany(models.Model):
     payroll_amount = fields.Monetary(
         string="Last Period Payroll Amount",
         currency_field="currency_id",
-        default=0.00,
         digits=dp.get_precision("Fiscal Documents"))
 
     coefficient_r = fields.Boolean(

--- a/l10n_br_fiscal/models/simplified_tax_range.py
+++ b/l10n_br_fiscal/models/simplified_tax_range.py
@@ -24,63 +24,51 @@ class SimplifiedTaxRange(models.Model):
     amount_deduced = fields.Monetary(
         string="Amount to be Deducted",
         currency_field="currency_id",
-        default=0.00,
         digits=dp.get_precision("Fiscal Documents"),
         required=True)
 
     inital_revenue = fields.Monetary(
         string="Initial Revenue",
         currency_field="currency_id",
-        default=0.00,
         digits=dp.get_precision("Fiscal Documents"))
 
     final_revenue = fields.Monetary(
         string="Final Revenue",
         currency_field="currency_id",
-        default=0.00,
         digits=dp.get_precision("Fiscal Documents"))
 
     total_tax_percent = fields.Float(
         string="Tax Percent",
-        default=0.00,
         digits=dp.get_precision("Fiscal Tax Percent"))
 
     tax_cpp_percent = fields.Float(
         string="Tax CPP Percent",
-        default=0.00,
         digits=dp.get_precision("Fiscal Tax Percent"))
 
     tax_csll_percent = fields.Float(
         string="Tax CSLL Percent",
-        default=0.00,
         digits=dp.get_precision("Fiscal Tax Percent"))
 
     tax_ipi_percent = fields.Float(
         string="Tax IPI Percent",
-        default=0.00,
         digits=dp.get_precision("Fiscal Tax Percent"))
 
     tax_icms_percent = fields.Float(
         string="Tax ICMS Percent",
-        default=0.00,
         digits=dp.get_precision("Fiscal Tax Percent"))
 
     tax_iss_percent = fields.Float(
         string="Tax ISS Percent",
-        default=0.00,
         digits=dp.get_precision("Fiscal Tax Percent"))
 
     tax_irpj_percent = fields.Float(
         string="Tax IRPJ Percent",
-        default=0.00,
         digits=dp.get_precision("Fiscal Tax Percent"))
 
     tax_cofins_percent = fields.Float(
         string="Tax COFINS Percent",
-        default=0.00,
         digits=dp.get_precision("Fiscal Tax Percent"))
 
     tax_pis_percent = fields.Float(
         string="Tax PIS Percent",
-        default=0.00,
         digits=dp.get_precision("Fiscal Tax Percent"))

--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -89,19 +89,16 @@ class Tax(models.Model):
 
     percent_amount = fields.Float(
         string="Percent",
-        default=0.00,
         digits=dp.get_precision("Fiscal Tax Percent"),
         required=True)
 
     percent_reduction = fields.Float(
         string="Percent Reduction",
-        default=0.00,
         digits=dp.get_precision("Fiscal Tax Percent"),
         required=True)
 
     percent_debit_credit = fields.Float(
         string="Percent Debit/Credit",
-        default=0.00,
         digits=dp.get_precision("Fiscal Tax Percent"),
         required=True)
 
@@ -112,7 +109,6 @@ class Tax(models.Model):
 
     value_amount = fields.Float(
         string="Value",
-        default=0.00,
         digits=dp.get_precision("Fiscal Tax Value"),
         required=True)
 
@@ -159,13 +155,11 @@ class Tax(models.Model):
 
     icmsst_mva_percent = fields.Float(
         string="MVA Percent",
-        default=0.00,
         digits=dp.get_precision("Fiscal Tax Percent"),
         required=True)
 
     icmsst_value = fields.Float(
         string="PFC Value",
-        default=0.00,
         digits=dp.get_precision("Fiscal Tax Value"),
         required=True)
 

--- a/l10n_br_fiscal/models/tax_estimate.py
+++ b/l10n_br_fiscal/models/tax_estimate.py
@@ -25,22 +25,18 @@ class TaxEstimate(models.Model):
 
     federal_taxes_national = fields.Float(
         string='Impostos Federais Nacional',
-        default=0.00,
         digits=dp.get_precision('Fiscal Tax Percent'))
 
     federal_taxes_import = fields.Float(
         string='Impostos Federais Importado',
-        default=0.00,
         digits=dp.get_precision('Fiscal Tax Percent'))
 
     state_taxes = fields.Float(
         string='Impostos Estaduais Nacional',
-        default=0.00,
         digits=dp.get_precision('Fiscal Tax Percent'))
 
     municipal_taxes = fields.Float(
         string='Impostos Municipais Nacional',
-        default=0.00,
         digits=dp.get_precision('Fiscal Tax Percent'))
 
     create_date = fields.Datetime(


### PR DESCRIPTION
Melhoria na performance da criação dos registros (sem custo na leitura) e limpeza do codigo, ver explicaçoes aqui https://github.com/OCA/l10n-brazil/pull/1107
Alem de limpar o codigo tb.