### PR TITLE
[12.0][FIX] l10n_br_fiscal: Em empresas com regime simples nacional os impostos informados na linha da operação fiscal são desconsiderados.

### DIFF
--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -17,6 +17,7 @@ from ..constants.fiscal import (
     TAX_DOMAIN_ISSQN,
     TAX_FRAMEWORK,
     TAX_FRAMEWORK_NORMAL,
+    TAX_FRAMEWORK_SIMPLES_ALL,
     TAX_ICMS_OR_ISSQN,
 )
 from ..constants.icms import ICMS_ORIGIN
@@ -210,17 +211,24 @@ class OperationLine(models.Model):
         cfop = self._get_cfop(company, partner)
         mapping_result["cfop"] = cfop
 
-        # 1 Get Tax Defs from Company
+        # Get Tax Defs from Company
         for tax_definition in company.tax_definition_ids.map_tax_definition(
             company, partner, product, ncm=ncm, nbm=nbm, nbs=nbs, cest=cest
         ):
             self._build_mapping_result(mapping_result, tax_definition)
 
-        # 2 From NCM
+        # From NCM
         if not ncm and product:
             ncm = product.ncm_id
 
-        if company.tax_framework == TAX_FRAMEWORK_NORMAL:
+        if company.tax_framework in TAX_FRAMEWORK_SIMPLES_ALL:
+            # From Operation Line
+            for tax_definition in self.tax_definition_ids.map_tax_definition(
+                company, partner, product, ncm=ncm, nbm=nbm, nbs=nbs, cest=cest
+            ):
+                self._build_mapping_result(mapping_result, tax_definition)
+
+        elif company.tax_framework == TAX_FRAMEWORK_NORMAL:
             tax_ipi = ncm.tax_ipi_id
             tax_ii = ncm.tax_ii_id
             mapping_result["taxes"][tax_ipi.tax_domain] = tax_ipi
@@ -228,7 +236,7 @@ class OperationLine(models.Model):
             if mapping_result["cfop"].destination == CFOP_DESTINATION_EXPORT:
                 mapping_result["taxes"][tax_ii.tax_domain] = tax_ii
 
-            # 3 From ICMS Regulation
+            # From ICMS Regulation
             if company.icms_regulation_id:
                 tax_icms_ids = company.icms_regulation_id.map_tax(
                     company=company,
@@ -243,19 +251,19 @@ class OperationLine(models.Model):
                 for tax in tax_icms_ids:
                     mapping_result["taxes"][tax.tax_domain] = tax
 
-            # 4 From Operation Line
+            # From Operation Line
             for tax_definition in self.tax_definition_ids.map_tax_definition(
                 company, partner, product, ncm=ncm, nbm=nbm, nbs=nbs, cest=cest
             ):
                 self._build_mapping_result(mapping_result, tax_definition)
 
-            # 5 From CFOP
+            # From CFOP
             for tax_definition in cfop.tax_definition_ids.map_tax_definition(
                 company, partner, product, ncm=ncm, nbm=nbm, nbs=nbs, cest=cest
             ):
                 self._build_mapping_result(mapping_result, tax_definition)
 
-            # 6 From Partner Profile
+            # From Partner Profile
             for (
                 tax_definition
             ) in partner.fiscal_profile_id.tax_definition_ids.map_tax_definition(

--- a/l10n_br_fiscal/tests/test_fiscal_document_generic.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_generic.py
@@ -616,12 +616,38 @@ class TestFiscalDocumentGeneric(SavepointCase):
                     "Error to mappping CFOP 5102"
                     " for Revenda de Simples Nacional Dentro do Estado.",
                 )
+                # IPI
+                self.assertEqual(
+                    line.ipi_tax_id.name,
+                    "IPI NT",
+                    "Error to mapping IPI Simples Nacional"
+                    " for Venda de Simples Nacional Fora do Estado.",
+                )
+                self.assertEqual(
+                    line.ipi_cst_id.code,
+                    "53",
+                    "Error to mapping CST 53 from IPI Simples Nacional"
+                    " for Venda de Simples Nacional Fora do Estado.",
+                )
             else:
                 self.assertEqual(
                     line.cfop_id.code,
                     "5101",
                     "Error to mapping CFOP 5101"
                     " for Venda de Simples Nacional Dentro do Estado.",
+                )
+                # IPI
+                self.assertEqual(
+                    line.ipi_tax_id.name,
+                    "IPI Outros",
+                    "Error to mapping IPI Simples Nacional"
+                    " for Venda de Simples Nacional Fora do Estado.",
+                )
+                self.assertEqual(
+                    line.ipi_cst_id.code,
+                    "99",
+                    "Error to mapping CST 99 from IPI Simples Nacional"
+                    " for Venda de Simples Nacional Fora do Estado.",
                 )
 
             # ICMS
@@ -643,20 +669,6 @@ class TestFiscalDocumentGeneric(SavepointCase):
             #    line.icmsfcp_tax_id.name, 'FCP 2%',
             #    "Erro ao mapear ICMS FCP 2%"
             #    " para Venda de Simples Nacional Dentro do Estado.")
-
-            # IPI
-            self.assertEqual(
-                line.ipi_tax_id.name,
-                "IPI Outros",
-                "Error to mapping IPI Simples Nacional"
-                " for Venda de Simples Nacional Fora do Estado.",
-            )
-            self.assertEqual(
-                line.ipi_cst_id.code,
-                "99",
-                "Error to mapping CST 99 from IPI Simples Nacional"
-                " for Venda de Simples Nacional Fora do Estado.",
-            )
 
             # PIS
             self.assertEqual(
@@ -709,11 +721,37 @@ class TestFiscalDocumentGeneric(SavepointCase):
                     "Error to mappping CFOP 6102"
                     " for Revenda de Simples Nacional Fora do Estado.",
                 )
+                # IPI
+                self.assertEqual(
+                    line.ipi_tax_id.name,
+                    "IPI NT",
+                    "Error to mapping IPI Simples Nacional"
+                    " for Venda de Simples Nacional Fora do Estado.",
+                )
+                self.assertEqual(
+                    line.ipi_cst_id.code,
+                    "53",
+                    "Error to mapping CST 53 from IPI Simples Nacional"
+                    " for Venda de Simples Nacional Fora do Estado.",
+                )
             else:
                 self.assertEqual(
                     line.cfop_id.code,
                     "6101",
                     "Error to mapping CFOP 6101"
+                    " for Venda de Simples Nacional Fora do Estado.",
+                )
+                # IPI
+                self.assertEqual(
+                    line.ipi_tax_id.name,
+                    "IPI Outros",
+                    "Error to mapping IPI Simples Nacional"
+                    " for Venda de Simples Nacional Fora do Estado.",
+                )
+                self.assertEqual(
+                    line.ipi_cst_id.code,
+                    "99",
+                    "Error to mapping CST 99 from IPI Simples Nacional"
                     " for Venda de Simples Nacional Fora do Estado.",
                 )
 
@@ -736,20 +774,6 @@ class TestFiscalDocumentGeneric(SavepointCase):
             #    line.icmsfcp_tax_id.name, 'FCP 2%',
             #    "Erro ao mapear ICMS FCP 2%"
             #    " para Venda de Simples Nacional Fora do Estado.")
-
-            # IPI
-            self.assertEqual(
-                line.ipi_tax_id.name,
-                "IPI Outros",
-                "Error to mapping IPI Simples Nacional"
-                " for Venda de Simples Nacional Fora do Estado.",
-            )
-            self.assertEqual(
-                line.ipi_cst_id.code,
-                "99",
-                "Error to mapping CST 99 from IPI Simples Nacional"
-                " for Venda de Simples Nacional Fora do Estado.",
-            )
 
             # PIS
             self.assertEqual(
@@ -895,12 +919,38 @@ class TestFiscalDocumentGeneric(SavepointCase):
                     "Error to mapping CFOP 7102"
                     " for Revenda de Contribuinte p/ o Exterior.",
                 )
+                # IPI
+                self.assertEqual(
+                    line.ipi_tax_id.name,
+                    "IPI NT",
+                    "Error to mapping IPI Simples Nacional"
+                    " for Venda de Simples Nacional Fora do Estado.",
+                )
+                self.assertEqual(
+                    line.ipi_cst_id.code,
+                    "53",
+                    "Error to mapping CST 53 from IPI Simples Nacional"
+                    " for Venda de Simples Nacional Fora do Estado.",
+                )
             else:
                 self.assertEqual(
                     line.cfop_id.code,
                     "7101",
                     "Error to mapping CFOP 7101"
                     " for Venda de Contribuinte p/ o Exterior.",
+                )
+                # IPI
+                self.assertEqual(
+                    line.ipi_tax_id.name,
+                    "IPI Outros",
+                    "Error to mapping IPI Simples Nacional"
+                    " for Venda de Simples Nacional Fora do Estado.",
+                )
+                self.assertEqual(
+                    line.ipi_cst_id.code,
+                    "99",
+                    "Error to mapping CST 99 from IPI Simples Nacional"
+                    " for Venda de Simples Nacional Fora do Estado.",
                 )
 
             # ICMS
@@ -922,20 +972,6 @@ class TestFiscalDocumentGeneric(SavepointCase):
             #    line.icmsfcp_tax_id.name, 'FCP 2%',
             #    "Erro ao mapear ICMS FCP 2%"
             #    " para Venda de Contribuinte p/ o Exterior.")
-
-            # IPI
-            self.assertEqual(
-                line.ipi_tax_id.name,
-                "IPI Outros",
-                "Error to mapping IPI Simples Nacional"
-                " for Venda de Simples Nacional Fora do Estado.",
-            )
-            self.assertEqual(
-                line.ipi_cst_id.code,
-                "99",
-                "Error to mapping CST 99 from IPI Simples Nacional"
-                " for Venda de Simples Nacional Fora do Estado.",
-            )
 
             # PIS
             self.assertEqual(

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210659594315000157550010000000011392461844.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210659594315000157550010000000011392461844.xml
@@ -89,12 +89,9 @@
                 </ICMS>
                 <IPI>
                     <cEnq>999</cEnq>
-                    <IPITrib>
-                        <CST>99</CST>
-                        <vBC>0.00</vBC>
-                        <pIPI>0.0000</pIPI>
-                        <vIPI>0.00</vIPI>
-                    </IPITrib>
+                    <IPINT>
+                        <CST>53</CST>
+                    </IPINT>
                 </IPI>
                 <PIS>
                     <PISOutr>

--- a/l10n_br_repair/tests/test_l10n_br_repair.py
+++ b/l10n_br_repair/tests/test_l10n_br_repair.py
@@ -244,9 +244,9 @@ class L10nBrRepairBaseTest(TransactionCase):
             else:
                 icms_tax = line.icms_tax_id
 
-                if "Revenda" in line.fiscal_operation_line_id.name:
-                    taxes["ipi"]["tax"] = self.env.ref("l10n_br_fiscal.tax_ipi_nt")
-                    taxes["ipi"]["cst"] = self.env.ref("l10n_br_fiscal.cst_ipi_53")
+            if "Revenda" in line.fiscal_operation_line_id.name:
+                taxes["ipi"]["tax"] = self.env.ref("l10n_br_fiscal.tax_ipi_nt")
+                taxes["ipi"]["cst"] = self.env.ref("l10n_br_fiscal.cst_ipi_53")
 
             # ICMS
             self.assertEqual(

--- a/l10n_br_sale/tests/test_l10n_br_sale.py
+++ b/l10n_br_sale/tests/test_l10n_br_sale.py
@@ -234,9 +234,9 @@ class L10nBrSaleBaseTest(SavepointCase):
             else:
                 icms_tax = line.icms_tax_id
 
-                if "Revenda" in line.fiscal_operation_line_id.name:
-                    taxes["ipi"]["tax"] = self.env.ref("l10n_br_fiscal.tax_ipi_nt")
-                    taxes["ipi"]["cst"] = self.env.ref("l10n_br_fiscal.cst_ipi_53")
+            if "Revenda" in line.fiscal_operation_line_id.name:
+                taxes["ipi"]["tax"] = self.env.ref("l10n_br_fiscal.tax_ipi_nt")
+                taxes["ipi"]["cst"] = self.env.ref("l10n_br_fiscal.cst_ipi_53")
 
             # ICMS
             self.assertEqual(


### PR DESCRIPTION
Pessoal,

Quando a empresa é do tipo Simples Nacional o sistema somente considera os impostos oriundos da configuração da empresa. Sendo assim, quando é necessário alguma parametrização pela linha da operação fiscal, o mesmo é ignorado.

Obs. Talvez seja para funcionar da forma como está hoje e eu que tenha deixado passar algo.

cc @mileo @renatonlima @rvalyi 