### PR TITLE
[12.0] Injeção do documento fiscal dummy na invoice

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -183,10 +183,10 @@ class AccountInvoice(models.Model):
 
     @api.model
     def create(self, values):
-        if not values.get("document_type_id"):
-            values.update(
-                {"fiscal_document_id": self.env.user.company_id.fiscal_dummy_id.id}
-            )
+        # if not values.get("document_type_id"):
+        #     values.update(
+        #         {"fiscal_document_id": self.env.user.company_id.fiscal_dummy_id.id}
+        #     )
         invoice = super().create(values)
         invoice._write_shadowed_fields()
         return invoice


### PR DESCRIPTION
Estou com uma dúvida em relação a essa injeção do fiscal_dummy na invoice quando a mesma não é um documento fiscal.
Se alguém puder me ajudar a entender qual a importância e o proposito dele pois eu comentei essas linhas e a principio não tive nenhum problema. É que com isso o problema reportado aqui https://github.com/OCA/l10n-brazil/issues/1340#issuecomment-999821285 é resolvido, mas eu realmente não sei se pode haver algum efeito colateral nisso.

Agradeço a todos.