### PR TITLE
[12.0][l10n_br_account_payment_order][IMP] use document_number when l10n_br_fiscal is installed

### DIFF
--- a/l10n_br_account_payment_order/models/account_invoice.py
+++ b/l10n_br_account_payment_order/models/account_invoice.py
@@ -76,10 +76,14 @@ class AccountInvoice(models.Model):
         return super().action_invoice_cancel()
 
     def get_invoice_fiscal_number(self):
-        """Como neste modulo nao temos o numero do documento fiscal,
-        vamos retornar o numero do core e deixar este metodo
-        para caso alguem queira sobrescrever"""
+        """
+        Como neste modulo nao temos o numero do documento fiscal,
+        testamos a presencia desse campo e se o módulo fiscal não tiver instalado,
+        retornamos o numero do invoice do core.
+        """
         self.ensure_one()
+        if hasattr(self, "document_number"):
+            return self.document_number
         return self.number
 
     def _pos_action_move_create(self):


### PR DESCRIPTION
solução alternativa para https://github.com/OCA/l10n-brazil/pull/1708, Resove com 2 linha de diff no código e evita toda casquinha vazia de um modulo inteiro que hoje não me parece ter um bom "signal to noise ratio" para ser justificado para algo tão trivial; não ha muito código para se mutualizar num modulo extra para manter so para isso hoje...

cc @netosjb @felipemotter @renatonlima @mbcosta @marcelsavegnago 