### PR TITLE
[12.0][BACKPORT][l10n_br_fiscal] fiscal backport

### DIFF
--- a/l10n_br_fiscal/models/document_event.py
+++ b/l10n_br_fiscal/models/document_event.py
@@ -156,14 +156,14 @@ class Event(models.Model):
         comodel_name="ir.attachment",
         string="XML",
         copy=False,
-        readony=True,
+        readonly=True,
     )
 
     file_response_id = fields.Many2one(
         comodel_name="ir.attachment",
         string="XML Response",
         copy=False,
-        readony=True,
+        readonly=True,
     )
 
     file_path = fields.Char(

--- a/l10n_br_fiscal/models/document_event.py
+++ b/l10n_br_fiscal/models/document_event.py
@@ -92,7 +92,6 @@ class Event(models.Model):
 
     origin = fields.Char(
         string="Source Document",
-        size=64,
         readonly=True,
         help="Document reference that generated this event.",
     )
@@ -145,7 +144,6 @@ class Event(models.Model):
 
     justification = fields.Char(
         string="Justification",
-        size=255,
     )
 
     display_name = fields.Char(

--- a/l10n_br_fiscal/models/invalidate_number.py
+++ b/l10n_br_fiscal/models/invalidate_number.py
@@ -69,7 +69,6 @@ class InvalidateNumber(models.Model):
 
     justification = fields.Char(
         string="Justification",
-        size=255,
         required=True,
         readonly=True,
         states={"draft": [("readonly", False)]},

--- a/l10n_br_fiscal/models/res_company.py
+++ b/l10n_br_fiscal/models/res_company.py
@@ -212,7 +212,7 @@ class ResCompany(models.Model):
         comodel_name="l10n_br_fiscal.simplified.tax.range",
         compute="_compute_simplifed_tax",
         store=True,
-        readyonly=True,
+        readonly=True,
         string="Simplified Tax Range",
     )
 

--- a/l10n_br_fiscal/models/res_company.py
+++ b/l10n_br_fiscal/models/res_company.py
@@ -199,7 +199,6 @@ class ResCompany(models.Model):
     annual_revenue = fields.Monetary(
         string="Annual Revenue",
         currency_field="currency_id",
-        digits=dp.get_precision("Fiscal Documents"),
     )
 
     simplifed_tax_id = fields.Many2one(
@@ -227,7 +226,6 @@ class ResCompany(models.Model):
     payroll_amount = fields.Monetary(
         string="Last Period Payroll Amount",
         currency_field="currency_id",
-        digits=dp.get_precision("Fiscal Documents"),
     )
 
     coefficient_r = fields.Boolean(

--- a/l10n_br_fiscal/models/simplified_tax_range.py
+++ b/l10n_br_fiscal/models/simplified_tax_range.py
@@ -24,20 +24,17 @@ class SimplifiedTaxRange(models.Model):
     amount_deduced = fields.Monetary(
         string="Amount to be Deducted",
         currency_field="currency_id",
-        digits=dp.get_precision("Fiscal Documents"),
         required=True,
     )
 
     inital_revenue = fields.Monetary(
         string="Initial Revenue",
         currency_field="currency_id",
-        digits=dp.get_precision("Fiscal Documents"),
     )
 
     final_revenue = fields.Monetary(
         string="Final Revenue",
         currency_field="currency_id",
-        digits=dp.get_precision("Fiscal Documents"),
     )
 
     total_tax_percent = fields.Float(

--- a/l10n_br_fiscal/wizards/base_wizard_mixin.py
+++ b/l10n_br_fiscal/wizards/base_wizard_mixin.py
@@ -51,7 +51,6 @@ class BaseWizardMixin(models.TransientModel):
 
     justification = fields.Text(
         string="Justification",
-        size=255,
     )
 
     document_status = fields.Text(string="Status", readonly=True)


### PR DESCRIPTION
backport com git cherry-pick de 4 commits do que deu para fazer backport depois do merge do modulo l10n_br_fiscal na14.0 (ver https://github.com/OCA/l10n-brazil/commits/14.0/l10n_br_fiscal ). De novo a ideia é minimizar o diff entre a v12 e a v14 para facilitar a manutenção (possibilitando futuros cherry-picks) e assim de facilitar a migração futura da galera que ta na 12.0.

Sobre a remoção dos campos size nesse commit https://github.com/OCA/l10n-brazil/commit/dc6bebe9edc38e3fe00601db1d03e616dedd1425 . E necessario porque na v14 isso da warning (e impedia o merge). Na v12 essa informação ja não era usada. Tambem temos essa informação no layout da NFe no modulo l10n_br_nfe_spec e poderiamos usa-la futuramente para validar os campos na hora do preenchimento. Tb poderia ser validado validando o schema da NFe antes de transmitir, algo que foi facilitado com esse commit no nfelib https://github.com/akretion/nfelib/pull/28

Contudo sou a favor de fazer essa limpeza na 12.0 ja.

