### PR TITLE
[14.0] Rename line_ids to fiscal_line_ids in fiscal document

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -10,7 +10,7 @@
     "maintainers": ["renatonlima"],
     "website": "https://github.com/OCA/l10n-brazil",
     "development_status": "Production/Stable",
-    "version": "14.0.3.2.0",
+    "version": "14.0.3.0.0",
     "depends": [
         "uom",
         "product",

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -156,7 +156,7 @@ class Document(models.Model):
         default=lambda self: self.env.company,
     )
 
-    line_ids = fields.One2many(
+    fiscal_line_ids = fields.One2many(
         comodel_name="l10n_br_fiscal.document.line",
         inverse_name="document_id",
         string="Document Lines",
@@ -348,18 +348,18 @@ class Document(models.Model):
             r.name = r._compute_document_name()
 
     @api.depends(
-        "line_ids.estimate_tax",
-        "line_ids.price_gross",
-        "line_ids.amount_untaxed",
-        "line_ids.amount_tax",
-        "line_ids.amount_taxed",
-        "line_ids.amount_total",
-        "line_ids.financial_total",
-        "line_ids.financial_total_gross",
-        "line_ids.financial_discount_value",
-        "line_ids.amount_tax_included",
-        "line_ids.amount_tax_not_included",
-        "line_ids.amount_tax_withholding",
+        "fiscal_line_ids.estimate_tax",
+        "fiscal_line_ids.price_gross",
+        "fiscal_line_ids.amount_untaxed",
+        "fiscal_line_ids.amount_tax",
+        "fiscal_line_ids.amount_taxed",
+        "fiscal_line_ids.amount_total",
+        "fiscal_line_ids.financial_total",
+        "fiscal_line_ids.financial_total_gross",
+        "fiscal_line_ids.financial_discount_value",
+        "fiscal_line_ids.amount_tax_included",
+        "fiscal_line_ids.amount_tax_not_included",
+        "fiscal_line_ids.amount_tax_withholding",
     )
     def _compute_amount(self):
         super()._compute_amount()
@@ -412,7 +412,7 @@ class Document(models.Model):
             new_doc.fiscal_operation_id = fsc_op
             new_doc._onchange_fiscal_operation_id()
 
-            for line in new_doc.line_ids:
+            for line in new_doc.fiscal_line_ids:
                 fsc_op_line = line.fiscal_operation_id.return_fiscal_operation_id
                 if not fsc_op_line:
                     raise ValidationError(

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -65,25 +65,25 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         if xpath_mappings is None:
             xpath_mappings = (
                 # (placeholder_xpath, fiscal_xpath)
-                ("//group[@name='fiscal_fields']", "//group[@name='fiscal_fields']"),
-                ("//page[@name='fiscal_taxes']", "//page[@name='fiscal_taxes']"),
+                (".//group[@name='fiscal_fields']", "//group[@name='fiscal_fields']"),
+                (".//page[@name='fiscal_taxes']", "//page[@name='fiscal_taxes']"),
                 (
-                    "//page[@name='fiscal_line_extra_info']",
+                    ".//page[@name='fiscal_line_extra_info']",
                     "//page[@name='fiscal_line_extra_info']",
                 ),
                 # these will only collect (invisible) fields for onchanges:
                 (
-                    "//group[@name='fiscal_taxes_fields']",
+                    ".//control[@name='fiscal_taxes_fields']...",
                     "//page[@name='fiscal_taxes']//field",
                 ),
                 (
-                    "//group[@name='fiscal_line_extra_info_fields']",
+                    ".//control[@name='fiscal_line_extra_info_fields']...",
                     "//page[@name='fiscal_line_extra_info']//field",
                 ),
             )
         for placeholder_xpath, fiscal_xpath in xpath_mappings:
             fiscal_nodes = fsc_doc.xpath(fiscal_xpath)
-            for target_node in doc.xpath(placeholder_xpath):
+            for target_node in doc.findall(placeholder_xpath):
                 if len(fiscal_nodes) == 1:
                     # replace unique placeholder
                     # (deepcopy is required to inject fiscal nodes in possible
@@ -94,6 +94,8 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                     # append multiple fields to placeholder container
                     for fiscal_node in fiscal_nodes:
                         field = deepcopy(fiscal_node)
+                        if not field.attrib.get("optional"):
+                            field.attrib["invisible"] = "1"
                         target_node.append(field)
         return doc
 

--- a/l10n_br_fiscal/models/document_fiscal_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin_methods.py
@@ -26,7 +26,7 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
 
     def _get_amount_lines(self):
         """Get object lines instaces used to compute fields"""
-        return self.mapped("line_ids")
+        return self.mapped("fiscal_line_ids")
 
     @api.model
     def _get_amount_fields(self):
@@ -44,7 +44,13 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
                     if field in line._fields.keys():
                         values[field] += line[field]
                     if field.replace("amount_", "") in line._fields.keys():
-                        values[field] += line[field.replace("amount_", "")]
+                        # FIXME this field creates an error in invoice form
+                        if field == "amount_financial_discount_value":
+                            values[
+                                "amount_financial_discount_value"
+                            ] += 0  # line.financial_discount_value
+                        else:
+                            values[field] += line[field.replace("amount_", "")]
             doc.update(values)
 
     def __document_comment_vals(self):
@@ -69,7 +75,7 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
             ).compute_message(
                 d.__document_comment_vals(), d.manual_customer_additional_data
             )
-            d.line_ids._document_comment()
+            d.fiscal_line_ids._document_comment()
 
     @api.onchange("fiscal_operation_id")
     def _onchange_fiscal_operation_id(self):

--- a/l10n_br_fiscal/models/document_workflow.py
+++ b/l10n_br_fiscal/models/document_workflow.py
@@ -291,7 +291,10 @@ class DocumentWorkflow(models.AbstractModel):
 
             if not self.operation_name:
                 self.operation_name = ", ".join(
-                    [line.name for line in self.line_ids.mapped("fiscal_operation_id")]
+                    [
+                        line.name
+                        for line in self.fiscal_line_ids.mapped("fiscal_operation_id")
+                    ]
                 )
 
             if self.document_electronic and not self.document_key:

--- a/l10n_br_fiscal/models/res_company.py
+++ b/l10n_br_fiscal/models/res_company.py
@@ -75,7 +75,7 @@ class ResCompany(models.Model):
             "fiscal_operation_type": "out",
             "partner_id": self.partner_id.id,
             "company_id": self.id,
-            "line_ids": [(0, 0, {"name": "dummy", "company_id": self.id})],
+            "fiscal_line_ids": [(0, 0, {"name": "dummy", "company_id": self.id})],
         }
 
     @api.model

--- a/l10n_br_fiscal/models/subsequent_document.py
+++ b/l10n_br_fiscal/models/subsequent_document.py
@@ -113,9 +113,11 @@ class SubsequentDocument(models.Model):
         new_doc._document_reference(reference_ids)
 
         new_doc._onchange_fiscal_operation_id()
-        new_doc.line_ids.write({"fiscal_operation_id": new_doc.fiscal_operation_id.id})
+        new_doc.fiscal_line_ids.write(
+            {"fiscal_operation_id": new_doc.fiscal_operation_id.id}
+        )
 
-        for item in new_doc.line_ids:
+        for item in new_doc.fiscal_line_ids:
             item._onchange_fiscal_operation_id()
             item._onchange_fiscal_operation_line_id()
             item._onchange_fiscal_taxes()

--- a/l10n_br_fiscal/tests/test_fiscal_document_generic.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_generic.py
@@ -40,7 +40,7 @@ class TestFiscalDocumentGeneric(SavepointCase):
         self.nfe_same_state._onchange_document_serie_id()
         self.nfe_same_state._onchange_fiscal_operation_id()
 
-        for line in self.nfe_same_state.line_ids:
+        for line in self.nfe_same_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
             line._onchange_ncm_id()
@@ -158,7 +158,7 @@ class TestFiscalDocumentGeneric(SavepointCase):
         self.nfe_other_state._onchange_document_serie_id()
         self.nfe_other_state._onchange_fiscal_operation_id()
 
-        for line in self.nfe_other_state.line_ids:
+        for line in self.nfe_other_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
             line._onchange_ncm_id()
@@ -281,7 +281,7 @@ class TestFiscalDocumentGeneric(SavepointCase):
         self.nfe_not_taxpayer._onchange_document_serie_id()
         self.nfe_not_taxpayer._onchange_fiscal_operation_id()
 
-        for line in self.nfe_not_taxpayer.line_ids:
+        for line in self.nfe_not_taxpayer.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
             line._onchange_ncm_id()
@@ -389,7 +389,7 @@ class TestFiscalDocumentGeneric(SavepointCase):
         self.nfe_not_taxpayer_pf._onchange_document_serie_id()
         self.nfe_not_taxpayer_pf._onchange_fiscal_operation_id()
 
-        for line in self.nfe_not_taxpayer_pf.line_ids:
+        for line in self.nfe_not_taxpayer_pf.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
             line._onchange_ncm_id()
@@ -498,7 +498,7 @@ class TestFiscalDocumentGeneric(SavepointCase):
         self.nfe_export._onchange_document_serie_id()
         self.nfe_export._onchange_fiscal_operation_id()
 
-        for line in self.nfe_export.line_ids:
+        for line in self.nfe_export.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
             line._onchange_ncm_id()
@@ -601,7 +601,7 @@ class TestFiscalDocumentGeneric(SavepointCase):
         self.nfe_sn_same_state._onchange_document_serie_id()
         self.nfe_sn_same_state._onchange_fiscal_operation_id()
 
-        for line in self.nfe_sn_same_state.line_ids:
+        for line in self.nfe_sn_same_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
 
@@ -721,7 +721,7 @@ class TestFiscalDocumentGeneric(SavepointCase):
         self.nfe_sn_other_state._onchange_document_serie_id()
         self.nfe_sn_other_state._onchange_fiscal_operation_id()
 
-        for line in self.nfe_sn_other_state.line_ids:
+        for line in self.nfe_sn_other_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
             line._onchange_ncm_id()
@@ -826,7 +826,7 @@ class TestFiscalDocumentGeneric(SavepointCase):
         self.nfe_sn_not_taxpayer._onchange_document_serie_id()
         self.nfe_sn_not_taxpayer._onchange_fiscal_operation_id()
 
-        for line in self.nfe_sn_not_taxpayer.line_ids:
+        for line in self.nfe_sn_not_taxpayer.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
             line._onchange_ncm_id()
@@ -919,7 +919,7 @@ class TestFiscalDocumentGeneric(SavepointCase):
         self.nfe_sn_export._onchange_document_serie_id()
         self.nfe_sn_export._onchange_fiscal_operation_id()
 
-        for line in self.nfe_sn_export.line_ids:
+        for line in self.nfe_sn_export.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
             line._onchange_ncm_id()
@@ -1041,13 +1041,13 @@ class TestFiscalDocumentGeneric(SavepointCase):
 
     def test_unlink_dummy_document_line(self):
         """ Test Dummy Fiscal Document Line Unlink Restrictions """
-        dummy_line = self.env.user.company_id.fiscal_dummy_id.line_ids[0]
+        dummy_line = self.env.user.company_id.fiscal_dummy_id.fiscal_line_ids[0]
         with self.assertRaises(UserError):
             dummy_line.unlink()
 
     def test_nfe_comments(self):
         self.nfe_not_taxpayer._document_comment()
-        additional_data = self.nfe_not_taxpayer.line_ids[0].additional_data
+        additional_data = self.nfe_not_taxpayer.fiscal_line_ids[0].additional_data
         self.assertEqual(
             additional_data,
             "manual comment test - Valor Aprox. dos Tributos: R$ 0,00"

--- a/l10n_br_fiscal/tests/test_fiscal_document_nfse.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_nfse.py
@@ -16,7 +16,7 @@ class TestFiscalDocumentNFSe(TransactionCase):
         self.nfse_same_state._onchange_document_serie_id()
         self.nfse_same_state._onchange_fiscal_operation_id()
 
-        for line in self.nfse_same_state.line_ids:
+        for line in self.nfse_same_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
             line._onchange_ncm_id()

--- a/l10n_br_fiscal/tests/test_subsequent_operation.py
+++ b/l10n_br_fiscal/tests/test_subsequent_operation.py
@@ -29,7 +29,7 @@ class TestSubsequentOperation(TransactionCase):
         self.nfe_simples_faturamento._onchange_company_id()
         self.nfe_simples_faturamento._onchange_document_serie_id()
 
-        for line in self.nfe_simples_faturamento.line_ids:
+        for line in self.nfe_simples_faturamento.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_fiscal_taxes()
 
@@ -51,7 +51,7 @@ class TestSubsequentOperation(TransactionCase):
             )
 
             # Subsequent Lines
-            for product in document.subsequent_document_id.line_ids:
+            for product in document.subsequent_document_id.fiscal_line_ids:
 
                 # Document Line ICMS tax
                 self.assertEqual(

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -323,7 +323,7 @@
             </page>
             <page name="products" string="Products and Services">
               <field
-                                name="line_ids"
+                                name="fiscal_line_ids"
                                 context="{'form_view_ref': 'l10n_br_fiscal.document_line_form', 'default_document_id': id, 'default_company_id': company_id, 'default_partner_id': partner_id, 'default_fiscal_operation_type': fiscal_operation_type, 'default_fiscal_operation_id': fiscal_operation_id, 'no_subcall': True}"
                             >
                 <tree>


### PR DESCRIPTION
Como no account.move existe o campo line_ids que é um o2m das account.move.line, o l10n_br_fiscal.document precisa ser alterado o campo line_ids para fiscal_line_ids para evitar problemas