### PR TITLE
[12.0] l10n_br_fiscal need_validation

### DIFF
--- a/l10n_br_fiscal/models/document_workflow.py
+++ b/l10n_br_fiscal/models/document_workflow.py
@@ -306,6 +306,17 @@ class DocumentWorkflow(models.AbstractModel):
                 self._generate_key()
 
     def _document_confirm(self):
+        for doc in self:
+            need_validation_products = [
+                l.product_id.name
+                for l in self.line_ids
+                if l.product_id and l.product_id.need_fiscal_validation
+            ]
+            if need_validation_products:
+                raise UserError(
+                    _("Products %s need a fiscal validation!")
+                    % (", ".join(need_validation_products))
+                )
         self._change_state(SITUACAO_EDOC_A_ENVIAR)
 
     def action_document_confirm(self):

--- a/l10n_br_fiscal/models/product_template.py
+++ b/l10n_br_fiscal/models/product_template.py
@@ -24,6 +24,10 @@ class ProductTemplate(models.Model):
 
     fiscal_type = fields.Selection(selection=PRODUCT_FISCAL_TYPE, string="Fiscal Type")
 
+    def _get_default_need_fiscal_validation(self):
+        if self.user_has_groups("l10n_br_fiscal.group_laxist_user"):
+            return True
+
     icms_origin = fields.Selection(
         selection=ICMS_ORIGIN, string="ICMS Origin", default=ICMS_ORIGIN_DEFAULT
     )
@@ -92,3 +96,5 @@ class ProductTemplate(models.Model):
     uot_id = fields.Many2one(comodel_name="uom.uom", string="Tax UoM")
 
     uot_factor = fields.Float(string="Tax UoM Factor")
+
+    need_fiscal_validation = fields.Boolean(default=_get_default_need_fiscal_validation)

--- a/l10n_br_fiscal/models/res_partner.py
+++ b/l10n_br_fiscal/models/res_partner.py
@@ -26,7 +26,7 @@ class ResPartner(models.Model):
         )
 
     def _get_default_need_fiscal_validation(self):
-        if self.user_has_groups('l10n_br_fiscal.group_laxist_user'):
+        if self.user_has_groups("l10n_br_fiscal.group_laxist_user"):
             return True
 
     tax_framework = fields.Selection(
@@ -85,7 +85,7 @@ class ResPartner(models.Model):
 
     need_fiscal_validation = fields.Boolean(
         default=_get_default_need_fiscal_validation,
-        track_visibility='onchange',
+        track_visibility="onchange",
     )
 
     def _inverse_fiscal_profile(self):

--- a/l10n_br_fiscal/models/res_partner.py
+++ b/l10n_br_fiscal/models/res_partner.py
@@ -25,6 +25,10 @@ class ResPartner(models.Model):
             [("default", "=", True), ("is_company", "=", is_company)], limit=1
         )
 
+    def _get_default_need_fiscal_validation(self):
+        if self.user_has_groups('l10n_br_fiscal.group_laxist_user'):
+            return True
+
     tax_framework = fields.Selection(
         selection=TAX_FRAMEWORK,
         default=TAX_FRAMEWORK_NORMAL,
@@ -77,6 +81,11 @@ class ResPartner(models.Model):
 
     city_id = fields.Many2one(
         track_visibility="onchange",
+    )
+
+    need_fiscal_validation = fields.Boolean(
+        default=_get_default_need_fiscal_validation,
+        track_visibility='onchange',
     )
 
     def _inverse_fiscal_profile(self):

--- a/l10n_br_fiscal/security/fiscal_security.xml
+++ b/l10n_br_fiscal/security/fiscal_security.xml
@@ -20,6 +20,12 @@
         <field name="implied_ids" eval="[(4, ref('l10n_br_fiscal.group_user'))]" />
     </record>
 
+    <record id="group_laxist_user" model="res.groups">
+        <field name="name">Fiscal Laxist User</field>
+        <field name="category_id" ref="module_category_l10n_br_fiscal_management" />
+        <field name="implied_ids" eval="[(4, ref('l10n_br_fiscal.group_user'))]" />
+    </record>
+
     <record id="group_data_maintenance" model="res.groups">
         <field name="name">Fiscal Data Maitenance</field>
         <field name="category_id" ref="base.module_category_hidden" />

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -9,6 +9,11 @@
         <field name="document_number" />
         <field name="partner_id" />
         <field name="document_type_id" />
+        <filter
+                    string="Need Fiscal Validation"
+                    name="need_fiscal_validation"
+                    domain="[('need_fiscal_validation', '=', True)]"
+                />
         <group expand='0' string='Group By...'>
           <filter
                         string="Month"
@@ -244,6 +249,10 @@
                                 attrs="{'readonly': [('issuer', '=', 'company')], 'required': [('issuer', '=', 'partner')]}"
                             />
               <field name="state_fiscal" />
+              <field
+                                name="need_fiscal_validation"
+                                groups="l10n_br_fiscal.group_manager"
+                            />
             </group>
           </group>
           <notebook>

--- a/l10n_br_fiscal/views/product_template_view.xml
+++ b/l10n_br_fiscal/views/product_template_view.xml
@@ -33,6 +33,13 @@
                     filter_domain="[('service_type_id', '=', raw_value)]"
                 />
             </field>
+            <xpath expr="//filter[@name='consumable']" position="after">
+                <filter
+                    string="Need Fiscal Validation"
+                    name="need_fiscal_validation"
+                    domain="[('need_fiscal_validation', '=', True)]"
+                />
+            </xpath>
         </field>
     </record>
 
@@ -60,13 +67,25 @@
                 <page name="fiscal" string="Fiscal" groups="l10n_br_fiscal.group_user">
                     <group>
                         <group>
-                            <field name="fiscal_type" required="1" />
+  			<field
+                                name="fiscal_type"
+                                required="1"
+                                iattrs="{'required': [('need_fiscal_validation', '=', False)]}"
+                            />
                             <field
                                 name="icms_origin"
-                                attrs="{'required': [('fiscal_type', '!=', '09')], 'invisible': [('fiscal_type', '=', '09')]}"
+                                attrs="{'required': [('fiscal_type', '!=', '09'), ('need_fiscal_validation', '=', False)], 'invisible': [('fiscal_type', '=', '09')]}"
                             />
-                            <field name="ncm_id" required="1" />
-                            <field name="tax_icms_or_issqn" required="1" />
+			    <field
+                                name="ncm_id"
+                                required="1"
+                                attrs="{'required': [('need_fiscal_validation', '=', False)]}"
+                            />
+			    <field
+                                name="tax_icms_or_issqn"
+                                required="1"
+                                attrs="{'required': [('need_fiscal_validation', '=', False)]}"
+                            />
                             <field
                                 name="service_type_id"
                                 attrs="{'invisible': [('fiscal_type', '!=', '09')]}"
@@ -83,11 +102,16 @@
                                     <field name="state_id" />
                                     <field name="city_id" />
                                     <field name="cnae_id" />
-                                </tree>
+                                  </tree>
                             </field>
+                            <field name="need_fiscal_validation" />
                         </group>
                         <group>
-                            <field name="fiscal_genre_id" required="1" />
+			    <field
+                                name="fiscal_genre_id"
+                                required="1"
+                                attrs="{'required': [('need_fiscal_validation', '=', False)]}"
+                            />
                             <field
                                 name="cest_id"
                                 attrs="{'invisible': [('fiscal_type', '=', '09')]}"

--- a/l10n_br_fiscal/views/product_template_view.xml
+++ b/l10n_br_fiscal/views/product_template_view.xml
@@ -67,23 +67,20 @@
                 <page name="fiscal" string="Fiscal" groups="l10n_br_fiscal.group_user">
                     <group>
                         <group>
-  			<field
+                            <field
                                 name="fiscal_type"
-                                required="1"
-                                iattrs="{'required': [('need_fiscal_validation', '=', False)]}"
+                                attrs="{'required': [('need_fiscal_validation', '=', False)]}"
                             />
                             <field
                                 name="icms_origin"
                                 attrs="{'required': [('fiscal_type', '!=', '09'), ('need_fiscal_validation', '=', False)], 'invisible': [('fiscal_type', '=', '09')]}"
                             />
-			    <field
+                            <field
                                 name="ncm_id"
-                                required="1"
                                 attrs="{'required': [('need_fiscal_validation', '=', False)]}"
                             />
-			    <field
+                            <field
                                 name="tax_icms_or_issqn"
-                                required="1"
                                 attrs="{'required': [('need_fiscal_validation', '=', False)]}"
                             />
                             <field
@@ -104,12 +101,14 @@
                                     <field name="cnae_id" />
                                   </tree>
                             </field>
-                            <field name="need_fiscal_validation" />
+                            <field
+                                name="need_fiscal_validation"
+                                groups="l10n_br_fiscal.group_manager"
+                            />
                         </group>
                         <group>
-			    <field
+                            <field
                                 name="fiscal_genre_id"
-                                required="1"
                                 attrs="{'required': [('need_fiscal_validation', '=', False)]}"
                             />
                             <field

--- a/l10n_br_fiscal/views/res_partner_view.xml
+++ b/l10n_br_fiscal/views/res_partner_view.xml
@@ -1,6 +1,21 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
 
+    <record id="l10n_br_base_res_partner_filter" model="ir.ui.view">
+        <field name="name">l10n_br_base.res.partner.filter</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_res_partner_filter" />
+        <field name="arch" type="xml">
+            <filter name="inactive" position="after">
+                <filter
+                    string="Need Fiscal Validation"
+                    name="need_fiscal_validation"
+                    domain="[('need_fiscal_validation', '=', True)]"
+                />
+            </filter>
+        </field>
+    </record>
+
     <record id="partner_form" model="ir.ui.view">
         <field name="name">l10n_br_fiscal.partner.form</field>
         <field name="model">res.partner</field>
@@ -25,6 +40,10 @@
                         attrs="{'readonly': [('fiscal_profile_id', '!=', False)]}"
                     />
                     <field name="cnae_main_id" />
+                    <field
+                        name="need_fiscal_validation"
+                        groups="l10n_br_fiscal.group_manager"
+                    />
                 </group>
             </group>
         </field>


### PR DESCRIPTION
Uma limitação no modulo fiscal atual é que qualquer usuário do fiscal tem que preencher campos como fiscal_type, icms_origin, tax_icms_or_issqn e ncm_id sempre que criar um novo produto. Mas tem algumas situaçoes onde isso não é legal, como:

1. usuario de compra que ta comprando um produto novo do qual ele ainda desconhece os parametros fiscais (que poderiam vir na importação do XML da NFe mais tarde por examplo).
2. usuario fazendo o inventario: precisa levantar o inventario e pode deixar os parametros fiscais para ajustar depois. Um usuario de estoque pode nao ser usuario fiscal (e não enxergar esses campos então) mas se ele for isso pode ser um problema.

A ideia é que temos aqui um novo grupo como "usuario fiscal leniente"/"Fiscal Laxist User".
Produtos (e tb parceiros) tem agora um flag need_fiscal_validation (inspirado pelo modulo base_tier_validation que poderia ser plugado por cima caso houver necessidade). Por padrão quando um usuário do grupo usuário fiscal leniente criar um novo produto ou usuario, esse flag need_fiscal_validation vem como True. Isso permite uma filtragem dos cadastros para uma revisão ulterior.

E por fim, se alguém tantar validar um documento fiscal que tiver um parceiro ou um produto precisando de validação fiscal, ai o Odoo bloca, reclamando que tem que validar os cadastros primeiro.


O que vcs acham? Tb nao seria impossivel empacotar isso como modulo separado, nao sei qual ficaria melhor...