### PR TITLE
[12.0][BACKPORT][l10n_br_fiscal] usability backport

### DIFF
--- a/l10n_br_fiscal/models/document_eletronic.py
+++ b/l10n_br_fiscal/models/document_eletronic.py
@@ -2,7 +2,8 @@
 # Copyright (C) 2019  KMEE INFORMATICA LTDA
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 from ..constants.fiscal import (
     DOCUMENT_ISSUER,
@@ -207,6 +208,8 @@ class DocumentEletronic(models.AbstractModel):
         if not xml_file:
             self._document_export()
             xml_file = self.authorization_file_id or self.send_file_id
+        if not xml_file:
+            raise UserError(_("No XML file generated!"))
         return self._target_new_tab(xml_file)
 
     def make_pdf(self):
@@ -216,9 +219,11 @@ class DocumentEletronic(models.AbstractModel):
         self.ensure_one()
         if not self.file_report_id:
             self.make_pdf()
+        if not self.file_report_id:
+            raise UserError(_("No PDF file generated!"))
         return self._target_new_tab(self.file_report_id)
 
     def _document_status(self):
-        """Retorna o status do docuemnto em texto e se necessário,
+        """Retorna o status do documento em texto e se necessário,
         atualiza o status do documento"""
         return

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -316,7 +316,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             taxes = self.env["l10n_br_fiscal.tax"]
             for tax in mapping_result["taxes"].values():
                 taxes |= tax
-            self.fiscal_tax_ids = [(6, 0, taxes.ids)]
+            self.fiscal_tax_ids = taxes
             self._update_taxes()
             self.comment_ids = self.fiscal_operation_line_id.comment_ids
 

--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -170,20 +170,6 @@ class Tax(models.Model):
         ("fiscal_tax_code_uniq", "unique (name)", "Tax already exists with this name !")
     ]
 
-    def get_account_tax(self, fiscal_operation_type=FISCAL_OUT):
-        account_tax_type = {"out": "sale", "in": "purchase"}
-        type_tax_use = account_tax_type.get(fiscal_operation_type, "sale")
-
-        account_taxes = self.env["account.tax"].search(
-            [
-                ("fiscal_tax_id", "=", self.ids),
-                ("active", "=", True),
-                ("type_tax_use", "=", type_tax_use),
-            ]
-        )
-
-        return account_taxes
-
     def cst_from_tax(self, fiscal_operation_type=FISCAL_OUT):
         self.ensure_one()
         cst = self.env["l10n_br_fiscal.cst"]
@@ -712,8 +698,7 @@ class Tax(models.Model):
         taxes = {}
 
         for tax in self.sorted(key=lambda t: t.compute_sequence):
-            tax_dict = TAX_DICT_VALUES.copy()
-            taxes[tax.tax_domain] = tax_dict
+            taxes[tax.tax_domain] = dict(TAX_DICT_VALUES)
             try:
                 # Define CST FROM TAX
                 operation_line = kwargs.get("operation_line")

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -106,7 +106,7 @@
                         string="Visualizar XML"
                         groups="l10n_br_fiscal.group_user"
                         class="btn-primary"
-                        attrs="{'invisible': [('state_edoc', '=', 'em_digitacao')]}"
+                        attrs="{'invisible': ['|', ('document_electronic', '=', False), ('state_edoc', '=', 'em_digitacao')]}"
                     />
             <button
                         name="action_document_cancel"

--- a/l10n_br_fiscal/wizards/base_wizard_mixin.py
+++ b/l10n_br_fiscal/wizards/base_wizard_mixin.py
@@ -74,7 +74,6 @@ class BaseWizardMixin(models.TransientModel):
             "document_key",
             "document_number",
             "document_serie",
-            "document_status",
             "document_type_id",
             "partner_id",
             "rps_number",


### PR DESCRIPTION
backport de 3 commits do PR de migração para a 13 https://github.com/OCA/l10n-brazil/pull/1571

https://github.com/OCA/l10n-brazil/commit/3c167c4218e71a68e0e5e8346ddcce7fb366038d é uma limpeza trivial de codigo não mais usado.

Os 2 outros commits resolvem problemas identificados pelo @britoederr no PR #1571