### PR TITLE
[12.0][FIX][BUG] Method _name_search for fiscal data abstract.

### DIFF
--- a/l10n_br_fiscal/models/data_abstract.py
+++ b/l10n_br_fiscal/models/data_abstract.py
@@ -43,7 +43,7 @@ class DataAbstract(models.AbstractModel):
                     "('name', 'ilike', self + '%')]",
                 )
 
-            orm.setup_modifiers(node)
+                orm.setup_modifiers(node)
             model_view["arch"] = etree.tostring(doc)
 
         return model_view

--- a/l10n_br_fiscal/models/data_abstract.py
+++ b/l10n_br_fiscal/models/data_abstract.py
@@ -67,7 +67,13 @@ class DataAbstract(models.AbstractModel):
                     ],
                 ]
             )
-            return self._search(domain, limit=limit, access_rights_uid=name_get_uid)
+            recs = self._search(
+                expression.AND([domain, args]),
+                limit=limit,
+                access_rights_uid=name_get_uid,
+            )
+            return self.browse(recs).name_get()
+
         return super()._name_search(
             name, args=args, operator=operator, limit=limit, name_get_uid=name_get_uid
         )


### PR DESCRIPTION
Method _name_search should return browse records, if you try to search for example Document Type in Fiscal Document you got this error

![image](https://user-images.githubusercontent.com/6341149/122422839-da882700-cf63-11eb-9bab-aea3df6efd3d.png)

Fixed https://github.com/OCA/l10n-brazil/issues/1473

O erro acontece ao tentar pesquisar um item, caso testado foi o campo "Tipo de Documento" no "Documento Fiscal" pelo o que entendi é preciso passar no retorno os objetos e não o metodo _search

cc @vanderleiromera @renatonlima @rvalyi @marcelsavegnago @mileo 
 