### PR TITLE
[12.0] Campo tax_icms_or_issqn visível nas linhas dos documentos fiscais

### DIFF
--- a/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
@@ -28,11 +28,17 @@
           <field name="uot_id" force_save="1" invisible="1" />
           <field name="fiscal_price" force_save="1" invisible="1" />
           <field name="fiscal_quantity" force_save="1" invisible="1" />
-          <field name="tax_icms_or_issqn" force_save="1" invisible="1" />
           <field name="fiscal_tax_ids" force_save="1" invisible="1" readonly="1" />
         </group>
         <notebook>
+          <field name="product_id" force_save="1" invisible="1" />
           <page name="fiscal_taxes" string="Taxes">
+            <group>
+              <field
+                                name="tax_icms_or_issqn"
+                                attrs="{'readonly': [('product_id', '!=', False), ('tax_icms_or_issqn', '!=', False)], 'required': [('fiscal_tax_ids', '!=', False)]}"
+                            />
+            </group>
             <notebook>
               <page
                                 name="issqn"


### PR DESCRIPTION
Pessoal em alguns casos, principalmente quando é emitida alguma NF-e sem o campo do produto preenchido como NF-e complementares, o campo tax_icms_or_issqn deve ser visível para poder ser preenchido manualmente. (Esse campo continua sendo preenchido automático quando o produto é informado. 

![image](https://user-images.githubusercontent.com/211005/166518088-79c4f615-1d45-498e-a495-cbb3aae227aa.png)