### PR TITLE
[12.0][BUG] Correção do financial_move_line_ids que as vezes fica em branco.

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -111,7 +111,7 @@ class AccountInvoice(models.Model):
         """Get object lines instaces used to compute fields"""
         return self.mapped("invoice_line_ids")
 
-    @api.depends("move_id.line_ids", "move_id.state")
+    @api.depends("move_id.line_ids")
     def _compute_financial(self):
         for invoice in self:
             lines = invoice.move_id.line_ids.filtered(

--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -81,6 +81,7 @@ class AccountInvoice(models.Model):
     financial_move_line_ids = fields.Many2many(
         comodel_name="account.move.line",
         string="Financial Move Lines",
+        relation="account_invoice_account_financial_move_line_rel",
         store=True,
         compute="_compute_financial",
     )
@@ -111,7 +112,7 @@ class AccountInvoice(models.Model):
         """Get object lines instaces used to compute fields"""
         return self.mapped("invoice_line_ids")
 
-    @api.depends("move_id.line_ids")
+    @api.depends("move_id.line_ids", "move_id.state")
     def _compute_financial(self):
         for invoice in self:
             lines = invoice.move_id.line_ids.filtered(


### PR DESCRIPTION
Pessoal, ao instalar o módulo **br_account** e o **fiscal** e apenas esses, sem nenhum outro módulo há uma grande chance de acontecer um bug, numa proporção maior que 1 pra 5 (20%). Ao testar 5 vezes pelo menos 1 vez acontece o bug de certeza.

O bug é no campo **financial_move_line_ids** que não é gravado ao validar a fatura:
![Peek 2021-09-20 23-00](https://user-images.githubusercontent.com/634278/134100830-df751edb-9639-429d-a116-0d4da179a4b2.gif)

O problema é resolvido removendo o "move_id.state" do depends do _compute_financial.

Vi que no módulo [**account_payment_order** ](https://github.com/OCA/l10n-brazil/blob/584b51d47236b14388a0654d8895f25bd1b16230/l10n_br_account_payment_order/models/account_invoice.py) o mesmo problema já tinha sido detectado pelo @mbcosta, onde foi feito fix temporário, localmente apenas para o próprio módulo:

```
# TODO - apesar do campo financial_move_line_ids ser do tipo
#  compute esta sendo preciso chamar o metodo porque as vezes
#  ocorre da linha vir vazia o que impede de entrar no FOR
#  abaixo causando o não preenchimento de dados usados no Boleto,
#  isso deve ser melhor investigado
inv._compute_financial()
```

Acredito que essa PR possa resolver o problema de forma geral.


