### PR TITLE
[12.0][FIX] Data na chave do documento fiscal

### DIFF
--- a/l10n_br_fiscal/models/document_workflow.py
+++ b/l10n_br_fiscal/models/document_workflow.py
@@ -255,8 +255,9 @@ class DocumentWorkflow(models.AbstractModel):
                 MODELO_FISCAL_NFCE,
                 MODELO_FISCAL_CTE,
             ):
+                date = fields.Datetime.context_timestamp(record, record.document_date)
                 chave_edoc = ChaveEdoc(
-                    ano_mes=record.document_date.strftime("%y%m").zfill(4),
+                    ano_mes=date.strftime("%y%m").zfill(4),
                     cnpj_emitente=record.company_cnpj_cpf,
                     codigo_uf=(
                         record.company_state_id


### PR DESCRIPTION
Substitui a PR #1692

@renatonlima @rvalyi 

Fiz a alteração para que a conversão seja na hora de imprimir/serializar a informação.
Dessa forma o timezone é pego do contexto, segui o mesmo exemplo que já foi feito em outras partes do l10n_br

