### PR TITLE
[FIX] check if sale_id.note is false

### DIFF
--- a/l10n_br_sale_stock/wizards/stock_invoice_onshipping.py
+++ b/l10n_br_sale_stock/wizards/stock_invoice_onshipping.py
@@ -25,7 +25,7 @@ class StockInvoiceOnshipping(models.TransientModel):
             )
             if pick.sale_id.payment_term_id.id != values["payment_term_id"]:
                 values.update({"payment_term_id": pick.sale_id.payment_term_id.id})
-            if pick.sale_id.copy_note:
+            if pick.sale_id.copy_note and pick.sale_id.note:
                 values.update(
                     {
                         "customer_additional_data": (


### PR DESCRIPTION
Se estiver definido para copiar as observações do pedido nos dados adicionais do documento fiscal e o campo sale_id.note estiver vazio é gerado um erro ao concatenar bool + str, para resolver isso é verificado se o sale_id.note não é false.