### PR TITLE
[12.0][IMP] Validate XML before export

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -436,6 +436,10 @@ class NFe(spec_models.StackedModel):
             record._export_fields_pagamentos()
             processador = record._processador()
             for edoc in record.serialize():
+                try:
+                    processador.valida_xml(edoc)
+                except Exception as e:
+                    raise UserError(_("Erro de validação do XML: {}".format(e)))
                 processo = None
                 for p in processador.processar_documento(edoc):
                     processo = p

--- a/l10n_br_nfse_ginfes/models/document.py
+++ b/l10n_br_nfse_ginfes/models/document.py
@@ -258,6 +258,11 @@ class Document(models.Model):
 
             if not protocolo:
                 for edoc in record.serialize():
+                    try:
+                        processador.valida_xml(edoc)
+                    except Exception as e:
+                        raise UserError(_(
+                            "Erro de validação do XML: {}".format(e)))
                     processo = None
                     for p in processador.processar_documento(edoc):
                         processo = p

--- a/l10n_br_nfse_paulistana/models/document.py
+++ b/l10n_br_nfse_paulistana/models/document.py
@@ -292,6 +292,12 @@ class Document(models.Model):
 
             if not protocolo:
                 for edoc in record.serialize():
+                    try:
+                        processador.valida_xml(edoc)
+                    except Exception as e:
+                        raise UserError(_(
+                            "Erro de validação do XML: {}".format(e)))
+
                     processo = None
                     for p in processador.processar_documento(edoc):
                         processo = p


### PR DESCRIPTION
With this pull request the system will validate the document XML with the XSD file before send it. This will avoid the generic rejection "225: Falha no Schema XML do lote de NFe".