### PR TITLE
[12.0][FIX]  Número da rua no cadastro de parceiros.

### DIFF
--- a/l10n_br_base/__manifest__.py
+++ b/l10n_br_base/__manifest__.py
@@ -9,7 +9,7 @@
     "author": "Akretion,Odoo Community Association (OCA)",
     "maintainers": ["renatonlima", "rvalyi"],
     "website": "https://github.com/OCA/l10n-brazil",
-    "version": "12.0.3.2.1",
+    "version": "12.0.4.0.0",
     "depends": ["base", "base_setup", "base_address_city", "base_address_extended"],
     "data": [
         "security/ir.model.access.csv",

--- a/l10n_br_base/data/res_country_data.xml
+++ b/l10n_br_base/data/res_country_data.xml
@@ -145,7 +145,7 @@
         <field name="bc_code">1058</field>
         <field name="siscomex_code">105</field>
         <field name="enforce_cities">1</field>
-        <field name="street_format" eval="'%(street)s'" />
+        <field name="street_format" eval="'%(street_name)s'" />
         <field name="name_position">before</field>
         <field
             name="address_format"

--- a/l10n_br_base/demo/l10n_br_base_demo.xml
+++ b/l10n_br_base/demo/l10n_br_base_demo.xml
@@ -16,7 +16,7 @@
         <field name="name">Intel do Brasil</field>
         <field name="legal_name">Intel do Brasil</field>
         <field name="cnpj_cpf">86.144.802/0001-90</field>
-        <field name="street">Avenida Doutor Chucri Zaidan</field>
+        <field name="street_name">Avenida Doutor Chucri Zaidan</field>
         <field name="street_number">920</field>
         <field name="district">Vila Cordeiro</field>
         <field name="street2" />
@@ -38,7 +38,7 @@
         <field name="name">AMD do Brasil</field>
         <field name="legal_name">AMD South America Ltda</field>
         <field name="cnpj_cpf">62.228.384/0001-51</field>
-        <field name="street">Rua Samuel Morse</field>
+        <field name="street_name">Rua Samuel Morse</field>
         <field name="street_number">134</field>
         <field name="district">Brooklin</field>
         <field name="street2">15º andar - Conjunto 151</field>
@@ -60,7 +60,7 @@
         <field name="name">LG do Brasil</field>
         <field name="legal_name">LG ELECTRONICS DA AMAZÔNIA LTDA</field>
         <field name="cnpj_cpf">92.737.124/0001-72</field>
-        <field name="street">Avenida Javari</field>
+        <field name="street_name">Avenida Javari</field>
         <field name="street_number">s/n</field>
         <field name="district">Distrito Industrial</field>
         <field name="street2">Lote 2.45/1E</field>
@@ -83,7 +83,7 @@
         <field name="name">Samsung Recife</field>
         <field name="legal_name">Samsung Recife LTDA</field>
         <field name="cnpj_cpf">21.717.475/0001-73</field>
-        <field name="street">Av. República do Líbano</field>
+        <field name="street_name">Av. República do Líbano</field>
         <field name="street_number">251</field>
         <field name="district">Centro</field>
         <field name="street2" />
@@ -106,7 +106,7 @@
         <field name="name">Positivo Informatica</field>
         <field name="legal_name">Positivo Informatica S/A</field>
         <field name="cnpj_cpf">77.256.611/0001-20</field>
-        <field name="street">Rua Senador Accioly Filho</field>
+        <field name="street_name">Rua Senador Accioly Filho</field>
         <field name="street_number">5200</field>
         <field name="district">Cidade Industrial</field>
         <field name="street2" />
@@ -129,7 +129,7 @@
         <field name="name">Dell Computadores do Brasil</field>
         <field name="legal_name">Dell Computadores do Brasil LTDA</field>
         <field name="cnpj_cpf">73.623.891/0001-06</field>
-        <field name="street">Avenida Ipiranga</field>
+        <field name="street_name">Avenida Ipiranga</field>
         <field name="street_number">6681</field>
         <field name="district">Partenon</field>
         <field name="street2" />
@@ -152,7 +152,7 @@
         <field name="name">Info Bahia</field>
         <field name="legal_name">Informatica Bahia LTDA</field>
         <field name="cnpj_cpf">14.685.381/0001-02</field>
-        <field name="street">Rua Francisco Muniz Barreto</field>
+        <field name="street_name">Rua Francisco Muniz Barreto</field>
         <field name="street_number">2</field>
         <field name="district">Terreiro de Jesus</field>
         <field name="street2" />
@@ -175,7 +175,7 @@
         <field name="name">Informatica Manaus</field>
         <field name="legal_name">Informatica Manaus</field>
         <field name="cnpj_cpf">38.633.837/0001-40</field>
-        <field name="street">Avenida Javari</field>
+        <field name="street_name">Avenida Javari</field>
         <field name="street_number">s/n</field>
         <field name="district">Distrito Industrial</field>
         <field name="street2">Lote 4.45/5E</field>
@@ -198,7 +198,7 @@
         <field name="name">Cliente 1 SP Contribuinte</field>
         <field name="legal_name">Cliente 1 SP</field>
         <field name="cnpj_cpf">81.493.979/0001-89</field>
-        <field name="street">Rua Samuel Morse</field>
+        <field name="street_name">Rua Samuel Morse</field>
         <field name="street_number">135</field>
         <field name="district">Brooklin</field>
         <field name="street2">20º andar - Conjunto 151</field>
@@ -220,7 +220,7 @@
         <field name="name">Cliente 2 -SP - Simples Nacional</field>
         <field name="legal_name">Cliente 2 - SP</field>
         <field name="cnpj_cpf">12.046.835/0001-61</field>
-        <field name="street">Avenida Doutor Chucri Zaidan</field>
+        <field name="street_name">Avenida Doutor Chucri Zaidan</field>
         <field name="street_number">950</field>
         <field name="district">Vila Cordeiro</field>
         <field name="street2" />
@@ -242,7 +242,7 @@
         <field name="name">Cliente 3 - Z/F Manaus - Contribuinte</field>
         <field name="legal_name">Cliente 3 - Manaus</field>
         <field name="cnpj_cpf">46.081.676/0001-58</field>
-        <field name="street">Avenida Javari</field>
+        <field name="street_name">Avenida Javari</field>
         <field name="street_number">s/n</field>
         <field name="district">Distrito Industrial</field>
         <field name="street2">Lote 8.45/30E</field>
@@ -265,7 +265,7 @@
         <field name="name">Cliente 4 - Z/F Manaus - Simples Nacional</field>
         <field name="legal_name">Cliente 4 - Manaus</field>
         <field name="cnpj_cpf">84.148.732/0001-13</field>
-        <field name="street">Avenida Javari</field>
+        <field name="street_name">Avenida Javari</field>
         <field name="street_number">s/n</field>
         <field name="district">Distrito Industrial</field>
         <field name="street2">Lote 9.45/15E</field>
@@ -288,7 +288,7 @@
         <field name="name">Cliente 5 - Contribuinte - PE</field>
         <field name="legal_name">Cliente 5 PE</field>
         <field name="cnpj_cpf">14.753.702/0001-50</field>
-        <field name="street">Av. República do Líbano</field>
+        <field name="street_name">Av. República do Líbano</field>
         <field name="street_number">255</field>
         <field name="district">Centro</field>
         <field name="street2" />
@@ -311,7 +311,7 @@
         <field name="name">Cliente 6 - Simples Nacional- PE</field>
         <field name="legal_name">Cliente 6 Recife LTDA</field>
         <field name="cnpj_cpf">97.449.840/0001-78</field>
-        <field name="street">Av. República do Líbano</field>
+        <field name="street_name">Av. República do Líbano</field>
         <field name="street_number">275</field>
         <field name="district">Centro</field>
         <field name="street2" />
@@ -334,7 +334,7 @@
         <field name="name">Cliente 7 RS - Contribuinte</field>
         <field name="legal_name">Cliente 7 - RS</field>
         <field name="cnpj_cpf">43.266.887/0001-77</field>
-        <field name="street">Avenida Ipiranga</field>
+        <field name="street_name">Avenida Ipiranga</field>
         <field name="street_number">6690</field>
         <field name="district">Partenon</field>
         <field name="street2" />
@@ -357,7 +357,7 @@
         <field name="name">Cliente 8 RS - Simples Nacional</field>
         <field name="legal_name">Cliente 7 - RS</field>
         <field name="cnpj_cpf">32.406.080/0001-76</field>
-        <field name="street">Avenida Ipiranga</field>
+        <field name="street_name">Avenida Ipiranga</field>
         <field name="street_number">6600</field>
         <field name="district">Partenon</field>
         <field name="street2" />
@@ -391,7 +391,7 @@
         <field name="country_id" ref="base.br" />
         <field name="street_number">807</field>
         <field name="phone">(11) 9999-9999</field>
-        <field name="street">Avenida Paulista</field>
+        <field name="street_name">Avenida Paulista</field>
         <field name="street2">CJ 2315</field>
         <field name="city_id" ref="l10n_br_base.city_3550308" />
         <field name="state_id" ref="base.state_br_sp" />
@@ -419,7 +419,7 @@
         <field name="country_id" ref="base.br" />
         <field name="street_number">47</field>
         <field name="phone">(21) 9999-9999</field>
-        <field name="street">Rua Acre</field>
+        <field name="street_name">Rua Acre</field>
         <field name="street2">sala 1310</field>
         <field name="website">http://www.akretion.com</field>
         <field name="state_id" ref="base.state_br_rj" />
@@ -449,7 +449,7 @@
         <field name="country_id" ref="base.br" />
         <field name="street_number">586</field>
         <field name="phone">(11) 9999-9999</field>
-        <field name="street">Rua Paulo Dias</field>
+        <field name="street_name">Rua Paulo Dias</field>
         <field name="website">http://www.akretion.com</field>
         <field name="state_id" ref="base.state_br_sp" />
         <field
@@ -463,7 +463,7 @@
         <field name="name">Cliente 9 MG - PJ Não Contribuinte</field>
         <field name="legal_name">Cliente 9 MG</field>
         <field name="cnpj_cpf">26.355.289/0001-55</field>
-        <field name="street">R PRESIDENTE ROOSEVELT</field>
+        <field name="street_name">R PRESIDENTE ROOSEVELT</field>
         <field name="street_number">63</field>
         <field name="district">Morro Chic</field>
         <field name="street2" />
@@ -485,7 +485,7 @@
         <field name="name">Cliente 10 MG - PF Não Contribuinte</field>
         <field name="legal_name">Cliente 10 PF</field>
         <field name="cnpj_cpf">276.288.360-11</field>
-        <field name="street">R PRESIDENTE ROOSEVELT</field>
+        <field name="street_name">R PRESIDENTE ROOSEVELT</field>
         <field name="street_number">63</field>
         <field name="district">Morro Chic</field>
         <field name="street2" />
@@ -518,7 +518,7 @@
         <field name="country_id" ref="base.br" />
         <field name="street_number">07</field>
         <field name="phone">(11) 3090 9303</field>
-        <field name="street">R Coronel Renno</field>
+        <field name="street_name">R Coronel Renno</field>
         <field name="city_id" ref="l10n_br_base.city_3132404" />
         <field name="state_id" ref="base.state_br_mg" />
         <field
@@ -533,7 +533,7 @@
         <field name="supplier">1</field>
         <field name="customer">1</field>
         <field name="is_company">1</field>
-        <field name="street">3404  Edgewood Road</field>
+        <field name="street_name">3404  Edgewood Road</field>
         <field name="city">Jonesboro</field>
         <field
             name="state_id"
@@ -551,7 +551,7 @@
         <field name="name">Cliente 11 SP - PF Não Contribuinte</field>
         <field name="legal_name">Cliente 11 PF</field>
         <field name="cnpj_cpf">765.865.078-12</field>
-        <field name="street">Rua do Bosque</field>
+        <field name="street_name">Rua do Bosque</field>
         <field name="street_number">238</field>
         <field name="district">Barra Funda</field>
         <field name="street2" />

--- a/l10n_br_base/demo/res_company_demo.xml
+++ b/l10n_br_base/demo/res_company_demo.xml
@@ -4,7 +4,7 @@
     <record id="base.main_partner" model="res.partner">
         <field name="name">Sua Empresa</field>
         <field name="legal_name">Sua Empresa Ltda</field>
-        <field name="street">Avenida Paulista</field>
+        <field name="street_name">Avenida Paulista</field>
         <field name="street_number">1</field>
         <field name="city_id" ref="l10n_br_base.city_3550308" />
         <field name="zip">01311-000</field>
@@ -28,7 +28,7 @@
     <record id="lucro_presumido_partner" model="res.partner">
         <field name="name">Empresa Lucro Presumido</field>
         <field name="legal_name">Empresa Lucro Presumido Ltda</field>
-        <field name="street">Avenida Paulista</field>
+        <field name="street_name">Avenida Paulista</field>
         <field name="street_number">1</field>
         <field name="district">Bela Vista</field>
         <field name="state_id" ref="base.state_br_sp" />
@@ -54,7 +54,7 @@
     <record id="simples_nacional_partner" model="res.partner">
         <field name="name">TESTE - Simples Nacional</field>
         <field name="company_name">TESTE - Simples Nacional</field>
-        <field name="street">Rua Paulo Dias</field>
+        <field name="street_name">Rua Paulo Dias</field>
         <field name="street_number">586</field>
         <field name="city_id" ref="l10n_br_base.city_3501152" />
         <field name="zip">18125-000</field>

--- a/l10n_br_base/demo/res_users_demo.xml
+++ b/l10n_br_base/demo/res_users_demo.xml
@@ -21,7 +21,7 @@
         <field name="company_id" eval="None" />
         <field name="customer" eval="False" />
         <field name="company_name">Empresa Simples</field>
-        <field name="street">Rua Paulo Dias</field>
+        <field name="street_name">Rua Paulo Dias</field>
         <field name="street_number">586</field>
         <field name="city_id" ref="l10n_br_base.city_3501152" />
         <field name="zip">18125-000</field>
@@ -36,7 +36,7 @@
         <field name="company_id" eval="None" />
         <field name="customer" eval="False" />
         <field name="company_name">Empresa Lucro Presumido</field>
-        <field name="street">AV Paulista</field>
+        <field name="street_name">AV Paulista</field>
         <field name="street_number">1001</field>
         <field name="city_id" ref="l10n_br_base.city_3501152" />
         <field name="zip">18125-000</field>

--- a/l10n_br_base/migrations/12.0.4.0.0/pre-migration.py
+++ b/l10n_br_base/migrations/12.0.4.0.0/pre-migration.py
@@ -1,0 +1,13 @@
+from openupgradelib import openupgrade
+
+
+def street_migrate(env):
+    openupgrade.logged_query(
+        env.cr,
+        """UPDATE res_partner set street_name=street WHERE street_name IS NULL""",
+    )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    street_migrate(env)

--- a/l10n_br_base/views/res_partner_address_view.xml
+++ b/l10n_br_base/views/res_partner_address_view.xml
@@ -15,7 +15,7 @@
                         class="o_address_zip"
                     />
                     <field
-                        name="street"
+                        name="street_name"
                         placeholder="Street..."
                         class="o_address_street"
                     />

--- a/l10n_br_delivery/demo/l10n_br_delivery_demo.xml
+++ b/l10n_br_delivery/demo/l10n_br_delivery_demo.xml
@@ -8,7 +8,7 @@
         <field name="name">Transportadora - Teste</field>
         <field name="legal_name">Transportadora - Teste</field>
         <field name="cnpj_cpf">21.221.265/0001-90</field>
-        <field name="street">Estrada do Caminho Velho</field>
+        <field name="street_name">Estrada do Caminho Velho</field>
         <field name="street_number">1</field>
         <field name="district">Jardim Nova Cidade</field>
         <field name="street2"></field>

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -49,7 +49,7 @@ class ResPartner(spec_models.SpecModel):
         compute="_compute_nfe_data", inverse="_inverse_nfe40_CPF", store=True
     )
     nfe40_xLgr = fields.Char(related="street", readonly=False)
-    nfe40_nro = fields.Char(related="street_number", readonly=False)
+    nfe40_nro = fields.Char(related="street_number", readonly=True)
     nfe40_xCpl = fields.Char(related="street2", readonly=False)
     nfe40_xBairro = fields.Char(related="district", readonly=False)
     nfe40_cMun = fields.Char(related="city_id.ibge_code", readonly=True)

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -48,10 +48,10 @@ class ResPartner(spec_models.SpecModel):
     nfe40_CPF = fields.Char(
         compute="_compute_nfe_data", inverse="_inverse_nfe40_CPF", store=True
     )
-    nfe40_xLgr = fields.Char(related="street", readonly=False)
+    nfe40_xLgr = fields.Char(related="street_name", readonly=True)
     nfe40_nro = fields.Char(related="street_number", readonly=True)
-    nfe40_xCpl = fields.Char(related="street2", readonly=False)
-    nfe40_xBairro = fields.Char(related="district", readonly=False)
+    nfe40_xCpl = fields.Char(related="street2", readonly=True)
+    nfe40_xBairro = fields.Char(related="district", readonly=True)
     nfe40_cMun = fields.Char(related="city_id.ibge_code", readonly=True)
     nfe40_xMun = fields.Char(related="city_id.name", readonly=True)
     # Char overriding Selection:

--- a/l10n_br_nfe/tests/test_nfe_import.py
+++ b/l10n_br_nfe/tests/test_nfe_import.py
@@ -74,7 +74,7 @@ class NFeImportTest(SavepointCase):
         self.assertEqual(nfe.partner_id.legal_name, "Alimentos Ltda.")
 
         # enderDest
-        self.assertEqual(nfe.partner_id.street, "Rua Fonseca")  # related xLgr
+        self.assertEqual(nfe.partner_id.street_name, "Rua Fonseca")  # related xLgr
         self.assertEqual(nfe.partner_id.zip, "13877123")  # related CEP
         self.assertEqual(nfe.partner_id.city_id.name, "São João da Boa Vista")
 


### PR DESCRIPTION
Tinha um bug bem chatinho no cadastro de parceiros, o número da rua nunca salvava de primeira e também volta e meia ao editar a rua o número se apagava. Essa PR resolve o problema. 