### PR TITLE
[12.0][REF] Movido o método de Criação dos Comentários do modulo l10n_br_account para o l10n_br_fiscal

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -459,21 +459,6 @@ class AccountInvoice(models.Model):
         for invoice in self:
             if invoice.document_type_id:
                 if invoice.issuer == DOCUMENT_ISSUER_COMPANY:
-                    if (
-                        not invoice.comment_ids
-                        and invoice.fiscal_operation_id.comment_ids
-                    ):
-                        invoice.comment_ids |= self.fiscal_operation_id.comment_ids
-
-                    for line in invoice.invoice_line_ids:
-                        if (
-                            not line.comment_ids
-                            and line.fiscal_operation_line_id.comment_ids
-                        ):
-                            line.comment_ids |= (
-                                line.fiscal_operation_line_id.comment_ids
-                            )
-
                     invoice.fiscal_document_id._document_date()
                     invoice.fiscal_document_id._document_number()
 

--- a/l10n_br_fiscal/models/document_workflow.py
+++ b/l10n_br_fiscal/models/document_workflow.py
@@ -300,6 +300,12 @@ class DocumentWorkflow(models.AbstractModel):
 
     def _document_confirm(self):
         if self.issuer == DOCUMENT_ISSUER_COMPANY:
+            if not self.comment_ids and self.fiscal_operation_id.comment_ids:
+                self.comment_ids |= self.fiscal_operation_id.comment_ids
+
+            for line in self.line_ids:
+                if not line.comment_ids and line.fiscal_operation_line_id.comment_ids:
+                    line.comment_ids |= line.fiscal_operation_line_id.comment_ids
             self._change_state(SITUACAO_EDOC_A_ENVIAR)
 
     def action_document_confirm(self):


### PR DESCRIPTION
Moved Comments creation method to be also used when l10n_br_account are not installed.

Movido o método de criação dos Comentários/Observações Fiscais do modulo l10n_br_account para o l10n_br_fiscal, assim o carregamento dos campos irá funcionar mesmo na situação em que o l10n_br_account não estiver instalado, isso foi dividido em dois commits por estarem em módulos diferentes e para permitir o cherry-pick.

Uma segunda alteração foi a remoção do método _fiscal_document_object(self) na Operação Fiscal que retornava o objeto account.invoice isso eu vi com o @renatonlima e pelo o que entendi estava errado porque sempre deve retornar o objeto l10n_br_fiscal.document, portanto isso não deve ser feito, se alguém souber outra razão e se isso deve ser mantido será bom informar e colocar um comentário no código sobre a importância do método.

cc @rvalyi @marcelsavegnago @mileo 

