### PR TITLE
[12.0][FIX] Zeros no número do documento (CNAB)

### DIFF
--- a/l10n_br_account_payment_order/models/account_invoice.py
+++ b/l10n_br_account_payment_order/models/account_invoice.py
@@ -103,7 +103,7 @@ class AccountInvoice(models.Model):
             inv._compute_financial()
 
             for index, interval in enumerate(inv.financial_move_line_ids):
-                inv_number = inv.get_invoice_fiscal_number().split("/")[-1].zfill(8)
+                inv_number = inv.get_invoice_fiscal_number().split("/")[-1]
                 numero_documento = inv_number + "/" + str(index + 1).zfill(2)
 
                 sequence = inv.payment_mode_id.get_own_number_sequence(


### PR DESCRIPTION
Pessoal, isso não é bem um FIX, é mais uma sugestão. Tem necessidade de preencher o número do documento com zeros?
Por exemplo se eu faço um boleto para a nota fiscal de nº 8960, no boleto impresso a informação do documento é escrito assim: 00008960.
Eu e o @felipemotter preferimos imprimir 8960 diretamente, sem zeros, pois fica mais legível ao usuário.

É importante preencher com zeros somente na hora de inserir no arquivo de remessa, mas esse tratamento já é feito lá, fiz o teste utilizando essa pr e não tive nenhum problema, estou usando em conjunto com o brcobrança.

@mbcosta 



