### PR TITLE
[14.0] Consultar impostos aproximados via IBPT API

### DIFF
--- a/l10n_br_fiscal/models/data_ncm_nbs_abstract.py
+++ b/l10n_br_fiscal/models/data_ncm_nbs_abstract.py
@@ -94,22 +94,24 @@ class DataNcmNbsAbstract(models.AbstractModel):
 
                 result = self._get_ibpt(config, record.code_unmasked)
 
-                values = {
-                    object_field: record.id,
-                    "key": result.chave,
-                    "origin": result.fonte,
-                    "state_id": company.state_id.id,
-                    "state_taxes": result.estadual,
-                    "federal_taxes_national": result.nacional,
-                    "federal_taxes_import": result.importado,
-                }
+                if result:
 
-                self.env["l10n_br_fiscal.tax.estimate"].create(values)
+                    values = {
+                        object_field: record.id,
+                        "key": result.chave,
+                        "origin": result.fonte,
+                        "state_id": company.state_id.id,
+                        "state_taxes": result.estadual,
+                        "federal_taxes_national": result.nacional,
+                        "federal_taxes_import": result.importado,
+                    }
 
-                record.message_post(
-                    body=_("{} Tax Estimate Updated").format(object_name),
-                    subject=_("{} Tax Estimate Updated").format(object_name),
-                )
+                    self.env["l10n_br_fiscal.tax.estimate"].create(values)
+
+                    record.message_post(
+                        body=_("{} Tax Estimate Updated").format(object_name),
+                        subject=_("{} Tax Estimate Updated").format(object_name),
+                    )
 
             except Exception as e:
                 _logger.warning(

--- a/l10n_br_fiscal/models/ibpt/taxes.py
+++ b/l10n_br_fiscal/models/ibpt/taxes.py
@@ -23,7 +23,7 @@ DeOlhoNoImposto = namedtuple("Config", "token cnpj uf")
 
 def _request(ws_url, params):
     try:
-        response = requests.get(ws_url, params=params)
+        response = requests.get(ws_url, params=params, timeout=5)
         if response.ok:
             data = response.json()
             return namedtuple("Result", [k.lower() for k in data.keys()])(
@@ -39,15 +39,9 @@ def _request(ws_url, params):
                 )
             )
         elif response.status_code == requests.codes.not_found:
-            # TODO
-            raise UserError(
-                _(
-                    "IBPT Forbidden - token={!r}, "
-                    "cnpj={!r}, UF={!r}".format(
-                        params.get("token"), params.get("cnpj"), params.get("uf")
-                    )
-                )
-            )
+            raise UserError(_("IBPT URL not found - {!r}".format(ws_url)))
+        elif response.status_code == requests.codes.service_unavailable:
+            raise UserError(_("IBPT Service Unavailable - {!r}".format(ws_url)))
     except Exception as e:
         raise UserError(_("Error in the request: {}".format(e)))
 

--- a/l10n_br_fiscal/tests/test_ibpt.py
+++ b/l10n_br_fiscal/tests/test_ibpt.py
@@ -1,0 +1,93 @@
+# Copyright 2019 Akretion - Renato Lima <renato.lima@akretion.com.br>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from erpbrasil.base import misc
+
+from odoo.tests import SavepointCase
+
+from odoo.addons.l10n_br_fiscal.models.ibpt.taxes import (
+    DeOlhoNoImposto,
+    get_ibpt_product,
+    get_ibpt_service,
+)
+
+
+class TestIbpt(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+
+        super().setUpClass()
+        cls.company = cls._create_compay()
+        cls._switch_user_company(cls.env.user, cls.company)
+        cls.product_tmpl_model = cls.env["product.template"]
+        cls.tax_estimate_model = cls.env["l10n_br_fiscal.tax.estimate"]
+        cls.ncm_model = cls.env["l10n_br_fiscal.ncm"]
+        cls.nbs_model = cls.env["l10n_br_fiscal.nbs"]
+
+    @classmethod
+    def _switch_user_company(cls, user, company):
+        """Add a company to the user's allowed & set to current."""
+        user.write(
+            {
+                "company_ids": [(6, 0, (company + user.company_ids).ids)],
+                "company_id": company.id,
+            }
+        )
+
+    @classmethod
+    def _check_ibpt_api(cls, company, ncm_nbs):
+        """Check if IBPT API Webservice is online"""
+
+        result = False
+        try:
+            config = DeOlhoNoImposto(
+                company.ibpt_token,
+                misc.punctuation_rm(company.cnpj_cpf),
+                company.state_id.code,
+            )
+            if ncm_nbs._name == "l10n_br_fiscal.ncm":
+                result = bool(get_ibpt_product(config, ncm_nbs.code_unmasked))
+
+            if ncm_nbs._name == "l10n_br_fiscal.nbs":
+                result = bool(get_ibpt_service(config, ncm_nbs.code_unmasked))
+        except Exception:
+            result = False
+        return result
+
+    @classmethod
+    def _create_compay(cls):
+        """Create and config Company to test IBPT API"""
+        # Creating a company
+        company = cls.env["res.company"].create(
+            {
+                "name": "Company Test Fiscal BR",
+                "cnpj_cpf": "02.960.895/0002-12",
+                "country_id": cls.env.ref("base.br").id,
+                "state_id": cls.env.ref("base.state_br_es").id,
+                "ibpt_api": True,
+                "ibpt_update_days": 0,
+                "ibpt_token": (
+                    "dsaaodNP5i6RCu007nPQjiOPe5XIefnx"
+                    "StS2PzOV3LlDRVNGdVJ5OOUlwWZhjFZk"
+                ),
+            }
+        )
+
+        if not cls._check_ibpt_api(company, cls.env.ref("l10n_br_fiscal.ncm_85030010")):
+            company.write({"ibpt_api": False})
+
+        return company
+
+    @classmethod
+    def _create_product_tmpl(cls, name, ncm):
+        """Create products related with NCM"""
+
+        product = cls.product_tmpl_model.create({"name": name, "ncm_id": ncm.id})
+        return product
+
+    @classmethod
+    def _create_service_tmpl(cls, name, nbs):
+        """Create services related with NBS"""
+
+        product = cls.product_tmpl_model.create({"name": name, "nbs_id": nbs.id})
+        return product

--- a/l10n_br_fiscal/tests/test_ibpt_product.py
+++ b/l10n_br_fiscal/tests/test_ibpt_product.py
@@ -1,18 +1,17 @@
 # Copyright 2019 Akretion - Renato Lima <renato.lima@akretion.com.br>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo.tests import SavepointCase
+from .test_ibpt import TestIbpt
 
 
-class TestIbptProduct(SavepointCase):
+class TestIbptProduct(TestIbpt):
     @classmethod
     def setUpClass(cls):
+
         super().setUpClass()
-        cls.company = cls._create_compay()
-        cls._switch_user_company(cls.env.user, cls.company)
         cls.ncm_85030010 = cls.env.ref("l10n_br_fiscal.ncm_85030010")
         cls.ncm_85014029 = cls.env.ref("l10n_br_fiscal.ncm_85014029")
-        cls.product_tmpl_model = cls.env["product.template"]
+
         cls.product_tmpl_1 = cls._create_product_tmpl(
             name="Product Test 1 - With NCM: 8503.00.10", ncm=cls.ncm_85030010
         )
@@ -25,46 +24,12 @@ class TestIbptProduct(SavepointCase):
             name="Product Test 3 - With NCM: 8501.40.29", ncm=cls.ncm_85014029
         )
 
-        cls.tax_estimate_model = cls.env["l10n_br_fiscal.tax.estimate"]
-        cls.ncm_model = cls.env["l10n_br_fiscal.ncm"]
-
-    @classmethod
-    def _switch_user_company(cls, user, company):
-        """Add a company to the user's allowed & set to current."""
-        user.write(
-            {
-                "company_ids": [(6, 0, (company + user.company_ids).ids)],
-                "company_id": company.id,
-            }
-        )
-
-    @classmethod
-    def _create_compay(cls):
-        # Creating a company
-        company = cls.env["res.company"].create(
-            {
-                "name": "Company Test Fiscal BR",
-                "cnpj_cpf": "02.960.895/0002-12",
-                "country_id": cls.env.ref("base.br").id,
-                "state_id": cls.env.ref("base.state_br_es").id,
-                "ibpt_api": True,
-                "ibpt_update_days": 0,
-                "ibpt_token": (
-                    "dsaaodNP5i6RCu007nPQjiOPe5XIefnx"
-                    "StS2PzOV3LlDRVNGdVJ5OOUlwWZhjFZk"
-                ),
-            }
-        )
-        return company
-
-    @classmethod
-    def _create_product_tmpl(cls, name, ncm):
-        # Creating a product
-        product = cls.product_tmpl_model.create({"name": name, "ncm_id": ncm.id})
-        return product
-
     def test_update_ibpt_product(self):
         """Check tax estimate update"""
+
+        if not self.company.ibpt_api:
+            return
+
         self.ncm_85030010.action_ibpt_inquiry()
         self.assertTrue(self.ncm_85030010.tax_estimate_ids)
 
@@ -77,11 +42,19 @@ class TestIbptProduct(SavepointCase):
 
     def test_ncm_count_product_template(self):
         """Check product template relation with NCM"""
+
+        if not self.company.ibpt_api:
+            return
+
         self.assertEqual(self.ncm_85030010.product_tmpl_qty, 2)
         self.assertEqual(self.ncm_85014029.product_tmpl_qty, 1)
 
     def test_update_scheduled(self):
         """Check NCM update scheduled"""
+
+        if not self.company.ibpt_api:
+            return
+
         ncms = self.ncm_model.search(
             [("id", "in", (self.ncm_85030010.id, self.ncm_85014029.id))]
         )

--- a/l10n_br_fiscal/tests/test_ibpt_service.py
+++ b/l10n_br_fiscal/tests/test_ibpt_service.py
@@ -1,71 +1,35 @@
 # Copyright 2019 Akretion - Renato Lima <renato.lima@akretion.com.br>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo.tests import SavepointCase
+from .test_ibpt import TestIbpt
 
 
-class TestIbptService(SavepointCase):
+class TestIbptService(TestIbpt):
     @classmethod
     def setUpClass(cls):
-        super().setUpClass()
 
-        cls.company = cls._create_compay()
-        cls._switch_user_company(cls.env.user, cls.company)
+        super().setUpClass()
         cls.nbs_115069000 = cls.env.ref("l10n_br_fiscal.nbs_115069000")
         cls.nbs_124043300 = cls.env.ref("l10n_br_fiscal.nbs_124043300")
-        cls.product_tmpl_model = cls.env["product.template"]
-        cls.product_tmpl_1 = cls._create_product_tmpl(
+
+        cls.product_tmpl_1 = cls._create_service_tmpl(
             name="Service Test 1 - With NBS: 1.1506.90.00", nbs=cls.nbs_115069000
         )
 
-        cls.product_tmpl_2 = cls._create_product_tmpl(
+        cls.product_tmpl_2 = cls._create_service_tmpl(
             name="Product Test 2 - With NBS: 1.1506.90.00", nbs=cls.nbs_115069000
         )
 
-        cls.product_tmpl_3 = cls._create_product_tmpl(
+        cls.product_tmpl_3 = cls._create_service_tmpl(
             name="Product Test 3 - With NBS: 1.2404.33.00", nbs=cls.nbs_124043300
         )
 
-        cls.tax_estimate_model = cls.env["l10n_br_fiscal.tax.estimate"]
-        cls.nbs_model = cls.env["l10n_br_fiscal.nbs"]
-
-    @classmethod
-    def _switch_user_company(cls, user, company):
-        """Add a company to the user's allowed & set to current."""
-        user.write(
-            {
-                "company_ids": [(6, 0, (company + user.company_ids).ids)],
-                "company_id": company.id,
-            }
-        )
-
-    @classmethod
-    def _create_compay(cls):
-        # Creating a company
-        company = cls.env["res.company"].create(
-            {
-                "name": "Company Test Fiscal BR",
-                "cnpj_cpf": "02.960.895/0002-12",
-                "country_id": cls.env.ref("base.br").id,
-                "state_id": cls.env.ref("base.state_br_es").id,
-                "ibpt_api": True,
-                "ibpt_update_days": 0,
-                "ibpt_token": (
-                    "dsaaodNP5i6RCu007nPQjiOPe5XIefnx"
-                    "StS2PzOV3LlDRVNGdVJ5OOUlwWZhjFZk"
-                ),
-            }
-        )
-        return company
-
-    @classmethod
-    def _create_product_tmpl(cls, name, nbs):
-        # Creating a product
-        product = cls.product_tmpl_model.create({"name": name, "nbs_id": nbs.id})
-        return product
-
     def test_update_ibpt_service(self):
         """Check tax estimate update"""
+
+        if not self.company.ibpt_api:
+            return
+
         self.nbs_115069000.action_ibpt_inquiry()
         self.assertTrue(self.nbs_115069000.tax_estimate_ids)
 
@@ -78,11 +42,19 @@ class TestIbptService(SavepointCase):
 
     def test_nbs_count_product_template(self):
         """Check product template relation with NBS"""
+
+        if not self.company.ibpt_api:
+            return
+
         self.assertEqual(self.nbs_115069000.product_tmpl_qty, 2)
         self.assertEqual(self.nbs_124043300.product_tmpl_qty, 1)
 
     def test_update_scheduled(self):
         """Check NBS update scheduled"""
+
+        if not self.company.ibpt_api:
+            return
+
         nbss = self.nbs_model.search(
             [("id", "in", (self.nbs_115069000.id, self.nbs_124043300.id))]
         )


### PR DESCRIPTION
Recentemente alguns PRs tiveram falhas no travis porque o web Service da IBPT API que faz a consulta dos impostos estimados estava indisponível retornando o código: 503 Service Unavailable:

Para evitar que a indisponibilidade do webservice gere um erro no travis, eu fiz algumas alterações:

- [x] Tratar o retorno da consulta da IBPT API;
- [x] Tratar os códigos de erros retornado pela requisição HTTP ao WS;
- [x] Nos testes faz primeiro uma consulta ao WS se tiver algum erro desabilita a consulta IBPT API no cadastro da empresa.
- [x] Refatoramento dos testes para eliminar código duplicado nos testes IBPT_Product e IBPT_Service. 