### PR TITLE
[14.0][FIX] _search_name method in data.abstract

### DIFF
--- a/l10n_br_fiscal/models/data_abstract.py
+++ b/l10n_br_fiscal/models/data_abstract.py
@@ -68,12 +68,11 @@ class DataAbstract(models.AbstractModel):
                     ],
                 ]
             )
-            recs = self._search(
+            return self._search(
                 expression.AND([domain, args]),
                 limit=limit,
                 access_rights_uid=name_get_uid,
             )
-            return self.browse(recs).name_get()
 
         return super()._name_search(
             name, args=args, operator=operator, limit=limit, name_get_uid=name_get_uid


### PR DESCRIPTION
Correção do método _search_name utilizados nos cadastros fiscais como NCM, CEST, CFOP e etc..

Extraído via cherry-pick do commit https://github.com/akretion/l10n-brazil/commit/b4a6eccd1ae068950d8834e653a06519a925e1f8 no PR  #1688 