### PR TITLE
[12.0][FIX] invoice_line_tax_ids field view widget

### DIFF
--- a/l10n_br_account/views/account_invoice_line_view.xml
+++ b/l10n_br_account/views/account_invoice_line_view.xml
@@ -89,7 +89,7 @@
                                 name="invoice_line_tax_ids"
                                 context="{'type': invoice_type}"
                                 domain="[('type_tax_use','!=','none'),('company_id', '=', company_id)]"
-                                widget="many2many"
+                                widget="many2many_tags"
                                 options="{'no_create': True}"
                             />
                         </group>

--- a/l10n_br_purchase/models/purchase_order_line.py
+++ b/l10n_br_purchase/models/purchase_order_line.py
@@ -111,4 +111,4 @@ class PurchaseOrderLine(models.Model):
     @api.onchange("fiscal_tax_ids")
     def _onchange_fiscal_tax_ids(self):
         super()._onchange_fiscal_tax_ids()
-        self.taxes_id |= self.fiscal_tax_ids.account_taxes(user_type="purchase")
+        self._compute_tax_id()

--- a/l10n_br_purchase/views/purchase_view.xml
+++ b/l10n_br_purchase/views/purchase_view.xml
@@ -34,15 +34,17 @@
               </xpath>
               <xpath
                 expr="//field[@name='order_line']/tree/field[@name='taxes_id']"
-                position="attributes"
-            >
-                  <attribute name="invisible">1</attribute>
-              </xpath>
+                position="replace"
+            />
               <xpath
-                expr="//field[@name='order_line']/tree/field[@name='taxes_id']"
+                expr="//field[@name='order_line']/tree/field[@name='price_unit']"
                 position="before"
             >
-                  <field name="fiscal_tax_ids" widget="many2many_tags" />
+                  <field
+                    name="fiscal_tax_ids"
+                    widget="many2many_tags"
+                    options="{'no_create': True}"
+                />
               </xpath>
               <xpath
                 expr="//field[@name='order_line']/tree/field[@name='company_id']"


### PR DESCRIPTION
Ao criar uma fatura como documento fiscal através do pedido de compras caso as linhas tenha impostos, ao abrir a linha da fatura:

![image](https://user-images.githubusercontent.com/211005/176259763-7d9317dc-b0c2-4d9e-bca6-64c973c049c2.png)

Isso acontece porque o widget do campo invoice_line_tax_ids na visão pai do objeto account.invoice.line o widget está como many2many_tags e na visão herdada deve ser mantido o mesmo widget.

Eu depurei um pouco módulo e a diferença que eu percebi e que o campo com o widget many2many_tags no dicionário values do método create, new tem o valor de: 

'invoice_line_tax_ids': [43, 35, 57, 3]

E o retorno de um campo many2many geralmente é [(6, 0, [43, 35, 57, 3])], para não precisar alterar o dicionário values é melhor deixar o widget nativo.

cc @rvalyi @netosjb 