### PR TITLE
[12.0][FIX] Create and relate fiscal.tax and account.tax

### DIFF
--- a/l10n_br_account/models/fiscal_tax.py
+++ b/l10n_br_account/models/fiscal_tax.py
@@ -36,7 +36,7 @@ class FiscalTax(models.Model):
                         "name": fiscal_tax.name + " " + tax_users.get(tax_use),
                         "type_tax_use": tax_use,
                         "fiscal_tax_ids": [(4, fiscal_tax.id)],
-                        "tax_group_id": fiscal_tax.account_tax_group().id,
+                        "tax_group_id": fiscal_tax.tax_group_id.account_tax_group().id,
                         "amount": 0.00,
                     }
 


### PR DESCRIPTION
Ao criar um imposto fiscal, ele é relacionado aos impostos contábeis, porém se não existir um imposto contábil, é criado um imposto, mas ao criar esse novo imposto contábil estava sendo gerado um erro porque o método para pegar o grupo de imposto contábil esta no objeto fiscal.tax.group e não no fiscal.tax.