### PR TITLE
[14.0][l10n_br_fiscal][FORWARD PORT][REF] l10n_br_fiscal: Moved Comments creation method to be also used …

### DIFF
--- a/l10n_br_fiscal/models/document_workflow.py
+++ b/l10n_br_fiscal/models/document_workflow.py
@@ -302,6 +302,12 @@ class DocumentWorkflow(models.AbstractModel):
 
     def _document_confirm(self):
         if self.issuer == DOCUMENT_ISSUER_COMPANY:
+            if not self.comment_ids and self.fiscal_operation_id.comment_ids:
+                self.comment_ids |= self.fiscal_operation_id.comment_ids
+
+            for line in self.fiscal_line_ids:
+                if not line.comment_ids and line.fiscal_operation_line_id.comment_ids:
+                    line.comment_ids |= line.fiscal_operation_line_id.comment_ids
             self._change_state(SITUACAO_EDOC_A_ENVIAR)
 
     def action_document_confirm(self):


### PR DESCRIPTION
foward port de https://github.com/OCA/l10n-brazil/pull/1849 da parte do modulo l10n_br_fiscal
a parte referente ao modulo l10n_br_account esta marcada como TODO em https://github.com/OCA/l10n-brazil/issues/1578
cc @mbcosta 