### PR TITLE
[12.0][FIX] l10n_br_contract: contract.line.name

### DIFF
--- a/l10n_br_contract/models/contract_contract.py
+++ b/l10n_br_contract/models/contract_contract.py
@@ -88,7 +88,9 @@ class ContractContract(models.Model):
             invoice.fiscal_document_id._onchange_company_id()
 
             for line in invoice.invoice_line_ids:
+                name = line.name
                 line._onchange_product_id_fiscal()
+                line.name = name
                 line.price_unit = line.contract_line_id.price_unit
                 line._onchange_fiscal_operation_id()
                 line._onchange_fiscal_tax_ids()


### PR DESCRIPTION
Atualmente o nome da linha do contrato é ignorado e o sistema assume o nome do produto.