### PR TITLE
[14.0][FIX] Geração dos boletos sem a criação automática do arquivo de remessa.

### DIFF
--- a/l10n_br_account_payment_order/models/account_move.py
+++ b/l10n_br_account_payment_order/models/account_move.py
@@ -56,49 +56,58 @@ class AccountMove(models.Model):
 
     def action_post(self):
         result = super().action_post()
+        self.load_cnab_info()
+        return result
+
+    def load_cnab_info(self):
+        # Se não possui Modo de Pagto não há nada a ser feito
+        if not self.payment_mode_id:
+            return
+        # Se não gera Ordem de Pagto não há nada a ser feito
+        if not self.payment_mode_id.payment_order_ok:
+            return
+        # Podem existir Modo de Pagto q geram Ordens mas não são CNAB
+        # por isso nesse caso tbm nada a ser feito
+        if self.payment_mode_id.payment_method_code not in BR_CODES_PAYMENT_ORDER:
+            return
+        # TODO - apesar do campo financial_move_line_ids ser do tipo
+        #  compute esta sendo preciso chamar o metodo porque as vezes
+        #  ocorre da linha vir vazia o que impede de entrar no FOR
+        #  abaixo causando o não preenchimento de dados usados no Boleto,
+        #  isso deve ser melhor investigado
+        self._compute_financial()
+        for index, interval in enumerate(self.financial_move_line_ids):
+            inv_number = self.get_invoice_fiscal_number().split("/")[-1]
+            numero_documento = inv_number + "/" + str(index + 1).zfill(2)
+
+            sequence = self.payment_mode_id.get_own_number_sequence(
+                self, numero_documento
+            )
+
+            interval.own_number = (
+                sequence if interval.payment_mode_id.generate_own_number else "0"
+            )
+            interval.document_number = numero_documento
+            interval.company_title_identification = hex(interval.id).upper()
+            instructions = ""
+            if self.eval_payment_mode_instructions:
+                instructions = self.eval_payment_mode_instructions + "\n"
+            if self.instructions:
+                instructions += self.instructions + "\n"
+            interval.instructions = instructions
+            # Codigo de Instrução do Movimento pode variar,
+            # mesmo no CNAB 240
+            interval.mov_instruction_code_id = (
+                self.payment_mode_id.cnab_sending_code_id.id
+            )
         filtered_invoice_ids = self.filtered(
             lambda s: (
                 s.payment_mode_id and s.payment_mode_id.auto_create_payment_order
             )
         )
-
         if filtered_invoice_ids:
-            # TODO - apesar do campo financial_move_line_ids ser do tipo
-            #  compute esta sendo preciso chamar o metodo porque as vezes
-            #  ocorre da linha vir vazia o que impede de entrar no FOR
-            #  abaixo causando o não preenchimento de dados usados no Boleto,
-            #  isso deve ser melhor investigado
-            self._compute_financial()
-
-            for index, interval in enumerate(self.financial_move_line_ids):
-                inv_number = self.get_invoice_fiscal_number().split("/")[-1]
-                numero_documento = inv_number + "/" + str(index + 1).zfill(2)
-
-                sequence = self.payment_mode_id.get_own_number_sequence(
-                    self, numero_documento
-                )
-
-                interval.own_number = (
-                    sequence if interval.payment_mode_id.generate_own_number else "0"
-                )
-                interval.document_number = numero_documento
-                interval.company_title_identification = hex(interval.id).upper()
-                instructions = ""
-                if self.eval_payment_mode_instructions:
-                    instructions = self.eval_payment_mode_instructions + "\n"
-                if self.instructions:
-                    instructions += self.instructions + "\n"
-                interval.instructions = instructions
-                # Codigo de Instrução do Movimento pode variar,
-                # mesmo no CNAB 240
-                interval.mov_instruction_code_id = (
-                    self.payment_mode_id.cnab_sending_code_id.id
-                )
-
             # Criação das Linha na Ordem de Pagamento
             filtered_invoice_ids.create_account_payment_line()
-
-        return result
 
     def unlink(self):
 


### PR DESCRIPTION
Os boletos das faturas não estavam sendo geradas caso a opção "Adicionar automaticamente ao validar a fatura"(auto_create_payment_order) não estivesse marcado como True.

Pelo que vi, na migração o código foi simplificado e acabou gerando essa pequena regressão, alterei o código para que o comportamento ficasse como era na 12.0

Temos casos de uso onde o usuário prefere selecionar as linhas da fatura manualmente no arquivo de remessa.

cc @mbcosta 