### PR TITLE
[12.0] Convertido o campo origem do ICMS no Product Template em um campo property

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -9,7 +9,7 @@
     "author": "Akretion, Odoo Community Association (OCA)",
     "maintainers": ["renatonlima"],
     "website": "https://github.com/OCA/l10n-brazil",
-    "version": "12.0.23.1.0",
+    "version": "12.0.24.0.0",
     "development_status": "Production/Stable",
     "depends": [
         "uom",

--- a/l10n_br_fiscal/migrations/12.0.24.0.0/pre-migration.py
+++ b/l10n_br_fiscal/migrations/12.0.24.0.0/pre-migration.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2022 - Renato Lima - Akretion
+# License AGPL-3.0 or later (
+# http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    field_property = env.ref("l10n_br_fiscal.field_product_template__icms_origin")
+
+    companies = env["res.company"].search([])
+    for company in companies:
+        products = env["product.template"].search(
+            [
+                "|",
+                ("company_id", "=", company.id),
+                ("company_id", "=", False),
+                ("icms_origin", "!=", False),
+            ]
+        )
+        for product in products:
+            env["ir.property"].create(
+                {
+                    "name": "icms_origin",
+                    "fields_id": field_property.id,
+                    "company_id": company.id,
+                    "type": "selection",
+                    "res_id": "{},{}".format(product._name, product.id),
+                    "value_text": product.icms_origin,
+                }
+            )

--- a/l10n_br_fiscal/models/product_template.py
+++ b/l10n_br_fiscal/models/product_template.py
@@ -25,7 +25,10 @@ class ProductTemplate(models.Model):
     fiscal_type = fields.Selection(selection=PRODUCT_FISCAL_TYPE, string="Fiscal Type")
 
     icms_origin = fields.Selection(
-        selection=ICMS_ORIGIN, string="ICMS Origin", default=ICMS_ORIGIN_DEFAULT
+        selection=ICMS_ORIGIN,
+        string="ICMS Origin",
+        company_dependent=True,
+        default=ICMS_ORIGIN_DEFAULT,
     )
 
     ncm_id = fields.Many2one(


### PR DESCRIPTION
Em alguns casos em um ambiente multi-company o campo icms_origin pode ter valores diferentes, por exemplo: Se existir na mesma base de dados duas empresas onde uma empresa que importa produtos diretamente e que a origem do ICMS seria "6 - Estrangeira – importação direta, sem similar nacional" e a outra empresa que revende esses materiais a origem do ICMS seria "2 - Estrangeira – adquirida no mercado interno, exceto a indicada".

Para que isso seja possível o campo icms_origin no cadastro de produtos deve ser um campo do tipo property que pode ser definido para cada empresa.