### PR TITLE
[12.0][FIX] l10n_br_fiscal: Fix ICMS FCP domains to avoid invisible registers

### DIFF
--- a/l10n_br_fiscal/models/icms_regulation.py
+++ b/l10n_br_fiscal/models/icms_regulation.py
@@ -86,7 +86,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP AC",
         domain=[
             ("state_from_id.code", "=", "AC"),
-            ("state_to_ids.code", "=", "AC"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
         ],
     )
@@ -129,7 +128,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP AL",
         domain=[
             ("state_from_id.code", "=", "AL"),
-            ("state_to_ids.code", "=", "AL"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
         ],
     )
@@ -172,7 +170,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP AM",
         domain=[
             ("state_from_id.code", "=", "AM"),
-            ("state_to_ids.code", "=", "AM"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
         ],
     )
@@ -215,7 +212,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP AP",
         domain=[
             ("state_from_id.code", "=", "AP"),
-            ("state_to_ids.code", "=", "AP"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
         ],
     )
@@ -259,7 +255,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP BA",
         domain=[
             ("state_from_id.code", "=", "BA"),
-            ("state_to_ids.code", "=", "BA"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
         ],
     )
@@ -303,7 +298,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP CE",
         domain=[
             ("state_from_id.code", "=", "CE"),
-            ("state_to_ids.code", "=", "CE"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
         ],
     )
@@ -347,7 +341,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP DF",
         domain=[
             ("state_from_id.code", "=", "DF"),
-            ("state_to_ids.code", "=", "DF"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
         ],
     )
@@ -391,7 +384,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP ES",
         domain=[
             ("state_from_id.code", "=", "ES"),
-            ("state_to_ids.code", "=", "ES"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
         ],
     )
@@ -435,7 +427,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP GO",
         domain=[
             ("state_from_id.code", "=", "GO"),
-            ("state_to_ids.code", "=", "GO"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
         ],
     )
@@ -479,7 +470,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP MA",
         domain=[
             ("state_from_id.code", "=", "MA"),
-            ("state_to_ids.code", "=", "MA"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
         ],
     )
@@ -523,7 +513,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP MT",
         domain=[
             ("state_from_id.code", "=", "MT"),
-            ("state_to_ids.code", "=", "MT"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
         ],
     )
@@ -567,7 +556,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP MS",
         domain=[
             ("state_from_id.code", "=", "MS"),
-            ("state_to_ids.code", "=", "MS"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
         ],
     )
@@ -611,7 +599,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP MG",
         domain=[
             ("state_from_id.code", "=", "MG"),
-            ("state_to_ids.code", "=", "MG"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
         ],
     )
@@ -655,7 +642,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP PA",
         domain=[
             ("state_from_id.code", "=", "PA"),
-            ("state_to_ids.code", "=", "PA"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
         ],
     )
@@ -699,7 +685,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP PB",
         domain=[
             ("state_from_id.code", "=", "PB"),
-            ("state_to_ids.code", "=", "PB"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
         ],
     )
@@ -743,7 +728,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP PR",
         domain=[
             ("state_from_id.code", "=", "PR"),
-            ("state_to_ids.code", "=", "PR"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
         ],
     )
@@ -787,7 +771,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP PE",
         domain=[
             ("state_from_id.code", "=", "PE"),
-            ("state_to_ids.code", "=", "PE"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
         ],
     )
@@ -831,7 +814,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP PI",
         domain=[
             ("state_from_id.code", "=", "PI"),
-            ("state_to_ids.code", "=", "PI"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
         ],
     )
@@ -875,7 +857,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP RN",
         domain=[
             ("state_from_id.code", "=", "RN"),
-            ("state_to_ids.code", "=", "RN"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
         ],
     )
@@ -919,7 +900,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP RS",
         domain=[
             ("state_from_id.code", "=", "RS"),
-            ("state_to_ids.code", "=", "RS"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
         ],
     )
@@ -963,7 +943,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP RJ",
         domain=[
             ("state_from_id.code", "=", "RJ"),
-            ("state_to_ids.code", "=", "RJ"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
         ],
     )
@@ -1007,7 +986,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP RO",
         domain=[
             ("state_from_id.code", "=", "RO"),
-            ("state_to_ids.code", "=", "RO"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
         ],
     )
@@ -1051,7 +1029,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP RR",
         domain=[
             ("state_from_id.code", "=", "RR"),
-            ("state_to_ids.code", "=", "RR"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
         ],
     )
@@ -1095,7 +1072,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP SC",
         domain=[
             ("state_from_id.code", "=", "SC"),
-            ("state_to_ids.code", "=", "SC"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
         ],
     )
@@ -1138,7 +1114,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP SP",
         domain=[
             ("state_from_id.code", "=", "SP"),
-            ("state_to_ids.code", "=", "SP"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
         ],
     )
@@ -1182,7 +1157,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP SE",
         domain=[
             ("state_from_id.code", "=", "SE"),
-            ("state_to_ids.code", "=", "SE"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
         ],
     )
@@ -1226,7 +1200,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP TO",
         domain=[
             ("state_from_id.code", "=", "TO"),
-            ("state_to_ids.code", "=", "TO"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
         ],
     )


### PR DESCRIPTION
Altera o dominio dos campos icms_fcp_{UF}_id para todos os Estados, de forma que passem a mostrar também FCPs com outros Estados de destino.

Atualmente, caso seja criado um registro de ICMS FCP cujos Estados de destino não incluam o Estado de origem, este registro é criado sem problemas e é aplicado no cálculo de impostos, mas (após a página do Regulamento ICMS ser atualizada) não pode ser acessado de local nenhum, tornando impossível modifica-lo ou deleta-lo.

Criação de um registro ICMS FCP com origem em SP e destino não incluindo SP:
![registro](https://user-images.githubusercontent.com/63242917/164015604-1d5e8183-4bb5-4852-b60c-1f0104cf3f87.png)

Imposto incluso na criação de uma nova order.line em uma Sale Order:
![order_line](https://user-images.githubusercontent.com/63242917/164015723-cf20c057-cc9b-4174-809f-74142ef4681b.png)

Visão do Regulamento ICMS para SP com domínio atual:
![icms_regulation](https://user-images.githubusercontent.com/63242917/164015953-82e0d0b4-0dfa-4fa0-9f1d-bfb192c8bd87.png)

Visão do Regulamento ICMS para SP com domínio modificado:
![icms_regulation_after](https://user-images.githubusercontent.com/63242917/164016855-9f87efbd-a54c-4466-84a5-a77601d8c169.png)

