### PR TITLE
[14.0][FIX] l10n_br_fiscal: remove widgets from chatter section

### DIFF
--- a/l10n_br_fiscal/views/certificate_view.xml
+++ b/l10n_br_fiscal/views/certificate_view.xml
@@ -77,9 +77,9 @@
                     </group>
                 </sheet>
                 <div class="oe_chatter">
-                    <field name="message_follower_ids" widget="mail_followers" />
-                    <field name="activity_ids" widget="mail_activity" />
-                    <field name="message_ids" widget="mail_thread" />
+                    <field name="message_follower_ids" groups="base.group_user" />
+                    <field name="activity_ids" />
+                    <field name="message_ids" />
                 </div>
             </form>
         </field>

--- a/l10n_br_fiscal/views/closing.xml
+++ b/l10n_br_fiscal/views/closing.xml
@@ -141,9 +141,9 @@
             </sheet>
             <div class="o_attachment_preview" />
             <div class="oe_chatter">
-                <field name="message_follower_ids" widget="mail_followers" />
-                <field name="activity_ids" widget="mail_activity" />
-                <field name="message_ids" widget="mail_thread" />
+                <field name="message_follower_ids" groups="base.group_user" />
+                <field name="activity_ids" />
+                <field name="message_ids" />
             </div>
             </form>
         </field>

--- a/l10n_br_fiscal/views/icms_regulation_view.xml
+++ b/l10n_br_fiscal/views/icms_regulation_view.xml
@@ -35,9 +35,9 @@
               </notebook>
             </sheet>
             <div class="oe_chatter">
-                <field name="message_follower_ids" widget="mail_followers" />
-                <field name="activity_ids" widget="mail_activity" />
-                <field name="message_ids" widget="mail_thread" />
+                <field name="message_follower_ids" groups="base.group_user" />
+                <field name="activity_ids" />
+                <field name="message_ids" />
             </div>
           </form>
         </field>

--- a/l10n_br_fiscal/views/nbs_view.xml
+++ b/l10n_br_fiscal/views/nbs_view.xml
@@ -111,9 +111,9 @@
                     </notebook>
                 </sheet>
                 <div class="oe_chatter">
-                    <field name="message_follower_ids" widget="mail_followers" />
-                    <field name="activity_ids" widget="mail_activity" />
-                    <field name="message_ids" widget="mail_thread" />
+                    <field name="message_follower_ids" groups="base.group_user" />
+                    <field name="activity_ids" />
+                    <field name="message_ids" />
                 </div>
             </form>
         </field>

--- a/l10n_br_fiscal/views/ncm_view.xml
+++ b/l10n_br_fiscal/views/ncm_view.xml
@@ -156,9 +156,9 @@
                     </notebook>
                 </sheet>
                 <div class="oe_chatter">
-                    <field name="message_follower_ids" widget="mail_followers" />
-                    <field name="activity_ids" widget="mail_activity" />
-                    <field name="message_ids" widget="mail_thread" />
+                    <field name="message_follower_ids" groups="base.group_user" />
+                    <field name="activity_ids" />
+                    <field name="message_ids" />
                 </div>
             </form>
         </field>

--- a/l10n_br_fiscal/views/operation_line_view.xml
+++ b/l10n_br_fiscal/views/operation_line_view.xml
@@ -91,9 +91,9 @@
                     </notebook>
                 </sheet>
                 <div class="oe_chatter">
-                    <field name="message_follower_ids" widget="mail_followers" />
-                    <field name="activity_ids" widget="mail_activity" />
-                    <field name="message_ids" widget="mail_thread" />
+                    <field name="message_follower_ids" groups="base.group_user" />
+                    <field name="activity_ids" />
+                    <field name="message_ids" />
                 </div>
             </form>
         </field>

--- a/l10n_br_fiscal/views/operation_view.xml
+++ b/l10n_br_fiscal/views/operation_view.xml
@@ -132,9 +132,9 @@
                     </notebook>
                 </sheet>
                 <div class="oe_chatter">
-                    <field name="message_follower_ids" widget="mail_followers" />
-                    <field name="activity_ids" widget="mail_activity" />
-                    <field name="message_ids" widget="mail_thread" />
+                    <field name="message_follower_ids" groups="base.group_user" />
+                    <field name="activity_ids" />
+                    <field name="message_ids" />
                 </div>
             </form>
         </field>

--- a/l10n_br_fiscal/views/service_type_view.xml
+++ b/l10n_br_fiscal/views/service_type_view.xml
@@ -108,9 +108,9 @@
                     </notebook>
                 </sheet>
                 <div class="oe_chatter">
-                    <field name="message_follower_ids" widget="mail_followers" />
-                    <field name="activity_ids" widget="mail_activity" />
-                    <field name="message_ids" widget="mail_thread" />
+                    <field name="message_follower_ids" groups="base.group_user" />
+                    <field name="activity_ids" />
+                    <field name="message_ids" />
                 </div>
             </form>
         </field>

--- a/l10n_br_fiscal/views/tax_definition_view.xml
+++ b/l10n_br_fiscal/views/tax_definition_view.xml
@@ -183,9 +183,9 @@
           </notebook>
         </sheet>
         <div class="oe_chatter">
-          <field name="message_follower_ids" widget="mail_followers" />
-          <field name="activity_ids" widget="mail_activity" />
-          <field name="message_ids" widget="mail_thread" />
+            <field name="message_follower_ids" groups="base.group_user" />
+            <field name="activity_ids" />
+            <field name="message_ids" />
         </div>
       </form>
     </field>

--- a/l10n_br_fiscal/views/uom_uom.xml
+++ b/l10n_br_fiscal/views/uom_uom.xml
@@ -20,9 +20,9 @@
             </field>
             <form position="inside">
                 <div class="oe_chatter">
-                    <field name="message_follower_ids" widget="mail_followers" />
-                    <field name="activity_ids" widget="mail_activity" />
-                    <field name="message_ids" widget="mail_thread" />
+                    <field name="message_follower_ids" groups="base.group_user" />
+                    <field name="activity_ids" />
+                    <field name="message_ids" />
                 </div>
             </form>
         </field>


### PR DESCRIPTION
Percebi alguns warnings na view do documento fiscal. Pesquisei no código fonte do Odoo e vi que em nenhum lugar está chamando estes widgets.

![image](https://user-images.githubusercontent.com/3595132/158451589-d071562f-3163-4479-b6eb-113cc5e175f6.png)
