### PR TITLE
[12.0][l10n_br_fiscal][FIX] clean related fields.Selection

### DIFF
--- a/l10n_br_fiscal/models/cst.py
+++ b/l10n_br_fiscal/models/cst.py
@@ -3,7 +3,7 @@
 
 from odoo import _, fields, models
 
-from ..constants.fiscal import FISCAL_IN_OUT_ALL, TAX_DOMAIN
+from ..constants.fiscal import FISCAL_IN_OUT_ALL
 
 
 class CST(models.Model):
@@ -25,7 +25,6 @@ class CST(models.Model):
     )
 
     tax_domain = fields.Selection(
-        selection=TAX_DOMAIN,
         related="tax_group_id.tax_domain",
         string="Tax Domain",
         required=True,

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -63,7 +63,7 @@ class Document(models.Model):
     )
 
     fiscal_operation_type = fields.Selection(
-        related=False,
+        store=True,
     )
 
     document_number = fields.Char(
@@ -149,10 +149,6 @@ class Document(models.Model):
         ),
     )
 
-    processador_edoc = fields.Selection(
-        related="company_id.processador_edoc",
-        store=True,
-    )
     line_ids = fields.One2many(
         comodel_name="l10n_br_fiscal.document.line",
         inverse_name="document_id",

--- a/l10n_br_fiscal/models/document_fiscal_invoice_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_invoice_mixin.py
@@ -3,7 +3,7 @@
 
 from odoo import api, fields, models
 
-from ..constants.fiscal import DOCUMENT_ISSUER_COMPANY, NFE_IND_IE_DEST, TAX_FRAMEWORK
+from ..constants.fiscal import DOCUMENT_ISSUER_COMPANY
 
 
 class FiscalDocumentInvoiceMixin(models.AbstractModel):
@@ -35,7 +35,6 @@ class FiscalDocumentInvoiceMixin(models.AbstractModel):
     )
 
     partner_ind_ie_dest = fields.Selection(
-        selection=NFE_IND_IE_DEST,
         string="Contribuinte do ICMS",
         related="partner_id.ind_ie_dest",
     )
@@ -57,7 +56,6 @@ class FiscalDocumentInvoiceMixin(models.AbstractModel):
     )
 
     partner_tax_framework = fields.Selection(
-        selection=TAX_FRAMEWORK,
         string="Tax Framework",
         related="partner_id.tax_framework",
     )
@@ -161,7 +159,6 @@ class FiscalDocumentInvoiceMixin(models.AbstractModel):
     )
 
     company_tax_framework = fields.Selection(
-        selection=TAX_FRAMEWORK,
         string="Company Tax Framework",
         related="company_id.tax_framework",
     )

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin.py
@@ -6,9 +6,7 @@ from odoo import api, fields, models
 from odoo.addons import decimal_precision as dp
 
 from ..constants.fiscal import (
-    CFOP_DESTINATION,
     FISCAL_COMMENT_LINE,
-    FISCAL_IN_OUT,
     PRODUCT_FISCAL_TYPE,
     TAX_BASE_TYPE,
     TAX_BASE_TYPE_PERCENT,
@@ -142,7 +140,6 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     )
 
     fiscal_operation_type = fields.Selection(
-        selection=FISCAL_IN_OUT,
         related="fiscal_operation_id.fiscal_operation_type",
         string="Fiscal Operation Type",
         readonly=True,
@@ -162,7 +159,6 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     )
 
     cfop_destination = fields.Selection(
-        selection=CFOP_DESTINATION,
         related="cfop_id.destination",
         string="CFOP Destination",
     )

--- a/l10n_br_fiscal/models/document_fiscal_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin.py
@@ -8,7 +8,6 @@ from ..constants.fiscal import (
     FINAL_CUSTOMER,
     FINAL_CUSTOMER_YES,
     FISCAL_COMMENT_DOCUMENT,
-    FISCAL_IN_OUT,
     NFE_IND_PRES,
     NFE_IND_PRES_DEFAULT,
 )
@@ -56,7 +55,6 @@ class FiscalDocumentMixin(models.AbstractModel):
     )
 
     fiscal_operation_type = fields.Selection(
-        selection=FISCAL_IN_OUT,
         related="fiscal_operation_id.fiscal_operation_type",
         string="Fiscal Operation Type",
         readonly=True,

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -4,8 +4,6 @@
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
-from ..constants.fiscal import TAX_FRAMEWORK
-
 
 class DocumentLine(models.Model):
     _name = "l10n_br_fiscal.document.line"
@@ -46,7 +44,6 @@ class DocumentLine(models.Model):
     )
 
     tax_framework = fields.Selection(
-        selection=TAX_FRAMEWORK,
         related="company_id.tax_framework",
         string="Tax Framework",
     )

--- a/l10n_br_fiscal/models/document_workflow.py
+++ b/l10n_br_fiscal/models/document_workflow.py
@@ -12,8 +12,6 @@ from ..constants.fiscal import (
     MODELO_FISCAL_NFCE,
     MODELO_FISCAL_NFE,
     MODELO_FISCAL_NFSE,
-    PROCESSADOR,
-    PROCESSADOR_NENHUM,
     SITUACAO_EDOC,
     SITUACAO_EDOC_A_ENVIAR,
     SITUACAO_EDOC_AUTORIZADA,
@@ -66,12 +64,6 @@ class DocumentWorkflow(models.AbstractModel):
 
     correction_reason = fields.Char(
         string="Correction Reason",
-    )
-
-    processador_edoc = fields.Selection(
-        string="Processador",
-        selection=PROCESSADOR,
-        default=PROCESSADOR_NENHUM,
     )
 
     def _direct_draft_send(self):

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -7,9 +7,7 @@ from odoo.exceptions import UserError
 from ..constants.fiscal import (
     CFOP_DESTINATION_EXPORT,
     FISCAL_COMMENT_LINE,
-    FISCAL_IN_OUT_ALL,
     NFE_IND_IE_DEST,
-    OPERATION_FISCAL_TYPE,
     OPERATION_STATE,
     OPERATION_STATE_DEFAULT,
     PRODUCT_FISCAL_TYPE,
@@ -63,7 +61,6 @@ class OperationLine(models.Model):
     )
 
     fiscal_operation_type = fields.Selection(
-        selection=FISCAL_IN_OUT_ALL,
         related="fiscal_operation_id.fiscal_operation_type",
         string="Fiscal Operation Type",
         store=True,
@@ -71,7 +68,6 @@ class OperationLine(models.Model):
     )
 
     fiscal_type = fields.Selection(
-        selection=OPERATION_FISCAL_TYPE,
         related="fiscal_operation_id.fiscal_type",
         string="Fiscal Type",
         store=True,

--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -16,7 +16,6 @@ from ..constants.fiscal import (
     TAX_BASE_TYPE,
     TAX_BASE_TYPE_PERCENT,
     TAX_BASE_TYPE_VALUE,
-    TAX_DOMAIN,
 )
 from ..constants.icms import (
     ICMS_BASE_TYPE,
@@ -119,7 +118,6 @@ class Tax(models.Model):
     )
 
     tax_domain = fields.Selection(
-        selection=TAX_DOMAIN,
         related="tax_group_id.tax_domain",
         string="Tax Domain",
         required=True,

--- a/l10n_br_fiscal/models/tax_definition.py
+++ b/l10n_br_fiscal/models/tax_definition.py
@@ -9,7 +9,6 @@ from ..constants.fiscal import (
     FISCAL_OUT,
     OPERATION_STATE,
     OPERATION_STATE_DEFAULT,
-    TAX_DOMAIN,
 )
 from ..tools import misc
 
@@ -67,7 +66,6 @@ class TaxDefinition(models.Model):
     )
 
     tax_domain = fields.Selection(
-        selection=TAX_DOMAIN,
         related="tax_group_id.tax_domain",
         store=True,
         string="Tax Domain",


### PR DESCRIPTION
Simplifica o código: quando um select é herdado não precisa especificar o atributo selection dele.
Sendo que isso é algo que teremos que fazer também na v14 porque na 14 da WARNING (bloca os testes Runbot) então é melhor anticipar essa simplificação do código e minimizar o diff para a manutenção futura. Código não DRY tb é fonte de inconsistências e bugs bem cabeludos.
Menos 33 linhas!