### PR TITLE
[14.0][REF] Geração do Certificado Fake, removido dependência do PyOpenSSL. 

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -110,7 +110,7 @@
         "python": [
             "erpbrasil.base",
             "erpbrasil.assinatura",
-            "OpenSSL",
+            "cryptography",
         ]
     },
 }

--- a/l10n_br_fiscal/hooks.py
+++ b/l10n_br_fiscal/hooks.py
@@ -6,6 +6,9 @@ import logging
 
 from odoo import SUPERUSER_ID, _, api, tools
 
+from .constants.fiscal import CERTIFICATE_TYPE_ECNPJ
+from .tools import misc
+
 _logger = logging.getLogger(__name__)
 
 
@@ -85,20 +88,22 @@ def post_init_hook(cr, registry):
                 kind="demo",
             )
 
-    #    companies = [
-    #        env.ref("base.main_company", raise_if_not_found=False),
-    #        env.ref("l10n_br_base.empresa_lucro_presumido", raise_if_not_found=False),
-    #        env.ref("l10n_br_base.empresa_simples_nacional", raise_if_not_found=False),
-    #    ]
+        env = api.Environment(cr, SUPERUSER_ID, {})
 
-    #        for company in companies:
-    #            l10n_br_fiscal_certificate_id = env["l10n_br_fiscal.certificate"]
-    #            company.certificate_nfe_id = l10n_br_fiscal_certificate_id.create(
-    #                misc.prepare_fake_certificate_vals()
-    #            )
-    #            company.certificate_ecnpj_id = l10n_br_fiscal_certificate_id.create(
-    #                misc.prepare_fake_certificate_vals(cert_type=CERTIFICATE_TYPE_ECNPJ)
-    #            )
+        companies = [
+            env.ref("base.main_company", raise_if_not_found=False),
+            env.ref("l10n_br_base.empresa_lucro_presumido", raise_if_not_found=False),
+            env.ref("l10n_br_base.empresa_simples_nacional", raise_if_not_found=False),
+        ]
+
+        for company in companies:
+            l10n_br_fiscal_certificate_id = env["l10n_br_fiscal.certificate"]
+            company.certificate_nfe_id = l10n_br_fiscal_certificate_id.create(
+                misc.prepare_fake_certificate_vals()
+            )
+            company.certificate_ecnpj_id = l10n_br_fiscal_certificate_id.create(
+                misc.prepare_fake_certificate_vals(cert_type=CERTIFICATE_TYPE_ECNPJ)
+            )
 
     if tools.config["without_demo"]:
         prodfiles = []

--- a/l10n_br_fiscal/models/certificate.py
+++ b/l10n_br_fiscal/models/certificate.py
@@ -66,9 +66,7 @@ class Certificate(models.Model):
 
     file = fields.Binary(string="file", prefetch=True, required=True)
 
-    file_name = fields.Char(
-        string="File Name", compute="_compute_description", size=255
-    )
+    file_name = fields.Char(string="File Name", compute="_compute_name", size=255)
 
     password = fields.Char(string="Password", required=True)
 
@@ -116,8 +114,10 @@ class Certificate(models.Model):
                     c.owner_name or "",
                     format_date(self.env, c.date_expiration),
                 )
+                c.file_name = c.name + ".p12"
             else:
                 c.name = False
+                c.file_name = False
 
     @api.depends("date_expiration")
     def _compute_is_valid(self):

--- a/l10n_br_fiscal/views/certificate_view.xml
+++ b/l10n_br_fiscal/views/certificate_view.xml
@@ -54,7 +54,8 @@
                     </group>
                     <group>
                         <group string="File">
-                            <field name="file" />
+                            <field name="file_name" invisible="1" />
+                            <field name="file" filename="file_name" />
                         </group>
                         <group string="Password">
                             <field name="password" password="True" />

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # generated from manifests external_dependencies
+cryptography
 erpbrasil.assinatura
 erpbrasil.base
 erpbrasil.edoc
@@ -7,5 +8,4 @@ nfelib
 num2words
 odoo_test_helper
 pycep_correios
-pyOpenSSL
 workalendar


### PR DESCRIPTION
O mesmo que #1777 

Porém tem 2 dois commits adicionais:

1) reativei o código comentando que insere os certificado fake nas empresas de demostração. c56815f8b0a7e4f0e1df0811b790907caff44a08

2) Inclui um fix para exibição do nome do arquivo do certificado d4b979ece8b9da8df3cd30893b3691f7a39983d9
vou fazer um back-port desse commit para a v12 também.

Obs: lembrando que ainda precisar ser aprovado o merge no erp.assinatura para remoção dos warning e melhorar compatibilidade das libs com o trevis: https://github.com/erpbrasil/erpbrasil.assinatura/pull/26
