### PR TITLE
[12.0][l10n_br_fiscal][FIX] store=True for related _order fields

### DIFF
--- a/l10n_br_fiscal/models/cst.py
+++ b/l10n_br_fiscal/models/cst.py
@@ -28,8 +28,8 @@ class CST(models.Model):
         selection=TAX_DOMAIN,
         related="tax_group_id.tax_domain",
         string="Tax Domain",
-        required=True,
         readonly=True,
+        store=True,
     )
 
     _sql_constraints = [

--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -63,6 +63,7 @@ class Tax(models.Model):
         related="tax_group_id.sequence",
         help="The sequence field is used to define the "
         "order in which taxes are displayed.",
+        store=True,
     )
 
     compute_sequence = fields.Integer(
@@ -122,8 +123,8 @@ class Tax(models.Model):
         selection=TAX_DOMAIN,
         related="tax_group_id.tax_domain",
         string="Tax Domain",
-        required=True,
         readonly=True,
+        store=True,
     )
 
     cst_in_id = fields.Many2one(


### PR DESCRIPTION
os objetos `l10n_br.fiscal.tax` e `l10n_br.fiscal.cst` tem uma ordenação por campos que são related sem ser store=True. Isso não funciona e a ordem não é a esperada.

Depois de botar store=True, eu tambem tive que remover o required=True para funcionar na hora de instalação do modulo com a carga csv. Mas ja que os campos são store=True e readonly=True, isso não é nenhum problema.

cc @renatonlima 