### PR TITLE
[12.0][FIX] payment_pagseguro: Timeout for pagseguro step tour

### DIFF
--- a/payment_pagseguro/static/src/js/pagseguro_tour.js
+++ b/payment_pagseguro/static/src/js/pagseguro_tour.js
@@ -110,10 +110,21 @@ odoo.define("payment_pagseguro.tour", function (require) {
             },
             {
                 content: "payment authorized",
+                extra_trigger: ".bg-success",
                 trigger:
                     '.bg-success span:contains("Your payment has been authorized.")',
+                timeout: 20000,
+            },
+            {
+                content: "finish",
+                trigger: "body",
+                // Leave /shop/confirmation to prevent RPC loop to
+                //      /shop/payment/get_status.
+                // The RPC could be handled in python while the tour is
+                //      killed (and the session), leading to crashes
                 run: function () {
-                    // It's a check
+                    // Redirect in JS to avoid the RPC loop (20x1sec)
+                    window.location.href = "/aboutus";
                 },
             },
         ]

--- a/payment_pagseguro/tests/test_pagseguro.py
+++ b/payment_pagseguro/tests/test_pagseguro.py
@@ -21,7 +21,7 @@ class PagseguroTest(odoo.tests.HttpCase):
             "odoo.__DEBUG__.services['web_tour.tour'].run('shop_buy_pagseguro')",
             "odoo.__DEBUG__.services['web_tour.tour'].tours.shop_buy_pagseguro.ready",
             login="admin",
-            timeout=20000,
+            timeout=40000,
         )
 
         tx = self.env["payment.transaction"].search([], limit=1, order="id desc")


### PR DESCRIPTION
Notamos que em alguns testes do travis na OCA o último passo da tour da pagseguro resultava em erro.
Olhando as logs do travis, vimos que isso acontecia quando a resposta da Pagseguro demorava alguns segundos a mais que o normal (2s).
Adicionamos o timeout no último passo e mais um passo de segurança para voltar a tela de about us.
Exemplo de builds que encontramos esse erro:
https://app.travis-ci.com/github/OCA/l10n-brazil/jobs/566453661 
