### PR TITLE
[12.0][FIX] Remove store from amount_price_gross

### DIFF
--- a/l10n_br_fiscal/models/document_fiscal_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin.py
@@ -111,7 +111,6 @@ class FiscalDocumentMixin(models.AbstractModel):
     amount_price_gross = fields.Monetary(
         compute="_compute_amount",
         string="Amount Gross",
-        store=True,
         readonly=True,
         help="Amount without discount.",
     )


### PR DESCRIPTION
Pelo campo amount_price_gross ser calculado pelo _compute_amount sem ter um api.depends() definido e também ser store = True, o valor acaba ficando zerado no documento. Como outros campos não já tem o store, seguimos esse padrão.

Consegue validar @renatonlima ?