### PR TITLE
[12.0][REM] Button to document view

### DIFF
--- a/l10n_br_repair/views/repair_order.xml
+++ b/l10n_br_repair/views/repair_order.xml
@@ -24,20 +24,6 @@
                         modifiers="{'readonly':true}"
                     />
                 </button>
-                <button
-                    name="action_view_document"
-                    type="object"
-                    class="oe_stat_button"
-                    icon="fa-pencil-square-o"
-                    attrs="{'invisible': [('fiscal_document_count', '=', 0)]}"
-                >
-                    <field
-                        name="fiscal_document_count"
-                        widget="statinfo"
-                        string="Fiscal Documents"
-                        modifiers="{'readonly':true}"
-                    />
-                </button>
             </button>
             <field name="amount_untaxed" position="before">
                 <field


### PR DESCRIPTION
Remove button that leads to l10n_br_fiscal.document view directly in repair_order view.