### PR TITLE
[12.0][FIX] fiscal_type property field in Account Invoice Report

### DIFF
--- a/l10n_br_account/report/account_invoice_report.py
+++ b/l10n_br_account/report/account_invoice_report.py
@@ -79,10 +79,10 @@ class AccountInvoiceReport(models.Model):
             , sub.document_serie_id
             , sub.fiscal_operation_id
             , sub.fiscal_operation_line_id
+            , sub.cfop_id
             , sub.ncm_id
             , sub.cest_id
             , sub.fiscal_type
-            , sub.cfop_id
             , sub.icms_value
             , sub.icmsst_value
             , sub.ipi_value
@@ -102,10 +102,10 @@ class AccountInvoiceReport(models.Model):
             , fd.document_serie_id
             , fdl.fiscal_operation_id
             , fdl.fiscal_operation_line_id
+            , fdl.cfop_id
             , fdl.ncm_id
             , fdl.cest_id
-            , ip.value_text as fiscal_type
-            , fdl.cfop_id
+            , fdl.fiscal_type
             , SUM(fdl.icms_value) as icms_value
             , SUM(fdl.icmsst_value) as icmsst_value
             , SUM(fdl.ipi_value) as ipi_value
@@ -130,10 +130,6 @@ class AccountInvoiceReport(models.Model):
             LEFT JOIN product_product prd ON prd.id = ail.product_id
             LEFT JOIN product_template prd_tmpl ON
              prd_tmpl.id = prd.product_tmpl_id
-            LEFT JOIN ir_property ip ON
-             ip.name = 'fiscal_type'
-             AND ip.type = 'selection'
-             AND ip.res_id = 'product.template,' || prd_tmpl.id
         """
         return from_str
 
@@ -141,7 +137,6 @@ class AccountInvoiceReport(models.Model):
         group_by_str = super()._group_by()
         group_by_str += """
                 , fd.issuer
-                , ip.value_text
                 , fd.document_type_id
                 , fd.document_serie_id
                 , fdl.fiscal_operation_id
@@ -149,5 +144,6 @@ class AccountInvoiceReport(models.Model):
                 , fdl.cfop_id
                 , fdl.ncm_id
                 , fdl.cest_id
+                , fdl.fiscal_type
         """
         return group_by_str


### PR DESCRIPTION
Como o campo do fiscal_type agora é um campo property havia sido alterado no relatório de faturas para obter os valores desse campo através do property porém em um ambiente multi-empresa os valores dos relatórios estavam sendo multiplicados pela quantidade de property por empresa.

Como esse campo fica armazenado no l10n_br_fiscal.document.line, foi alterado o relatório para obter o valor através da linha do documento fiscal.