### PR TITLE
[14.0][ADD] format.address.mixin

### DIFF
--- a/l10n_br_base/models/__init__.py
+++ b/l10n_br_base/models/__init__.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2015  Renato Lima - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+from . import format_address_mixin
 from . import res_bank
 from . import res_city
 from . import res_country_state

--- a/l10n_br_base/models/format_address_mixin.py
+++ b/l10n_br_base/models/format_address_mixin.py
@@ -1,0 +1,14 @@
+# Copyright (C) 2021  Renato Lima - Akretion
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import models
+
+
+class FormatAddressMixin(models.AbstractModel):
+    _inherit = "format.address.mixin"
+
+    def _fields_view_get_address(self, arch):
+        address_view_id = self.env.company.country_id.address_view_id.sudo()
+        if address_view_id.model != self._name:
+            address_view_id.model = None
+        return super()._fields_view_get_address(arch)


### PR DESCRIPTION
O endereço do objeto parceiro (res.partner) podem ser modificados através do objeto herdado format.address.mixin que substitui o <div class="o_address_format"> que contém os campos do endereço de acordo com a visão do país do usuário.

Na versão 12.0 para simplificar a alteração dos campos na localização em outros objetos como o res.company, crm.lead por exemplo, na versão 14.0 esta sendo testado https://github.com/odoo/odoo/blob/14.0/odoo/addons/base/models/res_partner.py#L51 se a visão com os campos de endereço no país tem o model igual ao model do objeto (self) esse PR verifica se o objeto for diferente ele deixa nulo o campo model e chama o super do método _fields_view_get_address para ser executado corretamente. 

Antes de fazer esse PR eu tentei definir a view sem um model mas isso não funciona porque na instalação do módulo é verificado a visão.