### PR TITLE
[FIX] _compute_nfe40_xEnder method

### DIFF
--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -81,7 +81,7 @@ class ResPartner(spec_models.SpecModel):
                 [i for i in [rec.street, rec.street_number] if i]
             )
             if rec.street2:
-                rec.nfe40_xEnder = ' - '.join(rec.nfe40_xEnder, rec.street2)
+                rec.nfe40_xEnder = ' - '.join((rec.nfe40_xEnder, rec.street2))
 
     @api.multi
     def _compute_nfe40_enderDest(self):


### PR DESCRIPTION
No commit https://github.com/akretion/l10n-brazil/commit/efd3aafaadd8d9c4ab64863b487ff553ddeab66a#diff-41c01563118ad424c014b53a2f29c034b9850239d18ea1a4104c3b6cb449d33a tem um erro, ao usar o método join do objeto string tem que enviar uma tupla como argumento , da forma que estava esta sendo enviado dois argumentos.