### PR TITLE
[12.0][FIX] Allows create line_section and line_note

### DIFF
--- a/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
@@ -37,7 +37,7 @@
               <field
                                 name="tax_icms_or_issqn"
                                 force_save="1"
-                                attrs="{'readonly': [('product_id', '!=', False), ('tax_icms_or_issqn', '!=', False)], 'required': [('fiscal_tax_ids', '!=', False)]}"
+                                attrs="{'readonly': [('product_id', '!=', False), ('tax_icms_or_issqn', '!=', False)], 'required': [('tax_icms_or_issqn', '!=', False), ('fiscal_tax_ids', '!=', False)]}"
                             />
             </group>
             <notebook>


### PR DESCRIPTION
Ao tentar criar uma de sessão ou nota atualmente em um pedido de venda, ou fatura esta aparecendo a seguinte mensagem:

![image](https://user-images.githubusercontent.com/211005/175555249-66b03399-5183-486d-9d6c-1cf19c9fa290.png)
