### PR TITLE
[12.0][FIX] l10n_br_nfse: garantindo a regeração do pdf quando o status da NFSE for igual a 4

### DIFF
--- a/l10n_br_nfse_issnet/models/l10n_br_fiscal_document.py
+++ b/l10n_br_nfse_issnet/models/l10n_br_fiscal_document.py
@@ -384,6 +384,8 @@ class Document(models.Model):
                     record._change_state(SITUACAO_EDOC_AUTORIZADA)
 
             record.write(vals)
+            if record.status_code == '4':
+                record.make_pdf()
         return
 
     def _exec_before_SITUACAO_EDOC_CANCELADA(self, old_state, new_state):


### PR DESCRIPTION
O DANFSE não é regerado quando muda para o status para autorizado e portanto os codigos de autorização não aparecem no DANFSE.. Sendo assim, forcei a regeração no final do processo.

Qualquer dúvida, critica ou sugestão é bem vinda.