### PR TITLE
[12.0][FIX] Export NFref

### DIFF
--- a/l10n_br_nfe/models/document_related.py
+++ b/l10n_br_nfe/models/document_related.py
@@ -70,7 +70,8 @@ class NFeRelated(spec_models.StackedModel):
         """Set schema data which are not just related fields"""
         for rec in self:
             document = rec.document_related_id
-            document_key = document.document_key[3:] if document.document_key else ""
+            document_key = document.document_key[3:] \
+                if document.document_key else rec.document_key or ""
             if rec.document_type_id:
                 if rec.document_type_id.code in (
                     MODELO_FISCAL_NFE,


### PR DESCRIPTION
Export tag NFref without errors if the field document_related_id is not filled.