### PR TITLE
[12.0][FIX] l10n_br_fiscal: Remove obrigatoriedade de preenchimento do campo issqn_fg_city na view

### DIFF
--- a/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
@@ -41,10 +41,7 @@
                             >
                 <group>
                   <field name="issqn_tax_id" />
-                  <field
-                                        name="issqn_fg_city_id"
-                                        attrs="{'required': [('tax_icms_or_issqn', '=', 'issqn')]}"
-                                    />
+                  <field name="issqn_fg_city_id" />
                   <field
                                         name="issqn_eligibility"
                                         attrs="{'required': [('tax_icms_or_issqn', '=', 'issqn')]}"


### PR DESCRIPTION
Pessoal,

Este campo gera problemas quando é gerado uma invoice sem operação fiscal. 

A forma mais simples e meio porca é esta removendo o required do campo na view. Porém, podemos resolver também pegando o valor default a cidade da empresa ou colocando mais alguma condição no required da view. Eu estava fazendo o teste filtrando se tinha operação fiscal.. teria apenas que adicionar ela invisible na na view mas não sei se teria alguma impacto. Alguma sugestão ?

cc @mileo @renatonlima @rvalyi 