### PR TITLE
[12.0][FIX] Compute field own_number_without_zfill should keep right zeros.

### DIFF
--- a/l10n_br_account_payment_order/models/account_move_line.py
+++ b/l10n_br_account_payment_order/models/account_move_line.py
@@ -231,9 +231,31 @@ class AccountMoveLine(models.Model):
     @api.multi
     @api.depends('own_number')
     def _compute_own_number_without_zfill(self):
+        """
+        No arquivo de retorno do CNAB o campo pode ter um tamanho
+        diferente, o tamanho do campo é preenchido na totalidade
+        com zeros a esquerda, e no odoo o tamanho do sequencial pode
+        estar diferente
+        ex.: retorno cnab 0000000000000201 own_number 0000000201
+
+        O campo own_number_without_zfill foi a forma que encontrei
+        para poder fazer um search o nosso_numero_cnab_retorno.lstrip("0") e
+        ter algo:
+        ex.:
+        arquivo retorno cnab 201 own_number_without_zfill 201
+
+        É usado o lstrip() para manter os zeros a direita, exemplo:
+            VALOR '0000000090'
+            | strip | rstrip | lstrip | 9 000000009 90
+
+            Valor '00000000201'
+            | strip | rstrip | lstrip | 201 00000000201 201
+
+        :return: Valor sem os zeros a esquerda
+        """
         for record in self:
             if record.own_number:
-                record.own_number_without_zfill = record.own_number.strip('0')
+                record.own_number_without_zfill = record.own_number.lstrip('0')
 
     @api.multi
     @api.depends('payment_mode_id')


### PR DESCRIPTION
Compute field own_number_without_zfill should keep right zeros to avoid error

            VALOR '0000000090'
            | strip | rstrip | lstrip | 9 000000009 90

            Valor '00000000201'
            | strip | rstrip | lstrip | 201 00000000201 201

PR simples talvez poderia estar apenas como um commit no PR do BRCobranca, porém para evitar conflito de arquivo durante "rebase" e sendo uma correção fiz esse PR

cc @renatonlima @rvalyi @marcelsavegnago @mileo 