### PR TITLE
[14.0] fix auto install coa

### DIFF
--- a/l10n_br_base/__init__.py
+++ b/l10n_br_base/__init__.py
@@ -13,8 +13,7 @@ from odoo import api, tools, SUPERUSER_ID
 _auto_install_l10n_original = account._auto_install_l10n
 
 
-def _auto_install_l10n_br_generic_module(cr, registry):
-    env = api.Environment(cr, SUPERUSER_ID, {})
+def _auto_install_l10n_br_generic_module(env):
     country_code = env.company.country_id.code
     if country_code and country_code.upper() == "BR":
         if (
@@ -36,7 +35,7 @@ def _auto_install_l10n_br_generic_module(cr, registry):
         )
         module_ids.sudo().button_install()
     else:
-        _auto_install_l10n_original(cr, registry)
+        _auto_install_l10n_original(env)
 
 
 account._auto_install_l10n = _auto_install_l10n_br_generic_module


### PR DESCRIPTION
Depois do merge do módulo l10n_br_base  começou  a dar um erro caso tentasse instalar o l10n_br_coa
Essa PR resolve isso, no odoo 14 a chamada do método _auto_install_l10n ficou um pouco mais simples.

Obs: está dá dando uma outra excpetion ao tentar instalar o coa_simples, estou tentando resolver isso também.