### PR TITLE
[12.0][l10n_br_hr] fix erp.brasil dependency

### DIFF
--- a/l10n_br_hr/__manifest__.py
+++ b/l10n_br_hr/__manifest__.py
@@ -25,7 +25,7 @@
     ],
     "demo": ["demo/hr_employee_dependent_demo.xml"],
     "test": [],
-    "external_dependencies": {"python": ["erpbrasil.base.fiscal"]},
+    "external_dependencies": {"python": ["erpbrasil.base"]},
     "installable": True,
     "auto_install": False,
     "license": "AGPL-3",


### PR DESCRIPTION
o modulo fiscal do erp.brasil.fiscal na verdade faz parte do pacote erp.brasil. Isso deve resolver o erro no runboat aqui: https://runboat.odoo-community.org/api/v1/builds/b78ea478e-0559-4c37-9f88-ab937d00bb4a/init-log

cc @marcelsavegnago 