### PR TITLE
[12.0][FIX] Carregamento dos impostos 

### DIFF
--- a/l10n_br_account/models/account_invoice_line.py
+++ b/l10n_br_account/models/account_invoice_line.py
@@ -257,9 +257,8 @@ class AccountInvoiceLine(models.Model):
         self.clear_caches()
         return result
 
-    @api.onchange("fiscal_tax_ids")
-    def _onchange_fiscal_tax_ids(self):
-        super()._onchange_fiscal_tax_ids()
+    def _update_fiscal_tax_ids(self, taxes):
+        super()._update_fiscal_tax_ids(taxes)
         user_type = "sale"
         if self.invoice_id.type in ("in_invoice", "in_refund"):
             user_type = "purchase"

--- a/l10n_br_account/views/account_invoice_line_view.xml
+++ b/l10n_br_account/views/account_invoice_line_view.xml
@@ -89,7 +89,7 @@
                                 name="invoice_line_tax_ids"
                                 context="{'type': invoice_type}"
                                 domain="[('type_tax_use','!=','none'),('company_id', '=', company_id)]"
-                                widget="many2many_tags"
+                                widget="many2many"
                                 options="{'no_create': True}"
                             />
                         </group>

--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -186,7 +186,6 @@ class SaleOrderLine(models.Model):
                 self.product_uom_qty * self.price_unit or 1
             )
 
-    @api.onchange("fiscal_tax_ids")
-    def _onchange_fiscal_tax_ids(self):
-        super()._onchange_fiscal_tax_ids()
+    def _update_fiscal_tax_ids(self, taxes):
+        super()._update_fiscal_tax_ids(taxes)
         self.tax_id |= self.fiscal_tax_ids.account_taxes(user_type="sale")


### PR DESCRIPTION
Os impostos não estavam sendo copiados corretamente para os campos nativos do Odoo, no sales (tax_ids) e no account (invoice_tax_line_ids). Existia um @onchange para fazer esse comportamento, mas nem sempre ele era chamado.

Segue um exemplo onde as informações dos "taxes" eram perdidas, neste caso foi na troca do produto, mas as vezes acontecia de já vir tudo zerado.
![Peek 2021-11-27 14-52](https://user-images.githubusercontent.com/634278/143691889-d171cd81-e313-401b-9b75-40adfce97c8f.gif)

Consequentemente, sem esses taxes, os respectivos  **move_lines** também não eram criados e o total da fatura também era calculado errado:
![image](https://user-images.githubusercontent.com/634278/143693473-c1fb2f7b-bbba-4ce3-83c1-596d72d62058.png)

Esta PR altera um pouco o fluxo para garantir o carregamento dessas informações.

Outra coisa que percebi foi que na view, o widget **many2many_tags** do field **invoice_line_tax_ids** estava com um comportamento estranho, depois de validar a fatura, a visão desse campo ficava em branco, mas apenas na visão mesmo, pois a informação estava sendo persistida, se olhasse pela visão do "fiscal details" a informação era exibida normalmente, a unica forma que eu consegui resolver isso foi alterando o widget para o many2many padrão.

Atualmente isso era umas das coisas que mais tava incomodando na emissão da nota fiscal para mim.

@renatonlima @rvalyi @mbcosta @marcelsavegnago @felipemotter @vanderleiromera



