### PR TITLE
[14.0][FIX] Correct type internal group for accumulated depreciation

### DIFF
--- a/l10n_br_coa/data/account_type_data.xml
+++ b/l10n_br_coa/data/account_type_data.xml
@@ -71,7 +71,11 @@
             model="account.account.type"
             id="account.data_account_type_depreciation"
         >
-            <field name="name">Ativo / Não Circulante / (-) Depreciação</field>
+            <field
+                name="name"
+            >Ativo / Não Circulante / (-) Depreciação Acumulada</field>
+            <field name="internal_group">asset</field>
+            <field name="include_initial_balance" eval="True" />
         </record>
 
         <record model="account.account.type" id="data_account_type_intangible_assets">
@@ -84,7 +88,9 @@
             model="account.account.type"
             id="data_account_type_fixed_assets_amortization"
         >
-            <field name="name">Ativo / Não Circulante / (-) Amortização</field>
+            <field
+                name="name"
+            >Ativo / Não Circulante / (-) Amortização Acumulada</field>
             <field name="type">other</field>
             <field name="internal_group">asset</field>
         </record>


### PR DESCRIPTION
O account.account.type "account.data_account_type_depreciation" originalmente está sendo renomeado para ser referente as contas de Depreciação Acumulada redutoras do ativo.

Já que originalmente é um type do grupo despesas, e isso não é alterado em momento algum, acaba que essa classificação fica divergente do nome.

Existiam duas possibilidades: 

1. Não alterar o type original e criar um totalmente novo com esse intuito
2. Alterar o internal_group do original

Como algumas pessoas talvez já usem esse type e ele já é previsto nas contas de ativo dentro dos planos de conta da localização, a alteração do grupo original me pareceu menos intrusiva e completa.

PS: Junto eu alterei o nome para Depreciação acumulada e aproveitei e também modifiquei o type de Amortização para Amortização Acumulada. Acredito que fica mais legível.

 