### PR TITLE
[REF] Standard OCA website spec_driven_model

### DIFF
--- a/spec_driven_model/__manifest__.py
+++ b/spec_driven_model/__manifest__.py
@@ -9,6 +9,7 @@
     'maintainers': ['rvalyi'],
     'license': 'LGPL-3',
     'author': 'Akretion,Odoo Community Association (OCA)',
+    "website": "https://github.com/OCA/l10n-brazil",
     'depends': [
     ],
     'data': [


### PR DESCRIPTION
mesma coisa do que https://github.com/OCA/l10n-brazil/pull/1419 so que pro modulo spec_driven_model que ficou faltando.