### PR TITLE
[12.0][FIX] Picking invoicing details

### DIFF
--- a/l10n_br_sale_stock/wizards/stock_invoice_onshipping.py
+++ b/l10n_br_sale_stock/wizards/stock_invoice_onshipping.py
@@ -78,5 +78,9 @@ class StockInvoiceOnshipping(models.TransientModel):
             # sale_line_id é preciso ignora-la
             if moves.sale_line_id:
                 values["sale_line_ids"] = [(6, 0, moves.sale_line_id.ids)]
+                line = moves.sale_line_id
+                if line.quantity != values['quantity'] and line.discount:
+                    values['discount_value'] = values['quantity'] * \
+                        values['price_unit'] * (line.discount / 100)
 
         return values

--- a/l10n_br_sale_stock/wizards/stock_invoice_onshipping.py
+++ b/l10n_br_sale_stock/wizards/stock_invoice_onshipping.py
@@ -73,12 +73,15 @@ class StockInvoiceOnshipping(models.TransientModel):
         values = super()._get_invoice_line_values(moves, invoice_values, invoice)
         # Devido ao KEY com sale_line_id aqui
         # vem somente um registro
-        if len(moves) == 1:
+        if len(moves) == 1 or len(moves.mapped('sale_line_id')) == 1:
             # Caso venha apenas uma linha porem sem
             # sale_line_id é preciso ignora-la
+            moves = moves[0]
             if moves.sale_line_id:
                 values["sale_line_ids"] = [(6, 0, moves.sale_line_id.ids)]
                 line = moves.sale_line_id
+                if line.price_unit != values['price_unit']:
+                    values['price_unit'] = values['fiscal_price'] = line.price_unit
                 if line.quantity != values['quantity'] and line.discount:
                     values['discount_value'] = values['quantity'] * \
                         values['price_unit'] * (line.discount / 100)


### PR DESCRIPTION
This Pull Request solves some user cases while invoicing a picking:

- [x] The discount value being passed to the invoice lines, instead of the discount percentage, even when it was delivered less than the Sale Order quantity.
- [x] When delivered more than the original quantity, the price going to the invoice lines was the original price of the product, not the price defined in the Sale Order.