### PR TITLE
[14.0][FIX] Compensation account type in off-balance

### DIFF
--- a/l10n_br_coa/data/account_type_data.xml
+++ b/l10n_br_coa/data/account_type_data.xml
@@ -304,7 +304,7 @@
         <record model="account.account.type" id="data_account_type_compensation_assets">
             <field name="name">Ativo / Outros / Compensação</field>
             <field name="type">other</field>
-            <field name="internal_group">asset</field>
+            <field name="internal_group">off_balance</field>
         </record>
 
         <record
@@ -313,7 +313,7 @@
         >
             <field name="name">Passivo / Outros / Compensação</field>
             <field name="type">other</field>
-            <field name="internal_group">liability</field>
+            <field name="internal_group">off_balance</field>
         </record>
 
     </data>


### PR DESCRIPTION
Como está descrito no próprio código, as contas de compensação não fazem parte do balanço, então acho que o ideal seria os types relacionados estarem no internal_group com esse fim.


https://github.com/OCA/l10n-brazil/blob/765df48eb355eadde24e6a88a43291efec75e19e/l10n_br_coa/data/account_type_data.xml#L298-L302
