### PR TITLE
[12.0][ADD] Number and partner name in filename of danfe

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -622,11 +622,12 @@ class NFe(spec_models.StackedModel):
         )
         # TODO: Alterar a opção output_dir para devolter também o arquivo do XML
         # no retorno, evitando a releitura do arquivo.
+        filename = '%s - NF - %s.pdf' % (self.document_number, self.partner_name)
 
         self.file_report_id = self.env["ir.attachment"].create(
             {
-                "name": self.document_key + ".pdf",
-                "datas_fname": self.document_key + ".pdf",
+                "name": filename,
+                "datas_fname": filename,
                 "res_model": self._name,
                 "res_id": self.id,
                 "datas": base64.b64encode(pdf),

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -622,7 +622,7 @@ class NFe(spec_models.StackedModel):
         )
         # TODO: Alterar a opção output_dir para devolter também o arquivo do XML
         # no retorno, evitando a releitura do arquivo.
-        filename = '%s - NF - %s.pdf' % (self.document_number, self.partner_name)
+        filename = '%s - NF - %s.pdf' % (self.document_number, self.partner_name.replace('/', ''))
 
         self.file_report_id = self.env["ir.attachment"].create(
             {


### PR DESCRIPTION
With this Pull Request, the danfe file name becomes `<document_number> - <partner_name>.pdf` instead of `<document_key>.pdf`. 