### PR TITLE
[FIX] Upgrade black version in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
           - --remove-duplicate-keys
           - --remove-unused-variables
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-prettier


### PR DESCRIPTION
Fix error in pre-commit run --all-files:

black....................................................................Failed
- hook id: black
- exit code: 1

Traceback (most recent call last):
  File "/home/cristiano/.cache/pre-commit/repo3yf5gfff/py_env-python3/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/home/cristiano/.cache/pre-commit/repo3yf5gfff/py_env-python3/lib/python3.8/site-packages/black/__init__.py", line 6606, in patched_main
    patch_click()
  File "/home/cristiano/.cache/pre-commit/repo3yf5gfff/py_env-python3/lib/python3.8/site-packages/black/__init__.py", line 6595, in patch_click
    from click import _unicodefun  # type: ignore
ImportError: cannot import name '_unicodefun' from 'click' (/home/cristiano/.cache/pre-commit/repo3yf5gfff/py_env-python3/lib/python3.8/site-packages/click/__init__.py)
