### PR TITLE
[12.0][FIX] Standard name to City field in l10n_br_delivery.

### DIFF
--- a/l10n_br_delivery/demo/l10n_br_delivery_demo.xml
+++ b/l10n_br_delivery/demo/l10n_br_delivery_demo.xml
@@ -35,7 +35,7 @@
         <field name="rntc_code">Teste - Codigo RTNC 1</field>
         <field name="country_id" ref="base.br"/>
         <field name="state_id" ref="base.state_br_sp"/>
-        <field name="l10n_br_city_id" ref="l10n_br_base.city_3518800"/>
+        <field name="city_id" ref="l10n_br_base.city_3518800"/>
         <field name="active" eval="1"/>
         <field name="manufacture_year">2000</field>
         <field name="model_year">2001</field>
@@ -51,7 +51,7 @@
         <field name="rntc_code">Teste - Codigo RTNC 2</field>
         <field name="country_id" ref="base.br"/>
         <field name="state_id" ref="base.state_br_sp"/>
-        <field name="l10n_br_city_id" ref="l10n_br_base.city_3518800"/>
+        <field name="city_id" ref="l10n_br_base.city_3518800"/>
         <field name="active" eval="1"/>
         <field name="manufacture_year">2010</field>
         <field name="model_year">2011</field>

--- a/l10n_br_delivery/models/vehicle.py
+++ b/l10n_br_delivery/models/vehicle.py
@@ -45,7 +45,7 @@ class CarrierVehicle(models.Model):
         domain="[('country_id', '=', country_id)]",
     )
 
-    l10n_br_city_id = fields.Many2one(
+    city_id = fields.Many2one(
         comodel_name='res.city',
         string='City',
         domain="[('state_id', '=', state_id)]",

--- a/l10n_br_delivery/views/l10n_br_delivery_view.xml
+++ b/l10n_br_delivery/views/l10n_br_delivery_view.xml
@@ -19,7 +19,7 @@
                 <field name="rntc_code"/>
                 <field name="country_id"/>
                 <field name="state_id"/>
-                <field name="l10n_br_city_id"/>
+                <field name="city_id"/>
                 <field name="manufacture_year"/>
                 <field name="model_year"/>
                 <field name="type"/>


### PR DESCRIPTION
Simple PR, just changed the name of field City to keep the standard, it was missing in https://github.com/OCA/l10n-brazil/pull/1301 

Alteração simples que ficou faltando no PR do delivery(link acima), como o merge é recente não há necessidade de script de migração.

cc @renatonlima @rvalyi 