### PR TITLE
[12.0] l10n_br_nfe: Clear document_number field for imported documents

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -291,6 +291,12 @@ class NFe(spec_models.StackedModel):
 
     nfe40_vLiq = fields.Monetary(related="amount_financial_total")
 
+    partner_document_number = fields.Char(
+        string="Partner Document Number",
+        copy=False,
+        index=True,
+    )
+
     @api.depends("fiscal_additional_data", "fiscal_additional_data")
     def _compute_nfe40_additional_data(self):
         for record in self:
@@ -676,6 +682,13 @@ class NFe(spec_models.StackedModel):
             vals.update(new_value)
         else:
             super(NFe, self)._build_many2one(comodel, vals, new_value, key, value, path)
+
+    def _prepare_import_dict(self, vals, model=None):
+        vals = super(NFe, self)._prepare_import_dict(vals, model)
+        if all(key in vals for key in ("document_number", "nfe40_nNF")):
+            vals["partner_document_number"] = vals.get("nfe40_nNF")
+            vals["document_number"] = ""
+        return vals
 
     def view_pdf(self):
         if not self.filtered(filter_processador_edoc_nfe):

--- a/l10n_br_nfe/views/nfe_document_view.xml
+++ b/l10n_br_nfe/views/nfe_document_view.xml
@@ -37,6 +37,13 @@
                   <field name="nfe40_detPag" />
               </group>
           </page>
+          <!-- Add Partner Document Number to view -->
+          <xpath
+                expr="//group[@name='document_header_left']/field[@name='document_number']"
+                position="after"
+            >
+                <field name="partner_document_number" invisible="1" />
+          </xpath>
       </field>
   </record>
 


### PR DESCRIPTION
Divisão de #1701

Como o campo document_number deve ser único para cada documento, a importação da númeração dada a nfe pelo parceiro não pode ser realizada nele.
Assim, durante a importação a numeração do parceiro é inserida no campo partner_document_number e o campo document_number é deixado em branco.

O novo campo está invisivel na visão temporariamente. Nos próximos passos da divisão do PR original, quando o campo imported_document for inserido, será utilizado como condição para mostrar ou não este campo.