### PR TITLE
[12.0][FIX] l10n_br_currency_rate_update: converts the value returned by the BCB.

### DIFF
--- a/l10n_br_currency_rate_update/models/res_currency_rate_provider_bcb.py
+++ b/l10n_br_currency_rate_update/models/res_currency_rate_provider_bcb.py
@@ -75,9 +75,9 @@ class ResCurrencyRateProviderBCB(models.Model):
                         ).strftime(DEFAULT_SERVER_DATE_FORMAT)
 
                         if data.get(rate_date):
-                            data[rate_date][cur] = rate.get("cotacaoVenda")
+                            data[rate_date][cur] = 1 / rate.get("cotacaoVenda")
                         else:
-                            rate_dict = {cur: rate.get("cotacaoVenda")}
+                            rate_dict = {cur: 1 / rate.get("cotacaoVenda")}
                             data[rate_date] = rate_dict
 
             return data


### PR DESCRIPTION
Neste caso, desta forma o sistema converte para o valor de quanto uma unidade da moeda da empresa representa na moeda estrangeira similar ao comportamento padrão do sistema. Atualmente, o valor da cotação é o valor de quanto uma unidade da moeda da moeda estrangeira representa na moeda da empresa.

Enfim, utilizando o exemplo do Dólar, atualmente o valor retornado é 4,97 e não 0,20. (valores aproximados).

Tentei trabalhar com o módulo currency_rate_inverted mas não tive o resultado esperado.. pensei que isto resolveria mas não tive sucesso.

Ref. #1483 