### PR TITLE
[12.0][FIX] nosso_numero no retorno Itaú (CNAB/Boleto)

### DIFF
--- a/l10n_br_account_payment_brcobranca/parser/cnab_file_parser.py
+++ b/l10n_br_account_payment_brcobranca/parser/cnab_file_parser.py
@@ -211,7 +211,12 @@ class CNABFileParser(FileParser):
 
             # Nosso numero vem com o Digito Verificador
             # ex.: 00000000000002010
-            nosso_numero_sem_dig = linha_cnab["nosso_numero"][:-1]
+
+            # Com exceção no itaú(341) que já vem sem o dígito verificador.
+            if self.bank.code_bc == "341":
+                nosso_numero_sem_dig = linha_cnab["nosso_numero"]
+            else:
+                nosso_numero_sem_dig = linha_cnab["nosso_numero"][:-1]
 
             # No arquivo de retorno do CNAB o campo pode ter um tamanho
             # diferente, o tamanho do campo é preenchido na totalidade


### PR DESCRIPTION
No módulo de cobrança bancaria (payment_order) utilizando o banco Itaú (cnab400) não estava sendo possível fazer o processamento do arquivo de retorno do banco, os boletos baixados não eram encontrados, isso estava ocorrendo pois o "nosso número" que vem no arquivo de retorno do Itaú já vem sem o digito verificador.


