### PR TITLE
[12.0][FIX] l10n_br_sale: change fiscal_operation_id domain

### DIFF
--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -25,7 +25,7 @@ class SaleOrder(models.Model):
 
     @api.model
     def _fiscal_operation_domain(self):
-        domain = [("state", "=", "approved")]
+        domain = [("state", "=", "approved"), ("fiscal_operation_type", "=", "out")]
         return domain
 
     fiscal_operation_id = fields.Many2one(

--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -19,7 +19,7 @@ class SaleOrderLine(models.Model):
 
     @api.model
     def _fiscal_operation_domain(self):
-        domain = [("state", "=", "approved")]
+        domain = [("state", "=", "approved"), ("fiscal_operation_type", "=", "out")]
         return domain
 
     fiscal_operation_id = fields.Many2one(


### PR DESCRIPTION
Ajuste no dominio do campo fiscal_operation_id na sale.order e sale.order.line para que sejam mostrados apenas as operações de saída, de maneira semelhante ao que acontece para purchase.order, onde são mostradas apenas operações de entrada.

Atual:
![antes](https://user-images.githubusercontent.com/63242917/163227617-fd3a0f23-54af-4e2b-9aeb-00620524caf6.png)

Com a modificação:
![depois](https://user-images.githubusercontent.com/63242917/163227697-61c5228e-17ef-4994-93fd-d402ee735a49.png)
