### PR TITLE
[12.0] revert fix ci logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,11 +54,6 @@ install:
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - export WKHTMLTOPDF_VERSION=0.12.5
   - travis_install_nightly
-  - cwd=$(pwd)
-  - if [[ $ODOO_REPO == "odoo/odoo" ]]; then cd ${HOME}/odoo-${VERSION}; fi
-  - if [[ $ODOO_REPO == "OCA/OCB" ]]; then cd ${HOME}/OCB-${VERSION}; fi
-  - if [[ $TESTS == "1" ]]; then git revert 13f02a60c8706b808a57535ac9648a1b0c0741a9 --no-edit; fi
-  - cd $cwd
 
 script:
   - travis_run_tests


### PR DESCRIPTION
Isso faz um revert exato do commit dessa PR https://github.com/OCA/l10n-brazil/pull/1587
Pois depois de 10 dias a Odoo SA finalemente fez o merge da resolução do problema (pela comunidade): 
https://github.com/odoo/odoo/commit/57f078b68b79bfdb53d4d7bb71b6672b4ad8e661

![26b250a738ea4abc7a5af4d42ad93af0](https://user-images.githubusercontent.com/16926/131375508-695d25d9-f503-421f-bbe8-35d2fb0c1c62.jpg)
