### PR TITLE
[12.0][REF] l10n_br_nfe: fiscal document module integration standard document line

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -9,7 +9,7 @@ odoo_version: 14.0
 org_name: Odoo Community Association (OCA)
 org_slug: OCA
 rebel_module_groups: []
-repo_description: 'TODO: add repo description.'
+repo_description: "TODO: add repo description."
 repo_name: l10n-brazil
 repo_slug: l10n-brazil
 repo_website: https://github.com/OCA/l10n-brazil

--- a/l10n_br_fiscal/models/document_workflow.py
+++ b/l10n_br_fiscal/models/document_workflow.py
@@ -258,7 +258,7 @@ class DocumentWorkflow(models.AbstractModel):
                 date = fields.Datetime.context_timestamp(record, record.document_date)
                 chave_edoc = ChaveEdoc(
                     ano_mes=date.strftime("%y%m").zfill(4),
-                    cnpj_emitente=record.company_cnpj_cpf,
+                    cnpj_cpf_emitente=record.company_cnpj_cpf,
                     codigo_uf=(
                         record.company_state_id
                         and record.company_state_id.ibge_code

--- a/l10n_br_nfe/models/cest.py
+++ b/l10n_br_nfe/models/cest.py
@@ -1,9 +1,20 @@
 # Copyright (C) 2021  Renato Lima - Akretion <renato.lima@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import api, models
 
 
 class Cest(models.Model):
     _inherit = "l10n_br_fiscal.cest"
     _nfe_search_keys = ["code_unmasked"]
+
+    @api.model
+    def match_or_create_m2o(self, rec_dict, parent_dict, model=None):
+        """If CEST not found, break hard, don't create it"""
+
+        if rec_dict.get("code_unmasked"):
+            domain = [("code_unmasked", "=", rec_dict.get("code_unmasked"))]
+            match = self.search(domain, limit=1)
+            if match:
+                return match.id
+        return False

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -618,7 +618,7 @@ class NFe(spec_models.StackedModel):
             self.nfe40_detPag and self.nfe40_detPag[0].nfe40_tPag == "90"
         ):
             return False
-        return super()._export_field(xsd_field, class_obj, member_spec)
+        return super()._export_field(xsd_field, class_obj, member_spec, export_value)
 
     def _export_many2one(self, field_name, xsd_required, class_obj=None):
         self.ensure_one()

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -466,9 +466,12 @@ class NFeLine(spec_models.StackedModel):
 
     def _compute_nfe40_ICMSUFDest(self):
         for record in self:
-            record.nfe40_pICMSInter = str(
-                "%.02f" % record.icms_origin_percent or record.icms_percent
-            )
+            if not record.icms_origin_percent and not record.icms_percent:
+                record.nfe40_pICMSInter = False
+            else:
+                record.nfe40_pICMSInter = str(
+                    "%.02f" % record.icms_origin_percent or record.icms_percent
+                )
             record.nfe40_pFCPUFDest = record.icmsfcp_percent
             record.nfe40_pICMSUFDest = record.icms_destination_percent
             record.nfe40_pICMSInterPart = record.icms_sharing_percent

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -16,6 +16,14 @@ ICMS_ST_CST_CODES = ["60", "10"]
 
 
 class NFeLine(spec_models.StackedModel):
+    """Classe para mapear a linha do documento fiscal com a linha da NF-e
+
+    Observações: Não deve ser definido nenhum related para o campo nfe40_vBC,
+    O nome desse campo colide com campos de vários objetos como nfe.40.icms,
+    nfe.40.ipi, nfe.40.pis, nfe.40.cofins. O campo nfe40_vBC deve ser populado
+    através dos métodos _export_fields_*
+    """
+
     _name = "l10n_br_fiscal.document.line"
     _inherit = ["l10n_br_fiscal.document.line", "nfe.40.det"]
     _stacked = "nfe.40.det"
@@ -70,61 +78,153 @@ class NFeLine(spec_models.StackedModel):
         > <ICMSUFDest>
     - <impostoDevol>"""
 
-    # The nfe.40.prod mixin (prod XML tag) cannot be injected in
-    # the product.product object because the tag includes attributes from the
-    # Odoo fiscal document line and because we may have an Nfe with
-    # lines decsriptions instead of full blown products.
-    # So a part of the mapping is done
-    # in the fiscal document line:
-    # from Odoo -> XML by using related fields/_compute
-    # from XML -> Odoo by overriding the product default_get method
-    nfe40_cProd = fields.Char(
-        related="product_id.default_code",
-    )
+    ##########################
+    # NF-e spec related fields
+    ##########################
 
-    nfe40_cEAN = fields.Char(
-        related="product_id.barcode",
-    )
+    ######################################
+    # NF-e tag: prod
+    # Grupo I. Produtos e Serviços da NF-e
+    ######################################
 
-    nfe40_cEANTrib = fields.Char(
-        related="product_id.barcode",
-    )
+    # nfe40_cProd = fields.Char(related="product_id.default_code")
 
-    nfe40_uCom = fields.Char(
-        related="uom_id.code",
-    )
+    nfe40_cEAN = fields.Char(related="product_id.barcode")
 
-    nfe40_qCom = fields.Float(
-        string="nfe40 qCom",
-        related="quantity",
-    )
+    # nfe40_xProd = fields.Char(related="name") TODO
+
+    nfe40_NCM = fields.Char(related="ncm_id.code_unmasked")
+
+    # NVE TODO
+
+    nfe40_CEST = fields.Char(related="cest_id.code_unmasked")
+
+    # indEscala TODO
+
+    # CNPJFab TODO
+
+    # cBenef TODO
+
+    # TODO em uma importação de XML deve considerar esse campo na busca do
+    # ncm_id
+    nfe40_EXTIPI = fields.Char(related="ncm_id.exception")
+
+    nfe40_CFOP = fields.Char(related="cfop_id.code")
+
+    nfe40_uCom = fields.Char(related="uom_id.code")
+
+    nfe40_qCom = fields.Float(string="nfe40 qCom", related="quantity")
 
     nfe40_vUnCom = fields.Float(
         related="price_unit",
         string="Valor unitário de comercialização",
     )
 
-    nfe40_uTrib = fields.Char(
-        related="uot_id.code",
-    )
+    nfe40_vProd = fields.Monetary(related="price_gross")
 
-    nfe40_qTrib = fields.Float(
-        string="nfe40_qTrib",
-        related="fiscal_quantity",
-    )
+    nfe40_cEANTrib = fields.Char(related="product_id.barcode")
+
+    nfe40_uTrib = fields.Char(related="uot_id.code")
+
+    nfe40_qTrib = fields.Float(string="nfe40_qTrib", related="fiscal_quantity")
 
     nfe40_vUnTrib = fields.Float(
         related="fiscal_price",
         string="Valor unitário de tributação",
     )
 
-    nfe40_vProd = fields.Monetary(
-        related="price_gross",
-    )
+    nfe40_vFrete = fields.Monetary(related="freight_value")
 
+    nfe40_vSeg = fields.Monetary(related="insurance_value")
+
+    nfe40_vDesc = fields.Monetary(related="discount_value")
+
+    nfe40_vOutro = fields.Monetary(related="other_value")
+
+    # nfe40_vBC = fields.Monetary(string="FIXME Não usar esse campo!")
+
+    # NFE_IND_TOT = { TODO
+    #     "0": "0=Valor do item (vProd) não compõe o valor total da NF-e",
+    #     "1": "Valor do item (vProd) compõe o valor total da NF- e (vProd) (v2.0)",
+    # }
+    #
+    nfe40_indTot = fields.Selection(default="1")
+
+    ##########################
+    # NF-e tag: id
+    # Compute Methods
+    ##########################
+
+    # TODO
+
+    ##########################
+    # NF-e tag: id
+    # Inverse Methods
+    ##########################
+
+    # TODO
+
+    ################################
+    # Framework Spec model's methods
+    ################################
+
+    def _export_fields_nfe_40_prod(self, xsd_fields, class_obj, export_dict):
+
+        nfe40_cProd = self.product_id.default_code or self.nfe40_cProd or ""
+        export_dict["cProd"] = nfe40_cProd
+
+        nfe40_xProd = self.product_id.name or self.name or ""
+        export_dict["xProd"] = nfe40_xProd[:120].replace("\n", "").strip()
+
+        nfe40_cEAN = nfe40_cEANTrib = self.product_id.barcode or "SEM GTIN"
+        export_dict["cEAN"] = export_dict["cEANTrib"] = nfe40_cEAN
+
+    ###########################################################
+    # NF-e tag: DI
+    # Grupo I01. Produtos e Serviços / Declaração de Importação
+    ###########################################################
+
+    # TODO
+
+    ######################################################
+    # NF-e tag: detExport
+    # Grupo I03. Produtos e Serviços / Grupo de Exportação
+    ######################################################
+
+    # TODO
+
+    ###################################################
+    # NF-e tag: xPed e nItemPed
+    # Grupo I05. Produtos e Serviços / Pedido de Compra
+    ####################################################
+
+    nfe40_xPed = fields.Char(related="partner_order")
+
+    nfe40_nItemPed = fields.Char(related="partner_order_line")
+
+    #################################################
+    # NF-e tag: nFCI
+    # Grupo I07. Produtos e Serviços / Grupo Diversos
+    #################################################
+
+    # TODO
+
+    #######################################
+    # NF-e tag: rastro
+    # Grupo I80. Rastreabilidade de produto
+    #######################################
+
+    # TODO
+
+    #######################################
+    # NF-e tag: veicProd, med, arma, comb
+    # Grupo J. Produto Específico
+    #######################################
+
+    # Overriden to define default value for normal product
     nfe40_choice9 = fields.Selection(
-        [
-            ("normal", "Produto Normal"),  # overriden to allow normal product
+        selection=[
+            ("normal", "Produto Normal"),
             ("nfe40_veicProd", "Veículo"),
             ("nfe40_med", "Medicamento"),
             ("nfe40_arma", "Arma"),
@@ -135,126 +235,109 @@ class NFeLine(spec_models.StackedModel):
         default="normal",
     )
 
-    nfe40_choice11 = fields.Selection(
-        compute="_compute_choice11",
-        store=True,
-    )
+    #####################################################
+    # NF-e tag: veicProd
+    # Grupo JA. Detalhamento Específico de Veículos novos
+    #####################################################
 
-    nfe40_choice12 = fields.Selection(
-        compute="_compute_choice12",
-        store=True,
-    )
+    # TODO
 
-    nfe40_choice15 = fields.Selection(
-        compute="_compute_choice15",
-        store=True,
-    )
+    ######################################################
+    # NF-e tag: med
+    # Grupo K. Detalhamento Específico de Medicamento e de
+    # matérias-primas farmacêuticas
+    ######################################################
 
-    nfe40_choice3 = fields.Selection(
-        compute="_compute_choice3",
-        store=True,
-    )
+    # TODO
 
-    nfe40_choice20 = fields.Selection(
-        compute="_compute_nfe40_choice20",
-        store=True,
-    )
+    ################################################
+    # NF-e tag: arma
+    # Grupo L. Detalhamento Específico de Armamentos
+    ################################################
 
-    nfe40_choice13 = fields.Selection(
-        compute="_compute_nfe40_choice13",
-        store=True,
-        string="Tipo de Tributação do PIS",
-    )
+    # TODO
 
-    nfe40_choice16 = fields.Selection(
-        compute="_compute_nfe40_choice16",
-        store=True,
-        string="Tipo de Tributação do COFINS",
-    )
+    ###################################################
+    # NF-e tag: comb
+    # Grupo LA. Detalhamento Específico de Combustíveis
+    ###################################################
 
-    nfe40_choice10 = fields.Selection(
-        compute="_compute_nfe40_choice10",
-        store=True,
-    )
+    # TODO
 
-    nfe40_orig = fields.Selection(
-        related="icms_origin",
-    )
+    #################################################################
+    # NF-e tag: nRECOPI
+    # Grupo LB. Detalhamento Específico para Operação com Papel Imune
+    #################################################################
 
-    nfe40_modBC = fields.Selection(
-        related="icms_base_type",
-    )
+    # TODO
 
-    nfe40_vICMS = fields.Monetary(
-        related="icms_value",
-    )
+    #################################################################
+    # NF-e tag: imposto
+    # Grupo M. Tributos incidentes no Produto ou Serviço
+    #################################################################
 
-    nfe40_vPIS = fields.Monetary(
-        string="Valor do PIS (NFe)",
-        related="pis_value",
-    )
+    nfe40_vTotTrib = fields.Monetary(related="estimate_tax")
 
-    nfe40_vCOFINS = fields.Monetary(
-        string="Valor do COFINS (NFe)",
-        related="cofins_value",
-    )
+    def _export_fields_nfe_40_imposto(self, xsd_fields, class_obj, export_dict):
 
-    nfe40_CFOP = fields.Char(
-        related="cfop_id.code",
-    )
+        if self.nfe40_choice10 == "nfe40_ICMS":
+            xsd_fields.remove("nfe40_ISSQN")
+        else:
+            xsd_fields.remove("nfe40_ICMS")
+            xsd_fields.remove("nfe40_II")
 
-    nfe40_indTot = fields.Selection(
-        default="1",
-    )
+        if (
+            not self.icms_value
+            or self.partner_id.ind_ie_dest != "9"
+            or self.partner_id.state_id == self.company_id.state_id
+            or self.partner_id.country_id != self.company_id.country_id
+        ):
+            xsd_fields.remove("nfe40_ICMSUFDest")
 
-    nfe40_vIPI = fields.Monetary(
-        related="ipi_value",
-    )
+        if not self.pisst_value:
+            xsd_fields.remove("nfe40_PISST")
 
-    nfe40_infAdProd = fields.Char(
-        compute="_compute_nfe40_infAdProd",
-    )
+        if not self.cofinsst_value:
+            xsd_fields.remove("nfe40_COFINSST")
 
-    nfe40_xPed = fields.Char(
-        related="partner_order",
-    )
+        if not self.ii_value:
+            xsd_fields.remove("nfe40_II")
 
-    nfe40_nItemPed = fields.Char(
-        related="partner_order_line",
-    )
+    ##################################################
+    # NF-e tag: ICMS
+    # Grupo N01. ICMS Normal e ST
+    # Grupo N02. Grupo Tributação do ICMS= 00
+    # Grupo N03. Grupo Tributação do ICMS= 10
+    # Grupo N04. Grupo Tributação do ICMS= 20
+    # Grupo N05. Grupo Tributação do ICMS= 30
+    # Grupo N06. Grupo Tributação do ICMS= 40, 41, 50
+    # Grupo N07. Grupo Tributação do ICMS= 51
+    # Grupo N08. Grupo Tributação do ICMS= 60
+    # Grupo N09. Grupo Tributação do ICMS= 70
+    # Grupo N10. Grupo Tributação do ICMS= 90
+    #################################################
 
-    nfe40_vFrete = fields.Monetary(
-        related="freight_value",
-    )
+    nfe40_choice11 = fields.Selection(compute="_compute_choice11", store=True)
 
-    nfe40_vTotTrib = fields.Monetary(
-        related="estimate_tax",
-    )
+    nfe40_orig = fields.Selection(related="icms_origin")
 
-    nfe40_PISAliq = fields.Many2one(
-        "nfe.40.pisaliq",
-        string="Código de Situação Tributária do PIS (Alíquota)",
-        help="Código de Situação Tributária do PIS."
-        "\n01 – Operação Tributável - Base de Cálculo = Valor da Operação"
-        "\nAlíquota Normal (Cumulativo/Não Cumulativo);"
-        "\n02 - Operação Tributável - Base de Calculo = Valor da Operação"
-        "\n(Alíquota Diferenciada);",
-    )
+    nfe40_modBC = fields.Selection(related="icms_base_type")
 
-    nfe40_COFINSAliq = fields.Many2one(
-        "nfe.40.cofinsaliq",
-        string="Código de Situação Tributária do COFINS (Alíquota)",
-        help="Código de Situação Tributária do COFINS."
-        "\n01 – Operação Tributável - Base de Cálculo = Valor da Operação"
-        "\nAlíquota Normal (Cumulativo/Não Cumulativo);"
-        "\n02 - Operação Tributável - Base de Calculo = Valor da Operação"
-        "\n(Alíquota Diferenciada);",
-    )
+    nfe40_pICMS = fields.Float(related="icms_percent", string="pICMS")
 
-    # Todo: Calcular
-    nfe40_vFCPUFDest = fields.Monetary(
-        string="Valor total do ICMS relativo ao Fundo de Combate à Pobreza",
-    )
+    nfe40_vICMS = fields.Monetary(related="icms_value")
+
+    # ICMS ST
+    nfe40_vBCST = fields.Monetary(related="icmsst_base")
+
+    nfe40_modBCST = fields.Selection(related="icmsst_base_type")
+
+    nfe40_vICMSST = fields.Monetary(related="icmsst_value")
+
+    # COLOCAR NA ORDEM
+    nfe40_pICMSST = fields.Float(related="icmsst_percent", string="pICMSST")
+    nfe40_pMVAST = fields.Float(related="icmsst_mva_percent", string="pMVAST")
+    nfe40_pRedBCST = fields.Float(related="icmsst_reduction", string="pRedBCST")
 
     # Todo: Calcular
     nfe40_vFCPSTRet = fields.Monetary(
@@ -263,29 +346,11 @@ class NFeLine(spec_models.StackedModel):
     nfe40_vCredICMSSN = fields.Monetary(
         string="ICMS SN Crédito", related="icmssn_credit_value"
     )
-    nfe40_vDesc = fields.Monetary(related="discount_value")
 
-    # TODO toxic field from several tags, should not even be injected!
-    # meanwhile forcing a string on it avoids .pot issues.
-    nfe40_vBC = fields.Monetary(string="FIXME Não usar esse campo!")
-
-    nfe40_vBCST = fields.Monetary(related="icmsst_base")
-    nfe40_modBCST = fields.Selection(related="icmsst_base_type")
-    nfe40_vICMSST = fields.Monetary(related="icmsst_value")
-
-    @api.depends("additional_data")
-    def _compute_nfe40_infAdProd(self):
-        for record in self:
-            if record.additional_data:
-                record.nfe40_infAdProd = (
-                    normalize("NFKD", record.additional_data)
-                    .encode("ASCII", "ignore")
-                    .decode("ASCII")
-                    .replace("\n", "")
-                    .replace("\r", "")
-                )
-            else:
-                record.nfe40_infAdProd = False
+    ##########################
+    # NF-e tag: ICMS
+    # Compute Methods
+    ##########################
 
     @api.depends("icms_cst_id")
     def _compute_choice11(self):
@@ -305,84 +370,10 @@ class NFeLine(spec_models.StackedModel):
 
             record.nfe40_choice11 = icms_choice
 
-    @api.depends("pis_cst_id")
-    def _compute_choice12(self):
-        for record in self:
-            if record.pis_cst_id.code in ["01", "02"]:
-                record.nfe40_choice12 = "nfe40_PISAliq"
-            elif record.pis_cst_id.code == "03":
-                record.nfe40_choice12 = "nfe40_PISQtde"
-            elif record.pis_cst_id.code in ["04", "06", "07", "08", "09"]:
-                record.nfe40_choice12 = "nfe40_PISNT"
-            else:
-                record.nfe40_choice12 = "nfe40_PISOutr"
-
-    @api.depends("cofins_cst_id")
-    def _compute_choice15(self):
-        for record in self:
-            if record.cofins_cst_id.code in ["01", "02"]:
-                record.nfe40_choice15 = "nfe40_COFINSAliq"
-            elif record.cofins_cst_id.code == "03":
-                record.nfe40_choice15 = "nfe40_COFINSQtde"
-            elif record.cofins_cst_id.code in ["04", "06", "07", "08", "09"]:
-                record.nfe40_choice15 = "nfe40_COFINSNT"
-            else:
-                record.nfe40_choice15 = "nfe40_COFINSOutr"
-
-    @api.depends("ipi_cst_id")
-    def _compute_choice3(self):
-        for record in self:
-            if record.ipi_cst_id.code in ["00", "49", "50", "99"]:
-                record.nfe40_choice3 = "nfe40_IPITrib"
-            else:
-                record.nfe40_choice3 = "nfe40_IPINT"
-
-    @api.depends("ipi_base_type")
-    def _compute_nfe40_choice20(self):
-        for record in self:
-            if record.ipi_base_type == "percent":
-                record.nfe40_choice20 = "nfe40_pIPI"
-            else:
-                record.nfe40_choice20 = "nfe40_vUnid"
-
-    @api.depends("pis_base_type")
-    def _compute_nfe40_choice13(self):
-        for record in self:
-            if record.pis_base_type == "percent":
-                record.nfe40_choice13 = "nfe40_pPIS"
-            else:
-                record.nfe40_choice13 = "nfe40_vAliqProd"
-
-    @api.depends("cofins_base_type")
-    def _compute_nfe40_choice16(self):
-        for record in self:
-            if record.cofins_base_type == "percent":
-                record.nfe40_choice16 = "nfe40_pCOFINS"
-            else:
-                record.nfe40_choice16 = "nfe40_vAliqProd"
-
-    @api.depends("tax_icms_or_issqn")
-    def _compute_nfe40_choice10(self):
-        for record in self:
-            if record.tax_icms_or_issqn == "icms":
-                record.nfe40_choice10 = "nfe40_ICMS"
-            else:
-                record.nfe40_choice10 = "nfe40_ISSQN"
-
-    @api.model
-    def _prepare_import_dict(
-        self, values, model=None, parent_dict=None, defaults_model=None
-    ):
-        values = super()._prepare_import_dict(
-            values, model, parent_dict, defaults_model
-        )
-        if not values.get("name"):
-            values["name"] = values.get("nfe40_xProd")
-            if values.get("product_id"):
-                values["ncm_id"] = (
-                    self.env["product.product"].browse(values["product_id"]).ncm_id.id
-                )
-        return values
+    ##########################
+    # NF-e tag: ICMS
+    # Inverse Methods
+    ##########################
 
     def _export_fields_icms(self):
         icms = {
@@ -430,208 +421,486 @@ class NFeLine(spec_models.StackedModel):
             )
         return icms
 
-    def _export_fields(self, xsd_fields, class_obj, export_dict):
-        if class_obj._name == "nfe.40.imposto":
-            xsd_fields = [i for i in xsd_fields]
-            if self.nfe40_choice10 == "nfe40_ICMS":
-                xsd_fields.remove("nfe40_ISSQN")
-            else:
-                xsd_fields.remove("nfe40_ICMS")
-                xsd_fields.remove("nfe40_II")
-        elif class_obj._name == "nfe.40.icms":
-            xsd_fields = [self.nfe40_choice11]
-            icms_tag = self.nfe40_choice11.replace("nfe40_", "")  # FIXME
-            binding_module = sys.modules[self._binding_module]
-            icms_binding = getattr(binding_module, icms_tag + "Type")
-            icms_dict = self._export_fields_icms()
-            export_dict[icms_tag] = icms_binding(**icms_dict)
-        elif class_obj._name == "nfe.40.icmsufdest":
-            # DIFAL
-            self.nfe40_vBCUFDest = str("%.02f" % self.icms_destination_base)
-            self.nfe40_vBCFCPUFDest = str("%.02f" % self.icmsfcp_base)
-            self.nfe40_pFCPUFDest = str("%.04f" % self.icmsfcp_percent)
-            self.nfe40_pICMSUFDest = str("%.04f" % self.icms_destination_percent)
-            self.nfe40_pICMSInter = str(
-                "%.02f" % self.icms_origin_percent or self.icms_percent
-            )
-            self.nfe40_pICMSInterPart = str(
-                "%.04f" % self.icms_sharing_percent or 100.0
-            )
-            self.nfe40_vFCPUFDest = str("%.02f" % self.icmsfcp_value)
-            self.nfe40_vICMSUFDest = str("%.02f" % self.icms_destination_value)
-            self.nfe40_vICMSUFRemet = str("%.02f" % self.icms_origin_value)
-        elif class_obj._name == "nfe.40.tipi":
-            xsd_fields = [
-                f
-                for f in xsd_fields
-                if f not in [i[0] for i in class_obj._fields["nfe40_choice3"].selection]
-            ]
-            xsd_fields += [self.nfe40_choice3]
-        elif class_obj._name == "nfe.40.pis":
-            xsd_fields = [self.nfe40_choice12]
-        elif class_obj._name == "nfe.40.cofins":
-            xsd_fields = [self.nfe40_choice15]
-        elif class_obj._name == "nfe.40.ipitrib":
-            xsd_fields = [i for i in xsd_fields]
-            if self.nfe40_choice20 == "nfe40_pIPI":
-                xsd_fields.remove("nfe40_qUnid")
-                xsd_fields.remove("nfe40_vUnid")
-            else:
-                xsd_fields.remove("nfe40_vBC")
-                xsd_fields.remove("nfe40_pIPI")
-        elif class_obj._name == "nfe.40.pisoutr":
-            xsd_fields = [i for i in xsd_fields]
-            if self.nfe40_choice13 == "nfe40_pPIS":
-                xsd_fields.remove("nfe40_qBCProd")
-                xsd_fields.remove("nfe40_vAliqProd")
-            else:
-                xsd_fields.remove("nfe40_vBC")
-                xsd_fields.remove("nfe40_pPIS")
-        elif class_obj._name == "nfe.40.cofinsoutr":
-            xsd_fields = [i for i in xsd_fields]
-            if self.nfe40_choice16 == "nfe40_pCOFINS":
-                xsd_fields.remove("nfe40_qBCProd")
-                xsd_fields.remove("nfe40_vAliqProd")
-            else:
-                xsd_fields.remove("nfe40_vBC")
-                xsd_fields.remove("nfe40_pCOFINS")
+    def _export_fields_nfe_40_icms(self, xsd_fields, class_obj, export_dict):
 
-        self.nfe40_NCM = self.ncm_id.code_unmasked or False
-        self.nfe40_CEST = self.cest_id and self.cest_id.code_unmasked or False
-        self.nfe40_pICMS = self.icms_percent
-        self.nfe40_pICMSST = self.icmsst_percent
-        self.nfe40_pMVAST = self.icmsst_mva_percent
-        self.nfe40_pRedBCST = self.icmsst_reduction
-        self.nfe40_pIPI = self.ipi_percent
-        self.nfe40_pPIS = self.pis_percent
-        self.nfe40_pCOFINS = self.cofins_percent
-        self.nfe40_cEnq = str(self.ipi_guideline_id.code or "999").zfill(3)
-        return super()._export_fields(xsd_fields, class_obj, export_dict)
+        # TODO Not Implemented
+        if "nfe40_ICMSPart" in xsd_fields:
+            xsd_fields.remove("nfe40_ICMSPart")
 
-    # flake8: noqa: C901
-    def _export_field(self, xsd_field, class_obj, member_spec, export_value=None):
-        # ISSQN
-        if xsd_field == "nfe40_cMunFG":
-            return self.issqn_fg_city_id.ibge_code
-        if xsd_field == "nfe40_cListServ":
-            return self.service_type_id.code
-        if xsd_field == "nfe40_vDeducao":
-            return self.issqn_deduction_amount
-        if xsd_field == "nfe40_vOutro":
-            return self.issqn_other_amount
-        if xsd_field == "nfe40_vDescIncond":
-            return self.issqn_desc_incond_amount
-        if xsd_field == "nfe40_vDescCond":
-            return self.issqn_desc_cond_amount
-        if xsd_field == "nfe40_vISSRet":
-            return self.issqn_wh_value
-        if xsd_field == "nfe40_indISS":
-            return self.issqn_eligibility
-        if xsd_field == "nfe40_cServico":
-            return ""  # TODO
-        if xsd_field == "nfe40_cMun":
-            return self.issqn_fg_city_id.ibge_code  # TODO
-        if xsd_field == "nfe40_cPais" and self.issqn_fg_city_id:
-            return self.issqn_fg_city_id.state_id.country_id.bc_code[1:]  # TODO
-        if xsd_field == "nfe40_nProcesso":
-            return ""  # TODO
-        if xsd_field == "nfe40_indIncentivo":
-            return self.issqn_incentive
-        if xsd_field == "nfe40_xProd":
-            return self.name[:120].replace("\n", "").strip()
-        if xsd_field in ["nfe40_cEAN", "nfe40_cEANTrib"] and not self[xsd_field]:
-            return "SEM GTIN"
-        elif xsd_field == "nfe40_CST":
-            if class_obj._name.startswith("nfe.40.icms"):
-                return self.icms_cst_id.code
-            elif class_obj._name.startswith("nfe.40.ipi"):
-                return self.ipi_cst_id.code
-            elif class_obj._name.startswith("nfe.40.pis"):
-                return self.pis_cst_id.code
-            elif class_obj._name.startswith("nfe.40.cofins"):
-                return self.cofins_cst_id.code
-        elif xsd_field == "nfe40_CSOSN":
-            if self.nfe40_choice11 == "nfe40_ICMSSN101":
-                return "101"
-        elif xsd_field == "nfe40_vBC":
-            field_name = "nfe40_vBC"
-            if class_obj._name.startswith("nfe.40.icms"):
-                field_name = "icms_base"
-            elif class_obj._name.startswith("nfe.40.ipi"):
-                field_name = "ipi_base"
-            elif class_obj._name.startswith("nfe.40.pis"):
-                field_name = "pis_base"
-            elif class_obj._name.startswith("nfe.40.cofins"):
-                field_name = "cofins_base"
-            return self._export_float_monetary(
-                field_name,
-                member_spec,
-                class_obj,
-                class_obj._fields[xsd_field].xsd_required,
+        # TODO Not Implemented
+        if "nfe40_ICMSST" in xsd_fields:
+            xsd_fields.remove("nfe40_ICMSST")
+
+        xsd_fields = [self.nfe40_choice11]
+        icms_tag = self.nfe40_choice11.replace("nfe40_", "")  # FIXME
+        binding_module = sys.modules[self._binding_module]
+        icms_binding = getattr(binding_module, icms_tag + "Type")
+        icms_dict = self._export_fields_icms()
+        export_dict[icms_tag] = icms_binding(**icms_dict)
+
+    #######################################
+    # NF-e tag: ICMSPart
+    # Grupo N10a. Grupo de Partilha do ICMS
+    #######################################
+
+    # TODO
+
+    #########################################
+    # NF-e tag: ICMSST
+    # Grupo N10b. Grupo de Repasse do ICMS ST
+    #########################################
+
+    # TODO
+
+    #####################################
+    # NF-e tag: ICMSUFDest
+    # Grupo NA. ICMS para a UF de destino
+    #####################################
+
+    nfe40_vBCUFDest = fields.Monetary(related="icms_destination_base")
+    nfe40_vBCFCPUFDest = fields.Monetary(related="icmsfcp_base")
+    nfe40_pFCPUFDest = fields.Monetary(compute="_compute_nfe40_ICMSUFDest")
+    nfe40_pICMSUFDest = fields.Monetary(compute="_compute_nfe40_ICMSUFDest")
+    nfe40_pICMSInter = fields.Selection(compute="_compute_nfe40_ICMSUFDest")
+    nfe40_pICMSInterPart = fields.Monetary(compute="_compute_nfe40_ICMSUFDest")
+
+    def _compute_nfe40_ICMSUFDest(self):
+        for record in self:
+            record.nfe40_pICMSInter = str(
+                "%.02f" % record.icms_origin_percent or record.icms_percent
             )
-        elif xsd_field in (
-            "nfe40_vBCSTRet",
-            "nfe40_pST",
-            "nfe40_vICMSSubstituto",
-            "nfe40_vICMSSTRet",
-        ):
-            if self.icms_cst_id.code in ICMS_ST_CST_CODES:
-                return self._export_float_monetary(
-                    xsd_field, member_spec, class_obj, True
-                )
+            record.nfe40_pFCPUFDest = record.icmsfcp_percent
+            record.nfe40_pICMSUFDest = record.icms_destination_percent
+            record.nfe40_pICMSInterPart = record.icms_sharing_percent
+
+    nfe40_vFCPUFDest = fields.Monetary(related="icmsfcp_value")
+    nfe40_vICMSUFDest = fields.Monetary(related="icms_destination_value")
+    nfe40_vICMSUFRemet = fields.Monetary(related="icms_origin_value")
+
+    ##################################################
+    # NF-e tag: IPI
+    # Grupo O. Imposto sobre Produtos Industrializados
+    ##################################################
+
+    nfe40_choice3 = fields.Selection(compute="_compute_choice3", store=True)
+
+    nfe40_choice20 = fields.Selection(
+        compute="_compute_nfe40_choice20",
+        store=True,
+    )
+
+    # CNPJProd TODO
+
+    # cSelo TODO
+
+    # qSelo TODO
+
+    nfe40_cEnq = fields.Char(related="ipi_guideline_id.code")
+
+    nfe40_pIPI = fields.Float(related="ipi_percent", string="pIPI")
+
+    nfe40_vIPI = fields.Monetary(related="ipi_value")
+
+    ##########################
+    # NF-e tag: IPI
+    # Compute Methods
+    ##########################
+
+    @api.depends("ipi_cst_id")
+    def _compute_choice3(self):
+        for record in self:
+            if record.ipi_cst_id.code in ["00", "49", "50", "99"]:
+                record.nfe40_choice3 = "nfe40_IPITrib"
+            else:
+                record.nfe40_choice3 = "nfe40_IPINT"
+
+    @api.depends("ipi_base_type")
+    def _compute_nfe40_choice20(self):
+        for record in self:
+            if record.ipi_base_type == "percent":
+                record.nfe40_choice20 = "nfe40_pIPI"
+            else:
+                record.nfe40_choice20 = "nfe40_vUnid"
+
+    ##########################
+    # NF-e tag: IPI
+    # Inverse Methods
+    ##########################
+
+    def _export_fields_nfe_40_tipi(self, xsd_fields, class_obj, export_dict):
+
+        if not self.ipi_cst_id.code in ["00", "49", "50", "99"]:
+            xsd_fields.remove("nfe40_IPITrib")
         else:
-            return super()._export_field(xsd_field, class_obj, member_spec)
+            xsd_fields.remove("nfe40_IPINT")
 
-    def _export_many2one(self, field_name, xsd_required, class_obj=None):
-        self.ensure_one()
-        if field_name in self._stacking_points.keys():
-            if field_name == "nfe40_ISSQN" and not self.service_type_id:
-                return False
-            elif field_name == "nfe40_ICMS" and self.service_type_id:
-                return False
-            elif field_name == "nfe40_ICMSUFDest" and (
-                not self.icms_value
-                or self.partner_id.ind_ie_dest != "9"
-                or self.partner_id.state_id == self.company_id.state_id
-                or self.partner_id.country_id != self.company_id.country_id
-            ):
-                return False
-            # TODO add condition
-            elif field_name in ["nfe40_II", "nfe40_PISST", "nfe40_COFINSST"]:
-                return False
+    def _export_fields_ipi(self, xsd_fields, class_obj, export_dict):
 
-            elif (not xsd_required) and field_name not in [
-                "nfe40_PIS",
-                "nfe40_COFINS",
-                "nfe40_IPI",
-                "nfe40_ICMSUFDest",
-            ]:
-                comodel = self.env[self._stacking_points.get(field_name).comodel_name]
-                fields = [
-                    f for f in comodel._fields if f.startswith(self._field_prefix)
-                ]
-                sub_tag_read = self.read(fields)[0]
-                if not any(
-                    v
-                    for k, v in sub_tag_read.items()
-                    if k.startswith(self._field_prefix)
-                ):
-                    return False
+        export_dict["CST"] = self.ipi_cst_id.code
+        export_dict["vBC"] = self.ipi_base
 
-        return super()._export_many2one(field_name, xsd_required, class_obj)
+    def _export_fields_nfe_40_ipitrib(self, xsd_fields, class_obj, export_dict):
 
-    def _export_float_monetary(
-        self, field_name, member_spec, class_obj, xsd_required, export_value=None
+        self._export_fields_ipi(xsd_fields, class_obj, export_dict)
+
+        if self.nfe40_choice20 == "nfe40_pIPI":
+            xsd_fields.remove("nfe40_qUnid")
+            xsd_fields.remove("nfe40_vUnid")
+        else:
+            xsd_fields.remove("nfe40_vBC")
+            xsd_fields.remove("nfe40_pIPI")
+
+    def _export_fields_nfe_40_ipint(self, xsd_fields, class_obj, export_dict):
+
+        self._export_fields_ipi(xsd_fields, class_obj, export_dict)
+
+    ################################
+    # NF-e tag: II
+    # Grupo P. Imposto de Importação
+    ################################
+
+    # vBC TODO
+
+    nfe40_vDespAdu = fields.Monetary(related="ii_customhouse_charges")
+
+    nfe40_vII = fields.Monetary(related="ii_value")
+
+    nfe40_vIOF = fields.Monetary(related="ii_iof_value")
+
+    ###############
+    # NF-e tag: PIS
+    # Grupo Q. PIS
+    ###############
+
+    nfe40_choice12 = fields.Selection(compute="_compute_choice12", store=True)
+
+    nfe40_choice13 = fields.Selection(
+        compute="_compute_nfe40_choice13",
+        store=True,
+        string="Tipo de Tributação do PIS",
+    )
+
+    nfe40_PISAliq = fields.Many2one(
+        comodel_name="nfe.40.pisaliq",
+        string="Código de Situação Tributária do PIS (Alíquota)",
+        help="Código de Situação Tributária do PIS."
+        "\n01 – Operação Tributável - Base de Cálculo = Valor da Operação"
+        "\nAlíquota Normal (Cumulativo/Não Cumulativo);"
+        "\n02 - Operação Tributável - Base de Calculo = Valor da Operação"
+        "\n(Alíquota Diferenciada);",
+    )
+
+    nfe40_vPIS = fields.Monetary(
+        string="Valor do PIS (NFe)",
+        related="pis_value",
+    )
+
+    ##########################
+    # NF-e tag: PIS
+    # Compute Methods
+    ##########################
+
+    @api.depends("pis_cst_id")
+    def _compute_choice12(self):
+        for record in self:
+            if record.pis_cst_id.code in ["01", "02"]:
+                record.nfe40_choice12 = "nfe40_PISAliq"
+            elif record.pis_cst_id.code == "03":
+                record.nfe40_choice12 = "nfe40_PISQtde"
+            elif record.pis_cst_id.code in ["04", "06", "07", "08", "09"]:
+                record.nfe40_choice12 = "nfe40_PISNT"
+            else:
+                record.nfe40_choice12 = "nfe40_PISOutr"
+
+    @api.depends("pis_base_type")
+    def _compute_nfe40_choice13(self):
+        for record in self:
+            if record.pis_base_type == "percent":
+                record.nfe40_choice13 = "nfe40_pPIS"
+            else:
+                record.nfe40_choice13 = "nfe40_vAliqProd"
+
+    ##########################
+    # NF-e tag: PIS
+    # Inverse Methods
+    ##########################
+
+    nfe40_pPIS = fields.Float(related="pis_percent", string="nfe40_pPIS")
+
+    def _export_fields_nfe_40_pis(self, xsd_fields, class_obj, export_dict):
+
+        remove_tags = {
+            "nfe40_PISAliq": ["nfe40_PISQtde", "nfe40_PISNT", "nfe40_PISOutr"],
+            "nfe40_PISQtde": ["nfe40_PISAliq", "nfe40_PISNT", "nfe40_PISOutr"],
+            "nfe40_PISNT": ["nfe40_PISAliq", "nfe40_PISQtde", "nfe40_PISOutr"],
+            "nfe40_PISOutr": ["nfe40_PISAliq", "nfe40_PISQtde", "nfe40_PISNT"],
+        }
+
+        for tag_to_remove in remove_tags.get(self.nfe40_choice12):
+            xsd_fields.remove(tag_to_remove)
+
+    def _export_fields_pis(self, xsd_fields, class_obj, export_dict):
+
+        export_dict["CST"] = self.pis_cst_id.code
+        export_dict["vBC"] = self.pis_base
+
+    def _export_fields_nfe_40_pisaliq(self, xsd_fields, class_obj, export_dict):
+
+        self._export_fields_pis(xsd_fields, class_obj, export_dict)
+
+    def _export_fields_nfe_40_pisqtde(self, xsd_fields, class_obj, export_dict):
+
+        self._export_fields_pis(xsd_fields, class_obj, export_dict)
+
+    def _export_fields_nfe_40_pisoutr(self, xsd_fields, class_obj, export_dict):
+
+        self._export_fields_pis(xsd_fields, class_obj, export_dict)
+
+        if self.nfe40_choice13 == "nfe40_pPIS":
+            xsd_fields.remove("nfe40_qBCProd")
+            xsd_fields.remove("nfe40_vAliqProd")
+
+        if self.nfe40_choice13 == "nfe40_vAliqProd":
+            xsd_fields.remove("nfe40_vBC")
+            xsd_fields.remove("nfe40_pPIS")
+
+    #################
+    # NF-e tag: PISST
+    # Grupo R. PIS ST
+    #################
+
+    # TODO
+
+    ##################
+    # NF-e tag: COFINS
+    # Grupo S. COFINS
+    ##################
+
+    nfe40_choice15 = fields.Selection(compute="_compute_choice15", store=True)
+
+    nfe40_choice16 = fields.Selection(
+        compute="_compute_nfe40_choice16",
+        store=True,
+        string="Tipo de Tributação do COFINS",
+    )
+
+    nfe40_pCOFINS = fields.Float(related="cofins_percent", string="nfe40_pCOFINS")
+
+    nfe40_vCOFINS = fields.Monetary(
+        string="Valor do COFINS (NFe)",
+        related="cofins_value",
+    )
+
+    nfe40_COFINSAliq = fields.Many2one(
+        comodel_name="nfe.40.cofinsaliq",
+        string="Código de Situação Tributária do COFINS (Alíquota)",
+        help="Código de Situação Tributária do COFINS."
+        "\n01 – Operação Tributável - Base de Cálculo = Valor da Operação"
+        "\nAlíquota Normal (Cumulativo/Não Cumulativo);"
+        "\n02 - Operação Tributável - Base de Calculo = Valor da Operação"
+        "\n(Alíquota Diferenciada);",
+    )
+
+    ##########################
+    # NF-e tag: COFINS
+    # Compute Methods
+    ##########################
+
+    @api.depends("cofins_cst_id")
+    def _compute_choice15(self):
+        for record in self:
+            if record.cofins_cst_id.code in ["01", "02"]:
+                record.nfe40_choice15 = "nfe40_COFINSAliq"
+            elif record.cofins_cst_id.code == "03":
+                record.nfe40_choice15 = "nfe40_COFINSQtde"
+            elif record.cofins_cst_id.code in ["04", "06", "07", "08", "09"]:
+                record.nfe40_choice15 = "nfe40_COFINSNT"
+            else:
+                record.nfe40_choice15 = "nfe40_COFINSOutr"
+
+    @api.depends("cofins_base_type")
+    def _compute_nfe40_choice16(self):
+        for record in self:
+            if record.cofins_base_type == "percent":
+                record.nfe40_choice16 = "nfe40_pCOFINS"
+            else:
+                record.nfe40_choice16 = "nfe40_vAliqProd"
+
+    ##########################
+    # NF-e tag: COFINS
+    # Inverse Methods
+    ##########################
+
+    # TODO
+
+    def _export_fields_nfe_40_cofins(self, xsd_fields, class_obj, export_dict):
+        remove_tags = {
+            "nfe40_COFINSAliq": [
+                "nfe40_COFINSQtde",
+                "nfe40_COFINSNT",
+                "nfe40_COFINSOutr",
+            ],
+            "nfe40_COFINSQtde": [
+                "nfe40_COFINSAliq",
+                "nfe40_COFINSNT",
+                "nfe40_COFINSOutr",
+            ],
+            "nfe40_COFINSNT": [
+                "nfe40_COFINSAliq",
+                "nfe40_COFINSQtde",
+                "nfe40_COFINSOutr",
+            ],
+            "nfe40_COFINSOutr": [
+                "nfe40_COFINSAliq",
+                "nfe40_COFINSQtde",
+                "nfe40_COFINSNT",
+            ],
+        }
+
+        for tag_to_remove in remove_tags.get(self.nfe40_choice15):
+            xsd_fields.remove(tag_to_remove)
+
+    def _export_fields_cofins(self, xsd_fields, class_obj, export_dict):
+
+        export_dict["CST"] = self.cofins_cst_id.code
+        export_dict["vBC"] = self.cofins_base
+        export_dict["vCOFINS"] = self.cofins_value
+
+    def _export_fields_nfe_40_cofinsaliq(self, xsd_fields, class_obj, export_dict):
+
+        self._export_fields_cofins(xsd_fields, class_obj, export_dict)
+
+    def _export_fields_nfe_40_cofinsqtde(self, xsd_fields, class_obj, export_dict):
+
+        self._export_fields_cofins(xsd_fields, class_obj, export_dict)
+
+    def _export_fields_nfe_40_cofinsoutr(self, xsd_fields, class_obj, export_dict):
+
+        self._export_fields_cofins(xsd_fields, class_obj, export_dict)
+
+        if self.nfe40_choice16 == "nfe40_pCOFINS":
+            xsd_fields.remove("nfe40_qBCProd")
+            xsd_fields.remove("nfe40_vAliqProd")
+
+        if self.nfe40_choice16 == "nfe40_vAliqProd":
+            xsd_fields.remove("nfe40_vBC")
+            xsd_fields.remove("nfe40_pCOFINS")
+
+    ####################
+    # NF-e tag: COFINSST
+    # Grupo T. COFINS ST
+    ####################
+
+    # TODO
+
+    #################
+    # NF-e tag: ISSQN
+    # Grupo U. ISSQN
+    #################
+
+    nfe40_vISSQN = fields.Monetary(related="issqn_value")
+
+    nfe40_cMunFG = fields.Char(related="issqn_fg_city_id.ibge_code")
+
+    nfe40_cListServ = fields.Char(related="service_type_id.code")
+
+    nfe40_vDeducao = fields.Monetary(related="issqn_deduction_amount")
+
+    nfe40_vDescIncond = fields.Monetary(related="issqn_desc_incond_amount")
+
+    nfe40_vDescCond = fields.Monetary(related="issqn_desc_cond_amount")
+
+    nfe40_vISSRet = fields.Monetary(related="issqn_wh_value")
+
+    nfe40_indISS = fields.Selection(related="issqn_eligibility")
+
+    # nfe40_cServico TODO
+
+    nfe40_cMun = fields.Char(related="issqn_fg_city_id.ibge_code")
+
+    nfe40_cPais = fields.Char(
+        related="issqn_fg_city_id.state_id.country_id.bc_code",
+    )
+
+    # nfe40_nProcesso TODO
+
+    nfe40_indIncentivo = fields.Selection(related="issqn_incentive")
+
+    #####################################################
+    # NF-e tag: impostoDevol
+    # Grupo UA. Tributos Devolvidos (para o item da NF-e)
+    #####################################################
+
+    # TODO
+
+    ########################
+    # NF-e tag: total
+    # Grupo W. Total da NF-e
+    ########################
+
+    nfe40_choice10 = fields.Selection(
+        compute="_compute_nfe40_choice10",
+        store=True,
+    )
+
+    ##########################
+    # NF-e tag: total
+    # Compute Methods
+    ##########################
+
+    @api.depends("tax_icms_or_issqn")
+    def _compute_nfe40_choice10(self):
+        for record in self:
+            if record.tax_icms_or_issqn == "issqn":
+                record.nfe40_choice10 = "nfe40_ISSQN"
+            else:
+                record.nfe40_choice10 = "nfe40_ICMS"
+
+    #######################################################
+    # NF-e tag: infAdProd
+    # Grupo V. Informações adicionais (para o item da NF-e)
+    #######################################################
+
+    nfe40_infAdProd = fields.Char(compute="_compute_nfe40_infAdProd")
+
+    ##########################
+    # NF-e tag: infAdProd
+    # Compute Methods
+    ##########################
+
+    @api.depends("additional_data")
+    def _compute_nfe40_infAdProd(self):
+        for record in self:
+            if record.additional_data:
+                record.nfe40_infAdProd = (
+                    normalize("NFKD", record.additional_data)
+                    .encode("ASCII", "ignore")
+                    .decode("ASCII")
+                    .replace("\n", "")
+                    .replace("\r", "")
+                )
+            else:
+                record.nfe40_infAdProd = False
+
+    # Todo: Calcular
+    nfe40_vFCPUFDest = fields.Monetary(
+        string="Valor total do ICMS relativo ao Fundo de Combate à Pobreza",
+    )
+
+    @api.model
+    def _prepare_import_dict(
+        self, values, model=None, parent_dict=None, defaults_model=None
     ):
-        if not self[field_name] and not xsd_required:
-            if not (
-                class_obj._name == "nfe.40.imposto" and field_name == "nfe40_vTotTrib"
-            ) and not (class_obj._name == "nfe.40.fat"):
-                self[field_name] = False
-                return False
-        return super()._export_float_monetary(
-            field_name, member_spec, class_obj, xsd_required
+        values = super()._prepare_import_dict(
+            values, model, parent_dict, defaults_model
         )
+        if not values.get("name"):
+            values["name"] = values.get("nfe40_xProd")
+            if values.get("product_id"):
+                values["ncm_id"] = (
+                    self.env["product.product"].browse(values["product_id"]).ncm_id.id
+                )
+        return values
 
     def _build_attr(self, node, fields, vals, path, attr):
         key = "nfe40_%s" % (attr.get_name(),)  # TODO schema wise
@@ -643,18 +912,6 @@ class NFeLine(spec_models.StackedModel):
             "nfe40_ICMSUFDest",
         ]:
             vals["nfe40_choice11"] = key
-
-        if key.startswith("nfe40_IPI") and key != "nfe40_IPI":
-            vals["nfe40_choice3"] = key
-
-        if key.startswith("nfe40_PIS") and key not in ["nfe40_PIS", "nfe40_PISST"]:
-            vals["nfe40_choice12"] = key
-
-        if key.startswith("nfe40_COFINS") and key not in [
-            "nfe40_COFINS",
-            "nfe40_COFINSST",
-        ]:
-            vals["nfe40_choice15"] = key
 
         if key == "nfe40_vUnCom":
             vals["price_unit"] = float(value)
@@ -692,7 +949,8 @@ class NFeLine(spec_models.StackedModel):
         return super()._build_attr(node, fields, vals, path, attr)
 
     def _build_string_not_simple_type(self, key, vals, value, node):
-        if key not in ["nfe40_CST", "nfe40_modBC", "nfe40_CSOSN", "nfe40_vBC"]:
+        # if key not in ["nfe40_CST", "nfe40_modBC", "nfe40_CSOSN", "nfe40_vBC"]:
+        if key not in ["nfe40_CST", "nfe40_modBC", "nfe40_CSOSN"]:
             super()._build_string_not_simple_type(key, vals, value, node)
             # TODO avoid collision with cls prefix
         elif key == "nfe40_CST":
@@ -722,15 +980,6 @@ class NFeLine(spec_models.StackedModel):
                 )
         elif key == "nfe40_modBC":
             vals["icms_base_type"] = value
-        elif key == "nfe40_vBC":
-            if node.original_tagname_.startswith("ICMS"):
-                vals["icms_base"] = value
-            elif node.original_tagname_.startswith("IPI"):
-                vals["ipi_base"] = value
-            elif node.original_tagname_.startswith("PIS"):
-                vals["pis_base"] = value
-            elif node.original_tagname_.startswith("COFINS"):
-                vals["cofins_base"] = value
 
     # flake8: noqa: C901
     def _build_many2one(self, comodel, vals, new_value, key, value, path):

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -202,6 +202,17 @@ class ResPartner(spec_models.SpecModel):
             if xsd_field == self.nfe40_choice2:
                 return cnpj_cpf
 
+        if xsd_field in ("nfe40_CNPJ", "nfe40_CPF"):
+            # Caso o CNPJ/CPF esteja em branco e o parceiro tenha um parent_id
+            # É exportado o CNPJ/CPF do parent_id é importate para o endereço
+            # de entrega/retirada
+            if not self.cnpj_cpf and self.parent_id:
+                cnpj_cpf = self.parent_id.cnpj_cpf
+            else:
+                cnpj_cpf = self.cnpj_cpf
+
+            return punctuation_rm(cnpj_cpf)
+
         if self.country_id.code != "BR":
             if xsd_field == "nfe40_xBairro":
                 return "EX"
@@ -214,7 +225,8 @@ class ResPartner(spec_models.SpecModel):
 
             if xsd_field == "nfe40_UF":
                 return "EX"
+
             if xsd_field == "nfe40_idEstrangeiro":
                 return self.vat or self.cnpj_cpf or self.rg or "EXTERIOR"
 
-        return super()._export_field(xsd_field, class_obj, member_spec)
+        return super()._export_field(xsd_field, class_obj, member_spec, export_value)

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -63,6 +63,12 @@ class ResPartner(spec_models.SpecModel):
     # Char overriding Selection:
     nfe40_UF = fields.Char(related="state_id.code")
 
+    # Emit
+    nfe40_choice6 = fields.Selection(
+        selection=[("nfe40_CNPJ", "CNPJ"), ("nfe40_CPF", "CPF")],
+        string="CNPJ/CPF do Emitente",
+    )
+
     # nfe.40.tendereco
     nfe40_CEP = fields.Char(
         compute="_compute_nfe_data", inverse="_inverse_nfe40_CEP"
@@ -139,10 +145,18 @@ class ResPartner(spec_models.SpecModel):
                 if rec.country_id.code != "BR":
                     rec.nfe40_choice7 = "nfe40_idEstrangeiro"
                 elif rec.is_company:
+                    rec.nfe40_choice2 = "nfe40_CNPJ"
+                    rec.nfe40_choice6 = "nfe40_CNPJ"
                     rec.nfe40_choice7 = "nfe40_CNPJ"
+                    rec.nfe40_choice8 = "nfe40_CNPJ"
+                    rec.nfe40_choice19 = "nfe40_CNPJ"
                     rec.nfe40_CNPJ = cnpj_cpf
                 else:
+                    rec.nfe40_choice2 = "nfe40_CPF"
+                    rec.nfe40_choice6 = "nfe40_CPF"
                     rec.nfe40_choice7 = "nfe40_CPF"
+                    rec.nfe40_choice8 = "nfe40_CPF"
+                    rec.nfe40_choice19 = "nfe40_CPF"
                     rec.nfe40_CPF = cnpj_cpf
 
             if rec.inscr_est and rec.is_company:
@@ -157,12 +171,29 @@ class ResPartner(spec_models.SpecModel):
         for rec in self:
             if rec.nfe40_CNPJ:
                 rec.is_company = True
+                rec.nfe40_choice2 = "nfe40_CPF"
+                rec.nfe40_choice6 = "nfe40_CPF"
+                if rec.country_id.code != "BR":
+                    rec.nfe40_choice7 = "nfe40_idEstrangeiro"
+                else:
+                    rec.nfe40_choice7 = "nfe40_CNPJ"
+                rec.nfe40_choice7 = "nfe40_CPF"
+                rec.nfe40_choice8 = "nfe40_CPF"
+                rec.nfe40_choice19 = "nfe40_CPF"
                 rec.cnpj_cpf = cnpj_cpf.formata(str(rec.nfe40_CNPJ))
 
     def _inverse_nfe40_CPF(self):
         for rec in self:
             if rec.nfe40_CPF:
                 rec.is_company = False
+                rec.nfe40_choice2 = "nfe40_CNPJ"
+                rec.nfe40_choice6 = "nfe40_CNPJ"
+                if rec.country_id.code != "BR":
+                    rec.nfe40_choice7 = "nfe40_idEstrangeiro"
+                else:
+                    rec.nfe40_choice7 = "nfe40_CPF"
+                rec.nfe40_choice8 = "nfe40_CNPJ"
+                rec.nfe40_choice19 = "nfe40_CNPJ"
                 rec.cnpj_cpf = cnpj_cpf.formata(str(rec.nfe40_CPF))
 
     def _inverse_nfe40_IE(self):
@@ -201,17 +232,6 @@ class ResPartner(spec_models.SpecModel):
 
             if xsd_field == self.nfe40_choice2:
                 return cnpj_cpf
-
-        if xsd_field in ("nfe40_CNPJ", "nfe40_CPF"):
-            # Caso o CNPJ/CPF esteja em branco e o parceiro tenha um parent_id
-            # É exportado o CNPJ/CPF do parent_id é importate para o endereço
-            # de entrega/retirada
-            if not self.cnpj_cpf and self.parent_id:
-                cnpj_cpf = self.parent_id.cnpj_cpf
-            else:
-                cnpj_cpf = self.cnpj_cpf
-
-            return punctuation_rm(cnpj_cpf)
 
         if self.country_id.code != "BR":
             if xsd_field == "nfe40_xBairro":

--- a/l10n_br_nfe/models/tax_ipi_guideline.py
+++ b/l10n_br_nfe/models/tax_ipi_guideline.py
@@ -1,9 +1,20 @@
 # Copyright (C) 2021  Renato Lima - Akretion <renato.lima@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import api, models
 
 
 class TaxIpiGuideline(models.Model):
     _inherit = "l10n_br_fiscal.tax.ipi.guideline"
     _nfe_search_keys = ["code_unmasked"]
+
+    @api.model
+    def match_or_create_m2o(self, rec_dict, parent_dict, model=None):
+        """If IpiGuideline not found, break hard, don't create it"""
+
+        if rec_dict.get("code_unmasked"):
+            domain = [("code_unmasked", "=", rec_dict.get("code_unmasked"))]
+            match = self.search(domain, limit=1)
+            if match:
+                return match.id
+        return False

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000012062777161.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000012062777161.xml
@@ -64,7 +64,7 @@
             <prod>
                 <cProd>E-COM11</cProd>
                 <cEAN>SEM GTIN</cEAN>
-                <xProd>[E-COM11] Cabinet with Doors</xProd>
+                <xProd>Cabinet with Doors</xProd>
                 <NCM>94033000</NCM>
                 <CFOP>5102</CFOP>
                 <uCom>UNID</uCom>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000022062777169.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000022062777169.xml
@@ -63,7 +63,7 @@
             <prod>
                 <cProd>FURN_9001</cProd>
                 <cEAN>SEM GTIN</cEAN>
-                <xProd>[FURN_9001] Flipover</xProd>
+                <xProd>Flipover</xProd>
                 <NCM>96100000</NCM>
                 <CFOP>5102</CFOP>
                 <uCom>UNID</uCom>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000032062777166.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000032062777166.xml
@@ -66,7 +66,7 @@
             <prod>
                 <cProd>E-COM10</cProd>
                 <cEAN>SEM GTIN</cEAN>
-                <xProd>[E-COM10] Pedal Bin</xProd>
+                <xProd>Pedal Bin</xProd>
                 <NCM>73239900</NCM>
                 <CFOP>6102</CFOP>
                 <uCom>UNID</uCom>

--- a/l10n_br_nfe/tests/test_nfe_import_wizard.py
+++ b/l10n_br_nfe/tests/test_nfe_import_wizard.py
@@ -46,7 +46,7 @@ class NFeImportWizardTest(SavepointCase):
         )
         # Check wizard product info
         self.assertEqual(
-            wizard.imported_products_ids[0].product_name, "[E-COM11] Cabinet with Doors"
+            wizard.imported_products_ids[0].product_name, "Cabinet with Doors"
         )
         self.assertEqual(wizard.imported_products_ids[0].uom_com, "UNID")
         self.assertEqual(wizard.imported_products_ids[0].quantity_com, 1)

--- a/l10n_br_nfe/wizards/import_document.py
+++ b/l10n_br_nfe/wizards/import_document.py
@@ -79,14 +79,14 @@ class NfeImport(models.TransientModel):
             self.document_key = document.chave
             self.document_number = int(document.numero_documento)
             self.document_serie = int(document.numero_serie)
-            self.partner_cpf_cnpj = document.cnpj_emitente
+            self.partner_cpf_cnpj = document.cnpj_cpf_emitente
             self.partner_name = (
                 parsed_xml.infNFe.emit.xFant or parsed_xml.infNFe.emit.xNome
             )
             self.partner_id = self.env["res.partner"].search(
                 [
                     "|",
-                    ("cnpj_cpf", "=", document.cnpj_emitente),
+                    ("cnpj_cpf", "=", document.cnpj_cpf_emitente),
                     ("nfe40_xNome", "=", parsed_xml.infNFe.emit.xNome),
                 ],
                 limit=1,
@@ -124,7 +124,7 @@ class NfeImport(models.TransientModel):
         )
 
         self.fiscal_operation_type = (
-            "in" if document.cnpj_emitente != self.company_id.cnpj_cpf else "out"
+            "in" if document.cnpj_cpf_emitente != self.company_id.cnpj_cpf else "out"
         )
 
         edoc = self.env["l10n_br_fiscal.document"].import_xml(


### PR DESCRIPTION
Pessoal,

Recentemente eu havia feito um PR #1924 para padronizar a integração entre os campos dos objetos de negócio e os objetos da NF-e, Eu estou criando esse PR para fazer a mesma padronização no objeto que integra a linha do documento fiscal com a linha da NF-e.

Basicamente Esse PR implementa a mesma padronização:

```python
class NFeLine():
    # class metadata

    ##########################
    # NF-e spec related fields
    ##########################

    ######################################
    # NF-e tag: prod
    # Grupo I. Produtos e Serviços da NF-e
    ######################################

    # nfe40_cProd = fields.Char(related="product_id.default_code")

    nfe40_cEAN = fields.Char(related="product_id.barcode")

    # nfe40_xProd = fields.Char(related="name") TODO

    nfe40_NCM = fields.Char(related="ncm_id.code_unmasked")

    # NVE TODO

    nfe40_CEST = fields.Char(related="cest_id.code_unmasked")

    # indEscala TODO

    # CNPJFab TODO

    # cBenef TODO

    ##########################
    # NF-e tag: prod
    # Compute Methods
    ##########################

    def _compute_nfe40_prod(self, xsd_fields, class_obj, export_dict):
        ...

    ##########################
    # NF-e tag: id
    # Inverse Methods
    ##########################

    def _inverse_nfe40_prod(self):
        ...


    ################################
    # Framework Spec model's methods
    ################################
 
    def _export_fields_nfe_40_prod(self, xsd_fields, class_obj, export_dict):
        ...

   ################################
    # Business Model Methods
    ################################

    def _onchange_product_id_fiscal(self):
        ...
```

## Alterações

A mudança considerável neste PR foi o refatoramento dos métodos _export_fields e _export_field que são método utilizados para remover tags e alterar os valores de algumas tags. Esses métodos estavam muito grandes o que iria gerar uma dificuldade em mante-los futuramente, hoje basicamente esses métodos são responsáveis:

* _export_fields: controlar o fluxo das tags a ser removidas ou substituídas em determinadas condições.
* _export_field: Atribuir ou remover valores das tags de dados.

Para melhorar esse implementação eu removi o método _export_field pois apesar de ser util esse método teria algumas limitações para reutiliza-lo através de outros métodos. Como o objeto da linha da NF-e tem uma complexidade maior o método que deveria ser utilizado seria o _export_fields pois com esse método é possível controlar o fluxo das tags exportadas e atribuir ou remover valores de qualquer tag. Eu defini uma convenção para quebrar a lógica dentro desses métodos em outros método menores, nessa convenção caso você queria alterar algum valor de alguma tag você deve criar um método com a mesma assinatura do _export_fields mas com o nome _export_fields_CLASS_SPEC, por exemplo: se quiser alterar algum valor dentro da tag prod representada pelo objeto nfe.40.prod, você deve criar um método:

```python
def _export_fields_nfe_40_prod(self, xsd_fields, class_obj, export_dict):
```

Para implementar essa convenção eu implementei a seguinte lógica no método método herdado pelo spec model:

```python
def _export_fields(self, xsd_fields, class_obj, export_dict):
    """Método utilizado para mapear os campos do documento fiscal com as
    tags da NF-e. Esse método"""

    xsd_fields = [i for i in xsd_fields]
    try:
        class_name = class_obj._name.replace(".", "_")
        export_method_name = "_export_fields_%s" % class_name
        if hasattr(self, export_method_name):
            export_method = getattr(self, export_method_name)
            export_method(xsd_fields, class_obj, export_dict)
    except AttributeError:
        pass

    return super()._export_fields(xsd_fields, class_obj, export_dict)
```

Eu diria que essa funcionalidade poderia ser transferida para o spec_model no [spec_driven_model](https://github.com/OCA/l10n-brazil/tree/12.0/spec_driven_model) adicionando neste [método](https://github.com/OCA/l10n-brazil/blob/12.0/spec_driven_model/models/spec_export.py#L54)  essa lógica.

### Outras alterações em andamento

* Organização das tags na sequencia que são definidas no XSD do schema da NF-e;
* Criar linhas de NF-e sem o produto (product_id) apenas preenchendo o código (cProd) e descrição (xProd);
* Adicionado mapeamento para os campos vSeg;
* Adicionado mapeamento para os campos vOutro;
* Adicionar testes.

Devido a arquitetura da localização por essas alterações serem feitas no módulo l10n_br_nfe essas mudanças serão facilmente portadas para a versão 14.0 para mante-las compatíveis. Com o tempo a P&D vai naturalmente ser focada nas versões 14.0, 15.0 e 16.0.