### PR TITLE
[FIX] Amount icms sn credit

### DIFF
--- a/l10n_br_fiscal/data/l10n_br_fiscal_comment_data.xml
+++ b/l10n_br_fiscal/data/l10n_br_fiscal_comment_data.xml
@@ -20,7 +20,7 @@
         <field name="name">Simples Nacional permissão de crédito</field>
         <field
             name="comment"
-        >SIMPLES NACIONAL - Documento emitido por ME ou EPP optante pelo simples nacional, não gera direito a credito fiscal de IPI. Permite o aproveitamento de crédito de ICMS no valor de ${format_amount(doc.amount_icmssn_value)},  nos termos do artigo 23 da LC 123/2006.</field>
+        >SIMPLES NACIONAL - Documento emitido por ME ou EPP optante pelo simples nacional, não gera direito a credito fiscal de IPI. Permite o aproveitamento de crédito de ICMS no valor de ${format_amount(doc.amount_icmssn_credit_value)},  nos termos do artigo 23 da LC 123/2006.</field>
         <field name="comment_type">fiscal</field>
         <field name="object">l10n_br_fiscal.document.mixin</field>
     </record>

--- a/l10n_br_fiscal/models/document_fiscal_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin.py
@@ -131,8 +131,8 @@ class FiscalDocumentMixin(models.AbstractModel):
         compute="_compute_amount",
     )
 
-    amount_icmssn_value = fields.Monetary(
-        string="ICMSSN Value",
+    amount_icmssn_credit_value = fields.Monetary(
+        string="ICMSSN Credit Value",
         compute="_compute_amount",
     )
 

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -423,7 +423,7 @@
                   <group string="ICMS">
                     <field name="amount_icms_base" />
                     <field name="amount_icms_value" />
-                    <field name="amount_icmssn_value" />
+                    <field name="amount_icmssn_credit_value" />
                   </group>
                   <group string="ICMS ST">
                     <field name="amount_icmsst_base" />


### PR DESCRIPTION
O valor total do aproveitamento de crédito do icms do simples nacional estava retornando zerado na informação adicional da nota fiscal:

![image](https://user-images.githubusercontent.com/634278/126086307-900b5468-4b48-4c47-9354-b3ca7640fece.png)

A variavel que estava configurada para esse fim era a `amount_icmssn_value`, porém ela não estava sendo calculada no método `_compute_amount`. O motivo, pelo que percebi é que não existe nenhuma variavel `icmssn_value` nas linhas do documento. A variavel que está sendo utilizada para esse fim nas linhas é a `icmss_credit_value`.

A solução que encontrei foi alterar a variavel `amount_icmssn_value` para `amount_icmssn_credit_value`.
