### PR TITLE
[12.0][REF] Cálculo da alíquota efetiva para empresas do Simples Nacional.

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -444,7 +444,7 @@ class AccountInvoice(models.Model):
                 fiscal_price=line.fiscal_price,
                 fiscal_quantity=line.fiscal_quantity,
                 uot=line.uot_id,
-                icmssn_range=line.icmssn_range_id,
+                cfop_type_move=line.cfop_id.type_move,
                 ind_final=line.ind_final,
             )["taxes"]
 

--- a/l10n_br_account/models/account_tax.py
+++ b/l10n_br_account/models/account_tax.py
@@ -37,7 +37,7 @@ class AccountTax(models.Model):
         fiscal_price=None,
         fiscal_quantity=None,
         uot=None,
-        icmssn_range=None,
+        cfop_type_move=None,
         icms_origin=None,
         ind_final=FINAL_CUSTOMER_NO,
     ):
@@ -102,7 +102,7 @@ class AccountTax(models.Model):
             other_value=other_value,
             freight_value=freight_value,
             operation_line=operation_line,
-            icmssn_range=icmssn_range,
+            cfop_type_move=cfop_type_move,
             icms_origin=icms_origin or product.icms_origin,
             ind_final=ind_final,
         )

--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -91,6 +91,7 @@
         "views/dfe/dfe_views.xml",
         "views/operation_dashboard_view.xml",
         "views/document_event_view.xml",
+        "views/simplified_tax_effecitve_view.xml",
         # Wizards
         "wizards/document_cancel_wizard.xml",
         "wizards/document_correction_wizard.xml",

--- a/l10n_br_fiscal/data/l10n_br_fiscal_comment_data.xml
+++ b/l10n_br_fiscal/data/l10n_br_fiscal_comment_data.xml
@@ -18,9 +18,25 @@
 
     <record id="fiscal_comment_sn_permissao_credito" model="l10n_br_fiscal.comment">
         <field name="name">Simples Nacional permissão de crédito</field>
-        <field
-            name="comment"
-        >SIMPLES NACIONAL - Documento emitido por ME ou EPP optante pelo simples nacional, não gera direito a credito fiscal de IPI. Permite o aproveitamento de crédito de ICMS no valor de ${format_amount(doc.amount_icmssn_credit_value)},  nos termos do artigo 23 da LC 123/2006.</field>
+        <field name="comment">
+SIMPLES NACIONAL - Documento emitido por ME ou EPP optante pelo simples nacional, não gera direito a credito fiscal de IPI. Permite o aproveitamento de crédito de ICMS no valor de ${format_amount(doc.amount_icmssn_credit_value)}, correspondente à alíquota de
+%- if doc.is_sale_industry():
+%- if not doc.is_sale_commerce():
+ ${doc.company_id.icmssn_credit_industry}%
+%- endif
+%- endif
+%- if doc.is_sale_commerce():
+%- if not doc.is_sale_industry():
+ ${doc.company_id.icmssn_credit_commerce}%
+%- endif
+%- endif
+%- if doc.is_sale_industry():
+%- if doc.is_sale_commerce():
+ ${doc.company_id.icmssn_credit_industry}% para indústrialização e de ${doc.company_id.icmssn_credit_commerce}% para revenda
+%- endif
+%- endif
+, nos termos do artigo 23 da LC 123/2006.
+        </field>
         <field name="comment_type">fiscal</field>
         <field name="object">l10n_br_fiscal.document.mixin</field>
     </record>

--- a/l10n_br_fiscal/models/__init__.py
+++ b/l10n_br_fiscal/models/__init__.py
@@ -52,6 +52,7 @@ from . import product_template
 from . import product_product
 from . import simplified_tax
 from . import simplified_tax_range
+from . import simplified_tax_effective
 from . import operation
 from . import operation_line
 from . import operation_document_type

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin.py
@@ -30,7 +30,6 @@ from ..constants.fiscal import (
     TAX_DOMAIN_PIS,
     TAX_DOMAIN_PIS_ST,
     TAX_DOMAIN_PIS_WH,
-    TAX_FRAMEWORK_SIMPLES_ALL,
     TAX_ICMS_OR_ISSQN,
 )
 from ..constants.icms import (
@@ -57,21 +56,6 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     @api.model
     def _default_operation(self):
         return False
-
-    @api.model
-    def _default_icmssn_range_id(self):
-        company = self.env.user.company_id
-        stax_range_id = self.env["l10n_br_fiscal.simplified.tax.range"]
-
-        if self.env.context.get("default_company_id"):
-            company = self.env["res.company"].browse(
-                self.env.context.get("default_company_id")
-            )
-
-        if company.tax_framework in TAX_FRAMEWORK_SIMPLES_ALL:
-            stax_range_id = company.simplified_tax_range_id
-
-        return stax_range_id
 
     @api.model
     def _operation_domain(self):
@@ -488,7 +472,6 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     icmssn_range_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.simplified.tax.range",
         string="Simplified Range Tax",
-        default=_default_icmssn_range_id,
     )
 
     icmssn_tax_id = fields.Many2one(
@@ -854,12 +837,6 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     inss_wh_reduction = fields.Float(string="INSS RET % Reduction")
 
     inss_wh_value = fields.Monetary(string="INSS RET Value")
-
-    simple_value = fields.Monetary(string="National Simple Taxes")
-
-    simple_without_icms_value = fields.Monetary(
-        string="National Simple Taxes without ICMS"
-    )
 
     comment_ids = fields.Many2many(
         comodel_name="l10n_br_fiscal.comment",

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -546,8 +546,6 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         self.icmssn_percent = tax_dict.get("percent_amount")
         self.icmssn_reduction = tax_dict.get("percent_reduction")
         self.icmssn_credit_value = tax_dict.get("tax_value")
-        self.simple_value = self.icmssn_base * self.icmssn_range_id.total_tax_percent
-        self.simple_without_icms_value = self.simple_value - self.icmssn_credit_value
 
     @api.onchange(
         "icmssn_base", "icmssn_percent", "icmssn_reduction", "icmssn_credit_value"

--- a/l10n_br_fiscal/models/document_fiscal_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin_methods.py
@@ -28,6 +28,14 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
         """Get object lines instaces used to compute fields"""
         return self.mapped("line_ids")
 
+    def is_sale_industry(self):
+        types = self.line_ids.mapped("cfop_id").mapped("type_move")
+        return "sale_industry" in types
+
+    def is_sale_commerce(self):
+        types = self.line_ids.mapped("cfop_id").mapped("type_move")
+        return "sale_commerce" in types
+
     @api.model
     def _get_amount_fields(self):
         """Get all fields with 'amount_' prefix"""

--- a/l10n_br_fiscal/models/res_company.py
+++ b/l10n_br_fiscal/models/res_company.py
@@ -517,7 +517,7 @@ class ResCompany(models.Model):
             self._del_tax_definition(TAX_DOMAIN_INSS_WH)
 
     @api.depends("annual_revenue", "payroll_amount")
-    def _compute_simplifed_tax(self):
+    def _compute_simplified_tax(self):
         for record in self:
             record._calculate_coefficient_r()
 

--- a/l10n_br_fiscal/models/res_company.py
+++ b/l10n_br_fiscal/models/res_company.py
@@ -54,7 +54,6 @@ class ResCompany(models.Model):
         partner_fields = super()._get_company_address_fields(partner)
         partner_fields.update(
             {
-                "tax_framework": partner.tax_framework,
                 "cnae_main_id": partner.cnae_main_id,
             }
         )
@@ -64,6 +63,11 @@ class ResCompany(models.Model):
         """Write the l10n_br specific functional fields."""
         for c in self:
             c.partner_id.cnae_main_id = c.cnae_main_id
+
+    @api.depends("partner_id", "partner_id.tax_framework")
+    def _compute_tax_framework(self):
+        for c in self:
+            c.tax_framework = c.partner_id.tax_framework
 
     def _inverse_tax_framework(self):
         """Write the l10n_br specific functional fields."""
@@ -169,8 +173,9 @@ class ResCompany(models.Model):
     tax_framework = fields.Selection(
         selection=TAX_FRAMEWORK,
         default=TAX_FRAMEWORK_NORMAL,
-        compute="_compute_address",
+        compute="_compute_tax_framework",
         inverse="_inverse_tax_framework",
+        store=True,
         string="Tax Framework",
     )
 

--- a/l10n_br_fiscal/models/simplified_tax.py
+++ b/l10n_br_fiscal/models/simplified_tax.py
@@ -2,7 +2,9 @@
 # Copyright (C) 2020  Luis Felipe Mileo - KMEE
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import fields, models
+from odoo import api, fields, models
+
+from ..constants.fiscal import TAX_FRAMEWORK_SIMPLES
 
 
 class SimplifiedTax(models.Model):
@@ -31,3 +33,14 @@ class SimplifiedTax(models.Model):
         string="Coefficient R",
         readonly=True,
     )
+
+    @api.model
+    def create(self, vals):
+        """Override create for update effective tax lines in all companys"""
+        record = super().create(vals)
+        companies = self.env["res.company"].search(
+            [("tax_framework", "=", TAX_FRAMEWORK_SIMPLES)]
+        )
+        for company in companies:
+            company.update_effective_tax_lines()
+        return record

--- a/l10n_br_fiscal/models/simplified_tax_effective.py
+++ b/l10n_br_fiscal/models/simplified_tax_effective.py
@@ -1,0 +1,147 @@
+from odoo import api, fields, models
+
+from odoo.addons import decimal_precision as dp
+
+
+class SimplifiedTaxEffective(models.Model):
+    _name = "l10n_br_fiscal.simplified.tax.effective"
+    _description = "Effective Tax Rate for Simples Nacional"
+
+    _sql_constraints = [
+        (
+            "sn_effective_tax_unique",
+            "unique (simplified_tax_id,company_id)",
+            "There is already an effective tax line for this "
+            "company and this Simples Nacional table",
+        )
+    ]
+
+    simplified_tax_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.simplified.tax",
+        string="Annex",
+        help="Annex Tax Table of Simples Nacional",
+        required=True,
+    )
+
+    company_id = fields.Many2one(
+        comodel_name="res.company",
+        string="Company",
+        ondelete="cascade",
+    )
+
+    current_range_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.simplified.tax.range",
+        string="Range",
+        help="Range into which the company falls based on current revenue.",
+        compute="_compute_current_range_id",
+        store=True,
+    )
+
+    current_effective_tax = fields.Float(
+        string="Tax Rate %",
+        help="Effective tax of Simples Nacional, when the activity falls"
+        "under this annex, based on the current range.",
+        digits=dp.get_precision("Fiscal Tax Percent"),
+        compute="_compute_current_effective_tax",
+        store=True,
+    )
+
+    tax_icms_percent = fields.Float(
+        string="ICMS %",
+        digits=dp.get_precision("Fiscal Tax Percent"),
+        compute="_compute_tax_icms_percent",
+        store=True,
+    )
+
+    tax_cpp_percent = fields.Float(
+        string="CPP %", digits=dp.get_precision("Fiscal Tax Percent")
+    )
+
+    tax_csll_percent = fields.Float(
+        string="CSLL %", digits=dp.get_precision("Fiscal Tax Percent")
+    )
+
+    tax_ipi_percent = fields.Float(
+        string="IPI %", digits=dp.get_precision("Fiscal Tax Percent")
+    )
+
+    tax_iss_percent = fields.Float(
+        string="ISS %", digits=dp.get_precision("Fiscal Tax Percent")
+    )
+
+    tax_irpj_percent = fields.Float(
+        string="IRPJ %", digits=dp.get_precision("Fiscal Tax Percent")
+    )
+
+    tax_cofins_percent = fields.Float(
+        string="COFINS %", digits=dp.get_precision("Fiscal Tax Percent")
+    )
+
+    tax_pis_percent = fields.Float(
+        string="PIS %", digits=dp.get_precision("Fiscal Tax Percent")
+    )
+
+    @api.depends(
+        "current_effective_tax",
+        "current_range_id",
+        "current_range_id.tax_icms_percent",
+        "current_range_id.tax_cpp_percent",
+        "current_range_id.tax_csll_percent",
+        "current_range_id.tax_ipi_percent",
+        "current_range_id.tax_irpj_percent",
+        "current_range_id.tax_cofins_percent",
+        "current_range_id.tax_pis_percent",
+        "current_range_id.tax_iss_percent",
+    )
+    def _compute_tax_icms_percent(self):
+        for rec in self:
+            range_id = rec.current_range_id
+            rec.tax_icms_percent = rec.calculate_tax(range_id.tax_icms_percent)
+            rec.tax_cpp_percent = rec.calculate_tax(range_id.tax_cpp_percent)
+            rec.tax_csll_percent = rec.calculate_tax(range_id.tax_csll_percent)
+            rec.tax_ipi_percent = rec.calculate_tax(range_id.tax_ipi_percent)
+            rec.tax_irpj_percent = rec.calculate_tax(range_id.tax_irpj_percent)
+            rec.tax_cofins_percent = rec.calculate_tax(range_id.tax_cofins_percent)
+            rec.tax_pis_percent = rec.calculate_tax(range_id.tax_pis_percent)
+            rec.tax_iss_percent = rec.calculate_tax(range_id.tax_iss_percent)
+
+    def calculate_tax(self, x_tax_rate):
+        self.ensure_one()
+        effective_total_tax = self.current_effective_tax
+        effective_x_tax = effective_total_tax * (x_tax_rate / 100)
+        return round(effective_x_tax, 2)
+
+    @api.depends("company_id", "company_id.annual_revenue", "current_range_id")
+    def _compute_current_effective_tax(self):
+        for record in self:
+            annual_revenue = record.company_id.annual_revenue
+            tax_range_id = record.current_range_id
+            record.current_effective_tax = 0.0
+            if not tax_range_id:
+                return
+            if annual_revenue:
+                tax = annual_revenue * tax_range_id.total_tax_percent / 100
+                tax = tax - tax_range_id.amount_deduced
+                tax = tax / annual_revenue
+                tax = tax * 100
+                record.current_effective_tax = tax
+            else:
+                record.current_effective_tax = tax_range_id.total_tax_percent
+
+    @api.depends(
+        "company_id",
+        "company_id.annual_revenue",
+        "company_id.coefficient_r",
+    )
+    def _compute_current_range_id(self):
+        for record in self:
+            company_id = record.company_id
+            tax_range = record.env["l10n_br_fiscal.simplified.tax.range"].search(
+                [
+                    ("simplified_tax_id", "=", record.simplified_tax_id.id),
+                    ("inital_revenue", "<=", company_id.annual_revenue),
+                    ("final_revenue", ">=", company_id.annual_revenue),
+                ],
+                limit=1,
+            )
+            record.current_range_id = tax_range

--- a/l10n_br_fiscal/models/simplified_tax_effective.py
+++ b/l10n_br_fiscal/models/simplified_tax_effective.py
@@ -49,36 +49,57 @@ class SimplifiedTaxEffective(models.Model):
     tax_icms_percent = fields.Float(
         string="ICMS %",
         digits=dp.get_precision("Fiscal Tax Percent"),
-        compute="_compute_tax_icms_percent",
+        compute="_compute_tax_percent",
         store=True,
     )
 
     tax_cpp_percent = fields.Float(
-        string="CPP %", digits=dp.get_precision("Fiscal Tax Percent")
+        string="CPP %",
+        digits=dp.get_precision("Fiscal Tax Percent"),
+        compute="_compute_tax_percent",
+        store=True,
     )
 
     tax_csll_percent = fields.Float(
-        string="CSLL %", digits=dp.get_precision("Fiscal Tax Percent")
+        string="CSLL %",
+        digits=dp.get_precision("Fiscal Tax Percent"),
+        compute="_compute_tax_percent",
+        store=True,
     )
 
     tax_ipi_percent = fields.Float(
-        string="IPI %", digits=dp.get_precision("Fiscal Tax Percent")
+        string="IPI %",
+        digits=dp.get_precision("Fiscal Tax Percent"),
+        compute="_compute_tax_percent",
+        store=True,
     )
 
     tax_iss_percent = fields.Float(
-        string="ISS %", digits=dp.get_precision("Fiscal Tax Percent")
+        string="ISS %",
+        digits=dp.get_precision("Fiscal Tax Percent"),
+        compute="_compute_tax_percent",
+        store=True,
     )
 
     tax_irpj_percent = fields.Float(
-        string="IRPJ %", digits=dp.get_precision("Fiscal Tax Percent")
+        string="IRPJ %",
+        digits=dp.get_precision("Fiscal Tax Percent"),
+        compute="_compute_tax_percent",
+        store=True,
     )
 
     tax_cofins_percent = fields.Float(
-        string="COFINS %", digits=dp.get_precision("Fiscal Tax Percent")
+        string="COFINS %",
+        digits=dp.get_precision("Fiscal Tax Percent"),
+        compute="_compute_tax_percent",
+        store=True,
     )
 
     tax_pis_percent = fields.Float(
-        string="PIS %", digits=dp.get_precision("Fiscal Tax Percent")
+        string="PIS %",
+        digits=dp.get_precision("Fiscal Tax Percent"),
+        compute="_compute_tax_percent",
+        store=True,
     )
 
     @api.depends(
@@ -93,7 +114,7 @@ class SimplifiedTaxEffective(models.Model):
         "current_range_id.tax_pis_percent",
         "current_range_id.tax_iss_percent",
     )
-    def _compute_tax_icms_percent(self):
+    def _compute_tax_percent(self):
         for rec in self:
             range_id = rec.current_range_id
             rec.tax_icms_percent = rec.calculate_tax(range_id.tax_icms_percent)

--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -530,9 +530,8 @@ class Tax(models.Model):
         tax_dict = taxes_dict.get(tax.tax_domain)
         partner = kwargs.get("partner")
         company = kwargs.get("company")
-        currency = kwargs.get("currency", company.currency_id)
         cst = kwargs.get("cst", self.env["l10n_br_fiscal.cst"])
-        icmssn_range = kwargs.get("icmssn_range")
+        cfop_id = kwargs.get("cfop")
 
         # Get Computed IPI Tax
         tax_dict_ipi = taxes_dict.get("ipi", {})
@@ -545,10 +544,11 @@ class Tax(models.Model):
         # Partner ICMS's Contributor
         if partner.ind_ie_dest in (NFE_IND_IE_DEST_1, NFE_IND_IE_DEST_2):
             if cst.code in ICMS_SN_CST_WITH_CREDIT:
-                icms_sn_percent = currency.round(
-                    company.simplified_tax_percent
-                    * (icmssn_range.tax_icms_percent / 100)
-                )
+                icms_sn_percent = 0.0
+                if cfop_id.type_move == "sale_commerce":
+                    icms_sn_percent = company.icmssn_credit_commerce
+                if cfop_id.type_move == "sale_industry":
+                    icms_sn_percent = company.icmssn_credit_industry
 
                 tax_dict["percent_amount"] = icms_sn_percent
                 tax_dict["value_amount"] = icms_sn_percent

--- a/l10n_br_fiscal/security/ir.model.access.csv
+++ b/l10n_br_fiscal/security/ir.model.access.csv
@@ -103,3 +103,5 @@
 "l10n_br_fiscal_dfe_xml_manager","Consut DFe XML for Manager","model_l10n_br_fiscal_dfe_xml","l10n_br_fiscal.group_manager",1,1,1,1
 "l10n_br_fiscal_mdfe_user","MDFe for User","model_l10n_br_fiscal_mdfe","l10n_br_fiscal.group_user",1,1,1,0
 "l10n_br_fiscal_mdfe_manager","MDFe for Manager","model_l10n_br_fiscal_mdfe","l10n_br_fiscal.group_manager",1,1,1,1
+"l10n_br_fiscal_simplified_effective_tax_user","SN Effective Tax for User","model_l10n_br_fiscal_simplified_tax_effective","l10n_br_fiscal.group_user",1,1,1,0
+"l10n_br_fiscal_simplified_effective_tax_manager","SN Effective Tax for Manager","model_l10n_br_fiscal_simplified_tax_effective","l10n_br_fiscal.group_manager",1,1,1,1

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -14,3 +14,4 @@ from . import test_subsequent_operation
 from . import test_uom_uom
 from . import test_fiscal_document_nfse
 from . import test_ncm
+from . import test_icmssn

--- a/l10n_br_fiscal/tests/test_icmssn.py
+++ b/l10n_br_fiscal/tests/test_icmssn.py
@@ -1,0 +1,70 @@
+import logging
+
+from unidecode import unidecode
+
+from odoo.tests.common import TransactionCase
+
+_logger = logging.getLogger(__name__)
+
+
+class TestNFE(TransactionCase):
+    def test_icmssn_tax_rate(self):
+        """Test to verify if the calculation of the icms credit
+        for Simples Nacional companies is correct."""
+        document_model = self.env["l10n_br_fiscal.document"]
+        document_line_model = self.env["l10n_br_fiscal.document.line"]
+        akretion_partner = self.env.ref("l10n_br_base.res_partner_address_ak3")
+        company_id = self.env.ref("l10n_br_base.empresa_simples_nacional")
+        self.env.user.company_ids += company_id
+        self.env.user.company_id = company_id
+        document = document_model.create(
+            {
+                "partner_id": akretion_partner.id,
+                "document_type_id": self.env.ref("l10n_br_fiscal.document_55").id,
+                "fiscal_operation_id": self.env.ref("l10n_br_fiscal.fo_venda").id,
+            }
+        )
+        document._onchange_fiscal_operation_id()
+        document._onchange_document_type_id()
+        document._onchange_document_serie_id()
+        # venda de industrialização própria.
+        line = document_line_model.create(
+            {
+                "document_id": document.id,
+                "company_id": document.company_id.id,
+                "partner_id": document.partner_id.id,
+                "fiscal_operation_type": document.fiscal_operation_type,
+                "fiscal_operation_id": document.fiscal_operation_id.id,
+                "product_id": self.env.ref("product.product_product_4d").id,
+            }
+        )
+        line._onchange_product_id_fiscal()
+        line.fiscal_operation_line_id = self.env.ref("l10n_br_fiscal.fo_venda_venda")
+        line._onchange_fiscal_operation_line_id()
+        # Revenda
+        line2 = document_line_model.create(
+            {
+                "document_id": document.id,
+                "company_id": document.company_id.id,
+                "partner_id": document.partner_id.id,
+                "fiscal_operation_type": document.fiscal_operation_type,
+                "fiscal_operation_id": document.fiscal_operation_id.id,
+                "product_id": self.env.ref("product.product_product_4d").id,
+            }
+        )
+        line2._onchange_product_id_fiscal()
+        line2.fiscal_operation_line_id = self.env.ref("l10n_br_fiscal.fo_venda_revenda")
+        line2._onchange_fiscal_operation_line_id()
+        document.comment_ids = [
+            (4, self.env.ref("l10n_br_fiscal.fiscal_comment_sn_permissao_credito").id)
+        ]
+        document._compute_amount()
+        document.action_document_confirm()
+        icmss_credit_info = (
+            "Permite o aproveitamento de crédito de ICMS no valor de "
+            + "R$ 40.20, correspondente à alíquota de 2.7% para indústrialização "
+            + "e de 2.66% para revenda"
+        )
+        self.assertIn(
+            unidecode(icmss_credit_info), unidecode(document.fiscal_additional_data)
+        )

--- a/l10n_br_fiscal/views/res_company_view.xml
+++ b/l10n_br_fiscal/views/res_company_view.xml
@@ -30,11 +30,19 @@
                                     <field name="payroll_amount" />
                                 </group>
                                 <group>
-                                    <field name="simplified_tax_id" />
-                                    <field name="simplified_tax_range_id" />
                                     <field name="coefficient_r" />
                                     <field name="coefficient_r_percent" />
-                                    <field name="simplified_tax_percent" />
+                                </group>
+                                <group
+                                    colspan="4"
+                                    string="Current Effective Taxes for Simples Nacional"
+                                >
+                                    <field
+                                        colspan="4"
+                                        nolabel="1"
+                                        name="sn_effective_tax_ids"
+                                        readonly="True"
+                                    />
                                 </group>
                             </group>
                             <group

--- a/l10n_br_fiscal/views/simplified_tax_effecitve_view.xml
+++ b/l10n_br_fiscal/views/simplified_tax_effecitve_view.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="simplified_tax_effecitve_tree" model="ir.ui.view">
+        <field name="name">l10n_br_fiscal.simplified.tax.effecitve.tree</field>
+        <field name="model">l10n_br_fiscal.simplified.tax.effective</field>
+        <field name="arch" type="xml">
+            <tree create="0" delete="0">
+                <field name="simplified_tax_id" />
+                <field name="current_range_id" />
+                <field name="current_effective_tax" />
+                <field name="tax_irpj_percent" />
+                <field name="tax_csll_percent" />
+                <field name="tax_cofins_percent" />
+                <field name="tax_pis_percent" />
+                <field name="tax_cpp_percent" />
+                <field name="tax_icms_percent" />
+                <field name="tax_iss_percent" />
+                <field name="tax_ipi_percent" />
+            </tree>
+        </field>
+    </record>
+</odoo>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000012062777161.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000012062777161.xml
@@ -82,8 +82,8 @@
                     <ICMSSN101>
                         <orig>0</orig>
                         <CSOSN>101</CSOSN>
-                        <pCredSN>2.7000</pCredSN>
-                        <vCredICMSSN>0.38</vCredICMSSN>
+                        <pCredSN>2.6600</pCredSN>
+                        <vCredICMSSN>0.37</vCredICMSSN>
                     </ICMSSN101>
                 </ICMS>
                 <IPI>


### PR DESCRIPTION
Atualmente o módulo fiscal não suporta que uma empresa do regime Simples Nacional possa exercer mais de um tipo de atividade ao mesmo tempo, como por exemplo ser uma indústria e comércio. Com a alteração dessa PR o módulo fiscal passa a calcular todos os impostos efetivos, para cada anexo do simples nacional existente.

Antes da PR:
![image](https://user-images.githubusercontent.com/634278/157334901-5067d286-7ae0-4e6b-a0ac-66158a35b9ee.png)

Depois da PR:
![sn](https://user-images.githubusercontent.com/634278/157331380-3d680f19-6820-4921-ac38-dc21bbecc3d1.gif)

Antes da PR, caso fosse emitido um nota fiscal que contivesse um item que fosse venda ( produção própria) e também um outro como ( revenda ) o valor da alíquota  do "ICMS permitido para aproveitamento de credito" ficava errado,  o mesmo valor era aplicado para os dois itens, porém é preciso diferenciar, os itens de produção própria devem ser calculados com base no ANEXO 2 do Simples Nacional (Indústria) e os itens de revenda com base no ANEXO 1 (Comércio) 

Depois da PR:
![Peek 2022-03-08 19-29](https://user-images.githubusercontent.com/634278/157336725-40852f86-f824-4964-8064-2ef5044d70f0.gif)

Também arrumei a informação que é impressa na nota fiscal do simples nacional para comportar os dois tipos ao mesmo tempo:
![image](https://user-images.githubusercontent.com/634278/157337069-da59a0ef-55ad-4081-995d-5842ccfcf93c.png)

Essa PR era pra ser apenas um pequeno FIX, mas no fim ficou um pouco maior que o esperado rss.



