### PR TITLE
[14.0][FIX] l10n_br_fiscal: next fiscal number

### DIFF
--- a/l10n_br_fiscal/models/document_serie.py
+++ b/l10n_br_fiscal/models/document_serie.py
@@ -97,7 +97,9 @@ class DocumentSerie(models.Model):
     def next_seq_number(self):
         self.ensure_one()
         document_number = self.internal_sequence_id._next()
-        if self._is_invalid_number(document_number):
+        if self._is_invalid_number(document_number) or self.check_number_in_use(
+            document_number
+        ):
             document_number = self.next_seq_number()
         return document_number
 


### PR DESCRIPTION
trivial fix, corrige o próximo número do documento fiscal.

quando foi feito esse port https://github.com/OCA/l10n-brazil/pull/1921 ficou faltando a logica dentro do next_seq_number(self) acho que é porque ficou faltando algum port anterior.

dessa maneira o código fica conforme está na 12.0