### PR TITLE
[12.0][FIX] l10n_br_nfe: Demo data, ID inexistente causava erro no testes/Travis

### DIFF
--- a/l10n_br_nfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_nfe/demo/fiscal_document_demo.xml
@@ -20,14 +20,6 @@
         <field name="fiscal_operation_type">out</field>
     </record>
 
-    <function model="l10n_br_fiscal.document" name="_onchange_company_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_same_state')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_same_state')]" />
-    </function>
-
     <record id="demo_nfe_line_same_state_1-1" model="l10n_br_fiscal.document.line">
         <field name="document_id" ref="demo_nfe_same_state" />
         <field name="name">Teste</field>
@@ -44,22 +36,10 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
     </function>
 
-    <record id="demo_nfe_line_same_state_1-1" model="l10n_br_fiscal.document.line">
-        <field name="price_unit">100</field>
-    </record>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
-    </function>
-
     <function
         model="l10n_br_fiscal.document.line"
         name="_onchange_fiscal_operation_line_id"
     >
-        <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
     </function>
 
@@ -79,22 +59,10 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
     </function>
 
-    <record id="demo_nfe_line_same_state_1-2" model="l10n_br_fiscal.document.line">
-        <field name="price_unit">100</field>
-    </record>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
-    </function>
-
     <function
         model="l10n_br_fiscal.document.line"
         name="_onchange_fiscal_operation_line_id"
     >
-        <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
     </function>
 
@@ -117,14 +85,6 @@
         <field name="fiscal_operation_type">out</field>
     </record>
 
-    <function model="l10n_br_fiscal.document" name="_onchange_company_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state')]" />
-    </function>
-
     <record
         id="demo_nfe_national_sale_for_same_state-1"
         model="l10n_br_fiscal.document.line"
@@ -143,26 +103,11 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]" />
     </function>
 
-    <record
-        id="demo_nfe_national_sale_for_same_state-1"
-        model="l10n_br_fiscal.document.line"
-    >
-        <field name="quantity">1</field>
-    </record>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]" />
-    </function>
-
     <function
         model="l10n_br_fiscal.document.line"
         name="_onchange_fiscal_operation_line_id"
     >
         <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state')]" />
     </function>
 
     <!-- NFe Test - Pessoa Física - ICMS 18% with a reduction of 51.11% -->
@@ -184,14 +129,6 @@
         <field name="fiscal_operation_type">out</field>
     </record>
 
-    <function model="l10n_br_fiscal.document" name="_onchange_company_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11')]" />
-    </function>
-
     <record
         id="demo_nfe_natural_icms_18_red_51_11-1"
         model="l10n_br_fiscal.document.line"
@@ -210,18 +147,10 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]" />
     </function>
 
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]" />
-    </function>
-
     <function
         model="l10n_br_fiscal.document.line"
         name="_onchange_fiscal_operation_line_id"
     >
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]" />
     </function>
 
@@ -244,14 +173,6 @@
         <field name="fiscal_operation_type">out</field>
     </record>
 
-    <function model="l10n_br_fiscal.document" name="_onchange_company_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale')]" />
-    </function>
-
     <record id="demo_nfe_natural_icms_7_resale-1" model="l10n_br_fiscal.document.line">
         <field name="document_id" ref="demo_nfe_natural_icms_7_resale" />
         <field name="name">Teste</field>
@@ -267,22 +188,10 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
     </function>
 
-    <record id="demo_nfe_natural_icms_7_resale-1" model="l10n_br_fiscal.document.line">
-        <field name="quantity">2</field>
-    </record>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
-    </function>
-
     <function
         model="l10n_br_fiscal.document.line"
         name="_onchange_fiscal_operation_line_id"
     >
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
     </function>
 


### PR DESCRIPTION
Removed unncessary onchanges and record with wrong ID.

Nos dados de demonstração do modulo l10n_br_nfe existia um ID errado https://github.com/OCA/l10n-brazil/blob/12.0/l10n_br_nfe/demo/fiscal_document_demo.xml#L165 e isso causava erro nos testes/Travis, segue o LOG do último PR feito no repo https://app.travis-ci.com/github/OCA/l10n-brazil/jobs/565412386#L2638 
![image](https://user-images.githubusercontent.com/6341149/161103737-ee6cc090-5fd3-4228-9b0d-862274201470.png)

![image](https://user-images.githubusercontent.com/6341149/161103909-bc90e9e3-cc73-4234-9d04-ceb9c7c98296.png)

Isso fazia com que os dados de demo do modulo l10n_br_nfe não fossem carregados, o que pode causar erro no caso de outros módulos que usem esses dados.

Aproveitando para resolver o problema eu vi com o @renatonlima que é desnecessário na criação dos dados de demo chamar os métodos "_onchange_company_id" e "_onchange_fiscal_operation_id"  no objeto "l10n_br_fiscal.document" e os "_onchange_fiscal_operation_id" e "_onchange_fiscal_taxes" no objeto "l10n_br_fiscal.document.line" por isso foram removidos inclusive o XML com o ID errado.

@rvalyi @marcelsavegnago @mileo @netosjb @felipemotter 