### PR TITLE
[12.0] l10n_br_nfe: build_many2one now builds a 'delivery' type contact for nfe40_entrega

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -578,6 +578,23 @@ class NFe(spec_models.StackedModel):
             super()._build_many2one(
                 self.env["res.partner"], vals, new_value, "partner_id", value, path
             )
+        elif key == "nfe40_entrega" and self.env.context.get("edoc_type") == "in":
+            enderEntreg_value = self.env["res.partner"].build_attrs(value, path=path)
+            new_value.update(enderEntreg_value)
+            parent_domain = [("nfe40_CNPJ", "=", new_value.get("nfe40_CNPJ"))]
+            parent_partner_match = self.env["res.partner"].search(
+                parent_domain, limit=1
+            )
+            new_vals = {
+                "nfe40_CNPJ": False,
+                "type": "delivery",
+                "parent_id": parent_partner_match.id,
+                "company_type": "person",
+            }
+            new_value.update(new_vals)
+            super()._build_many2one(
+                self.env["res.partner"], vals, new_value, key, value, path
+            )
         elif self.env.context.get("edoc_type") == "in" and key in [
             "nfe40_dest",
             "nfe40_enderDest",


### PR DESCRIPTION
Divisão de #1701

Esta mudança faz com que o campo nfe40_entrega seja importado como um contato de tipo 'delivery', e adicionado como endereço de entrega do contato pai em questão.