### PR TITLE
[14.0][FIX] wrong tracking parameter in res.partner ind_final field

### DIFF
--- a/l10n_br_fiscal/models/res_partner.py
+++ b/l10n_br_fiscal/models/res_partner.py
@@ -61,7 +61,7 @@ class ResPartner(models.Model):
         selection=FINAL_CUSTOMER,
         string="Final Consumption Operation",
         default=FINAL_CUSTOMER_NO,
-        track_visibility="onchange",
+        tracking=True,
     )
 
     cnpj_cpf = fields.Char(


### PR DESCRIPTION
To avoid log warning messages:

`WARNING db odoo.fields: Field res.partner.ind_final: unknown parameter 'track_visibility', if this is an actual parameter you may want to override the method _valid_field_parameter on the relevant model in order to allow it 
`