### PR TITLE
[12.0][l10n_br_resource] 12.0 pre commit l10n_br_resource

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,6 @@ exclude: |
   ^l10n_br_product_contract/|
   ^l10n_br_purchase/|
   ^l10n_br_repair/|
-  ^l10n_br_resource/|
   ^l10n_br_website_sale/|
   ^l10n_br_website_sale_delivery/|
   ^payment_cielo/|

--- a/l10n_br_resource/models/resource_calendar.py
+++ b/l10n_br_resource/models/resource_calendar.py
@@ -21,7 +21,6 @@ class ResourceCalendar(models.Model):
             res |= self._compute_recursive_leaves(calendar.parent_id)
         return res
 
-    @api.multi
     @api.depends("parent_id")
     def _compute_leave_ids(self):
         for calendar in self:
@@ -54,7 +53,6 @@ class ResourceCalendar(models.Model):
                 _("Error! You cannot create recursive calendars.")
             )
 
-    @api.multi
     def get_leave_intervals(
         self, resource_id=None, start_datetime=None, end_datetime=None
     ):
@@ -92,7 +90,6 @@ class ResourceCalendar(models.Model):
             leaves.append(leave)
         return leaves
 
-    @api.multi
     def data_eh_feriado(self, data):
         """Verificar se uma data é feriado.
         :param datetime data_referencia: Se nenhuma data referencia for passada
@@ -115,7 +112,6 @@ class ResourceCalendar(models.Model):
                         return True
         return False
 
-    @api.multi
     def data_eh_feriado_bancario(self, data_referencia):
         """Verificar se uma data é feriado bancário.
         :param datetime data_referencia: Se nenhuma data referencia for
@@ -138,7 +134,6 @@ class ResourceCalendar(models.Model):
         leaves_count = self.env["resource.calendar.leaves"].search_count(domain)
         return leaves_count
 
-    @api.multi
     def data_eh_feriado_emendado(self, data_referencia):
         """Verificar se uma data é feriado emendado.
         :param datetime data_referencia: Se nenhuma data referencia for passada
@@ -168,7 +163,6 @@ class ResourceCalendar(models.Model):
 
         return eh_feriado and (dia_antes_eh_segunda or dia_depois_eh_sexta)
 
-    @api.multi
     def data_eh_dia_util(self, data):
         """Verificar se data é dia util.
         :param datetime data: Se nenhuma data referencia for passada
@@ -180,7 +174,6 @@ class ResourceCalendar(models.Model):
             data = datetime.now()
         return not self.data_eh_feriado(data) and data.weekday() <= 4 or False
 
-    @api.multi
     def quantidade_dias_uteis(self, data_inicio, data_fim):
         """Calcular a quantidade de dias úteis em determinado período.
         :param datetime data_inicio: Se nenhuma data referencia for passada
@@ -201,7 +194,6 @@ class ResourceCalendar(models.Model):
 
         return dias_uteis
 
-    @api.multi
     def proximo_dia_util(self, data_referencia):
         """Retornar o próximo dia util.
         :param datetime data_referencia: Se nenhuma data referencia for passada
@@ -216,7 +208,6 @@ class ResourceCalendar(models.Model):
                 return data_referencia
             data_referencia += timedelta(days=1)
 
-    @api.multi
     def get_dias_base(self, data_from, data_to, mes_comercial=True):
         """Calcular a quantidade de dias que devem ser remunerados em
         determinado intervalo de tempo.
@@ -238,7 +229,6 @@ class ResourceCalendar(models.Model):
         else:
             return quantidade_dias
 
-    @api.multi
     def data_eh_dia_util_bancario(self, data):
         """Verificar se data é dia util.
         :param datetime data: Se nenhuma data referencia for passada
@@ -254,7 +244,6 @@ class ResourceCalendar(models.Model):
             return False
         return True
 
-    @api.multi
     def proximo_dia_util_bancario(self, data_referencia):
         """Retornar o próximo dia util.
         :param datetime data_referencia: Se nenhuma data referencia for passada

--- a/l10n_br_resource/models/resource_calendar.py
+++ b/l10n_br_resource/models/resource_calendar.py
@@ -93,7 +93,7 @@ class ResourceCalendar(models.Model):
         return leaves
 
     @api.multi
-    def data_eh_feriado(self, data_referencia=datetime.now()):
+    def data_eh_feriado(self, data):
         """Verificar se uma data é feriado.
         :param datetime data_referencia: Se nenhuma data referencia for passada
                                     verifique se hoje eh feriado no calendario
@@ -106,7 +106,8 @@ class ResourceCalendar(models.Model):
         :return boolean True se a data referencia for feriado
                         False se a data referencia nao for feriado
         """
-        data = data_referencia
+        if not data:
+            data = datetime.now()
         for leave in self.leave_ids:
             if leave.date_from <= data:
                 if leave.date_to >= data:
@@ -115,7 +116,7 @@ class ResourceCalendar(models.Model):
         return False
 
     @api.multi
-    def data_eh_feriado_bancario(self, data_referencia=datetime.now()):
+    def data_eh_feriado_bancario(self, data_referencia):
         """Verificar se uma data é feriado bancário.
         :param datetime data_referencia: Se nenhuma data referencia for
                                     passada verifique se hoje é feriado
@@ -127,6 +128,8 @@ class ResourceCalendar(models.Model):
         :return int leaves_count: +1 se for feriado bancário
                                    0 se a data nao for feriado bancário
         """
+        if not data_referencia:
+            data_referencia = datetime.now()
         domain = [
             ("date_from", "<=", data_referencia.strftime("%Y-%m-%d %H:%M:%S")),
             ("date_to", ">=", data_referencia.strftime("%Y-%m-%d %H:%M:%S")),
@@ -136,7 +139,7 @@ class ResourceCalendar(models.Model):
         return leaves_count
 
     @api.multi
-    def data_eh_feriado_emendado(self, data_referencia=datetime.now()):
+    def data_eh_feriado_emendado(self, data_referencia):
         """Verificar se uma data é feriado emendado.
         :param datetime data_referencia: Se nenhuma data referencia for passada
                                    verifique se hoje é feriado emendado.
@@ -146,6 +149,8 @@ class ResourceCalendar(models.Model):
 
         :return retorna True ou False
         """
+        if not data_referencia:
+            data_referencia = datetime.now()
         eh_feriado = self.data_eh_feriado(data_referencia)
         dia_antes = data_referencia - timedelta(days=1)
         dia_depois = data_referencia + timedelta(days=1)
@@ -164,19 +169,19 @@ class ResourceCalendar(models.Model):
         return eh_feriado and (dia_antes_eh_segunda or dia_depois_eh_sexta)
 
     @api.multi
-    def data_eh_dia_util(self, data=datetime.now()):
+    def data_eh_dia_util(self, data):
         """Verificar se data é dia util.
         :param datetime data: Se nenhuma data referencia for passada
                               verifique o dia de hoje.
         :return boolean True: Se for dia útil
                         False: Se Não for dia útil
         """
+        if not data:
+            data = datetime.now()
         return not self.data_eh_feriado(data) and data.weekday() <= 4 or False
 
     @api.multi
-    def quantidade_dias_uteis(
-        self, data_inicio=datetime.now(), data_fim=datetime.now()
-    ):
+    def quantidade_dias_uteis(self, data_inicio, data_fim):
         """Calcular a quantidade de dias úteis em determinado período.
         :param datetime data_inicio: Se nenhuma data referencia for passada
                                    verifique o dia de hoje.
@@ -184,6 +189,10 @@ class ResourceCalendar(models.Model):
                                    verifique o dia de hoje.
         :return int: Quantidade de dias úteis
         """
+        if not data_inicio:
+            data_inicio = datetime.now()
+        if not data_fim:
+            data_fim = datetime.now()
         dias_uteis = 0
         while data_inicio <= data_fim:
             if self.data_eh_dia_util(data_inicio):
@@ -193,12 +202,14 @@ class ResourceCalendar(models.Model):
         return dias_uteis
 
     @api.multi
-    def proximo_dia_util(self, data_referencia=datetime.now()):
+    def proximo_dia_util(self, data_referencia):
         """Retornar o próximo dia util.
         :param datetime data_referencia: Se nenhuma data referencia for passada
                                    verifique se amanha é dia útil.
         :return datetime Proximo dia util apartir da data referencia
         """
+        if not data_referencia:
+            data_referencia = datetime.now()
         data_referencia += timedelta(days=1)
         while data_referencia:
             if self.data_eh_dia_util(data_referencia):
@@ -206,15 +217,17 @@ class ResourceCalendar(models.Model):
             data_referencia += timedelta(days=1)
 
     @api.multi
-    def get_dias_base(
-        self, data_from=datetime.now(), data_to=datetime.now(), mes_comercial=True
-    ):
+    def get_dias_base(self, data_from, data_to, mes_comercial=True):
         """Calcular a quantidade de dias que devem ser remunerados em
         determinado intervalo de tempo.
         :param datetime data_from: Data inicial do intervalo de tempo.
                datetime data_end: Data final do intervalo
         :return int : quantidade de dias que devem ser remunerada
         """
+        if not data_from:
+            data_from = datetime.now()
+        if not data_to:
+            data_to = datetime.now()
         # Mes comercial sempre será 30 dias
         if mes_comercial:
             return 30 - data_from.day + 1
@@ -226,13 +239,15 @@ class ResourceCalendar(models.Model):
             return quantidade_dias
 
     @api.multi
-    def data_eh_dia_util_bancario(self, data=datetime.now()):
+    def data_eh_dia_util_bancario(self, data):
         """Verificar se data é dia util.
         :param datetime data: Se nenhuma data referencia for passada
                               verifique o dia de hoje.
         :return boolean True: Se for dia útil
                         False: Se Não for dia útil
         """
+        if not data:
+            data = datetime.now()
         if data.weekday() >= 5:
             return False
         elif self.data_eh_feriado_bancario(data):
@@ -240,12 +255,14 @@ class ResourceCalendar(models.Model):
         return True
 
     @api.multi
-    def proximo_dia_util_bancario(self, data_referencia=datetime.now()):
+    def proximo_dia_util_bancario(self, data_referencia):
         """Retornar o próximo dia util.
         :param datetime data_referencia: Se nenhuma data referencia for passada
                                    verifique se amanha é dia útil.
         :return datetime Proximo dia util apartir da data referencia
         """
+        if not data_referencia:
+            data_referencia = datetime.now()
         data_referencia += timedelta(days=1)
         if self.data_eh_dia_util_bancario(data_referencia):
             return data_referencia

--- a/l10n_br_resource/models/resource_calendar_leaves.py
+++ b/l10n_br_resource/models/resource_calendar_leaves.py
@@ -3,49 +3,53 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import logging
+
 from odoo import fields, models
 
 _logger = logging.getLogger(__name__)
 
 TIPO_FERIADO = {
-    'F': 'Feriado',
-    'B': 'Feriado bancário',
-    'C': 'Data comemorativa',
+    "F": "Feriado",
+    "B": "Feriado bancário",
+    "C": "Data comemorativa",
 }
 
 
 ABRANGENCIA_FERIADO = {
-    'N': 'Nacional',
-    'E': 'Estadual',
-    'M': 'Municipal',
+    "N": "Nacional",
+    "E": "Estadual",
+    "M": "Municipal",
 }
 
 
 class ResourceCalendarLeave(models.Model):
 
-    _inherit = 'resource.calendar.leaves'
+    _inherit = "resource.calendar.leaves"
 
     country_id = fields.Many2one(
-        'res.country', string=u'País',
-        related='calendar_id.country_id',
+        "res.country",
+        string=u"País",
+        related="calendar_id.country_id",
     )
     state_id = fields.Many2one(
-        'res.country.state', u'Estado',
-        related='calendar_id.state_id',
+        "res.country.state",
+        u"Estado",
+        related="calendar_id.state_id",
         domain="[('country_id','=',country_id)]",
-        readonly=True
+        readonly=True,
     )
     l10n_br_city_id = fields.Many2one(
-        'res.city', u'Municipio',
-        related='calendar_id.l10n_br_city_id',
+        "res.city",
+        u"Municipio",
+        related="calendar_id.l10n_br_city_id",
         domain="[('state_id','=',state_id)]",
-        readonly=True
+        readonly=True,
     )
     leave_type = fields.Selection(
-        string=u'Tipo',
+        string=u"Tipo",
         selection=[item for item in TIPO_FERIADO.items()],
     )
     abrangencia = fields.Selection(
-        string=u'Abrangencia',
+        string=u"Abrangencia",
         selection=[item for item in ABRANGENCIA_FERIADO.items()],
     )

--- a/l10n_br_resource/readme/HISTORY.rst
+++ b/l10n_br_resource/readme/HISTORY.rst
@@ -2,4 +2,3 @@
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 * [MIG] Migration to version 10.0
-

--- a/l10n_br_resource/tests/test_resource_calendar.py
+++ b/l10n_br_resource/tests/test_resource_calendar.py
@@ -1,242 +1,276 @@
 # Copyright 2016 KMEE - Luis Felipe Mileo <mileo@kmee.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields
 import odoo.tests.common as test_common
+from odoo import fields
 
 
 class TestResourceCalendar(test_common.SingleTransactionCase):
-
     def setUp(self):
         super(TestResourceCalendar, self).setUp()
 
-        self.resource_calendar = self.env['resource.calendar']
-        self.resource_leaves = self.env['resource.calendar.leaves']
-        self.holiday_import = self.env['wizard.workalendar.holiday.import']
+        self.resource_calendar = self.env["resource.calendar"]
+        self.resource_leaves = self.env["resource.calendar.leaves"]
+        self.holiday_import = self.env["wizard.workalendar.holiday.import"]
 
-        self.nacional_calendar_id = self.resource_calendar.create({
-            'name': u'Calendario Nacional',
-            'country_id': self.env.ref("base.br").id,
-        })
-        self.leave_nacional_01 = self.resource_leaves.create({
-            'name': u'Tiradentes',
-            'date_from': fields.Datetime.to_datetime('2016-03-21 00:00:00'),
-            'date_to': fields.Datetime.to_datetime('2016-03-21 23:59:59'),
-            'calendar_id': self.nacional_calendar_id.id,
-            'leave_type': u'F',
-            'abrangencia': u'N',
-        })
-        self.estadual_calendar_id = self.resource_calendar.create({
-            'name': u'Calendario Estadual',
-            'parent_id': self.nacional_calendar_id.id,
-        })
-        self.leave_estadual_01 = self.resource_leaves.create({
-            'name': u'Aniversario de SP',
-            'date_from': fields.Datetime.to_datetime('2016-01-25 00:00:00'),
-            'date_to': fields.Datetime.to_datetime('2016-01-25 23:59:59'),
-            'calendar_id': self.estadual_calendar_id.id,
-            'leave_type': u'F',
-            'abrangencia': u'E',
-        })
-        self.municipal_calendar_id = self.resource_calendar.create({
-            'name': u'Calendario Municipal',
-            'parent_id': self.estadual_calendar_id.id,
-        })
-        self.leave_municipal_01 = self.resource_leaves.create({
-            'name': u'Aniversario Chapeco',
-            'date_from': fields.Datetime.to_datetime('2016-08-25 00:00:00'),
-            'date_to': fields.Datetime.to_datetime('2016-08-25 23:59:59'),
-            'calendar_id': self.municipal_calendar_id.id,
-            'leave_type': u'F',
-            'abrangencia': u'M',
-        })
+        self.nacional_calendar_id = self.resource_calendar.create(
+            {
+                "name": u"Calendario Nacional",
+                "country_id": self.env.ref("base.br").id,
+            }
+        )
+        self.leave_nacional_01 = self.resource_leaves.create(
+            {
+                "name": u"Tiradentes",
+                "date_from": fields.Datetime.to_datetime("2016-03-21 00:00:00"),
+                "date_to": fields.Datetime.to_datetime("2016-03-21 23:59:59"),
+                "calendar_id": self.nacional_calendar_id.id,
+                "leave_type": u"F",
+                "abrangencia": u"N",
+            }
+        )
+        self.estadual_calendar_id = self.resource_calendar.create(
+            {
+                "name": u"Calendario Estadual",
+                "parent_id": self.nacional_calendar_id.id,
+            }
+        )
+        self.leave_estadual_01 = self.resource_leaves.create(
+            {
+                "name": u"Aniversario de SP",
+                "date_from": fields.Datetime.to_datetime("2016-01-25 00:00:00"),
+                "date_to": fields.Datetime.to_datetime("2016-01-25 23:59:59"),
+                "calendar_id": self.estadual_calendar_id.id,
+                "leave_type": u"F",
+                "abrangencia": u"E",
+            }
+        )
+        self.municipal_calendar_id = self.resource_calendar.create(
+            {
+                "name": u"Calendario Municipal",
+                "parent_id": self.estadual_calendar_id.id,
+            }
+        )
+        self.leave_municipal_01 = self.resource_leaves.create(
+            {
+                "name": u"Aniversario Chapeco",
+                "date_from": fields.Datetime.to_datetime("2016-08-25 00:00:00"),
+                "date_to": fields.Datetime.to_datetime("2016-08-25 23:59:59"),
+                "calendar_id": self.municipal_calendar_id.id,
+                "leave_type": u"F",
+                "abrangencia": u"M",
+            }
+        )
 
         # Testar workalendar_holiday_import
 
-        self.calendar_id_sp = self.resource_calendar.create({
-            'name': u'Calendario de Sao Paulo',
-            'country_id': self.env.ref("base.br").id,
-            'state_id': self.env.ref("base.state_br_sp").id,
-            'l10n_br_city_id': self.env.ref("l10n_br_base.city_3500105").id
-        })
+        self.calendar_id_sp = self.resource_calendar.create(
+            {
+                "name": u"Calendario de Sao Paulo",
+                "country_id": self.env.ref("base.br").id,
+                "state_id": self.env.ref("base.state_br_sp").id,
+                "l10n_br_city_id": self.env.ref("l10n_br_base.city_3500105").id,
+            }
+        )
 
     def test_00_add_leave_nacional(self):
         """ Inclusao de um novo Feriado no calendario nacional """
-        self.leave_nacional_02 = self.resource_leaves.create({
-            'name': u'Natal',
-            'date_from': fields.Datetime.to_datetime('2016-12-24 00:00:00'),
-            'date_to': fields.Datetime.to_datetime('2016-12-24 23:59:59'),
-            'calendar_id': self.nacional_calendar_id.id,
-            'leave_type': u'F',
-            'abrangencia': u'N',
-        })
-        self.assertEqual(self.leave_nacional_02.name, u'Natal')
-        self.assertEqual(self.leave_nacional_02.calendar_id,
-                         self.nacional_calendar_id)
+        self.leave_nacional_02 = self.resource_leaves.create(
+            {
+                "name": u"Natal",
+                "date_from": fields.Datetime.to_datetime("2016-12-24 00:00:00"),
+                "date_to": fields.Datetime.to_datetime("2016-12-24 23:59:59"),
+                "calendar_id": self.nacional_calendar_id.id,
+                "leave_type": u"F",
+                "abrangencia": u"N",
+            }
+        )
+        self.assertEqual(self.leave_nacional_02.name, u"Natal")
+        self.assertEqual(self.leave_nacional_02.calendar_id, self.nacional_calendar_id)
         self.assertEqual(2, len(self.nacional_calendar_id.leave_ids))
 
     def test_01_add_leave_estadual(self):
         """ Inclusao de um novo Feriado no calendario Estadual """
-        self.leave_estadual_02 = self.resource_leaves.create({
-            'name': u'Aniversario MG',
-            'date_from': fields.Datetime.to_datetime('2016-07-16 00:00:00'),
-            'date_to': fields.Datetime.to_datetime('2016-07-16 23:59:59'),
-            'calendar_id': self.estadual_calendar_id.id,
-            'leave_type': u'F',
-            'abrangencia': u'E',
-        })
-        self.assertEqual(self.leave_estadual_02.name, u'Aniversario MG')
-        self.assertEqual(self.leave_estadual_02.calendar_id,
-                         self.estadual_calendar_id)
+        self.leave_estadual_02 = self.resource_leaves.create(
+            {
+                "name": u"Aniversario MG",
+                "date_from": fields.Datetime.to_datetime("2016-07-16 00:00:00"),
+                "date_to": fields.Datetime.to_datetime("2016-07-16 23:59:59"),
+                "calendar_id": self.estadual_calendar_id.id,
+                "leave_type": u"F",
+                "abrangencia": u"E",
+            }
+        )
+        self.assertEqual(self.leave_estadual_02.name, u"Aniversario MG")
+        self.assertEqual(self.leave_estadual_02.calendar_id, self.estadual_calendar_id)
         self.assertEqual(3, len(self.estadual_calendar_id.leave_ids))
 
     def test_02_add_leave_municipal(self):
         """ Inclusao de um novo Feriado no calendario municipal """
-        self.leave_municipal_02 = self.resource_leaves.create({
-            'name': u'Aniversario Itajuba',
-            'date_from': fields.Datetime.to_datetime('2016-03-19 00:00:00'),
-            'date_to': fields.Datetime.to_datetime('2016-03-19 23:59:59'),
-            'calendar_id': self.municipal_calendar_id.id,
-            'leave_type': u'F',
-            'abrangencia': u'M',
-        })
-        self.assertEqual(self.leave_municipal_02.name, u'Aniversario Itajuba')
-        self.assertEqual(self.leave_municipal_02.calendar_id,
-                         self.municipal_calendar_id)
+        self.leave_municipal_02 = self.resource_leaves.create(
+            {
+                "name": u"Aniversario Itajuba",
+                "date_from": fields.Datetime.to_datetime("2016-03-19 00:00:00"),
+                "date_to": fields.Datetime.to_datetime("2016-03-19 23:59:59"),
+                "calendar_id": self.municipal_calendar_id.id,
+                "leave_type": u"F",
+                "abrangencia": u"M",
+            }
+        )
+        self.assertEqual(self.leave_municipal_02.name, u"Aniversario Itajuba")
+        self.assertEqual(
+            self.leave_municipal_02.calendar_id, self.municipal_calendar_id
+        )
         self.assertEqual(4, len(self.municipal_calendar_id.leave_ids))
 
     def test_03_data_eh_feriado(self):
-        data = fields.Datetime.to_datetime('2016-08-25 00:00:01')
+        data = fields.Datetime.to_datetime("2016-08-25 00:00:01")
         data_eh_feriado = self.municipal_calendar_id.data_eh_feriado(data)
         self.assertTrue(data_eh_feriado)
 
     def test_04_obter_feriados_no_periodo(self):
         self.holidays = self.municipal_calendar_id.get_leave_intervals(
-            start_datetime=fields.Datetime.to_datetime('2016-08-01 00:00:00'),
-            end_datetime=fields.Datetime.to_datetime('2016-08-31 00:00:00'),
+            start_datetime=fields.Datetime.to_datetime("2016-08-01 00:00:00"),
+            end_datetime=fields.Datetime.to_datetime("2016-08-31 00:00:00"),
         )
         self.assertEqual(1, len(self.holidays))
 
     def test_05_data_eh_feriado_emendado(self):
-        data = fields.Datetime.to_datetime('2016-08-25 00:00:01')
-        data_eh_feriado_emendado = \
-            self.municipal_calendar_id.data_eh_feriado_emendado(data)
+        data = fields.Datetime.to_datetime("2016-08-25 00:00:01")
+        data_eh_feriado_emendado = self.municipal_calendar_id.data_eh_feriado_emendado(
+            data
+        )
         self.assertTrue(data_eh_feriado_emendado)
-        data = fields.Datetime.to_datetime('2016-03-19 00:00:01')
-        data_eh_feriado_emendado = \
-            self.municipal_calendar_id.data_eh_feriado_emendado(data)
+        data = fields.Datetime.to_datetime("2016-03-19 00:00:01")
+        data_eh_feriado_emendado = self.municipal_calendar_id.data_eh_feriado_emendado(
+            data
+        )
         self.assertFalse(data_eh_feriado_emendado)
 
     def test_06_obter_proximo_dia_util(self):
         """Dado uma data obter proximo dia util"""
         # 21-03 e feriado
-        anterior_ao_feriado = fields.Datetime.to_datetime(
-            '2016-03-20 00:00:01')
+        anterior_ao_feriado = fields.Datetime.to_datetime("2016-03-20 00:00:01")
         proximo_dia_util = self.municipal_calendar_id.proximo_dia_util(
-            anterior_ao_feriado)
-        self.assertEqual(proximo_dia_util,
-                         fields.Datetime.to_datetime('2016-03-22 00:00:01'),
-                         u'Partindo de um feriado, proximo dia util invalido')
+            anterior_ao_feriado
+        )
+        self.assertEqual(
+            proximo_dia_util,
+            fields.Datetime.to_datetime("2016-03-22 00:00:01"),
+            u"Partindo de um feriado, proximo dia util invalido",
+        )
 
-        anterior_ao_fds = fields.Datetime.to_datetime('2016-12-16 00:00:01')
-        proximo_dia_util = self.municipal_calendar_id.proximo_dia_util(
-            anterior_ao_fds)
-        self.assertEqual(proximo_dia_util,
-                         fields.Datetime.to_datetime('2016-12-19 00:00:01'),
-                         u'Partindo de um fds, proximo dia util invalido')
+        anterior_ao_fds = fields.Datetime.to_datetime("2016-12-16 00:00:01")
+        proximo_dia_util = self.municipal_calendar_id.proximo_dia_util(anterior_ao_fds)
+        self.assertEqual(
+            proximo_dia_util,
+            fields.Datetime.to_datetime("2016-12-19 00:00:01"),
+            u"Partindo de um fds, proximo dia util invalido",
+        )
 
     def test_07_get_dias_base(self):
-        """ Dado um intervalo de tempo, fornecer a quantidade de dias base
+        """Dado um intervalo de tempo, fornecer a quantidade de dias base
         para calculos da folha de pagamento"""
-        data_inicio = fields.Datetime.to_datetime('2017-01-01 00:00:01')
-        data_final = fields.Datetime.to_datetime('2017-01-31 23:59:59')
+        data_inicio = fields.Datetime.to_datetime("2017-01-01 00:00:01")
+        data_final = fields.Datetime.to_datetime("2017-01-31 23:59:59")
 
         total = self.resource_calendar.get_dias_base(data_inicio, data_final)
-        self.assertEqual(total, 30,
-                         u'Calculo de Dias Base de Jan incorreto')
+        self.assertEqual(total, 30, u"Calculo de Dias Base de Jan incorreto")
 
-        data_inicio = fields.Datetime.to_datetime('2017-02-01 00:00:01')
-        data_final = fields.Datetime.to_datetime('2017-02-28 23:59:59')
+        data_inicio = fields.Datetime.to_datetime("2017-02-01 00:00:01")
+        data_final = fields.Datetime.to_datetime("2017-02-28 23:59:59")
 
         total = self.resource_calendar.get_dias_base(data_inicio, data_final)
-        self.assertEqual(total, 30,
-                         'Calculo de Dias Base de Fev incorreto')
+        self.assertEqual(total, 30, "Calculo de Dias Base de Fev incorreto")
 
     def test_08_data_eh_dia_util(self):
-        """ Verificar se datas sao dias uteis
-        """
-        segunda = fields.Datetime.to_datetime('2017-01-09 00:00:01')
-        terca = fields.Datetime.to_datetime('2017-01-10 00:00:01')
-        sabado = fields.Datetime.to_datetime('2017-01-07 00:00:01')
-        domingo = fields.Datetime.to_datetime('2017-01-08 00:00:01')
-        feriado = fields.Datetime.to_datetime('2016-08-25 00:00:00')
+        """Verificar se datas sao dias uteis"""
+        segunda = fields.Datetime.to_datetime("2017-01-09 00:00:01")
+        terca = fields.Datetime.to_datetime("2017-01-10 00:00:01")
+        sabado = fields.Datetime.to_datetime("2017-01-07 00:00:01")
+        domingo = fields.Datetime.to_datetime("2017-01-08 00:00:01")
+        feriado = fields.Datetime.to_datetime("2016-08-25 00:00:00")
 
         self.assertTrue(
             self.municipal_calendar_id.data_eh_dia_util(segunda),
-            u"ERRO: Segunda eh dia util!")
+            u"ERRO: Segunda eh dia util!",
+        )
         self.assertTrue(
             self.municipal_calendar_id.data_eh_dia_util(terca),
-            u"ERRO: Terca eh dia util!")
+            u"ERRO: Terca eh dia util!",
+        )
 
         self.assertTrue(
             not self.municipal_calendar_id.data_eh_dia_util(sabado),
-            u"ERRO: Sabado nao eh dia util!")
+            u"ERRO: Sabado nao eh dia util!",
+        )
         self.assertTrue(
             not self.municipal_calendar_id.data_eh_dia_util(domingo),
-            u"ERRO: Domingo nao eh dia util!")
+            u"ERRO: Domingo nao eh dia util!",
+        )
 
         self.assertTrue(
             not self.municipal_calendar_id.data_eh_dia_util(feriado),
-            u"ERRO: Feriado nao eh dia util!")
+            u"ERRO: Feriado nao eh dia util!",
+        )
 
-        self.leave_nacional_02 = self.resource_leaves.create({
-            'name': u'Feriado 2017',
-            'date_from': fields.Datetime.to_datetime('2017-01-21 00:00:00'),
-            'date_to': fields.Datetime.to_datetime('2017-01-21 23:59:59'),
-            'calendar_id': self.nacional_calendar_id.id,
-            'leave_type': u'F',
-            'abrangencia': u'N',
-        })
-        feriado2 = fields.Datetime.to_datetime('2017-01-21 00:00:00')
+        self.leave_nacional_02 = self.resource_leaves.create(
+            {
+                "name": u"Feriado 2017",
+                "date_from": fields.Datetime.to_datetime("2017-01-21 00:00:00"),
+                "date_to": fields.Datetime.to_datetime("2017-01-21 23:59:59"),
+                "calendar_id": self.nacional_calendar_id.id,
+                "leave_type": u"F",
+                "abrangencia": u"N",
+            }
+        )
+        feriado2 = fields.Datetime.to_datetime("2017-01-21 00:00:00")
         self.assertTrue(
             not self.municipal_calendar_id.data_eh_dia_util(feriado2),
-            u"ERRO: Feriado2 nao eh dia util!")
+            u"ERRO: Feriado2 nao eh dia util!",
+        )
 
     def test_09_quantidade_dia_util(self):
-        """ Calcular a qunatidade de dias uteis.
-        """
-        data_inicio = fields.Datetime.to_datetime('2017-01-01 00:00:01')
-        data_final = fields.Datetime.to_datetime('2017-01-31 23:59:59')
+        """Calcular a qunatidade de dias uteis."""
+        data_inicio = fields.Datetime.to_datetime("2017-01-01 00:00:01")
+        data_final = fields.Datetime.to_datetime("2017-01-31 23:59:59")
 
         total_dias_uteis = self.resource_calendar.quantidade_dias_uteis(
-            data_inicio, data_final)
-        self.assertEqual(total_dias_uteis, 22,
-                         u'ERRO: Total dias uteis mes Jan/2017 invalido')
+            data_inicio, data_final
+        )
+        self.assertEqual(
+            total_dias_uteis, 22, u"ERRO: Total dias uteis mes Jan/2017 invalido"
+        )
 
-        data_inicio = fields.Datetime.to_datetime('2018-01-01 00:00:01')
-        data_final = fields.Datetime.to_datetime('2018-01-31 23:59:59')
+        data_inicio = fields.Datetime.to_datetime("2018-01-01 00:00:01")
+        data_final = fields.Datetime.to_datetime("2018-01-31 23:59:59")
 
         total_dias_uteis = self.resource_calendar.quantidade_dias_uteis(
-            data_inicio, data_final)
-        self.assertEqual(total_dias_uteis, 23,
-                         u'ERRO: Total dias uteis mes Jan/2018 invalido')
+            data_inicio, data_final
+        )
+        self.assertEqual(
+            total_dias_uteis, 23, u"ERRO: Total dias uteis mes Jan/2018 invalido"
+        )
 
     def test_10_data_eh_feriado_bancario(self):
         """
-         Validar se data eh feriado bancario.
+        Validar se data eh feriado bancario.
         """
         # adicionando feriado bancario
-        self.resource_leaves.create({
-            'name': u'Feriado Bancario',
-            'date_from': fields.Datetime.to_datetime('2017-01-13 00:00:00'),
-            'date_to': fields.Datetime.to_datetime('2017-01-13 23:59:59'),
-            'calendar_id': self.nacional_calendar_id.id,
-            'leave_type': u'B',
-            'abrangencia': u'N',
-        })
-        data = fields.Datetime.to_datetime('2017-01-13 01:02:03')
-        data_eh_feriado_bancario = self.nacional_calendar_id.\
-            data_eh_feriado_bancario(data)
+        self.resource_leaves.create(
+            {
+                "name": u"Feriado Bancario",
+                "date_from": fields.Datetime.to_datetime("2017-01-13 00:00:00"),
+                "date_to": fields.Datetime.to_datetime("2017-01-13 23:59:59"),
+                "calendar_id": self.nacional_calendar_id.id,
+                "leave_type": u"B",
+                "abrangencia": u"N",
+            }
+        )
+        data = fields.Datetime.to_datetime("2017-01-13 01:02:03")
+        data_eh_feriado_bancario = self.nacional_calendar_id.data_eh_feriado_bancario(
+            data
+        )
         self.assertTrue(data_eh_feriado_bancario)
 
     def test_12_get_country_from_calendar(self):
@@ -244,40 +278,41 @@ class TestResourceCalendar(test_common.SingleTransactionCase):
         Validar se o retorno do pais do holiday esta correto
         :return:
         """
-        holiday = self.holiday_import.create({
-            'interval_type': u'days',
-            'calendar_id': self.nacional_calendar_id.id,
-        })
+        holiday = self.holiday_import.create(
+            {
+                "interval_type": u"days",
+                "calendar_id": self.nacional_calendar_id.id,
+            }
+        )
 
         country_id = self.holiday_import.get_country_from_calendar(holiday)
-        self.assertEqual(country_id.code, u'BR', u'Pais incorreto.')
+        self.assertEqual(country_id.code, u"BR", u"Pais incorreto.")
 
     def test_16_proximo_dia_util_bancario(self):
-        data = fields.Datetime.to_datetime('2017-01-13 00:00:00')
-        prox_dia_ultil = self.nacional_calendar_id. \
-            proximo_dia_util_bancario(data)
-        self.assertEqual(prox_dia_ultil, fields.Datetime.
-                         to_datetime('2017-01-16 00:00:00'))
+        data = fields.Datetime.to_datetime("2017-01-13 00:00:00")
+        prox_dia_ultil = self.nacional_calendar_id.proximo_dia_util_bancario(data)
+        self.assertEqual(
+            prox_dia_ultil, fields.Datetime.to_datetime("2017-01-16 00:00:00")
+        )
 
     def test_17_holiday_import(self):
-        holiday = self.holiday_import.create({
-            'start_date': fields.Datetime.to_datetime('2018-08-28 00:00:00'),
-            'interval_type': u'years',
-            'calendar_id': self.nacional_calendar_id.id,
-        })
+        holiday = self.holiday_import.create(
+            {
+                "start_date": fields.Datetime.to_datetime("2018-08-28 00:00:00"),
+                "interval_type": u"years",
+                "calendar_id": self.nacional_calendar_id.id,
+            }
+        )
         res = holiday.holiday_import()
         self.assertTrue(res)
-        data = fields.Datetime.to_datetime('2019-03-05 00:00:00')
-        data_eh_feriado = \
-            self.nacional_calendar_id.data_eh_feriado_bancario(data)
+        data = fields.Datetime.to_datetime("2019-03-05 00:00:00")
+        data_eh_feriado = self.nacional_calendar_id.data_eh_feriado_bancario(data)
         self.assertTrue(data_eh_feriado)
 
     def test_18_data_eh_dia_util_bancario(self):
-        data = fields.Datetime.to_datetime('2017-01-16 00:00:00')
-        dia_util = self.nacional_calendar_id. \
-            data_eh_dia_util_bancario(data)
+        data = fields.Datetime.to_datetime("2017-01-16 00:00:00")
+        dia_util = self.nacional_calendar_id.data_eh_dia_util_bancario(data)
         self.assertTrue(dia_util)
-        data = fields.Datetime.to_datetime('2017-01-13 00:00:00')
-        feriado = self.nacional_calendar_id. \
-            data_eh_dia_util_bancario(data)
+        data = fields.Datetime.to_datetime("2017-01-13 00:00:00")
+        feriado = self.nacional_calendar_id.data_eh_dia_util_bancario(data)
         self.assertFalse(feriado)

--- a/l10n_br_resource/tools/__init__.py
+++ b/l10n_br_resource/tools/__init__.py
@@ -1,2 +1,1 @@
 from . import brazil_all_holidays_set
-

--- a/l10n_br_resource/tools/brazil_all_holidays_set.py
+++ b/l10n_br_resource/tools/brazil_all_holidays_set.py
@@ -9,7 +9,7 @@ class BrazilianHoliday:
 
         self.estado_ibge = estado_ibge
         self.municipio_ibge = municipio_ibge
-        self.municipio_nome = ''
+        self.municipio_nome = ""
         self.abrangencia = abrangencia
         self.tipo = tipo
         self.nome = nome
@@ -18,13 +18,13 @@ class BrazilianHoliday:
 
 # Commemorative holidays list
 COMMEMORATIVE_HOLIDAYS = [
-    'Consciência Negra',
+    "Consciência Negra",
 ]
 
 
 def brazil_all_holidays_set(year):
     """Returns all holidays in brazil
-     with their respective type and coverage"""
+    with their respective type and coverage"""
 
     holidays_set = []
 
@@ -35,11 +35,12 @@ def brazil_all_holidays_set(year):
         holiday_date = national_holidays[0]
 
         if national_holidays[1] in COMMEMORATIVE_HOLIDAYS:
-            tipo_feriado = 'C'
+            tipo_feriado = "C"
         else:
-            tipo_feriado = 'F'
-        holiday_obj = BrazilianHoliday(holiday_name, holiday_date, None, None,
-                                       'N', tipo_feriado)
+            tipo_feriado = "F"
+        holiday_obj = BrazilianHoliday(
+            holiday_name, holiday_date, None, None, "N", tipo_feriado
+        )
         if not any(x.nome == holiday_obj.nome for x in holidays_set):
             holidays_set.append(holiday_obj)
 
@@ -49,8 +50,7 @@ def brazil_all_holidays_set(year):
         holiday_name = bank_holidays[1]
         holiday_date = bank_holidays[0]
 
-        holiday_obj = BrazilianHoliday(holiday_name, holiday_date, None, None,
-                                       'N', 'B')
+        holiday_obj = BrazilianHoliday(holiday_name, holiday_date, None, None, "N", "B")
         if not any(x.nome == holiday_obj.nome for x in holidays_set):
             holidays_set.append(holiday_obj)
 
@@ -64,12 +64,15 @@ def brazil_all_holidays_set(year):
                 holiday_name = state_holidays[1]
                 holiday_date = state_holidays[0]
 
-                holiday_obj = BrazilianHoliday(holiday_name, holiday_date,
-                                               estado_ibge, None, 'E', 'F')
+                holiday_obj = BrazilianHoliday(
+                    holiday_name, holiday_date, estado_ibge, None, "E", "F"
+                )
 
                 # Check if is just a state holiday
-                if not any((x.nome == holiday_obj.nome and
-                            not x.estado_ibge) for x in holidays_set):
+                if not any(
+                    (x.nome == holiday_obj.nome and not x.estado_ibge)
+                    for x in holidays_set
+                ):
                     holidays_set.append(holiday_obj)
 
     # Get brazilian municipal holidays
@@ -84,13 +87,14 @@ def brazil_all_holidays_set(year):
                 holiday_name = city_holiday[1]
                 holiday_date = city_holiday[0]
 
-                holiday_obj = BrazilianHoliday(holiday_name, holiday_date,
-                                               estado_ibge,
-                                               municipio_ibge,
-                                               'M', 'F')
+                holiday_obj = BrazilianHoliday(
+                    holiday_name, holiday_date, estado_ibge, municipio_ibge, "M", "F"
+                )
 
                 # Check if is just a municipal holiday
-                if not any((x.nome == holiday_obj.nome and
-                            not x.municipio_ibge) for x in holidays_set):
+                if not any(
+                    (x.nome == holiday_obj.nome and not x.municipio_ibge)
+                    for x in holidays_set
+                ):
                     holidays_set.append(holiday_obj)
     return holidays_set

--- a/l10n_br_resource/views/resource_calendar_leaves_view.xml
+++ b/l10n_br_resource/views/resource_calendar_leaves_view.xml
@@ -1,21 +1,20 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright 2016 KMEE - Luis Felipe Miléo <mileo@kmee.com.br>
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
-
 <odoo>
     <record model="ir.ui.view" id="resource_calendar_leaves_form_view">
         <field name="name">resource.calendar.leaves.form (in l10n_br_resource)</field>
         <field name="model">resource.calendar.leaves</field>
-        <field name="inherit_id" ref="resource.resource_calendar_leave_form"/>
+        <field name="inherit_id" ref="resource.resource_calendar_leave_form" />
         <field name="arch" type="xml">
             <field name="calendar_id" position="after">
-                <field name="country_id"/>
-                <field name="state_id"/>
-                <field name="l10n_br_city_id"/>
+                <field name="country_id" />
+                <field name="state_id" />
+                <field name="l10n_br_city_id" />
             </field>
             <field name="name" position="after">
-                <field name="leave_type"/>
-                <field name="abrangencia"/>
+                <field name="leave_type" />
+                <field name="abrangencia" />
             </field>
         </field>
     </record>
@@ -23,11 +22,11 @@
     <record model="ir.ui.view" id="resource_calendar_leaves_search_view">
         <field name="name">resource.calendar.leaves.search (in l10n_br_resource)</field>
         <field name="model">resource.calendar.leaves</field>
-        <field name="inherit_id" ref="resource.view_resource_calendar_leaves_search"/>
+        <field name="inherit_id" ref="resource.view_resource_calendar_leaves_search" />
         <field name="arch" type="xml">
             <field name="calendar_id" position="after">
-                <field name="leave_type"/>
-                <field name="abrangencia"/>
+                <field name="leave_type" />
+                <field name="abrangencia" />
             </field>
         </field>
     </record>
@@ -35,11 +34,11 @@
     <record model="ir.ui.view" id="resource_calendar_leaves_tree_view">
         <field name="name">resource.calendar.leaves.tree (in l10n_br_resource)</field>
         <field name="model">resource.calendar.leaves</field>
-        <field name="inherit_id" ref="resource.resource_calendar_leave_tree"/>
+        <field name="inherit_id" ref="resource.resource_calendar_leave_tree" />
         <field name="arch" type="xml">
             <field name="calendar_id" position="after">
-                <field name="leave_type"/>
-                <field name="abrangencia"/>
+                <field name="leave_type" />
+                <field name="abrangencia" />
             </field>
         </field>
     </record>

--- a/l10n_br_resource/views/resource_calendar_menu.xml
+++ b/l10n_br_resource/views/resource_calendar_menu.xml
@@ -1,22 +1,22 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright 2016 KMEE - Luis Felipe Miléo <mileo@kmee.com.br>
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
-
 <odoo>
         <act_window
-            id="action_workalendar_holiday_import"
-            name="Action Import Brazilian Holidays"
-            res_model="wizard.workalendar.holiday.import"
-            src_model="resource.calendar"
-            view_type="form"
-            view_mode="form"
-            target="new"
-        />
+        id="action_workalendar_holiday_import"
+        name="Action Import Brazilian Holidays"
+        res_model="wizard.workalendar.holiday.import"
+        src_model="resource.calendar"
+        view_type="form"
+        view_mode="form"
+        target="new"
+    />
 
         <menuitem
-                action="action_workalendar_holiday_import"
-                id="sub_menu_impotigrt_holidays"
-                name="Import Brazilian Holidays"
-                parent="resource.menu_resource_config"
-                sequence="11"/>
+        action="action_workalendar_holiday_import"
+        id="sub_menu_impotigrt_holidays"
+        name="Import Brazilian Holidays"
+        parent="resource.menu_resource_config"
+        sequence="11"
+    />
 </odoo>

--- a/l10n_br_resource/views/resource_calendar_view.xml
+++ b/l10n_br_resource/views/resource_calendar_view.xml
@@ -1,19 +1,18 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright 2016 KMEE - Luis Felipe Miléo <mileo@kmee.com.br>
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
-
 <odoo>
 
     <record model="ir.ui.view" id="resource_calendar_form_view">
         <field name="name">resource.calendar.form (in l10n_br_resource)</field>
         <field name="model">resource.calendar</field>
-        <field name="inherit_id" ref="resource.resource_calendar_form"/>
+        <field name="inherit_id" ref="resource.resource_calendar_form" />
         <field name="arch" type="xml">
             <field name="company_id" position="before">
-                <field name="country_id"/>
-                <field name="state_id"/>
-                <field name="l10n_br_city_id"/>
-                <field name="parent_id"/>
+                <field name="country_id" />
+                <field name="state_id" />
+                <field name="l10n_br_city_id" />
+                <field name="parent_id" />
             </field>
         </field>
     </record>
@@ -21,12 +20,12 @@
     <record model="ir.ui.view" id="resource_calendar_search_view">
         <field name="name">resource.calendar.search (in l10n_br_resource)</field>
         <field name="model">resource.calendar</field>
-        <field name="inherit_id" ref="resource.view_resource_calendar_search"/>
+        <field name="inherit_id" ref="resource.view_resource_calendar_search" />
         <field name="arch" type="xml">
             <field name="company_id" position="before">
-                <field name="country_id"/>
-                <field name="state_id"/>
-                <field name="l10n_br_city_id"/>
+                <field name="country_id" />
+                <field name="state_id" />
+                <field name="l10n_br_city_id" />
             </field>
         </field>
     </record>
@@ -34,13 +33,13 @@
     <record model="ir.ui.view" id="resource_calendar_tree_view">
         <field name="name">resource.calendar.tree (in l10n_br_resource)</field>
         <field name="model">resource.calendar</field>
-        <field name="inherit_id" ref="resource.view_resource_calendar_tree"/>
+        <field name="inherit_id" ref="resource.view_resource_calendar_tree" />
         <field name="arch" type="xml">
             <field name="company_id" position="before">
-                <field name="country_id"/>
-                <field name="state_id"/>
-                <field name="l10n_br_city_id"/>
-                <field name="parent_id"/>
+                <field name="country_id" />
+                <field name="state_id" />
+                <field name="l10n_br_city_id" />
+                <field name="parent_id" />
             </field>
         </field>
     </record>

--- a/l10n_br_resource/wizards/workalendar_holiday_import_views.xml
+++ b/l10n_br_resource/wizards/workalendar_holiday_import_views.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version='1.0' encoding='UTF-8' ?>
 <odoo>
 
         <record id="view_workalendar_holiday_import" model="ir.ui.view">
@@ -7,10 +7,10 @@
             <field name="arch" type="xml">
                 <form string="Import Brazilian Holidays">
                     <div class="oe_title">
-                        <label string="Import Public Holidays from" for="start_date"/>
-                        <field name="start_date" class="oe_inline" readonly="0"/>
-                        <label string="until" for="end_date"/>
-                        <field name="end_date" class="oe_inline" readonly="1"/>
+                        <label string="Import Public Holidays from" for="start_date" />
+                        <field name="start_date" class="oe_inline" readonly="0" />
+                        <label string="until" for="end_date" />
+                        <field name="end_date" class="oe_inline" readonly="1" />
                     </div>
                     <group>
                         <group string="Interval">
@@ -19,7 +19,12 @@
                         </group>
                     </group>
                     <footer>
-                        <button name="holiday_import" string="Import" type="object" class="oe_highlight"/>
+                        <button
+                        name="holiday_import"
+                        string="Import"
+                        type="object"
+                        class="oe_highlight"
+                    />
                         or
                         <button string="Cancel" class="oe_link" special="cancel" />
                     </footer>

--- a/l10n_br_resource/wizards/workalendar_holiday_import_wizard.py
+++ b/l10n_br_resource/wizards/workalendar_holiday_import_wizard.py
@@ -5,6 +5,7 @@ import logging
 
 import pytz
 from dateutil.relativedelta import relativedelta
+
 from odoo import api, fields, models
 
 from ..tools.brazil_all_holidays_set import brazil_all_holidays_set
@@ -22,7 +23,7 @@ _INTERVALS = {
 class WorkalendarHolidayImport(models.TransientModel):
 
     _name = "wizard.workalendar.holiday.import"
-    _description = 'Wizard de import de feriados'
+    _description = "Wizard de import de feriados"
 
     @api.multi
     @api.depends("start_date", "interval_number", "interval_type")

--- a/l10n_br_resource/wizards/workalendar_holiday_import_wizard.py
+++ b/l10n_br_resource/wizards/workalendar_holiday_import_wizard.py
@@ -25,7 +25,6 @@ class WorkalendarHolidayImport(models.TransientModel):
     _name = "wizard.workalendar.holiday.import"
     _description = "Wizard de import de feriados"
 
-    @api.multi
     @api.depends("start_date", "interval_number", "interval_type")
     def _compute_end_date(self):
         for wiz in self:
@@ -49,19 +48,16 @@ class WorkalendarHolidayImport(models.TransientModel):
     )
     calendar_id = fields.Many2one("resource.calendar", string="Work Time")
 
-    @api.multi
     def get_state_from_calendar(self, holiday):
         state = self.env["res.country.state"].search(
             [("ibge_code", "=", holiday.estado_ibge)]
         )
         return state or False
 
-    @api.multi
     def get_country_from_calendar(self, holiday):
         country = self.env.ref("base.br")
         return country or False
 
-    @api.multi
     def get_calendar_for_country(self):
         country = self.env.ref("base.br")
         if not self.env["resource.calendar"].search_count(
@@ -80,7 +76,6 @@ class WorkalendarHolidayImport(models.TransientModel):
                 [("country_id", "=", country.id)]
             )[0]
 
-    @api.multi
     def get_calendar_for_state(self, holiday):
         state = self.get_state_from_calendar(holiday)
         if not self.env["resource.calendar"].search_count(
@@ -101,7 +96,6 @@ class WorkalendarHolidayImport(models.TransientModel):
                 0
             ]
 
-    @api.multi
     def get_calendar_for_city(self, holiday):
         if not self.env["res.city"].search_count(
             [("ibge_code", "=", holiday.municipio_ibge)]
@@ -142,7 +136,6 @@ class WorkalendarHolidayImport(models.TransientModel):
                 [("l10n_br_city_id", "=", city_id.id)]
             )[0]
 
-    @api.multi
     def holiday_import(self):
         tz_br = pytz.timezone("America/Sao_Paulo")
 


### PR DESCRIPTION
Same reasoning as #1433 but with the module l10n_br_resource

The PR contains flake8 fixes for these errors:
```
l10n_br_resource/models/resource_calendar.py:96:47: B008 Do not perform function calls in argument defaults.  The call is performed only once at function definition time. All calls to your function will reuse the result of that definition-time function call.  If this is intended, assign the function call to a module-level variable and use that variable as a default value.
l10n_br_resource/models/resource_calendar.py:118:56: B008 Do not perform function calls in argument defaults.  The call is performed only once at function definition time. All calls to your function will reuse the result of that definition-time function call.  If this is intended, assign the function call to a module-level variable and use that variable as a default value.
l10n_br_resource/models/resource_calendar.py:139:56: B008 Do not perform function calls in argument defaults.  The call is performed only once at function definition time. All calls to your function will reuse the result of that definition-time function call.  If this is intended, assign the function call to a module-level variable and use that variable as a default value.
l10n_br_resource/models/resource_calendar.py:167:37: B008 Do not perform function calls in argument defaults.  The call is performed only once at function definition time. All calls to your function will reuse the result of that definition-time function call.  If this is intended, assign the function call to a module-level variable and use that variable as a default value.
l10n_br_resource/models/resource_calendar.py:178:27: B008 Do not perform function calls in argument defaults.  The call is performed only once at function definition time. All calls to your function will reuse the result of that definition-time function call.  If this is intended, assign the function call to a module-level variable and use that variable as a default value.
l10n_br_resource/models/resource_calendar.py:178:52: B008 Do not perform function calls in argument defaults.  The call is performed only once at function definition time. All calls to your function will reuse the result of that definition-time function call.  If this is intended, assign the function call to a module-level variable and use that variable as a default value.
l10n_br_resource/models/resource_calendar.py:196:48: B008 Do not perform function calls in argument defaults.  The call is performed only once at function definition time. All calls to your function will reuse the result of that definition-time function call.  If this is intended, assign the function call to a module-level variable and use that variable as a default value.
l10n_br_resource/models/resource_calendar.py:210:25: B008 Do not perform function calls in argument defaults.  The call is performed only once at function definition time. All calls to your function will reuse the result of that definition-time function call.  If this is intended, assign the function call to a module-level variable and use that variable as a default value.
l10n_br_resource/models/resource_calendar.py:210:49: B008 Do not perform function calls in argument defaults.  The call is performed only once at function definition time. All calls to your function will reuse the result of that definition-time function call.  If this is intended, assign the function call to a module-level variable and use that variable as a default value.
l10n_br_resource/models/resource_calendar.py:229:46: B008 Do not perform function calls in argument defaults.  The call is performed only once at function definition time. All calls to your function will reuse the result of that definition-time function call.  If this is intended, assign the function call to a module-level variable and use that variable as a default value.
l10n_br_resource/models/resource_calendar.py:243:57: B008 Do not perform function calls in argument defaults.  The call is performed only once at function definition time. All calls to your function will reuse the result of that definition-time function call.  If this is intended, assign the function call to a module-level variable and use that variable as a default value.
```

That being said I left the datetime.now() function while Odoo code traditionally uses fields.Datetime.now() instead. But it turns out it does almost the same thing (only reset microseconds). In doubt I didn't change and left datetime.now().