### PR TITLE
[12][IMP] Alterações para suportar o banco Ailos

### DIFF
--- a/l10n_br_account_payment_brcobranca/constants/br_cobranca.py
+++ b/l10n_br_account_payment_brcobranca/constants/br_cobranca.py
@@ -24,6 +24,7 @@ DICT_BRCOBRANCA_BANK = {
     "033": BankRecord("santander", retorno=["240"], remessa=["400"]),
     "041": BankRecord("banrisul", retorno=["400"], remessa=["400"]),
     "070": BankRecord("banco_brasilia", retorno=[], remessa=["400"]),
+    "085": BankRecord("ailos", retorno=["240"], remessa=["240"]),
     "097": BankRecord("credisis", retorno=["400"], remessa=["400"]),
     "104": BankRecord("caixa", retorno=["240"], remessa=["240"]),
     "136": BankRecord("unicred", retorno=["400"], remessa=["240", "400"]),

--- a/l10n_br_account_payment_brcobranca/models/account_payment_order.py
+++ b/l10n_br_account_payment_brcobranca/models/account_payment_order.py
@@ -130,6 +130,7 @@ class PaymentOrder(models.Model):
         remessa_values = {
             "carteira": str(self.payment_mode_id.boleto_wallet),
             "agencia": bank_account_id.bra_number,
+            "digito_agencia": bank_account_id.bra_number_dig,
             "conta_corrente": int(misc.punctuation_rm(bank_account_id.acc_number)),
             "digito_conta": bank_account_id.acc_number_dig[0],
             "empresa_mae": bank_account_id.partner_id.legal_name[:30],
@@ -137,6 +138,7 @@ class PaymentOrder(models.Model):
                 bank_account_id.partner_id.cnpj_cpf
             ),
             "pagamentos": pagamentos,
+            "convenio": self.payment_mode_id.code_convetion,
             "sequencial_remessa": self.payment_mode_id.cnab_sequence_id.next_by_id(),
         }
 


### PR DESCRIPTION
Alterações no módulo BrCobrança para suportar a implementação do banco Ailos.

A implementação já existia na lib Brcobrança, mas estava desatualizada, antigamente o banco se chamava Cecred, fiz uma PR solicitando as alterações lá: https://github.com/kivanio/brcobranca/pull/227

já fiz o teste em produção e está funcionando bem

@mbcosta 
