### PR TITLE
[14.0][MIG][FIX] Fixed icms regulation using partner's state_id to get origin for ICMS Difal

### DIFF
--- a/l10n_br_fiscal/models/icms_regulation.py
+++ b/l10n_br_fiscal/models/icms_regulation.py
@@ -1475,7 +1475,7 @@ class ICMSRegulation(models.Model):
         domain = [
             ("icms_regulation_id", "=", self.id),
             ("state", "=", "approved"),
-            ("state_from_id", "=", partner.state_id.id),
+            ("state_from_id", "=", company.state_id.id),
             ("state_to_ids", "=", partner.state_id.id),
             ("tax_group_id", "=", tax_group_icms.id),
         ]


### PR DESCRIPTION
Como requisitado pelo @marcelsavegnago, cherry-pick do fix de #1909