### PR TITLE
[12.0][FIX] Valor Recebido no retorno bancário para o banco Itaú.

### DIFF
--- a/l10n_br_account_payment_brcobranca/parser/cnab_file_parser.py
+++ b/l10n_br_account_payment_brcobranca/parser/cnab_file_parser.py
@@ -524,6 +524,11 @@ class CNABFileParser(FileParser):
             valor_recebido + valor_desconto + valor_abatimento
         ) - valor_juros_mora
 
+        # No itaú(341) o valor recebido (valor principal) já vem com a tarifa descontada
+        # precisamos atualizar o valor recebido para que a reconcialiação feche.
+        if self.bank.code_bc == "341":
+            valor_recebido_calculado += valor_tarifa
+
         row_list.append(
             {
                 "name": account_move_line.invoice_id.number,


### PR DESCRIPTION
 Pequeno fix para os lançamentos e reconciliação das cobranças **Itaú** ao processar os retornos do banco.

No Itaú o valor_recebido, ou valor principal como é chamado no manual do Itaú, vem por padrão sem o valor da tarifa somada, diferente do que é esperado no código atual.

Acrescentei um if no código para tratar essa exceção.

Se alguém achar ruim esse tipo de hack, podemos ver também para adicionar um flag em algum cadastro para tratar esse tipo de situação, talvez no modelo do banco ou do modo de pagamento.

@mbcosta @marcelsavegnago  @mileo 