### PR TITLE
[12.0][FIX] Add the nfe40_choice7 field and depends to the compute

### DIFF
--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -101,7 +101,7 @@ class ResPartner(spec_models.SpecModel):
         """Set schema data which are not just related fields"""
         for rec in self:
             if rec.cnpj_cpf:
-                if rec.company_id.partner_id.country_id != rec.country_id:
+                if rec.country_id.code != 'BR':
                     rec.nfe40_choice7 = 'nfe40_idEstrangeiro'
                 elif rec.is_company:
                     rec.nfe40_CNPJ = punctuation_rm(
@@ -145,6 +145,6 @@ class ResPartner(spec_models.SpecModel):
             if self.country_id.code != 'BR':
                 return 'EX'
         if xsd_field == 'nfe40_idEstrangeiro':
-            if self.company_id.partner_id.country_id != self.country_id:
                 return 'EXTERIOR'
+            if self.country_id.code != 'BR':
         return super()._export_field(xsd_field, class_obj, member_spec)

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -96,12 +96,14 @@ class ResPartner(spec_models.SpecModel):
             rec.nfe40_enderDest = rec.id
 
     @api.multi
-    @api.depends('company_type', 'cnpj_cpf')
+    @api.depends('company_type', 'cnpj_cpf', 'country_id')
     def _compute_nfe_data(self):
         """Set schema data which are not just related fields"""
         for rec in self:
             if rec.cnpj_cpf:
-                if rec.is_company:
+                if rec.company_id.partner_id.country_id != rec.country_id:
+                    rec.nfe40_choice7 = 'nfe40_idEstrangeiro'
+                elif rec.is_company:
                     rec.nfe40_CNPJ = punctuation_rm(
                         rec.cnpj_cpf)
                     rec.nfe40_choice7 = 'nfe40_CNPJ'

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -96,6 +96,7 @@ class ResPartner(spec_models.SpecModel):
             rec.nfe40_enderDest = rec.id
 
     @api.multi
+    @api.depends('company_type', 'cnpj_cpf')
     def _compute_nfe_data(self):
         """Set schema data which are not just related fields"""
         for rec in self:

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -74,6 +74,13 @@ class ResPartner(spec_models.SpecModel):
         ('nfe40_CPF', 'CPF')],
         "CNPJ/CPF do Parceiro")
 
+    nfe40_choice7 = fields.Selection([
+        ('nfe40_CNPJ', 'CNPJ'),
+        ('nfe40_CPF', 'CPF'),
+        ('nfe40_idEstrangeiro', 'idEstrangeiro')],
+        compute='_compute_nfe_data',
+        string="CNPJ/CPF/idEstrangeiro")
+
     @api.multi
     def _compute_nfe40_xEnder(self):
         for rec in self:
@@ -96,9 +103,11 @@ class ResPartner(spec_models.SpecModel):
                 if rec.is_company:
                     rec.nfe40_CNPJ = punctuation_rm(
                         rec.cnpj_cpf)
+                    rec.nfe40_choice7 = 'nfe40_CNPJ'
                 else:
                     rec.nfe40_CPF = punctuation_rm(
                         rec.cnpj_cpf)
+                    rec.nfe40_choice7 = 'nfe40_CPF'
 
     def _inverse_nfe40_CNPJ(self):
         for rec in self:

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -145,6 +145,6 @@ class ResPartner(spec_models.SpecModel):
             if self.country_id.code != 'BR':
                 return 'EX'
         if xsd_field == 'nfe40_idEstrangeiro':
-                return 'EXTERIOR'
             if self.country_id.code != 'BR':
+                return self.vat or self.cnpj_cpf or self.rg or "EXTERIOR"
         return super()._export_field(xsd_field, class_obj, member_spec)


### PR DESCRIPTION
Olá pessoal, durante testes de emissão de NF-e percebemos que o CNPJ não estava indo para o XML e rastreamos o problema até o compute _compute_nfe_data que não estava sendo executado. Além disso notamos que o campo nfe40_choice7 não estava sendo preenchido. 

A forma que achamos para corrigir isso, foi chamando o compute para o campo nfe40_choice7 e adicionando o depends para o compute _compute_nfe_data. Quanto ao depends no compute não tenho muita certeza se ele deveria estar ali, mas foi a única forma que conseguimos fazer funcionar. Caso tenham alguma outra solução, fico a disposição para corrigir.

cc: @gabrielcardoso21 
