### PR TITLE
[14.0][FIX] l10n_br_fiscal: change ibpt service timeout value

### DIFF
--- a/l10n_br_fiscal/models/ibpt/taxes.py
+++ b/l10n_br_fiscal/models/ibpt/taxes.py
@@ -23,7 +23,7 @@ DeOlhoNoImposto = namedtuple("Config", "token cnpj uf")
 
 def _request(ws_url, params):
     try:
-        response = requests.get(ws_url, params=params, timeout=5)
+        response = requests.get(ws_url, params=params, timeout=15)
         if response.ok:
             data = response.json()
             return namedtuple("Result", [k.lower() for k in data.keys()])(


### PR DESCRIPTION
Não sei se procede a necessidade mas ao fazer teste local quase tive que mudar para 20 segundos o timeout. Porém, pode ter sido por conta de algum teste eu estava testando com um cnpj diferente do token da empresa.