### PR TITLE
[14.0] Update python lib erpbrasil.assinatura version 1.4.0

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -109,7 +109,7 @@
     "external_dependencies": {
         "python": [
             "erpbrasil.base",
-            "erpbrasil.assinatura-nopyopenssl",
+            "erpbrasil.assinatura",
         ]
     },
 }

--- a/l10n_br_nfse/__manifest__.py
+++ b/l10n_br_nfse/__manifest__.py
@@ -13,7 +13,7 @@
     "external_dependencies": {
         "python": [
             "erpbrasil.edoc",
-            "erpbrasil.assinatura-nopyopenssl",
+            "erpbrasil.assinatura",
             "erpbrasil.transmissao",
             "erpbrasil.base",
         ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # generated from manifests external_dependencies
-erpbrasil.assinatura-nopyopenssl
+erpbrasil.assinatura
 erpbrasil.base
 erpbrasil.edoc
 erpbrasil.transmissao


### PR DESCRIPTION
Recentemente foi feito a liberação da versão 1.4.0 da lib erpbrasil.assinatura com as últimas mudanças, então neste caso podemos voltar a utilizar a versão oficial da lib.