### PR TITLE
[14.0][FIX] Company street_number

### DIFF
--- a/l10n_br_base/__manifest__.py
+++ b/l10n_br_base/__manifest__.py
@@ -9,7 +9,7 @@
     "author": "Akretion,Odoo Community Association (OCA)",
     "maintainers": ["renatonlima", "rvalyi"],
     "website": "https://github.com/OCA/l10n-brazil",
-    "version": "14.0.1.1.0",
+    "version": "14.0.2.0.0",
     "depends": ["base", "base_setup", "base_address_city", "base_address_extended"],
     "data": [
         "security/ir.model.access.csv",

--- a/l10n_br_base/data/res_country_data.xml
+++ b/l10n_br_base/data/res_country_data.xml
@@ -145,7 +145,7 @@
         <field name="bc_code">1058</field>
         <field name="siscomex_code">105</field>
         <field name="enforce_cities">1</field>
-        <field name="street_format" eval="'%(street_name)s'" />
+        <field name="street_format" eval="'%(street_name)s, %(street_number)s'" />
         <field name="name_position">before</field>
         <field
             name="address_format"

--- a/l10n_br_base/data/res_country_data.xml
+++ b/l10n_br_base/data/res_country_data.xml
@@ -149,7 +149,7 @@
         <field name="name_position">before</field>
         <field
             name="address_format"
-            eval="'%(street)s, %(street_number)s %(street2)s\n%(district)s\n%(zip)s - %(city)s-%(state_code)s\n%(country_name)s'"
+            eval="'%(street)s %(street2)s\n%(district)s\n%(zip)s - %(city)s-%(state_code)s\n%(country_name)s'"
         />
         <field name="address_view_id" ref="l10n_br_base_res_partner_address" />
         <field name="vat_label">CNPJ/CPF</field>

--- a/l10n_br_base/migrations/14.0.2.0.0/post-migration.py 
+++ b/l10n_br_base/migrations/14.0.2.0.0/post-migration.py 
@@ -1,0 +1,19 @@
+import logging
+
+_logger = logging.getLogger(__name__)
+try:
+    from openupgradelib import openupgrade
+except ImportError:
+    openupgrade = None
+
+
+def migrate(cr, version):
+    cr.execute(
+        """UPDATE res_partner
+        SET street=(street_name||', '||street_number)
+        WHERE country_id =(
+            SELECT id
+            FROM res_country
+            WHERE code='BR');
+        """
+    )

--- a/l10n_br_zip/tests/test_l10n_br_zip_res_partner.py
+++ b/l10n_br_zip/tests/test_l10n_br_zip_res_partner.py
@@ -200,7 +200,7 @@ class L10nBRZipTest(TransactionCase):
         )
         self.assertEqual(
             self.res_partner.street_name,
-            "Avenida Paulista, 2100",
+            "Avenida Paulista",
             "Error in method zip_search with PyCEP-Correios"
             "to mapping field street_name.",
         )


### PR DESCRIPTION
Conforme relatado na issue #1704 resolvemos o problema corrigindo o street_format da localização para incluir o number.

Na 14.0 o odoo está zerando os campos do endereço que não estão expressos no street_format, conforme essas linhas:
https://github.com/OCA/OCB/blob/a2094d9984d830f3ef3e4f8c4991e4dd19b08e3d/addons/base_address_extended/models/res_partner.py#L75-L76

O compute citado a cima era chamado quando houvesse alteração no campo street. Nos casos dos res.partner normais não havia nenhuma chamada, porém ao calcular os campos de endereço do res.company alguns metodos alteravam esse field e por fim apagavam o street_number nesse caso.
