### PR TITLE
[12.0] use newly published nfelib==1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,11 @@ install:
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - export WKHTMLTOPDF_VERSION=0.12.5
   - travis_install_nightly
+  - cwd=$(pwd)
+  - if [[ $ODOO_REPO == "odoo/odoo" ]]; then cd ${HOME}/odoo-${VERSION}; fi
+  - if [[ $ODOO_REPO == "OCA/OCB" ]]; then cd ${HOME}/OCB-${VERSION}; fi
+  - if [[ $TESTS == "1" ]]; then git revert 13f02a60c8706b808a57535ac9648a1b0c0741a9 --no-edit; fi
+  - cd $cwd
 
 script:
   - travis_run_tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,9 @@ erpbrasil.edoc.pdf==1.0.1
 nfselib.ginfes==0.2.0
 nfselib.issnet==0.2.0
 nfselib.paulistana==0.2.0
+nfelib==1.1
 xmldiff==2.4
 lxml==4.6.3
--e git+https://github.com/akretion/nfelib.git@master_gen_v4_00#egg=nfelib
 -e git+https://github.com/OCA/openupgradelib.git@master#egg=openupgradelib
 -e git://github.com/erpbrasil/febraban-python.git@v0.7.1#egg=febraban
 vcrpy


### PR DESCRIPTION
nfelib is pretty solid right now so I cut a 1.0 release for pypi. This will help the l10n_br_nfe migration where the python package come from the module manifests and help noob installations.