### PR TITLE
[12.0] l10n_br_nfe: Overwrite match_or_create_m2o for city, state and country

### DIFF
--- a/l10n_br_nfe/models/res_city.py
+++ b/l10n_br_nfe/models/res_city.py
@@ -1,10 +1,22 @@
 # Copyright 2019 Akretion (Raphaël Valyi <raphael.valyi@akretion.com>)
 # Copyright 2021 Akretion (Renato Lima <renato.lima@akretion.com>)
+# Copyright 2022 KMEE  (Renan Hiroki Bastos <renan.hiroki@kmee.com.br>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import api, models
 
 
 class ResCity(models.Model):
     _inherit = "res.city"
     _nfe_search_keys = ["ibge_code"]
+
+    @api.model
+    def match_or_create_m2o(self, rec_dict, parent_dict, model=None):
+        """If city not found, break hard, don't create it"""
+
+        if rec_dict.get("ibge_code"):
+            domain = [("ibge_code", "=", rec_dict.get("ibge_code"))]
+            match = self.search(domain, limit=1)
+            if match:
+                return match.id
+        return False

--- a/l10n_br_nfe/models/res_country.py
+++ b/l10n_br_nfe/models/res_country.py
@@ -1,0 +1,19 @@
+# Copyright (C) 2022  Renan Hiroki Bastos - KMEE <renan.hiroki@kmee.com.br>
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import api, models
+
+
+class Country(models.Model):
+    _inherit = "res.country"
+
+    @api.model
+    def match_or_create_m2o(self, rec_dict, parent_dict, model=None):
+        """If country not found, break hard, don't create it"""
+
+        if rec_dict.get("bc_code"):
+            domain = [("bc_code", "=", rec_dict.get("bc_code"))]
+            match = self.search(domain, limit=1)
+            if match:
+                return match.id
+        return False

--- a/l10n_br_nfe/models/res_country.py
+++ b/l10n_br_nfe/models/res_country.py
@@ -6,6 +6,7 @@ from odoo import api, models
 
 class Country(models.Model):
     _inherit = "res.country"
+    _nfe_search_keys = ["bc_code"]
 
     @api.model
     def match_or_create_m2o(self, rec_dict, parent_dict, model=None):

--- a/l10n_br_nfe/models/res_country_state.py
+++ b/l10n_br_nfe/models/res_country_state.py
@@ -1,10 +1,21 @@
 # Copyright 2019 Akretion (Raphaël Valyi <raphael.valyi@akretion.com>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import api, models
 
 
 class ResCountryState(models.Model):
     _inherit = "res.country.state"
     _nfe_search_keys = ["ibge_code", "code"]
     _nfe_extra_domain = [("ibge_code", "!=", False)]
+
+    @api.model
+    def match_or_create_m2o(self, rec_dict, parent_dict, model=None):
+        """If state not found, break hard, don't create it"""
+
+        if rec_dict.get("code"):
+            domain = [("code", "=", rec_dict.get("code")), ("ibge_code", "!=", False)]
+            match = self.search(domain, limit=1)
+            if match:
+                return match.id
+        return False

--- a/l10n_br_nfe/models/res_country_state.py
+++ b/l10n_br_nfe/models/res_country_state.py
@@ -1,4 +1,5 @@
 # Copyright 2019 Akretion (Raphaël Valyi <raphael.valyi@akretion.com>)
+# Copyright 2022 KMEE  (Renan Hiroki Bastos <renan.hiroki@kmee.com.br>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, models

--- a/l10n_br_nfe/models/uom.py
+++ b/l10n_br_nfe/models/uom.py
@@ -11,8 +11,8 @@ class Uom(models.Model):
     def match_or_create_m2o(self, rec_dict, parent_dict, model=None):
         """If uom not found, break hard, don't create it"""
 
-        if rec_dict.get("name"):
-            domain = [("code", "=", rec_dict.get("name"))]
+        if rec_dict.get("code"):
+            domain = [("code", "=", rec_dict.get("code"))]
             match = self.search(domain, limit=1)
             if match:
                 return match.id


### PR DESCRIPTION
Divisão de #1701 

Sobrescreve o método match_or_create_m2o de spec_driven_model.spec_import em res.country, res.country_state e res.city, para que durante a importação de nfe não sejam criadas novas cidades, estados e países.

Além disso, troca campo de match da uom de name para code.