### PR TITLE
[12.0][IMP] financial_total_gross and financial_discount_value

### DIFF
--- a/l10n_br_fiscal/models/document_fiscal_line_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin.py
@@ -231,6 +231,16 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         compute="_compute_amounts",
     )
 
+    financial_total_gross = fields.Monetary(
+        string="Amount Financial Gross",
+        compute="_compute_amounts",
+    )
+
+    financial_discount_value = fields.Monetary(
+        string="Financial Discount Value",
+        compute="_compute_amounts",
+    )
+
     amount_tax_not_included = fields.Monetary(string="Amount Tax not Included")
 
     amount_tax_withholding = fields.Monetary(string="(-) Amount Tax Withholding")

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -148,8 +148,12 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 and (not record.cfop_id or record.cfop_id.finance_move)
             ):
                 record.financial_total = record.amount_taxed
+                record.financial_total_gross = (
+                    record.financial_total + record.discount_value
+                )
+                record.financial_discount_value = record.discount_value
             else:
-                record.financial_total = 0.0
+                record.financial_total_gross = record.financial_total = 0.0
 
     def _compute_taxes(self, taxes, cst=None):
         self.ensure_one()

--- a/l10n_br_fiscal/models/document_fiscal_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin.py
@@ -315,6 +315,16 @@ class FiscalDocumentMixin(models.AbstractModel):
         compute="_compute_amount",
     )
 
+    amount_financial_total_gross = fields.Monetary(
+        string="Amount Financial Gross",
+        compute="_compute_amounts",
+    )
+
+    amount_financial_discount_value = fields.Monetary(
+        string="Financial Discount Value",
+        compute="_compute_amounts",
+    )
+
     amount_insurance_value = fields.Monetary(
         string="Insurance Value",
         compute="_compute_amount",

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -482,6 +482,8 @@
                     <field name="amount_total" />
                     <field name="amount_tax_withholding" />
                     <field name="amount_financial_total" />
+                    <field name="amount_financial_total_gross" />
+                    <field name="amount_financial_discount_value" />
                   </group>
                 </group>
               </group>

--- a/l10n_br_sale_stock/tests/test_sale_stock.py
+++ b/l10n_br_sale_stock/tests/test_sale_stock.py
@@ -133,6 +133,7 @@ class TestSaleStock(SavepointCase):
             "price_gross",
             "amount_taxed",
             "financial_total",
+            "financial_total_gross",
             "fiscal_price",
             "amount_fiscal",
             "price_unit",


### PR DESCRIPTION
Essa PR adiciona ao fiscal 2 novos campos de somatória de valor.

Na linha do documento fiscal:

**financial_total_gross
financial_discount_value**

No documento fiscal:

**amount_financial_total_gross
amount_financial_discount_value**

Esses campos vão servir de base para popular os dados da fatura na nota fiscal:

![image](https://user-images.githubusercontent.com/634278/135130439-4a11241e-8c93-40dd-8012-6997c5aa38e8.png)

Escolhi por essas informações diretamente no fiscal, pois talvez possa ser útil para outros documentos fiscais.

Outro detalhe, no fiscal já existe **amount_discount_value** e um **amount_total_gross** porém essas informações não filtram apenas o que faz parte do faturamento, por exemplo uma linha de bonificação não pode ser somado no valor de faturamento (financial)

Co-Authored-By: felipemotter <6812128+felipemotter@users.noreply.github.com>