### PR TITLE
[12.0] l10n_br_nfe: Adição do wizard de importação de nf-e por xml

### DIFF
--- a/l10n_br_nfe/__init__.py
+++ b/l10n_br_nfe/__init__.py
@@ -2,3 +2,4 @@
 
 from .hooks import post_init_hook
 from . import models
+from . import wizards

--- a/l10n_br_nfe/__manifest__.py
+++ b/l10n_br_nfe/__manifest__.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2019  Renato Lima - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+
 {
     "name": "NF-e",
     "summary": "Brazilian Eletronic Invoice NF-e .",
@@ -24,6 +25,12 @@
         "views/res_company_view.xml",
         "views/nfe_document_view.xml",
         "views/res_config_settings_view.xml",
+        # Wizards
+        "wizards/import_document.xml",
+        # Actions,
+        "views/nfe_action.xml",
+        # Menus
+        "views/nfe_menu.xml",
     ],
     "demo": [
         "demo/res_users_demo.xml",

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import base64
+import io
 import logging
 import re
 import string
@@ -11,7 +12,7 @@ from io import StringIO
 from unicodedata import normalize
 
 from erpbrasil.assinatura import certificado as cert
-from erpbrasil.base.fiscal.edoc import ChaveEdoc
+from erpbrasil.base.fiscal.edoc import ChaveEdoc, cnpj_cpf
 from erpbrasil.edoc.nfe import NFe as edoc_nfe
 from erpbrasil.edoc.pdf import base
 from erpbrasil.transmissao import TransmissaoSOAP
@@ -63,6 +64,14 @@ def filter_processador_edoc_nfe(record):
     ]:
         return True
     return False
+
+
+def parse_xml_nfe(xml):
+    arq = io.BytesIO()
+    arq.write(xml)
+    arq.seek(0)
+    nfe_binding = nfe_sub.parse(arq, silence=True)
+    return nfe_binding
 
 
 class NFe(spec_models.StackedModel):
@@ -504,9 +513,17 @@ class NFe(spec_models.StackedModel):
     ##########################
 
     nfe40_infRespTec = fields.Many2one(
-        comodel_name="res.partner",
-        related="company_id.technical_support_id",
+        comodel_name="res.partner", compute="_compute_resp_tec_data"
     )
+
+    def _compute_resp_tec_data(self):
+        for record in self:
+            if record.company_id.technical_support_id:
+                record.nfe40_infRespTec = record.company_id.technical_support_id
+
+    ##########################
+
+    imported_document = fields.Boolean(string="Imported", default=False)
 
     ################################
     # Framework Spec model's methods
@@ -694,6 +711,30 @@ class NFe(spec_models.StackedModel):
             record.authorization_event_id = event_id
             xml_assinado = processador.assina_raiz(edoc, edoc.infNFe.Id)
             self._valida_xml(xml_assinado)
+
+    def _invert_fiscal_operation_type(self, document, nfe_binding, edoc_type):
+        if edoc_type == "in" and document.company_id.cnpj_cpf != cnpj_cpf.formata(
+            nfe_binding.infNFe.emit.CNPJ
+        ):
+            document.fiscal_operation_type = "in"
+            document.issuer = "partner"
+
+    def _import_xml(self, nfe_binding, dry_run, edoc_type="out"):
+        document = (
+            self.env["nfe.40.infnfe"]
+            .with_context(
+                tracking_disable=True,
+                edoc_type=edoc_type,
+                lang="pt_BR",
+            )
+            .build(nfe_binding.infNFe, dry_run=dry_run)
+        )
+        document.imported_document = True
+        self._invert_fiscal_operation_type(document, nfe_binding, edoc_type)
+        return document
+
+    def import_xml(self, nfe_binding, dry_run, edoc_type="out"):
+        return self._import_xml(nfe_binding, dry_run, edoc_type)
 
     def atualiza_status_nfe(self, infProt, xml_file):
         self.ensure_one()

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -47,6 +47,10 @@ class NFeLine(spec_models.StackedModel):
         related="product_id.barcode",
     )
 
+    nfe40_xProd = fields.Char(
+        related="product_id.name",
+    )
+
     nfe40_uCom = fields.Char(
         related="uom_id.code",
     )

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -47,10 +47,6 @@ class NFeLine(spec_models.StackedModel):
         related="product_id.barcode",
     )
 
-    nfe40_xProd = fields.Char(
-        related="product_id.name",
-    )
-
     nfe40_uCom = fields.Char(
         related="uom_id.code",
     )

--- a/l10n_br_nfe/models/product_product.py
+++ b/l10n_br_nfe/models/product_product.py
@@ -56,8 +56,11 @@ class ProductProduct(models.Model):
             values["list_price"] = parent_dict.get("nfe40_vUnCom")
 
         # Barcode
-        if parent_dict.get("nfe40_cEAN") and parent_dict["nfe40_cEAN"] != "SEM GTIN":
-            values["barcode"] = parent_dict["nfe40_cEAN"]
+        if (
+            parent_dict.get("nfe40_cEANTrib")
+            and parent_dict["nfe40_cEANTrib"] != "SEM GTIN"
+        ):
+            values["barcode"] = parent_dict["nfe40_cEANTrib"]
 
         # NCM
         if parent_dict.get("nfe40_NCM"):

--- a/l10n_br_nfe/tests/__init__.py
+++ b/l10n_br_nfe/tests/__init__.py
@@ -5,6 +5,7 @@
 # from . import test_nfe_export
 from . import test_nfe_structure
 from . import test_nfe_import
+from . import test_nfe_import_wizard
 from . import test_nfe_serialize
 from . import test_nfe_serialize_lc
 from . import test_nfe_serialize_sn

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200181583054000129550010000000052062777166.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200181583054000129550010000000052062777166.xml
@@ -1,0 +1,171 @@
+<NFe xmlns="http://www.portalfiscal.inf.br/nfe">
+    <infNFe versao="4.00" Id="NFe35200181583054000129550010000000052062777166">
+        <ide>
+            <cUF>35</cUF>
+            <cNF>06277716</cNF>
+            <natOp>Venda</natOp>
+            <mod>55</mod>
+            <serie>1</serie>
+            <nNF>5</nNF>
+            <dhEmi>2020-01-01T12:00:00+01:00</dhEmi>
+            <dhSaiEnt>2020-01-01T12:00:00+01:00</dhSaiEnt>
+            <tpNF>1</tpNF>
+            <idDest>1</idDest>
+            <cMunFG>3501152</cMunFG>
+            <tpImp>1</tpImp>
+            <tpEmis>1</tpEmis>
+            <cDV>1</cDV>
+            <tpAmb>2</tpAmb>
+            <finNFe>1</finNFe>
+            <indFinal>1</indFinal>
+            <indPres>0</indPres>
+            <procEmi>0</procEmi>
+            <verProc>Odoo Brasil OCA 12.0</verProc>
+        </ide>
+        <emit>
+            <CNPJ>81583054000129</CNPJ>
+            <xNome>Empresa Lucro Presumido Ltda</xNome>
+            <xFant>Empresa Lucro Presumido</xFant>
+            <enderEmit>
+                <xLgr>Avenida Paulista</xLgr>
+                <nro>1</nro>
+                <xBairro>Bela Vista</xBairro>
+                <cMun>3550308</cMun>
+                <xMun>São Paulo</xMun>
+                <UF>SP</UF>
+                <CEP>01311000</CEP>
+                <cPais>1058</cPais>
+                <xPais>Brasil</xPais>
+                <fone>551199999999</fone>
+            </enderEmit>
+            <IE>078016350838</IE>
+            <CRT>3</CRT>
+        </emit>
+        <dest>
+            <CNPJ>81493979000189</CNPJ>
+            <xNome>NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL</xNome>
+            <enderDest>
+                <xLgr>Rua Samuel Morse</xLgr>
+                <nro>135</nro>
+                <xCpl>20º andar - Conjunto 151</xCpl>
+                <xBairro>Brooklin</xBairro>
+                <cMun>3550308</cMun>
+                <xMun>São Paulo</xMun>
+                <UF>SP</UF>
+                <CEP>04576060</CEP>
+                <cPais>1058</cPais>
+                <xPais>Brasil</xPais>
+                <fone>551134782150</fone>
+            </enderDest>
+            <indIEDest>1</indIEDest>
+            <IE>460429771334</IE>
+            <email>cliente1@cliente1.com.br</email>
+        </dest>
+        <entrega>
+            <CNPJ>81583054000129</CNPJ>
+            <xLgr>XXXXXXXXXXXX</xLgr>
+            <nro>586</nro>
+            <xCpl>XXXXXXXXX</xCpl>
+            <xBairro>XXXXXXX</xBairro>
+            <cMun>9999999</cMun>
+            <xMun>XXXXXX</xMun>
+            <UF>XX</UF>
+            <CEP>18125000</CEP>
+            <cPais>0000</cPais>
+            <xPais>XXXXXX</xPais>
+            <IE>114472132119</IE>
+        </entrega>
+        <det nItem="1">
+            <prod>
+                <cProd>E-COM11</cProd>
+                <cEAN>SEM GTIN</cEAN>
+                <xProd>[E-COM11] Cabinet with Doors</xProd>
+                <NCM>94033000</NCM>
+                <CFOP>5102</CFOP>
+                <uCom>UNID</uCom>
+                <qCom>1.0000</qCom>
+                <vUnCom>14.0000000000</vUnCom>
+                <vProd>14.00</vProd>
+                <cEANTrib>SEM GTIN</cEANTrib>
+                <uTrib>UNID</uTrib>
+                <qTrib>1.0000</qTrib>
+                <vUnTrib>14.0000000000</vUnTrib>
+                <indTot>1</indTot>
+            </prod>
+            <imposto>
+                <vTotTrib>0.00</vTotTrib>
+                <ICMS>
+                    <ICMSSN101>
+                        <orig>0</orig>
+                        <CSOSN>101</CSOSN>
+                        <pCredSN>2.7000</pCredSN>
+                        <vCredICMSSN>0.38</vCredICMSSN>
+                    </ICMSSN101>
+                </ICMS>
+                <IPI>
+                    <cEnq>999</cEnq>
+                    <IPINT>
+                        <CST>53</CST>
+                    </IPINT>
+                </IPI>
+                <PIS>
+                    <PISOutr>
+                        <CST>49</CST>
+                        <vBC>0.00</vBC>
+                        <pPIS>0.0000</pPIS>
+                        <vPIS>0.00</vPIS>
+                    </PISOutr>
+                </PIS>
+                <COFINS>
+                    <COFINSOutr>
+                        <CST>49</CST>
+                        <vBC>0.00</vBC>
+                        <pCOFINS>0.0000</pCOFINS>
+                        <vCOFINS>0.00</vCOFINS>
+                    </COFINSOutr>
+                </COFINS>
+            </imposto>
+        </det>
+        <total>
+            <ICMSTot>
+                <vBC>0.00</vBC>
+                <vICMS>0.00</vICMS>
+                <vICMSDeson>0.00</vICMSDeson>
+                <vFCPUFDest>0.00</vFCPUFDest>
+                <vICMSUFDest>0.00</vICMSUFDest>
+                <vICMSUFRemet>0.00</vICMSUFRemet>
+                <vFCP>0.00</vFCP>
+                <vBCST>0.00</vBCST>
+                <vST>0.00</vST>
+                <vFCPST>0.00</vFCPST>
+                <vFCPSTRet>0.00</vFCPSTRet>
+                <vProd>14.00</vProd>
+                <vFrete>0.00</vFrete>
+                <vSeg>0.00</vSeg>
+                <vDesc>0.00</vDesc>
+                <vII>0.00</vII>
+                <vIPI>0.00</vIPI>
+                <vIPIDevol>0.00</vIPIDevol>
+                <vPIS>0.00</vPIS>
+                <vCOFINS>0.00</vCOFINS>
+                <vOutro>0.00</vOutro>
+                <vNF>14.00</vNF>
+                <vTotTrib>0.00</vTotTrib>
+            </ICMSTot>
+        </total>
+        <transp>
+            <modFrete>9</modFrete>
+        </transp>
+        <pag>
+            <detPag>
+                <indPag>0</indPag>
+                <tPag>01</tPag>
+                <vPag>14.00</vPag>
+            </detPag>
+            <vTroco>0.00</vTroco>
+        </pag>
+        <infAdic>
+            <infAdFisco>Documento emitido por: Marc Demo</infAdFisco>
+        </infAdic>
+    </infNFe>
+</NFe>

--- a/l10n_br_nfe/tests/test_nfe_import_wizard.py
+++ b/l10n_br_nfe/tests/test_nfe_import_wizard.py
@@ -1,0 +1,72 @@
+import base64
+import logging
+import os
+
+from odoo.tests import SavepointCase
+
+_logger = logging.getLogger(__name__)
+
+
+class NFeImportWizardTest(SavepointCase):
+    def setUp(self):
+        super(NFeImportWizardTest, self).setUp()
+        self.wizard = self.env["l10n_br_nfe.import_xml"].create(
+            {
+                "company_id": self.env.ref("base.main_company").id,
+                "importing_type": "xml_file",
+            }
+        )
+        path = os.path.dirname(os.path.abspath(__file__))
+        path_1 = path + (
+            "/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000012062777161.xml"
+        )
+        with open(path_1, "rb") as f:
+            self.xml_1 = f.read()
+        path_2 = path + (
+            "/nfe/v4_00/leiauteNFe/NFe35200181583054000129550010000000052062777166.xml"
+        )
+        with open(path_2, "rb") as f:
+            self.xml_2 = f.read()
+
+    def test_onchange_nfe_xml(self):
+        xml = self.xml_1
+        wizard = self.wizard
+        wizard.nfe_xml = base64.b64encode(xml)
+        wizard._onchange_partner_id()
+        # Check wizard header info
+        self.assertEqual(
+            wizard.document_key, "35200159594315000157550010000000012062777161"
+        )
+        self.assertEqual(wizard.document_number, "1")
+        self.assertEqual(wizard.document_serie, "1")
+        self.assertEqual(wizard.partner_cpf_cnpj, "59.594.315/0001-57")
+        self.assertEqual(wizard.partner_name, "TESTE - Simples Nacional")
+        self.assertEqual(
+            wizard.partner_id, self.env.ref("l10n_br_base.simples_nacional_partner")
+        )
+        # Check wizard product info
+        self.assertEqual(
+            wizard.imported_products_ids[0].product_name, "[E-COM11] Cabinet with Doors"
+        )
+        self.assertEqual(wizard.imported_products_ids[0].uom_com, "UNID")
+        self.assertEqual(wizard.imported_products_ids[0].quantity_com, 1)
+        self.assertEqual(wizard.imported_products_ids[0].price_unit_com, 14)
+        self.assertEqual(wizard.imported_products_ids[0].uom_trib, "UNID")
+        self.assertEqual(wizard.imported_products_ids[0].quantity_trib, 1)
+        self.assertEqual(wizard.imported_products_ids[0].price_unit_trib, 14)
+        self.assertEqual(wizard.imported_products_ids[0].total, 14)
+
+    def test_match_country_state_city(self):
+        xml = self.xml_2
+        wizard = self.wizard
+        product_10 = self.env.ref("product.product_product_10")
+        wizard.nfe_xml = base64.b64encode(xml)
+        wizard._onchange_partner_id()
+        wizard.imported_products_ids[0].product_id = product_10
+        wizard.imported_products_ids[0].uom_internal = product_10.uom_id
+        action = wizard.import_nfe_xml()
+        edoc = self.env["l10n_br_fiscal.document"].browse(action["res_id"])
+        delivery_adress = edoc.partner_id.child_ids[0]
+        self.assertFalse(delivery_adress.country_id)
+        self.assertFalse(delivery_adress.crc_state_id)
+        self.assertFalse(delivery_adress.city_id)

--- a/l10n_br_nfe/views/nfe_action.xml
+++ b/l10n_br_nfe/views/nfe_action.xml
@@ -22,4 +22,25 @@
         </field>
     </record>
 
+    <!-- Imported Documents Action -->
+    <record id="imported_document_action" model="ir.actions.act_window">
+        <field name="name">Imported Document</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">l10n_br_fiscal.document</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">tree,kanban,form</field>
+        <field name="search_view_id" ref="l10n_br_fiscal.document_search" />
+        <field name="view_id" ref="l10n_br_fiscal.document_tree" />
+        <field name="domain">[('imported_document', '=', True)]</field>
+        <field name="context">{'default_fiscal_operation_type': 'in'}</field>
+        <field name="help" type="html">
+          <p class="o_view_nocontent_smiling_face">
+            Create a new Document
+          </p><p>
+            Odoo helps you easily track all activities
+            related to a fiscal operation.
+          </p>
+        </field>
+    </record>
+
 </odoo>

--- a/l10n_br_nfe/views/nfe_document_view.xml
+++ b/l10n_br_nfe/views/nfe_document_view.xml
@@ -37,6 +37,46 @@
                   <field name="nfe40_detPag" />
               </group>
           </page>
+
+          <!-- Hide confirm button for imported documents -->
+          <xpath expr="//form/field[@name='document_type']" position="after">
+              <field name="imported_document" invisible="1" />
+          </xpath>
+          <xpath
+                expr="//header/button[@name='action_document_confirm']"
+                position="attributes"
+            >
+              <attribute
+                    name="attrs"
+                >{'invisible': ['|', ('state_edoc', '!=', 'em_digitacao'), ('imported_document', '=', True)]}</attribute>
+          </xpath>
+
+          <!-- Hide buttons for imported documents -->
+          <xpath
+                expr="//header/button[@name='action_document_correction']"
+                position="attributes"
+            >
+              <attribute
+                    name="attrs"
+                >{'invisible': ['|', ('state_edoc', '!=', 'autorizada'), ('imported_document', '=', True)]}</attribute>
+          </xpath>
+          <xpath
+                expr="//header/button[@name='action_create_return']"
+                position="attributes"
+            >
+              <attribute
+                    name="attrs"
+                >{'invisible': ['|', ('state_edoc', '!=', 'autorizada'), ('imported_document', '=', True)]}</attribute>
+          </xpath>
+          <xpath
+                expr="//header/button[@name='action_document_cancel']"
+                position="attributes"
+            >
+              <attribute
+                    name="attrs"
+                >{'invisible': ['|', '|', ('state_edoc', '!=', 'autorizada'), ('document_electronic', '=', False), ('imported_document', '=', True)]}</attribute>
+          </xpath>
+
       </field>
   </record>
 

--- a/l10n_br_nfe/views/nfe_menu.xml
+++ b/l10n_br_nfe/views/nfe_menu.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
 
-  # NFe Main Menu
-  <menuitem
-        id="nfe_menu"
-        name="NF-es"
-        groups="l10n_br_nfe.group_user"
-        parent="l10n_br_fiscal.document_menu"
-        sequence="10"
+    <menuitem
+        id="nfe_import_document"
+        action="l10n_br_nfe_import_xml_action"
+        name="Import NF-e"
+        parent="l10n_br_fiscal.document_sub_menu"
+        sequence="46"
+        groups="l10n_br_fiscal.group_manager"
     />
 
-  # NFe Fiscal Documents
-  <menuitem
-        id="nfe_document_menu"
-        action="nfe_document_action"
-        name="NF-e"
-        groups="l10n_br_nfe.group_user"
-        parent="nfe_menu"
-        sequence="10"
+    <!-- Imported Documents Menu-->
+    <menuitem
+        id="imported_document_menu"
+        action="imported_document_action"
+        name="Imported Document"
+        parent="l10n_br_fiscal.document_sub_menu"
+        sequence="20"
+        groups="l10n_br_fiscal.group_user,l10n_br_fiscal.group_manager"
     />
 
 </odoo>

--- a/l10n_br_nfe/wizards/__init__.py
+++ b/l10n_br_nfe/wizards/__init__.py
@@ -1,2 +1,3 @@
-from . import l10n_br_account_nfe_export_invoice
-from . import l10n_br_account_nfe_export
+# from . import l10n_br_account_nfe_export_invoice
+# from . import l10n_br_account_nfe_export
+from . import import_document

--- a/l10n_br_nfe/wizards/import_document.py
+++ b/l10n_br_nfe/wizards/import_document.py
@@ -1,0 +1,182 @@
+# Copyright (C) 2021  Gabriel Cardoso de Faria - Kmee
+# Copyright (C) 2022  Renan Hiroki Bastos - Kmee
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+import base64
+
+from erpbrasil.base.fiscal.edoc import detectar_chave_edoc
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+from odoo.addons.l10n_br_fiscal.constants.fiscal import FISCAL_IN_OUT_ALL
+from odoo.addons.l10n_br_nfe.models.document import parse_xml_nfe
+
+IMPORTING_TYPES = [
+    ("xml_file", "NFe XML File"),
+    ("nfe_key", "NFe key (Not Implemented)"),
+    ("manually", "Manually (Not Implemented)"),
+]
+
+
+class NfeImport(models.TransientModel):
+    """ Importar XML Nota Fiscal Eletrônica """
+
+    _name = "l10n_br_nfe.import_xml"
+    _inherit = "l10n_br_fiscal.base.wizard.mixin"
+
+    company_id = fields.Many2one(
+        comodel_name="res.company",
+        string="Company",
+        default=lambda self: self.env.user.company_id,
+    )
+
+    importing_type = fields.Selection(
+        string="Importing Type", selection=IMPORTING_TYPES, required=True
+    )
+
+    nfe_xml = fields.Binary(
+        string="NFe XML to Import",
+    )
+
+    fiscal_operation_type = fields.Selection(
+        string="Fiscal Operation Type", selection=FISCAL_IN_OUT_ALL
+    )
+
+    partner_cpf_cnpj = fields.Char(string="Partner Documentation")
+
+    partner_name = fields.Char(string="Partner Name")
+
+    imported_products_ids = fields.One2many(
+        string="Imported Products",
+        comodel_name="l10n_br_nfe.import_xml.products",
+        inverse_name="import_xml_id",
+    )
+
+    def _parse_xml_import_wizard(self, xml):
+        parsed_xml = parse_xml_nfe(xml)
+        document = detectar_chave_edoc(parsed_xml.infNFe.Id[3:])
+
+        return parsed_xml, document
+
+    @api.onchange("nfe_xml")
+    def _onchange_partner_id(self):
+        if self.nfe_xml:
+            parsed_xml, document = self._parse_xml_import_wizard(
+                base64.b64decode(self.nfe_xml)
+            )
+
+            nfe_model_code = self.env.ref("l10n_br_fiscal.document_55").code
+
+            if document.modelo_documento != nfe_model_code:
+                raise UserError(
+                    _(
+                        f"Incorrect fiscal document model! "
+                        f"Accepted one is {nfe_model_code}"
+                    )
+                )
+
+            self.document_key = document.chave
+            self.document_number = int(document.numero_documento)
+            self.document_serie = int(document.numero_serie)
+            self.partner_cpf_cnpj = document.cnpj_emitente
+            self.partner_name = (
+                parsed_xml.infNFe.emit.xFant or parsed_xml.infNFe.emit.xNome
+            )
+            self.partner_id = self.env["res.partner"].search(
+                [
+                    "|",
+                    ("cnpj_cpf", "=", document.cnpj_emitente),
+                    ("nfe40_xNome", "=", parsed_xml.infNFe.emit.xNome),
+                ],
+                limit=1,
+            )
+            self._check_nfe_xml_products(parsed_xml)
+
+    def _check_nfe_xml_products(self, parsed_xml):
+        product_ids = []
+        for product in parsed_xml.infNFe.det:
+            product_ids.append(
+                self.env["l10n_br_nfe.import_xml.products"]
+                .create(
+                    {
+                        "product_name": product.prod.xProd,
+                        "uom_com": product.prod.uCom,
+                        "quantity_com": product.prod.qCom,
+                        "price_unit_com": product.prod.vUnCom,
+                        "uom_trib": product.prod.uTrib,
+                        "quantity_trib": product.prod.qTrib,
+                        "price_unit_trib": product.prod.vUnTrib,
+                        "total": product.prod.vProd,
+                        "import_xml_id": self.id,
+                    }
+                )
+                .id
+            )
+        if product_ids:
+            self.imported_products_ids = [(6, 0, product_ids)]
+
+    @api.multi
+    def import_nfe_xml(self):
+
+        parsed_xml, document = self._parse_xml_import_wizard(
+            base64.b64decode(self.nfe_xml)
+        )
+
+        self.fiscal_operation_type = (
+            "in" if document.cnpj_emitente != self.company_id.cnpj_cpf else "out"
+        )
+
+        edoc = self.env["l10n_br_fiscal.document"].import_xml(
+            parsed_xml,
+            dry_run=False,
+            edoc_type=self.fiscal_operation_type,
+        )
+
+        self._set_partner_as_supplier(edoc)
+        self._attach_original_nfe_xml_to_document(edoc)
+
+        return {
+            "name": _("Documento Importado"),
+            "type": "ir.actions.act_window",
+            "target": "current",
+            "views": [[False, "form"]],
+            "res_id": edoc.id,
+            "res_model": "l10n_br_fiscal.document",
+        }
+
+    def _set_partner_as_supplier(self, edoc):
+        edoc.partner_id.supplier = True
+
+    def _attach_original_nfe_xml_to_document(self, edoc):
+        vals = {
+            "name": "NFe-Importada-{}.xml".format(edoc.document_key),
+            "datas": base64.b64decode(self.nfe_xml),
+            "datas_fname": "NFe-Importada-{}.xml".format(edoc.document_key),
+            "description": "XML NFe - Importada por XML",
+            "res_model": "l10n_br_fiscal.document",
+            "res_id": edoc.id,
+        }
+        self.env["ir.attachment"].create(vals)
+
+
+class NfeImportProducts(models.TransientModel):
+    _name = "l10n_br_nfe.import_xml.products"
+
+    product_name = fields.Char(string="Product Name")
+
+    uom_com = fields.Char(string="UOM Comercial")
+
+    quantity_com = fields.Float(string="Comercial Quantity")
+
+    price_unit_com = fields.Float(string="Comercial Price Unit")
+
+    uom_trib = fields.Char(string="UOM Fiscal")
+
+    quantity_trib = fields.Float(string="Fiscal Quantity")
+
+    price_unit_trib = fields.Float(string="Fiscal Price Unit")
+
+    total = fields.Float(string="Total")
+
+    import_xml_id = fields.Many2one(comodel_name="l10n_br_nfe.import_xml")

--- a/l10n_br_nfe/wizards/import_document.py
+++ b/l10n_br_nfe/wizards/import_document.py
@@ -20,7 +20,7 @@ IMPORTING_TYPES = [
 
 
 class NfeImport(models.TransientModel):
-    """ Importar XML Nota Fiscal Eletrônica """
+    """Importar XML Nota Fiscal Eletrônica"""
 
     _name = "l10n_br_nfe.import_xml"
     _inherit = "l10n_br_fiscal.base.wizard.mixin"

--- a/l10n_br_nfe/wizards/import_document.xml
+++ b/l10n_br_nfe/wizards/import_document.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2021 KMEE
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record id="l10n_br_nfe_import_xml_form" model="ir.ui.view">
+        <field name="name">l10n_br_nfe.import_xml.form</field>
+        <field name="model">l10n_br_nfe.import_xml</field>
+        <field name="arch" type="xml">
+            <form string="Importar XML NF-e">
+                <group>
+                    <field name="company_id" />
+                    <field name="importing_type" />
+                    <field
+                        name="nfe_xml"
+                        attrs="{'invisible': [('importing_type', '!=', 'xml_file')], 'required': [('importing_type', '=', 'xml_file')]}"
+                    />
+                </group>
+                <separator
+                    string="Pré Visualização da NF-e"
+                    attrs="{'invisible': [('nfe_xml', '=', False)]}"
+                />
+                <group attrs="{'invisible': [('nfe_xml', '=', False)]}">
+                    <group>
+                        <field name="document_key" readonly="True" />
+                        <field name="document_number" readonly="True" />
+                        <field name="document_serie" readonly="True" />
+                    </group>
+                    <group>
+                        <field name="partner_cpf_cnpj" readonly="True" />
+                        <field name="partner_name" readonly="True" />
+                        <field name="partner_id" readonly="True" />
+                    </group>
+                </group>
+                <separator
+                    string="NFe XML Products"
+                    attrs="{'invisible': [('nfe_xml', '=', False)]}"
+                />
+                <group attrs="{'invisible': [('nfe_xml', '=', False)]}">
+                    <field name="imported_products_ids" nolabel="1">
+                        <tree string="Views" editable="top">
+                            <field name="product_name" readonly="False" />
+                            <field name="quantity_com" readonly="True" />
+                            <field name="uom_com" readonly="True" />
+                            <field name="price_unit_com" readonly="True" />
+                            <field name="total" readonly="True" />
+                        </tree>
+                    </field>
+                </group>
+                <footer>
+                    <button
+                        name="import_nfe_xml"
+                        string="Importar"
+                        class="btn-primary"
+                        type="object"
+                        attrs="{'invisible': [('importing_type', '!=', 'xml_file')]}"
+                    />
+                    <button string="Cancel" class="btn-default" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="l10n_br_nfe_import_xml_action" model="ir.actions.act_window">
+        <field name="name">Importar NF-e XML</field>
+        <field name="res_model">l10n_br_nfe.import_xml</field>
+        <field name="view_mode">form</field>
+        <field name="context">{}</field>
+        <field name="target">new</field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Divisão de #1701

Este PR contém a parte principal da importação de nfes. Aqui estão inclusos o wizard de importação, mudanças nas visões e testes.

Além disso foi necessário um pequeno ajuste no campo nfe40_InfRespTec para que a importação funcione. Existe um problema na importação de campos computados e relacionais, vou criar um issue para discuti-lo. Este problema, porém, não atrapalha em nada o funcionamento do resto da importação.

Para realizar a importação basta usar este menu no módulo fiscal

![Screenshot from 2022-06-15 12-21-12](https://user-images.githubusercontent.com/63242917/173864755-8704b264-3f69-4ac8-a30b-1a67676bf5e3.png)

