### PR TITLE
[12.0][FIX] Concatenate the NFe prefix and key

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -298,10 +298,16 @@ class NFe(spec_models.StackedModel):
     @api.depends("fiscal_operation_type", "nfe_transmission")
     def _compute_nfe_data(self):
         """Set schema data which are not just related fields"""
-        for record in self:
+        for record in self.filtered(filter_processador_edoc_nfe):
             # id
-            if record.document_type_id and record.document_type_id.prefix:
-                record.nfe40_Id = record.document_type_id.prefix + record.document_key
+            if (
+                record.document_type_id
+                and record.document_type_id.prefix
+                and record.document_key
+            ):
+                record.nfe40_Id = "{}{}".format(
+                    record.document_type_id.prefix, record.document_key
+                )
             else:
                 record.nfe40_Id = None
 


### PR DESCRIPTION
Se o campo document_key estiver em branco (em uma NF-e de entrada de fornecedor ou outros documentos fiscais) é gerado um erro de concatenação de string e bool