### PR TITLE
[12.0] Criar campos relacionais para faturas de retenções de impostos

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -107,6 +107,38 @@ class AccountInvoice(models.Model):
         store=True,
     )
 
+    withholding_invoice_ids = fields.Many2many(
+        comodel_name="account.invoice",
+        relation="account_invoice_withholding_invoice_rel",
+        column1="invoice_id",
+        column2="withholding_invoice_id",
+        compute="_compute_withholding_invoice_ids",
+        store=True,
+        string="Withholding Invoice",
+    )
+
+    withholding_origin_ids = fields.Many2many(
+        comodel_name="account.invoice",
+        relation="account_invoice_withholding_invoice_rel",
+        column1="withholding_invoice_id",
+        column2="invoice_id",
+        compute="_compute_withholding_invoice_ids",
+        store=True,
+        string="Withholding Origin Invoice",
+    )
+
+    @api.depends("move_id.line_ids")
+    def _compute_withholding_invoice_ids(self):
+        for invoice in self.filtered(lambda i: i.move_id):
+            invoices = (
+                self.env["account.invoice.line"]
+                .search(
+                    [("wh_move_line_id", "in", invoice.move_id.mapped("line_ids").ids)]
+                )
+                .mapped("invoice_id")
+            )
+            invoice.withholding_invoice_ids = invoices
+
     def _get_amount_lines(self):
         """Get object lines instaces used to compute fields"""
         return self.mapped("invoice_line_ids")

--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -88,6 +88,7 @@ class AccountMove(models.Model):
     def post(self, invoice=False):
         result = super().post(invoice)
         if invoice:
+            self.create_wh_invoices()
             if (
                 invoice.document_type_id
                 and invoice.document_electronic

--- a/l10n_br_account/views/account_invoice_view.xml
+++ b/l10n_br_account/views/account_invoice_view.xml
@@ -261,6 +261,22 @@
             <field name="amount_tax" position="after">
                 <field string="(-) Tax Withholding" name="amount_tax_withholding" />
             </field>
+            <notebook position="inside">
+                <page
+                    string="Retenções"
+                    name="withholding_invoice"
+                    attrs="{'invisible': [('withholding_invoice_ids', '=', [])]}"
+                >
+                    <field name="withholding_invoice_ids" />
+                </page>
+                <page
+                    string="Retenções Faturas de Origem"
+                    name="withholding_origin"
+                    attrs="{'invisible': [('withholding_origin_ids', '=', [])]}"
+                >
+                    <field name="withholding_origin_ids" />
+                </page>
+            </notebook>
         </field>
     </record>
 


### PR DESCRIPTION
Esse PR adiciona dois campos no objeto account.invoice:

### withholding_invoice_ids: Para relacionar as guias de retenções geradas em um documento fiscal:

<img width="1438" alt="Captura de Tela 2022-06-27 às 15 52 34" src="https://user-images.githubusercontent.com/211005/176015435-e1ad1e86-dd02-49ae-bc78-c1ed13496bac.png">

### withholding_origin_ids: Relacionar os documentos fiscais referente a essa guia de retenção de imposto:
 
<img width="721" alt="Captura de Tela 2022-06-27 às 15 53 26" src="https://user-images.githubusercontent.com/211005/176015715-8547164b-78a8-4969-9960-9af5cb5a1da3.png">

