### PR TITLE
[12.0][FIX] Teste com o contexto/fusohorario da data errado

### DIFF
--- a/l10n_br_account_payment_order/tests/test_base_class.py
+++ b/l10n_br_account_payment_order/tests/test_base_class.py
@@ -2,9 +2,8 @@
 #   Luis Felipe Mileo <mileo@kmee.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
-from datetime import datetime
-
 from odoo.exceptions import UserError
+from odoo.fields import Date
 from odoo.tests import SavepointCase, tagged
 
 
@@ -64,7 +63,9 @@ class TestL10nBrAccountPaymentOder(SavepointCase):
         line_create = (
             self.env["account.payment.line.create"]
             .with_context(active_model="account.payment.order", active_id=order.id)
-            .create({"date_type": "move", "move_date": datetime.now()})
+            .create(
+                {"date_type": "move", "move_date": Date.context_today(self.env.user)}
+            )
         )
         line_create.payment_mode = "same"
         line_create.move_line_filters_change()
@@ -74,7 +75,11 @@ class TestL10nBrAccountPaymentOder(SavepointCase):
             self.env["account.payment.line.create"]
             .with_context(active_model="account.payment.order", active_id=order.id)
             .create(
-                {"date_type": "due", "target_move": "all", "due_date": datetime.now()}
+                {
+                    "date_type": "due",
+                    "target_move": "all",
+                    "due_date": Date.context_today(self.env.user),
+                }
             )
         )
         line_created_due.populate()


### PR DESCRIPTION
Os testes no módulo l10n_br_account_payment_order estavam falhando, mas a falha só acontecia em determinado horário, o motivo é por causa das datas que estavam sendo comparadas com contextos diferentes.

Os dados demos estavam sendo criados com o contexto do usuário OdooBot  (timezone de Europe/Bruxelas GTM+1)
porém na classe de teste a data estava sendo pega direto do servidor sem contexto, no caso GMT +0

Por esse motivo, se vc rodasse os testes as 23:01 (horario do servidor - gtm 0) os dados demos eram criados com a data um dia a frente.

