### PR TITLE
[12.0] Fiscal Document amount financial

### DIFF
--- a/l10n_br_fiscal/models/document_fiscal_line_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin.py
@@ -226,6 +226,11 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         compute="_compute_amounts",
     )
 
+    financial_total = fields.Monetary(
+        string="Amount Financial",
+        compute="_compute_amounts",
+    )
+
     amount_tax_not_included = fields.Monetary(string="Amount Tax not Included")
 
     amount_tax_withholding = fields.Monetary(string="(-) Amount Tax Withholding")

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -147,9 +147,9 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 and record.fiscal_operation_line_id.add_to_amount
                 and (not record.cfop_id or record.cfop_id.finance_move)
             ):
-                record.amount_financial = record.amount_taxed
+                record.financial_total = record.amount_taxed
             else:
-                record.amount_financial = 0.0
+                record.financial_total = 0.0
 
     def _compute_taxes(self, taxes, cst=None):
         self.ensure_one()

--- a/l10n_br_fiscal/models/document_fiscal_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin.py
@@ -295,7 +295,7 @@ class FiscalDocumentMixin(models.AbstractModel):
         string="Amount Tax Withholding", compute="_compute_amount"
     )
 
-    amount_financial = fields.Monetary(
+    amount_financial_total = fields.Monetary(
         string="Amount Financial",
         compute="_compute_amount",
     )

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -83,11 +83,6 @@ class DocumentLine(models.Model):
         compute="_compute_amounts",
     )
 
-    amount_financial = fields.Monetary(
-        string="Amount Financial",
-        compute="_compute_amounts",
-    )
-
     amount_total = fields.Monetary(
         string="Amount Total",
         compute="_compute_amounts",

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -481,7 +481,7 @@
                     <field name="amount_tax" />
                     <field name="amount_total" />
                     <field name="amount_tax_withholding" />
-                    <field name="amount_financial" />
+                    <field name="amount_financial_total" />
                   </group>
                 </group>
               </group>

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -416,7 +416,7 @@ class NFe(spec_models.StackedModel):
         }
 
     def _export_fields_pagamentos(self):
-        if not self.amount_financial:
+        if not self.amount_financial_total:
             self.nfe40_detPag = [
                 (5, 0, 0),
                 (0, 0, self._prepare_amount_financial("0", "90", 0.00)),

--- a/l10n_br_nfe/tests/test_nfe_serialize.py
+++ b/l10n_br_nfe/tests/test_nfe_serialize.py
@@ -66,7 +66,7 @@ class TestNFeExport(TransactionCase):
             nfe_id.nfe40_nNF = "1"
             nfe_id.nfe40_cDV = "1"
             financial_vals = nfe_id._prepare_amount_financial(
-                "0", "01", nfe_id.amount_financial
+                "0", "01", nfe_id.amount_financial_total
             )
             nfe_id.nfe40_detPag = [(5, 0, 0), (0, 0, financial_vals)]
             nfe_id.with_context(lang="pt_BR")._document_export()

--- a/l10n_br_nfse/report/danfse.xml
+++ b/l10n_br_nfse/report/danfse.xml
@@ -554,7 +554,7 @@ row {
                     (=) Valor Líquido R$
                 </div>
                 <div class="col-2 linha centro br">
-                    <span t-field="doc.amount_financial" />
+                    <span t-field="doc.amount_financial_total" />
                 </div>
                 <div class="col-2 rotulo br">
                     Incentivador Cultural: 2 - Não

--- a/l10n_br_sale/views/sale_view.xml
+++ b/l10n_br_sale/views/sale_view.xml
@@ -53,7 +53,7 @@
             </field>
             <field name="amount_total" position="after">
                 <field
-                    name="amount_financial"
+                    name="amount_financial_total"
                     widget='monetary'
                     options="{'currency_field': 'currency_id'}"
                 />


### PR DESCRIPTION
Pessoal,


Esse PR corrige um problema acabou passando despercebido no PR https://github.com/OCA/l10n-brazil/pull/1420:

No objeto l10n_br_fiscal.document.line existia o campo financial_amount, mas por não esta no l10n_br_fiscal.document.fiscal.mixin e ser usado 10n_br_fiscal.document.fiscal.mixin.methods gerava um erro nos pedido de venda, compras...

Foi renomeado o campo no l10n_br_fiscal.document.line de amount_financial financial_total e no l10n_br_fiscal.document de amount_financial para amount_financial_total para ser calculado os totais corretamente.

* Esse PR não precisa de script de migração, porque hoje esses campos são calculados. 