### PR TITLE
[12.0][FIX] default_fiscal_operation_type in _change_action_view method context

### DIFF
--- a/l10n_br_account/models/fiscal_operation.py
+++ b/l10n_br_account/models/fiscal_operation.py
@@ -52,7 +52,7 @@ class Operation(models.Model):
         journal_type = TYPE2JOURNAL[invoice_type]
         new_action["context"] = {
             "type": invoice_type,
-            "default_fiscal_operation_type": self.fiscal_type,
+            "default_fiscal_operation_type": self.fiscal_operation_type,
             "default_fiscal_operation_id": self.id,
             "journal_type": journal_type,
         }


### PR DESCRIPTION
Ao criar um documento fiscal através do menu "Fiscal / Documento Fiscal / Documento Fiscal de Entrada | Saída, o valor padrão para o campo fiscal_operation_type não estava sendo definido corretamente.