### PR TITLE
[12.0][FIX] l10n_br_contract: populating the invoice.tax_line_ids field

### DIFF
--- a/l10n_br_contract/models/contract_contract.py
+++ b/l10n_br_contract/models/contract_contract.py
@@ -87,6 +87,9 @@ class ContractContract(models.Model):
                 line._onchange_product_id_fiscal()
                 line.price_unit = line.contract_line_id.price_unit
                 line._onchange_fiscal_operation_id()
+                line._onchange_fiscal_tax_ids()
+
+            invoice._onchange_invoice_line_ids()
 
     @api.multi
     def _prepare_recurring_invoices_values(self, date_ref=False):


### PR DESCRIPTION
Quando é criado uma invoice pelo módulo de contratos os impostos são carregados na linha da invoice mas não são gerados dados para o campo invoice.tax_line_ids

cc @mileo @gabrielcardoso21 @luismalta @renatonlima @rvalyi 