### PR TITLE
Inserindo o toml que não instala sozinho

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 num2words==0.5.4
 pycep-correios==5.0.0
 workalendar==7.1.1
+toml=0.10.2
 erpbrasil.base==2.1.0
 erpbrasil.assinatura==1.2.0
 erpbrasil.transmissao==1.0.0


### PR DESCRIPTION
Ainda assim é importante notar que não resolve o problema do XMLSEC, somente com a #PR22 do ERPBRASIL. 

Ainda assim se ignorar estes requirements e utilizar os antigos tudo funciona normalmente, estou fazendo esta PR só para antecipar as mudanças que estão por vir.

ACHO EU

Importante é tentar deixar a -b MAIN 12.0 estável que agora não está estável