### PR TITLE
[12.0][FIX] Limit payment_line search (brcobrança)

### DIFF
--- a/l10n_br_account_payment_brcobranca/parser/cnab_file_parser.py
+++ b/l10n_br_account_payment_brcobranca/parser/cnab_file_parser.py
@@ -259,7 +259,11 @@ class CNABFileParser(FileParser):
                 continue
 
             payment_line = self.env["account.payment.line"].search(
-                [("move_line_id", "=", account_move_line.id)]
+                [
+                    ("move_line_id", "=", account_move_line.id),
+                    ("state", "not in", ["cancel", "draft"]),
+                ],
+                limit=1,
             )
 
             # A Linha de Pagamento pode ter N bank.payment.line


### PR DESCRIPTION
Ao tentar importar um arquivo de retorno estava estourando essa exception:

![image](https://user-images.githubusercontent.com/634278/142124540-bf05cc32-5c54-4050-b95e-64a27fe3eb8c.png)

As vezes o move_line tinha mais de um payment_line e era blocado pelo ensure_one() alterei o código para filtrar melhor e limitar o resultado a 1.

@mbcosta 