### PR TITLE
[12.0][FIX] Inutilização do número (módulo fiscal)

### DIFF
--- a/l10n_br_nfe/models/invalidate_number.py
+++ b/l10n_br_nfe/models/invalidate_number.py
@@ -59,7 +59,9 @@ class InvalidateNumber(models.Model):
         event_id = self.event_ids.create_event_save_xml(
             company_id=self.company_id,
             environment=(
-                EVENT_ENV_PROD if self.nfe_environment == "1" else EVENT_ENV_HML
+                EVENT_ENV_PROD
+                if self.company_id.nfe_environment == "1"
+                else EVENT_ENV_HML
             ),
             event_type="3",
             xml_file=processo.envio_xml.decode("utf-8"),


### PR DESCRIPTION
Ao tentar inutilizar o número de um documento fiscal, utilizando o caminho Fiscal>Documents>Invalidate Number
Estava estourando a exception a baixo, na hora de confirmar:

File "/opt/odoo/auto/addons/l10n_br_nfe/models/invalidate_number.py", line 62, in _invalidate
    EVENT_ENV_PROD if self.nfe_environment == "1" else EVENT_ENV_HML
AttributeError: 'l10n_br_fiscal.invalidate.number' object has no attribute 'nfe_environment'

Essa PR corrige isso.