### PR TITLE
[12.0][FIX] Onchange method for State field must be called.

### DIFF
--- a/l10n_br_base/models/party_mixin.py
+++ b/l10n_br_base/models/party_mixin.py
@@ -78,8 +78,12 @@ class PartyMixin(models.AbstractModel):
     def _onchange_zip(self):
         self.zip = misc.format_zipcode(self.zip, self.country_id.code)
 
+    # TODO: O metodo tanto no res.partner quanto no res.company chamam
+    #  _onchange_state e aqui também deveria, porém por algum motivo
+    #  ainda desconhecido se o metodo estiver com o mesmo nome não é
+    #  chamado, por isso aqui está sendo adicionado o final _id
     @api.onchange("state_id")
-    def _onchange_state(self):
+    def _onchange_state_id(self):
         self.city_id = None
 
     @api.onchange("city_id")

--- a/l10n_br_base/tests/test_base_onchange.py
+++ b/l10n_br_base/tests/test_base_onchange.py
@@ -30,7 +30,13 @@ class L10nBrBaseOnchangeTest(SavepointCase):
         cls.partner_01 = (
             cls.env["res.partner"]
             .with_context(tracking_disable=True)
-            .create({"name": "Partner Test 01", "zip": "29161-695"})
+            .create(
+                {
+                    "name": "Partner Test 01",
+                    "zip": "29161-695",
+                    "city_id": cls.env.ref("l10n_br_base.city_3205002").id,
+                }
+            )
         )
 
     def test_onchange(self):
@@ -41,10 +47,17 @@ class L10nBrBaseOnchangeTest(SavepointCase):
         self.company_01._onchange_city_id()
         self.company_01._onchange_zip()
         self.company_01._onchange_state()
+        # TODO: O metodo tanto no res.partner quanto no res.company chamam
+        #  _onchange_state e aqui também deveria, porém por algum motivo
+        #  ainda desconhecido se o metodo estiver com o mesmo nome não é
+        #  chamado, por isso existe outro metodo com o final _id
+        self.company_01._onchange_state_id()
 
         self.partner_01._onchange_cnpj_cpf()
         self.partner_01._onchange_city_id()
         self.partner_01._onchange_zip()
+        self.partner_01._onchange_state()
+        self.partner_01._onchange_state_id()
 
     def test_inverse_fields(self):
         self.company_01.inscr_mun = "692015742119"


### PR DESCRIPTION
Onchange method for State field must be called.

Tanto o res.partner quanto do res.company possuem um método chamado _onchange_state, na localização esses objetos herdam o l10n_br_base.party.mixin onde existia um método com o mesmo nome que apenas apaga a Cidade ao alterar o Estado, porém por algum motivo ele não era chamado tanto na tela quanto nos testes, só consegui fazer ser chamado alterando o nome do metodo para _onchange_state_id não encontrei o motivo do problema por isso deixei um TODO. Tanto o método do core quanto da localização são chamados ao alterar o campo na tela.

cc @renatonlima @rvalyi 