### PR TITLE
[12.0] Alterações relacionadas ao campo ind_final

### DIFF
--- a/l10n_br_account/models/account_invoice_line.py
+++ b/l10n_br_account/models/account_invoice_line.py
@@ -78,6 +78,8 @@ class AccountInvoiceLine(models.Model):
 
     partner_company_type = fields.Selection(related="partner_id.company_type")
 
+    ind_final = fields.Selection(related="invoice_id.ind_final")
+
     fiscal_genre_code = fields.Char(
         related="fiscal_genre_id.code",
         string="Fiscal Product Genre Code",

--- a/l10n_br_account/models/account_tax.py
+++ b/l10n_br_account/models/account_tax.py
@@ -3,6 +3,8 @@
 
 from odoo import fields, models
 
+from odoo.addons.l10n_br_fiscal.constants.fiscal import FINAL_CUSTOMER_NO
+
 
 class AccountTax(models.Model):
     _inherit = "account.tax"
@@ -37,6 +39,7 @@ class AccountTax(models.Model):
         uot=None,
         icmssn_range=None,
         icms_origin=None,
+        ind_final=FINAL_CUSTOMER_NO,
     ):
         """Returns all information required to apply taxes
             (in self + their children in case of a tax goup).
@@ -90,6 +93,7 @@ class AccountTax(models.Model):
             operation_line=operation_line,
             icmssn_range=icmssn_range,
             icms_origin=icms_origin or product.icms_origin,
+            ind_final=ind_final,
         )
 
         account_taxes_by_domain = {}

--- a/l10n_br_contract/models/contract_line.py
+++ b/l10n_br_contract/models/contract_line.py
@@ -34,6 +34,8 @@ class ContractLine(models.Model):
         string="Partner",
     )
 
+    ind_final = fields.Selection(related="contract_id.ind_final")
+
     @api.multi
     def _prepare_invoice_line(self, invoice_id=False, invoice_values=False):
         values = super()._prepare_invoice_line(invoice_id, invoice_values)

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -472,7 +472,6 @@ class Document(models.Model):
         super()._onchange_fiscal_operation_id()
         if self.fiscal_operation_id:
             self.fiscal_operation_type = self.fiscal_operation_id.fiscal_operation_type
-            self.ind_final = self.fiscal_operation_id.ind_final
 
         if self.issuer == DOCUMENT_ISSUER_COMPANY and not self.document_type_id:
             self.document_type_id = self.company_id.document_type_id

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -181,6 +181,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             icmssn_range=self.icmssn_range_id,
             icms_origin=self.icms_origin,
             icms_cst_id=self.icms_cst_id,
+            ind_final=self.ind_final,
         )
 
     def _prepare_br_fiscal_dict(self, default=False):

--- a/l10n_br_fiscal/models/document_fiscal_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin_methods.py
@@ -71,6 +71,11 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
             )
             d.line_ids._document_comment()
 
+    @api.onchange("partner_id")
+    def _onchange_partner_id(self):
+        if self.partner_id:
+            self.ind_final = self.ind_final
+
     @api.onchange("fiscal_operation_id")
     def _onchange_fiscal_operation_id(self):
         if self.fiscal_operation_id:

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -64,6 +64,8 @@ class DocumentLine(models.Model):
         string="Product",
     )
 
+    ind_final = fields.Selection(related="document_id.ind_final")
+
     # Amount Fields
     amount_untaxed = fields.Monetary(
         string="Amount Untaxed",

--- a/l10n_br_fiscal/models/operation.py
+++ b/l10n_br_fiscal/models/operation.py
@@ -5,8 +5,6 @@ from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 from ..constants.fiscal import (
-    FINAL_CUSTOMER,
-    FINAL_CUSTOMER_YES,
     FISCAL_COMMENT_DOCUMENT,
     FISCAL_IN_OUT_ALL,
     OPERATION_FISCAL_TYPE,
@@ -41,12 +39,6 @@ class Operation(models.Model):
         required=True,
         readonly=True,
         states={"draft": [("readonly", False)]},
-    )
-
-    ind_final = fields.Selection(
-        selection=FINAL_CUSTOMER,
-        string="Final Consumption Operation",
-        default=FINAL_CUSTOMER_YES,
     )
 
     default_price_unit = fields.Selection(

--- a/l10n_br_fiscal/models/res_partner.py
+++ b/l10n_br_fiscal/models/res_partner.py
@@ -5,6 +5,8 @@
 from odoo import api, fields, models
 
 from ..constants.fiscal import (
+    FINAL_CUSTOMER,
+    FINAL_CUSTOMER_NO,
     NFE_IND_IE_DEST,
     NFE_IND_IE_DEST_9,
     NFE_IND_IE_DEST_DEFAULT,
@@ -52,6 +54,13 @@ class ResPartner(models.Model):
         inverse="_inverse_fiscal_profile",
         domain="[('is_company', '=', is_company)]",
         default=_default_fiscal_profile_id,
+        track_visibility="onchange",
+    )
+
+    ind_final = fields.Selection(
+        selection=FINAL_CUSTOMER,
+        string="Final Consumption Operation",
+        default=FINAL_CUSTOMER_NO,
         track_visibility="onchange",
     )
 

--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -7,6 +7,7 @@ from odoo.tools import float_is_zero
 from odoo.addons import decimal_precision as dp
 
 from ..constants.fiscal import (
+    FINAL_CUSTOMER_NO,
     FINAL_CUSTOMER_YES,
     FISCAL_IN,
     FISCAL_OUT,
@@ -349,6 +350,7 @@ class Tax(models.Model):
         insurance_value = kwargs.get("insurance_value", 0.00)
         freight_value = kwargs.get("freight_value", 0.00)
         other_value = kwargs.get("other_value", 0.00)
+        ind_final = kwargs.get("ind_final", FINAL_CUSTOMER_NO)
 
         add_to_base = [insurance_value, freight_value, other_value]
         remove_from_base = [discount_value]
@@ -357,7 +359,7 @@ class Tax(models.Model):
         tax_dict_ipi = taxes_dict.get("ipi", {})
 
         if partner.ind_ie_dest in (NFE_IND_IE_DEST_2, NFE_IND_IE_DEST_9) or (
-            operation_line.fiscal_operation_id.ind_final == FINAL_CUSTOMER_YES
+            ind_final == FINAL_CUSTOMER_YES
         ):
             # Add IPI in ICMS Base
             add_to_base.append(tax_dict_ipi.get("tax_value", 0.00))
@@ -678,6 +680,7 @@ class Tax(models.Model):
             operation_line,
             icmssn_range,
             icms_origin,
+            ind_final,
         return
             {
                 'amount_included': float

--- a/l10n_br_fiscal/views/operation_view.xml
+++ b/l10n_br_fiscal/views/operation_view.xml
@@ -72,7 +72,6 @@
                             <field name="name" />
                             <field name="fiscal_operation_type" />
                             <field name="fiscal_type" />
-                            <field name="ind_final" />
                             <field name="company_id" />
                         </group>
                         <group>

--- a/l10n_br_fiscal/views/res_partner_view.xml
+++ b/l10n_br_fiscal/views/res_partner_view.xml
@@ -25,6 +25,7 @@
                         attrs="{'readonly': [('fiscal_profile_id', '!=', False)]}"
                     />
                     <field name="cnae_main_id" />
+                    <field name="ind_final" />
                 </group>
             </group>
         </field>

--- a/l10n_br_purchase/models/purchase_order_line.py
+++ b/l10n_br_purchase/models/purchase_order_line.py
@@ -66,6 +66,8 @@ class PurchaseOrderLine(models.Model):
         string="Tax Framework",
     )
 
+    ind_final = fields.Selection(related="order_id.ind_final")
+
     @api.depends(
         "product_uom_qty",
         "price_unit",

--- a/l10n_br_repair/models/repair_fee.py
+++ b/l10n_br_repair/models/repair_fee.py
@@ -31,6 +31,8 @@ class RepairFee(models.Model):
         string="Partner",
     )
 
+    ind_final = fields.Selection(related="repair_id.ind_final")
+
     comment_ids = fields.Many2many(
         comodel_name="l10n_br_fiscal.comment",
         relation="repair_fee_comment_rel",

--- a/l10n_br_repair/models/repair_line.py
+++ b/l10n_br_repair/models/repair_line.py
@@ -31,6 +31,8 @@ class RepairLine(models.Model):
         string="Partner",
     )
 
+    ind_final = fields.Selection(related="repair_id.ind_final")
+
     comment_ids = fields.Many2many(
         comodel_name="l10n_br_fiscal.comment",
         relation="repair_line_comment_rel",

--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -98,6 +98,8 @@ class SaleOrderLine(models.Model):
         related="company_id.delivery_costs",
     )
 
+    ind_final = fields.Selection(related="order_id.ind_final")
+
     def _get_protected_fields(self):
         protected_fields = super()._get_protected_fields()
         return protected_fields + [

--- a/l10n_br_sale/views/sale_view.xml
+++ b/l10n_br_sale/views/sale_view.xml
@@ -65,6 +65,7 @@
             <field name="validity_date" position="after">
                 <field name="fiscal_operation_id" required="True" />
                 <field name="ind_pres" required="True" />
+                <field name="ind_final" required="True" />
             </field>
             <field name="note" position="replace">
                 <group>

--- a/l10n_br_stock_account/models/stock_move.py
+++ b/l10n_br_stock_account/models/stock_move.py
@@ -59,6 +59,8 @@ class StockMove(models.Model):
         string="Comments",
     )
 
+    ind_final = fields.Selection(related="picking_id.ind_final")
+
     # O price_unit fica negativo por metodos do core
     # durante o processo chamado pelo botão Validate p/
     # valorização de estoque, sem o compute o valor permance positivo.


### PR DESCRIPTION
O Campo ind_final é utilizado para definir se o destinatário é um consumidor final, a definição desse campo é utilizada para o calculo dos impostos. Hoje esse campo se encontra na Operação Fiscal mas não é o lugar correto pois acabaria ter que duplicar as operações fiscais. Esse PR remove o campo ind_final na operação, adapta o calculo dos impostos para utilizar o campo ind_final dos documentos (Pedido de Venda, Compras, NFe e etc), também foi adicionado no parceiro que é copiado nos documentos (Pedido de venda, pedido de compras, NFe e etc).