### PR TITLE
[12.0[FIX] Número do documento no arquivo de remessa

### DIFF
--- a/l10n_br_account_payment_order/models/bank_payment_line.py
+++ b/l10n_br_account_payment_order/models/bank_payment_line.py
@@ -178,7 +178,7 @@ class BankPaymentLine(models.Model):
             "nosso_numero": self.own_number,
             "documento_sacado": misc.punctuation_rm(self.partner_id.cnpj_cpf),
             "nome_sacado": self.partner_id.legal_name.strip()[:40],
-            "numero": str(self.document_number)[:10],
+            "numero": self.document_number,
             "endereco_sacado": str(
                 self.partner_id.street_name + ", " + str(self.partner_id.street_number)
             )[:40],


### PR DESCRIPTION
Ao criar a linha da remessa, o document_number está sendo cortado
Por exemplo, no caso a baixo:
![image](https://user-images.githubusercontent.com/634278/142129502-372ec821-8fff-45f5-b807-70d54fffa3a0.png)

o "número do documento"  está com 11 caracteres, por causa da limitação de 10 caracteres, no arquivo de remessa está sendo impresso "00000159/0"

Será que podemos remover essa limitação ou existe alguma outra questão ?
