### PR TITLE
[12.0] Correções na Emissão da NF-e

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -60,10 +60,14 @@ def filter_processador_edoc_nfe(record):
 
 class NFe(spec_models.StackedModel):
     _name = 'l10n_br_fiscal.document'
-    _inherit = ["l10n_br_fiscal.document", "nfe.40.infnfe", "nfe.40.infadic",
-                "nfe.40.exporta"]
+    _inherit = [
+        "l10n_br_fiscal.document",
+        "nfe.40.infnfe",
+        "nfe.40.infadic",
+        "nfe.40.exporta"
+    ]
     _stacked = 'nfe.40.infnfe'
-    _stack_skip = ('nfe40_veicTransp')
+    _stack_skip = ('nfe40_veicTransp', 'nfe40_exporta')
     _field_prefix = 'nfe40_'
     _schema_name = 'nfe'
     _schema_version = '4.0.0'

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -437,19 +437,6 @@ class NFeLine(spec_models.StackedModel):
                 xsd_fields.remove('nfe40_vBC')
                 xsd_fields.remove('nfe40_pCOFINS')
 
-        if class_obj._name == 'nfe.40.icmsufdest':
-            # DIFAL
-            self.nfe40_vBCUFDest = str("%.02f" % self.icms_destination_base)
-            self.nfe40_vBCFCPUFDest = str("%.02f" % self.icmsfcp_base)
-            self.nfe40_pFCPUFDest = str("%.04f" % self.icmsfcp_percent)
-            self.nfe40_pICMSUFDest = str("%.04f" % self.icms_destination_percent)
-            if self.icms_origin_percent:
-                self.nfe40_pICMSInter = str("%.02f" % self.icms_origin_percent)
-            self.nfe40_pICMSInterPart = str("%.04f" % self.icms_sharing_percent)
-            self.nfe40_vFCPUFDest = str("%.02f" % self.icmsfcp_value)
-            self.nfe40_vICMSUFDest = str("%.02f" % self.icms_destination_value)
-            self.nfe40_vICMSUFRemet = str("%.02f" % self.icms_origin_value)
-
         self.nfe40_NCM = self.ncm_id.code_unmasked or False
         self.nfe40_CEST = self.cest_id and self.cest_id.code_unmasked or False
         self.nfe40_qCom = self.quantity

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -39,7 +39,7 @@ class ResPartner(spec_models.SpecModel):
                              inverse='_inverse_nfe40_CNPJ',
                              store=True)
     nfe40_CPF = fields.Char(compute='_compute_nfe_data',
-                            inverse='_inverse_nfe40_CNPJ',
+                            inverse='_inverse_nfe40_CPF',
                             store=True)
     nfe40_xLgr = fields.Char(related='street', readonly=False)
     nfe40_nro = fields.Char(related='street_number', readonly=False)
@@ -58,7 +58,7 @@ class ResPartner(spec_models.SpecModel):
 
     # nfe.40.dest
     nfe40_xNome = fields.Char(related='legal_name')
-    nfe40_enderDest = fields.Many2one('res.partner',
+    nfe40_enderDest = fields.Many2one(comodel_name='res.partner',
                                       compute='_compute_nfe40_enderDest')
     nfe40_indIEDest = fields.Selection(related='ind_ie_dest')
     nfe40_IE = fields.Char(related='inscr_est')
@@ -69,17 +69,22 @@ class ResPartner(spec_models.SpecModel):
     # nfe.40.infresptec
     nfe40_xContato = fields.Char(related='legal_name')
 
-    nfe40_choice2 = fields.Selection([
-        ('nfe40_CNPJ', 'CNPJ'),
-        ('nfe40_CPF', 'CPF')],
-        "CNPJ/CPF do Parceiro")
+    nfe40_choice2 = fields.Selection(
+        selection=[
+            ('nfe40_CNPJ', 'CNPJ'),
+            ('nfe40_CPF', 'CPF')
+        ],
+        string="CNPJ/CPF do Parceiro",
+    )
 
-    nfe40_choice7 = fields.Selection([
-        ('nfe40_CNPJ', 'CNPJ'),
-        ('nfe40_CPF', 'CPF'),
-        ('nfe40_idEstrangeiro', 'idEstrangeiro')],
+    nfe40_choice7 = fields.Selection(
+        selection=[
+            ('nfe40_CNPJ', 'CNPJ'),
+            ('nfe40_CPF', 'CPF'),
+            ('nfe40_idEstrangeiro', 'idEstrangeiro')],
         compute='_compute_nfe_data',
-        string="CNPJ/CPF/idEstrangeiro")
+        string="CNPJ/CPF/idEstrangeiro",
+    )
 
     @api.multi
     def _compute_nfe40_xEnder(self):


### PR DESCRIPTION
Algumas correções da NF-e:

- [x] Removido código duplicado do DIFAL no método _export_fields do l10n_br_document.line;
- [x] Adicionado a classe nfe.40.exporta no atributo  _stack_skip para não preencher a tag vazia no XML quando não tiver nenhuma informação na tag.
- [x] No partner o campo nfe40_CPF estava com o atributo inverse errado.
- [x] Adicionado na definições dos campos o nome dos atributos para deixar o código mais legível  