### PR TITLE
[12.0][FIX] l10n_br_contract: o método _prepare_br_fiscal está ignorando a quantidade calculada pelo módulo contract_variable_quantity

### DIFF
--- a/l10n_br_contract/models/contract_line.py
+++ b/l10n_br_contract/models/contract_line.py
@@ -37,8 +37,10 @@ class ContractLine(models.Model):
     @api.multi
     def _prepare_invoice_line(self, invoice_id=False, invoice_values=False):
         values = super()._prepare_invoice_line(invoice_id, invoice_values)
+        quantity = values.get("quantity")
         if values:
             values.update(self._prepare_br_fiscal_dict())
+            values["quantity"] = quantity
         return values
 
     @api.model


### PR DESCRIPTION
Quando é utilizado o módulo contract_variable_quantity o método _prepare_br_fiscal ignora a quantidade calculada.

Cabe a alteração aqui ou seria melhor criar um módulo adicional para localizar o contract_variable_quantity?

ping @renatonlima @rvalyi 