### PR TITLE
[12.0][IMP] l10n_br_account_payment_brcobranca: update library BRcobranca to version 10.0.0

### DIFF
--- a/l10n_br_account_payment_brcobranca/models/account_move_line.py
+++ b/l10n_br_account_payment_brcobranca/models/account_move_line.py
@@ -149,11 +149,11 @@ class AccountMoveLine(models.Model):
                     }
                 )
 
+            bank_account = move_line.payment_mode_id.fixed_journal_id.bank_account_id
             if bank_account_id.bank_id.code_bc in ("021", "004"):
-                digito_conta_corrente = move_line.payment_mode_id.bank_id.acc_number_dig
                 boleto_cnab_api_data.update(
                     {
-                        "digito_conta_corrente": digito_conta_corrente,
+                        "digito_conta_corrente": bank_account.acc_number_dig,
                     }
                 )
 
@@ -163,6 +163,13 @@ class AccountMoveLine(models.Model):
                     {
                         "byte_idt": move_line.payment_mode_id.boleto_byte_idt,
                         "posto": move_line.payment_mode_id.boleto_post,
+                    }
+                )
+            # Campo usado no Unicred
+            if bank_account_id.bank_id.code_bc == "136":
+                boleto_cnab_api_data.update(
+                    {
+                        "conta_corrente_dv": bank_account.acc_number_dig,
                     }
                 )
 


### PR DESCRIPTION
Update library BRcobranca to version 10.0.0

Alterações necessárias para usar a biblioteca BRCobranca versão 10.0.0, para criar a image do Servidor API veja o PR https://github.com/akretion/boleto_cnab_api/pull/15 

Recomendo homologar a alteração, é possível testar localmente o modulo l10n_br_account_payment_brcobranca com os dados de demonstração e rodando os testes dos seguintes casos:

* Impressão do Boleto e Geração do Arquivo Remessa
Banco do Brasil 400
Itau 400
Bradesco 400
Unicred 400
Sicred 240
Ailos 240
Caixa Econômica Federal 240

* Processar arquivo de Retorno:
Unicred 400
Ailos 240

IMPORTANTE: Esses testes devem ser feitos em um ambiente local para que sejam feitas consultas reais em um Servidor API, os testes identificam quando estão rodando aqui no github para nesse caso simular/mock esse processo.

No caso do banco que você implementou não estar na lista acima é recomendado você testar com dados de demonstração ou em um banco de dados de homologação esse determinado Banco X CNAB Y gerando um Boleto, comparando um Arquivo de Remessa gerado antes e depois ( no caso de estar em um ambiente linux é possível usar o comando diff para comparar os arquivos ) e importando um Arquivo de Retorno com Valor Pago para que aconteça a conciliação e assim confirmar se os valores estão corretos; e se puder considere incluir dados de demonstração e testes no modulo para que no futuro essa verificação manual desse caso seja desnecessária.
 
Essa alteração causa erro em uma imagem anterior porque o campo do Digito da Conta Bancaria no Unicred 400 não é esperado, e até onde sei não é possível identificar a versão do BRCobranca que está rodando para poder incluir ou não um valor no dicionario.

Essa atualização deve ser revisada e bem testada antes do merge para evitar problemas em ambientes de produção.

cc @rvalyi @renatonlima @marcelsavegnago @mileo @felipemotter @netosjb @marcos-mendez 