### PR TITLE
[12.0][FIX] Avoid Comparing apples and oranges warning

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -208,7 +208,7 @@ class AccountInvoice(models.Model):
                 continue
             if (
                 invoice.fiscal_document_id
-                and invoice.fiscal_document_id
+                and invoice.fiscal_document_id.id
                 != self.env.user.company_id.fiscal_dummy_id.id
             ):
                 unlink_documents |= invoice.fiscal_document_id


### PR DESCRIPTION
Correção da comparação errada entre objetos que esta gerando a seguinte mensagem de warning no log:

`WARNING db odoo.models: Comparing apples and oranges: l10n_br_fiscal.document(37,) == 1 (/odoo/external-src/l10n-brazil/l10n_br_account/models/account_invoice.py:212)`