### PR TITLE
[12.0][FIX] cleanup: fiscal chatter/mail.thread fix

### DIFF
--- a/l10n_br_account/views/fiscal_invoice_view.xml
+++ b/l10n_br_account/views/fiscal_invoice_view.xml
@@ -126,6 +126,13 @@
                     context="{'form_view_ref': 'l10n_br_account.fiscal_invoice_line_form', 'default_document_id': fiscal_document_id, 'default_company_id': company_id, 'default_partner_id': partner_id, 'default_fiscal_operation_type': fiscal_operation_type, 'default_fiscal_operation_id': fiscal_operation_id, 'no_subcall': True}"
                 />
         </xpath>
+        <xpath expr="//sheet" position="after">
+            <div class="oe_chatter">
+                <field name="message_follower_ids" widget="mail_followers" />
+                <field name="activity_ids" widget="mail_activity" />
+                <field name="message_ids" widget="mail_thread" />
+            </div>
+        </xpath>
       </field>
     </record>
 

--- a/l10n_br_account/wizards/__init__.py
+++ b/l10n_br_account/wizards/__init__.py
@@ -3,4 +3,5 @@
 from . import base_wizard_mixin
 from . import account_invoice_refund
 from . import wizard_document_cancel
+from . import wizard_document_correction
 from . import wizard_document_invalidate

--- a/l10n_br_account/wizards/wizard_document_cancel.py
+++ b/l10n_br_account/wizards/wizard_document_cancel.py
@@ -12,3 +12,5 @@ class DocumentCancelWizard(models.TransientModel):
         super().do_cancel()
         if self.invoice_id:
             self.invoice_id.action_cancel()
+            msg = "Cancelamento: {}".format(self.justification)
+            self.invoice_id.message_post(body=msg)

--- a/l10n_br_account/wizards/wizard_document_correction.py
+++ b/l10n_br_account/wizards/wizard_document_correction.py
@@ -1,0 +1,15 @@
+# Copyright (C) 2021  Raphaël Valyi - Akretion <raphael.valyi@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class DocumentCorrectionWizard(models.TransientModel):
+    _inherit = "l10n_br_fiscal.document.correction.wizard"
+
+    def doit(self):
+        super().doit()
+        for wizard in self:
+            if wizard.invoice_id:
+                msg = "Carta de correção: {}".format(wizard.justification)
+                self.invoice_id.message_post(body=msg)

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -38,8 +38,6 @@ class Document(models.Model):
 
     _name = "l10n_br_fiscal.document"
     _inherit = [
-        "mail.thread",
-        "mail.activity.mixin",
         "l10n_br_fiscal.document.mixin",
         "l10n_br_fiscal.document.electronic",
         "l10n_br_fiscal.document.invoice.mixin",

--- a/l10n_br_fiscal/models/document_workflow.py
+++ b/l10n_br_fiscal/models/document_workflow.py
@@ -339,8 +339,6 @@ class DocumentWorkflow(models.AbstractModel):
         self.cancel_reason = justificative
         if self._change_state(SITUACAO_EDOC_CANCELADA):
             self.cancel_reason = justificative
-            msg = "Cancelamento: {}".format(justificative)
-            self.message_post(body=msg)
 
     def action_document_cancel(self):
         self.ensure_one()
@@ -372,8 +370,6 @@ class DocumentWorkflow(models.AbstractModel):
     def _document_correction(self, justificative):
         self.ensure_one()
         self.correction_reason = justificative
-        msg = "Carta de correção: {}".format(justificative)
-        self.message_post(body=msg)
 
     def action_document_correction(self):
         self.ensure_one()

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -495,11 +495,6 @@
             </page>
           </notebook>
         </sheet>
-        <div class="oe_chatter">
-            <field name="message_follower_ids" widget="mail_followers" />
-            <field name="activity_ids" widget="mail_activity" />
-            <field name="message_ids" widget="mail_thread" />
-        </div>
       </form>
     </field>
   </record>


### PR DESCRIPTION
Quando @renatonlima  e eu cogitamos a extração do modulo l10n_br_fiscal para a v12, a KMEE tinha adotado uma localizçao não OCA nas v10/v11 que não herdava do account.invoice do Odoo e se integrava com ele depois de gerir as account.move.line por conta propria. Na Akretion gente não gostava dessa abordagem porque isso significava uma integração ruim com o ecosistema Odoo/OCA que trabalha sempre na base da criação e edição de account.invoice (ou account.move depois da v13).

Mas enfim a gente pensava que seria possível pelo menos ter uma convergência  ate ter um modulo fiscal comum e nisso o l10n_br_fiscal.document pode ser usado de forma independente e herdava de mail.thread.

So que a KMEE abandonou aquela architetura da v10/v11 dela e voltou na nossa arquitetura das v8/v10 com os modulos l10n_br_account, l10n_br_sale,* l10n_br_purchase*... integrados de forma transparente no ecosistema Odoo.

Nisso hoje o l10n_br_fiscal.document so é usado dentro de uma account.invoice. Mas o account.invoice ja herda do mail.thread.

**Nisso as mensagens postadas no mail.thread do  l10n_br_fiscal.document (eventos de cancelamente e de carta de correçao) eram simplesmente escondida num outro mail.thread** apenas do documento que ninguém ia consultar porque hoje por examplo a gente so enxerga o l10n_br_fiscal.document atraves do account.invoice e da herança dele.

Nesse PR eu assumo de tirar o mail.thread (e mail.activity) do l10n_br_fiscal.document para:

1. **resolver esse problema de usabilidade**
2. **melhorar a performance**: o mail.thread tem um custo bem importante: ter 2 mail.threads num mesmo invoice era um grande tiro no pé...

Depois de tirar o mail.thread eu alterei um l10n_br_account para botar as mensagens de cancelamento e de carta de correçao de volta no chatter do invoice como pode ser visto nesses 2 prints:

![2021-07-19_22-37](https://user-images.githubusercontent.com/16926/126251579-32496099-5eb6-4408-9726-743424b6b384.png)

![2021-07-19_22-39](https://user-images.githubusercontent.com/16926/126251591-1b1a193f-3c94-45d2-967f-dda99dbde5bf.png)

