### PR TITLE
[13.0][REF] Porte da geração do certificado fake para o erpbrasil.assinatura

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -109,7 +109,7 @@
     "external_dependencies": {
         "python": [
             "erpbrasil.base",
-            "erpbrasil.assinatura",
+            "erpbrasil.assinatura-nopyopenssl",
         ]
     },
 }

--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -110,7 +110,6 @@
         "python": [
             "erpbrasil.base",
             "erpbrasil.assinatura",
-            "OpenSSL",
         ]
     },
 }

--- a/l10n_br_fiscal/models/certificate.py
+++ b/l10n_br_fiscal/models/certificate.py
@@ -66,9 +66,7 @@ class Certificate(models.Model):
 
     file = fields.Binary(string="file", prefetch=True, required=True)
 
-    file_name = fields.Char(
-        string="File Name", compute="_compute_description", size=255
-    )
+    file_name = fields.Char(string="File Name", compute="_compute_name", size=255)
 
     password = fields.Char(string="Password", required=True)
 
@@ -116,8 +114,10 @@ class Certificate(models.Model):
                     c.owner_name or "",
                     format_date(self.env, c.date_expiration),
                 )
+                c.file_name = c.name + ".p12"
             else:
                 c.name = False
+                c.file_name = False
 
     @api.depends("date_expiration")
     def _compute_is_valid(self):

--- a/l10n_br_fiscal/tests/test_certificate.py
+++ b/l10n_br_fiscal/tests/test_certificate.py
@@ -3,12 +3,12 @@
 
 from datetime import timedelta
 
+from erpbrasil.assinatura import misc
+
 from odoo import fields
 from odoo.exceptions import ValidationError
 from odoo.tests import common
 from odoo.tools.misc import format_date
-
-from ..tools import misc
 
 
 class TestCertificate(common.TransactionCase):

--- a/l10n_br_fiscal/tools/misc.py
+++ b/l10n_br_fiscal/tools/misc.py
@@ -4,10 +4,9 @@
 
 import logging
 import os
-from base64 import b64encode
 
+from erpbrasil.assinatura import misc
 from erpbrasil.base.misc import punctuation_rm
-from OpenSSL import crypto
 
 from odoo.tools import config
 
@@ -58,52 +57,10 @@ def prepare_fake_certificate_vals(
         "type": cert_type,
         "subtype": "a1",
         "password": passwd,
-        "file": create_fake_certificate_file(valid, passwd, issuer, country, subject),
+        "file": misc.create_fake_certificate_file(
+            valid, passwd, issuer, country, subject
+        ),
     }
-
-
-def create_fake_certificate_file(valid, passwd, issuer, country, subject):
-    """Creating a fake certificate
-
-        TODO: Move this method to erpbrasil
-
-    :param valid: True or False
-    :param passwd: Some password
-    :param issuer: Some string, like EMISSOR A TESTE
-    :param country: Some country: BR
-    :param subject: Some string: CERTIFICADO VALIDO TESTE
-    :return: base64 file
-    """
-    key = crypto.PKey()
-    key.generate_key(crypto.TYPE_RSA, 2048)
-
-    cert = crypto.X509()
-
-    cert.get_issuer().C = country
-    cert.get_issuer().CN = issuer
-
-    cert.get_subject().C = country
-    cert.get_subject().CN = subject
-
-    cert.set_serial_number(2009)
-
-    if valid:
-        time_before = 0
-        time_after = 365 * 24 * 60 * 60
-    else:
-        time_before = -1 * (365 * 24 * 60 * 60)
-        time_after = 0
-
-    cert.gmtime_adj_notBefore(time_before)
-    cert.gmtime_adj_notAfter(time_after)
-    cert.set_pubkey(key)
-    cert.sign(key, "md5")
-
-    p12 = crypto.PKCS12()
-    p12.set_privatekey(key)
-    p12.set_certificate(cert)
-
-    return b64encode(p12.export(passwd))
 
 
 def path_edoc_company(company_id):

--- a/l10n_br_fiscal/tools/misc.py
+++ b/l10n_br_fiscal/tools/misc.py
@@ -5,7 +5,7 @@
 import logging
 import os
 
-from erpbrasil.assinatura import misc
+from erpbrasil.assinatura import misc  # pylint: disable=missing-manifest-dependency
 from erpbrasil.base.misc import punctuation_rm
 
 from odoo.tools import config

--- a/l10n_br_fiscal/views/certificate_view.xml
+++ b/l10n_br_fiscal/views/certificate_view.xml
@@ -54,7 +54,8 @@
                     </group>
                     <group>
                         <group string="File">
-                            <field name="file" />
+                            <field name="file_name" invisible="1" />
+                            <field name="file" filename="file_name" />
                         </group>
                         <group string="Password">
                             <field name="password" password="True" />

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # generated from manifests external_dependencies
-erpbrasil.assinatura
+erpbrasil.assinatura-nopyopenssl
 erpbrasil.base
 nfelib
 num2words

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ erpbrasil.base
 nfelib
 num2words
 odoo_test_helper
-pyOpenSSL


### PR DESCRIPTION
backport do #1843 sem o commit https://github.com/OCA/l10n-brazil/pull/1843/commits/13a741ce8a88e789fa37fd4fa34d1561366dca3f

substitui a pr #1777 

depende do https://github.com/erpbrasil/erpbrasil.assinatura/pull/32

