### PR TITLE
[12.0][FIX] l10n_br_contract: set currency_id as editable

### DIFF
--- a/l10n_br_contract/models/contract_contract.py
+++ b/l10n_br_contract/models/contract_contract.py
@@ -8,6 +8,10 @@ class ContractContract(models.Model):
     _name = "contract.contract"
     _inherit = [_name, "l10n_br_fiscal.document.mixin"]
 
+    currency_id = fields.Many2one(
+        readonly=False,
+    )
+
     @api.model
     def _fiscal_operation_domain(self):
         domain = [("state", "=", "approved")]


### PR DESCRIPTION
Nativamente o campo currency_id é editável mas o modelo fiscal.document.mixin faz com que este campo fique readonly quando é instalado o módulo l10n_br_contract.

cc @mileo @renatonlima @rvalyi 