### PR TITLE
[FIX] Comment and additional data for document fiscal line

### DIFF
--- a/l10n_br_fiscal/demo/fiscal_document_demo.xml
+++ b/l10n_br_fiscal/demo/fiscal_document_demo.xml
@@ -305,6 +305,11 @@
             name="fiscal_operation_line_id"
             ref="l10n_br_fiscal.fo_venda_venda_nao_contribuinte"
         />
+        <field
+            name="comment_ids"
+            eval="[(6,0,[ref('l10n_br_fiscal.fiscal_line_comment_dummy')])]"
+        />
+        <field name="manual_additional_data">manual comment test</field>
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_product_id_fiscal">

--- a/l10n_br_fiscal/models/comment.py
+++ b/l10n_br_fiscal/models/comment.py
@@ -119,7 +119,7 @@ class Comment(models.Model):
 
         if self.ids:
             return False
-            
+
         from jinja2.sandbox import SandboxedEnvironment
 
         mako_template_env = SandboxedEnvironment(

--- a/l10n_br_fiscal/models/comment.py
+++ b/l10n_br_fiscal/models/comment.py
@@ -115,7 +115,7 @@ class Comment(models.Model):
 
         return u"{pre}{0}{post}".format(formatted_amount, pre=pre, post=post)
 
-    def compute_message(self, vals):
+    def compute_message(self, vals, manual_comment=None):
         from jinja2.sandbox import SandboxedEnvironment
 
         mako_template_env = SandboxedEnvironment(
@@ -158,12 +158,11 @@ class Comment(models.Model):
         mako_safe_env = copy.copy(mako_template_env)
         mako_safe_env.autoescape = False
 
-        result = []
+        comments = [manual_comment] if manual_comment else []
         for record in self:
             template = mako_safe_env.from_string(tools.ustr(record.comment))
-            render_result = template.render(vals)
-            result.append(render_result)
-        return result
+            comments.append(template.render(vals))
+        return " - ".join(comments)
 
     def action_test_message(self):
         vals = {"user": self.env.user, "ctx": self._context, "doc": self.object_id}

--- a/l10n_br_fiscal/models/comment.py
+++ b/l10n_br_fiscal/models/comment.py
@@ -116,6 +116,10 @@ class Comment(models.Model):
         return u"{pre}{0}{post}".format(formatted_amount, pre=pre, post=post)
 
     def compute_message(self, vals, manual_comment=None):
+
+        if self.ids:
+            return False
+            
         from jinja2.sandbox import SandboxedEnvironment
 
         mako_template_env = SandboxedEnvironment(

--- a/l10n_br_fiscal/models/comment.py
+++ b/l10n_br_fiscal/models/comment.py
@@ -158,11 +158,11 @@ class Comment(models.Model):
         mako_safe_env = copy.copy(mako_template_env)
         mako_safe_env.autoescape = False
 
-        result = ""
+        result = []
         for record in self:
             template = mako_safe_env.from_string(tools.ustr(record.comment))
             render_result = template.render(vals)
-            result += render_result + "\n"
+            result.append(render_result)
         return result
 
     def action_test_message(self):

--- a/l10n_br_fiscal/models/comment.py
+++ b/l10n_br_fiscal/models/comment.py
@@ -117,7 +117,7 @@ class Comment(models.Model):
 
     def compute_message(self, vals, manual_comment=None):
 
-        if self.ids:
+        if not self.ids and not manual_comment:
             return False
 
         from jinja2.sandbox import SandboxedEnvironment

--- a/l10n_br_fiscal/models/comment.py
+++ b/l10n_br_fiscal/models/comment.py
@@ -98,7 +98,6 @@ class Comment(models.Model):
     # This way we can format numbers in currency template on fiscal observation
     # msg We'll call this function when setting the variables env below
     def format_amount(self, env, amount, currency):
-        self.ensure_one()
         fmt = "%.{}f".format(currency.decimal_places)
         lang = env["res.lang"]._lang_get("pt_BR")
 

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin.py
@@ -842,6 +842,8 @@ class FiscalDocumentLineMixin(models.AbstractModel):
 
     additional_data = fields.Char(string="Additional Data")
 
+    manual_additional_data = fields.Char(string="Manual Additional Data", help="Additional data manually entered by user")
+
     amount_estimate_tax = fields.Monetary(
         string="Amount Estimate Tax",
     )

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin.py
@@ -842,7 +842,9 @@ class FiscalDocumentLineMixin(models.AbstractModel):
 
     additional_data = fields.Char(string="Additional Data")
 
-    manual_additional_data = fields.Char(string="Manual Additional Data", help="Additional data manually entered by user")
+    manual_additional_data = fields.Char(
+        string="Manual Additional Data", help="Additional data manually entered by user"
+    )
 
     amount_estimate_tax = fields.Monetary(
         string="Amount Estimate Tax",

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -273,11 +273,14 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         }
 
     def _document_comment(self):
-        for d in self.filtered("comment_ids"):
-            d.additional_data = d.additional_data or ""
-            d.additional_data += d.comment_ids.compute_message(
-                d.__document_comment_vals()
-            )
+        for d in self:
+            d.additional_data = d.manual_additional_data or ""
+            for comment_id in d.comment_ids:
+                if d.additional_data:
+                    d.additional_data += " "
+                d.additional_data += comment_id.compute_message(
+                    d.__document_comment_vals()
+                )
 
     @api.onchange("fiscal_operation_id")
     def _onchange_fiscal_operation_id(self):

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -274,13 +274,9 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
 
     def _document_comment(self):
         for d in self:
-            d.additional_data = d.manual_additional_data or ""
-            for comment_id in d.comment_ids:
-                if d.additional_data:
-                    d.additional_data += " "
-                d.additional_data += comment_id.compute_message(
-                    d.__document_comment_vals()
-                )
+            comments = [d.manual_additional_data or ""]
+            comments.extend(d.comment_ids.compute_message(d.__document_comment_vals()))
+            d.additional_data = " - ".join([c for c in comments if c])
 
     @api.onchange("fiscal_operation_id")
     def _onchange_fiscal_operation_id(self):

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -274,9 +274,9 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
 
     def _document_comment(self):
         for d in self:
-            comments = [d.manual_additional_data or ""]
-            comments.extend(d.comment_ids.compute_message(d.__document_comment_vals()))
-            d.additional_data = " - ".join([c for c in comments if c])
+            d.additional_data = d.comment_ids.compute_message(
+                d.__document_comment_vals(), d.manual_additional_data
+            )
 
     @api.onchange("fiscal_operation_id")
     def _onchange_fiscal_operation_id(self):

--- a/l10n_br_fiscal/models/document_fiscal_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin.py
@@ -81,8 +81,18 @@ class FiscalDocumentMixin(models.AbstractModel):
         string="Fiscal Additional Data",
     )
 
+    manual_fiscal_additional_data = fields.Char(
+        string="Manual Fiscal Additional Data",
+        help="Fiscal Additional data manually entered by user",
+    )
+
     customer_additional_data = fields.Text(
         string="Customer Additional Data",
+    )
+
+    manual_customer_additional_data = fields.Char(
+        string="Manual Customer Additional Data",
+        help="Customer Additional data manually entered by user",
     )
 
     ind_final = fields.Selection(

--- a/l10n_br_fiscal/models/document_fiscal_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin_methods.py
@@ -57,9 +57,8 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
     def _document_comment(self):
         for d in self:
             # Fiscal Comments
-            fsc_comments = []
-            fsc_comments.append(d.fiscal_additional_data or "")
-            fsc_comments.append(
+            fsc_comments = [d.manual_fiscal_additional_data or ""]
+            fsc_comments.extend(
                 d.comment_ids.filtered(
                     lambda c: c.comment_type == COMMENT_TYPE_FISCAL
                 ).compute_message(d.__document_comment_vals())
@@ -68,9 +67,8 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
             d.fiscal_additional_data = ", ".join([c for c in fsc_comments if c])
 
             # Commercial Comments
-            com_comments = []
-            com_comments.append(d.customer_additional_data or "")
-            com_comments.append(
+            com_comments = [d.manual_customer_additional_data or ""]
+            com_comments.extend(
                 d.comment_ids.filtered(
                     lambda c: c.comment_type == COMMENT_TYPE_COMMERCIAL
                 ).compute_message(d.__document_comment_vals())

--- a/l10n_br_fiscal/models/document_fiscal_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin_methods.py
@@ -57,24 +57,18 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
     def _document_comment(self):
         for d in self:
             # Fiscal Comments
-            fsc_comments = [d.manual_fiscal_additional_data or ""]
-            fsc_comments.extend(
-                d.comment_ids.filtered(
-                    lambda c: c.comment_type == COMMENT_TYPE_FISCAL
-                ).compute_message(d.__document_comment_vals())
-                or ""
+            d.fiscal_additional_data = d.comment_ids.filtered(
+                lambda c: c.comment_type == COMMENT_TYPE_FISCAL
+            ).compute_message(
+                d.__document_comment_vals(), d.manual_fiscal_additional_data
             )
-            d.fiscal_additional_data = ", ".join([c for c in fsc_comments if c])
 
             # Commercial Comments
-            com_comments = [d.manual_customer_additional_data or ""]
-            com_comments.extend(
-                d.comment_ids.filtered(
-                    lambda c: c.comment_type == COMMENT_TYPE_COMMERCIAL
-                ).compute_message(d.__document_comment_vals())
-                or ""
+            d.customer_additional_data = d.comment_ids.filtered(
+                lambda c: c.comment_type == COMMENT_TYPE_COMMERCIAL
+            ).compute_message(
+                d.__document_comment_vals(), d.manual_customer_additional_data
             )
-            d.customer_additional_data = ", ".join([c for c in com_comments if c])
             d.line_ids._document_comment()
 
     @api.onchange("fiscal_operation_id")

--- a/l10n_br_fiscal/tests/test_fiscal_document_generic.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_generic.py
@@ -993,3 +993,10 @@ class TestFiscalDocumentGeneric(SavepointCase):
         dummy_line = self.env.user.company_id.fiscal_dummy_id.line_ids[0]
         with self.assertRaises(UserError):
             dummy_line.unlink()
+
+    def test_nfe_comments(self):
+        self.nfe_not_taxpayer._document_comment()
+        additional_data = self.nfe_not_taxpayer.line_ids[0].additional_data
+        self.assertEqual(
+            additional_data, "manual comment test - Val Aprox Tributos Federal R$ 0.00"
+        )

--- a/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
@@ -912,7 +912,7 @@
             <group>
                 <field name="comment_ids" widget="many2many_tags" />
                 <field name="manual_additional_data" />
-                <field name="additional_data" readonly="1"/>
+                <field name="additional_data" readonly="1" />
             </group>
           </page>
         </notebook>

--- a/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
@@ -911,7 +911,8 @@
             </group>
             <group>
                 <field name="comment_ids" widget="many2many_tags" />
-                <field name="additional_data" />
+                <field name="manual_additional_data" />
+                <field name="additional_data" readonly="1"/>
             </group>
           </page>
         </notebook>

--- a/l10n_br_fiscal/views/document_fiscal_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_fiscal_mixin_view.xml
@@ -10,8 +10,10 @@
             <field name="fiscal_operation_id" required="1" />
         </group>
         <group name="l10n_br_fiscal_comment">
-            <field name="fiscal_additional_data" />
-            <field name="customer_additional_data" />
+            <field name="manual_fiscal_additional_data" />
+            <field name="fiscal_additional_data" readonly="1" />
+            <field name="manual_customer_additional_data" />
+            <field name="customer_additional_data" readonly="1" />
         </group>
       </form>
     </field>

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -489,8 +489,10 @@
             <page name="extra_info" string="Extra Info">
                 <group>
                     <field name="comment_ids" widget="many2many_tags" />
-                    <field name="fiscal_additional_data" />
-                    <field name="customer_additional_data" />
+                    <field name="manual_fiscal_additional_data" />
+                    <field name="fiscal_additional_data" readonly="1" />
+                    <field name="manual_customer_additional_data" />
+                    <field name="customer_additional_data" readonly="1" />
                 </group>
             </page>
           </notebook>

--- a/l10n_br_nfse_paulistana/tests/nfse/paulistana.xml
+++ b/l10n_br_nfse_paulistana/tests/nfse/paulistana.xml
@@ -45,7 +45,7 @@
             <CEP>4576060</CEP>
         </EnderecoTomador>
         <EmailTomador>cliente1@cliente1.com.br</EmailTomador>
-        <Discriminacao>[ODOO_DEV] Customized Odoo Development|Documento emitido por: Marc Demo||</Discriminacao>
+        <Discriminacao>[ODOO_DEV] Customized Odoo Development|Documento emitido por: Marc Demo|</Discriminacao>
         <ValorCargaTributaria>0</ValorCargaTributaria>
         <FonteCargaTributaria>100.0</FonteCargaTributaria>
     </RPS>

--- a/l10n_br_purchase_stock/demo/purchase_order.xml
+++ b/l10n_br_purchase_stock/demo/purchase_order.xml
@@ -34,8 +34,12 @@
         <field name="user_id" ref="base.user_admin" />
         <field name="company_id" ref="base.main_company" />
         <field name="notes">TESTE - TERMOS E CONDIÇÕES</field>
-        <field name="customer_additional_data">TESTE - CUSTOMER ADDITIONAL DATA</field>
-        <field name="fiscal_additional_data">TESTE - FISCAL ADDITIONAL DATA</field>
+        <field
+            name="manual_customer_additional_data"
+        >TESTE - CUSTOMER ADDITIONAL DATA</field>
+        <field
+            name="manual_fiscal_additional_data"
+        >TESTE - FISCAL ADDITIONAL DATA</field>
     </record>
 
     <function model="purchase.order" name="_onchange_fiscal_operation_id">
@@ -57,7 +61,7 @@
         <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
         <field name="partner_order">999999</field>
         <field name="partner_order_line">001</field>
-        <field name="additional_data">Teste - Additional Data</field>
+        <field name="manual_additional_data">Teste - Additional Data</field>
         <field name="insurance_value">10</field>
         <field name="other_value">10</field>
         <field name="freight_value">10</field>
@@ -86,7 +90,7 @@
         <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
         <field name="partner_order">999999</field>
         <field name="partner_order_line">002</field>
-        <field name="additional_data">Teste - Additional Data</field>
+        <field name="manual_additional_data">Teste - Additional Data</field>
         <field name="insurance_value">10</field>
         <field name="other_value">10</field>
         <field name="freight_value">10</field>
@@ -110,8 +114,12 @@
         <field name="user_id" ref="base.user_admin" />
         <field name="company_id" ref="base.main_company" />
         <field name="notes">TESTE - TERMOS E CONDIÇÕES</field>
-        <field name="customer_additional_data">TESTE - CUSTOMER ADDITIONAL DATA</field>
-        <field name="fiscal_additional_data">TESTE - FISCAL ADDITIONAL DATA</field>
+        <field
+            name="manual_customer_additional_data"
+        >TESTE - CUSTOMER ADDITIONAL DATA</field>
+        <field
+            name="manual_fiscal_additional_data"
+        >TESTE - FISCAL ADDITIONAL DATA</field>
     </record>
 
     <function model="purchase.order" name="_onchange_fiscal_operation_id">
@@ -133,7 +141,7 @@
         <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
         <field name="partner_order">0000001</field>
         <field name="partner_order_line">001</field>
-        <field name="additional_data">Teste - Additional Data</field>
+        <field name="manual_additional_data">Teste - Additional Data</field>
         <field name="insurance_value">10</field>
         <field name="other_value">10</field>
         <field name="freight_value">10</field>
@@ -162,7 +170,7 @@
         <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
         <field name="partner_order">0000001</field>
         <field name="partner_order_line">002</field>
-        <field name="additional_data">Teste - Additional Data</field>
+        <field name="manual_additional_data">Teste - Additional Data</field>
         <field name="insurance_value">10</field>
         <field name="other_value">10</field>
         <field name="freight_value">10</field>

--- a/l10n_br_repair/views/repair_order.xml
+++ b/l10n_br_repair/views/repair_order.xml
@@ -68,8 +68,8 @@
             <field name="quotation_notes" position="after">
                 <group>
                     <field name="copy_repair_quotation_notes" />
-                    <field name="customer_additional_data" />
-                    <field name="fiscal_additional_data" />
+                    <field name="manual_customer_additional_data" />
+                    <field name="manual_fiscal_additional_data" />
                 </group>
             </field>
 

--- a/l10n_br_sale/views/sale_view.xml
+++ b/l10n_br_sale/views/sale_view.xml
@@ -69,8 +69,8 @@
                         name="note"
                         placeholder="Terms and conditions... (note: you can setup default ones in the Configuration menu)"
                     />
-                    <field name="customer_additional_data" />
-                    <field name="fiscal_additional_data" />
+                    <field name="manual_customer_additional_data" />
+                    <field name="manual_fiscal_additional_data" />
                 </group>
             </field>
             <xpath expr="//field[@name='order_line']" position="attributes">

--- a/l10n_br_sale_stock/demo/sale_order_demo.xml
+++ b/l10n_br_sale_stock/demo/sale_order_demo.xml
@@ -48,8 +48,12 @@
         <field name="company_id" ref="base.main_company" />
         <field name="copy_note">True</field>
         <field name="note">TESTE - TERMOS E CONDIÇÕES</field>
-        <field name="customer_additional_data">TESTE - CUSTOMER ADDITIONAL DATA</field>
-        <field name="fiscal_additional_data">TESTE - FISCAL ADDITIONAL DATA</field>
+        <field
+            name="manual_customer_additional_data"
+        >TESTE - CUSTOMER ADDITIONAL DATA</field>
+        <field
+            name="manual_fiscal_additional_data"
+        >TESTE - FISCAL ADDITIONAL DATA</field>
     </record>
 
     <record id="main_sl_l10n_br_sale_stock_1_1" model="sale.order.line">
@@ -130,8 +134,12 @@
         <field name="company_id" ref="base.main_company" />
         <field name="copy_note">True</field>
         <field name="note">TESTE de criação de duas Notas de Serviço e Produto</field>
-        <field name="customer_additional_data">TESTE - CUSTOMER ADDITIONAL DATA</field>
-        <field name="fiscal_additional_data">TESTE - FISCAL ADDITIONAL DATA</field>
+        <field
+            name="manual_customer_additional_data"
+        >TESTE - CUSTOMER ADDITIONAL DATA</field>
+        <field
+            name="manual_fiscal_additional_data"
+        >TESTE - FISCAL ADDITIONAL DATA</field>
     </record>
 
     <record id="main_sl_l10n_br_sale_stock_2_1" model="sale.order.line">
@@ -192,8 +200,12 @@
         <field name="company_id" ref="base.main_company" />
         <field name="copy_note">True</field>
         <field name="note">TESTE - TERMOS E CONDIÇÕES</field>
-        <field name="customer_additional_data">TESTE - CUSTOMER ADDITIONAL DATA</field>
-        <field name="fiscal_additional_data">TESTE - FISCAL ADDITIONAL DATA</field>
+        <field
+            name="manual_customer_additional_data"
+        >TESTE - CUSTOMER ADDITIONAL DATA</field>
+        <field
+            name="manual_fiscal_additional_data"
+        >TESTE - FISCAL ADDITIONAL DATA</field>
     </record>
 
     <record id="main_sl_l10n_br_sale_stock_3_1" model="sale.order.line">
@@ -274,8 +286,12 @@
         <field name="company_id" ref="base.main_company" />
         <field name="copy_note">True</field>
         <field name="note">TESTE - TERMOS E CONDIÇÕES</field>
-        <field name="customer_additional_data">TESTE - CUSTOMER ADDITIONAL DATA</field>
-        <field name="fiscal_additional_data">TESTE - FISCAL ADDITIONAL DATA</field>
+        <field
+            name="manual_customer_additional_data"
+        >TESTE - CUSTOMER ADDITIONAL DATA</field>
+        <field
+            name="manual_fiscal_additional_data"
+        >TESTE - FISCAL ADDITIONAL DATA</field>
     </record>
 
     <record id="main_sl_l10n_br_sale_stock_4_1" model="sale.order.line">

--- a/l10n_br_sale_stock/wizards/stock_invoice_onshipping.py
+++ b/l10n_br_sale_stock/wizards/stock_invoice_onshipping.py
@@ -28,8 +28,8 @@ class StockInvoiceOnshipping(models.TransientModel):
             if pick.sale_id.copy_note and pick.sale_id.note:
                 values.update(
                     {
-                        "customer_additional_data": (
-                            pick.sale_id.customer_additional_data
+                        "manual_customer_additional_data": (
+                            pick.sale_id.manual_customer_additional_data
                             + " TERMOS E CONDIÇÕES: "
                             + pick.sale_id.note,
                         )


### PR DESCRIPTION
Erros encontrados ao revisar o fluxo de validação do documento fiscal, mais especificamente verificando os “comments” nas linhas do documento fiscal:

- Toda vez que é necessário revalidar um documento fiscal, o comment é adicionado novamente ao campo “additional_data”, sem apagar o anterior.
![repetitivo](https://user-images.githubusercontent.com/6812128/125873857-46434615-e9fd-4aaa-b167-ce66cd6f30d6.png)

- Se houver mais de um “comment” selecionado, um erro é acusado ao validar o documento.
![PR](https://user-images.githubusercontent.com/6812128/125873754-43004d8c-269b-452a-8c52-1d9f33d15d0c.gif)

Este PR pretende resolver este problemas, presumindo que é uma escolha permitir que o usuário possa colocar outras informações manuais diretamente no campo “additional_data” e múltiplos “comment”.


**Sou novo em tudo isso e dicas construtivas sempre são bem vindas, desculpem se fiz alguma besteira.
