### PR TITLE
[14.0][IMP] l10n_br_fiscal: add city_taxation_code_ids on tax_definition

### DIFF
--- a/l10n_br_fiscal/models/city_taxation_code.py
+++ b/l10n_br_fiscal/models/city_taxation_code.py
@@ -32,3 +32,12 @@ class CityTaxationCode(models.Model):
         comodel_name="l10n_br_fiscal.cnae",
         string="CNAE Code",
     )
+
+    tax_definition_ids = fields.Many2many(
+        comodel_name="l10n_br_fiscal.tax.definition",
+        relation="tax_definition_city_taxation_code_rel",
+        column1="city_taxation_code_id",
+        column2="tax_definition_id",
+        readonly=True,
+        string="Tax Definition",
+    )

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -333,6 +333,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 nbm=self.nbm_id,
                 nbs=self.nbs_id,
                 cest=self.cest_id,
+                city_taxation_code=self.city_taxation_code_id,
             )
 
             self.ipi_guideline_id = mapping_result["ipi_guideline"]
@@ -797,6 +798,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
     def _onchange_city_taxation_code_id(self):
         if self.city_taxation_code_id:
             self.cnae_id = self.city_taxation_code_id.cnae_id
+            self._onchange_fiscal_operation_id()
 
     @api.model
     def _add_fields_to_amount(self):

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -191,6 +191,7 @@ class OperationLine(models.Model):
         nbm=None,
         nbs=None,
         cest=None,
+        city_taxation_code=None,
     ):
 
         mapping_result = {
@@ -208,7 +209,14 @@ class OperationLine(models.Model):
 
         # 1 Get Tax Defs from Company
         for tax_definition in company.tax_definition_ids.map_tax_definition(
-            company, partner, product, ncm=ncm, nbm=nbm, nbs=nbs, cest=cest
+            company,
+            partner,
+            product,
+            ncm=ncm,
+            nbm=nbm,
+            nbs=nbs,
+            cest=cest,
+            city_taxation_code=city_taxation_code,
         ):
             self._build_mapping_result(mapping_result, tax_definition)
 
@@ -241,13 +249,27 @@ class OperationLine(models.Model):
 
         # 4 From Operation Line
         for tax_definition in self.tax_definition_ids.map_tax_definition(
-            company, partner, product, ncm=ncm, nbm=nbm, nbs=nbs, cest=cest
+            company,
+            partner,
+            product,
+            ncm=ncm,
+            nbm=nbm,
+            nbs=nbs,
+            cest=cest,
+            city_taxation_code=city_taxation_code,
         ):
             self._build_mapping_result(mapping_result, tax_definition)
 
         # 5 From CFOP
         for tax_definition in cfop.tax_definition_ids.map_tax_definition(
-            company, partner, product, ncm=ncm, nbm=nbm, nbs=nbs, cest=cest
+            company,
+            partner,
+            product,
+            ncm=ncm,
+            nbm=nbm,
+            nbs=nbs,
+            cest=cest,
+            city_taxation_code=city_taxation_code,
         ):
             self._build_mapping_result(mapping_result, tax_definition)
 
@@ -255,7 +277,14 @@ class OperationLine(models.Model):
         for (
             tax_definition
         ) in partner.fiscal_profile_id.tax_definition_ids.map_tax_definition(
-            company, partner, product, ncm=ncm, nbm=nbm, nbs=nbs, cest=cest
+            company,
+            partner,
+            product,
+            ncm=ncm,
+            nbm=nbm,
+            nbs=nbs,
+            cest=cest,
+            city_taxation_code=city_taxation_code,
         ):
             self._build_mapping_result(mapping_result, tax_definition)
 

--- a/l10n_br_fiscal/models/tax_definition.py
+++ b/l10n_br_fiscal/models/tax_definition.py
@@ -198,6 +198,14 @@ class TaxDefinition(models.Model):
         string="Products",
     )
 
+    city_taxation_code_ids = fields.Many2many(
+        comodel_name="l10n_br_fiscal.city.taxation.code",
+        relation="tax_definition_city_taxation_code_rel",
+        column1="tax_definition_id",
+        column2="city_taxation_code_id",
+        string="City Taxation Codes",
+    )
+
     date_start = fields.Datetime(
         string="Start Date",
         readonly=True,
@@ -331,7 +339,15 @@ class TaxDefinition(models.Model):
         return write_super
 
     def map_tax_definition(
-        self, company, partner, product, ncm=None, nbm=None, nbs=None, cest=None
+        self,
+        company,
+        partner,
+        product,
+        ncm=None,
+        nbm=None,
+        nbs=None,
+        cest=None,
+        city_taxation_code=None,
     ):
 
         if not ncm:
@@ -357,6 +373,9 @@ class TaxDefinition(models.Model):
             "|",
             ("cest_ids", "=", False),
             ("cest_ids", "=", cest.id),
+            "|",
+            ("city_taxation_code_ids", "=", False),
+            ("city_taxation_code_ids", "=", city_taxation_code.id),
             "|",
             ("product_ids", "=", False),
             ("product_ids", "=", product.id),

--- a/l10n_br_fiscal/views/tax_definition_view.xml
+++ b/l10n_br_fiscal/views/tax_definition_view.xml
@@ -177,6 +177,16 @@
                                 />
               </group>
             </page>
+            <page name="city_taxation_codes_page" string="City Taxation Code">
+              <group name="city_taxation_codes" string="City Taxation Codes">
+                <field
+                                    name="city_taxation_code_ids"
+                                    force_save="1"
+                                    nolabel="1"
+                                    colspan="2"
+                                />
+              </group>
+            </page>
             <page name="products_page" string="Product">
               <group name="products" string="Products">
                 <field name="product_ids" force_save="1" nolabel="1" colspan="2" />


### PR DESCRIPTION
Permite configura nas linhas das operacoes fiscais, em Definição de Tributos, regra para aplicar x imposto a X codigos de tributação da cidade. Isto permite configurar coisas como ISSQN 4% para o codigo de tribução X ou ISSQN 2% para o codigo de tributação Y

![image](https://user-images.githubusercontent.com/3595132/166253401-1c883991-850a-4bc4-a14e-cf49216355a5.png)


