### PR TITLE
[12.0] l10n_br_fiscal store=True em campos de totais

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -227,9 +227,7 @@ class AccountInvoice(models.Model):
 
     @api.one
     @api.depends(
-        "invoice_line_ids.price_total",
-        "tax_line_ids.amount",
-        "tax_line_ids.amount_rounding",
+        "invoice_line_ids",
         "currency_id",
         "company_id",
         "date_invoice",

--- a/l10n_br_contract/models/contract_contract.py
+++ b/l10n_br_contract/models/contract_contract.py
@@ -67,12 +67,14 @@ class ContractContract(models.Model):
         string="Comments",
     )
 
-    @api.multi
     def _get_amount_lines(self):
         """Get object lines instaces used to compute fields"""
         return self.mapped("contract_line_ids")
 
-    @api.multi
+    @api.depends("contract_line_ids")
+    def _compute_amount(self):
+        super()._compute_amount()
+
     def _prepare_invoice(self, date_invoice, journal=None):
         self.ensure_one()
         invoice_vals = self._prepare_br_fiscal_dict()
@@ -97,7 +99,6 @@ class ContractContract(models.Model):
 
             invoice._onchange_invoice_line_ids()
 
-    @api.multi
     def _prepare_recurring_invoices_values(self, date_ref=False):
         """
         Overwrite contract method to verify and create invoices according to
@@ -158,7 +159,6 @@ class ContractContract(models.Model):
 
         return inv_ids
 
-    @api.multi
     def recurring_create_invoice(self):
         """
         override the contract method to allow posting for more than one invoice

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -349,7 +349,20 @@ class Document(models.Model):
         for r in self:
             r.name = r._compute_document_name()
 
-    @api.depends("line_ids")
+    @api.depends(
+        "line_ids.estimate_tax",
+        "line_ids.price_gross",
+        "line_ids.amount_untaxed",
+        "line_ids.amount_tax",
+        "line_ids.amount_taxed",
+        "line_ids.amount_total",
+        "line_ids.financial_total",
+        "line_ids.financial_total_gross",
+        "line_ids.financial_discount_value",
+        "line_ids.amount_tax_included",
+        "line_ids.amount_tax_not_included",
+        "line_ids.amount_tax_withholding",
+    )
     def _compute_amount(self):
         super()._compute_amount()
 

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -349,6 +349,10 @@ class Document(models.Model):
         for r in self:
             r.name = r._compute_document_name()
 
+    @api.depends("line_ids")
+    def _compute_amount(self):
+        super()._compute_amount()
+
     @api.model
     def create(self, values):
         if not values.get("document_date"):

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -747,8 +747,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
     @api.model
     def _update_fiscal_quantity(self, product_id, price, quantity, uom_id, uot_id):
         result = {"uot_id": uom_id, "fiscal_quantity": quantity, "fiscal_price": price}
-
-        if uom_id != uot_id:
+        if uot_id and uom_id != uot_id:
             result["uot_id"] = uot_id
             if product_id and price and quantity:
                 product = self.env["product.product"].browse(product_id)

--- a/l10n_br_fiscal/models/document_fiscal_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin.py
@@ -116,223 +116,269 @@ class FiscalDocumentMixin(models.AbstractModel):
     amount_untaxed = fields.Monetary(
         string="Amount Untaxed",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_icms_base = fields.Monetary(
         string="ICMS Base",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_icms_value = fields.Monetary(
         string="ICMS Value",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_icmsst_base = fields.Monetary(
         string="ICMS ST Base",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_icmsst_value = fields.Monetary(
         string="ICMS ST Value",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_icmssn_credit_value = fields.Monetary(
         string="ICMSSN Credit Value",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_icmsfcp_base = fields.Monetary(
         string="ICMS FCP Base",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_icmsfcp_value = fields.Monetary(
         string="ICMS FCP Value",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_ipi_base = fields.Monetary(
         string="IPI Base",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_ipi_value = fields.Monetary(
         string="IPI Value",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_pis_base = fields.Monetary(
         string="PIS Base",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_pis_value = fields.Monetary(
         string="PIS Value",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_pis_wh_base = fields.Monetary(
         string="PIS Ret Base",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_pis_wh_value = fields.Monetary(
         string="PIS Ret Value",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_cofins_base = fields.Monetary(
         string="COFINS Base",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_cofins_value = fields.Monetary(
         string="COFINS Value",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_cofins_wh_base = fields.Monetary(
         string="COFINS Ret Base",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_cofins_wh_value = fields.Monetary(
         string="COFINS Ret Value",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_issqn_base = fields.Monetary(
         string="ISSQN Base",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_issqn_value = fields.Monetary(
         string="ISSQN Value",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_issqn_wh_base = fields.Monetary(
         string="ISSQN Ret Base",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_issqn_wh_value = fields.Monetary(
         string="ISSQN Ret Value",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_csll_base = fields.Monetary(
         string="CSLL Base",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_csll_value = fields.Monetary(
         string="CSLL Value",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_csll_wh_base = fields.Monetary(
         string="CSLL Ret Base",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_csll_wh_value = fields.Monetary(
         string="CSLL Ret Value",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_irpj_base = fields.Monetary(
         string="IRPJ Base",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_irpj_value = fields.Monetary(
         string="IRPJ Value",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_irpj_wh_base = fields.Monetary(
         string="IRPJ Ret Base",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_irpj_wh_value = fields.Monetary(
         string="IRPJ Ret Value",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_inss_base = fields.Monetary(
         string="INSS Base",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_inss_value = fields.Monetary(
         string="INSS Value",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_inss_wh_base = fields.Monetary(
         string="INSS Ret Base",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_inss_wh_value = fields.Monetary(
         string="INSS Ret Value",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_estimate_tax = fields.Monetary(
         string="Amount Estimate Tax",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_tax = fields.Monetary(
         string="Amount Tax",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_total = fields.Monetary(
         string="Amount Total",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_tax_withholding = fields.Monetary(
-        string="Amount Tax Withholding", compute="_compute_amount"
+        string="Amount Tax Withholding",
+        compute="_compute_amount",
+        strore=True,
     )
 
     amount_financial_total = fields.Monetary(
         string="Amount Financial",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_discount_value = fields.Monetary(
         string="Amount Discount",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_financial_total_gross = fields.Monetary(
         string="Amount Financial Gross",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_financial_discount_value = fields.Monetary(
         string="Financial Discount Value",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_insurance_value = fields.Monetary(
         string="Insurance Value",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_other_value = fields.Monetary(
         string="Other Costs",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_freight_value = fields.Monetary(
         string="Freight Value",
         compute="_compute_amount",
+        store=True,
     )

--- a/l10n_br_fiscal/tests/test_fiscal_document_generic.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_generic.py
@@ -606,9 +606,13 @@ class TestFiscalDocumentGeneric(SavepointCase):
             line._onchange_commercial_quantity()
 
             # set fake estimate tax
-            line.ncm_id.write(
+            line.ncm_id.tax_estimate_ids.create(
                 {
-                    "estimate_tax_national": 33.00,
+                    "ncm_id": line.ncm_id.id,
+                    "state_id": line.company_id.state_id.id,
+                    "key": "fake estimate tax",
+                    "origin": "fake estimate tax",
+                    "federal_taxes_national": 33.00,
                 }
             )
 

--- a/l10n_br_nfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_nfe/demo/fiscal_document_demo.xml
@@ -43,6 +43,10 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
     </function>
 
+    <record id="demo_nfe_line_same_state_1-1" model="l10n_br_fiscal.document.line">
+        <field name="price_unit">100</field>
+    </record>
+
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
     </function>
@@ -51,6 +55,10 @@
         model="l10n_br_fiscal.document.line"
         name="_onchange_fiscal_operation_line_id"
     >
+        <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
     </function>
 
@@ -70,6 +78,10 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
     </function>
 
+    <record id="demo_nfe_line_same_state_1-2" model="l10n_br_fiscal.document.line">
+        <field name="price_unit">100</field>
+    </record>
+
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
     </function>
@@ -78,6 +90,10 @@
         model="l10n_br_fiscal.document.line"
         name="_onchange_fiscal_operation_line_id"
     >
+        <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
     </function>
 
@@ -126,6 +142,10 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]" />
     </function>
 
+    <record id="demo_nfe_national_sale_for_same_state-1" model="l10n_br_fiscal.document.line">
+        <field name="quantity">1</field>
+    </record>
+
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]" />
     </function>
@@ -135,6 +155,10 @@
         name="_onchange_fiscal_operation_line_id"
     >
         <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]" />
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state')]" />
     </function>
 
     <!-- NFe Test - Pessoa Física - ICMS 18% with a reduction of 51.11% -->
@@ -193,6 +217,10 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]" />
     </function>
 
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]" />
+    </function>
+
     <!-- NFe Test - Pessoa Física - ICMS 4% Imported for Resale -->
     <record id="demo_nfe_natural_icms_7_resale" model="l10n_br_fiscal.document">
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -235,6 +263,10 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
     </function>
 
+    <record id="demo_nfe_natural_icms_7_resale-1" model="l10n_br_fiscal.document.line">
+        <field name="quantity">2</field>
+    </record>
+
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
     </function>
@@ -243,6 +275,10 @@
         model="l10n_br_fiscal.document.line"
         name="_onchange_fiscal_operation_line_id"
     >
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
     </function>
 

--- a/l10n_br_nfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_nfe/demo/fiscal_document_demo.xml
@@ -43,14 +43,6 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
     </function>
 
-    <function model="l10n_br_fiscal.document.line" name="_onchange_commercial_quantity">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_ncm_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
-    </function>
-
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
     </function>
@@ -59,10 +51,6 @@
         model="l10n_br_fiscal.document.line"
         name="_onchange_fiscal_operation_line_id"
     >
-        <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
     </function>
 
@@ -82,14 +70,6 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
     </function>
 
-    <function model="l10n_br_fiscal.document.line" name="_onchange_commercial_quantity">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_ncm_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
-    </function>
-
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
     </function>
@@ -98,10 +78,6 @@
         model="l10n_br_fiscal.document.line"
         name="_onchange_fiscal_operation_line_id"
     >
-        <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
     </function>
 
@@ -150,14 +126,6 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]" />
     </function>
 
-    <function model="l10n_br_fiscal.document.line" name="_onchange_commercial_quantity">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_ncm_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]" />
-    </function>
-
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]" />
     </function>
@@ -166,10 +134,6 @@
         model="l10n_br_fiscal.document.line"
         name="_onchange_fiscal_operation_line_id"
     >
-        <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
         <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]" />
     </function>
 
@@ -218,14 +182,6 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]" />
     </function>
 
-    <function model="l10n_br_fiscal.document.line" name="_onchange_commercial_quantity">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_ncm_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]" />
-    </function>
-
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]" />
     </function>
@@ -234,10 +190,6 @@
         model="l10n_br_fiscal.document.line"
         name="_onchange_fiscal_operation_line_id"
     >
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]" />
     </function>
 
@@ -283,14 +235,6 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
     </function>
 
-    <function model="l10n_br_fiscal.document.line" name="_onchange_commercial_quantity">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_ncm_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
-    </function>
-
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
     </function>
@@ -299,10 +243,6 @@
         model="l10n_br_fiscal.document.line"
         name="_onchange_fiscal_operation_line_id"
     >
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
     </function>
 

--- a/l10n_br_nfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_nfe/demo/fiscal_document_demo.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
+<!-- pylint:disable=duplicate-xml-record-id -->
 <odoo noupdate="1">
 
     <!-- NFe Test - Empresa Contribuinte - Mesmo Estado -->
@@ -142,7 +143,10 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]" />
     </function>
 
-    <record id="demo_nfe_national_sale_for_same_state-1" model="l10n_br_fiscal.document.line">
+    <record
+        id="demo_nfe_national_sale_for_same_state-1"
+        model="l10n_br_fiscal.document.line"
+    >
         <field name="quantity">1</field>
     </record>
 

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -51,13 +51,23 @@ class NFeLine(spec_models.StackedModel):
         related="uom_id.code",
     )
 
-    nfe40_uTrib = fields.Char(
-        related="uot_id.code",
+    nfe40_qCom = fields.Float(
+        string="nfe40 qCom",
+        related="quantity",
     )
 
     nfe40_vUnCom = fields.Float(
         related="price_unit",
         string="Valor unitário de comercialização",
+    )
+
+    nfe40_uTrib = fields.Char(
+        related="uot_id.code",
+    )
+
+    nfe40_qTrib = fields.Float(
+        string="nfe40_qTrib",
+        related="fiscal_quantity",
     )
 
     nfe40_vUnTrib = fields.Float(
@@ -438,8 +448,6 @@ class NFeLine(spec_models.StackedModel):
 
         self.nfe40_NCM = self.ncm_id.code_unmasked or False
         self.nfe40_CEST = self.cest_id and self.cest_id.code_unmasked or False
-        self.nfe40_qCom = self.quantity
-        self.nfe40_qTrib = self.fiscal_quantity
         self.nfe40_pICMS = self.icms_percent
         self.nfe40_pICMSST = self.icmsst_percent
         self.nfe40_pMVAST = self.icmsst_mva_percent

--- a/l10n_br_nfe/tests/test_nfe_serialize.py
+++ b/l10n_br_nfe/tests/test_nfe_serialize.py
@@ -40,6 +40,8 @@ class TestNFeExport(TransactionCase):
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
 
+        nfe._compute_amount()
+
     def test_serialize_xml(self):
         for nfe in self.nfe_list:
             nfe_id = nfe["record_id"]

--- a/l10n_br_repair/models/repair_order.py
+++ b/l10n_br_repair/models/repair_order.py
@@ -110,7 +110,7 @@ class RepairOrder(models.Model):
         lines += [lin for lin in self.mapped("fees_lines")]
         return lines
 
-    @api.depends("operations.price_total", "fees_lines.price_total")
+    @api.depends("operations", "fees_lines")
     def _compute_amount(self):
         super()._compute_amount()
 


### PR DESCRIPTION
isso é uma atualização desse PR inicial do @renatonlima https://github.com/OCA/l10n-brazil/pull/1411. Realmente como os campos foram re-ordenados não rolou de fazer apenas um rebase.

Eu tb atualizei os @api.depends onde o _compute_amount precisaria ser re-calculado.

A principal vantagem que eu vejo desses store=True vai ser quando importa notas fiscais e que o Odoo e o sistema do fornecedor podem chegar a arredondamentos diferentes (soma dos arrondamentos != arrondamento da soma; fato do Odoo usar floats e não decimais...). Isso é importante pros account.invoice e documentos fiscais. Tb evitaria alterações intempestivas com notas fiscais fechadas caso o código ou dado de algum calculo muda.

Mas talvez a gente não quer adicionar essas 44 colunas para sale_oder, purchase_order, stock_picking onde não tem vantagem em persistir esses campos se o calculo deles é rápido. E deveria ser, o Odoo fazendo a soma dos pre-fetch dos campos em todas as linhas de cada documento. Se isso for um problema poderiamos tb botar store=True apenas nos campos de totais que aparecem em visões de lista.

Então vou deixar o PR assim como rascunho inicial. Para BI eu nem acho o argumento dos campos store=True no documento valido no documento, pois temos eles nas linhas ja e BI funciona melhor em cima das linhas.

Agora o que eu falo sobre ter os campos store=False em sale_oder, purchase_order, stock_picking... isso a gente poderia tb ter o mesmo questionamento com as linhas desses documentos, pois hoje temos, mas talvez podemos fazer melhor, não é motivo para encher o banco de colunas sem pensar. Bom tb acrescentar esses 44 campos pode não ser o melhor (tamanho do banco, desempenho dos pre-fetch...), tb não seria nada demais pro Postgres arguentar.

cc @renatonlima @netosjb @felipemotter @marcelsavegnago