### PR TITLE
[12.0][FIX] Script de migração dos campos fiscal_type e origin_icms 

### DIFF
--- a/l10n_br_fiscal/migrations/12.0.24.0.0/pre-migration.py
+++ b/l10n_br_fiscal/migrations/12.0.24.0.0/pre-migration.py
@@ -9,15 +9,12 @@ from openupgradelib import openupgrade
 def migrate(env, version):
     field_property = env.ref("l10n_br_fiscal.field_product_template__icms_origin")
 
+    env.cr.execute(
+        "SELECT id, icms_origin FROM product_template WHERE icms_origin is not NULL"
+    )
+    products = env.cr.fetchall()
     companies = env["res.company"].search([])
     for company in companies:
-        env.cr.execute(
-            "SELECT id, icms_origin FROM product_template "
-            "WHERE icms_origin is not NULL "
-            "AND (company_id=%s OR company_id IS NULL)",
-            (company.id,),
-        )
-        products = env.cr.fetchall()
         for product in products:
             env["ir.property"].create(
                 {

--- a/l10n_br_fiscal/migrations/12.0.25.0.0/pre-migration.py
+++ b/l10n_br_fiscal/migrations/12.0.25.0.0/pre-migration.py
@@ -9,15 +9,12 @@ from openupgradelib import openupgrade
 def migrate(env, version):
     field_property = env.ref("l10n_br_fiscal.field_product_template__fiscal_type")
 
+    env.cr.execute(
+        "SELECT id, fiscal_type FROM product_template WHERE fiscal_type is not NULL"
+    )
+    products = env.cr.fetchall()
     companies = env["res.company"].search([])
     for company in companies:
-        env.cr.execute(
-            "SELECT id, fiscal_type FROM product_template "
-            "WHERE fiscal_type is not NULL "
-            "AND (company_id=%s OR company_id IS NULL)",
-            (company.id,),
-        )
-        products = env.cr.fetchall()
         for product in products:
             env["ir.property"].create(
                 {


### PR DESCRIPTION
Nas PRs #1810 e #1811 os campo  fiscal_type e origin_icms dos produtos foram alterados para serem property  
Essa PR altera o script de migração para que os valores desses dois campos sejam aplicados para todas a empresas, independente do company_id que está atrelado ao product_template.

Sem essa PR as outras empresas ficam com esses valores zerados.

cc @renatonlima 