### PR TITLE
[14.0][FIX] l10n_br_fiscal: product variants tax definition

### DIFF
--- a/l10n_br_fiscal/models/product_template.py
+++ b/l10n_br_fiscal/models/product_template.py
@@ -105,6 +105,5 @@ class ProductTemplate(models.Model):
         relation="tax_definition_product_rel",
         column1="product_id",
         column2="tax_definition_id",
-        readonly=True,
         string="Tax Definition",
     )


### PR DESCRIPTION
Na V14 quando é adicionado uma variante em tax definition (lah em linha da operacao fiscal) o sistema apresenta erro de relacionamento com tax_definition. Em alguns casos o sistema até permite gravar a linha da operacao fiscal mas quando o modulo fiscal eh atualizado a mensagem de erro aparece durante a atualização

![image](https://user-images.githubusercontent.com/3595132/166256461-decb1cef-15c5-4f55-a6bd-ced11c2293bb.png)
