### PR TITLE
[13.0][MIGR] fix account.tax.repartition.line COA loading

### DIFF
--- a/l10n_br_coa/models/account_chart_template.py
+++ b/l10n_br_coa/models/account_chart_template.py
@@ -80,12 +80,48 @@ class AccountChartTemplate(models.Model):
                         refund_account_id = group_account.get(
                             acc_names.get(tax.type_tax_use, {}).get("refund_account_id")
                         )
-
                     tax.write(
                         {
-                            "account_id": account_id,
-                            "refund_account_id": refund_account_id,
+                            "invoice_repartition_line_ids": [
+                                (5, 0, 0),
+                                (
+                                    0,
+                                    0,
+                                    {
+                                        "factor_percent": 100,
+                                        "repartition_type": "base",
+                                    },
+                                ),
+                                (
+                                    0,
+                                    0,
+                                    {
+                                        "factor_percent": 100,
+                                        "repartition_type": "tax",
+                                        "account_id": account_id,
+                                    },
+                                ),
+                            ],
+                            "refund_repartition_line_ids": [
+                                (5, 0, 0),
+                                (
+                                    0,
+                                    0,
+                                    {
+                                        "factor_percent": 100,
+                                        "repartition_type": "base",
+                                    },
+                                ),
+                                (
+                                    0,
+                                    0,
+                                    {
+                                        "factor_percent": 100,
+                                        "repartition_type": "tax",
+                                        "account_id": refund_account_id,
+                                    },
+                                ),
+                            ],
                         }
                     )
-
         return account_ref, taxes_ref


### PR DESCRIPTION
as taxas não tem mais campos account_id e refund_account_id. Agora tem um account.tax.repartion.line, que permite uma contabilização mais fina dos impostos. Por enquanto, eu não vejo utilidade disso no Brasil mas se queremos lançar os impostos como antes, temos que instanciar as taxas dessa maneira.