### PR TITLE
[FIX] Typo in 'purchase_create_invoice_policy' field parameter

### DIFF
--- a/l10n_br_purchase_stock/models/purchase_order.py
+++ b/l10n_br_purchase_stock/models/purchase_order.py
@@ -13,7 +13,7 @@ class PurchaseOrder(models.Model):
             ("purchase_order", _("Purchase Order")),
             ("stock_picking", _("Stock Picking")),
         ],
-        relation="company_id.purchase_create_invoice_policy",
+        related="company_id.purchase_create_invoice_policy",
     )
 
     @api.model


### PR DESCRIPTION
  Este PR é um correção simples para um erro no nome do parametro do campo purchase_create_invoice_policy do modelo purchase_order.
  O campo é um related com o campo de mesmo nome do res.company não uma nova tabela.