### PR TITLE
[12.0][IMP] BR fields in the Sale Report

### DIFF
--- a/l10n_br_sale/demo/l10n_br_sale.xml
+++ b/l10n_br_sale/demo/l10n_br_sale.xml
@@ -23,11 +23,16 @@
         <field name="product_id" ref="product.product_product_27" />
         <field name="product_uom_qty">2</field>
         <field name="product_uom" ref="uom.product_uom_unit" />
+        <!-- Apesar do Preço ser defindo aqui o _onchange_product_id_fiscal altera o valor -->
         <field name="price_unit">500</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
         <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda" />
     </record>
+
+    <function model="sale.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_sl_only_products_1_2')]" />
+    </function>
 
     <function model="sale.order.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('main_sl_only_products_1_2')]" />
@@ -50,6 +55,10 @@
         <field name="discount_fixed">True</field>
         <field name="discount_value">50.0</field>
     </record>
+
+    <function model="sale.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_sl_only_products_2_2')]" />
+    </function>
 
     <function model="sale.order.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('main_sl_only_products_2_2')]" />
@@ -86,6 +95,10 @@
         <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_servico" />
     </record>
 
+    <function model="sale.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_sl_only_services_1_2')]" />
+    </function>
+
     <function model="sale.order.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('main_sl_only_services_1_2')]" />
     </function>
@@ -105,6 +118,10 @@
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
         <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_servico" />
     </record>
+
+    <function model="sale.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_sl_only_services_2_2')]" />
+    </function>
 
     <function model="sale.order.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('main_sl_only_services_2_2')]" />
@@ -141,6 +158,10 @@
         <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda" />
     </record>
 
+    <function model="sale.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_sl_product_service_1_2')]" />
+    </function>
+
     <function model="sale.order.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('main_sl_product_service_1_2')]" />
     </function>
@@ -163,6 +184,10 @@
             ref="l10n_br_fiscal.fo_venda_servico_ind"
         />
     </record>
+
+    <function model="sale.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_sl_product_service_2_2')]" />
+    </function>
 
     <function model="sale.order.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('main_sl_product_service_2_2')]" />
@@ -200,6 +225,10 @@
         <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda" />
     </record>
 
+    <function model="sale.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('sn_sl_only_products_1_2')]" />
+    </function>
+
     <function model="sale.order.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('sn_sl_only_products_1_2')]" />
     </function>
@@ -219,6 +248,10 @@
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
         <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda" />
     </record>
+
+    <function model="sale.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('sn_sl_only_products_2_2')]" />
+    </function>
 
     <function model="sale.order.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('sn_sl_only_products_2_2')]" />
@@ -255,6 +288,10 @@
         <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_servico" />
     </record>
 
+    <function model="sale.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('sn_sl_only_services_1_2')]" />
+    </function>
+
     <function model="sale.order.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('sn_sl_only_services_1_2')]" />
     </function>
@@ -274,6 +311,10 @@
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
         <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_servico" />
     </record>
+
+    <function model="sale.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('sn_sl_only_services_2_2')]" />
+    </function>
 
     <function model="sale.order.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('sn_sl_only_services_2_2')]" />
@@ -310,6 +351,10 @@
         <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda" />
     </record>
 
+    <function model="sale.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('sn_sl_product_service_1_2')]" />
+    </function>
+
     <function model="sale.order.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('sn_sl_product_service_1_2')]" />
     </function>
@@ -332,6 +377,10 @@
             ref="l10n_br_fiscal.fo_venda_servico_ind"
         />
     </record>
+
+    <function model="sale.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('sn_sl_product_service_2_2')]" />
+    </function>
 
     <function model="sale.order.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('sn_sl_product_service_2_2')]" />
@@ -369,6 +418,10 @@
         <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda" />
     </record>
 
+    <function model="sale.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('lc_sl_only_products_1_2')]" />
+    </function>
+
     <function model="sale.order.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('lc_sl_only_products_1_2')]" />
     </function>
@@ -388,6 +441,10 @@
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
         <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda" />
     </record>
+
+    <function model="sale.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('lc_sl_only_products_2_2')]" />
+    </function>
 
     <function model="sale.order.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('lc_sl_only_products_2_2')]" />
@@ -424,6 +481,10 @@
         <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_servico" />
     </record>
 
+    <function model="sale.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('lc_sl_only_services_1_2')]" />
+    </function>
+
     <function model="sale.order.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('lc_sl_only_services_1_2')]" />
     </function>
@@ -443,6 +504,10 @@
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
         <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_servico" />
     </record>
+
+    <function model="sale.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('lc_sl_only_services_2_2')]" />
+    </function>
 
     <function model="sale.order.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('lc_sl_only_services_2_2')]" />
@@ -479,6 +544,10 @@
         <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda" />
     </record>
 
+    <function model="sale.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('lc_sl_product_service_1_2')]" />
+    </function>
+
     <function model="sale.order.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('lc_sl_product_service_1_2')]" />
     </function>
@@ -501,6 +570,10 @@
             ref="l10n_br_fiscal.fo_venda_servico_ind"
         />
     </record>
+
+    <function model="sale.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('lc_sl_product_service_2_2')]" />
+    </function>
 
     <function model="sale.order.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('lc_sl_product_service_2_2')]" />

--- a/l10n_br_sale/report/sale_report.py
+++ b/l10n_br_sale/report/sale_report.py
@@ -3,9 +3,11 @@
 
 from odoo import fields, models
 
+from odoo.addons import decimal_precision as dp
 from odoo.addons.l10n_br_fiscal.constants.fiscal import (
     NFE_IND_PRES,
     NFE_IND_PRES_DEFAULT,
+    PRODUCT_FISCAL_TYPE,
 )
 
 
@@ -35,6 +37,69 @@ class SaleReport(models.Model):
         string="CFOP",
     )
 
+    fiscal_type = fields.Selection(
+        selection=PRODUCT_FISCAL_TYPE, string="Product Fiscal Type"
+    )
+
+    cest_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.cest",
+        string="CEST",
+    )
+
+    ncm_id = fields.Many2one(comodel_name="l10n_br_fiscal.ncm", string="NCM")
+
+    nbm_id = fields.Many2one(comodel_name="l10n_br_fiscal.nbm", string="NBM")
+
+    icms_value = fields.Float(
+        string="ICMS Value",
+        digits=dp.get_precision("Account"),
+    )
+
+    icmsst_value = fields.Float(
+        string="ICMS ST Value",
+        digits=dp.get_precision("Account"),
+    )
+
+    ipi_value = fields.Float(
+        string="IPI Value",
+        digits=dp.get_precision("Account"),
+    )
+
+    pis_value = fields.Float(
+        string="PIS Value",
+        digits=dp.get_precision("Account"),
+    )
+
+    cofins_value = fields.Float(
+        string="COFINS Value",
+        digits=dp.get_precision("Account"),
+    )
+
+    ii_value = fields.Float(
+        string="II Value",
+        digits=dp.get_precision("Account"),
+    )
+
+    freight_value = fields.Float(
+        string="Freight Value",
+        digits=dp.get_precision("Account"),
+    )
+
+    insurance_value = fields.Float(
+        string="Insurance Value",
+        digits=dp.get_precision("Account"),
+    )
+
+    other_value = fields.Float(
+        string="Other Value",
+        digits=dp.get_precision("Account"),
+    )
+
+    total_with_taxes = fields.Float(
+        string="Total with Taxes",
+        digits=dp.get_precision("Account"),
+    )
+
     def _query(self, with_clause="", fields=None, groupby="", from_clause=""):
         if fields is None:
             fields = {}
@@ -47,6 +112,33 @@ class SaleReport(models.Model):
                 ),
                 "ind_pres": ", s.ind_pres",
                 "cfop_id": ", l.cfop_id as cfop_id",
+                "fiscal_type": ", l.fiscal_type as fiscal_type",
+                "ncm_id": ", l.ncm_id as ncm_id",
+                "nbm_id": ", l.nbm_id as nbm_id",
+                "cest_id": ", l.cest_id as cest_id",
+                "icms_value": ", SUM(l.icms_value) as icms_value",
+                "icmsst_value": ", SUM(l.icmsst_value) as icmsst_value",
+                "ipi_value": ", SUM(l.ipi_value) as ipi_value",
+                "cofins_value": ", SUM(l.cofins_value) as cofins_value",
+                "pis_value": ", SUM(l.pis_value) as pis_value",
+                "ii_value": ", SUM(l.ii_value) as ii_value",
+                "freight_value": ", SUM(l.freight_value) as freight_value",
+                "insurance_value": ", SUM(l.insurance_value) as insurance_value",
+                "other_value": ", SUM(l.other_value) as other_value",
+                "total_with_taxes": """
+                    , SUM(l.price_total / CASE COALESCE(s.currency_rate, 0)
+                        WHEN 0 THEN 1.0 ELSE s.currency_rate END)
+                    + SUM(CASE WHEN l.ipi_value IS NULL THEN
+                       0.00 ELSE l.ipi_value END)
+                    + SUM(CASE WHEN l.icmsst_value IS NULL THEN
+                       0.00 ELSE l.icmsst_value END)
+                    + SUM(CASE WHEN l.freight_value IS NULL THEN
+                       0.00 ELSE l.freight_value END)
+                    + SUM(CASE WHEN l.insurance_value IS NULL THEN
+                       0.00 ELSE l.insurance_value END)
+                    + SUM(CASE WHEN l.other_value IS NULL THEN
+                       0.00 ELSE l.other_value END)
+                    as total_with_taxes""",
             }
         )
         groupby += """
@@ -54,6 +146,10 @@ class SaleReport(models.Model):
             , l.fiscal_operation_line_id
             , s.ind_pres
             , l.cfop_id
+            , l.fiscal_type
+            , l.ncm_id
+            , l.nbm_id
+            , l.cest_id
         """
         return super()._query(
             with_clause=with_clause,

--- a/l10n_br_sale/report/sale_report_view.xml
+++ b/l10n_br_sale/report/sale_report_view.xml
@@ -25,6 +25,30 @@
                     name="cfop_id"
                     context="{'group_by':'cfop_id'}"
                 />
+                <filter
+                    string="Product Fiscal Type"
+                    icon="terp-stock_symbol-selection"
+                    name="fiscal_type"
+                    context="{'group_by':'fiscal_type'}"
+                />
+                <filter
+                    string="NCM"
+                    icon="terp-stock_symbol-selection"
+                    name="ncm"
+                    context="{'group_by':'ncm_id'}"
+                />
+                <filter
+                    string="NBM"
+                    icon="terp-stock_symbol-selection"
+                    name="nbm"
+                    context="{'group_by':'nbm_id'}"
+                />
+                <filter
+                    string="CEST"
+                    icon="terp-stock_symbol-selection"
+                    name="cest"
+                    context="{'group_by':'cest_id'}"
+                />
             </filter>
         </field>
     </record>


### PR DESCRIPTION
Included BR fields in the sales report.

Incluídos os campos com valores de ICMS, ICMSST, IPI, COFINS, PIS, Frete, Seguro, Outros Valores, Total com Impostos e a possibilidade de Agrupar pelo Tipo Fiscal do Produto, NCM, NBM e CEST.

Teste com os dados de demo da empresa de Lucro Presumido:

![image](https://user-images.githubusercontent.com/6341149/133135261-add7cd11-8c9b-415f-9e9d-453aa3a794fd.png)

OBS.: Na tradução do "Untaxed Amount Invoiced" parece estar faltando o "S" está "Total Faturado em Impostos"

cc @renatonlima @rvalyi 