### PR TITLE
[12.0][FIX] nfe40_mod selection -> now supports NFP: Nota Fiscal do Produtor Rural

### DIFF
--- a/l10n_br_nfe/__manifest__.py
+++ b/l10n_br_nfe/__manifest__.py
@@ -24,6 +24,7 @@
         "views/res_company_view.xml",
         "views/nfe_document_view.xml",
         "views/res_config_settings_view.xml",
+        "views/nfe_document_related_view.xml",
     ],
     "demo": [
         "demo/res_users_demo.xml",

--- a/l10n_br_nfe/models/document_related.py
+++ b/l10n_br_nfe/models/document_related.py
@@ -174,9 +174,9 @@ class NFeRelated(spec_models.StackedModel):
         return super()._export_fields(xsd_fields, class_obj, export_dict)
 
     def _prepare_NFP_values(self):
-        self.state_id = self.produtor_partner_id.state_id
+        self.state_id = self.produtor_partner_id.state_id or self.state_id
         self.cpfcnpj_type = (
             "cpf" if self.produtor_partner_id.type == "person" else "cnpj"
-        )
-        self.cnpj_cpf = self.produtor_partner_id.cnpj_cpf
-        self.inscr_est = self.produtor_partner_id.inscr_est
+        ) or self.cpfcnpj_type
+        self.cnpj_cpf = self.produtor_partner_id.cnpj_cpf or self.cnpj_cpf
+        self.inscr_est = self.produtor_partner_id.inscr_est or self.inscr_est

--- a/l10n_br_nfe/models/document_related.py
+++ b/l10n_br_nfe/models/document_related.py
@@ -51,7 +51,8 @@ class NFeRelated(spec_models.StackedModel):
     )
 
     nfe40_choice5 = fields.Selection(
-        [("nfe40_CNPJ", "CNPJ"), ("nfe40_CPF", "CPF")], "CNPJ/CPF do Produtor"
+        selection=[("nfe40_CNPJ", "CNPJ"), ("nfe40_CPF", "CPF")],
+        string="CNPJ/CPF do Produtor",
     )
 
     nfe40_mod = fields.Selection(
@@ -176,7 +177,7 @@ class NFeRelated(spec_models.StackedModel):
     def _prepare_NFP_values(self):
         self.state_id = self.produtor_partner_id.state_id or self.state_id
         self.cpfcnpj_type = (
-            "cpf" if self.produtor_partner_id.type == "person" else "cnpj"
+            "cnpj" if self.produtor_partner_id.is_company else "cpf"
         ) or self.cpfcnpj_type
         self.cnpj_cpf = self.produtor_partner_id.cnpj_cpf or self.cnpj_cpf
         self.inscr_est = self.produtor_partner_id.inscr_est or self.inscr_est

--- a/l10n_br_nfe/models/document_related.py
+++ b/l10n_br_nfe/models/document_related.py
@@ -31,6 +31,10 @@ class NFeRelated(spec_models.StackedModel):
     # all m2o below this level will be stacked even if not required:
     _rec_name = "nfe40_refNFe"
 
+    produtor_partner_id = fields.Many2one(
+        comodel_name="res.partner", string="Produtor", required=False
+    )
+
     nfe40_choice4 = fields.Selection(
         compute="_compute_nfe_data",
         inverse="_inverse_nfe40_choice4",
@@ -48,6 +52,17 @@ class NFeRelated(spec_models.StackedModel):
 
     nfe40_choice5 = fields.Selection(
         [("nfe40_CNPJ", "CNPJ"), ("nfe40_CPF", "CPF")], "CNPJ/CPF do Produtor"
+    )
+
+    nfe40_mod = fields.Selection(
+        selection=[
+            ("2B", "2B"),
+            ("2C", "2C"),
+            ("2D", "2D"),
+            ("01", "01"),
+            ("02", "02"),
+            ("04", "04"),
+        ],
     )
 
     # TODO
@@ -69,7 +84,16 @@ class NFeRelated(spec_models.StackedModel):
     #     store=True,
     # )
 
-    @api.depends("document_type_id")
+    @api.depends(
+        "document_type_id",
+        "state_id",
+        "document_date",
+        "cnpj_cpf",
+        "inscr_est",
+        "document_serie",
+        "document_number",
+        "cpfcnpj_type",
+    )
     def _compute_nfe_data(self):
         """Set schema data which are not just related fields"""
         for rec in self:
@@ -88,6 +112,7 @@ class NFeRelated(spec_models.StackedModel):
                 else:
                     if rec.document_type_id.code == MODELO_FISCAL_RL:
                         rec.nfe40_choice4 = "nfe40_refNFP"
+                        rec._prepare_NFP_values()
                     elif rec.document_type_id.code == MODELO_FISCAL_CUPOM_FISCAL_ECF:
                         rec.nfe40_choice4 = "nfe40_refECF"
                     elif rec.document_type_id.code in (
@@ -95,27 +120,38 @@ class NFeRelated(spec_models.StackedModel):
                         MODELO_FISCAL_04,
                     ):
                         rec.nfe40_choice4 = "nfe40_refNF"
-                    rec.nfe40_cUF = document.partner_id.state_id.ibge_code
+
+                    rec.nfe40_cUF = rec.state_id.ibge_code
                     rec.nfe40_AAMM = (
-                        fields.Datetime.from_string(
-                            document.authorization_date
-                        ).strftime("%y%m")
-                        if document.authorization_date
+                        fields.Datetime.from_string(rec.document_date).strftime("%y%m")
+                        if rec.document_date
                         else ""
                     )
                     if rec.cpfcnpj_type == "cpf":
+                        rec.nfe40_choice5 = "nfe40_CPF"
                         rec.nfe40_CPF = rec.cnpj_cpf
+                        rec.nfe40_CNPJ = ""
                     else:
+                        rec.nfe40_choice5 = "nfe40_CNPJ"
                         rec.nfe40_CNPJ = rec.cnpj_cpf
+                        rec.nfe40_CPF = ""
+
                     rec.nfe40_IE = rec.inscr_est
-                    rec.nfe40_mod = rec.document_type_id.code
-                    rec.nfe40_serie = document.document_serie
-                    rec.nfe40_nNF = document.document_number
+                    rec.nfe40_mod = (
+                        rec.document_type_id.code
+                        if (rec.document_type_id.code, rec.document_type_id.code)
+                        in rec._fields["nfe40_mod"].selection
+                        else ""
+                    )
+                    rec.nfe40_serie = rec.document_serie
+                    rec.nfe40_nNF = rec.document_number
 
     def _inverse_nfe40_choice4(self):
         for rec in self:
             if rec.nfe40_choice4 == "nfe40_refNFe":
                 rec.document_type_id = self.env.ref("l10n_br_fiscal.document_55")
+            elif rec.nfe40_choice4 == "nfe40_refNFP":
+                rec.document_type_id = self.env.ref("l10n_br_fiscal.document_04")
 
     def _inverse_nfe40_refNFe(self):
         for rec in self:
@@ -136,3 +172,11 @@ class NFeRelated(spec_models.StackedModel):
             ]
             xsd_fields += [self.nfe40_choice4]
         return super()._export_fields(xsd_fields, class_obj, export_dict)
+
+    def _prepare_NFP_values(self):
+        self.state_id = self.produtor_partner_id.state_id
+        self.cpfcnpj_type = (
+            "cpf" if self.produtor_partner_id.type == "person" else "cnpj"
+        )
+        self.cnpj_cpf = self.produtor_partner_id.cnpj_cpf
+        self.inscr_est = self.produtor_partner_id.inscr_est

--- a/l10n_br_nfe/tests/test_account_supplier_nfe.py
+++ b/l10n_br_nfe/tests/test_account_supplier_nfe.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 
+from odoo import fields
 from odoo.tests.common import TransactionCase
 
 
@@ -52,4 +53,25 @@ class TestSupplierNFe(TransactionCase):
         ).action_invoice_open()
         self.assertEqual(
             self.invoice_same_state.state, "open", "Invoice should be in state Open"
+        )
+
+        # Add a related document
+        self.invoice_same_state.write(
+            {
+                "document_related_ids": (
+                    0,
+                    0,
+                    {
+                        "document_type_id": self.env.ref(
+                            "l10n_br_fiscal.document_04"
+                        ).id,
+                        "document_serie": "4",
+                        "state_id": self.env.ref("base.state_br_sp").id,
+                        "document_date": fields.Datetime.now(),
+                        "cpfcnpj_type": "cnpj",
+                        "cnpj_cpf": "30.805.965/0001-12",
+                        "inscr_est": "215031186110",
+                    },
+                )
+            }
         )

--- a/l10n_br_nfe/views/nfe_document_related_view.xml
+++ b/l10n_br_nfe/views/nfe_document_related_view.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="document_related_form_inherit" model="ir.ui.view">
+        <field name="name">l10n_br_nfe.document.related.form.inherit</field>
+        <field name="model">l10n_br_fiscal.document.related</field>
+        <field name="priority">50</field>
+        <field name="inherit_id" ref="l10n_br_fiscal.document_related_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='document_type_id']/.." position="after">
+                <group>
+                    <field name="produtor_partner_id" invisible="1" />
+                </group>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="document_related_ids_form_inherit" model="ir.ui.view">
+        <field name="name">l10n_br_nfe.document.related.ids.form.inherit</field>
+        <field name="model">l10n_br_fiscal.document</field>
+        <field name="priority">50</field>
+        <field name="inherit_id" ref="l10n_br_fiscal.document_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='document_related_ids']" position="attributes">
+                <attribute
+                    name="context"
+                >{'default_produtor_partner_id': partner_id}</attribute>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
This PR fixes and improves the functions of related document specifically for type NFP.

- FIXED: broken dynamic selection for field nfe40_mod
- FIXED: _compute_nfe_data depend fields
- FIXED: _compute_nfe_data non-electronic documents cannot access field document (not available) -> changed to rec
- IMPROVED: _compute_nfe_data auto completion for fields that come from produtor_partner_id