### PR TITLE
[12.0][l10n_br_account][FIX] fix typo: stored=True -> store=True

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -104,7 +104,7 @@ class AccountInvoice(models.Model):
 
     document_type = fields.Char(
         related="document_type_id.code",
-        stored=True,
+        store=True,
     )
 
     def _get_amount_lines(self):


### PR DESCRIPTION
trabalhando na migração para a v14 https://github.com/OCA/l10n-brazil/pull/1688 eu encontrei e resolvi essa typo. O impacto não parece ter sido tão grave, mas é bom corrigir para ter esse campo no SQL como esperado.