### PR TITLE
[12.0][IMP] add municipio_prestacao_servico (issqn_fg_city_id)

### DIFF
--- a/l10n_br_nfse/models/document_line.py
+++ b/l10n_br_nfse/models/document_line.py
@@ -113,6 +113,7 @@ class DocumentLine(models.Model):
             "item_lista_servico": self.service_type_id.code
             and self.service_type_id.code.replace(".", ""),
             "codigo_tributacao_municipio": self.city_taxation_code_id.code or "",
+            "municipio_prestacao_servico": self.issqn_fg_city_id.ibge_code or "",
             "discriminacao": str(self.name[:2000] or ""),
             "codigo_cnae": misc.punctuation_rm(self.cnae_id.code) or None,
             "valor_desconto_incondicionado": round(self.discount_value, 2),


### PR DESCRIPTION
Este campo pode não ser utilizado por todos os provedores mas é o campo relacionado com a natureza de tributacao do documento fiscal. 

![image](https://user-images.githubusercontent.com/3595132/143162272-099cf173-aa7b-4c5e-abbc-889500037472.png)


Sendo assim, entendo que o valor o campo issqn_fg_city_id deveria ser o campo para informar a cidade onde foi prestado o serviço. Outra opção, é assumir de cara o codigo da cidade do destinatário.

Obs. Pensei em implementar em outra PR um default para o campo issqn_fg_city_id onde, quando a natureza de tributação for igual a 2 assume o código da cidade do tomador e quando for diferente assume o código da cidade do prestador e mantém ainda em aberto para alteração o campo issqn_fg_city_id. 


![image](https://user-images.githubusercontent.com/3595132/143163517-0abc29f2-aac6-4fc1-ad16-cd38bf0a785b.png)


ping @mileo @renatonlima @rvalyi @felipemotter @netosjb 


