### PR TITLE
[12.0] [l10n_br_fiscal] lint

### DIFF
--- a/l10n_br_fiscal/models/closing.py
+++ b/l10n_br_fiscal/models/closing.py
@@ -323,10 +323,10 @@ class FiscalClosing(models.Model):
         archive = io.BytesIO()
 
         with zipfile.ZipFile(archive, 'w') as zip_archive:
-            for dirname, subdirs, files in os.walk(files_dir):
+            for dirname, subdirs, _files in os.walk(files_dir):
                 for subdir in subdirs:
                     path_subdir = files_dir+'/'+subdir
-                    for cnpj_dirname, cnpj_subdirs, cnpj_files in os.walk(path_subdir):
+                    for cnpj_dirname, _cnpj_subdirs, cnpj_files in os.walk(path_subdir):
                         for filename in cnpj_files:
                             zip_archive.write(
                                 os.path.join(cnpj_dirname, filename),

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -7,30 +7,6 @@ from odoo import api, models
 from odoo.osv.orm import setup_modifiers
 
 from .tax import TAX_DICT_VALUES
-
-from ..constants.fiscal import (
-    TAX_DOMAIN_COFINS,
-    TAX_DOMAIN_COFINS_WH,
-    TAX_DOMAIN_COFINS_ST,
-    TAX_DOMAIN_CSLL,
-    TAX_DOMAIN_CSLL_WH,
-    TAX_DOMAIN_ICMS,
-    TAX_DOMAIN_ICMS_FCP,
-    TAX_DOMAIN_ICMS_SN,
-    TAX_DOMAIN_ICMS_ST,
-    TAX_DOMAIN_II,
-    TAX_DOMAIN_INSS,
-    TAX_DOMAIN_INSS_WH,
-    TAX_DOMAIN_IPI,
-    TAX_DOMAIN_IRPJ,
-    TAX_DOMAIN_IRPJ_WH,
-    TAX_DOMAIN_ISSQN,
-    TAX_DOMAIN_ISSQN_WH,
-    TAX_DOMAIN_PIS,
-    TAX_DOMAIN_PIS_WH,
-    TAX_DOMAIN_PIS_ST,
-)
-
 from ..constants.icms import (
     ICMS_BASE_TYPE_DEFAULT,
     ICMS_ST_BASE_TYPE_DEFAULT
@@ -271,70 +247,12 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             line.amount_estimate_tax = compute_result.get(
                 'amount_estimate_tax', 0.0)
             for tax in line.fiscal_tax_ids:
-
                 computed_tax = computed_taxes.get(tax.tax_domain, {})
-
-                if tax.tax_domain == TAX_DOMAIN_IPI:
-                    line.ipi_tax_id = tax
-                    self._set_fields_ipi(computed_tax)
-                if tax.tax_domain == TAX_DOMAIN_II:
-                    line.ii_tax_id = tax
-                    self._set_fields_ii(computed_tax)
-                if tax.tax_domain == TAX_DOMAIN_PIS:
-                    line.pis_tax_id = tax
-                    self._set_fields_pis(computed_tax)
-                if tax.tax_domain == TAX_DOMAIN_PIS_ST:
-                    line.pisst_tax_id = tax
-                    self._set_fields_pisst(computed_tax)
-                if tax.tax_domain == TAX_DOMAIN_COFINS:
-                    line.cofins_tax_id = tax
-                    self._set_fields_cofins(computed_tax)
-                if tax.tax_domain == TAX_DOMAIN_COFINS_ST:
-                    line.cofinsst_tax_id = tax
-                    self._set_fields_cofinsst(computed_tax)
-                if tax.tax_domain == TAX_DOMAIN_ICMS:
-                    line.icms_tax_id = tax
-                    self._set_fields_icms(computed_tax)
-                if tax.tax_domain == TAX_DOMAIN_ICMS_SN:
-                    line.icmssn_tax_id = tax
-                    self._set_fields_icmssn(computed_tax)
-                if tax.tax_domain == TAX_DOMAIN_ICMS_ST:
-                    line.icmsst_tax_id = tax
-                    self._set_fields_icmsst(computed_tax)
-                if tax.tax_domain == TAX_DOMAIN_ICMS_FCP:
-                    line.icmsfcp_tax_id = tax
-                    self._set_fields_icmsfcp(computed_tax)
-                if tax.tax_domain == TAX_DOMAIN_ISSQN:
-                    line.issqn_tax_id = tax
-                    self._set_fields_issqn(computed_tax)
-                if tax.tax_domain == TAX_DOMAIN_CSLL:
-                    line.csll_tax_id = tax
-                    self._set_fields_csll(computed_tax)
-                if tax.tax_domain == TAX_DOMAIN_IRPJ:
-                    line.irpj_tax_id = tax
-                    self._set_fields_irpj(computed_tax)
-                if tax.tax_domain == TAX_DOMAIN_INSS:
-                    line.inss_tax_id = tax
-                    self._set_fields_inss(computed_tax)
-
-                if tax.tax_domain == TAX_DOMAIN_ISSQN_WH:
-                    line.issqn_wh_tax_id = tax
-                    self._set_fields_issqn_wh(computed_tax)
-                if tax.tax_domain == TAX_DOMAIN_PIS_WH:
-                    line.pis_wh_tax_id = tax
-                    self._set_fields_pis_wh(computed_tax)
-                if tax.tax_domain == TAX_DOMAIN_COFINS_WH:
-                    line.cofins_wh_tax_id = tax
-                    self._set_fields_cofins_wh(computed_tax)
-                if tax.tax_domain == TAX_DOMAIN_CSLL_WH:
-                    line.csll_wh_tax_id = tax
-                    self._set_fields_csll_wh(computed_tax)
-                if tax.tax_domain == TAX_DOMAIN_IRPJ_WH:
-                    line.irpj_wh_tax_id = tax
-                    self._set_fields_irpj_wh(computed_tax)
-                if tax.tax_domain == TAX_DOMAIN_INSS_WH:
-                    line.inss_wh_tax_id = tax
-                    self._set_fields_inss_wh(computed_tax)
+                if hasattr(line, "%s_tax_id" % (tax.tax_domain,)):
+                    setattr(line, "%s_tax_id" % (tax.tax_domain,), tax)
+                    method = getattr(self, "_set_fields_%s" % (tax.tax_domain,))
+                    if method:
+                        method(computed_tax)
 
     def _get_product_price(self):
         self.ensure_one()

--- a/l10n_br_fiscal/models/operation_dashboard.py
+++ b/l10n_br_fiscal/models/operation_dashboard.py
@@ -2,7 +2,7 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 import json
-from odoo import _, api, fields, models
+from odoo import _, fields, models
 
 from ..constants.fiscal import (
     SITUACAO_EDOC_A_ENVIAR,
@@ -37,11 +37,10 @@ class Operation(models.Model):
     #   de forma manual ou usando o ORM:
     #         query = self._where_calc(args)
     #         self._apply_ir_rules(query, 'read')
-
-    @api.one
     def _compute_kanban_dashboard(self):
-        self.kanban_dashboard = json.dumps(
-            self.get_operation_dashboard_datas())
+        for operation in self:
+            operation.kanban_dashboard = json.dumps(
+                operation.get_operation_dashboard_data())
 
     kanban_dashboard = fields.Text(
         compute='_compute_kanban_dashboard')
@@ -50,7 +49,8 @@ class Operation(models.Model):
         string='Color Index',
         default=0)
 
-    def get_operation_dashboard_datas(self):
+    def get_operation_dashboard_data(self):
+        self.ensure_one()
         title = ''
         if self.fiscal_type in ('sale', 'purchase'):
             title = _('Bills to pay') if self.fiscal_type == 'purchase' \

--- a/l10n_br_fiscal/tests/test_ibpt_product.py
+++ b/l10n_br_fiscal/tests/test_ibpt_product.py
@@ -7,30 +7,30 @@ from odoo.tests import SavepointCase
 class TestIbptProduct(SavepointCase):
 
     @classmethod
-    def setUpClass(self):
+    def setUpClass(cls):
         super().setUpClass()
-        self.company = self._create_compay()
-        self._switch_user_company(self.env.user, self.company)
-        self.ncm_85030010 = self.env.ref("l10n_br_fiscal.ncm_85030010")
-        self.ncm_85014029 = self.env.ref("l10n_br_fiscal.ncm_85014029")
-        self.product_tmpl_model = self.env["product.template"]
-        self.product_tmpl_1 = self._create_product_tmpl(
-            name="Product Test 1 - With NCM: 8503.00.10", ncm=self.ncm_85030010
+        cls.company = cls._create_compay()
+        cls._switch_user_company(cls.env.user, cls.company)
+        cls.ncm_85030010 = cls.env.ref("l10n_br_fiscal.ncm_85030010")
+        cls.ncm_85014029 = cls.env.ref("l10n_br_fiscal.ncm_85014029")
+        cls.product_tmpl_model = cls.env["product.template"]
+        cls.product_tmpl_1 = cls._create_product_tmpl(
+            name="Product Test 1 - With NCM: 8503.00.10", ncm=cls.ncm_85030010
         )
 
-        self.product_tmpl_2 = self._create_product_tmpl(
-            name="Product Test 2 - With NCM: 8503.00.10", ncm=self.ncm_85030010
+        cls.product_tmpl_2 = cls._create_product_tmpl(
+            name="Product Test 2 - With NCM: 8503.00.10", ncm=cls.ncm_85030010
         )
 
-        self.product_tmpl_3 = self._create_product_tmpl(
-            name="Product Test 3 - With NCM: 8501.40.29", ncm=self.ncm_85014029
+        cls.product_tmpl_3 = cls._create_product_tmpl(
+            name="Product Test 3 - With NCM: 8501.40.29", ncm=cls.ncm_85014029
         )
 
-        self.tax_estimate_model = self.env["l10n_br_fiscal.tax.estimate"]
-        self.ncm_model = self.env["l10n_br_fiscal.ncm"]
+        cls.tax_estimate_model = cls.env["l10n_br_fiscal.tax.estimate"]
+        cls.ncm_model = cls.env["l10n_br_fiscal.ncm"]
 
     @classmethod
-    def _switch_user_company(self, user, company):
+    def _switch_user_company(cls, user, company):
         """ Add a company to the user's allowed & set to current. """
         user.write({
             'company_ids': [(6, 0, (company + user.company_ids).ids)],
@@ -38,14 +38,14 @@ class TestIbptProduct(SavepointCase):
         })
 
     @classmethod
-    def _create_compay(self):
+    def _create_compay(cls):
         # Creating a company
-        company = self.env["res.company"].create(
+        company = cls.env["res.company"].create(
             {
                 "name": "Company Test Fiscal BR",
                 "cnpj_cpf": "02.960.895/0002-12",
-                "country_id": self.env.ref("base.br").id,
-                "state_id": self.env.ref("base.state_br_es").id,
+                "country_id": cls.env.ref("base.br").id,
+                "state_id": cls.env.ref("base.state_br_es").id,
                 "ibpt_api": True,
                 "ibpt_update_days": 0,
                 "ibpt_token": (
@@ -57,9 +57,9 @@ class TestIbptProduct(SavepointCase):
         return company
 
     @classmethod
-    def _create_product_tmpl(self, name, ncm):
+    def _create_product_tmpl(cls, name, ncm):
         # Creating a product
-        product = self.product_tmpl_model.create({"name": name, "ncm_id": ncm.id})
+        product = cls.product_tmpl_model.create({"name": name, "ncm_id": ncm.id})
         return product
 
     def test_update_ibpt_product(self):


### PR DESCRIPTION
more l10n_br_fiscal lint

@mileo as you can see, most of the code we still had to lint heavily comes from your company KMEE and was approved and pushed by you here https://github.com/OCA/l10n-brazil/pull/928
along with lot's of other very shitty untested code (models/mdfe, models/closing.py). You ended up fixing some of it, but 1 year later attachment.py was still all shitty...

This is really a problem you abuse your seat in the project PSC to push that kind of unsollicited code in the OCA and specially if you push it inside a critical module we wrote at 90% over many years without even getting our approval!! Please read again your code of l10n_br_fiscal/models/attachments.py before I tried to do something about it (hard to do anything as it is unused and untested code...)
https://github.com/akretion/l10n-brazil/blob/dc2436358509f77c3a8e51affc7bdf98884eb936/l10n_br_fiscal/models/attachment.py

Come one, is this 2020/2021 OCA quality code?? In which other OCA repo are such "contributions" accepted?
you have tests about variables like `value` or `config_ids` or `active_id` or `active_model` that you affect 3 lines before so your tests are useless (except from bloating the complexity beyond the flake8 OCA limits) and then you do nothing with these variables...

Moreover this kind of untested feature could perfectly be added in other modules. This way people could choose if they like your implementation or... may be not! But forcing us to bloat it inside the l10n_br_fiscal module and maintain it is not nice! Sorry to tell it loud and in plain English, but sadly you have been warned several times and you play it like you don't get it...

From what I saw, attachment,py seems somewhat tested in your other PR https://github.com/OCA/l10n-brazil/pull/1355/files so may be you can test if my refactor attempt didn't break it.
I made e comment BTW because I doubt your code works https://github.com/OCA/l10n-brazil/pull/1355/files#r645291763