### PR TITLE
[12.0][l10n_br_fiscal] line amount_financial assigned in _compute_amounts as advertised

### DIFF
--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -176,6 +176,16 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 record.amount_tax_withholding
             )
 
+            # Valor financeiro
+            if (
+                record.fiscal_operation_line_id
+                and record.fiscal_operation_line_id.add_to_amount
+                and (not record.cfop_id or record.cfop_id.finance_move)
+            ):
+                record.amount_financial = record.amount_taxed
+            else:
+                record.amount_financial = 0.0
+
     def _compute_taxes(self, taxes, cst=None):
         self.ensure_one()
         return taxes.compute_taxes(

--- a/l10n_br_fiscal/models/document_fiscal_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin_methods.py
@@ -48,12 +48,6 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
                         values[field] += line[field]
                     if field.replace('amount_', '') in line._fields.keys():
                         values[field] += line[field.replace('amount_', '')]
-
-                if line.fiscal_operation_line_id:
-                    if line.fiscal_operation_line_id.add_to_amount and (
-                            not line.cfop_id or line.cfop_id.finance_move):
-                        values['amount_financial'] += line.amount_taxed
-
             doc.update(values)
 
     def __document_comment_vals(self):


### PR DESCRIPTION
Em l10n_br_fiscal/models/document_line.py nos é prometido que o amount_financial da linha é computado no _compute_amounts das linhas definido em l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py

Porem isso nao acontecia, apenas tinha um calculo global do amount_financial do documento no compute_amount do documento em l10n_br_fiscal/models/document_fiscal_mixin.py
De forma que se alguem tanta ler o amount_financial de uma linha vai achar zero ou vai ter um erro.

Com esse PR, O amount_financial do documento passa a ser calculado a partir do amount_financial das linhas que por sua vez esta calculado no _compute_amounts das linhas como deveria acontecer.