### PR TITLE
[12.0][FIX] Incluído o campo user_id no shadowed_fields

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -48,6 +48,7 @@ SHADOWED_FIELDS = [
     "company_id",
     "currency_id",
     "partner_shipping_id",
+    "user_id",
 ]
 
 


### PR DESCRIPTION
Included field user_id in shadowed_fields, this field need to be the same in account.invoice and l10n_br_fiscal.document .

Incluido o campo user_id no shadowed_fields porque o valor do campo precisa ser o mesmo nos objetos account.invoice e l10n_br_fiscal.document

cc @renatonlima @rvalyi @marcelsavegnago @mileo