### PR TITLE
[FIX] Ao gerar faturas nos pedidos de vendas sem dados fiscais

### DIFF
--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -314,7 +314,7 @@ class SaleOrder(models.Model):
             # Identify how many Document Types exist
             for inv_line in invoice_created_by_super.invoice_line_ids:
 
-                if inv_line.display_type:
+                if inv_line.display_type or not inv_line.fiscal_operation_line_id:
                     continue
 
                 fiscal_document_type = (


### PR DESCRIPTION
Ao gerar uma fatura em um pedido de venda onde as linhas do pedido de venda não tem informações fiscais, é gerado um erro