### PR TITLE
[12.0][FIX]  Menu Action "Update Tax Estimate" do NCM e NBS

### DIFF
--- a/l10n_br_fiscal/data/l10n_br_fiscal_server_action.xml
+++ b/l10n_br_fiscal/data/l10n_br_fiscal_server_action.xml
@@ -6,7 +6,7 @@
         <field name="model_id" ref="model_l10n_br_fiscal_ncm" />
         <field name="binding_model_id" ref="model_l10n_br_fiscal_ncm" />
         <field name="state">code</field>
-        <field name="code">records.get_ibpt()</field>
+        <field name="code">records.action_ibpt_inquiry()</field>
     </record>
 
     <record id="nbs_get_get_ibpt_action" model="ir.actions.server">
@@ -14,7 +14,7 @@
         <field name="model_id" ref="model_l10n_br_fiscal_nbs" />
         <field name="binding_model_id" ref="model_l10n_br_fiscal_nbs" />
         <field name="state">code</field>
-        <field name="code">records.get_ibpt()</field>
+        <field name="code">records.action_ibpt_inquiry()</field>
     </record>
 
 </odoo>


### PR DESCRIPTION
Esta PR resolve o seguinte bug:

A action "Update Tax Estimate" no menu do modelo NCM estava dando erro:

![image](https://user-images.githubusercontent.com/634278/135727911-7496845c-4053-44cb-bb5c-bf4d4b2fbdea.png)
![image](https://user-images.githubusercontent.com/634278/135728073-ee10ac69-68e2-491e-a9ba-2e3846d7a0f2.png)
