### PR TITLE
[12.0][FIX] Conflict canceling NF-e with NFS-e installed

### DIFF
--- a/l10n_br_nfse_paulistana/models/document.py
+++ b/l10n_br_nfse_paulistana/models/document.py
@@ -374,6 +374,9 @@ class Document(models.Model):
             return status
 
     def _exec_before_SITUACAO_EDOC_CANCELADA(self, old_state, new_state):
-        super(Document, self)._exec_before_SITUACAO_EDOC_CANCELADA(
-            old_state, new_state)
-        return self.cancel_document_paulistana()
+        docs = self.filtered(filter_oca_nfse).filtered(filter_paulistana)
+        if docs:
+            return docs.cancel_document_paulistana()
+        return super(
+            Document, self - docs
+        )._exec_before_SITUACAO_EDOC_CANCELADA(old_state, new_state)


### PR DESCRIPTION
When both `l10n_br_nfe` and `l10n_br_nfse_paulistana` are installed, there's a conflict and the system can't cancel a NF-e. This Pull Request solves that.