### PR TITLE
[FIX] Not copy NF-e env and version always get from default

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -98,12 +98,14 @@ class NFe(spec_models.StackedModel):
     nfe_version = fields.Selection(
         selection=NFE_VERSIONS,
         string='NFe Version',
+        copy=False,
         default=lambda self: self.env.user.company_id.nfe_version,
     )
 
     nfe_environment = fields.Selection(
         selection=NFE_ENVIRONMENTS,
         string='NFe Environment',
+        copy=False,
         default=lambda self: self.env.user.company_id.nfe_environment,
     )
 


### PR DESCRIPTION
Se uma base de dados de produção for replicada para testes, se você duplicar uma já existente, o campo de ambiente e versão da NF-e não deve ser copiados, mas sim ser pego do atributo default dos respectivos campos.