### PR TITLE
[12.0] fix erro causado pelo fiscal dummy 

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -303,11 +303,12 @@ class NFe(spec_models.StackedModel):
                 record.nfe40_Id = None
 
             # tpNF
-            operation_2_tpNF = {
-                "out": "1",
-                "in": "0",
-            }
-            record.nfe40_tpNF = operation_2_tpNF[record.fiscal_operation_type]
+            if record.fiscal_operation_type:
+                operation_2_tpNF = {
+                    "out": "1",
+                    "in": "0",
+                }
+                record.nfe40_tpNF = operation_2_tpNF[record.fiscal_operation_type]
 
             # TpEmis
             if record.nfe_transmission:


### PR DESCRIPTION
Por causa do fiscal dummy, estava recebendo essa exception ao tentar registrar pagamento de uma fatura:

> File "/opt/odoo/auto/addons/l10n_br_nfe/models/document.py", line 310, in _compute_nfe_data
>     record.nfe40_tpNF = operation_2_tpNF[record.fiscal_operation_type]
> KeyError: False

Essa pr resolve o problema.


