### PR TITLE
[12.0][FIX] Chamada do botão "Enviar E-mail" no Documento Fiscal

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -534,6 +534,10 @@ class AccountInvoice(models.Model):
         self.ensure_one()
         return self.fiscal_document_id.view_pdf()
 
+    def action_send_email(self):
+        self.ensure_one()
+        return self.fiscal_document_id.action_send_email()
+
     def _get_refund_common_fields(self):
         fields = super()._get_refund_common_fields()
         fields += [


### PR DESCRIPTION
Esta PR resolve o seguinte problema:

Quando os módulos l10n_br_fiscal e l10n_br_account estão instalados juntos o botão de enviar e-mail no documento fiscal, não funciona, gera a seguinte exceção: 

> Odoo Server Error
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 656, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 314, in _handle_exception
    raise pycompat.reraise(type(exception), exception, sys.exc_info()[2])
  File "/opt/odoo/custom/src/odoo/odoo/tools/pycompat.py", line 87, in reraise
    raise value
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 698, in dispatch
    result = self._call_function(**self.params)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 346, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/service/model.py", line 98, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 339, in checked_call
    result = self.endpoint(*a, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 941, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 519, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 967, in call_button
    action = self._call_kw(model, method, args, {})
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 955, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 752, in call_kw
    method = getattr(type(model), name)
AttributeError: type object 'account.invoice' has no attribute 'action_send_email'
