### PR TITLE
[14.0][REF] Porte da geração do certificado fake para o erpbrasil.assinatura

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -109,7 +109,7 @@
     "external_dependencies": {
         "python": [
             "erpbrasil.base",
-            "erpbrasil.assinatura",
+            "erpbrasil.assinatura-nopyopenssl",
         ]
     },
 }

--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -110,7 +110,6 @@
         "python": [
             "erpbrasil.base",
             "erpbrasil.assinatura",
-            "OpenSSL",
         ]
     },
 }

--- a/l10n_br_fiscal/hooks.py
+++ b/l10n_br_fiscal/hooks.py
@@ -6,6 +6,9 @@ import logging
 
 from odoo import SUPERUSER_ID, _, api, tools
 
+from .constants.fiscal import CERTIFICATE_TYPE_ECNPJ
+from .tools import misc
+
 _logger = logging.getLogger(__name__)
 
 
@@ -85,20 +88,22 @@ def post_init_hook(cr, registry):
                 kind="demo",
             )
 
-    #    companies = [
-    #        env.ref("base.main_company", raise_if_not_found=False),
-    #        env.ref("l10n_br_base.empresa_lucro_presumido", raise_if_not_found=False),
-    #        env.ref("l10n_br_base.empresa_simples_nacional", raise_if_not_found=False),
-    #    ]
+        env = api.Environment(cr, SUPERUSER_ID, {})
 
-    #        for company in companies:
-    #            l10n_br_fiscal_certificate_id = env["l10n_br_fiscal.certificate"]
-    #            company.certificate_nfe_id = l10n_br_fiscal_certificate_id.create(
-    #                misc.prepare_fake_certificate_vals()
-    #            )
-    #            company.certificate_ecnpj_id = l10n_br_fiscal_certificate_id.create(
-    #                misc.prepare_fake_certificate_vals(cert_type=CERTIFICATE_TYPE_ECNPJ)
-    #            )
+        companies = [
+            env.ref("base.main_company", raise_if_not_found=False),
+            env.ref("l10n_br_base.empresa_lucro_presumido", raise_if_not_found=False),
+            env.ref("l10n_br_base.empresa_simples_nacional", raise_if_not_found=False),
+        ]
+
+        for company in companies:
+            l10n_br_fiscal_certificate_id = env["l10n_br_fiscal.certificate"]
+            company.certificate_nfe_id = l10n_br_fiscal_certificate_id.create(
+                misc.prepare_fake_certificate_vals()
+            )
+            company.certificate_ecnpj_id = l10n_br_fiscal_certificate_id.create(
+                misc.prepare_fake_certificate_vals(cert_type=CERTIFICATE_TYPE_ECNPJ)
+            )
 
     if tools.config["without_demo"]:
         prodfiles = []

--- a/l10n_br_fiscal/models/certificate.py
+++ b/l10n_br_fiscal/models/certificate.py
@@ -66,9 +66,7 @@ class Certificate(models.Model):
 
     file = fields.Binary(string="file", prefetch=True, required=True)
 
-    file_name = fields.Char(
-        string="File Name", compute="_compute_description", size=255
-    )
+    file_name = fields.Char(string="File Name", compute="_compute_name", size=255)
 
     password = fields.Char(string="Password", required=True)
 
@@ -116,8 +114,10 @@ class Certificate(models.Model):
                     c.owner_name or "",
                     format_date(self.env, c.date_expiration),
                 )
+                c.file_name = c.name + ".p12"
             else:
                 c.name = False
+                c.file_name = False
 
     @api.depends("date_expiration")
     def _compute_is_valid(self):

--- a/l10n_br_fiscal/tests/test_certificate.py
+++ b/l10n_br_fiscal/tests/test_certificate.py
@@ -3,12 +3,12 @@
 
 from datetime import timedelta
 
+from erpbrasil.assinatura import misc
+
 from odoo import fields
 from odoo.exceptions import ValidationError
 from odoo.tests import common
 from odoo.tools.misc import format_date
-
-from ..tools import misc
 
 
 class TestCertificate(common.TransactionCase):

--- a/l10n_br_fiscal/tools/misc.py
+++ b/l10n_br_fiscal/tools/misc.py
@@ -4,10 +4,9 @@
 
 import logging
 import os
-from base64 import b64encode
 
+from erpbrasil.assinatura import misc
 from erpbrasil.base.misc import punctuation_rm
-from OpenSSL import crypto
 
 from odoo.tools import config
 
@@ -58,52 +57,10 @@ def prepare_fake_certificate_vals(
         "type": cert_type,
         "subtype": "a1",
         "password": passwd,
-        "file": create_fake_certificate_file(valid, passwd, issuer, country, subject),
+        "file": misc.create_fake_certificate_file(
+            valid, passwd, issuer, country, subject
+        ),
     }
-
-
-def create_fake_certificate_file(valid, passwd, issuer, country, subject):
-    """Creating a fake certificate
-
-        TODO: Move this method to erpbrasil
-
-    :param valid: True or False
-    :param passwd: Some password
-    :param issuer: Some string, like EMISSOR A TESTE
-    :param country: Some country: BR
-    :param subject: Some string: CERTIFICADO VALIDO TESTE
-    :return: base64 file
-    """
-    key = crypto.PKey()
-    key.generate_key(crypto.TYPE_RSA, 2048)
-
-    cert = crypto.X509()
-
-    cert.get_issuer().C = country
-    cert.get_issuer().CN = issuer
-
-    cert.get_subject().C = country
-    cert.get_subject().CN = subject
-
-    cert.set_serial_number(2009)
-
-    if valid:
-        time_before = 0
-        time_after = 365 * 24 * 60 * 60
-    else:
-        time_before = -1 * (365 * 24 * 60 * 60)
-        time_after = 0
-
-    cert.gmtime_adj_notBefore(time_before)
-    cert.gmtime_adj_notAfter(time_after)
-    cert.set_pubkey(key)
-    cert.sign(key, "md5")
-
-    p12 = crypto.PKCS12()
-    p12.set_privatekey(key)
-    p12.set_certificate(cert)
-
-    return b64encode(p12.export(passwd))
 
 
 def path_edoc_company(company_id):

--- a/l10n_br_fiscal/views/certificate_view.xml
+++ b/l10n_br_fiscal/views/certificate_view.xml
@@ -54,7 +54,8 @@
                     </group>
                     <group>
                         <group string="File">
-                            <field name="file" />
+                            <field name="file_name" invisible="1" />
+                            <field name="file" filename="file_name" />
                         </group>
                         <group string="Password">
                             <field name="password" password="True" />

--- a/l10n_br_nfse/__manifest__.py
+++ b/l10n_br_nfse/__manifest__.py
@@ -13,7 +13,7 @@
     "external_dependencies": {
         "python": [
             "erpbrasil.edoc",
-            "erpbrasil.assinatura",
+            "erpbrasil.assinatura-nopyopenssl",
             "erpbrasil.transmissao",
             "erpbrasil.base",
         ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,4 @@ nfelib
 num2words
 odoo_test_helper
 pycep_correios
-pyOpenSSL
 workalendar

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # generated from manifests external_dependencies
-erpbrasil.assinatura
+erpbrasil.assinatura-nopyopenssl
 erpbrasil.base
 erpbrasil.edoc
 erpbrasil.transmissao


### PR DESCRIPTION
Substitui a PR #1778, depende da PR no erpbrasil.assinatura: https://github.com/erpbrasil/erpbrasil.assinatura/pull/32

Conforme foi sugerido pelo @renatonlima fiz o porte da criação do certificado para dentro do erpbrasil.assinatura.

