### PR TITLE
[13.0][REF] Geração do Certificado Fake, removido dependência do PyOpenSSL.

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -110,7 +110,7 @@
         "python": [
             "erpbrasil.base",
             "erpbrasil.assinatura",
-            "OpenSSL",
+            "cryptography",
         ]
     },
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # generated from manifests external_dependencies
+cryptography
 erpbrasil.assinatura
 erpbrasil.base
 nfelib
 num2words
 odoo_test_helper
-pyOpenSSL


### PR DESCRIPTION
Alteração da biblioteca usada parar gerar os certificado fake de PyOpenSSL para Cryptography

Isso deve resolver os problemas reportados aqui:

https://github.com/OCA/l10n-brazil/pull/1745#pullrequestreview-838497585
https://github.com/OCA/l10n-brazil/pull/1776#issuecomment-1013444298

Acreditamos que ao invés de caçar o problema de conflito/versão com a lib openSSL seja mais interessante essa mudança de biblioteca, a própria documentação do pyopenssl recomenda o cryptography:
https://www.pyopenssl.org/en/stable/api/crypto.html

Vimos também que outras localização aderiram a essa mudança, ex a l10n_es:
https://github.com/OCA/l10n-spain/pull/1705

Talvez mais tarde seja interessante fazer essa alteração nas bibliotecas erpbrasil também.