### PR TITLE
[12.0][FIX] Carregamento dos impostos 

### DIFF
--- a/l10n_br_account/models/account_invoice_line.py
+++ b/l10n_br_account/models/account_invoice_line.py
@@ -257,12 +257,16 @@ class AccountInvoiceLine(models.Model):
         self.clear_caches()
         return result
 
-    @api.onchange("fiscal_tax_ids")
-    def _onchange_fiscal_tax_ids(self):
-        super()._onchange_fiscal_tax_ids()
+    def _set_taxes(self):
+        super(AccountInvoiceLine, self)._set_taxes()
         user_type = "sale"
         if self.invoice_id.type in ("in_invoice", "in_refund"):
             user_type = "purchase"
         self.invoice_line_tax_ids |= self.fiscal_tax_ids.account_taxes(
             user_type=user_type
         )
+
+    @api.onchange("fiscal_tax_ids")
+    def _onchange_fiscal_tax_ids(self):
+        super()._onchange_fiscal_tax_ids()
+        self._set_taxes()

--- a/l10n_br_account/views/account_invoice_line_view.xml
+++ b/l10n_br_account/views/account_invoice_line_view.xml
@@ -89,7 +89,7 @@
                                 name="invoice_line_tax_ids"
                                 context="{'type': invoice_type}"
                                 domain="[('type_tax_use','!=','none'),('company_id', '=', company_id)]"
-                                widget="many2many_tags"
+                                widget="many2many"
                                 options="{'no_create': True}"
                             />
                         </group>

--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -186,7 +186,12 @@ class SaleOrderLine(models.Model):
                 self.product_uom_qty * self.price_unit or 1
             )
 
+    def _compute_tax_id(self):
+        super(SaleOrderLine, self)._compute_tax_id()
+        for line in self:
+            line.tax_id |= line.fiscal_tax_ids.account_taxes(user_type="sale")
+
     @api.onchange("fiscal_tax_ids")
     def _onchange_fiscal_tax_ids(self):
         super()._onchange_fiscal_tax_ids()
-        self.tax_id |= self.fiscal_tax_ids.account_taxes(user_type="sale")
+        self._compute_tax_id()


### PR DESCRIPTION
A solução que eu tinha apresentado na PR #1733 estava mal feita e mal mapeada

Essa PR soluciona o problema  da forma correta.

O que acontecia na verdade é que os impostos, **tax_id** no sales, **invoice_line_tax_ids** no account estavam sendo modificados pela localização, porém eram apagados pelos métodos nativos do Odoo, a solução foi fazer um override nesses métodos:
No sales foi feito um override no método _compute_tax_id()
No account foi feito um ovveride no método _set_taxes()

@vanderleiromera obrigado por ter testado a pr anterior e ter percebido o erro.

@marcelsavegnago @renatonlima @rvalyi @felipemotter @mileo 