### PR TITLE
[12.0] l10n_br_nfe: Now imports nfe40_transporta as a partner

### DIFF
--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -30,6 +30,7 @@ class ResPartner(spec_models.SpecModel):
         "nfe.40.dest",
         "nfe.40.tenderemi",
         "nfe.40.tinfresptec",
+        "nfe.40.transporta",
     ]
     _nfe_search_keys = ["nfe40_CNPJ", "nfe40_CPF", "nfe40_xNome"]
 
@@ -90,6 +91,15 @@ class ResPartner(spec_models.SpecModel):
         ],
         compute="_compute_nfe_data",
         string="CNPJ/CPF/idEstrangeiro",
+    )
+
+    # nfe.40.transporta
+    nfe40_choice19 = fields.Selection(
+        selection=[
+            ("nfe40_CNPJ", "CNPJ"),
+            ("nfe40_CPF", "CPF"),
+        ],
+        string="CNPJ/CPF",
     )
 
     def _compute_nfe40_xEnder(self):


### PR DESCRIPTION
Divisão de #1701 

Com esta mudança o campo de transportadora (nfe40_transporta) é importado como um res.partner.
Sem esta mudança o algoritmo ficava confuso, pois criava um objeto da classe "nfe.40.transporta" durante a importação e retornava seu id para o campo nfe40_transporta. Porém este campo é um res.partner, e este id era referente a algum outro parceiro aleatório, que aparecia no lugar da transportadora no l10n_br_fiscal.document criado.