### PR TITLE
[12.0] l10n_br_nfe: Arruma importação do campo xFant

### DIFF
--- a/l10n_br_nfe/models/res_company.py
+++ b/l10n_br_nfe/models/res_company.py
@@ -119,5 +119,5 @@ class ResCompany(spec_models.SpecModel):
             values, model
         )
         if not values.get("name"):
-            values["name"] = values.get("nfe40_xNome") or values.get("nfe40_xFant")
+            values["name"] = values.get("nfe40_xFant") or values.get("nfe40_xNome")
         return values

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -65,6 +65,7 @@ class ResPartner(spec_models.SpecModel):
 
     # nfe.40.dest
     nfe40_xNome = fields.Char(related="legal_name")
+    nfe40_xFant = fields.Char(related="name")
     nfe40_enderDest = fields.Many2one(
         comodel_name="res.partner", compute="_compute_nfe40_enderDest"
     )

--- a/l10n_br_nfe/tests/test_nfe_import.py
+++ b/l10n_br_nfe/tests/test_nfe_import.py
@@ -38,7 +38,7 @@ class NFeImportTest(SavepointCase):
             .build(nfe_binding.infNFe, dry_run=True)
         )
         assert isinstance(nfe.id, NewId)
-        self.assertEqual(nfe.partner_id.name, "Alimentos Ltda.")
+        self.assertEqual(nfe.partner_id.name, "Alimentos Saudaveis")
         self.assertEqual(nfe.line_ids[0].product_id.name, "QUINOA 100G (2X50G)")
 
     def test_import_in_nfe(self):
@@ -69,7 +69,7 @@ class NFeImportTest(SavepointCase):
 
         # here we check that emit and enderEmit
         # are now the supplier data (partner_id)
-        self.assertEqual(nfe.partner_id.name, "Alimentos Ltda.")
+        self.assertEqual(nfe.partner_id.name, "Alimentos Saudaveis")
         self.assertEqual(nfe.partner_id.cnpj_cpf, "34.128.745/0001-52")
         # this tests the _extract_related_values method for related values:
         self.assertEqual(nfe.partner_id.legal_name, "Alimentos Ltda.")


### PR DESCRIPTION
Divisão de #1701 

Arruma importação do campo nfe40_xFant em res_company e res_partner.

Em res_company, em alguns casos, o campo name era preenchido primeiramente com o valor de nfe40_xNome, e caso este não existisse, com o valor de nfe40_xFant.
Esta relação esta invertida, visto que o mapeamento correto é nfe40_xFant -> name e nfe40_xNome -> legal_name

Em res_partner apenas não existia um campo no qual realizar a importação, então ele foi adicionado.