### PR TITLE
[12.0][FIX] Fixed icms regulation using partner's state_id to get origin for ICMS Difal

### DIFF
--- a/l10n_br_fiscal/models/icms_regulation.py
+++ b/l10n_br_fiscal/models/icms_regulation.py
@@ -1475,7 +1475,7 @@ class ICMSRegulation(models.Model):
         domain = [
             ("icms_regulation_id", "=", self.id),
             ("state", "=", "approved"),
-            ("state_from_id", "=", partner.state_id.id),
+            ("state_from_id", "=", company.state_id.id),
             ("state_to_ids", "=", partner.state_id.id),
             ("tax_group_id", "=", tax_group_icms.id),
         ]


### PR DESCRIPTION
Fix de bug simples no qual o ICMS Regulation estava usando o Estado do parceiro tanto para a origem quanto para destino no calculo do ICMS Difal