### PR TITLE
[12.0][FIX] map_tax_icms_difal must get icms tax defs from destination

### DIFF
--- a/l10n_br_fiscal/models/icms_regulation.py
+++ b/l10n_br_fiscal/models/icms_regulation.py
@@ -1475,7 +1475,7 @@ class ICMSRegulation(models.Model):
         domain = [
             ("icms_regulation_id", "=", self.id),
             ("state", "=", "approved"),
-            ("state_from_id", "=", company.state_id.id),
+            ("state_from_id", "=", partner.state_id.id),
             ("state_to_ids", "=", partner.state_id.id),
             ("tax_group_id", "=", tax_group_icms.id),
         ]


### PR DESCRIPTION
Regressão da alteração realizada no PR #1917

No método map_tax_icms_difal, o domain onde é filtrado as definições dos impostos do ICMS de destino precisam ser filtrado pela origem e destino a mesma UF do parceiro, pois essa alíquota é a interna da UF de destino.