### PR TITLE
[12.0][l10n_br_coa] removed incorrect @api.multi

### DIFF
--- a/l10n_br_coa/models/account_chart_template.py
+++ b/l10n_br_coa/models/account_chart_template.py
@@ -50,11 +50,11 @@ class AccountChartTemplate(models.Model):
             group_accounts = {
                 int(p.res_id.split(',')[1]): {} for p in properties}
 
-            for property in properties:
-                group_accounts[int(property.res_id.split(',')[1])].update({
-                    property.fields_id.name:
+            for prop in properties:
+                group_accounts[int(prop.res_id.split(',')[1])].update({
+                    prop.fields_id.name:
                     account_ref.get(
-                        (int(property.value_reference.split(',')[1])), False)
+                        (int(prop.value_reference.split(',')[1])), False)
                 })
 
             taxes = self.env['account.tax'].browse(taxes_ref.values())

--- a/l10n_br_coa/models/account_chart_template.py
+++ b/l10n_br_coa/models/account_chart_template.py
@@ -1,13 +1,14 @@
 # Copyright 2020 KMEE
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, models
+from odoo import models
 
 
 class AccountChartTemplate(models.Model):
     _inherit = 'account.chart.template'
 
     def load_for_current_company(self, sale_tax_rate, purchase_tax_rate):
+        self.ensure_one()
         super().load_for_current_company(sale_tax_rate, purchase_tax_rate)
         # Remove Company default taxes configuration
         if self.currency_id == self.env.ref('base.BRL'):
@@ -16,9 +17,9 @@ class AccountChartTemplate(models.Model):
                 'account_purchase_tax_id': False,
             })
 
-    @api.multi
     def _load_template(self, company, code_digits=None,
                        account_ref=None, taxes_ref=None):
+        self.ensure_one()
         account_ref, taxes_ref = super()._load_template(
             company, code_digits, account_ref, taxes_ref
         )


### PR DESCRIPTION
Inicialmente era para fazer a mesma limpeza no l10n_br_coa do que no https://github.com/OCA/l10n-brazil/pull/1399

So que olhando melhor eu vi pelos corpo dos metodos e a defiiniçao dos super metodos que esses @api.multi tavam ate errados. Por sorte tava funcionando da forma como tava chamado. Botei os devidos self.ensure_one() tb.