### PR TITLE
[14.0][FIX][BUG] Get the current company should be made with self.env.company

### DIFF
--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -379,7 +379,7 @@ class Document(models.Model):
         ]
 
         for record in self.filtered(
-            lambda d: d != self.env.user.company_id.fiscal_dummy_id
+            lambda d: d != self.env.company.fiscal_dummy_id
             and d.state_edoc in forbidden_states_unlink
         ):
             raise ValidationError(

--- a/l10n_br_fiscal/tests/test_fiscal_document_generic.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_generic.py
@@ -1033,7 +1033,7 @@ class TestFiscalDocumentGeneric(SavepointCase):
 
     def test_unlink_dummy_document(self):
         """ Test Dummy Fiscal Document Unlink Restrictions """
-        dummy_document = self.env.user.company_id.fiscal_dummy_id
+        dummy_document = self.env.company.fiscal_dummy_id
         with self.assertRaises(IntegrityError), mute_logger("odoo.sql_db"):
             # as much as possible we ensure technical dummy fiscal documents
             # cannot be removed by mistake easily even from SQL
@@ -1041,7 +1041,7 @@ class TestFiscalDocumentGeneric(SavepointCase):
 
     def test_unlink_dummy_document_line(self):
         """ Test Dummy Fiscal Document Line Unlink Restrictions """
-        dummy_line = self.env.user.company_id.fiscal_dummy_id.fiscal_line_ids[0]
+        dummy_line = self.env.company.fiscal_dummy_id.fiscal_line_ids[0]
         with self.assertRaises(UserError):
             dummy_line.unlink()
 

--- a/l10n_br_nfse/models/document.py
+++ b/l10n_br_nfse/models/document.py
@@ -70,7 +70,7 @@ class Document(models.Model):
     nfse_environment = fields.Selection(
         selection=NFSE_ENVIRONMENTS,
         string="NFSe Environment",
-        default=lambda self: self.env.user.company_id.nfse_environment,
+        default=lambda self: self.env.company.nfse_environment,
     )
 
     def _document_date(self):


### PR DESCRIPTION
As reported in OCA maillist https://odoo-community.org/groups/contributors-15/contributors-235171?mode=thread&date_begin=&date_end= after v13 to get the current company should be made by self.env.company and not self.env.user.company_id, reference 

"As of version 13.0, a user can be logged in multiple companies at once. This allows the user to access information from multiple companies but also to create/edit records in a multi-company environment."
https://www.odoo.com/documentation/13.0/developer/howtos/company.html

Como reportado na lista de email de Contribuidores da OCA( link acima ) a partir da v13 houve uma alteração para permitir o usuário estar logado em multi-empresas, por isso ao buscar a empresa a partir do self.env é necessário usar o self.env.company e não o self.env.user.company_id

Eu alterei dois módulos l10n_br_fiscal e o l10n_br_nfse no mesmo commit por ser algo simples de uma linha, porém se for preciso posso ver de dividir o commit e o PR.

Talvez seja importante criar um issue para avaliar a necessidade de fazer alterações nos módulos do projeto como no exemplo abaixo:

class Record(models.Model):
    _name = 'record.shareable'
    _check_company_auto = True

    company_info = fields.Text(company_dependent=True)

    company_id = fields.Many2one(
        'res.company', required=True, default=lambda self: self.env.company
    )
    other_record_id = fields.Many2one('other.record', check_company=True)

cc @rvalyi @renatonlima @marcelsavegnago @mileo @gabrielcardoso21 @luismalta 