### PR TITLE
[12.0] Update financial move in fiscal document NFE XML

### DIFF
--- a/l10n_br_account_nfe/models/__init__.py
+++ b/l10n_br_account_nfe/models/__init__.py
@@ -1,2 +1,3 @@
 from . import account_payment_mode
+from . import account_move_line
 from . import document_workflow

--- a/l10n_br_account_nfe/models/account_move_line.py
+++ b/l10n_br_account_nfe/models/account_move_line.py
@@ -1,0 +1,34 @@
+# Copyright (C) 2022-Today - Akretion (<https://akretion.com/pt-BR>).
+# @author Renato Lima <renato.lima@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+from odoo.addons.l10n_br_fiscal.constants.fiscal import (
+    DOCUMENT_ISSUER_COMPANY,
+    MODELO_FISCAL_NFCE,
+    MODELO_FISCAL_NFE,
+    PROCESSADOR_OCA,
+    SITUACAO_EDOC_A_ENVIAR,
+)
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    def write(self, values):
+
+        result = super().write(values)
+        MOVE_LINE_FIELDS = ["date_maturity", "name", "amount_currency"]
+        if any(field in values.keys() for field in MOVE_LINE_FIELDS):
+            invoices = self.mapped("invoice_id")
+            for invoice in invoices.filtered(
+                lambda i: i.fiscal_document_id.id != i.company_id.fiscal_dummy_id.id
+                and i.processador_edoc == PROCESSADOR_OCA
+                and i.document_type_id.code in [MODELO_FISCAL_NFE, MODELO_FISCAL_NFCE]
+                and i.issuer == DOCUMENT_ISSUER_COMPANY
+                and i.state_edoc == SITUACAO_EDOC_A_ENVIAR
+            ):
+                invoice.fiscal_document_id.action_document_confirm()
+                invoice.fiscal_document_id._document_export()
+        return result


### PR DESCRIPTION
Atualmente não é possível alterar os dados de vencimento ou valor das duplicatas de uma NF-e porque a account.move.line é gerada quando a fatura é confirmada e gerado o XML, depois de confirmado e antes de transmitir se for alterado algum dado na account.move.line essa informação não é atualizada no XML da NFe.

Esse PR implementa a atualização do XML na NFe caso os vencimento, referencia ou valor for alterado.