### PR TITLE
[12.0][REF] Synchronize Sale Partner Shipping in Stock Picking.

### DIFF
--- a/l10n_br_sale_stock/models/sale_order.py
+++ b/l10n_br_sale_stock/models/sale_order.py
@@ -34,3 +34,29 @@ class SaleOrder(models.Model):
                     button_create_invoice_invisible = True
 
         self.button_create_invoice_invisible = button_create_invoice_invisible
+
+    @api.onchange("partner_shipping_id")
+    def _onchange_partner_shipping_id(self):
+        """
+        Caso ocorra a alteração do campo Endereço de Entrega/partner_shipping_id
+        depois do Pedido confirmado os stock.picking relacionados ficam com o
+        partner_id anterior, o que é errado, o metodo original apenas mostra uma
+        mensagem de alerta na tela orientando o usuário a corrigir manualmente,
+        mas como na localização com esse modulo pode se definir a criação da
+        Invoice a partir do stock.picking é melhor garantir a alteração do campo
+        partner_id da stock.picking afim de evitar erros na criação da Invoice.
+        :return: super()
+        """
+        # TODO: Verificar essa questão na migração a partir da v14
+
+        pickings = self.picking_ids.filtered(
+            lambda p: p.state not in ["done", "cancel"]
+            and p.partner_id != self.partner_shipping_id
+        )
+        # Atribuição da forma abaixo por algum motivo
+        # não funciona apenas o write
+        # for picking in pickings:
+        #    picking.partner_id = self.partner_shipping_id
+        pickings.write({"partner_id": self.partner_shipping_id.id})
+
+        return super()._onchange_partner_shipping_id()

--- a/l10n_br_sale_stock/tests/test_sale_stock.py
+++ b/l10n_br_sale_stock/tests/test_sale_stock.py
@@ -460,3 +460,16 @@ class TestSaleStock(SavepointCase):
         invoice_pick_3_4 = invoices.filtered(lambda t: not t.partner_shipping_id)
         self.assertIn(invoice_pick_3_4, picking3.invoice_ids)
         self.assertIn(invoice_pick_3_4, picking4.invoice_ids)
+
+    def test_synchronize_sale_partner_shipping_in_stock_picking(self):
+        """
+        Test the synchronize Sale Partner Shipping in Stock Picking
+        """
+        sale_order_1 = self.env.ref("l10n_br_sale_stock.main_so_l10n_br_sale_stock_1")
+        sale_order_1.action_confirm()
+        picking = sale_order_1.picking_ids
+        sale_order_1.partner_shipping_id = self.env.ref(
+            "l10n_br_base.res_partner_address_ak2"
+        ).id
+        sale_order_1._onchange_partner_shipping_id()
+        self.assertEqual(sale_order_1.partner_shipping_id, picking.partner_id)


### PR DESCRIPTION
Synchronize Sale Partner Shipping in Stock Picking.

Caso ocorra a alteração do campo Endereço de Entrega/partner_shipping_id depois do Pedido confirmado os stock.picking relacionados ficam com o partner_id anterior, o que é errado, o método original apenas mostra uma mensagem de alerta na tela orientando o usuário a corrigir manualmente, mas como na localização com o modulo l10n_br_sale_stock pode se definir a criação da Invoice a partir do stock.picking é melhor garantir a alteração do campo partner_id da stock.picking afim de evitar erros na criação da Invoice.

cc @renatonlima @rvalyi @marcelsavegnago @mileo 
