### PR TITLE
[12.0][FIX] l10n_br_contract: fix discount_value and price_unit

### DIFF
--- a/l10n_br_contract/models/contract_contract.py
+++ b/l10n_br_contract/models/contract_contract.py
@@ -91,11 +91,13 @@ class ContractContract(models.Model):
 
             for line in invoice.invoice_line_ids:
                 name = line.name
+                price = line.contract_line_id.price_unit
                 line._onchange_product_id_fiscal()
                 line.name = name
-                line.price_unit = line.contract_line_id.price_unit
+                line.price_unit = price
                 line._onchange_fiscal_operation_id()
                 line._onchange_fiscal_tax_ids()
+                line.price_unit = price
 
             invoice._onchange_invoice_line_ids()
 

--- a/l10n_br_contract/models/contract_line.py
+++ b/l10n_br_contract/models/contract_line.py
@@ -43,6 +43,9 @@ class ContractLine(models.Model):
         if values:
             values.update(self._prepare_br_fiscal_dict())
             values["quantity"] = quantity
+            values["discount_value"] = (self.quantity * self.price_unit) * (
+                self.discount / 100
+            )
         return values
 
     @api.model


### PR DESCRIPTION
- [x] fix discount_value
- [x] fix price_unit (resolvido porcamente)

O problema do price_unit é que se executar os métodos _onchange_product_id_fiscal e _onchange_fiscal_tax_ids o preço unitário do contrato é desconsiderado e a fatura assume o valor do preço de venda/compra configurado no produto.

https://github.com/OCA/l10n-brazil/blob/1ec5bb7a89772d33ca18aecfae2cc98a72adcbca/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py#L372

https://github.com/OCA/l10n-brazil/blob/1ec5bb7a89772d33ca18aecfae2cc98a72adcbca/l10n_br_account/models/account_invoice_line.py#L296

https://github.com/odoo/odoo/blob/0f9b472b68c2db019e7563ebb695f5f69687aa15/addons/account/models/account_invoice.py#L1822
