### PR TITLE
[12.0] Definida as opções no_create e no_create_edit em alguns campos nas visões

### DIFF
--- a/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
@@ -40,8 +40,14 @@
                                 attrs="{'invisible': [('tax_icms_or_issqn', '!=', 'issqn')]}"
                             >
                 <group>
-                  <field name="issqn_tax_id" />
-                  <field name="issqn_fg_city_id" />
+                  <field
+                                        name="issqn_tax_id"
+                                        options="{'no_create': True, 'no_create_edit': True}"
+                                    />
+                  <field
+                                        name="issqn_fg_city_id"
+                                        options="{'no_create': True, 'no_create_edit': True}"
+                                    />
                   <field
                                         name="issqn_eligibility"
                                         attrs="{'required': [('tax_icms_or_issqn', '=', 'issqn')]}"
@@ -103,7 +109,10 @@
                   </group>
                 </group>
                   <group string="Retenções">
-                    <field name="issqn_wh_tax_id" />
+                    <field
+                                        name="issqn_wh_tax_id"
+                                        options="{'no_create': True, 'no_create_edit': True}"
+                                    />
                   </group>
                   <group>
                       <group>
@@ -141,15 +150,18 @@
                     <field
                                         name="icms_tax_id"
                                         attrs="{'invisible': [('tax_framework', 'in', ('1', '2'))]}"
+                                        options="{'no_create': True, 'no_create_edit': True}"
                                     />
                     <field
                                         name="icmssn_tax_id"
                                         attrs="{'invisible': [('tax_framework', '=', '3')]}"
+                                        options="{'no_create': True, 'no_create_edit': True}"
                                     />
                     <field
                                         name="icms_cst_id"
                                         force_save="1"
                                         attrs="{'readonly': [('icms_tax_id', '!=', False)]}"
+                                        options="{'no_create': True, 'no_create_edit': True}"
                                     />
                     <field name="icms_cst_code" readonly="1" invisible="1" />
                     <field
@@ -165,6 +177,7 @@
                                             force_save="1"
                                             readonly="1"
                                             attrs="{'invisible': [('tax_framework', '=', '3')]}"
+                                            options="{'no_create': True, 'no_create_edit': True}"
                                         />
                         <field
                                             name="icms_base_type"
@@ -239,6 +252,7 @@
                         <field
                                             name="icmsst_tax_id"
                                             attrs="{'invisible': [('icms_cst_code', 'in', ('60', '500'))]}"
+                                            options="{'no_create': True, 'no_create_edit': True}"
                                         />
                         <field
                                             name="icmsst_base_type"
@@ -294,6 +308,7 @@
                           <field
                                             name="icmsfcp_tax_id"
                                             attrs="{'invisible': [('icms_cst_code', '=', '500')]}"
+                                            options="{'no_create': True, 'no_create_edit': True}"
                                         />
                         <field
                                             name="icmsfcp_base"
@@ -401,17 +416,22 @@
                                 attrs="{'invisible': [('tax_icms_or_issqn', '=', 'issqn')]}"
                             >
                   <group string="IPI">
-                      <field name="ipi_tax_id" />
+                      <field
+                                        name="ipi_tax_id"
+                                        options="{'no_create': True, 'no_create_edit': True}"
+                                    />
                       <field
                                         name="ipi_cst_id"
                                         force_save="1"
                                         attrs="{'readonly': [('ipi_tax_id', '!=', False)]}"
+                                        options="{'no_create': True, 'no_create_edit': True}"
                                     />
                       <field name="ipi_cst_code" readonly="1" invisible="1" />
                       <field
                                         name="ipi_guideline_id"
                                         force_save="1"
                                         attrs="{'readonly': [('ipi_tax_id', '!=', False)]}"
+                                        options="{'no_create': True, 'no_create_edit': True}"
                                     />
                   </group>
                   <group>
@@ -452,7 +472,10 @@
                                 attrs="{'invisible': [('cfop_destination', '!=', '3')]}"
                             >
                 <group string="II">
-                    <field name="ii_tax_id" />
+                    <field
+                                        name="ii_tax_id"
+                                        options="{'no_create': True, 'no_create_edit': True}"
+                                    />
                 </group>
                 <group>
                   <group>
@@ -467,17 +490,22 @@
               </page>
               <page name="pis" string="PIS">
                   <group name="pis" string="PIS">
-                    <field name="pis_tax_id" />
+                    <field
+                                        name="pis_tax_id"
+                                        options="{'no_create': True, 'no_create_edit': True}"
+                                    />
                     <field
                                         name="pis_cst_id"
                                         force_save="1"
                                         attrs="{'readonly': [('pis_tax_id', '!=', False)]}"
+                                        options="{'no_create': True, 'no_create_edit': True}"
                                     />
                     <field name="pis_cst_code" readonly="1" invisible="1" />
                     <field
                                         name="pis_credit_id"
                                         force_save="1"
                                         attrs="{'readonly': [('pis_tax_id', '!=', False)], 'invisible': [('fiscal_operation_type', '=', 'out')]}"
+                                        options="{'no_create': True, 'no_create_edit': True}"
                                     />
                   </group>
                   <group>
@@ -486,6 +514,7 @@
                                             name="pis_base_id"
                                             force_save="1"
                                             attrs="{'readonly': [('pis_tax_id', '!=', False)], 'invisible': [('fiscal_operation_type', '=', 'out')]}"
+                                            options="{'no_create': True, 'no_create_edit': True}"
                                         />
                       <field
                                             name="pis_base_type"
@@ -517,11 +546,15 @@
                     </group>
                   </group>
                   <group name="pis_st" string="PIS ST">
-                    <field name="pisst_tax_id" />
+                    <field
+                                        name="pisst_tax_id"
+                                        options="{'no_create': True, 'no_create_edit': True}"
+                                    />
                     <field
                                         name="pisst_cst_id"
                                         force_save="1"
                                         attrs="{'readonly': [('pisst_tax_id', '!=', False)]}"
+                                        options="{'no_create': True, 'no_create_edit': True}"
                                     />
                     <field name="pisst_cst_code" readonly="1" invisible="1" />
                   </group>
@@ -557,7 +590,10 @@
                     </group>
                   </group>
                   <group string="Retenções">
-                      <field name="pis_wh_tax_id" />
+                      <field
+                                        name="pis_wh_tax_id"
+                                        options="{'no_create': True, 'no_create_edit': True}"
+                                    />
                   </group>
                   <group>
                       <group>
@@ -588,17 +624,22 @@
               </page>
               <page name="cofins" string="COFINS">
                 <group name="cofins" string="COFINS">
-                  <field name="cofins_tax_id" />
+                  <field
+                                        name="cofins_tax_id"
+                                        options="{'no_create': True, 'no_create_edit': True}"
+                                    />
                   <field
                                         name="cofins_cst_id"
                                         force_save="1"
                                         attrs="{'readonly': [('cofins_tax_id', '!=', False)]}"
+                                        options="{'no_create': True, 'no_create_edit': True}"
                                     />
                   <field name="cofins_cst_code" readonly="1" invisible="1" />
                   <field
                                         name="cofins_credit_id"
                                         force_save="1"
                                         attrs="{'readonly': [('cofins_tax_id', '!=', False)], 'invisible': [('fiscal_operation_type', '=', 'out')]}"
+                                        options="{'no_create': True, 'no_create_edit': True}"
                                     />
                 </group>
                 <group>
@@ -607,6 +648,7 @@
                                             name="cofins_base_id"
                                             force_save="1"
                                             attrs="{'readonly': [('cofins_tax_id', '!=', False)], 'invisible': [('fiscal_operation_type', '=', 'out')]}"
+                                            options="{'no_create': True, 'no_create_edit': True}"
                                         />
                     <field
                                             name="cofins_base_type"
@@ -638,11 +680,15 @@
                   </group>
                 </group>
                 <group name="cofins_st" string="COFINS ST">
-                  <field name="cofinsst_tax_id" />
+                  <field
+                                        name="cofinsst_tax_id"
+                                        options="{'no_create': True, 'no_create_edit': True}"
+                                    />
                   <field
                                         name="cofinsst_cst_id"
                                         force_save="1"
                                         attrs="{'readonly': [('cofinsst_tax_id', '!=', False)]}"
+                                        options="{'no_create': True, 'no_create_edit': True}"
                                     />
                   <field name="cofinsst_cst_code" readonly="1" invisible="1" />
                 </group>
@@ -678,7 +724,10 @@
                   </group>
                 </group>
                   <group string="Retenções">
-                      <field name="cofins_wh_tax_id" />
+                      <field
+                                        name="cofins_wh_tax_id"
+                                        options="{'no_create': True, 'no_create_edit': True}"
+                                    />
                   </group>
                   <group>
                       <group>
@@ -742,7 +791,10 @@
                         </group>
                     </group>
                     <group string="Retenções">
-                        <field name="csll_wh_tax_id" />
+                        <field
+                                        name="csll_wh_tax_id"
+                                        options="{'no_create': True, 'no_create_edit': True}"
+                                    />
                     </group>
                     <group>
                         <group>
@@ -777,7 +829,10 @@
                                 attrs="{'invisible': [('fiscal_genre_code', '!=', '00')]}"
                             >
                     <group>
-                        <field name="irpj_tax_id" />
+                        <field
+                                        name="irpj_tax_id"
+                                        options="{'no_create': True, 'no_create_edit': True}"
+                                    />
                     </group>
                     <group>
                         <group>
@@ -806,7 +861,10 @@
                         </group>
                     </group>
                     <group string="Retenções">
-                        <field name="irpj_wh_tax_id" />
+                        <field
+                                        name="irpj_wh_tax_id"
+                                        options="{'no_create': True, 'no_create_edit': True}"
+                                    />
                     </group>
                     <group>
                         <group>
@@ -841,7 +899,10 @@
                                 attrs="{'invisible': [('fiscal_genre_code', '!=', '00')]}"
                             >
                     <group>
-                        <field name="inss_tax_id" />
+                        <field
+                                        name="inss_tax_id"
+                                        options="{'no_create': True, 'no_create_edit': True}"
+                                    />
                     </group>
                     <group>
                         <group>
@@ -870,7 +931,10 @@
                         </group>
                     </group>
                     <group string="Retenções">
-                        <field name="inss_wh_tax_id" />
+                        <field
+                                        name="inss_wh_tax_id"
+                                        options="{'no_create': True, 'no_create_edit': True}"
+                                    />
                     </group>
                     <group>
                         <group>

--- a/l10n_br_fiscal/views/document_fiscal_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_fiscal_mixin_view.xml
@@ -7,7 +7,11 @@
     <field name="arch" type="xml">
       <form>
         <group name="l10n_br_fiscal">
-            <field name="fiscal_operation_id" required="1" />
+            <field
+                        name="fiscal_operation_id"
+                        required="1"
+                        options="{'no_create': True, 'no_create_edit': True}"
+                    />
         </group>
         <group name="l10n_br_fiscal_comment">
             <field name="manual_fiscal_additional_data" />

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -192,7 +192,10 @@
             </h1>
           </div>
           <group name="l10n_br_fiscal" colspan="4">
-            <field name="fiscal_operation_id" /> <!-- USE MIXIN VIEW -->
+            <field
+                            name="fiscal_operation_id"
+                            options="{'no_create': True, 'no_create_edit': True}"
+                        /> <!-- USE MIXIN VIEW -->
             <field name="edoc_purpose" />
             <field name="ind_final" />
             <field name="ind_pres" />

--- a/l10n_br_fiscal/views/operation_line_view.xml
+++ b/l10n_br_fiscal/views/operation_line_view.xml
@@ -54,9 +54,18 @@
                             attrs="{'invisible': [('fiscal_operation_type', '=', 'all')]}"
                         >
                           <group>
-                            <field name="cfop_internal_id" />
-                            <field name="cfop_external_id" />
-                            <field name="cfop_export_id" />
+                            <field
+                                    name="cfop_internal_id"
+                                    options="{'no_create': True, 'no_create_edit': True}"
+                                />
+                            <field
+                                    name="cfop_external_id"
+                                    options="{'no_create': True, 'no_create_edit': True}"
+                                />
+                            <field
+                                    name="cfop_export_id"
+                                    options="{'no_create': True, 'no_create_edit': True}"
+                                />
                           </group>
                       </page>
                       <page name="tax_definitions" string="Tax Definitions">

--- a/l10n_br_fiscal/views/operation_view.xml
+++ b/l10n_br_fiscal/views/operation_view.xml
@@ -108,7 +108,10 @@
                                 <form>
                                     <group>
                                         <field name="company_id" invisible="1" />
-                                        <field name="document_type_id" />
+                                        <field
+                                            name="document_type_id"
+                                            options="{'no_create': True, 'no_create_edit': True}"
+                                        />
                                         <field
                                             name="document_serie_id"
                                             context="{'default_document_type_id': document_type_id, 'default_company_id': company_id}"

--- a/l10n_br_fiscal/views/product_template_view.xml
+++ b/l10n_br_fiscal/views/product_template_view.xml
@@ -65,7 +65,11 @@
                                 name="icms_origin"
                                 attrs="{'required': [('fiscal_type', '!=', '09')], 'invisible': [('fiscal_type', '=', '09')]}"
                             />
-                            <field name="ncm_id" required="1" />
+                            <field
+                                name="ncm_id"
+                                required="1"
+                                options="{'no_create': True, 'no_create_edit': True}"
+                            />
                             <field name="tax_icms_or_issqn" required="1" />
                             <field
                                 name="service_type_id"
@@ -79,35 +83,60 @@
                                 <tree editable="bottom">
                                     <field name="code" />
                                     <field name="name" />
-                                    <field name="service_type_id" />
-                                    <field name="state_id" />
-                                    <field name="city_id" />
-                                    <field name="cnae_id" />
+                                    <field
+                                        name="service_type_id"
+                                        options="{'no_create': True, 'no_create_edit': True}"
+                                    />
+                                    <field
+                                        name="state_id"
+                                        options="{'no_create': True, 'no_create_edit': True}"
+                                    />
+                                    <field
+                                        name="city_id"
+                                        options="{'no_create': True, 'no_create_edit': True}"
+                                    />
+                                    <field
+                                        name="cnae_id"
+                                        options="{'no_create': True, 'no_create_edit': True}"
+                                    />
                                 </tree>
                             </field>
                         </group>
                         <group>
-                            <field name="fiscal_genre_id" required="1" />
+                            <field
+                                name="fiscal_genre_id"
+                                required="1"
+                                options="{'no_create': True, 'no_create_edit': True}"
+                            />
                             <field
                                 name="cest_id"
                                 attrs="{'invisible': [('fiscal_type', '=', '09')]}"
+                                options="{'no_create': True, 'no_create_edit': True}"
                             />
                             <field
                                 name="nbm_id"
                                 attrs="{'invisible': [('fiscal_type', '=', '09')]}"
+                                options="{'no_create': True, 'no_create_edit': True}"
                             />
                             <field
                                 name="nbs_id"
                                 attrs="{'invisible': [('fiscal_type', '!=', '09')]}"
+                                options="{'no_create': True, 'no_create_edit': True}"
                             />
                         </group>
                         <group string="Tax UOM">
-                            <field name="uoe_id" />
+                            <field
+                                name="uoe_id"
+                                options="{'no_create': True, 'no_create_edit': True}"
+                            />
                             <field
                                 name="uoe_factor"
                                 attrs="{'invisible': [('fiscal_type', '=', False)], 'required': [('uot_id', '!=', False)]}"
                             />
-                            <field name="uot_id" />
+                            <field
+                                name="uot_id"
+                                options="{'no_create': True, 'no_create_edit': True}"
+                            />
                             <field
                                 name="uot_factor"
                                 attrs="{'invisible': [('uot_id', '=', False)], 'required': [('uot_id', '!=', False)]}"

--- a/l10n_br_fiscal/views/res_company_view.xml
+++ b/l10n_br_fiscal/views/res_company_view.xml
@@ -57,13 +57,17 @@
                                 </group>
                             </group>
                             <group string="CNAE">
-                                <field name="cnae_main_id" />
+                                <field
+                                    name="cnae_main_id"
+                                    options="{'no_create': True, 'no_create_edit': True}"
+                                />
                             </group>
                             <group colspan="4" string="Secondary CNAE">
                                 <field
                                     colspan="4"
                                     nolabel="1"
                                     name="cnae_secondary_ids"
+                                    options="{'no_create': True}"
                                 />
                             </group>
                         </page>
@@ -74,6 +78,7 @@
                                         name="piscofins_id"
                                         required="1"
                                         domain="{'3': [('piscofins_type', '=', 'company'), ('id', '!=', %(l10n_br_fiscal.tax_pis_cofins_simples_nacional)d)]}.get(tax_framework, [('piscofins_type', '=', 'company'), ('id', '=', %(l10n_br_fiscal.tax_pis_cofins_simples_nacional)d)])"
+                                        options="{'no_create': True, 'no_create_edit': True}"
                                     />
                                       <field name="tax_pis_wh_id" />
                                       <field name="tax_cofins_wh_id" />
@@ -101,10 +106,12 @@
                                         name="tax_icms_id"
                                         attrs="{'invisible': [('tax_framework', '=', '3')], 'required': [('tax_framework', 'in', ('1', '2'))]}"
                                         domain="{'3': [('tax_group_id', '=', %(l10n_br_fiscal.tax_group_icms)d)]}.get(tax_framework, [('tax_group_id', '=', %(l10n_br_fiscal.tax_group_icmssn)d)])"
+                                        options="{'no_create': True, 'no_create_edit': True}"
                                     />
                                       <field
                                         name="icms_regulation_id"
                                         attrs="{'invisible': [('tax_framework', '!=', '3')], 'required': [('tax_framework', '=', '3')]}"
+                                        options="{'no_create': True, 'no_create_edit': True}"
                                     />
                                   </group>
                                   <group name="issqn_taxes" string="ISSQN">

--- a/l10n_br_fiscal/views/res_partner_view.xml
+++ b/l10n_br_fiscal/views/res_partner_view.xml
@@ -24,7 +24,10 @@
                         force_save="1"
                         attrs="{'readonly': [('fiscal_profile_id', '!=', False)]}"
                     />
-                    <field name="cnae_main_id" />
+                    <field
+                        name="cnae_main_id"
+                        options="{'no_create': True, 'no_create_edit': True}"
+                    />
                     <field name="ind_final" />
                 </group>
             </group>

--- a/l10n_br_fiscal/views/tax_definition_view.xml
+++ b/l10n_br_fiscal/views/tax_definition_view.xml
@@ -68,7 +68,10 @@
         </header>
         <sheet>
           <group>
-            <field name="tax_group_id" />
+            <field
+                            name="tax_group_id"
+                            options="{'no_create': True, 'no_create_edit': True}"
+                        />
             <field name="type_in_out" invisible="1" />
             <field name="is_taxed" />
             <field
@@ -83,10 +86,12 @@
             <field
                             name="cst_id"
                             attrs="{'invisible': ['|', ('custom_tax', '=', False), ('tax_domain', 'not in', ('icmssn', 'icms', 'ipi', 'pis', 'pisst', 'cofins', 'cofinsst'))], 'required': [('custom_tax', '=', True), ('tax_domain', 'in', ('icms', 'ipi', 'pis', 'pisst', 'cofins', 'cofinsst'))]}"
+                            options="{'no_create': True, 'no_create_edit': True}"
                         />
             <field
                             name="ipi_guideline_id"
                             attrs="{'invisible': [('tax_domain', '!=', 'ipi')]}"
+                            options="{'no_create': True, 'no_create_edit': True}"
                         />
           </group>
           <group
@@ -94,8 +99,11 @@
                         string="State"
                         attrs="{'invisible': [('icms_regulation_id', '=', False)]}"
                     >
-            <field name="state_from_id" />
-            <field name="state_to_ids" />
+            <field
+                            name="state_from_id"
+                            options="{'no_create': True, 'no_create_edit': True}"
+                        />
+            <field name="state_to_ids" options="{'no_create': True}" />
           </group>
           <notebook>
             <page name="ncms_page" string="NCM">
@@ -111,7 +119,13 @@
                                         title="Search NCMs"
                                     />
                 </div>
-                <field name="ncm_ids" force_save="1" nolabel="1" colspan="2" />
+                <field
+                                    name="ncm_ids"
+                                    options="{'no_create': True}"
+                                    force_save="1"
+                                    nolabel="1"
+                                    colspan="2"
+                                />
                 <field name="ncm_exception" />
                 <field name="not_in_ncms" />
               </group>
@@ -129,7 +143,13 @@
                                         title="Search NBMs"
                                     />
                 </div>
-                <field name="nbm_ids" force_save="1" nolabel="1" colspan="2" />
+                <field
+                                    name="nbm_ids"
+                                    options="{'no_create': True}"
+                                    force_save="1"
+                                    nolabel="1"
+                                    colspan="2"
+                                />
                 <field name="not_in_nbms" />
               </group>
             </page>
@@ -146,7 +166,13 @@
                                         title="Search CESTs"
                                     />
                 </div>
-                <field name="cest_ids" force_save="1" nolabel="1" colspan="2" />
+                <field
+                                    name="cest_ids"
+                                    force_save="1"
+                                    nolabel="1"
+                                    colspan="2"
+                                    options="{'no_create': True}"
+                                />
               </group>
             </page>
             <page name="products_page" string="Product">

--- a/l10n_br_fiscal/views/tax_view.xml
+++ b/l10n_br_fiscal/views/tax_view.xml
@@ -48,7 +48,10 @@
                 <field name="sequence" invisible="1" />
                 <sheet>
                     <group>
-                        <field name="tax_group_id" />
+                        <field
+                            name="tax_group_id"
+                            options="{'no_create': True, 'no_create_edit': True}"
+                        />
                         <field name="name" />
                         <field
                             name="tax_base_type"
@@ -91,14 +94,17 @@
                         <field
                             name="uot_id"
                             attrs="{'invisible': [('tax_base_type', '!=', 'quantity')], 'required': [('tax_base_type', '=', 'quantity')]}"
+                            options="{'no_create': True, 'no_create_edit': True}"
                         />
                         <field
                             name="cst_in_id"
                             attrs="{'invisible': [('tax_domain', 'not in', ['icms', 'icmssn', 'ipi', 'pis', 'cofins'])]}"
+                            options="{'no_create': True, 'no_create_edit': True}"
                         />
                         <field
                             name="cst_out_id"
                             attrs="{'invisible': [('tax_domain', 'not in', ['icms', 'icmssn', 'ipi', 'pis', 'cofins'])]}"
+                            options="{'no_create': True, 'no_create_edit': True}"
                         />
                     </group>
                 </sheet>


### PR DESCRIPTION
A maioria das tabelas fiscais só tem permissão de escrita se estiver no grupo "Fiscal Maintenance Data" outros cadastros fiscais não precisam dessa permissão mas bom nos m2m não existir a opção de criar e criar e editar para não ser criado registros acidentalmente.