### PR TITLE
[12.0][FIX] l10n_br_nfse_issnet: corrige a inscrição municipal para tomador…

### DIFF
--- a/l10n_br_nfse_issnet/models/l10n_br_fiscal_document.py
+++ b/l10n_br_nfse_issnet/models/l10n_br_fiscal_document.py
@@ -128,8 +128,7 @@ class Document(models.Model):
                 InscricaoMunicipal=self.convert_type_nfselib(
                     tcIdentificacaoTomador, 'InscricaoMunicipal',
                     dados['inscricao_municipal'])
-                if dados['codigo_municipio'] == int('%s%s' % (
-                    self.company_id.partner_id.state_id.ibge_code,
+                if dados['codigo_municipio'] == int('%s' % (
                     self.company_id.partner_id.city_id.ibge_code
                 )) else None,
             ),


### PR DESCRIPTION
Corrige a comparação do código da cidade para determinar quando deve ou não incluir a inscrição municipal do tomador no XML. Antes era comparado com a concatenação entre código do estado + cidade.