### PR TITLE
[12.0][FIX] Street name in CNAB

### DIFF
--- a/l10n_br_account_payment_order/models/bank_payment_line.py
+++ b/l10n_br_account_payment_order/models/bank_payment_line.py
@@ -180,7 +180,7 @@ class BankPaymentLine(models.Model):
             "nome_sacado": self.partner_id.legal_name.strip()[:40],
             "numero": str(self.document_number)[:10],
             "endereco_sacado": str(
-                self.partner_id.street + ", " + str(self.partner_id.street_number)
+                self.partner_id.street_name + ", " + str(self.partner_id.street_number)
             )[:40],
             "bairro_sacado": self.partner_id.district.strip(),
             "cep_sacado": misc.punctuation_rm(self.partner_id.zip),


### PR DESCRIPTION
Pequeno FIX para corrigir este bug que estava estourando ao tentar gerar remessa CNAB.

```
  File "/opt/odoo/auto/addons/l10n_br_account_payment_order/models/bank_payment_line.py", line 183, in _prepare_boleto_bank_line_vals
    self.partner_id.street + ", " + str(self.partner_id.street_number)
TypeError: unsupported operand type(s) for +: 'bool' and 'str'
```