### PR TITLE
[12.0][l10n_br_account] pylint-odoo: W7940(dangerous-view-replace-wo-priority)

### DIFF
--- a/l10n_br_account/views/account_invoice_line_view.xml
+++ b/l10n_br_account/views/account_invoice_line_view.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <record id="invoice_line_form" model="ir.ui.view">
+    <record id="invoice_line_form" model="ir.ui.view" priority="30">
         <field name="name">l10n_br_account.invoice.line.form</field>
         <field name="model">account.invoice.line</field>
         <field name="inherit_id" ref="account.view_invoice_line_form"/>

--- a/l10n_br_account/views/fiscal_invoice_view.xml
+++ b/l10n_br_account/views/fiscal_invoice_view.xml
@@ -35,7 +35,7 @@
         </field>
     </record>
 
-    <record id="fiscal_invoice_form" model="ir.ui.view">
+    <record id="fiscal_invoice_form" model="ir.ui.view" priority="30">
       <field name="name">l10n_br_account.fiscal.invoice.form</field>
       <field name="model">account.invoice</field>
       <field name="inherit_id" ref="l10n_br_fiscal.document_form"/>


### PR DESCRIPTION
antes disso o pylint-odoo reclamava:
```
l10n_br_account/views/fiscal_invoice_view.xml:38: [W7940(dangerous-view-replace-wo-priority), ]  Dangerous use of "replace" from view with priority 0 < 99
l10n_br_account/views/account_invoice_line_view.xml:4: [W7940(dangerous-view-replace-wo-priority), ]  Dangerous use of "replace" from view with priority 0 < 99
```

Geralmente funcionava, mas ate conflitar com algum outro modulo precisando dos campos e carregando a visao numa ordem aleatoria.