### PR TITLE
[12.0][FIX] l10n_br_contract: incompatible with parameter to ignore lines with quantity 0

### DIFF
--- a/l10n_br_contract/models/contract_line.py
+++ b/l10n_br_contract/models/contract_line.py
@@ -37,5 +37,6 @@ class ContractLine(models.Model):
     @api.multi
     def _prepare_invoice_line(self, invoice_id=False, invoice_values=False):
         values = super()._prepare_invoice_line(invoice_id, invoice_values)
-        values.update(self._prepare_br_fiscal_dict())
+        if values:
+            values.update(self._prepare_br_fiscal_dict())
         return values


### PR DESCRIPTION
Existe uma opção no módulo de contratos para ignorar linhas com quantidade ZERO. Porém, é necessário desviar desta linha.

`values.update(self._prepare_br_fiscal_dict())`

cc @mileo @renatonlima @rvalyi 