### PR TITLE
[12.0] Correções na criação dos campos nfe40_dup e nfe40_detPag

### DIFF
--- a/l10n_br_account_nfe/models/document_workflow.py
+++ b/l10n_br_account_nfe/models/document_workflow.py
@@ -35,6 +35,8 @@ class DocumentWorkflow(models.AbstractModel):
 
     def action_document_confirm(self):
         for record in self.filtered(filter_nfe):
+            record.nfe40_dup = [(5,)]
+            record.nfe40_detPag = [(5,)]
             if record.amount_financial_total:
                 # TAG - Cobrança
                 duplicatas = record.env["nfe.40.dup"]

--- a/l10n_br_account_nfe/models/document_workflow.py
+++ b/l10n_br_account_nfe/models/document_workflow.py
@@ -10,6 +10,7 @@ from odoo.exceptions import UserError
 
 from odoo.addons.l10n_br_fiscal.constants.fiscal import (
     DOCUMENT_ISSUER_COMPANY,
+    EDOC_PURPOSE_DEVOLUCAO,
     MODELO_FISCAL_NFCE,
     MODELO_FISCAL_NFE,
     PROCESSADOR_OCA,
@@ -37,7 +38,10 @@ class DocumentWorkflow(models.AbstractModel):
         for record in self.filtered(filter_nfe):
             record.nfe40_dup = [(5,)]
             record.nfe40_detPag = [(5,)]
-            if record.amount_financial_total:
+            if (
+                record.amount_financial_total
+                and record.edoc_purpose != EDOC_PURPOSE_DEVOLUCAO
+            ):
                 # TAG - Cobrança
                 duplicatas = record.env["nfe.40.dup"]
                 count = 1

--- a/l10n_br_fiscal/constants/fiscal.py
+++ b/l10n_br_fiscal/constants/fiscal.py
@@ -466,6 +466,18 @@ WORKFLOW_EDOC = WORKFLOW_DOCUMENTO_NAO_ELETRONICO + [
     (SITUACAO_EDOC_REJEITADA, SITUACAO_EDOC_REJEITADA),
 ]
 
+EDOC_PURPOSE = [
+    ("1", "Normal"),
+    ("2", "Complementar"),
+    ("3", "Ajuste"),
+    ("4", "Devolução de mercadoria"),
+]
+
+EDOC_PURPOSE_NORMAL = "1"
+EDOC_PURPOSE_COMPLEMENTAR = "2"
+EDOC_PURPOSE_AJUSTE = "3"
+EDOC_PURPOSE_DEVOLUCAO = "4"
+
 PROCESSADOR_NENHUM = "nenhum"
 PROCESSADOR_OCA = "oca"
 

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -13,6 +13,8 @@ from ..constants.fiscal import (
     DOCUMENT_ISSUER_COMPANY,
     DOCUMENT_ISSUER_DICT,
     DOCUMENT_ISSUER_PARTNER,
+    EDOC_PURPOSE,
+    EDOC_PURPOSE_NORMAL,
     FISCAL_IN_OUT_DICT,
     MODELO_FISCAL_CTE,
     MODELO_FISCAL_NFCE,
@@ -166,14 +168,9 @@ class Document(models.Model):
     )
 
     edoc_purpose = fields.Selection(
-        selection=[
-            ("1", "Normal"),
-            ("2", "Complementar"),
-            ("3", "Ajuste"),
-            ("4", "Devolução de mercadoria"),
-        ],
+        selection=EDOC_PURPOSE,
         string="Finalidade",
-        default="1",
+        default=EDOC_PURPOSE_NORMAL,
     )
 
     event_ids = fields.One2many(

--- a/l10n_br_fiscal/models/operation.py
+++ b/l10n_br_fiscal/models/operation.py
@@ -5,6 +5,8 @@ from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 from ..constants.fiscal import (
+    EDOC_PURPOSE,
+    EDOC_PURPOSE_NORMAL,
     FISCAL_COMMENT_DOCUMENT,
     FISCAL_IN_OUT_ALL,
     OPERATION_FISCAL_TYPE,
@@ -45,14 +47,9 @@ class Operation(models.Model):
     )
 
     edoc_purpose = fields.Selection(
-        selection=[
-            ("1", "Normal"),
-            ("2", "Complementar"),
-            ("3", "Ajuste"),
-            ("4", "Devolução de mercadoria"),
-        ],
+        selection=EDOC_PURPOSE,
         string="Finalidade",
-        default="1",
+        default=EDOC_PURPOSE_NORMAL,
         readonly=True,
         states={"draft": [("readonly", False)]},
         track_visibility="onchange",


### PR DESCRIPTION
Eu peguei um caso não trivial, quando um documento (NF-e) é gerado e o CFOP esta definido para ser gerado financeiro, os campos são criados nfe40_dup e nfe40_detPag perfeitamente, porém se essa NF-e criada o CFOP estava errado e foi alterado para um CFOP que não gera financeiro ao confirmar a NF-e novamente os valores de nfe40_dup e nfe40_detPag continuam com os valores anteriores, isso ocorre porque no código https://github.com/OCA/l10n-brazil/blob/12.0/l10n_br_account_nfe/models/document_workflow.py#L38 não vai executado o código dentro do if porque agora a NF-e não tem mais nenhum financial_move_line_ids.

Para corrigir isso, eu fiz um commit para antes do if os valores dos campos nfe40_dup e nfe40_detPag serem sempre limpo.

O segundo commit foi para nos casos de uma NF-e de devolução não ser gerado valores nfe40_dup e nfe40_detPag, pois os CFOPs de devolução devem estar definidos para gerar financeiro, já que precisam ser abatidos da NF-e de origem ou ficar como nota de debito/credito no financeiro.

Esse PR depende do PR #1933