### PR TITLE
[12.0][FIX] Data na chave diverge com a data de emissão na NF-e.

### DIFF
--- a/l10n_br_fiscal/models/document_fiscal_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2019  Renato Lima - Akretion <renato.lima@akretion.com.br>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+from datetime import datetime, timedelta, timezone
+
 from odoo import api, fields, models
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
 
@@ -19,7 +21,8 @@ class FiscalDocumentMixin(models.AbstractModel):
     _description = "Document Fiscal Mixin"
 
     def _date_server_format(self):
-        return fields.Datetime.now().strftime(DEFAULT_SERVER_DATETIME_FORMAT)
+        date = datetime.now(tz=timezone(timedelta(hours=-3)))
+        return date.strftime(DEFAULT_SERVER_DATETIME_FORMAT)
 
     @api.model
     def _default_operation(self):


### PR DESCRIPTION
Ontem (31/10/2021) estava testando a emissão de nota fiscal em ambiente de homologação e me deparei com o seguinte erro de transmissão:

![image](https://user-images.githubusercontent.com/634278/139677200-edf28704-249b-4dc9-89f2-015dc78908a7.png)

> Fiscal Document: 55 - Nota Fiscal Eletrônica is Rejeitada: 502 - Rejeicao: Erro na Chave de Acesso - Campo ID nao corresponde a concatenacao dos campos correspondentes

Conferindo, vi que o erro estava relacionado a data (AAMM) que faz parte da chave de acesso. Essa data na chave estava divergente da data de emissão do documento, como pode ver a baixo:

![image](https://user-images.githubusercontent.com/634278/139678515-a5e01ec2-3269-4ec1-96a6-18dd26ddc435.png)

Composição da chave:
![image](https://user-images.githubusercontent.com/634278/139678666-ebc68cbf-8487-4eaa-92f4-33ac1f0c8021.png)

Olhando o código percebi que a data usada na chave era a data universal (UTC) e no restante do código o utilizado é o UTC-3 (horário de brasília), como o horário universal está sempre um pouco a frente, ele muda de dia primeiro, e consequentemente de mês primeiro, como a chave só leva a em consideração o ano e mes (AAMM) este BUG só acontece na virada do mês.

Sei que é um bug que vai ser difícil pegar em produção, pois vai acontecer somente algumas horas antes de virar o mês.
Mas se acontecer vai ser bem chato, então é melhor evitar.
