### PR TITLE
[12.0][REF+FIX] The account.move.line should be order by Date maturity

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -363,6 +363,12 @@ class AccountInvoice(models.Model):
         financial_lines = [
             line for line in lines if line[2]["account_id"] == self.account_id.id
         ]
+
+        # É preciso ordernar pela Data de Vencimento para ter as Numeração das Parcelas
+        # seguindo essa sequencia, se não fica confuso ter a última Parcela sendo
+        # a primeira a ser Paga
+        financial_lines.sort(key=lambda l: l[2].get("date_maturity"))
+
         count = 1
 
         for line in financial_lines:

--- a/l10n_br_account_due_list/models/__init__.py
+++ b/l10n_br_account_due_list/models/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from . import account_invoice
+from . import account_move_line

--- a/l10n_br_account_due_list/models/account_move_line.py
+++ b/l10n_br_account_due_list/models/account_move_line.py
@@ -1,0 +1,26 @@
+# Copyright (C) 2022-Today - Akretion (<http://www.akretion.com>).
+# @author Magno Costa <magno.costa@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class AccountMoveLine(models.Model):
+    """
+    As linhas precisam ser criadas conforme sequencia de
+    Data de Vencimentos/date_maturity senão ficam fora de ordem:
+     ex.:
+     N° da Parcela | Data de Vencimento
+     001           |  06/03/2022
+     002           |  05/05/2022
+     003           |  05/04/2022
+     Isso causa confusão pois como nesse exemplo a terceira parcela
+     fica como sendo a segunda.
+
+     Isso é importante também para a criação dos CNAB/Boletos:
+     ex.: own_number 201 31/12/2020, own_number 202 18/11/2020
+     Nesse caso a primeira parcela fica como sendo a segunda.
+    """
+
+    _inherit = "account.move.line"
+    _order = "date desc, date_maturity ASC, id desc"

--- a/l10n_br_account_payment_order/models/account_move_line.py
+++ b/l10n_br_account_payment_order/models/account_move_line.py
@@ -12,11 +12,6 @@ from ..constants import BR_CODES_PAYMENT_ORDER, ESTADOS_CNAB, SITUACAO_PAGAMENTO
 class AccountMoveLine(models.Model):
     _name = "account.move.line"
     _inherit = [_name, "l10n_br_cnab.change.methods"]
-    # As linhas de cobrança precisam ser criadas conforme sequencia de
-    # Data de Vencimentos/date_maturity senão ficam fora de ordem:
-    #  ex.: own_number 201 31/12/2020, own_number 202 18/11/2020
-    #  Isso causa confusão pois a primeira parcela fica como sendo a segunda.
-    _order = "date desc, date_maturity ASC, id desc"
 
     cnab_state = fields.Selection(
         selection=ESTADOS_CNAB,


### PR DESCRIPTION
The account.move.line should be order by Date maturity.

A account.move.line devem ser ordenadas pela Data de Vencimento para que sejam criadas as Parcelas de acordo com essa data, isso estava no l10n_br_account_payment_order e foi movido para o l10n_br_account_due_list para ser usado por outros modulos,  

Antes
![image](https://user-images.githubusercontent.com/6341149/157096404-108d6ca5-eb74-42b5-ab78-84b80cb43f6b.png)

Agora
![image](https://user-images.githubusercontent.com/6341149/157096455-12db2be6-8817-4781-91b4-b0bf8fb22643.png)

Também alterei na criação das account.move.lines o Name com esse mesmo objetivo, o segundo commit

Antes 
![image](https://user-images.githubusercontent.com/6341149/157096640-1db45b95-7cb0-44da-80f9-07b370d39100.png)

Agora
![image](https://user-images.githubusercontent.com/6341149/157096719-1df435ae-b524-40a1-a8f6-2c9c4027b706.png)


cc @renatonlima @rvalyi @marcelsavegnago @mileo @netosjb 