### PR TITLE
[12.0][FIX] Confirmação do documento quando o emitente é o parceiro

### DIFF
--- a/l10n_br_fiscal/models/document_workflow.py
+++ b/l10n_br_fiscal/models/document_workflow.py
@@ -299,7 +299,8 @@ class DocumentWorkflow(models.AbstractModel):
                 self._generate_key()
 
     def _document_confirm(self):
-        self._change_state(SITUACAO_EDOC_A_ENVIAR)
+        if self.issuer == DOCUMENT_ISSUER_COMPANY:
+            self._change_state(SITUACAO_EDOC_A_ENVIAR)
 
     def action_document_confirm(self):
         to_confirm = self.filtered(lambda inv: inv.state_edoc != SITUACAO_EDOC_A_ENVIAR)


### PR DESCRIPTION
Conforme reportado por @marcelsavegnago issue #1675, não estava sendo possível lançar uma nota fiscal de fornecedor.

O motivo é que o código estava seguindo o fluxo como se fosse uma nota fiscal a ser enviada pela empresa, adicionei uma verificação para interromper esse fluxo caso o emitente do documento não seja a empresa, agora o fluxo da transmissão da nota fiscal ( envio ) só irá continuar se o issuer ( emitente ) do documento for a própria empresa.

