### PR TITLE
[12.0][IMP] l10n_br_repair: add payment_term_id on invoices

### DIFF
--- a/l10n_br_repair/__manifest__.py
+++ b/l10n_br_repair/__manifest__.py
@@ -15,7 +15,7 @@
     "images": ["static/description/banner.png"],
     "conflicts": ["repair_discount"],
     "depends": [
-        "repair",
+        "repair_payment_term",
         "l10n_br_stock_account",
     ],
     "data": [

--- a/l10n_br_repair/models/repair_order.py
+++ b/l10n_br_repair/models/repair_order.py
@@ -357,6 +357,7 @@ class RepairOrder(models.Model):
                 "company_id": company_id,
                 "comment": self.quotation_notes,
                 "fiscal_position_id": fp_id,
+                "payment_term_id": self.payment_term_id.id,
             }
         )
 

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -5,3 +5,4 @@ account-invoicing
 account-reconcile
 mis-builder
 contract
+manufacture


### PR DESCRIPTION
Devido a sobreescrita dos métodos do módulo repair alguns módulos não são compatíveis com a localização. Sendo assim, um módulo importante é o módulo repair_payment_term que permite configurar o termo de pagamento e o mesmo é levado para a invoice.

Sei que não é a solução ideal mas por ora seria uma solução.

Dúvidas, críticas e sugestões são bem vindas. 