### PR TITLE
[12.0][FIX] l10n_br_repair: Ajustes de cálculos e localização do relatório Ordem de Reparo.

### DIFF
--- a/l10n_br_repair/__manifest__.py
+++ b/l10n_br_repair/__manifest__.py
@@ -25,6 +25,7 @@
         "views/repair_order.xml",
         "views/repair_fee.xml",
         "views/repair_line.xml",
+        "report/repair_templates_repair_order.xml",
     ],
     "demo": ["demo/res_company.xml", "demo/repair_order.xml"],
     "installable": True,

--- a/l10n_br_repair/models/fiscal_line_mixin.py
+++ b/l10n_br_repair/models/fiscal_line_mixin.py
@@ -152,6 +152,8 @@ class FiscalLineMixin(models.AbstractModel):
                 self.discount = (self.discount_value * 100) / (
                     self.product_uom_qty * self.price_unit
                 )
+            else:
+                self.discount = 0
 
     @api.onchange("fiscal_tax_ids")
     def _onchange_fiscal_tax_ids(self):

--- a/l10n_br_repair/models/fiscal_line_mixin.py
+++ b/l10n_br_repair/models/fiscal_line_mixin.py
@@ -57,34 +57,6 @@ class FiscalLineMixin(models.AbstractModel):
             "fiscal_operation_line_id",
         ]
 
-    @api.depends(
-        "product_uom_qty",
-        "price_unit",
-        "fiscal_price",
-        "fiscal_quantity",
-        "discount_value",
-        "freight_value",
-        "insurance_value",
-        "other_value",
-        "tax_id",
-    )
-    def _compute_price_subtotal(self):
-        super()._compute_price_subtotal()
-        for line in self:
-            # Update taxes fields
-            line._update_taxes()
-            # Call mixin compute method
-            line._compute_amounts()
-            # Update record
-            line.update(
-                {
-                    "price_subtotal": line.amount_untaxed,
-                    "price_tax": line.amount_tax,
-                    "price_gross": line.amount_untaxed + line.discount_value,
-                    "price_total": line.amount_total,
-                }
-            )
-
     @api.multi
     def _prepare_invoice_line(self, qty):
         self.ensure_one()
@@ -128,12 +100,6 @@ class FiscalLineMixin(models.AbstractModel):
 
         res.update(self._prepare_br_fiscal_dict())
         return res
-
-    @api.onchange("product_uom", "product_uom_qty")
-    def _onchange_product_uom(self):
-        """To call the method in the mixin to update
-        the price and fiscal quantity."""
-        self._onchange_commercial_quantity()
 
     @api.onchange("discount", "product_uom_qty", "price_unit")
     def _onchange_discount_percent(self):

--- a/l10n_br_repair/models/repair_fee.py
+++ b/l10n_br_repair/models/repair_fee.py
@@ -55,7 +55,6 @@ class RepairFee(models.Model):
         store=True,
     )
 
-    @api.one
     @api.depends(
         "price_unit",
         "repair_id",

--- a/l10n_br_repair/models/repair_line.py
+++ b/l10n_br_repair/models/repair_line.py
@@ -1,7 +1,7 @@
 # Copyright 2020 - TODAY, Marcel Savegnago - Escodoo - https://www.escodoo.com.br
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 from ...l10n_br_fiscal.constants.fiscal import TAX_FRAMEWORK
 
@@ -54,3 +54,34 @@ class RepairLine(models.Model):
         related="repair_id.company_id",
         store=True,
     )
+
+    @api.one
+    @api.depends(
+        "price_unit",
+        "repair_id",
+        "product_uom_qty",
+        "product_id",
+        "repair_id.invoice_method",
+    )
+    def _compute_price_subtotal(self):
+        super()._compute_price_subtotal()
+        for line in self:
+            # Update taxes fields
+            line._update_taxes()
+            # Call mixin compute method
+            line._compute_amounts()
+            # Update record
+            line.update(
+                {
+                    "price_subtotal": line.amount_untaxed,
+                    # 'price_tax': line.amount_tax,
+                    "price_gross": line.amount_untaxed + line.discount_value,
+                    "price_total": line.amount_total,
+                }
+            )
+
+    @api.onchange("product_uom", "product_uom_qty")
+    def _onchange_product_uom(self):
+        """To call the method in the mixin to update
+        the price and fiscal quantity."""
+        self._onchange_commercial_quantity()

--- a/l10n_br_repair/models/repair_line.py
+++ b/l10n_br_repair/models/repair_line.py
@@ -55,7 +55,6 @@ class RepairLine(models.Model):
         store=True,
     )
 
-    @api.one
     @api.depends(
         "price_unit",
         "repair_id",

--- a/l10n_br_repair/models/repair_order.py
+++ b/l10n_br_repair/models/repair_order.py
@@ -119,7 +119,6 @@ class RepairOrder(models.Model):
         """Compute the total amounts of the RO."""
         self._compute_amount()
 
-    @api.one
     @api.depends(
         "operations.price_subtotal",
         "invoice_method",
@@ -129,7 +128,6 @@ class RepairOrder(models.Model):
     def _amount_untaxed(self):
         self._compute_amount()
 
-    @api.one
     @api.depends(
         "operations.price_unit",
         "operations.product_uom_qty",
@@ -143,7 +141,6 @@ class RepairOrder(models.Model):
     def _amount_tax(self):
         self._compute_amount()
 
-    @api.one
     @api.depends("amount_untaxed", "amount_tax")
     def _amount_total(self):
         self._compute_amount()

--- a/l10n_br_repair/models/repair_order.py
+++ b/l10n_br_repair/models/repair_order.py
@@ -120,19 +120,31 @@ class RepairOrder(models.Model):
         self._compute_amount()
 
     @api.one
-    @api.depends('operations.price_subtotal', 'invoice_method', 'fees_lines.price_subtotal', 'pricelist_id.currency_id')
+    @api.depends(
+        "operations.price_subtotal",
+        "invoice_method",
+        "fees_lines.price_subtotal",
+        "pricelist_id.currency_id",
+    )
     def _amount_untaxed(self):
         self._compute_amount()
 
     @api.one
-    @api.depends('operations.price_unit', 'operations.product_uom_qty', 'operations.product_id',
-                 'fees_lines.price_unit', 'fees_lines.product_uom_qty', 'fees_lines.product_id',
-                 'pricelist_id.currency_id', 'partner_id')
+    @api.depends(
+        "operations.price_unit",
+        "operations.product_uom_qty",
+        "operations.product_id",
+        "fees_lines.price_unit",
+        "fees_lines.product_uom_qty",
+        "fees_lines.product_id",
+        "pricelist_id.currency_id",
+        "partner_id",
+    )
     def _amount_tax(self):
         self._compute_amount()
 
     @api.one
-    @api.depends('amount_untaxed', 'amount_tax')
+    @api.depends("amount_untaxed", "amount_tax")
     def _amount_total(self):
         self._compute_amount()
 

--- a/l10n_br_repair/models/repair_order.py
+++ b/l10n_br_repair/models/repair_order.py
@@ -119,6 +119,23 @@ class RepairOrder(models.Model):
         """Compute the total amounts of the RO."""
         self._compute_amount()
 
+    @api.one
+    @api.depends('operations.price_subtotal', 'invoice_method', 'fees_lines.price_subtotal', 'pricelist_id.currency_id')
+    def _amount_untaxed(self):
+        self._compute_amount()
+
+    @api.one
+    @api.depends('operations.price_unit', 'operations.product_uom_qty', 'operations.product_id',
+                 'fees_lines.price_unit', 'fees_lines.product_uom_qty', 'fees_lines.product_id',
+                 'pricelist_id.currency_id', 'partner_id')
+    def _amount_tax(self):
+        self._compute_amount()
+
+    @api.one
+    @api.depends('amount_untaxed', 'amount_tax')
+    def _amount_total(self):
+        self._compute_amount()
+
     @api.depends("state", "operations.invoice_line_id", "fees_lines.invoice_line_id")
     def _compute_get_invoiced(self):
         """

--- a/l10n_br_repair/report/repair_templates_repair_order.xml
+++ b/l10n_br_repair/report/repair_templates_repair_order.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="report_repair_order" inherit_id="repair.report_repairorder">
+
+        <xpath expr="//table[@class='table table-sm o_main_table']//tr//t/th[3]" position="before">
+            <th class="text-right">Discount Value</th>
+        </xpath>
+
+        <xpath expr="//table[@class='table table-sm o_main_table']//tbody//t[1]/tr[1]" position="replace">
+            <tr class="bg-200 o_line_section"><td colspan="6"><strong>Parts</strong></td></tr>
+        </xpath>
+
+        <xpath expr="//table[@class='table table-sm o_main_table']//tbody//t[2]/tr[1]" position="replace">
+            <tr class="bg-200 o_line_section"><td colspan="6"><strong>Operations</strong></td></tr>
+        </xpath>
+
+        <xpath expr="//table[@class='table table-sm o_main_table']//tbody//t[1]/td[@class='text-right o_price_total']" position="before">
+            <td class="text-right">
+                <span t-field="line.discount_value"/>
+            </td>
+        </xpath>
+
+        <xpath expr="//table[@class='table table-sm o_main_table']//tbody//t[2]//td[@class='text-right o_price_total']" position="before">
+            <td class="text-right">
+                <span t-field="fees.discount_value"/>
+            </td>
+        </xpath>
+
+         <xpath expr="//table[@class='table table-sm o_main_table']//tbody//t[1]/td[@class='text-center']" position="replace">
+            <td
+                t-if="doc.company_id.country_id.phone_code == 55"
+                name="td_taxes"
+                class="text-right"
+            >
+                 <t
+                    t-foreach="line.fiscal_tax_ids.filtered(lambda x: x.percent_amount or x.value_amount)"
+                    t-as="tax"
+                >
+                <!-- Usando o phone_code porque tanto code == 'br' ou code == br não funcionaram -->
+                    <small>
+                        <span t-esc="tax.name" />
+                        <br />
+                    </small>
+                 </t>
+            </td>
+            <!-- Pedido de empresas de outros países mantem o campo padrão de impostos-->
+            <td
+                t-if="doc.company_id.country_id.phone_code != 55"
+                name="td_taxes"
+                class="text-right"
+            >
+                <span
+                    t-esc="', '.join(map(lambda x: (x.description or x.name), line.tax_id))"
+                />
+            </td>
+        </xpath>
+
+        <xpath expr="//table[@class='table table-sm o_main_table']//tbody//t[2]//td[@class='text-center']" position="replace">
+            <td
+                t-if="doc.company_id.country_id.phone_code == 55"
+                name="td_taxes"
+                class="text-right"
+            >
+                 <t
+                    t-foreach="fees.fiscal_tax_ids.filtered(lambda x: x.percent_amount or x.value_amount)"
+                    t-as="tax"
+                >
+                <!-- Usando o phone_code porque tanto code == 'br' ou code == br não funcionaram -->
+                    <small>
+                        <span t-esc="tax.name" />
+                        <br />
+                    </small>
+                 </t>
+            </td>
+            <!-- Pedido de empresas de outros países mantem o campo padrão de impostos-->
+            <td
+                t-if="doc.company_id.country_id.phone_code != 55"
+                name="td_taxes"
+                class="text-right"
+            >
+                <span
+                    t-esc="', '.join(map(lambda x: (x.description or x.name), fees.tax_id))"
+                />
+            </td>
+        </xpath>
+
+        <!-- Inclusão de outros Totais usados no Brasil -->
+        <xpath expr="//div[@id='total']/div/table/t/tr[@class='border-black o_subtotal']" position="replace">
+            <!-- Replace foi necessário para colocar os Totais na ordem desejada. -->
+                <tr
+                    t-if="doc.amount_price_gross != doc.amount_untaxed"
+                    class="border-black o_subtotal"
+                    style=""
+                >
+                    <td name="td_amount_price_gross_label"><strong
+                        >Amount Gross</strong></td>
+                    <td name="td_amount_price_gross" class="text-right">
+                        <span t-field="doc.amount_price_gross"
+                              t-options='{"widget": "monetary", "display_currency": o.pricelist_id.currency_id}'/>
+                    </td>
+                </tr>
+
+                 <tr style="">
+                    <td name="td_amount_discount_value_label"><strong>Amount Discount</strong></td>
+                    <td name="td_amount_discount_value" class="text-right">
+                        <span t-field="doc.amount_discount_value"
+                              t-options='{"widget": "monetary", "display_currency": o.pricelist_id.currency_id}'/>
+                    </td>
+                </tr>
+
+                <tr style="">
+                    <td name="td_amount_untaxed_label"><strong>Amount Untaxed</strong></td>
+                    <td name="td_amount_untaxed" class="text-right">
+                        <span t-field="doc.amount_untaxed"
+                              t-options='{"widget": "monetary", "display_currency": o.pricelist_id.currency_id}'/>
+                    </td>
+                </tr>
+
+                <tr t-if="doc.amount_freight_value" style="">
+                    <td name="td_amount_freight_label"><strong>Freight</strong></td>
+                    <td name="td_amount_freight_value" class="text-right">
+                        <span t-field="doc.amount_freight_value"
+                              t-options='{"widget": "monetary", "display_currency": o.pricelist_id.currency_id}'/>
+                    </td>
+                </tr>
+
+                <tr t-if="doc.amount_insurance_value" style="">
+                    <td name="td_amount_insurance_label"><strong>Insurance</strong></td>
+                    <td name="td_amount_insurance_value" class="text-right">
+                        <span t-field="doc.amount_insurance_value"
+                              t-options='{"widget": "monetary", "display_currency": o.pricelist_id.currency_id}'/>
+                    </td>
+                </tr>
+
+                <tr t-if="doc.amount_other_value" style="">
+                    <td name="td_amount_costs_label"><strong>Other Costs</strong></td>
+                    <td name="td_amount_other_value" class="text-right">
+                        <span t-field="doc.amount_other_value"
+                              t-options='{"widget": "monetary", "display_currency": o.pricelist_id.currency_id}'/>
+                    </td>
+                </tr>
+
+        </xpath>
+
+    </template>
+</odoo>

--- a/l10n_br_repair/report/repair_templates_repair_order.xml
+++ b/l10n_br_repair/report/repair_templates_repair_order.xml
@@ -3,14 +3,14 @@
     <template id="report_repair_order" inherit_id="repair.report_repairorder">
 
         <xpath
-            expr="//table[@class='table table-sm o_main_table']//tr//t/th[3]"
+            expr="//table[hasclass('table', 'table-sm', 'o_main_table')]//tr//t/th[3]"
             position="before"
         >
             <th class="text-right">Discount Value</th>
         </xpath>
 
         <xpath
-            expr="//table[@class='table table-sm o_main_table']//tbody//t[1]/tr[1]"
+            expr="//table[hasclass('table', 'table-sm', 'o_main_table')]//tbody//t[1]/tr[1]"
             position="replace"
         >
             <tr class="bg-200 o_line_section"><td colspan="6"><strong
@@ -18,7 +18,7 @@
         </xpath>
 
         <xpath
-            expr="//table[@class='table table-sm o_main_table']//tbody//t[2]/tr[1]"
+            expr="//table[hasclass('table', 'table-sm', 'o_main_table')]//tbody//t[2]/tr[1]"
             position="replace"
         >
             <tr class="bg-200 o_line_section"><td colspan="6"><strong
@@ -26,7 +26,7 @@
         </xpath>
 
         <xpath
-            expr="//table[@class='table table-sm o_main_table']//tbody//t[1]/td[@class='text-right o_price_total']"
+            expr="//table[hasclass('table', 'table-sm', 'o_main_table')]//tbody//t[1]/td[hasclass('text-right', 'o_price_total')]"
             position="before"
         >
             <td class="text-right">
@@ -35,7 +35,7 @@
         </xpath>
 
         <xpath
-            expr="//table[@class='table table-sm o_main_table']//tbody//t[2]//td[@class='text-right o_price_total']"
+            expr="//table[hasclass('table', 'table-sm', 'o_main_table')]//tbody//t[2]//td[hasclass('text-right', 'o_price_total')]"
             position="before"
         >
             <td class="text-right">
@@ -44,7 +44,7 @@
         </xpath>
 
          <xpath
-            expr="//table[@class='table table-sm o_main_table']//tbody//t[1]/td[@class='text-center']"
+            expr="//table[hasclass('table', 'table-sm', 'o_main_table')]//tbody//t[1]/td[hasclass('text-center')]"
             position="replace"
         >
             <td
@@ -76,7 +76,7 @@
         </xpath>
 
         <xpath
-            expr="//table[@class='table table-sm o_main_table']//tbody//t[2]//td[@class='text-center']"
+            expr="//table[hasclass('table', 'table-sm', 'o_main_table')]//tbody//t[2]//td[hasclass('text-center')]"
             position="replace"
         >
             <td
@@ -109,7 +109,7 @@
 
         <!-- Inclusão de outros Totais usados no Brasil -->
         <xpath
-            expr="//div[@id='total']/div/table/t/tr[@class='border-black o_subtotal']"
+            expr="//div[@id='total']/div/table/t/tr[hasclass('border-black', 'o_subtotal')]"
             position="replace"
         >
             <!-- Replace foi necessário para colocar os Totais na ordem desejada. -->

--- a/l10n_br_repair/report/repair_templates_repair_order.xml
+++ b/l10n_br_repair/report/repair_templates_repair_order.xml
@@ -1,32 +1,52 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <odoo>
     <template id="report_repair_order" inherit_id="repair.report_repairorder">
 
-        <xpath expr="//table[@class='table table-sm o_main_table']//tr//t/th[3]" position="before">
+        <xpath
+            expr="//table[@class='table table-sm o_main_table']//tr//t/th[3]"
+            position="before"
+        >
             <th class="text-right">Discount Value</th>
         </xpath>
 
-        <xpath expr="//table[@class='table table-sm o_main_table']//tbody//t[1]/tr[1]" position="replace">
-            <tr class="bg-200 o_line_section"><td colspan="6"><strong>Parts</strong></td></tr>
+        <xpath
+            expr="//table[@class='table table-sm o_main_table']//tbody//t[1]/tr[1]"
+            position="replace"
+        >
+            <tr class="bg-200 o_line_section"><td colspan="6"><strong
+                    >Parts</strong></td></tr>
         </xpath>
 
-        <xpath expr="//table[@class='table table-sm o_main_table']//tbody//t[2]/tr[1]" position="replace">
-            <tr class="bg-200 o_line_section"><td colspan="6"><strong>Operations</strong></td></tr>
+        <xpath
+            expr="//table[@class='table table-sm o_main_table']//tbody//t[2]/tr[1]"
+            position="replace"
+        >
+            <tr class="bg-200 o_line_section"><td colspan="6"><strong
+                    >Operations</strong></td></tr>
         </xpath>
 
-        <xpath expr="//table[@class='table table-sm o_main_table']//tbody//t[1]/td[@class='text-right o_price_total']" position="before">
+        <xpath
+            expr="//table[@class='table table-sm o_main_table']//tbody//t[1]/td[@class='text-right o_price_total']"
+            position="before"
+        >
             <td class="text-right">
-                <span t-field="line.discount_value"/>
+                <span t-field="line.discount_value" />
             </td>
         </xpath>
 
-        <xpath expr="//table[@class='table table-sm o_main_table']//tbody//t[2]//td[@class='text-right o_price_total']" position="before">
+        <xpath
+            expr="//table[@class='table table-sm o_main_table']//tbody//t[2]//td[@class='text-right o_price_total']"
+            position="before"
+        >
             <td class="text-right">
-                <span t-field="fees.discount_value"/>
+                <span t-field="fees.discount_value" />
             </td>
         </xpath>
 
-         <xpath expr="//table[@class='table table-sm o_main_table']//tbody//t[1]/td[@class='text-center']" position="replace">
+         <xpath
+            expr="//table[@class='table table-sm o_main_table']//tbody//t[1]/td[@class='text-center']"
+            position="replace"
+        >
             <td
                 t-if="doc.company_id.country_id.phone_code == 55"
                 name="td_taxes"
@@ -55,7 +75,10 @@
             </td>
         </xpath>
 
-        <xpath expr="//table[@class='table table-sm o_main_table']//tbody//t[2]//td[@class='text-center']" position="replace">
+        <xpath
+            expr="//table[@class='table table-sm o_main_table']//tbody//t[2]//td[@class='text-center']"
+            position="replace"
+        >
             <td
                 t-if="doc.company_id.country_id.phone_code == 55"
                 name="td_taxes"
@@ -85,58 +108,75 @@
         </xpath>
 
         <!-- Inclusão de outros Totais usados no Brasil -->
-        <xpath expr="//div[@id='total']/div/table/t/tr[@class='border-black o_subtotal']" position="replace">
+        <xpath
+            expr="//div[@id='total']/div/table/t/tr[@class='border-black o_subtotal']"
+            position="replace"
+        >
             <!-- Replace foi necessário para colocar os Totais na ordem desejada. -->
                 <tr
-                    t-if="doc.amount_price_gross != doc.amount_untaxed"
-                    class="border-black o_subtotal"
-                    style=""
-                >
+                t-if="doc.amount_price_gross != doc.amount_untaxed"
+                class="border-black o_subtotal"
+                style=""
+            >
                     <td name="td_amount_price_gross_label"><strong
-                        >Amount Gross</strong></td>
+                    >Amount Gross</strong></td>
                     <td name="td_amount_price_gross" class="text-right">
-                        <span t-field="doc.amount_price_gross"
-                              t-options='{"widget": "monetary", "display_currency": o.pricelist_id.currency_id}'/>
+                        <span
+                        t-field="doc.amount_price_gross"
+                        t-options='{"widget": "monetary", "display_currency": o.pricelist_id.currency_id}'
+                    />
                     </td>
                 </tr>
 
                  <tr style="">
-                    <td name="td_amount_discount_value_label"><strong>Amount Discount</strong></td>
+                    <td name="td_amount_discount_value_label"><strong
+                    >Amount Discount</strong></td>
                     <td name="td_amount_discount_value" class="text-right">
-                        <span t-field="doc.amount_discount_value"
-                              t-options='{"widget": "monetary", "display_currency": o.pricelist_id.currency_id}'/>
+                        <span
+                        t-field="doc.amount_discount_value"
+                        t-options='{"widget": "monetary", "display_currency": o.pricelist_id.currency_id}'
+                    />
                     </td>
                 </tr>
 
                 <tr style="">
-                    <td name="td_amount_untaxed_label"><strong>Amount Untaxed</strong></td>
+                    <td name="td_amount_untaxed_label"><strong
+                    >Amount Untaxed</strong></td>
                     <td name="td_amount_untaxed" class="text-right">
-                        <span t-field="doc.amount_untaxed"
-                              t-options='{"widget": "monetary", "display_currency": o.pricelist_id.currency_id}'/>
+                        <span
+                        t-field="doc.amount_untaxed"
+                        t-options='{"widget": "monetary", "display_currency": o.pricelist_id.currency_id}'
+                    />
                     </td>
                 </tr>
 
                 <tr t-if="doc.amount_freight_value" style="">
                     <td name="td_amount_freight_label"><strong>Freight</strong></td>
                     <td name="td_amount_freight_value" class="text-right">
-                        <span t-field="doc.amount_freight_value"
-                              t-options='{"widget": "monetary", "display_currency": o.pricelist_id.currency_id}'/>
+                        <span
+                        t-field="doc.amount_freight_value"
+                        t-options='{"widget": "monetary", "display_currency": o.pricelist_id.currency_id}'
+                    />
                     </td>
                 </tr>
 
                 <tr t-if="doc.amount_insurance_value" style="">
                     <td name="td_amount_insurance_label"><strong>Insurance</strong></td>
                     <td name="td_amount_insurance_value" class="text-right">
-                        <span t-field="doc.amount_insurance_value"
-                              t-options='{"widget": "monetary", "display_currency": o.pricelist_id.currency_id}'/>
+                        <span
+                        t-field="doc.amount_insurance_value"
+                        t-options='{"widget": "monetary", "display_currency": o.pricelist_id.currency_id}'
+                    />
                     </td>
                 </tr>
 
                 <tr t-if="doc.amount_other_value" style="">
                     <td name="td_amount_costs_label"><strong>Other Costs</strong></td>
                     <td name="td_amount_other_value" class="text-right">
-                        <span t-field="doc.amount_other_value"
-                              t-options='{"widget": "monetary", "display_currency": o.pricelist_id.currency_id}'/>
+                        <span
+                        t-field="doc.amount_other_value"
+                        t-options='{"widget": "monetary", "display_currency": o.pricelist_id.currency_id}'
+                    />
                     </td>
                 </tr>
 


### PR DESCRIPTION
Fiz alguns ajustes no módulo de reparos.

- Alguns métodos foram movidos do arquivo fiscal_line_mixin para repair_fees e repair_line
- Corrige problema quando altera o valor do desconto para zero
- Sobrescrevi alguns métodos para garantir que sejam calculados os campos corretamente
- Sobrescrevi o relatório de ordem de reparo localizando o mesmo para o Brasil
- Adicionei coluna com desconto no relatório de ordem de reparo.

Qualquer dúvida, critica ou sugestão é bem vinda.
