### PR TITLE
[12.0][FIX] Verificação do número do documento fiscal no Boleto.

### DIFF
--- a/l10n_br_account_payment_order/models/account_invoice.py
+++ b/l10n_br_account_payment_order/models/account_invoice.py
@@ -82,7 +82,7 @@ class AccountInvoice(models.Model):
         retornamos o numero do invoice do core.
         """
         self.ensure_one()
-        if hasattr(self, "document_number"):
+        if hasattr(self, "document_number") and self.document_number:
             return self.document_number
         return self.number
 


### PR DESCRIPTION
pequeno fix para verificar se o número do documento fiscal não é nulo.

Isso deve resolver o erro reportado pelo @marcos-mendez na issue #1725 

@rvalyi  @marcelsavegnago  @mbcosta @felipemotter 