### PR TITLE
[12.0][BACKPORT] l10n_br_nfe: ir.config.parameter for nfe VerProc tag

### DIFF
--- a/l10n_br_nfe/__manifest__.py
+++ b/l10n_br_nfe/__manifest__.py
@@ -16,6 +16,8 @@
         "spec_driven_model",
     ],
     "data": [
+        # Data
+        "data/ir_config_parameter.xml",
         # Security
         "security/nfe_security.xml",
         # Views

--- a/l10n_br_nfe/data/ir_config_parameter.xml
+++ b/l10n_br_nfe/data/ir_config_parameter.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="nfe_version_name" model="ir.config_parameter" forcecreate="True">
+        <field name="key">l10n_br_nfe.version.name</field>
+        <field name="value">Odoo Brasil OCA v12.0</field>
+      </record>
+
+</odoo>

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -213,7 +213,10 @@ class NFe(spec_models.StackedModel):
     )
 
     nfe40_verProc = fields.Char(
-        default="Odoo Brasil v12.0",  # Shound be an ir.parameter?
+        copy=False,
+        default=lambda s: s.env["ir.config_parameter"]
+        .sudo()
+        .get_param("l10n_br_nfe.version.name", default="Odoo Brasil OCA v12.0"),
     )
 
     nfe40_CRT = fields.Selection(

--- a/l10n_br_nfe/models/res_config_settings.py
+++ b/l10n_br_nfe/models/res_config_settings.py
@@ -48,3 +48,8 @@ class ResConfigSettings(models.TransientModel):
         related="company_id.nfce_danfe_layout",
         readonly=False,
     )
+
+    nfe_version_name = fields.Char(
+        string="NFe Proc Version",
+        config_parameter="l10n_br_nfe.version.name",
+    )

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000012062777161.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000012062777161.xml
@@ -20,7 +20,7 @@
             <indFinal>1</indFinal>
             <indPres>0</indPres>
             <procEmi>0</procEmi>
-            <verProc>Odoo Brasil v12.0</verProc>
+            <verProc>Odoo Brasil OCA v12.0</verProc>
         </ide>
         <emit>
             <CNPJ>59594315000157</CNPJ>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000022062777169.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000022062777169.xml
@@ -20,7 +20,7 @@
             <indFinal>1</indFinal>
             <indPres>0</indPres>
             <procEmi>0</procEmi>
-            <verProc>Odoo Brasil v12.0</verProc>
+            <verProc>Odoo Brasil OCA v12.0</verProc>
         </ide>
         <emit>
             <CNPJ>81583054000129</CNPJ>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000032062777166.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000032062777166.xml
@@ -20,7 +20,7 @@
             <indFinal>1</indFinal>
             <indPres>0</indPres>
             <procEmi>0</procEmi>
-            <verProc>Odoo Brasil v12.0</verProc>
+            <verProc>Odoo Brasil OCA v12.0</verProc>
         </ide>
         <emit>
             <CNPJ>81583054000129</CNPJ>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200681583054000129550010000000012760018057-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200681583054000129550010000000012760018057-nf-e.xml
@@ -20,7 +20,7 @@
       <indFinal>1</indFinal>
       <indPres>0</indPres>
       <procEmi>0</procEmi>
-      <verProc>Odoo Brasil v12.0</verProc>
+      <verProc>Odoo Brasil OCA v12.0</verProc>
     </ide>
     <emit>
       <CNPJ>81583054000129</CNPJ>


### PR DESCRIPTION
Atualmente a tag da NF-e VerProc esta informada de forma hard code, esse PR é um backport do commit no PR da versão 14.0 https://github.com/OCA/l10n-brazil/pull/1674/commits/d286f1a2eb3cb8ad83431204734d3c85cddc00fe

![Captura de Tela 2021-11-25 às 10 30 15](https://user-images.githubusercontent.com/211005/143451281-ad11470a-175d-40cc-b898-09253e718f4d.png)

