### PR TITLE
[12.0][FIX] Exibição do nome do arquivo do certificado digital.

### DIFF
--- a/l10n_br_fiscal/models/certificate.py
+++ b/l10n_br_fiscal/models/certificate.py
@@ -66,9 +66,7 @@ class Certificate(models.Model):
 
     file = fields.Binary(string="file", prefetch=True, required=True)
 
-    file_name = fields.Char(
-        string="File Name", compute="_compute_description", size=255
-    )
+    file_name = fields.Char(string="File Name", compute="_compute_name", size=255)
 
     password = fields.Char(string="Password", required=True)
 
@@ -116,8 +114,10 @@ class Certificate(models.Model):
                     c.owner_name or "",
                     format_date(self.env, c.date_expiration),
                 )
+                c.file_name = c.name + ".p12"
             else:
                 c.name = False
+                c.file_name = False
 
     @api.depends("date_expiration")
     def _compute_is_valid(self):

--- a/l10n_br_fiscal/views/certificate_view.xml
+++ b/l10n_br_fiscal/views/certificate_view.xml
@@ -57,7 +57,8 @@
                     </group>
                     <group>
                         <group string="File">
-                            <field name="file" />
+                            <field name="file_name" invisible="1" />
+                            <field name="file" filename="file_name" />
                         </group>
                         <group string="Password">
                             <field name="password" password="True" />


### PR DESCRIPTION
Trivial fix, extraído da PR #1778 

Corrige o nome do arquivo do certificado, que antes estava ficando vazio, ao salvar o arquivo o odoo gerava o nome com base no nome do módulo e do modelo, mas a extensão fica zuada.

![image](https://user-images.githubusercontent.com/634278/149665302-69da0389-f9c1-459a-bf76-5185b5cd281b.png)


