### PR TITLE
[12.0][IMP] l10n_br_fiscal: rename tax fields (ret to wh)

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -9,7 +9,7 @@
     "author": "Akretion, Odoo Community Association (OCA)",
     "maintainers": ["renatonlima"],
     "website": "https://github.com/OCA/l10n-brazil",
-    "version": "12.0.17.5.0",
+    "version": "12.0.18.0.0",
     "development_status": "Production/Stable",
     "depends": [
         "uom",

--- a/l10n_br_fiscal/migrations/12.0.18.0.0/pre-migration.py
+++ b/l10n_br_fiscal/migrations/12.0.18.0.0/pre-migration.py
@@ -1,0 +1,73 @@
+# Copyright (C) 2021 - TODAY, Marcel Savegnago <marcel.savegnago@escodoo.com.br>
+# License AGPL-3.0 or later (
+# http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+_field_renames = [
+    (
+        "l10n_br_fiscal.document.mixin",
+        "l10n_br_fiscal_document_mixin",
+        "amount_pis_ret_base",
+        "amount_pis_wh_base",
+    ),
+    (
+        "l10n_br_fiscal.document.mixin",
+        "l10n_br_fiscal_document_mixin",
+        "amount_cofins_ret_base",
+        "amount_confis_wh_base",
+    ),
+    (
+        "l10n_br_fiscal.document.mixin",
+        "l10n_br_fiscal_document_mixin",
+        "amount_issqn_ret_base",
+        "amount_issqn_wh_base",
+    ),
+    (
+        "l10n_br_fiscal.document.mixin",
+        "l10n_br_fiscal_document_mixin",
+        "amount_csll_ret_base",
+        "amount_csll_wh_base",
+    ),
+    (
+        "l10n_br_fiscal.document.mixin",
+        "l10n_br_fiscal_document_mixin",
+        "amount_irpj_ret_base",
+        "amount_irpj_wh_base",
+    ),
+    (
+        "l10n_br_fiscal.document.mixin",
+        "l10n_br_fiscal_document_mixin",
+        "amount_pis_ret_value",
+        "amount_pis_wh_value",
+    ),
+    (
+        "l10n_br_fiscal.document.mixin",
+        "l10n_br_fiscal_document_mixin",
+        "amount_cofins_ret_value",
+        "amount_confis_wh_value",
+    ),
+    (
+        "l10n_br_fiscal.document.mixin",
+        "l10n_br_fiscal_document_mixin",
+        "amount_issqn_ret_value",
+        "amount_issqn_wh_value",
+    ),
+    (
+        "l10n_br_fiscal.document.mixin",
+        "l10n_br_fiscal_document_mixin",
+        "amount_csll_ret_value",
+        "amount_csll_wh_value",
+    ),
+    (
+        "l10n_br_fiscal.document.mixin",
+        "l10n_br_fiscal_document_mixin",
+        "amount_irpj_ret_value",
+        "amount_irpj_wh_value",
+    ),
+]
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    openupgrade.rename_fields(env, _field_renames)

--- a/l10n_br_fiscal/models/document_fiscal_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin.py
@@ -176,12 +176,12 @@ class FiscalDocumentMixin(models.AbstractModel):
         compute="_compute_amount",
     )
 
-    amount_pis_ret_base = fields.Monetary(
+    amount_pis_wh_base = fields.Monetary(
         string="PIS Ret Base",
         compute="_compute_amount",
     )
 
-    amount_pis_ret_value = fields.Monetary(
+    amount_pis_wh_value = fields.Monetary(
         string="PIS Ret Value",
         compute="_compute_amount",
     )
@@ -196,12 +196,12 @@ class FiscalDocumentMixin(models.AbstractModel):
         compute="_compute_amount",
     )
 
-    amount_cofins_ret_base = fields.Monetary(
+    amount_cofins_wh_base = fields.Monetary(
         string="COFINS Ret Base",
         compute="_compute_amount",
     )
 
-    amount_cofins_ret_value = fields.Monetary(
+    amount_cofins_wh_value = fields.Monetary(
         string="COFINS Ret Value",
         compute="_compute_amount",
     )
@@ -216,12 +216,12 @@ class FiscalDocumentMixin(models.AbstractModel):
         compute="_compute_amount",
     )
 
-    amount_issqn_ret_base = fields.Monetary(
+    amount_issqn_wh_base = fields.Monetary(
         string="ISSQN Ret Base",
         compute="_compute_amount",
     )
 
-    amount_issqn_ret_value = fields.Monetary(
+    amount_issqn_wh_value = fields.Monetary(
         string="ISSQN Ret Value",
         compute="_compute_amount",
     )
@@ -236,12 +236,12 @@ class FiscalDocumentMixin(models.AbstractModel):
         compute="_compute_amount",
     )
 
-    amount_csll_ret_base = fields.Monetary(
+    amount_csll_wh_base = fields.Monetary(
         string="CSLL Ret Base",
         compute="_compute_amount",
     )
 
-    amount_csll_ret_value = fields.Monetary(
+    amount_csll_wh_value = fields.Monetary(
         string="CSLL Ret Value",
         compute="_compute_amount",
     )
@@ -256,12 +256,12 @@ class FiscalDocumentMixin(models.AbstractModel):
         compute="_compute_amount",
     )
 
-    amount_irpj_ret_base = fields.Monetary(
+    amount_irpj_wh_base = fields.Monetary(
         string="IRPJ Ret Base",
         compute="_compute_amount",
     )
 
-    amount_irpj_ret_value = fields.Monetary(
+    amount_irpj_wh_value = fields.Monetary(
         string="IRPJ Ret Value",
         compute="_compute_amount",
     )

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -436,32 +436,32 @@
                   <group string="ISSQN">
                     <field name="amount_issqn_base" />
                     <field name="amount_issqn_value" />
-                    <field name="amount_issqn_ret_base" />
-                    <field name="amount_issqn_ret_value" />
+                    <field name="amount_issqn_wh_base" />
+                    <field name="amount_issqn_wh_value" />
                   </group>
                   <group string="PIS">
                     <field name="amount_pis_base" />
                     <field name="amount_pis_value" />
-                    <field name="amount_pis_ret_base" />
-                    <field name="amount_pis_ret_value" />
+                    <field name="amount_pis_wh_base" />
+                    <field name="amount_pis_wh_value" />
                   </group>
                   <group string="COFINS">
                     <field name="amount_cofins_base" />
                     <field name="amount_cofins_value" />
-                    <field name="amount_cofins_ret_base" />
-                    <field name="amount_cofins_ret_value" />
+                    <field name="amount_cofins_wh_base" />
+                    <field name="amount_cofins_wh_value" />
                   </group>
                   <group string="CSLL">
                     <field name="amount_csll_base" />
                     <field name="amount_csll_value" />
-                    <field name="amount_csll_ret_base" />
-                    <field name="amount_csll_ret_value" />
+                    <field name="amount_csll_wh_base" />
+                    <field name="amount_csll_wh_value" />
                   </group>
                   <group string="IRPJ">
                     <field name="amount_irpj_base" />
                     <field name="amount_irpj_value" />
-                    <field name="amount_irpj_ret_base" />
-                    <field name="amount_irpj_ret_value" />
+                    <field name="amount_irpj_wh_base" />
+                    <field name="amount_irpj_wh_value" />
                   </group>
                   <group string="INSS">
                     <field name="amount_inss_base" />

--- a/l10n_br_nfse/report/danfse.xml
+++ b/l10n_br_nfse/report/danfse.xml
@@ -381,7 +381,7 @@ row {
                        <span t-field="doc.amount_pis_value" />
                     </t>
                     <t t-else="">
-                       <span t-field="doc.amount_pis_ret_value" />
+                       <span t-field="doc.amount_pis_wh_value" />
                     </t>
                 </div>
                 <div class="col-1 rotulo br">
@@ -392,7 +392,7 @@ row {
                        <span t-field="doc.amount_cofins_value" />
                     </t>
                     <t t-else="">
-                       <span t-field="doc.amount_cofins_ret_value" />
+                       <span t-field="doc.amount_cofins_wh_value" />
                     </t>
                 </div>
                 <div class="col-1 rotulo br">
@@ -403,7 +403,7 @@ row {
                        <span t-field="doc.amount_csll_value" />
                     </t>
                     <t t-else="">
-                       <span t-field="doc.amount_csll_ret_value" />
+                       <span t-field="doc.amount_csll_wh_value" />
                     </t>
                 </div>
                 <div class="col-1 rotulo br">
@@ -414,7 +414,7 @@ row {
                        <span t-field="doc.amount_csll_value" />
                     </t>
                     <t t-else="">
-                       <span t-field="doc.amount_csll_ret_value" />
+                       <span t-field="doc.amount_csll_wh_value" />
                     </t>
                 </div>
                 <div class="col-1 rotulo br">


### PR DESCRIPTION
@renatonlima @rvalyi renomeei os campos ret para wh. Só fiquei na duvida com o script de migração por conta do mixin ser um modelo abstrato (se puderem orientar eu agradeço).

Obs. Já aproveitei este PR e fiz um commit separado para o danfse do módulo l10n_br_nfse