### PR TITLE
[12.0][FIX] l10n_br_account: dummy fiscal document line correction

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -223,6 +223,8 @@ class AccountInvoice(models.Model):
         default = default or {}
         if self.document_type_id:
             default["line_ids"] = False
+        else:
+            default["line_ids"] = self.line_ids[0]
         return super().copy(default)
 
     @api.one


### PR DESCRIPTION
Quando uma fatura sem tipo de documento fiscal é duplicada, o sistema estava criando novas linhas diferentes da linha do documento fiscal dummy. 

Este problema aumenta exponencialmente a cada duplicação de fatura sem tipo de documento fiscal associado.