### PR TITLE
[12.0][IMP] Check document number in use

### DIFF
--- a/l10n_br_fiscal/models/document_serie.py
+++ b/l10n_br_fiscal/models/document_serie.py
@@ -95,6 +95,18 @@ class DocumentSerie(models.Model):
     def next_seq_number(self):
         self.ensure_one()
         document_number = self.internal_sequence_id._next()
-        if self._is_invalid_number(document_number):
+
+        if self._is_invalid_number(document_number) or self.check_number_in_use(
+            document_number
+        ):
             document_number = self.next_seq_number()
         return document_number
+
+    def check_number_in_use(self, document_number):
+        """Checks if a document already exists using the number, this can happen in
+        some cases, for example invoices imported to odoo from other erp."""
+        return (
+            self.env["l10n_br_fiscal.document"]
+            .search([("document_number", "=", document_number)], limit=1)
+            .exists()
+        )


### PR DESCRIPTION
Adiciona uma verificação no método que gera o número do documento fiscal, caso o próximo número já esteja em um uso, pula para o próximo. 

Isso é importante pois podem ter casos que os documentos gerados pela a empresa foram importados ao sistema, sem passar pelo controle do sequenciador do número.

Um exemplo é o que já está acontecendo hoje com os dados de demostração, se você tentar criar uma nota fiscal na empresa simples nacional irá receber esse erro:
![image](https://user-images.githubusercontent.com/634278/155895642-ce44d701-0636-4b42-a3ad-768f3f6ed2ae.png)
O motivo é que já existe uma nota fiscal com o número 1 que foi inserido manualmente: https://github.com/OCA/l10n-brazil/blob/0b237c5423c156ca16c463816306c6ef72e5800b/l10n_br_nfe/demo/fiscal_document_demo.xml#L110
