### PR TITLE
[12.0][l10n_br_fiscal] _compute_* should assign all records

### DIFF
--- a/l10n_br_fiscal/models/certificate.py
+++ b/l10n_br_fiscal/models/certificate.py
@@ -116,6 +116,8 @@ class Certificate(models.Model):
                     c.owner_name or "",
                     format_date(self.env, c.date_expiration),
                 )
+            else:
+                c.name = False
 
     @api.depends("date_expiration")
     def _compute_is_valid(self):

--- a/l10n_br_fiscal/models/operation_document_type.py
+++ b/l10n_br_fiscal/models/operation_document_type.py
@@ -49,5 +49,4 @@ class OperationDocumentType(models.Model):
             document_serie = record.document_serie_id.name
             if not document_serie:
                 document_serie = "Series not defined"
-            if record.document_type_id:
-                record.name = record.document_type_id.name + " - " + document_serie
+            record.name = record.document_type_id.name + " - " + document_serie


### PR DESCRIPTION
Pessoal, na v12 isso cria erros do tipo CacheMiss nos logs e na v14 nao vai perdoar da bug direito entao bora corrigir isso na v12 ja...

Eu fiz um review sistematico dos _compute_* do l10n_br_fiscal e so achei esse no l10n_br_fiscal/models/certificate.py (na vdd foi o @renatonlima que achou)

no l10n_br_fiscal/models/operation_document_type.py pensei ver um falso positivo, mas ai vi que o document_type_id era required então aproveitei para simplificar o codigo.