### PR TITLE
[12.0][l10n_br_account_payment_order][REF] Payment mode sequence constraitnts

### DIFF
--- a/l10n_br_account_payment_order/models/account_payment_mode.py
+++ b/l10n_br_account_payment_order/models/account_payment_mode.py
@@ -153,33 +153,33 @@ class AccountPaymentMode(models.Model):
                 # Selecionavel na Ordem de Pagamento
                 record.payment_order_ok = True
 
-    @api.constrains("own_number_sequence_id")
-    def _check_own_number_sequence_id(self):
+    @api.constrains("own_number_sequence_id", "cnab_sequence_id")
+    def _check_sequences(self):
         for record in self:
-            already_in_use = record.search(
+            already_in_use = self.search(
                 [
                     ("id", "!=", record.id),
+                    "|",
                     ("own_number_sequence_id", "=", record.own_number_sequence_id.id),
+                    ("cnab_sequence_id", "=", record.cnab_sequence_id.id),
                 ],
                 limit=1,
             )
-            if already_in_use:
+
+            if already_in_use.own_number_sequence_id:
                 raise ValidationError(
-                    _("Sequence Own Number already in use by %s.") % already_in_use.name
+                    _(
+                        "Sequence Own Number already in use by {}!".format(
+                            already_in_use.name
+                        )
+                    )
                 )
 
-    @api.constrains("cnab_sequence_id")
-    def _check_cnab_sequence_id(self):
-        for record in self:
-            already_in_use = record.search(
-                [
-                    ("id", "!=", record.id),
-                    ("cnab_sequence_id", "=", record.cnab_sequence_id.id),
-                ]
-            )
-
-            if already_in_use:
+            if already_in_use.cnab_sequence_id:
                 raise ValidationError(
-                    _("Sequence CNAB Sequence already in use by %s.")
-                    % already_in_use.name
+                    _(
+                        "Sequence CNAB Sequence already in use by {}!".format(
+                            already_in_use.name
+                        )
+                    )
                 )


### PR DESCRIPTION
Ao invés de ter dois métodos constraints para o own_number_sequence_id e cnab_sequence_id foi refatorado para ter só um método, dessa forma não é preciso ter dois métodos e fazer dois search