### PR TITLE
[12.0][CI] revert "Keep unexpected index" log bloat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,11 @@ install:
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - export WKHTMLTOPDF_VERSION=0.12.5
   - travis_install_nightly
+  - cwd=$(pwd)
+  - if [[ $ODOO_REPO == "odoo/odoo" ]]; then cd ${HOME}/odoo-${VERSION}; fi
+  - if [[ $ODOO_REPO == "OCA/OCB" ]]; then cd ${HOME}/OCB-${VERSION}; fi
+  - if [[ $TESTS == "1" ]]; then git revert 13f02a60c8706b808a57535ac9648a1b0c0741a9 --no-edit; fi
+  - cd $cwd
 
 script:
   - travis_run_tests


### PR DESCRIPTION
Ola pessoal,

temos um problema importante: todos os PRs da 12.0 do OCA/l10n-brazil estão travados desde sexta 20 por conta desse commit da Odoo SA: https://github.com/odoo/odoo/commit/13f02a60c8706b808a57535ac9648a1b0c0741a9
(o commit é do 4 de Junho mas o push dele aconteceu sexta na vdd)

Eu expliquei o problema aqui: https://odoo-community.org/groups/contributors-15/contributors-204318?mode=date&date_begin=2021-08-01&date_end=2021-09-01

Basicamente, esse commit da Odoo SA acrescenta milhares de logs de index ja existente. O problema é que como no OCA/l10n-brazil na 12.0 os testes sao muito extensos, a gente explode o limite de tamanho de log do Travis e os testes param. Eh provável que alguns outros repos sejam blocados tb, vamos saber logo.

Eh improvável que a Odoo SA seja muito reativa para resolver esse problema. Porem tem bastante PRs para entrar, não e legal travar a 12.0 por dias e dias.

Nisso to propondo esse fix temporário no .travis.yml que simplesmente da um revert do commit problemático. La na frente quando a Odoo SA resolvera ou que a OCA tera um fix melhor, a gente podera reverter esse hack, mas por enquanto tou propondo isso para destravar o projeto.

Esse fix realmente destrava os PRs, ver por examplo esse do pin da nfelib 1.1 que nao passava e agora passa de novo: https://app.travis-ci.com/github/OCA/l10n-brazil/builds/235949881

cc @marcelsavegnago @renatonlima @mbcosta @britoederr @netosjb @felipemotter @rpsjr @luismalta @gabrielcardoso21 @ygcarvalh @marcos-mendez @mileo
