### PR TITLE
[12.0][IMP] l10n_br_contract: adiciona operação fiscal na linha criada via modelo de contrato

### DIFF
--- a/l10n_br_contract/models/contract_line.py
+++ b/l10n_br_contract/models/contract_line.py
@@ -39,3 +39,11 @@ class ContractLine(models.Model):
         values = super()._prepare_invoice_line(invoice_id, invoice_values)
         values.update(self._prepare_br_fiscal_dict())
         return values
+
+    @api.model
+    def create(self, values):
+        res = super().create(values)
+        if res.contract_id.fiscal_operation_id and not res.fiscal_operation_id:
+            res.fiscal_operation_id = res.contract_id.fiscal_operation_id
+            res._onchange_fiscal_operation_id()
+        return res


### PR DESCRIPTION
Quando é definido um modelo de contrato a linha criada no contrato não vem com a operação fiscal preenchida.

Se alguém tiver uma sugestão de tratar isso de uma forma melhor, eu agradeço.