### PR TITLE
[12.0][l10n_br_account] m2m column typo fix with migration script 

### DIFF
--- a/l10n_br_account/__manifest__.py
+++ b/l10n_br_account/__manifest__.py
@@ -7,7 +7,7 @@
     "license": "AGPL-3",
     "author": "Akretion, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-brazil",
-    "version": "12.0.6.0.0",
+    "version": "12.0.7.0.0",
     "depends": ["account_cancel", "l10n_br_coa", "l10n_br_fiscal"],
     "data": [
         # security

--- a/l10n_br_account/migrations/12.0.7.0.0/pre-migration.py
+++ b/l10n_br_account/migrations/12.0.7.0.0/pre-migration.py
@@ -1,0 +1,29 @@
+# Copyright (C) 2021 - Raphaêl Valyi - Akretion
+# License AGPL-3.0 or later (
+# http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+_column_renames = {
+    # l10n_br_account/models/account_tax.py
+    'l10n_br_fiscal_account_tax_rel': [
+        ('l10n_br_fiscal_tax_id', 'fiscal_tax_id'),
+    ],
+
+    # l10n_br_account/models/account_tax_template.py
+    'l10n_br_fiscal_account_template_tax_rel': [
+        ('l10n_br_fiscal_tax_id', 'fiscal_tax_id'),
+    ],
+}
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    openupgrade.rename_columns(env.cr, _column_renames)
+    openupgrade.rename_tables(env.cr, [
+        ('l10n_br_fiscal_account_tax_rel', 'fiscal_account_tax_rel')
+    ])
+    openupgrade.rename_tables(env.cr, [
+        ('l10n_br_fiscal_account_template_tax_rel', 'fiscal_account_template_tax_rel')
+    ])

--- a/l10n_br_account/models/account_tax.py
+++ b/l10n_br_account/models/account_tax.py
@@ -9,9 +9,9 @@ class AccountTax(models.Model):
 
     fiscal_tax_ids = fields.Many2many(
         comodel_name='l10n_br_fiscal.tax',
-        relation='l10n_br_fiscal_account_tax_rel',
-        colunm1='account_tax_id',
-        colunm2='fiscal_tax_id',
+        relation='fiscal_account_tax_rel',
+        column1='account_tax_id',
+        column2='fiscal_tax_id',
         string='Fiscal Taxes',
     )
 

--- a/l10n_br_account/models/account_tax_template.py
+++ b/l10n_br_account/models/account_tax_template.py
@@ -9,9 +9,9 @@ class AccountTaxTemplate(models.Model):
 
     fiscal_tax_ids = fields.Many2many(
         comodel_name='l10n_br_fiscal.tax',
-        relation='l10n_br_fiscal_account_template_tax_rel',
-        colunm1='account_tax_id',
-        colunm2='fiscal_tax_id',
+        relation='fiscal_account_template_tax_rel',
+        column1='account_tax_template_id',
+        column2='fiscal_tax_id',
         string='Fiscal Taxes',
     )
 


### PR DESCRIPTION
resolve o mesmo tipo de problema do que https://github.com/OCA/l10n-brazil/pull/1424 so que no l10n_br_account dessa vez. Felizmente isso é o ultimo erro desse no repo.

Antes:
![2021-06-05_11-56](https://user-images.githubusercontent.com/16926/120896063-3367cf00-c5f6-11eb-8d96-df376ae8c8e2.png)

Migraçao:
![2021-06-05_12-01](https://user-images.githubusercontent.com/16926/120896075-3ebafa80-c5f6-11eb-99e1-dddbd63d08cd.png)

Depois:
![2021-06-05_12-00](https://user-images.githubusercontent.com/16926/120896082-47abcc00-c5f6-11eb-88f8-80658ae66a7b.png)
