### PR TITLE
[12.0][FIX] incorterm_id in _shadowed_fields in l10n_br_delivery fixes #1596

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -41,7 +41,6 @@ SHADOWED_FIELDS = [
     "company_id",
     "currency_id",
     "partner_shipping_id",
-    "incoterm_id",
 ]
 
 

--- a/l10n_br_delivery/models/__init__.py
+++ b/l10n_br_delivery/models/__init__.py
@@ -1,5 +1,6 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+from . import account_invoice
 from . import delivery_carrier
 from . import vehicle
 from . import sale_order

--- a/l10n_br_delivery/models/account_invoice.py
+++ b/l10n_br_delivery/models/account_invoice.py
@@ -1,0 +1,12 @@
+# Copyright 2019 Akretion (Raphaël Valyi <raphael.valyi@akretion.com>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class AccountInvoice(models.Model):
+    _inherit = "account.invoice"
+
+    @api.model
+    def _shadowed_fields(self):
+        return super()._shadowed_fields() + ["incoterm_id"]


### PR DESCRIPTION
fix de #1596
melhor do que https://github.com/OCA/l10n-brazil/pull/1599 pois agora o campo incoterm_id esta sendo propagado da invoice ate o documento fiscal por estar dentro do _shadowed_fields apenas quando o modulo l10n_br_delivery esta instalado e que faz sentido ter o incoterm_id dentro do documento fiscal (para ter lo no picking pela herança). 

cc @vanderleiromera @marcos-mendez @mbcosta @renatonlima