### PR TITLE
[12.0][l10n_br_fiscal] m2m column typo fix with migration script

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -9,7 +9,7 @@
     "author": "Akretion, Odoo Community Association (OCA)",
     "maintainers": ["renatonlima"],
     "website": "https://github.com/OCA/l10n-brazil",
-    "version": "12.0.14.0.1",
+    "version": "12.0.15.0.0",
     "depends": [
         "uom",
         "decimal_precision",

--- a/l10n_br_fiscal/migrations/12.0.15.0.0/pre-migration.py
+++ b/l10n_br_fiscal/migrations/12.0.15.0.0/pre-migration.py
@@ -1,0 +1,75 @@
+# Copyright (C) 2021 - Raphaêl Valyi - Akretion
+# License AGPL-3.0 or later (
+# http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+_column_renames = {
+    # l10n_br_fiscal/models/cest.py
+    # l10n_br_fiscal/models/ncm_cest.py
+    'fiscal_cest_ncm_rel': [
+        ('l10n_br_fiscal_ncm_id', 'ncm_id'),
+        ('l10n_br_fiscal_cest_id', 'cest_id'),
+    ],
+
+    # l10n_br_fiscal/models/nbm.py
+    # l10n_br_fiscal/models/ncm_nbm.py
+    'fiscal_nbm_ncm_rel': [
+        ('l10n_br_fiscal_ncm_id', 'ncm_id'),
+        ('l10n_br_fiscal_nbm_id', 'nbm_id'),
+    ],
+
+    # l10n_br_fiscal/models/simplified_tax.py
+    'fiscal_simplified_tax_cnae_rel': [
+        ('l10n_br_fiscal_simplified_tax_id', 'simplified_tax_id'),
+        ('l10n_br_fiscal_cnae_id', 'cnae_id'),
+    ],
+
+    # l10n_br_fiscal/models/ncm_tax_pis_cofins.py
+    # l10n_br_fiscal/models/tax_pis_cofins.py
+    'fiscal_pis_cofins_ncm_rel': [
+        ('l10n_br_fiscal_ncm_id', 'ncm_id'),
+        ('l10n_br_fiscal_tax_pis_cofins_id', 'piscofins_id'),
+    ],
+
+    # l10n_br_fiscal/models/res_company.py
+    'res_company_fiscal_cnae_rel': [
+        ('res_company_id', 'company_id'),
+        ('l10n_br_fiscal_cnae_id', 'cnae_id'),
+    ],
+
+    # l10n_br_fiscal/models/tax_definition.py
+    'tax_definition_state_to_rel': [
+        ('l10n_br_fiscal_tax_definition_id', 'tax_definition_id'),
+        ('res_country_state_id', 'state_id'),
+    ],
+
+    # l10n_br_fiscal/models/tax_definition.py
+    'tax_definition_ncm_rel': [
+        ('l10n_br_fiscal_tax_definition_id', 'tax_definition_id'),
+        ('l10n_br_fiscal_ncm_id', 'ncm_id'),
+    ],
+    # l10n_br_fiscal/models/tax_definition.py
+    'tax_definition_cest_rel': [
+        ('l10n_br_fiscal_tax_definition_id', 'tax_definition_id'),
+        ('l10n_br_fiscal_cest_id', 'cest_id'),
+    ],
+
+    # l10n_br_fiscal/models/tax_definition.py
+    'tax_definition_nbm_rel': [
+        ('l10n_br_fiscal_tax_definition_id', 'tax_definition_id'),
+        ('l10n_br_fiscal_nbm_id', 'nbm_id'),
+    ],
+
+    # l10n_br_fiscal/models/tax_definition.py
+    'tax_definition_product_rel': [
+        ('l10n_br_fiscal_tax_definition_id', 'tax_definition_id'),
+        ('product_product_id', 'product_id'),  # TODO not with product_template??
+    ],
+}
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    openupgrade.rename_columns(env.cr, _column_renames)

--- a/l10n_br_fiscal/models/cest.py
+++ b/l10n_br_fiscal/models/cest.py
@@ -41,8 +41,8 @@ class Cest(models.Model):
     ncm_ids = fields.Many2many(
         comodel_name='l10n_br_fiscal.ncm',
         relation='fiscal_cest_ncm_rel',
-        colunm1='cest_id',
-        colunm2='ncm_id',
+        column1='cest_id',
+        column2='ncm_id',
         readonly=True,
         string='NCMs')
 

--- a/l10n_br_fiscal/models/nbm.py
+++ b/l10n_br_fiscal/models/nbm.py
@@ -31,8 +31,8 @@ class Nbm(models.Model):
     ncm_ids = fields.Many2many(
         comodel_name='l10n_br_fiscal.ncm',
         relation='fiscal_nbm_ncm_rel',
-        colunm1='nbm_id',
-        colunm2='ncm_id',
+        column1='nbm_id',
+        column2='ncm_id',
         readonly=True,
         string='NCMs')
 

--- a/l10n_br_fiscal/models/ncm_cest.py
+++ b/l10n_br_fiscal/models/ncm_cest.py
@@ -10,7 +10,7 @@ class NCM(models.Model):
     cest_ids = fields.Many2many(
         comodel_name='l10n_br_fiscal.cest',
         relation='fiscal_cest_ncm_rel',
-        colunm1='ncm_id',
-        colunm2='cest_id',
+        column1='ncm_id',
+        column2='cest_id',
         readonly=True,
         string='CESTs')

--- a/l10n_br_fiscal/models/ncm_nbm.py
+++ b/l10n_br_fiscal/models/ncm_nbm.py
@@ -10,7 +10,7 @@ class NCM(models.Model):
     nbm_ids = fields.Many2many(
         comodel_name='l10n_br_fiscal.nbm',
         relation='fiscal_nbm_ncm_rel',
-        colunm1='ncm_id',
-        colunm2='nbm_id',
+        column1='ncm_id',
+        column2='nbm_id',
         readonly=True,
         string='NBMs')

--- a/l10n_br_fiscal/models/ncm_tax_pis_cofins.py
+++ b/l10n_br_fiscal/models/ncm_tax_pis_cofins.py
@@ -10,7 +10,7 @@ class NCM(models.Model):
     piscofins_ids = fields.Many2many(
         comodel_name='l10n_br_fiscal.tax.pis.cofins',
         relation='fiscal_pis_cofins_ncm_rel',
-        colunm1='ncm_id',
-        colunm2='piscofins_id',
+        column1='ncm_id',
+        column2='piscofins_id',
         readonly=True,
         string='PIS/COFINS')

--- a/l10n_br_fiscal/models/res_company.py
+++ b/l10n_br_fiscal/models/res_company.py
@@ -110,8 +110,8 @@ class ResCompany(models.Model):
     cnae_secondary_ids = fields.Many2many(
         comodel_name="l10n_br_fiscal.cnae",
         relation="res_company_fiscal_cnae_rel",
-        colunm1="company_id",
-        colunm2="cnae_id",
+        column1="company_id",
+        column2="cnae_id",
         domain="[('internal_type', '=', 'normal'), "
                "('id', '!=', cnae_main_id)]",
         string="Secondary CNAE")

--- a/l10n_br_fiscal/models/simplified_tax.py
+++ b/l10n_br_fiscal/models/simplified_tax.py
@@ -16,8 +16,8 @@ class SimplifiedTax(models.Model):
     cnae_ids = fields.Many2many(
         comodel_name='l10n_br_fiscal.cnae',
         relation='fiscal_simplified_tax_cnae_rel',
-        colunm1='company_id',
-        colunm2='cnae_id',
+        column1='simplified_tax_id',
+        column2='cnae_id',
         domain="[('internal_type', '=', 'normal')]",
         string='CNAEs')
 

--- a/l10n_br_fiscal/models/tax_definition.py
+++ b/l10n_br_fiscal/models/tax_definition.py
@@ -104,8 +104,8 @@ class TaxDefinition(models.Model):
     state_to_ids = fields.Many2many(
         comodel_name='res.country.state',
         relation='tax_definition_state_to_rel',
-        colunm1='tax_definition_id',
-        colunm2='state_id',
+        column1='tax_definition_id',
+        column2='state_id',
         string='To States',
         domain=[('country_id.code', '=', 'BR')],
     )
@@ -131,8 +131,8 @@ class TaxDefinition(models.Model):
     ncm_ids = fields.Many2many(
         comodel_name='l10n_br_fiscal.ncm',
         relation='tax_definition_ncm_rel',
-        colunm1='tax_definition_id',
-        colunm2='ncm_id',
+        column1='tax_definition_id',
+        column2='ncm_id',
         readonly=True,
         string='NCMs',
     )
@@ -146,8 +146,8 @@ class TaxDefinition(models.Model):
     cest_ids = fields.Many2many(
         comodel_name='l10n_br_fiscal.cest',
         relation='tax_definition_cest_rel',
-        colunm1='tax_definition_id',
-        colunm2='ncm_id',
+        column1='tax_definition_id',
+        column2='cest_id',
         readonly=True,
         string='CESTs',
     )
@@ -167,8 +167,8 @@ class TaxDefinition(models.Model):
     nbm_ids = fields.Many2many(
         comodel_name='l10n_br_fiscal.nbm',
         relation='tax_definition_nbm_rel',
-        colunm1='tax_definition_id',
-        colunm2='nbm_id',
+        column1='tax_definition_id',
+        column2='nbm_id',
         readonly=True,
         string='NBMs',
     )
@@ -176,8 +176,8 @@ class TaxDefinition(models.Model):
     product_ids = fields.Many2many(
         comodel_name='product.product',
         relation='tax_definition_product_rel',
-        colunm1='tax_definition_id',
-        colunm2='product_id',
+        column1='tax_definition_id',
+        column2='product_id',
         string='Products',
     )
 

--- a/l10n_br_fiscal/models/tax_pis_cofins.py
+++ b/l10n_br_fiscal/models/tax_pis_cofins.py
@@ -69,8 +69,8 @@ class TaxPisCofins(models.Model):
     ncm_ids = fields.Many2many(
         comodel_name='l10n_br_fiscal.ncm',
         relation='fiscal_pis_cofins_ncm_rel',
-        colunm1='piscofins_id',
-        colunm2='ncm_id',
+        column1='piscofins_id',
+        column2='ncm_id',
         compute='_compute_ncms',
         store=True,
         readonly=True,


### PR DESCRIPTION
Pessoal, infelizmente o @renatonlima confundiu column com colunm quando definiu algumas relaçoes m2m. Nisso pro ORM do Odoo esses attributos colunm1 e colunm2 foi a mesma coisa do que nada: o ORM atribuiu nomes de colunas sozinho e a coisa funcionou bem.

Uma alternativa era simplesmente tirar os colunm1 e colunm2. Porem a gente pensou que depois para escrever alguns JOIN no SQL na hora de fazer uns reports ia ser bem chato ter esses nomes automaticos super verbosos. Nisso a gente preferiu corrigir e fazer um script d emigraçao.

Aqui rodei o script de migraçao ta:
![2021-06-04_03-45](https://user-images.githubusercontent.com/16926/120758907-c7e40b80-c4e8-11eb-9789-6b3c45c7babf.png)
