### PR TITLE
[12.0][l10n_br_fiscal] fix property migrations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ env:
 
 
 install:
-  - git clone --depth=1 https://github.com/OCA/maintainer-quality-tools.git
+  - git clone --depth=1 https://github.com/akretion/maintainer-quality-tools.git -b master-no-QUnitSuite
     ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - export WKHTMLTOPDF_VERSION=0.12.5

--- a/l10n_br_fiscal/migrations/12.0.25.0.0/pre-migration.py
+++ b/l10n_br_fiscal/migrations/12.0.25.0.0/pre-migration.py
@@ -11,14 +11,13 @@ def migrate(env, version):
 
     companies = env["res.company"].search([])
     for company in companies:
-        products = env["product.template"].search(
-            [
-                "|",
-                ("company_id", "=", company.id),
-                ("company_id", "=", False),
-                ("fiscal_type", "!=", False),
-            ]
+        env.cr.execute(
+            "SELECT id, fiscal_type FROM product_template "
+            "WHERE fiscal_type is not NULL "
+            "AND (company_id=%s OR company_id IS NULL)",
+            (company.id,),
         )
+        products = env.cr.fetchall()
         for product in products:
             env["ir.property"].create(
                 {
@@ -26,7 +25,7 @@ def migrate(env, version):
                     "fields_id": field_property.id,
                     "company_id": company.id,
                     "type": "selection",
-                    "res_id": "{},{}".format(product._name, product.id),
-                    "value_text": product.fiscal_type,
+                    "res_id": "product.template,{}".format(product[0]),
+                    "value_text": product[1],
                 }
             )


### PR DESCRIPTION
resolve esse bug https://github.com/OCA/l10n-brazil/issues/1862 e o mesmo tipo de bug com a migração do campo fiscal_type.
Basicamente no script de pre-migration, o update ainda nao rodou no banco mas os campos Python dos objetos já foram carregados e nisso nao tem mais esses campos icms_origin ou fiscal_type para usar um domain Odoo. Eu usar um SELECT então.

cc @vanderleiromera @renatonlima 