### PR TITLE
[12.0][FIX] fiscal document mixin street related fields

### DIFF
--- a/l10n_br_fiscal/models/document_fiscal_invoice_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_invoice_mixin.py
@@ -62,7 +62,7 @@ class FiscalDocumentInvoiceMixin(models.AbstractModel):
 
     partner_street = fields.Char(
         string="Partner Street",
-        related="partner_id.street",
+        related="partner_id.street_name",
     )
 
     partner_number = fields.Char(
@@ -165,7 +165,7 @@ class FiscalDocumentInvoiceMixin(models.AbstractModel):
 
     company_street = fields.Char(
         string="Company Street",
-        related="company_id.street",
+        related="company_id.street_name",
     )
 
     company_number = fields.Char(


### PR DESCRIPTION
Recentemente o campo street foi trocado pelo street e esse PR corrige os campos related no documento fiscal para usar o campo correto (street_name)