### PR TITLE
[14.0][l10n_br_nfe] cherry picks dos commits da 12.0

### DIFF
--- a/l10n_br_fiscal/demo/l10n_br_fiscal.cest-demo.csv
+++ b/l10n_br_fiscal/demo/l10n_br_fiscal.cest-demo.csv
@@ -28,3 +28,6 @@
 "cest_0200900","9.0","02.009.00","02","Jurubeba e similares","2205,22060090,22089000"
 "cest_0201000","10.0","02.010.00","02","Licores e similares","22087000"
 "cest_0100100","1.0","01.001.00","01","Catalisadores em colmeia cerâmica ou metálica para conversão catalítica de gases de escape de veículos e outros catalisadores","38151210,38151290"
+"cest_1703000","30.0","17.030.00","16","Produtos à base de cereais, obtidos por expansão ou torrefação","19041000,19049000"
+"cest_1705602","56.2","17.056.02","16","Outras bolachas, exceto casquinhas para sorvete e os biscoitos e bolachas relacionados nos CEST 17.056.00 e 17.056.01","19059020"
+"cest_1709700","97.0","17.097.00","16","Chá, mesmo aromatizado","0902,12119090,21069090"

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin.py
@@ -545,17 +545,15 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         domain=[("tax_domain", "=", TAX_DOMAIN_II)],
     )
 
-    ii_base = fields.Float(string="II Base", digits="Account")
+    ii_base = fields.Monetary(string="II Base")
 
     ii_percent = fields.Float(string="II %")
 
-    ii_value = fields.Float(string="II Value", digits="Account")
+    ii_value = fields.Monetary(string="II Value")
 
-    ii_iof_value = fields.Float(string="IOF Value", digits="Account")
+    ii_iof_value = fields.Monetary(string="IOF Value")
 
-    ii_customhouse_charges = fields.Float(
-        string="Despesas Aduaneiras", digits="Account"
-    )
+    ii_customhouse_charges = fields.Monetary(string="Despesas Aduaneiras")
 
     # PIS/COFINS Fields
     # COFINS

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -337,8 +337,8 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 ind_final=self.ind_final,
             )
 
-            self.ipi_guideline_id = mapping_result["ipi_guideline"]
             self.cfop_id = mapping_result["cfop"]
+            self.ipi_guideline_id = mapping_result["ipi_guideline"]
             taxes = self.env["l10n_br_fiscal.tax"]
             for tax in mapping_result["taxes"].values():
                 taxes |= tax

--- a/l10n_br_fiscal/models/document_fiscal_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin.py
@@ -162,6 +162,16 @@ class FiscalDocumentMixin(models.AbstractModel):
         store=True,
     )
 
+    amount_icms_destination_value = fields.Monetary(
+        string="ICMS Destination Value",
+        compute="_compute_amount",
+    )
+
+    amount_icms_origin_value = fields.Monetary(
+        string="ICMS Origin Value",
+        compute="_compute_amount",
+    )
+
     amount_ipi_base = fields.Monetary(
         string="IPI Base",
         compute="_compute_amount",
@@ -172,6 +182,21 @@ class FiscalDocumentMixin(models.AbstractModel):
         string="IPI Value",
         compute="_compute_amount",
         store=True,
+    )
+
+    amount_ii_base = fields.Monetary(
+        string="II Base",
+        compute="_compute_amount",
+    )
+
+    amount_ii_value = fields.Monetary(
+        string="II Value",
+        compute="_compute_amount",
+    )
+
+    amount_ii_customhouse_charges = fields.Monetary(
+        string="Customhouse Charges",
+        compute="_compute_amount",
     )
 
     amount_pis_base = fields.Monetary(

--- a/l10n_br_fiscal/models/document_fiscal_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin.py
@@ -165,11 +165,13 @@ class FiscalDocumentMixin(models.AbstractModel):
     amount_icms_destination_value = fields.Monetary(
         string="ICMS Destination Value",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_icms_origin_value = fields.Monetary(
         string="ICMS Origin Value",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_ipi_base = fields.Monetary(
@@ -187,16 +189,19 @@ class FiscalDocumentMixin(models.AbstractModel):
     amount_ii_base = fields.Monetary(
         string="II Base",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_ii_value = fields.Monetary(
         string="II Value",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_ii_customhouse_charges = fields.Monetary(
         string="Customhouse Charges",
         compute="_compute_amount",
+        store=True,
     )
 
     amount_pis_base = fields.Monetary(

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -175,10 +175,16 @@ class OperationLine(models.Model):
             cfop = self.cfop_export_id
         return cfop
 
+    def _build_mapping_result_ipi(self, mapping_result, tax_definition):
+        mapping_result[
+            "ipi_guideline"
+        ] = tax_definition.ipi_guideline_id or self.env.ref(
+            "l10n_br_fiscal.tax_guideline_999"
+        )
+
     def _build_mapping_result(self, mapping_result, tax_definition):
         mapping_result["taxes"][tax_definition.tax_domain] = tax_definition.tax_id
-        if tax_definition.ipi_guideline_id:
-            mapping_result["ipi_guideline"] = tax_definition.ipi_guideline_id
+        self._build_mapping_result_ipi(mapping_result, tax_definition)
 
     def map_fiscal_taxes(
         self,
@@ -199,7 +205,6 @@ class OperationLine(models.Model):
             "taxes": {},
             "cfop": False,
             "ipi_guideline": False,
-            "taxes_value": 0.00,
         }
 
         self.ensure_one()

--- a/l10n_br_nfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_nfe/demo/fiscal_document_demo.xml
@@ -43,6 +43,10 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
     </function>
 
+    <record id="demo_nfe_line_same_state_1-1" model="l10n_br_fiscal.document.line">
+        <field name="price_unit">100</field>
+    </record>
+
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
     </function>
@@ -51,6 +55,10 @@
         model="l10n_br_fiscal.document.line"
         name="_onchange_fiscal_operation_line_id"
     >
+        <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
     </function>
 
@@ -70,6 +78,10 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
     </function>
 
+    <record id="demo_nfe_line_same_state_1-2" model="l10n_br_fiscal.document.line">
+        <field name="price_unit">100</field>
+    </record>
+
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
     </function>
@@ -78,6 +90,10 @@
         model="l10n_br_fiscal.document.line"
         name="_onchange_fiscal_operation_line_id"
     >
+        <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
     </function>
 
@@ -126,6 +142,10 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]" />
     </function>
 
+    <record id="demo_nfe_national_sale_for_same_state-1" model="l10n_br_fiscal.document.line">
+        <field name="quantity">1</field>
+    </record>
+
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]" />
     </function>
@@ -135,6 +155,10 @@
         name="_onchange_fiscal_operation_line_id"
     >
         <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]" />
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state')]" />
     </function>
 
     <!-- NFe Test - Pessoa Física - ICMS 18% with a reduction of 51.11% -->
@@ -193,6 +217,10 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]" />
     </function>
 
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]" />
+    </function>
+
     <!-- NFe Test - Pessoa Física - ICMS 4% Imported for Resale -->
     <record id="demo_nfe_natural_icms_7_resale" model="l10n_br_fiscal.document">
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -235,6 +263,10 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
     </function>
 
+    <record id="demo_nfe_natural_icms_7_resale-1" model="l10n_br_fiscal.document.line">
+        <field name="quantity">2</field>
+    </record>
+
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
     </function>
@@ -243,6 +275,10 @@
         model="l10n_br_fiscal.document.line"
         name="_onchange_fiscal_operation_line_id"
     >
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
     </function>
 

--- a/l10n_br_nfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_nfe/demo/fiscal_document_demo.xml
@@ -43,14 +43,6 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
     </function>
 
-    <function model="l10n_br_fiscal.document.line" name="_onchange_commercial_quantity">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_ncm_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
-    </function>
-
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
     </function>
@@ -59,10 +51,6 @@
         model="l10n_br_fiscal.document.line"
         name="_onchange_fiscal_operation_line_id"
     >
-        <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
     </function>
 
@@ -82,14 +70,6 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
     </function>
 
-    <function model="l10n_br_fiscal.document.line" name="_onchange_commercial_quantity">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_ncm_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
-    </function>
-
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
     </function>
@@ -98,10 +78,6 @@
         model="l10n_br_fiscal.document.line"
         name="_onchange_fiscal_operation_line_id"
     >
-        <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
     </function>
 
@@ -150,14 +126,6 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]" />
     </function>
 
-    <function model="l10n_br_fiscal.document.line" name="_onchange_commercial_quantity">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_ncm_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]" />
-    </function>
-
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]" />
     </function>
@@ -166,10 +134,6 @@
         model="l10n_br_fiscal.document.line"
         name="_onchange_fiscal_operation_line_id"
     >
-        <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
         <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]" />
     </function>
 
@@ -218,14 +182,6 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]" />
     </function>
 
-    <function model="l10n_br_fiscal.document.line" name="_onchange_commercial_quantity">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_ncm_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]" />
-    </function>
-
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]" />
     </function>
@@ -234,10 +190,6 @@
         model="l10n_br_fiscal.document.line"
         name="_onchange_fiscal_operation_line_id"
     >
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]" />
     </function>
 
@@ -283,14 +235,6 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
     </function>
 
-    <function model="l10n_br_fiscal.document.line" name="_onchange_commercial_quantity">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_ncm_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
-    </function>
-
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
     </function>
@@ -299,10 +243,6 @@
         model="l10n_br_fiscal.document.line"
         name="_onchange_fiscal_operation_line_id"
     >
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
     </function>
 

--- a/l10n_br_nfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_nfe/demo/fiscal_document_demo.xml
@@ -142,7 +142,10 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]" />
     </function>
 
-    <record id="demo_nfe_national_sale_for_same_state-1" model="l10n_br_fiscal.document.line">
+    <record
+        id="demo_nfe_national_sale_for_same_state-1"
+        model="l10n_br_fiscal.document.line"
+    >
         <field name="quantity">1</field>
     </record>
 

--- a/l10n_br_nfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_nfe/demo/fiscal_document_demo.xml
@@ -19,14 +19,6 @@
         <field name="fiscal_operation_type">out</field>
     </record>
 
-    <function model="l10n_br_fiscal.document" name="_onchange_company_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_same_state')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_same_state')]" />
-    </function>
-
     <record id="demo_nfe_line_same_state_1-1" model="l10n_br_fiscal.document.line">
         <field name="document_id" ref="demo_nfe_same_state" />
         <field name="name">Teste</field>
@@ -43,22 +35,10 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
     </function>
 
-    <record id="demo_nfe_line_same_state_1-1" model="l10n_br_fiscal.document.line">
-        <field name="price_unit">100</field>
-    </record>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
-    </function>
-
     <function
         model="l10n_br_fiscal.document.line"
         name="_onchange_fiscal_operation_line_id"
     >
-        <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
     </function>
 
@@ -78,22 +58,10 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
     </function>
 
-    <record id="demo_nfe_line_same_state_1-2" model="l10n_br_fiscal.document.line">
-        <field name="price_unit">100</field>
-    </record>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
-    </function>
-
     <function
         model="l10n_br_fiscal.document.line"
         name="_onchange_fiscal_operation_line_id"
     >
-        <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
     </function>
 
@@ -116,14 +84,6 @@
         <field name="fiscal_operation_type">out</field>
     </record>
 
-    <function model="l10n_br_fiscal.document" name="_onchange_company_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state')]" />
-    </function>
-
     <record
         id="demo_nfe_national_sale_for_same_state-1"
         model="l10n_br_fiscal.document.line"
@@ -142,26 +102,11 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]" />
     </function>
 
-    <record
-        id="demo_nfe_national_sale_for_same_state-1"
-        model="l10n_br_fiscal.document.line"
-    >
-        <field name="quantity">1</field>
-    </record>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]" />
-    </function>
-
     <function
         model="l10n_br_fiscal.document.line"
         name="_onchange_fiscal_operation_line_id"
     >
         <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state')]" />
     </function>
 
     <!-- NFe Test - Pessoa Física - ICMS 18% with a reduction of 51.11% -->
@@ -183,14 +128,6 @@
         <field name="fiscal_operation_type">out</field>
     </record>
 
-    <function model="l10n_br_fiscal.document" name="_onchange_company_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11')]" />
-    </function>
-
     <record
         id="demo_nfe_natural_icms_18_red_51_11-1"
         model="l10n_br_fiscal.document.line"
@@ -209,18 +146,10 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]" />
     </function>
 
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]" />
-    </function>
-
     <function
         model="l10n_br_fiscal.document.line"
         name="_onchange_fiscal_operation_line_id"
     >
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]" />
     </function>
 
@@ -243,14 +172,6 @@
         <field name="fiscal_operation_type">out</field>
     </record>
 
-    <function model="l10n_br_fiscal.document" name="_onchange_company_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale')]" />
-    </function>
-
     <record id="demo_nfe_natural_icms_7_resale-1" model="l10n_br_fiscal.document.line">
         <field name="document_id" ref="demo_nfe_natural_icms_7_resale" />
         <field name="name">Teste</field>
@@ -266,22 +187,10 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
     </function>
 
-    <record id="demo_nfe_natural_icms_7_resale-1" model="l10n_br_fiscal.document.line">
-        <field name="quantity">2</field>
-    </record>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
-    </function>
-
     <function
         model="l10n_br_fiscal.document.line"
         name="_onchange_fiscal_operation_line_id"
     >
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
-    </function>
-
-    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
     </function>
 

--- a/l10n_br_nfe/models/__init__.py
+++ b/l10n_br_nfe/models/__init__.py
@@ -8,6 +8,7 @@ from . import product_product
 from . import ncm
 from . import nbm
 from . import cest
+from . import tax_ipi_guideline
 from . import document_related
 from . import document
 from . import document_line

--- a/l10n_br_nfe/models/__init__.py
+++ b/l10n_br_nfe/models/__init__.py
@@ -9,6 +9,7 @@ from . import ncm
 from . import nbm
 from . import cest
 from . import tax_ipi_guideline
+from . import document_type
 from . import document_related
 from . import document
 from . import document_line

--- a/l10n_br_nfe/models/__init__.py
+++ b/l10n_br_nfe/models/__init__.py
@@ -5,6 +5,7 @@ from . import res_country_state
 from . import res_partner
 from . import res_company
 from . import product_product
+from . import ncm
 from . import document_related
 from . import document
 from . import document_line

--- a/l10n_br_nfe/models/__init__.py
+++ b/l10n_br_nfe/models/__init__.py
@@ -7,6 +7,7 @@ from . import res_company
 from . import product_product
 from . import ncm
 from . import nbm
+from . import cest
 from . import document_related
 from . import document
 from . import document_line

--- a/l10n_br_nfe/models/__init__.py
+++ b/l10n_br_nfe/models/__init__.py
@@ -6,6 +6,7 @@ from . import res_partner
 from . import res_company
 from . import product_product
 from . import ncm
+from . import nbm
 from . import document_related
 from . import document
 from . import document_line

--- a/l10n_br_nfe/models/cest.py
+++ b/l10n_br_nfe/models/cest.py
@@ -1,0 +1,9 @@
+# Copyright (C) 2021  Renato Lima - Akretion <renato.lima@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class Cest(models.Model):
+    _inherit = "l10n_br_fiscal.cest"
+    _nfe_search_keys = ["code_unmasked"]

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -196,7 +196,7 @@ class NFe(spec_models.StackedModel):
 
     nfe40_tpImp = fields.Selection(
         compute="_compute_nfe_data",
-        inverse="_inverse_nfe40_tpEmis",
+        inverse="_inverse_nfe40_tpImp",
     )
 
     nfe40_modFrete = fields.Selection(

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -351,7 +351,7 @@ class NFe(spec_models.StackedModel):
     nfe40_det = fields.One2many(
         comodel_name="l10n_br_fiscal.document.line",
         inverse_name="document_id",
-        related="line_ids",
+        related="fiscal_line_ids",
     )
 
     ##########################

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -516,9 +516,9 @@ class NFe(spec_models.StackedModel):
             elif processo.resposta.cStat == "225":
                 state = SITUACAO_EDOC_REJEITADA
 
-                self._change_state(state)
+                record._change_state(state)
 
-                self.write(
+                record.write(
                     {
                         "status_code": processo.resposta.cStat,
                         "status_name": processo.resposta.xMotivo,

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -299,10 +299,16 @@ class NFe(spec_models.StackedModel):
     @api.depends("fiscal_operation_type", "nfe_transmission")
     def _compute_nfe_data(self):
         """Set schema data which are not just related fields"""
-        for record in self:
+        for record in self.filtered(filter_processador_edoc_nfe):
             # id
-            if record.document_type_id and record.document_type_id.prefix:
-                record.nfe40_Id = record.document_type_id.prefix + record.document_key
+            if (
+                record.document_type_id
+                and record.document_type_id.prefix
+                and record.document_key
+            ):
+                record.nfe40_Id = "{}{}".format(
+                    record.document_type_id.prefix, record.document_key
+                )
             else:
                 record.nfe40_Id = None
 

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -78,7 +78,13 @@ class NFe(spec_models.StackedModel):
     _nfe_search_keys = ["nfe40_Id"]
 
     # all m2o at this level will be stacked even if not required:
-    _force_stack_paths = ("infnfe.total", "infnfe.infAdic", "infnfe.exporta")
+    _force_stack_paths = (
+        "infnfe.total",
+        "infnfe.infAdic",
+        "infnfe.exporta",
+        "infnfe.cobr",
+        "infnfe.cobr.fat",
+    )
 
     def _compute_emit(self):
         for doc in self:  # TODO if out
@@ -273,6 +279,17 @@ class NFe(spec_models.StackedModel):
     nfe40_idDest = fields.Selection(
         compute="_compute_nfe40_idDest",
     )
+
+    ##########################
+    # NF-e tag: fat
+    ##########################
+    nfe40_nFat = fields.Char(related="document_number")
+
+    nfe40_vOrig = fields.Monetary(related="amount_financial_total_gross")
+
+    nfe40_vDesc = fields.Monetary(related="amount_financial_discount_value")
+
+    nfe40_vLiq = fields.Monetary(related="amount_financial_total")
 
     @api.depends("fiscal_additional_data", "fiscal_additional_data")
     def _compute_nfe40_additional_data(self):
@@ -575,13 +592,6 @@ class NFe(spec_models.StackedModel):
         if xsd_field == "nfe40_tpAmb":
             self.env.context = dict(self.env.context)
             self.env.context.update({"tpAmb": self[xsd_field]})
-        elif xsd_field == "nfe40_fat" and (
-            self.nfe40_detPag and self.nfe40_detPag[0].nfe40_tPag != "90"
-        ):
-            self._stacking_points["nfe40_fat"] = self._fields["nfe40_fat"]
-            res = super()._export_field(xsd_field, class_obj, member_spec)
-            self._stacking_points.pop("nfe40_fat")
-            return res
         elif xsd_field == "nfe40_vTroco" and (
             self.nfe40_detPag and self.nfe40_detPag[0].nfe40_tPag == "90"
         ):

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -5,6 +5,7 @@
 import base64
 import logging
 import re
+import string
 from datetime import datetime
 from io import StringIO
 from unicodedata import normalize
@@ -573,8 +574,16 @@ class NFe(spec_models.StackedModel):
                 value.enderEmit, path=path
             )
             new_value.update(enderEmit_value)
+            company_cnpj = self.env.user.company_id.cnpj_cpf.translate(
+                str.maketrans("", "", string.punctuation)
+            )
+            emit_cnpj = new_value.get("nfe40_CNPJ").translate(
+                str.maketrans("", "", string.punctuation)
+            )
+            if company_cnpj != emit_cnpj:
+                vals["issuer"] = "partner"
             new_value["is_company"] = True
-            new_value["cnpj_cpf"] = new_value.get("nfe40_CNPJ")
+            new_value["cnpj_cpf"] = emit_cnpj
             super()._build_many2one(
                 self.env["res.partner"], vals, new_value, "partner_id", value, path
             )

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -86,25 +86,15 @@ class NFe(spec_models.StackedModel):
         "infnfe.cobr.fat",
     )
 
-    def _compute_emit(self):
-        for doc in self:  # TODO if out
-            doc.nfe40_emit = doc.company_id
+    ##########################
+    # NF-e spec related fields
+    ##########################
 
-    # emit and dest are not related fields as their related fields
-    # can change depending if it's and incoming our outgoing NFe
-    # specially when importing (ERP NFe migration vs supplier Nfe).
-    nfe40_emit = fields.Many2one(
-        "res.company", compute="_compute_emit", readonly=True, string="Emit"
-    )
+    ##########################
+    # NF-e tag: infNFe
+    ##########################
 
-    @api.depends("partner_id")
-    def _compute_dest(self):
-        for doc in self:  # TODO if out
-            doc.nfe40_dest = doc.partner_id
-
-    nfe40_dest = fields.Many2one(
-        "res.partner", compute="_compute_dest", readonly=True, string="Dest"
-    )
+    nfe40_versao = fields.Char(related="document_version")
 
     nfe_version = fields.Selection(
         selection=NFE_VERSIONS,
@@ -113,12 +103,89 @@ class NFe(spec_models.StackedModel):
         default=lambda self: self.env.company.nfe_version,
     )
 
-    nfe_environment = fields.Selection(
-        selection=NFE_ENVIRONMENTS,
-        string="NFe Environment",
-        copy=False,
-        default=lambda self: self.env.user.company_id.nfe_environment,
+    nfe40_Id = fields.Char(
+        compute="_compute_id_tag",
+        inverse="_inverse_nfe40_Id",
     )
+
+    ##########################
+    # NF-e tag: id
+    # Compute Methods
+    ##########################
+
+    @api.depends("document_type_id", "document_key")
+    def _compute_id_tag(self):
+        """Set schema data which are not just related fields"""
+
+        for record in self.filtered(filter_processador_edoc_nfe):
+            # id
+            if (
+                record.document_type_id
+                and record.document_type_id.prefix
+                and record.document_key
+            ):
+                record.nfe40_Id = "{}{}".format(
+                    record.document_type_id.prefix, record.document_key
+                )
+            else:
+                record.nfe40_Id = None
+
+    ##########################
+    # NF-e tag: id
+    # Inverse Methods
+    ##########################
+
+    def _inverse_nfe40_Id(self):
+        for record in self:
+            if record.nfe40_Id:
+                record.document_key = re.findall(r"\d+", str(record.nfe40_Id))[0]
+
+    ##########################
+    # NF-e tag: ide
+    ##########################
+
+    # TODO criar uma função para tratar quando for entrada, hoje é campo calculado
+    nfe40_cUF = fields.Char(
+        related="company_id.partner_id.state_id.ibge_code",
+        string="nfe40_cUF",
+    )
+
+    # <cNF>17983659</cNF> TODO
+
+    nfe40_natOp = fields.Char(related="operation_name")
+
+    nfe40_mod = fields.Char(related="document_type_id.code", string="nfe40_mod")
+
+    nfe40_serie = fields.Char(related="document_serie")
+
+    nfe40_nNF = fields.Char(related="document_number")
+
+    nfe40_dhEmi = fields.Datetime(related="document_date")
+
+    nfe40_dhSaiEnt = fields.Datetime(related="date_in_out")
+
+    nfe40_tpNF = fields.Selection(
+        compute="_compute_ide_data",
+        inverse="_inverse_nfe40_tpNF",
+    )
+
+    nfe40_idDest = fields.Selection(compute="_compute_nfe40_idDest")
+
+    nfe40_cMunFG = fields.Char(related="company_id.partner_id.city_id.ibge_code")
+
+    nfe40_tpImp = fields.Selection(
+        compute="_compute_ide_data",
+        inverse="_inverse_nfe40_tpImp",
+    )
+
+    danfe_layout = fields.Selection(
+        selection=NFE_DANFE_LAYOUTS + NFCE_DANFE_LAYOUTS,
+        string="Danfe Layout",
+    )
+
+    nfe40_tpEmis = fields.Selection(
+        related="nfe_transmission"
+    )  # TODO no caso de entrada
 
     nfe_transmission = fields.Selection(
         selection=NFE_TRANSMISSIONS,
@@ -127,97 +194,24 @@ class NFe(spec_models.StackedModel):
         default=lambda self: self.env.user.company_id.nfe_transmission,
     )
 
-    nfe40_finNFe = fields.Selection(
-        related="edoc_purpose",
+    # <cDV>0</cDV> TODO
+
+    nfe40_tpAmb = fields.Selection(related="nfe_environment")
+
+    nfe_environment = fields.Selection(
+        selection=NFE_ENVIRONMENTS,
+        string="NFe Environment",
+        copy=False,
+        default=lambda self: self.env.user.company_id.nfe_environment,
     )
 
-    nfe40_versao = fields.Char(
-        related="document_version",
-    )
+    nfe40_finNFe = fields.Selection(related="edoc_purpose")
 
-    nfe40_nNF = fields.Char(
-        related="document_number",
-    )
+    nfe40_indFinal = fields.Selection(related="ind_final")
 
-    nfe40_Id = fields.Char(
-        compute="_compute_nfe_data",
-        inverse="_inverse_nfe40_Id",
-    )
+    nfe40_indPres = fields.Selection(related="ind_pres")
 
-    # TODO should be done by framework?
-    nfe40_det = fields.One2many(
-        comodel_name="l10n_br_fiscal.document.line",
-        inverse_name="document_id",
-        related="fiscal_line_ids",
-    )
-
-    nfe40_NFref = fields.One2many(
-        comodel_name="l10n_br_fiscal.document.related",
-        related="document_related_ids",
-        inverse_name="document_id",
-    )
-
-    nfe40_dhEmi = fields.Datetime(
-        related="document_date",
-    )
-
-    nfe40_dhSaiEnt = fields.Datetime(
-        related="date_in_out",
-    )
-
-    nfe40_natOp = fields.Char(
-        related="operation_name",
-    )
-
-    nfe40_serie = fields.Char(related="document_serie")
-
-    nfe40_indFinal = fields.Selection(
-        related="ind_final",
-    )
-
-    nfe40_indPres = fields.Selection(
-        related="ind_pres",
-    )
-
-    nfe40_vNF = fields.Monetary(
-        related="amount_total",
-    )
-
-    nfe40_tpAmb = fields.Selection(
-        related="nfe_environment",
-    )
-
-    nfe40_indIEDest = fields.Selection(
-        related="partner_ind_ie_dest", string="Contribuinte do ICMS (NFe)"
-    )
-
-    nfe40_tpNF = fields.Selection(
-        compute="_compute_nfe_data",
-        inverse="_inverse_nfe40_tpNF",
-    )
-
-    danfe_layout = fields.Selection(
-        selection=NFE_DANFE_LAYOUTS + NFCE_DANFE_LAYOUTS,
-        string="Danfe Layout",
-    )
-
-    nfe40_tpImp = fields.Selection(
-        compute="_compute_nfe_data",
-        inverse="_inverse_nfe40_tpImp",
-    )
-
-    nfe40_modFrete = fields.Selection(
-        default="9",
-    )
-
-    nfe40_tpEmis = fields.Selection(
-        compute="_compute_nfe_data",
-        inverse="_inverse_nfe40_tpEmis",
-    )
-
-    nfe40_procEmi = fields.Selection(
-        default="0",
-    )
+    nfe40_procEmi = fields.Selection(default="0")
 
     nfe40_verProc = fields.Char(
         copy=False,
@@ -226,70 +220,252 @@ class NFe(spec_models.StackedModel):
         .get_param("l10n_br_nfe.version.name", default="Odoo Brasil OCA v14"),
     )
 
+    ##########################
+    # NF-e tag: ide
+    # Compute Methods
+    ##########################
+
+    @api.depends("fiscal_operation_type", "nfe_transmission")
+    def _compute_ide_data(self):
+        """Set schema data which are not just related fields"""
+        for record in self.filtered(filter_processador_edoc_nfe):
+            # tpNF
+            if record.fiscal_operation_type:
+                operation_2_tpNF = {
+                    "out": "1",
+                    "in": "0",
+                }
+                record.nfe40_tpNF = operation_2_tpNF[record.fiscal_operation_type]
+
+            # tpImp
+            if record.issuer == DOCUMENT_ISSUER_COMPANY:
+                if record.document_type_id.code == MODELO_FISCAL_NFE:
+                    record.nfe40_tpImp = record.company_id.nfe_danfe_layout
+
+                if record.document_type_id.code == MODELO_FISCAL_NFCE:
+                    record.nfe40_tpImp = record.company_id.nfce_danfe_layout
+
+    @api.depends("partner_id", "company_id")
+    def _compute_nfe40_idDest(self):
+        for doc in self:
+            if doc.company_id.partner_id.state_id == doc.partner_id.state_id:
+                doc.nfe40_idDest = "1"
+            elif doc.company_id.partner_id.country_id == doc.partner_id.country_id:
+                doc.nfe40_idDest = "2"
+            else:
+                doc.nfe40_idDest = "3"
+
+    ##########################
+    # NF-e tag: ide
+    # Inverse Methods
+    ##########################
+
+    def _inverse_nfe40_tpNF(self):
+        for doc in self:
+            if doc.nfe40_tpNF:
+                tpNF_2_operation = {
+                    "1": "out",
+                    "0": "in",
+                }
+                doc.fiscal_operation_type = tpNF_2_operation[doc.nfe40_tpNF]
+
+    def _inverse_nfe40_tpImp(self):
+        for doc in self:
+            if doc.nfe40_tpImp:
+                doc.danfe_layout = doc.nfe40_tpImp
+
+    def _inverse_nfe40_tpEmis(self):
+        for doc in self:
+            if doc.nfe40_tpEmis:
+                doc.nfe_transmission = doc.nfe40_tpEmis
+
+    ##########################
+    # NF-e tag: NFref
+    ##########################
+
+    nfe40_NFref = fields.One2many(
+        comodel_name="l10n_br_fiscal.document.related",
+        related="document_related_ids",
+        inverse_name="document_id",
+    )
+
+    ##########################
+    # NF-e tag: emit
+    ##########################
+
+    # emit and dest are not related fields as their related fields
+    # can change depending if it's and incoming our outgoing NFe
+    # specially when importing (ERP NFe migration vs supplier Nfe).
+    nfe40_emit = fields.Many2one(
+        comodel_name="res.company",
+        compute="_compute_emit_data",
+        readonly=True,
+        string="Emit",
+    )
+
     nfe40_CRT = fields.Selection(
         related="company_tax_framework",
         string="Código de Regime Tributário (NFe)",
     )
 
-    nfe40_vFrete = fields.Monetary(
-        related="amount_freight_value",
+    ##########################
+    # NF-e tag: emit
+    # Compute Methods
+    ##########################
+
+    def _compute_emit_data(self):
+        for doc in self:  # TODO if out
+            doc.nfe40_emit = doc.company_id
+
+    ##########################
+    # NF-e tag: dest
+    ##########################
+
+    nfe40_dest = fields.Many2one(
+        comodel_name="res.partner",
+        compute="_compute_dest_data",
+        readonly=True,
+        string="Dest",
     )
 
-    nfe40_vFCPUFDest = fields.Monetary(
-        related="amount_icmsfcp_value",
+    nfe40_indIEDest = fields.Selection(
+        related="partner_ind_ie_dest",
+        string="Contribuinte do ICMS (NFe)",
     )
 
-    nfe40_vDesc = fields.Monetary(related="amount_discount_value")
+    ##########################
+    # NF-e tag: dest
+    # Compute Methods
+    ##########################
 
-    nfe40_vTotTrib = fields.Monetary(related="amount_estimate_tax")
+    @api.depends("partner_id")
+    def _compute_dest_data(self):
+        for doc in self:  # TODO if out
+            doc.nfe40_dest = doc.partner_id
 
-    nfe40_vBC = fields.Monetary(
-        string="BC do ICMS",
-        related="amount_icms_base",
+    ##########################
+    # NF-e tag: det
+    ##########################
+
+    # TODO should be done by framework?
+    nfe40_det = fields.One2many(
+        comodel_name="l10n_br_fiscal.document.line",
+        inverse_name="document_id",
+        related="line_ids",
     )
-    nfe40_vBCST = fields.Monetary(related="amount_icmsst_base")
+
+    ##########################
+    # NF-e tag: ICMSTot
+    ##########################
+
+    nfe40_vBC = fields.Monetary(string="BC do ICMS", related="amount_icms_base")
 
     nfe40_vICMS = fields.Monetary(related="amount_icms_value")
+
+    # <vICMSDeson>0.00</vICMSDeson> TODO
+
+    nfe40_vFCPUFDest = fields.Monetary(related="amount_icmsfcp_value")
+
+    nfe40_vICMSUFDest = fields.Monetary(related="amount_icms_destination_value")
+
+    nfe40_vICMSUFRemet = fields.Monetary(related="amount_icms_origin_value")
+
+    # <vFCP>0.00</vFCP> TODO
+
+    nfe40_vBCST = fields.Monetary(related="amount_icmsst_base")
+
     nfe40_vST = fields.Monetary(related="amount_icmsst_value")
+
+    # <vFCPST>0.00</vFCPST> TODO
+
+    # <vFCPSTRet>0.00</vFCPSTRet> TODO
+
+    nfe40_vProd = fields.Monetary(related="amount_price_gross")
+
+    nfe40_vFrete = fields.Monetary(related="amount_freight_value")
+
+    nfe40_vSeg = fields.Monetary(related="amount_insurance_value")
+
+    # TODO  Verificar as operações de bonificação se o desconto sai correto
+    # nfe40_vDesc = fields.Monetary(related="amount_financial_discount_value")
+    # nfe40_vDesc = fields.Monetary(related="amount_discount_value")
+    nfe40_vDesc = fields.Monetary(related="amount_discount_value")
+
+    nfe40_vII = fields.Monetary(related="amount_ii_value")
+
+    nfe40_vIPI = fields.Monetary(related="amount_ipi_value")
+
+    # <vIPIDevol>0.00</vIPIDevol> TODO
 
     nfe40_vPIS = fields.Monetary(
         string="Valor do PIS (NFe)", related="amount_pis_value"
     )
 
-    nfe40_vIPI = fields.Monetary(related="amount_ipi_value")
-
     nfe40_vCOFINS = fields.Monetary(
         string="valor do COFINS (NFe)", related="amount_cofins_value"
     )
 
-    nfe40_infAdFisco = fields.Char(
-        compute="_compute_nfe40_additional_data",
-    )
+    nfe40_vOutro = fields.Monetary(related="amount_other_value")
+
+    nfe40_vNF = fields.Monetary(related="amount_total")
+
+    nfe40_vTotTrib = fields.Monetary(related="amount_estimate_tax")
+
+    ##########################
+    # NF-e tag: ISSQNtot
+    ##########################
+
+    # TODO
+
+    ##########################
+    # NF-e tag: transp
+    ##########################
+
+    nfe40_modFrete = fields.Selection(default="9")
+
+    ##########################
+    # NF-e tag: transporta
+    ##########################
+
+    nfe40_transporta = fields.Many2one(comodel_name="res.partner")
+
+    ##########################
+    # NF-e tag: pag
+    ##########################
+
+    def _prepare_amount_financial(self, ind_pag, t_pag, v_pag):
+        return {
+            "nfe40_indPag": ind_pag,
+            "nfe40_tPag": t_pag,
+            "nfe40_vPag": v_pag,
+        }
+
+    def _export_fields_pagamentos(self):
+        if not self.amount_financial_total:
+            self.nfe40_detPag = [
+                (5, 0, 0),
+                (0, 0, self._prepare_amount_financial("0", "90", 0.00)),
+            ]
+        self.nfe40_detPag.__class__._field_prefix = "nfe40_"
+
+        # the following was disabled because it blocks the normal
+        # invoice validation https://github.com/OCA/l10n-brazil/issues/1559
+        # if not self.nfe40_detPag:  # (empty list)
+        #    raise UserError(_("Favor preencher os dados do pagamento"))
+
+    ##########################
+    # NF-e tag: infAdic
+    ##########################
+
+    nfe40_infAdFisco = fields.Char(compute="_compute_nfe40_additional_data")
+
+    ##########################
+    # NF-e tag: infCpl
+    ##########################
 
     nfe40_infCpl = fields.Char(
         compute="_compute_nfe40_additional_data",
     )
-
-    nfe40_transporta = fields.Many2one(comodel_name="res.partner")
-
-    nfe40_infRespTec = fields.Many2one(
-        comodel_name="res.partner", related="company_id.technical_support_id"
-    )
-
-    nfe40_idDest = fields.Selection(
-        compute="_compute_nfe40_idDest",
-    )
-
-    ##########################
-    # NF-e tag: fat
-    ##########################
-    nfe40_nFat = fields.Char(related="document_number")
-
-    nfe40_vOrig = fields.Monetary(related="amount_financial_total_gross")
-
-    nfe40_vDesc = fields.Monetary(related="amount_financial_discount_value")
-
-    nfe40_vLiq = fields.Monetary(related="amount_financial_total")
 
     @api.depends("fiscal_additional_data", "fiscal_additional_data")
     def _compute_nfe40_additional_data(self):
@@ -313,75 +489,115 @@ class NFe(spec_models.StackedModel):
                     .replace("\r", "")
                 )
 
-    @api.depends("fiscal_operation_type", "nfe_transmission")
-    def _compute_nfe_data(self):
-        """Set schema data which are not just related fields"""
-        for record in self.filtered(filter_processador_edoc_nfe):
-            # id
-            if (
-                record.document_type_id
-                and record.document_type_id.prefix
-                and record.document_key
+    ##########################
+    # NF-e tag: fat
+    ##########################
+    nfe40_nFat = fields.Char(related="document_number")
+
+    nfe40_vOrig = fields.Monetary(related="amount_financial_total_gross")
+
+    nfe40_vLiq = fields.Monetary(related="amount_financial_total")
+
+    ##########################
+    # NF-e tag: infRespTec
+    ##########################
+
+    nfe40_infRespTec = fields.Many2one(
+        comodel_name="res.partner",
+        related="company_id.technical_support_id",
+    )
+
+    ################################
+    # Framework Spec model's methods
+    ################################
+
+    def _export_field(self, xsd_field, class_obj, member_spec):
+        if xsd_field == "nfe40_tpAmb":
+            self.env.context = dict(self.env.context)
+            self.env.context.update({"tpAmb": self[xsd_field]})
+        elif xsd_field == "nfe40_vTroco" and (
+            self.nfe40_detPag and self.nfe40_detPag[0].nfe40_tPag == "90"
+        ):
+            return False
+        return super()._export_field(xsd_field, class_obj, member_spec)
+
+    def _export_many2one(self, field_name, xsd_required, class_obj=None):
+        self.ensure_one()
+        if field_name in self._stacking_points.keys():
+            if field_name == "nfe40_ISSQNtot" and not any(
+                t == "issqn"
+                for t in self.nfe40_det.mapped("product_id.tax_icms_or_issqn")
             ):
-                record.nfe40_Id = "{}{}".format(
-                    record.document_type_id.prefix, record.document_key
-                )
-            else:
-                record.nfe40_Id = None
+                return False
 
-            # tpNF
-            if record.fiscal_operation_type:
-                operation_2_tpNF = {
-                    "out": "1",
-                    "in": "0",
-                }
-                record.nfe40_tpNF = operation_2_tpNF[record.fiscal_operation_type]
+            elif (not xsd_required) and field_name not in ["nfe40_enderDest"]:
+                comodel = self.env[self._stacking_points.get(field_name).comodel_name]
+                fields = [
+                    f for f in comodel._fields if f.startswith(self._field_prefix)
+                ]
+                sub_tag_read = self.read(fields)[0]
+                if not any(
+                    v
+                    for k, v in sub_tag_read.items()
+                    if k.startswith(self._field_prefix)
+                ):
+                    return False
 
-            # TpEmis
-            if record.nfe_transmission:
-                record.nfe40_tpEmis = record.nfe_transmission
+        return super()._export_many2one(field_name, xsd_required, class_obj)
 
-            # tpImp
-            if record.issuer == DOCUMENT_ISSUER_COMPANY:
-                if record.document_type_id.code == MODELO_FISCAL_NFE:
-                    record.nfe40_tpImp = record.company_id.nfe_danfe_layout
+    def _export_one2many(self, field_name, class_obj=None):
+        res = super()._export_one2many(field_name, class_obj)
+        i = 0
+        for field_data in res:
+            i += 1
+            if class_obj._fields[field_name].comodel_name == "nfe.40.det":
+                field_data.nItem = i
+        return res
 
-                if record.document_type_id.code == MODELO_FISCAL_NFCE:
-                    record.nfe40_tpImp = record.company_id.nfce_danfe_layout
+    def _build_attr(self, node, fields, vals, path, attr):
+        key = "nfe40_%s" % (attr.get_name(),)  # TODO schema wise
+        value = getattr(node, attr.get_name())
 
-    @api.depends("partner_id", "company_id")
-    def _compute_nfe40_idDest(self):
-        for rec in self:
-            if rec.company_id.partner_id.state_id == rec.partner_id.state_id:
-                rec.nfe40_idDest = "1"
-            elif rec.company_id.partner_id.country_id == rec.partner_id.country_id:
-                rec.nfe40_idDest = "2"
-            else:
-                rec.nfe40_idDest = "3"
+        if key == "nfe40_mod":
+            vals["document_type_id"] = (
+                self.env["l10n_br_fiscal.document.type"]
+                .search([("code", "=", value)], limit=1)
+                .id
+            )
 
-    def _inverse_nfe40_tpNF(self):
-        for rec in self:
-            if rec.nfe40_tpNF:
-                tpNF_2_operation = {
-                    "1": "out",
-                    "0": "in",
-                }
-                rec.fiscal_operation_type = tpNF_2_operation[rec.nfe40_tpNF]
+        return super()._build_attr(node, fields, vals, path, attr)
 
-    def _inverse_nfe40_Id(self):
-        for record in self:
-            if record.nfe40_Id:
-                record.document_key = re.findall(r"\d+", str(record.nfe40_Id))[0]
+    def _build_many2one(self, comodel, vals, new_value, key, value, path):
+        if key == "nfe40_emit" and self.env.context.get("edoc_type") == "in":
+            enderEmit_value = self.env["res.partner"].build_attrs(
+                value.enderEmit, path=path
+            )
+            new_value.update(enderEmit_value)
+            new_value["is_company"] = True
+            new_value["cnpj_cpf"] = new_value.get("nfe40_CNPJ")
+            super()._build_many2one(
+                self.env["res.partner"], vals, new_value, "partner_id", value, path
+            )
+        elif self.env.context.get("edoc_type") == "in" and key in [
+            "nfe40_dest",
+            "nfe40_enderDest",
+        ]:
+            # this would be the emit/company data, but we won't update it on
+            # NFe import so just do nothing
+            return
+        elif (
+            self._name == "account.invoice"
+            and comodel._name == "l10n_br_fiscal.document"
+        ):
+            # module l10n_br_account_nfe
+            # stacked m2o
+            vals.update(new_value)
+        else:
+            super()._build_many2one(comodel, vals, new_value, key, value, path)
 
-    def _inverse_nfe40_tpEmis(self):
-        for record in self:
-            if record.nfe40_tpEmis:
-                record.nfe_transmission = record.nfe40_tpEmis
-
-    def _inverse_nfe40_tpImp(self):
-        for record in self:
-            if record.nfe40_tpImp:
-                record.danfe_layout = record.nfe40_tpImp
+    ################################
+    # Business Model Methods
+    ################################
 
     def _document_number(self):
         # TODO: Criar campos no fiscal para codigo aleatorio e digito verificador,
@@ -489,26 +705,6 @@ class NFe(spec_models.StackedModel):
         )
         self._change_state(state)
 
-    def _prepare_amount_financial(self, ind_pag, t_pag, v_pag):
-        return {
-            "nfe40_indPag": ind_pag,
-            "nfe40_tPag": t_pag,
-            "nfe40_vPag": v_pag,
-        }
-
-    def _export_fields_pagamentos(self):
-        if not self.amount_financial_total:
-            self.nfe40_detPag = [
-                (5, 0, 0),
-                (0, 0, self._prepare_amount_financial("0", "90", 0.00)),
-            ]
-        self.nfe40_detPag.__class__._field_prefix = "nfe40_"
-
-        # the following was disabled because it blocks the normal
-        # invoice validation https://github.com/OCA/l10n-brazil/issues/1559
-        # if not self.nfe40_detPag:  # (empty list)
-        #    raise UserError(_("Favor preencher os dados do pagamento"))
-
     def _valida_xml(self, xml_file):
         self.ensure_one()
         erros = nfe_sub.schema_validation(StringIO(xml_file))
@@ -564,120 +760,6 @@ class NFe(spec_models.StackedModel):
         for record in self.filtered(filter_processador_edoc_nfe):
             if not record.date_in_out:
                 record.date_in_out = fields.Datetime.now()
-
-    def _export_fields(self, xsd_fields, class_obj, export_dict):
-        if self.company_id.partner_id.state_id.ibge_code:
-            self.nfe40_cUF = self.company_id.partner_id.state_id.ibge_code
-        if self.document_type_id.code:
-            self.nfe40_mod = self.document_type_id.code
-        self.nfe40_cMunFG = self.company_id.partner_id.city_id.ibge_code
-        return super(NFe, self)._export_fields(xsd_fields, class_obj, export_dict)
-
-    def _export_field(self, xsd_field, class_obj, member_spec):
-        if xsd_field in ("nfe40_vICMSUFDest", "nfe40_vICMSUFRemet"):
-            if (
-                self.ind_final == "1"
-                and self.nfe40_idDest == "2"
-                and self.nfe40_indIEDest == "9"
-            ):
-                self.nfe40_vICMSUFDest = sum(
-                    self.fiscal_line_ids.mapped("nfe40_vICMSUFDest")
-                )
-                self.nfe40_vICMSUFRemet = sum(
-                    self.fiscal_line_ids.mapped("nfe40_vICMSUFRemet")
-                )
-            else:
-                self.nfe40_vICMSUFDest = 0.0
-                self.nfe40_vICMSUFRemet = 0.0
-        if xsd_field == "nfe40_tpAmb":
-            self.env.context = dict(self.env.context)
-            self.env.context.update({"tpAmb": self[xsd_field]})
-        elif xsd_field == "nfe40_vTroco" and (
-            self.nfe40_detPag and self.nfe40_detPag[0].nfe40_tPag == "90"
-        ):
-            return False
-        return super(NFe, self)._export_field(xsd_field, class_obj, member_spec)
-
-    def _export_many2one(self, field_name, xsd_required, class_obj=None):
-        self.ensure_one()
-        if field_name in self._stacking_points.keys():
-            if field_name == "nfe40_ISSQNtot" and not any(
-                t == "issqn"
-                for t in self.nfe40_det.mapped("product_id.tax_icms_or_issqn")
-            ):
-                return False
-
-            elif (not xsd_required) and field_name not in ["nfe40_enderDest"]:
-                comodel = self.env[self._stacking_points.get(field_name).comodel_name]
-                fields = [
-                    f for f in comodel._fields if f.startswith(self._field_prefix)
-                ]
-                sub_tag_read = self.read(fields)[0]
-                if not any(
-                    v
-                    for k, v in sub_tag_read.items()
-                    if k.startswith(self._field_prefix)
-                ):
-                    return False
-
-        return super(NFe, self)._export_many2one(field_name, xsd_required, class_obj)
-
-    def _export_float_monetary(self, field_name, member_spec, class_obj, xsd_required):
-        if field_name == "nfe40_vProd" and class_obj._name == "nfe.40.icmstot":
-            self[field_name] = sum(self["nfe40_det"].mapped("nfe40_vProd"))
-        return super(NFe, self)._export_float_monetary(
-            field_name, member_spec, class_obj, xsd_required
-        )
-
-    def _export_one2many(self, field_name, class_obj=None):
-        res = super(NFe, self)._export_one2many(field_name, class_obj)
-        i = 0
-        for field_data in res:
-            i += 1
-            if class_obj._fields[field_name].comodel_name == "nfe.40.det":
-                field_data.nItem = i
-        return res
-
-    def _build_attr(self, node, fields, vals, path, attr):
-        key = "nfe40_%s" % (attr.get_name(),)  # TODO schema wise
-        value = getattr(node, attr.get_name())
-
-        if key == "nfe40_mod":
-            vals["document_type_id"] = (
-                self.env["l10n_br_fiscal.document.type"]
-                .search([("code", "=", value)], limit=1)
-                .id
-            )
-
-        return super(NFe, self)._build_attr(node, fields, vals, path, attr)
-
-    def _build_many2one(self, comodel, vals, new_value, key, value, path):
-        if key == "nfe40_emit" and self.env.context.get("edoc_type") == "in":
-            enderEmit_value = self.env["res.partner"].build_attrs(
-                value.enderEmit, path=path
-            )
-            new_value.update(enderEmit_value)
-            new_value["is_company"] = True
-            new_value["cnpj_cpf"] = new_value.get("nfe40_CNPJ")
-            super()._build_many2one(
-                self.env["res.partner"], vals, new_value, "partner_id", value, path
-            )
-        elif self.env.context.get("edoc_type") == "in" and key in [
-            "nfe40_dest",
-            "nfe40_enderDest",
-        ]:
-            # this would be the emit/company data, but we won't update it on
-            # NFe import so just do nothing
-            return
-        elif (
-            self._name == "account.invoice"
-            and comodel._name == "l10n_br_fiscal.document"
-        ):
-            # module l10n_br_account_nfe
-            # stacked m2o
-            vals.update(new_value)
-        else:
-            super(NFe, self)._build_many2one(comodel, vals, new_value, key, value, path)
 
     def view_pdf(self):
         if not self.filtered(filter_processador_edoc_nfe):

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -720,17 +720,17 @@ class NFeLine(spec_models.StackedModel):
                             "l10n_br_fiscal.cst_icms_%s" % (icms.CST,)
                         ).id
                         # TODO search + log if not found
-                    if hasattr(icms, "modBC"):
+                    if hasattr(icms, "modBC") and icms.modBC is not None:
                         icms_vals["icms_base_type"] = float(icms.modBC)
                     if hasattr(icms, "orig"):
                         icms_vals["icms_origin"] = icms.orig
-                    if hasattr(icms, "vBC"):
+                    if hasattr(icms, "vBC") and icms.vBC is not None:
                         icms_vals["icms_base"] = float(icms.vBC)
-                    if hasattr(icms, "pICMS"):
+                    if hasattr(icms, "pICMS") and icms.pICMS is not None:
                         icms_vals["icms_percent"] = float(icms.pICMS)
-                    if hasattr(icms, "vICMS"):
+                    if hasattr(icms, "vICMS") and icms.vICMS is not None:
                         icms_vals["icms_value"] = float(icms.vICMS)
-                    if hasattr(icms, "pRedBC"):
+                    if hasattr(icms, "pRedBC") and icms.pRedBC is not None:
                         icms_vals["icms_reduction"] = float(icms.pRedBC)
                     if hasattr(icms, "motDesICMS") and icms.motDesICMS is not None:
                         icms_vals["icms_relief_id"] = self.env.ref(
@@ -738,73 +738,83 @@ class NFeLine(spec_models.StackedModel):
                         ).id
                     if hasattr(icms, "vICMSDeson") and icms.vICMSDeson is not None:
                         icms_vals["icms_relief_value"] = float(icms.vICMSDeson)
-                    if hasattr(icms, "vICMSSubstituto"):
+                    if (
+                        hasattr(icms, "vICMSSubstituto")
+                        and icms.vICMSSubstituto is not None
+                    ):
                         icms_vals["icms_substitute"] = float(icms.vICMSSubstituto)
 
                     # ICMS ST fields
                     # TODO map icmsst_tax_id
-                    if hasattr(icms, "modBCST"):
+                    if hasattr(icms, "modBCST") and icms.modBCST is not None:
                         icms_vals["icmsst_base_type"] = float(icms.modBCST)
-                    if hasattr(icms, "pMVAST"):
+                    if hasattr(icms, "pMVAST") and icms.pMVAST is not None:
                         icms_vals["icmsst_mva_percent"] = float(icms.pMVAST)
-                    if hasattr(icms, "pRedBCST"):
+                    if hasattr(icms, "pRedBCST") and icms.pRedBCST is not None:
                         icms_vals["icmsst_reduction"] = float(icms.pRedBCST)
-                    if hasattr(icms, "vBCST"):
+                    if hasattr(icms, "vBCST") and icms.vBCST is not None:
                         icms_vals["icmsst_base"] = float(icms.vBCST)
-                    if hasattr(icms, "pICMSST"):
+                    if hasattr(icms, "pICMSST") and icms.pICMSST is not None:
                         icms_vals["icmsst_percent"] = float(icms.pICMSST)
-                    if hasattr(icms, "vICMSST"):
+                    if hasattr(icms, "vICMSST") and icms.vICMSST is not None:
                         icms_vals["icmsst_value"] = float(icms.vICMSST)
-                    if hasattr(icms, "vBCSTRet"):
+                    if hasattr(icms, "vBCSTRet") and icms.vBCSTRet is not None:
                         icms_vals["icmsst_wh_base"] = float(icms.vBCSTRet)
-                    if hasattr(icms, "vICMSSTRet"):
+                    if hasattr(icms, "vICMSSTRet") and icms.vICMSSTRet is not None:
                         icms_vals["icmsst_wh_value"] = float(icms.vICMSSTRet)
 
                     # ICMS FCP Fields
                     # TODO map icmsfcp_tax_id
-                    if hasattr(icms, "pFCPUFDest"):
+                    if hasattr(icms, "pFCPUFDest") and icms.pFCPUFDest is not None:
                         icms_vals["icmsfcp_percent"] = float(icms.pFCPUFDest)
-                    if hasattr(icms, "vFCPUFDest"):
+                    if hasattr(icms, "vFCPUFDest") and icms.vFCPUFDest is not None:
                         icms_vals["icmsfcp_value"] = float(icms.vFCPUFDest)
-                    if hasattr(icms, "vBCFCPST"):
+                    if hasattr(icms, "vBCFCPST") and icms.vBCFCPST is not None:
                         icms_vals["icmsfcp_base"] = float(icms.vBCFCPST)
 
                     # ICMS DIFAL Fields
-                    if hasattr(icms, "vBCUFDest"):
+                    if hasattr(icms, "vBCUFDest") and icms.vBCUFDest is not None:
                         icms_vals["icms_destination_base"] = float(icms.vBCUFDest)
-                    if hasattr(icms, "pICMSUFDest"):
+                    if hasattr(icms, "pICMSUFDest") and icms.pICMSUFDest is not None:
                         icms_vals["icms_origin_percent"] = float(icms.pICMSUFDest)
-                    if hasattr(icms, "pICMSInter"):
+                    if hasattr(icms, "pICMSInter") and icms.pICMSInter is not None:
                         icms_vals["icms_destination_percent"] = float(icms.pICMSInter)
 
-                    if hasattr(icms, "pICMSInterPart"):
+                    if (
+                        hasattr(icms, "pICMSInterPart")
+                        and icms.pICMSInterPart is not None
+                    ):
                         icms_vals["icms_sharing_percent"] = float(icms.pICMSInterPart)
-                    if hasattr(icms, "vICMSUFRemet"):
+                    if hasattr(icms, "vICMSUFRemet") and icms.vICMSUFRemet is not None:
                         icms_vals["icms_origin_value"] = float(icms.vICMSUFRemet)
                     if hasattr(icms, "vICMSUFDest"):
                         icms_vals["icms_destination_value"] = float(icms.vICMSUFDest)
 
                     # ICMS Simples Nacional Fields
                     # TODO map icmssn_tax_id using CSOSN
-                    if hasattr(icms, "pCredSN"):
+                    if hasattr(icms, "CSOSN") and icms.CSOSN is not None:
+                        icms_vals["icms_cst_id"] = self.env.ref(
+                            "l10n_br_fiscal.cst_icmssn_%s" % (icms.CSOSN,)
+                        ).id
+                    if hasattr(icms, "pCredSN") and icms.pCredSN is not None:
                         icms_vals["icmssn_percent"] = float(icms.pCredSN)
-                    if hasattr(icms, "vCredICMSSN"):
+                    if hasattr(icms, "vCredICMSSN") and icms.vCredICMSSN is not None:
                         icms_vals["icmssn_credit_value"] = float(icms.vCredICMSSN)
 
                     # ICMS Retido Anteriormente
-                    if hasattr(icms, "vBCSTRet"):
+                    if hasattr(icms, "vBCSTRet") and icms.vBCSTRet is not None:
                         icms_vals["icmsst_wh_base"] = float(icms.vBCSTRet)
-                    if hasattr(icms, "vICMSSTRet"):
+                    if hasattr(icms, "vICMSSTRet") and icms.vICMSSTRet is not None:
                         icms_vals["icmsst_wh_value"] = float(icms.vICMSSTRet)
-                    if hasattr(icms, "vBCFCPSTRet"):
+                    if hasattr(icms, "vBCFCPSTRet") and icms.vBCFCPSTRet is not None:
                         icms_vals["icmsfcp_base_wh"] = float(icms.vBCFCPSTRet)
-                    if hasattr(icms, "vFCPSTRet"):
+                    if hasattr(icms, "vFCPSTRet") and icms.vFCPSTRet is not None:
                         icms_vals["icmsfcp_value_wh"] = float(icms.vFCPSTRet)
-                    if hasattr(icms, "vFCPST"):
+                    if hasattr(icms, "vFCPST") and icms.vFCPST is not None:
                         icms_vals["icmsfcpst_value"] = float(icms.vFCPST)
-                    if hasattr(icms, "vBCEfet"):
+                    if hasattr(icms, "vBCEfet") and icms.vBCEfet is not None:
                         icms_vals["effective_base_value"] = float(icms.vBCEfet)
-                    if hasattr(icms, "vICMSEfet"):
+                    if hasattr(icms, "vICMSEfet") and icms.vICMSEfet is not None:
                         icms_vals["icms_effective_value"] = float(icms.vICMSEfet)
             new_value.update(icms_vals)
         elif key == "nfe40_IPI":

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -51,13 +51,23 @@ class NFeLine(spec_models.StackedModel):
         related="uom_id.code",
     )
 
-    nfe40_uTrib = fields.Char(
-        related="uot_id.code",
+    nfe40_qCom = fields.Float(
+        string="nfe40 qCom",
+        related="quantity",
     )
 
     nfe40_vUnCom = fields.Float(
         related="price_unit",
         string="Valor unitário de comercialização",
+    )
+
+    nfe40_uTrib = fields.Char(
+        related="uot_id.code",
+    )
+
+    nfe40_qTrib = fields.Float(
+        string="nfe40_qTrib",
+        related="fiscal_quantity",
     )
 
     nfe40_vUnTrib = fields.Float(
@@ -441,8 +451,6 @@ class NFeLine(spec_models.StackedModel):
 
         self.nfe40_NCM = self.ncm_id.code_unmasked or False
         self.nfe40_CEST = self.cest_id and self.cest_id.code_unmasked or False
-        self.nfe40_qCom = self.quantity
-        self.nfe40_qTrib = self.fiscal_quantity
         self.nfe40_pICMS = self.icms_percent
         self.nfe40_pICMSST = self.icmsst_percent
         self.nfe40_pMVAST = self.icmsst_mva_percent

--- a/l10n_br_nfe/models/document_related.py
+++ b/l10n_br_nfe/models/document_related.py
@@ -104,7 +104,7 @@ class NFeRelated(spec_models.StackedModel):
                         else ""
                     )
                     if rec.cpfcnpj_type == "cpf":
-                        rec.nfe40_CPF = rec.cnjp_cpf
+                        rec.nfe40_CPF = rec.cnpj_cpf
                     else:
                         rec.nfe40_CNPJ = rec.cnpj_cpf
                     rec.nfe40_IE = rec.inscr_est

--- a/l10n_br_nfe/models/document_type.py
+++ b/l10n_br_nfe/models/document_type.py
@@ -1,0 +1,9 @@
+# Copyright (C) 2022  Renato Lima - Akretion <renato.lima@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class DocumentType(models.Model):
+    _inherit = "l10n_br_fiscal.document.type"
+    _nfe_search_keys = ["code"]

--- a/l10n_br_nfe/models/invalidate_number.py
+++ b/l10n_br_nfe/models/invalidate_number.py
@@ -59,7 +59,9 @@ class InvalidateNumber(models.Model):
         event_id = self.event_ids.create_event_save_xml(
             company_id=self.company_id,
             environment=(
-                EVENT_ENV_PROD if self.nfe_environment == "1" else EVENT_ENV_HML
+                EVENT_ENV_PROD
+                if self.company_id.nfe_environment == "1"
+                else EVENT_ENV_HML
             ),
             event_type="3",
             xml_file=processo.envio_xml.decode("utf-8"),

--- a/l10n_br_nfe/models/nbm.py
+++ b/l10n_br_nfe/models/nbm.py
@@ -1,0 +1,9 @@
+# Copyright (C) 2021  Renato Lima - Akretion <renato.lima@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class Nbm(models.Model):
+    _inherit = "l10n_br_fiscal.nbm"
+    _nfe_search_keys = ["code_unmasked"]

--- a/l10n_br_nfe/models/ncm.py
+++ b/l10n_br_nfe/models/ncm.py
@@ -1,0 +1,9 @@
+# Copyright (C) 2021  Renato Lima - Akretion <renato.lima@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class Ncm(models.Model):
+    _inherit = "l10n_br_fiscal.ncm"
+    _nfe_search_keys = ["code_unmasked"]

--- a/l10n_br_nfe/models/res_city.py
+++ b/l10n_br_nfe/models/res_city.py
@@ -1,10 +1,22 @@
 # Copyright 2019 Akretion (Raphaël Valyi <raphael.valyi@akretion.com>)
 # Copyright 2021 Akretion (Renato Lima <renato.lima@akretion.com>)
+# Copyright 2022 KMEE  (Renan Hiroki Bastos <renan.hiroki@kmee.com.br>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import api, models
 
 
 class ResCity(models.Model):
     _inherit = "res.city"
     _nfe_search_keys = ["ibge_code"]
+
+    @api.model
+    def match_or_create_m2o(self, rec_dict, parent_dict, model=None):
+        """If city not found, break hard, don't create it"""
+
+        if rec_dict.get("ibge_code"):
+            domain = [("ibge_code", "=", rec_dict.get("ibge_code"))]
+            match = self.search(domain, limit=1)
+            if match:
+                return match.id
+        return False

--- a/l10n_br_nfe/models/res_company.py
+++ b/l10n_br_nfe/models/res_company.py
@@ -119,5 +119,5 @@ class ResCompany(spec_models.SpecModel):
             values, model
         )
         if not values.get("name"):
-            values["name"] = values.get("nfe40_xNome") or values.get("nfe40_xFant")
+            values["name"] = values.get("nfe40_xFant") or values.get("nfe40_xNome")
         return values

--- a/l10n_br_nfe/models/res_country.py
+++ b/l10n_br_nfe/models/res_country.py
@@ -1,0 +1,19 @@
+# Copyright (C) 2022  Renan Hiroki Bastos - KMEE <renan.hiroki@kmee.com.br>
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import api, models
+
+
+class Country(models.Model):
+    _inherit = "res.country"
+
+    @api.model
+    def match_or_create_m2o(self, rec_dict, parent_dict, model=None):
+        """If country not found, break hard, don't create it"""
+
+        if rec_dict.get("bc_code"):
+            domain = [("bc_code", "=", rec_dict.get("bc_code"))]
+            match = self.search(domain, limit=1)
+            if match:
+                return match.id
+        return False

--- a/l10n_br_nfe/models/res_country.py
+++ b/l10n_br_nfe/models/res_country.py
@@ -6,6 +6,7 @@ from odoo import api, models
 
 class Country(models.Model):
     _inherit = "res.country"
+    _nfe_search_keys = ["bc_code"]
 
     @api.model
     def match_or_create_m2o(self, rec_dict, parent_dict, model=None):

--- a/l10n_br_nfe/models/res_country_state.py
+++ b/l10n_br_nfe/models/res_country_state.py
@@ -1,10 +1,21 @@
 # Copyright 2019 Akretion (Raphaël Valyi <raphael.valyi@akretion.com>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import api, models
 
 
 class ResCountryState(models.Model):
     _inherit = "res.country.state"
     _nfe_search_keys = ["ibge_code", "code"]
     _nfe_extra_domain = [("ibge_code", "!=", False)]
+
+    @api.model
+    def match_or_create_m2o(self, rec_dict, parent_dict, model=None):
+        """If state not found, break hard, don't create it"""
+
+        if rec_dict.get("code"):
+            domain = [("code", "=", rec_dict.get("code")), ("ibge_code", "!=", False)]
+            match = self.search(domain, limit=1)
+            if match:
+                return match.id
+        return False

--- a/l10n_br_nfe/models/res_country_state.py
+++ b/l10n_br_nfe/models/res_country_state.py
@@ -1,4 +1,5 @@
 # Copyright 2019 Akretion (Raphaël Valyi <raphael.valyi@akretion.com>)
+# Copyright 2022 KMEE  (Renan Hiroki Bastos <renan.hiroki@kmee.com.br>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, models

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -65,6 +65,7 @@ class ResPartner(spec_models.SpecModel):
 
     # nfe.40.dest
     nfe40_xNome = fields.Char(related="legal_name")
+    nfe40_xFant = fields.Char(related="name")
     nfe40_enderDest = fields.Many2one(
         comodel_name="res.partner", compute="_compute_nfe40_enderDest"
     )

--- a/l10n_br_nfe/models/tax_ipi_guideline.py
+++ b/l10n_br_nfe/models/tax_ipi_guideline.py
@@ -1,0 +1,9 @@
+# Copyright (C) 2021  Renato Lima - Akretion <renato.lima@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class TaxIpiGuideline(models.Model):
+    _inherit = "l10n_br_fiscal.tax.ipi.guideline"
+    _nfe_search_keys = ["code_unmasked"]

--- a/l10n_br_nfe/models/uom.py
+++ b/l10n_br_nfe/models/uom.py
@@ -11,8 +11,8 @@ class Uom(models.Model):
     def match_or_create_m2o(self, rec_dict, parent_dict, model=None):
         """If uom not found, break hard, don't create it"""
 
-        if rec_dict.get("name"):
-            domain = [("code", "=", rec_dict.get("name"))]
+        if rec_dict.get("code"):
+            domain = [("code", "=", rec_dict.get("code"))]
             match = self.search(domain, limit=1)
             if match:
                 return match.id

--- a/l10n_br_nfe/tests/__init__.py
+++ b/l10n_br_nfe/tests/__init__.py
@@ -8,3 +8,4 @@ from . import test_nfe_import
 from . import test_nfe_serialize
 from . import test_nfe_serialize_lc
 from . import test_nfe_serialize_sn
+from . import test_nfe_xml_validation

--- a/l10n_br_nfe/tests/test_nfe_import.py
+++ b/l10n_br_nfe/tests/test_nfe_import.py
@@ -38,7 +38,7 @@ class NFeImportTest(SavepointCase):
             .build(nfe_binding.infNFe, dry_run=True)
         )
         assert isinstance(nfe.id, NewId)
-        self.assertEqual(nfe.partner_id.name, "Alimentos Ltda.")
+        self.assertEqual(nfe.partner_id.name, "Alimentos Saudaveis")
         self.assertEqual(nfe.fiscal_line_ids[0].product_id.name, "QUINOA 100G (2X50G)")
 
     def test_import_in_nfe(self):
@@ -69,7 +69,7 @@ class NFeImportTest(SavepointCase):
 
         # here we check that emit and enderEmit
         # are now the supplier data (partner_id)
-        self.assertEqual(nfe.partner_id.name, "Alimentos Ltda.")
+        self.assertEqual(nfe.partner_id.name, "Alimentos Saudaveis")
         self.assertEqual(nfe.partner_id.cnpj_cpf, "34.128.745/0001-52")
         # this tests the _extract_related_values method for related values:
         self.assertEqual(nfe.partner_id.legal_name, "Alimentos Ltda.")

--- a/l10n_br_nfe/tests/test_nfe_serialize.py
+++ b/l10n_br_nfe/tests/test_nfe_serialize.py
@@ -40,6 +40,8 @@ class TestNFeExport(TransactionCase):
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
 
+        nfe._compute_amount()
+
     def test_serialize_xml(self):
         for nfe in self.nfe_list:
             nfe_id = nfe["record_id"]

--- a/l10n_br_nfe/tests/test_nfe_structure.py
+++ b/l10n_br_nfe/tests/test_nfe_structure.py
@@ -71,9 +71,11 @@ class NFeStructure(SavepointCase):
             "nfe40_retTrib",
             "nfe40_total",
             "nfe40_transp",
+            "nfe40_cobr",
+            "nfe40_fat",
         ]
         keys = [k for k in self.env["l10n_br_fiscal.document"]._stacking_points.keys()]
-        self.assertEqual(sorted(keys), doc_keys)
+        self.assertEqual(sorted(keys), sorted(doc_keys))
 
     def test_doc_line_stacking_points(self):
         line_keys = [

--- a/l10n_br_nfe/tests/test_nfe_xml_validation.py
+++ b/l10n_br_nfe/tests/test_nfe_xml_validation.py
@@ -1,0 +1,50 @@
+import logging
+
+from odoo.tests.common import TransactionCase
+
+from odoo.addons.l10n_br_fiscal.constants.fiscal import SITUACAO_EDOC_A_ENVIAR
+
+_logger = logging.getLogger(__name__)
+
+
+class TestXMLValidation(TransactionCase):
+    def test_xml_nfe_validation(self):
+        """In this test case, the CEP is deleted from the partner's record on purpose,
+        when confirming the NF-e an XML validation error must be presented."""
+        document_model = self.env["l10n_br_fiscal.document"]
+        document_line_model = self.env["l10n_br_fiscal.document.line"]
+        akretion_partner = self.env.ref("l10n_br_base.res_partner_address_ak3")
+        wrong_cep = "XoQC@33278"
+        akretion_partner.write({"zip": wrong_cep})
+        company_id = self.env.ref("l10n_br_base.empresa_lucro_presumido")
+        self.env.user.company_ids += company_id
+        self.env.user.company_id = company_id
+        document = document_model.create(
+            {
+                "partner_id": akretion_partner.id,
+                "document_type_id": self.env.ref("l10n_br_fiscal.document_55").id,
+                "fiscal_operation_id": self.env.ref("l10n_br_fiscal.fo_venda").id,
+            }
+        )
+        document._onchange_fiscal_operation_id()
+        document._onchange_document_type_id()
+        document._onchange_document_serie_id()
+        line = document_line_model.create(
+            {
+                "document_id": document.id,
+                "company_id": document.company_id.id,
+                "partner_id": document.partner_id.id,
+                "fiscal_operation_type": document.fiscal_operation_type,
+                "fiscal_operation_id": document.fiscal_operation_id.id,
+                "product_id": self.env.ref("product.product_product_4d").id,
+            }
+        )
+        line._onchange_product_id_fiscal()
+        line._onchange_fiscal_operation_line_id()
+        document.action_document_confirm()
+        document.action_document_send()
+        _logger.info(
+            "(Test Result) XML Validation Message: %s" % (document.xml_error_message)
+        )
+        self.assertTrue("CEP" in document.xml_error_message)
+        self.assertEqual(document.state_edoc, SITUACAO_EDOC_A_ENVIAR)

--- a/l10n_br_nfe/views/nfe_document_view.xml
+++ b/l10n_br_nfe/views/nfe_document_view.xml
@@ -33,6 +33,7 @@
                     name="nfe_finance"
                     attrs="{'invisible': [('document_type', 'not in', ['55', '65'])]}"
                 >
+                  <field name="nfe40_dup" />
                   <field name="nfe40_detPag" />
               </group>
           </page>


### PR DESCRIPTION
Esse é um cherry-pick exaustivo dos commits da 12.0 no l10n_ br_nfe que estavam faltando.
Esse PR esta incluindo os 5 commits desse port do l10n_br_fiscal https://github.com/OCA/l10n-brazil/pull/1973 pro testes de NFe passarem. Depois do merge de #1973 o rebase ira então matar esses 5 commits.

O cherry-pick foi bastante automatico, porem tem esses 3 commits que eu não precisei re-fazer porque de alguma forma as alterações deles ja tinham sido incluidas na branch 14.0:

```
commit 42fe66416a0562479d6ee5d1d30bbc0baf491227
Author: Renato Lima <renato.lima@akretion.com>
Date:   Wed Nov 10 19:13:05 2021 -0300

    [ADD] ir.config.parameter for nfe VerProc tag
    

commit 69852ee02af23c5e82bce3278e81a7bfa2b5e6e7
Author: Marcel Savegnago <marcel.savegnago@gmail.com>
Date:   Fri Nov 26 00:02:04 2021 -0300

    [FIX] nfe_version (max 20 characters)


commit 921a7e215d971b049484ec1d247a9bf2b9612edc
Author: Renato Lima <renato.lima@akretion.com>
Date:   Tue Nov 30 18:30:50 2021 -0300

    [FIX] ICMSUFDest NFE tag
```