### PR TITLE
[12.0][FIX] _force_stack_paths attribute in spec_driven_model

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -57,10 +57,7 @@ def filter_processador_edoc_nfe(record):
 
 class NFe(spec_models.StackedModel):
     _name = "l10n_br_fiscal.document"
-    _inherit = [
-        "l10n_br_fiscal.document",
-        "nfe.40.infnfe",
-    ]
+    _inherit = ["l10n_br_fiscal.document", "nfe.40.infnfe"]
     _stacked = "nfe.40.infnfe"
     _stack_skip = "nfe40_veicTransp"
     _field_prefix = "nfe40_"
@@ -69,7 +66,6 @@ class NFe(spec_models.StackedModel):
     _odoo_module = "l10n_br_nfe"
     _spec_module = "odoo.addons.l10n_br_nfe_spec.models.v4_00.leiauteNFe"
     _spec_tab_name = "NFe"
-    #    _concrete_skip = ('nfe.40.det',) # will be mixed in later
     _nfe_search_keys = ["nfe40_Id"]
 
     # all m2o at this level will be stacked even if not required:

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -60,8 +60,6 @@ class NFe(spec_models.StackedModel):
     _inherit = [
         "l10n_br_fiscal.document",
         "nfe.40.infnfe",
-        "nfe.40.infadic",
-        "nfe.40.exporta",
     ]
     _stacked = "nfe.40.infnfe"
     _stack_skip = "nfe40_veicTransp"
@@ -71,12 +69,11 @@ class NFe(spec_models.StackedModel):
     _odoo_module = "l10n_br_nfe"
     _spec_module = "odoo.addons.l10n_br_nfe_spec.models.v4_00.leiauteNFe"
     _spec_tab_name = "NFe"
-    _stacking_points = {}
     #    _concrete_skip = ('nfe.40.det',) # will be mixed in later
     _nfe_search_keys = ["nfe40_Id"]
 
     # all m2o at this level will be stacked even if not required:
-    _force_stack_paths = ("infnfe.total", "infnfe.infAdic")
+    _force_stack_paths = ("infnfe.total", "infnfe.infAdic", "infnfe.exporta")
 
     def _compute_emit(self):
         for doc in self:  # TODO if out

--- a/l10n_br_nfe/tests/test_nfe_structure.py
+++ b/l10n_br_nfe/tests/test_nfe_structure.py
@@ -54,15 +54,20 @@ class NFeStructure(SavepointCase):
     def test_m2o_stacked(self):
         # not stacked because optional
         nfe_model = self.env["l10n_br_fiscal.document"]
-        assert "nfe40_ide" not in nfe_model._fields.keys()
-        assert "nfe40_imposto" not in nfe_model._fields.keys()
+        # nfe40_cana is optional so its fields shoudn't be stacked
+        assert "nfe40_safra" not in nfe_model._fields.keys()
 
     def test_doc_stacking_points(self):
         doc_keys = [
             "nfe40_ICMSTot",
             "nfe40_ISSQNtot",
+            "nfe40_exporta",
             "nfe40_ide",
+            "nfe40_infAdic",
             "nfe40_pag",
+            "nfe40_refECF",
+            "nfe40_refNF",
+            "nfe40_refNFP",
             "nfe40_retTrib",
             "nfe40_total",
             "nfe40_transp",

--- a/l10n_br_nfe/views/nfe_document_view.xml
+++ b/l10n_br_nfe/views/nfe_document_view.xml
@@ -36,12 +36,6 @@
                   <field name="nfe40_detPag" />
               </group>
           </page>
-          <field name="customer_additional_data" position="after">
-              <field
-                    name="nfe40_infAdic"
-                    attrs="{'invisible': [('document_type', 'not in', ['55', '65'])]}"
-                />
-          </field>
       </field>
   </record>
 

--- a/spec_driven_model/models/spec_models.py
+++ b/spec_driven_model/models/spec_models.py
@@ -307,7 +307,7 @@ class StackedModel(SpecModel):
                 continue
             child_concrete = SpecModel._get_concrete(child._name)
             field_path = name.replace(registry[node._name]._field_prefix, "")
-            if path + '.' + field_path in cls._force_stack_paths:
+            if path + "." + field_path in cls._force_stack_paths:
                 classes.add(child)
 
             if f["type"] == "one2many":
@@ -318,8 +318,10 @@ class StackedModel(SpecModel):
             # inicial if where we look if node has a concrete model or not.
             # many2one
             elif (child_concrete is None or child_concrete == cls._name) and (
-                f["xsd_required"] or f["choice"] or path in cls._force_stack_paths
-                or path + '.' + field_path in cls._force_stack_paths
+                f["xsd_required"]
+                or f["choice"]
+                or path in cls._force_stack_paths
+                or path + "." + field_path in cls._force_stack_paths
             ):
                 # then we will STACK the child in the current class
                 # TODO if model not used in any other field!!

--- a/spec_driven_model/models/spec_models.py
+++ b/spec_driven_model/models/spec_models.py
@@ -307,6 +307,9 @@ class StackedModel(SpecModel):
                 continue
             child_concrete = SpecModel._get_concrete(child._name)
             field_path = name.replace(registry[node._name]._field_prefix, "")
+            if path + '.' + field_path in cls._force_stack_paths:
+                classes.add(child)
+
             if f["type"] == "one2many":
                 # _logger.info("%s    \u2261 <%s> %s" % (
                 #     indent, field_path, child_concrete or child._name))
@@ -316,6 +319,7 @@ class StackedModel(SpecModel):
             # many2one
             elif (child_concrete is None or child_concrete == cls._name) and (
                 f["xsd_required"] or f["choice"] or path in cls._force_stack_paths
+                or path + '.' + field_path in cls._force_stack_paths
             ):
                 # then we will STACK the child in the current class
                 # TODO if model not used in any other field!!


### PR DESCRIPTION
Recentemente eu encontrei um bug que estava dificultando a implementação de modelos stacked usando o atributo _force_stack_paths, para contornar essa falha estava sendo definidos objetos no inherit para transforma-los em stacked, com esse PR agora não é mais necessário adicionar os objetos no inherit, basta usar o _force_stack_paths.