### PR TITLE
[12.0][l10n_br_fiscal][BACKPORT] backport pr 1759

### DIFF
--- a/l10n_br_fiscal/models/document_fiscal_line_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin.py
@@ -197,8 +197,6 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     price_gross = fields.Monetary(
         compute="_compute_amounts",
         string="Amount Gross",
-        store=True,
-        readonly=True,
         help="Amount without discount.",
     )
 

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -155,6 +155,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 record.financial_discount_value = record.discount_value
             else:
                 record.financial_total_gross = record.financial_total = 0.0
+                record.financial_discount_value = 0.0
 
     def _compute_taxes(self, taxes, cst=None):
         self.ensure_one()

--- a/l10n_br_fiscal/models/document_fiscal_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin.py
@@ -108,6 +108,7 @@ class FiscalDocumentMixin(models.AbstractModel):
 
     amount_price_gross = fields.Monetary(
         compute="_compute_amount",
+        store=True,
         string="Amount Gross",
         readonly=True,
         help="Amount without discount.",

--- a/l10n_br_fiscal/models/document_fiscal_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin.py
@@ -368,7 +368,7 @@ class FiscalDocumentMixin(models.AbstractModel):
     amount_tax_withholding = fields.Monetary(
         string="Amount Tax Withholding",
         compute="_compute_amount",
-        strore=True,
+        store=True,
     )
 
     amount_financial_total = fields.Monetary(


### PR DESCRIPTION
backport de 2 commits que eu precisei para botar #1759 verde na 14.0 (o financial_discount_value não definido cria um erro de cachemiss que não passa de um warning na 12 mas da erro na 14)