### PR TITLE
[12.0][FIX] Fill ICMS FCP fields only if not empty

### DIFF
--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -370,11 +370,14 @@ class NFeLine(spec_models.StackedModel):
             'pCredSN': str('%.04f' % self.icmssn_percent),
             'vCredICMSSN': str("%.02f" % self.icmssn_credit_value),
 
-            # FUNDO DE COMBATE À POBREZA
-            'vBCFCPST': str('%.02f' % self.icmsfcp_base),
-            'pFCPST': str('%.04f' % self.icmsfcp_percent),
-            'vFCPST': str('%.02f' % self.icmsfcpst_value),
         }
+        if self.icmsfcp_percent:
+            icms.update({
+                # FUNDO DE COMBATE À POBREZA
+                'vBCFCPST': str('%.02f' % self.icmsfcp_base),
+                'pFCPST': str('%.04f' % self.icmsfcp_percent),
+                'vFCPST': str('%.02f' % self.icmsfcpst_value),
+            })
         return icms
 
     def _export_fields(self, xsd_fields, class_obj, export_dict):


### PR DESCRIPTION
This Pull Request was made to avoid the rejection 881, that occurs when the tags of the tax ICMS FCP are exported even when the tax is not present in the item.