### PR TITLE
[12.0][FIX] Conflito visão do sale_commission com o l10n_br_account

### DIFF
--- a/l10n_br_account/views/account_invoice_view.xml
+++ b/l10n_br_account/views/account_invoice_view.xml
@@ -43,6 +43,7 @@
     <record id="invoice_form" model="ir.ui.view">
         <field name="name">l10n_br_account.invoice.form</field>
         <field name="model">account.invoice</field>
+        <field name="priority">30</field>
         <field name="inherit_id" ref="account.invoice_form" />
         <field name="arch" type="xml">
             <div name="button_box" position="inside">


### PR DESCRIPTION
Quando o módulo [sale_commission](https://github.com/OCA/commission/tree/12.0/sale_commission) da OCA é instalado junto ao l10n_br_account a visão da fatura fica com comportamento errado, os dados padrão ao criar uma nova linha da fatura não são carregados.

O motivo é que extensão da view da invoice declarado no módulo de comissões estava sobrescrevendo as definição de contexto do invoice_line_ids.

Como pode ver nas linhas a baixo:

No l10n_br_account:
https://github.com/OCA/l10n-brazil/blob/ec5391d495ddddcd1ff7bc2fdebb3909b3c97249/l10n_br_account/views/account_invoice_view.xml#L130-L132

No sale_commission:
https://github.com/OCA/commission/blob/8aa75c527ec092d3f86578763b0e26e372e9c61f/sale_commission/views/account_invoice_view.xml#L37

Para resolver isso foi alterado o priority da view do l10n_br_account para que o carregamento ficasse por ultimo.

