### PR TITLE
[12.0][IMP] Purchase Report with BR fields

### DIFF
--- a/l10n_br_purchase/demo/l10n_br_purchase.xml
+++ b/l10n_br_purchase/demo/l10n_br_purchase.xml
@@ -16,14 +16,14 @@
         <value eval="[ref('main_po_only_products')]" />
     </function>
 
-
     <record id="main_pl_only_products_1_2" model="purchase.order.line">
         <field name="order_id" ref="main_po_only_products" />
         <field name="name">Office Chair Black</field>
         <field name="product_id" ref="product.product_product_12" />
         <field name="product_qty">4</field>
         <field name="product_uom" ref="uom.product_uom_unit" />
-        <field name="price_unit">12.50</field>
+        <!-- Apesar do Preço ser defindo aqui o _onchange_product_id_fiscal altera o valor -->
+        <field name="price_unit">25.0</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
         <field
             name="fiscal_operation_line_id"
@@ -31,6 +31,10 @@
         />
         <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
     </record>
+
+    <function model="purchase.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_pl_only_products_1_2')]" />
+    </function>
 
     <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('main_pl_only_products_1_2')]" />
@@ -42,11 +46,11 @@
 
     <record id="main_pl_only_products_2_2" model="purchase.order.line">
         <field name="order_id" ref="main_po_only_products" />
-        <field name="name">Laptop Customized</field>
+        <field name="name">Drawer</field>
         <field name="product_id" ref="product.product_product_27" />
         <field name="product_qty">2</field>
         <field name="product_uom" ref="uom.product_uom_unit" />
-        <field name="price_unit">3645.00</field>
+        <field name="price_unit">50.00</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
         <field
             name="fiscal_operation_line_id"
@@ -54,6 +58,10 @@
         />
         <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
     </record>
+
+    <function model="purchase.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_pl_only_products_2_2')]" />
+    </function>
 
     <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('main_pl_only_products_2_2')]" />
@@ -78,14 +86,13 @@
         <value eval="[ref('lp_po_only_products')]" />
     </function>
 
-
     <record id="lp_pl_only_products_1_2" model="purchase.order.line">
         <field name="order_id" ref="lp_po_only_products" />
         <field name="name">Office Chair Black</field>
         <field name="product_id" ref="product.product_product_12" />
         <field name="product_qty">4</field>
         <field name="product_uom" ref="uom.product_uom_unit" />
-        <field name="price_unit">12.50</field>
+        <field name="price_unit">25.00</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
         <field
             name="fiscal_operation_line_id"
@@ -93,6 +100,10 @@
         />
         <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
     </record>
+
+    <function model="purchase.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('lp_pl_only_products_1_2')]" />
+    </function>
 
     <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('lp_pl_only_products_1_2')]" />
@@ -104,11 +115,11 @@
 
     <record id="lp_pl_only_products_2_2" model="purchase.order.line">
         <field name="order_id" ref="lp_po_only_products" />
-        <field name="name">Laptop Customized</field>
+        <field name="name">Drawer</field>
         <field name="product_id" ref="product.product_product_27" />
         <field name="product_qty">2</field>
         <field name="product_uom" ref="uom.product_uom_unit" />
-        <field name="price_unit">12.50</field>
+        <field name="price_unit">50.00</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
         <field
             name="fiscal_operation_line_id"
@@ -116,6 +127,10 @@
         />
         <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
     </record>
+
+    <function model="purchase.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('lp_pl_only_products_2_2')]" />
+    </function>
 
     <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('lp_pl_only_products_2_2')]" />
@@ -146,7 +161,7 @@
         <field name="product_id" ref="product.product_product_12" />
         <field name="product_qty">4</field>
         <field name="product_uom" ref="uom.product_uom_unit" />
-        <field name="price_unit">3645.00</field>
+        <field name="price_unit">25.00</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
         <field
             name="fiscal_operation_line_id"
@@ -154,6 +169,10 @@
         />
         <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
     </record>
+
+    <function model="purchase.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('sn_pl_only_products_1_2')]" />
+    </function>
 
     <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('sn_pl_only_products_1_2')]" />
@@ -165,11 +184,11 @@
 
     <record id="sn_pl_only_products_2_2" model="purchase.order.line">
         <field name="order_id" ref="sn_po_only_products" />
-        <field name="name">Laptop Customized</field>
+        <field name="name">Drawer</field>
         <field name="product_id" ref="product.product_product_27" />
         <field name="product_qty">2</field>
         <field name="product_uom" ref="uom.product_uom_unit" />
-        <field name="price_unit">3645.00</field>
+        <field name="price_unit">50.00</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
         <field
             name="fiscal_operation_line_id"
@@ -177,6 +196,10 @@
         />
         <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
     </record>
+
+    <function model="purchase.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('sn_pl_only_products_2_2')]" />
+    </function>
 
     <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('sn_pl_only_products_2_2')]" />

--- a/l10n_br_purchase/reports/purchase_report.py
+++ b/l10n_br_purchase/reports/purchase_report.py
@@ -1,7 +1,11 @@
-# Copyright (C) 2020  Renato Lima - Akretion
+# Copyright (C) 2020 - TODAY Renato Lima - Akretion
+# Copyright (C) 2021 - TODAY Magno Costa - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from odoo import fields, models
+
+from odoo.addons import decimal_precision as dp
+from odoo.addons.l10n_br_fiscal.constants.fiscal import PRODUCT_FISCAL_TYPE
 
 
 class PurchaseReport(models.Model):
@@ -19,18 +23,116 @@ class PurchaseReport(models.Model):
         readonly=True,
     )
 
+    cfop_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.cfop",
+        string="CFOP",
+    )
+
+    fiscal_type = fields.Selection(selection=PRODUCT_FISCAL_TYPE, string="Tipo Fiscal")
+
+    cest_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.cest",
+        string="CEST",
+    )
+
+    ncm_id = fields.Many2one(comodel_name="l10n_br_fiscal.ncm", string="NCM")
+
+    nbm_id = fields.Many2one(comodel_name="l10n_br_fiscal.nbm", string="NBM")
+
+    icms_value = fields.Float(
+        string="ICMS Value",
+        digits=dp.get_precision("Account"),
+    )
+
+    icmsst_value = fields.Float(
+        string="ICMS ST Value",
+        digits=dp.get_precision("Account"),
+    )
+
+    ipi_value = fields.Float(
+        string="IPI Value",
+        digits=dp.get_precision("Account"),
+    )
+
+    pis_value = fields.Float(
+        string="PIS Value",
+        digits=dp.get_precision("Account"),
+    )
+
+    cofins_value = fields.Float(
+        string="COFINS Value",
+        digits=dp.get_precision("Account"),
+    )
+
+    ii_value = fields.Float(
+        string="II Value",
+        digits=dp.get_precision("Account"),
+    )
+
+    freight_value = fields.Float(
+        string="Freight Value",
+        digits=dp.get_precision("Account"),
+    )
+
+    insurance_value = fields.Float(
+        string="Insurance Value",
+        digits=dp.get_precision("Account"),
+    )
+
+    other_value = fields.Float(
+        string="Other Value",
+        digits=dp.get_precision("Account"),
+    )
+
+    total_with_taxes = fields.Float(
+        string="Total with Taxes",
+        digits=dp.get_precision("Account"),
+    )
+
     def _select(self):
         select_str = super()._select()
         select_str += """
-            , l.fiscal_operation_id as fiscal_operation_id,
-            l.fiscal_operation_line_id as fiscal_operation_line_id
+            , l.fiscal_operation_id as fiscal_operation_id
+            , l.fiscal_operation_line_id as fiscal_operation_line_id
+            , l.cfop_id
+            , l.fiscal_type
+            , l.ncm_id
+            , l.nbm_id
+            , l.cest_id
+            , SUM(l.icms_value) as icms_value
+            , SUM(l.icmsst_value) as icmsst_value
+            , SUM(l.ipi_value) as ipi_value
+            , SUM(l.pis_value) as pis_value
+            , SUM(l.cofins_value) as cofins_value
+            , SUM(l.ii_value) as ii_value
+            , SUM(l.freight_value) as freight_value
+            , SUM(l.insurance_value) as insurance_value
+            , SUM(l.other_value) as other_value
+            , SUM(l.price_unit / COALESCE(NULLIF(cr.rate, 0), 1.0) * l.product_qty
+            )::decimal(16,2)
+             + SUM(CASE WHEN l.ipi_value IS NULL THEN
+              0.00 ELSE l.ipi_value END)
+             + SUM(CASE WHEN l.icmsst_value IS NULL THEN
+              0.00 ELSE l.icmsst_value END)
+             + SUM(CASE WHEN l.freight_value IS NULL THEN
+              0.00 ELSE l.freight_value END)
+             + SUM(CASE WHEN l.insurance_value IS NULL THEN
+              0.00 ELSE l.insurance_value END)
+             + SUM(CASE WHEN l.other_value IS NULL THEN
+              0.00 ELSE l.other_value END)
+            as total_with_taxes
         """
         return select_str
 
     def _group_by(self):
         group_by_str = super()._group_by()
         group_by_str += """
-            , l.fiscal_operation_id,
-            l.fiscal_operation_line_id
+            , l.fiscal_operation_id
+            , l.fiscal_operation_line_id
+            , l.cfop_id
+            , l.fiscal_type
+            , l.ncm_id
+            , l.nbm_id
+            , l.cest_id
         """
         return group_by_str

--- a/l10n_br_purchase/reports/purchase_report_views.xml
+++ b/l10n_br_purchase/reports/purchase_report_views.xml
@@ -17,6 +17,36 @@
                     name="fiscal_operation_line_id"
                     context="{'group_by':'fiscal_operation_line_id'}"
                 />
+                <filter
+                    string="CFOP"
+                    icon="terp-stock_symbol-selection"
+                    name="cfop"
+                    context="{'group_by':'cfop_id'}"
+                />
+                <filter
+                    string="Product Fiscal Type"
+                    icon="terp-stock_symbol-selection"
+                    name="fiscal_type"
+                    context="{'group_by':'fiscal_type'}"
+                />
+                <filter
+                    string="NCM"
+                    icon="terp-stock_symbol-selection"
+                    name="ncm"
+                    context="{'group_by':'ncm_id'}"
+                />
+                <filter
+                    string="NBM"
+                    icon="terp-stock_symbol-selection"
+                    name="nbm"
+                    context="{'group_by':'nbm_id'}"
+                />
+                <filter
+                    string="CEST"
+                    icon="terp-stock_symbol-selection"
+                    name="cest"
+                    context="{'group_by':'cest_id'}"
+                />
             </filter>
         </field>
     </record>


### PR DESCRIPTION
Purchase Report with BR fields.

Incluído os campos dos Valores de Impostos, Frete, Seguro, Outros Valores, Valor Total com Impostos  e a possibilidade de Agrupar por NCM, NBM, CEST e Tipo Fiscal do Produto no relatório de Compras.

Para testes com os dados de demo usar a empresa de Lucro Presumido por ter os impostos:
![image](https://user-images.githubusercontent.com/6341149/132034379-588bc04e-3124-4414-a4f1-779d044b966d.png)

![image](https://user-images.githubusercontent.com/6341149/132034473-450700f5-1ec1-4e57-8618-cbaec12f3e24.png)

cc @renatonlima @rvalyi 