### PR TITLE
[12.0][FIX] cancel payment_order, see https://github.com/OCA/bank-payment/pull/860

### DIFF
--- a/l10n_br_account_payment_brcobranca/tests/test_payment_order.py
+++ b/l10n_br_account_payment_brcobranca/tests/test_payment_order.py
@@ -701,6 +701,7 @@ class TestPaymentOrder(SavepointCase):
             [("payment_mode_id", "=", self.invoice_cef.payment_mode_id.id)]
         )
         # Open payment order
+        payment_order.action_cancel()
         payment_order.draft2open()
 
         # Verifica se deve testar com o mock


### PR DESCRIPTION
tentativa de resolver os testes no l10n_br_account_payment_brcobranca/tests/test_payment_order.py

Teve essa mudança no upstream do account_payment https://github.com/OCA/bank-payment/pull/860 e nao podemos mais detonar linhas de pagamento confirmadas, tem que chamar action_cancel() antes.

Isso deve resolver a questão dos 3 ou 4 PR aprovados que passaram os testes mas para os quais o merge nao rolou esses dias.

cc @marcelsavegnago @renatonlima @felipemotter @netosjb @mbcosta 
