### PR TITLE
[12.0][FIX] Erro ao criar um imposto no fiscal quando o l10n_br_account esta intalado

### DIFF
--- a/l10n_br_account/models/fiscal_tax.py
+++ b/l10n_br_account/models/fiscal_tax.py
@@ -43,9 +43,7 @@ class FiscalTax(models.Model):
                     self.env["account.tax"].create(tax_values)
 
             else:
-                account_taxes.write(
-                    {"fiscal_tax_ids": [(4, t.id) for t in account_taxes]}
-                )
+                account_taxes.write({"fiscal_tax_ids": [(4, fiscal_tax.id)]})
 
     @api.model
     def create(self, values):


### PR DESCRIPTION
Depois que o l10n_br_account esta instalado ao criar um fiscal.tax não é possível criar um fiscal.tax porque se houver algum account.tax com o mesmo grupo de impostos o fiscal.tax os dois (fiscal.tax e account.tax) são relacionados esse PR corrige o erro do create do fiscal.tax