### PR TITLE
[14.0][IMP] l10n_br_fiscal: add cnae_id

### DIFF
--- a/l10n_br_fiscal/models/document_fiscal_line_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin.py
@@ -853,3 +853,8 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     estimate_tax = fields.Monetary(
         string="Estimate Tax",
     )
+
+    cnae_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.cnae",
+        string="CNAE Code",
+    )

--- a/l10n_br_fiscal/views/document_line_view.xml
+++ b/l10n_br_fiscal/views/document_line_view.xml
@@ -57,6 +57,10 @@
                                     name="city_taxation_code_id"
                                     attrs="{'invisible': [('fiscal_genre_code', '!=', '00'), ('cfop_id', '!=', False)]}"
                                 />
+                <field
+                                    name="cnae_id"
+                                    attrs="{'invisible': [('fiscal_genre_code', '!=', '00'), ('cfop_id', '!=', False)]}"
+                                />
               </group>
               <group name="l10n_br_fiscal" string="Operation">
                 <field name="fiscal_operation_type" invisible="1" readonly="1" />


### PR DESCRIPTION
Ref. https://github.com/OCA/l10n-brazil/issues/1865

Movendo o campo cnae_id do módulo l10n_br_nfse para o l10n_br_fiscal

Obs. No módulo l10n_br_nfse é aplicado um dominio para filtrar apenas os cnaes vinculados na empresa. Porém, isto impacta na informação do cnae no caso da compra do serviço. No caso de venda, posteriormente pode ser sobreposto o dominio do campo cnae_id para permitir apenas a seleção do cnae principal e secundários configurados na empresa.

Exemplo:
https://github.com/OCA/l10n-brazil/pull/1854/commits/ceafbe8d0f05410f756f12848943a08abb055fab