### PR TITLE
[12.0] Adicionado índices em alguns campos chaves

### DIFF
--- a/l10n_br_fiscal/models/document_fiscal_line_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin.py
@@ -84,7 +84,11 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         default=lambda self: self.env.ref("base.BRL"),
     )
 
-    product_id = fields.Many2one(comodel_name="product.product", string="Product")
+    product_id = fields.Many2one(
+        comodel_name="product.product",
+        string="Product",
+        index=True,
+    )
 
     tax_icms_or_issqn = fields.Selection(
         selection=TAX_ICMS_OR_ISSQN,

--- a/l10n_br_fiscal/models/document_fiscal_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin.py
@@ -52,6 +52,7 @@ class FiscalDocumentMixin(models.AbstractModel):
 
     partner_id = fields.Many2one(
         comodel_name="res.partner",
+        index=True,
     )
 
     fiscal_operation_type = fields.Selection(


### PR DESCRIPTION
Esse PR adiciona em alguns campos no documento fiscal e na definição de impostos o atributo index=True que cria indices no banco de dados para melhorar a performance no caso de grandes volumes de dados.