### PR TITLE
[12.0][FIX] l10n_br_sale_stock: Criação da Fatura a partir do stock.picking

### DIFF
--- a/l10n_br_sale_stock/wizards/stock_invoice_onshipping.py
+++ b/l10n_br_sale_stock/wizards/stock_invoice_onshipping.py
@@ -81,6 +81,119 @@ class StockInvoiceOnshipping(models.TransientModel):
             # Caso venha apenas uma linha porem sem
             # sale_line_id é preciso ignora-la
             if moves.sale_line_id:
+                # TODO - Outros modulos podem sobre escrever o metodo
+                #  _prepare_invoice_line do objeto sale_order_line
+                #  para incluir novos campos ex.: modulo sale_commission
+                #  inclui a comissão e isso funciona quando a Fatura
+                #  account.invoice é criada a partir do sale.order,
+                #  mas quando é criada a partir do stock.picking
+                #  essa informação não existe é sem o código abaixo
+                #  a account.invoice é criada sem essa informação,
+                #  provavelmente existe uma forma melhor de resolver.
+
+                # Campos comuns das linhas do Pedido de Vendas
+                # e as linhas da Fatura/Invoice.
+                sol_fields = [key for key in self.env["sale.order.line"]._fields.keys()]
+
+                acl_fields = [
+                    key for key in self.env["account.invoice.line"]._fields.keys()
+                ]
+
+                # Campos que devem ser desconsiderados
+                skipped_fields = [
+                    "id",
+                    "display_name",
+                    "state",
+                    "create_date",
+                    "product_image",
+                    "create_uid",
+                    "write_uid",
+                    "price_subtotal",
+                    "write_date",
+                    "price_total",
+                    "__last_update",
+                    "amount_total",
+                    "amount_fiscal",
+                    "financial_total",
+                    "name",
+                    "display_type",
+                    # Caso de endereço De Entrega diferente do De Faturamento
+                    "partner_id",
+                    # TODO deveria estar aqui?
+                    # values_prepare_inv_line
+                    #  campo        | valor stock.move |  valor prepare_invoice_line
+                    #  fiscal_price |     100.0        |  500.0
+                    "fiscal_price",
+                    #  campo        | valor stock.move |  valor prepare_invoice_line
+                    #  amount_taxed |     -200.0       |  1000.0
+                    "amount_taxed",
+                    #  campo        | valor stock.move |  valor prepare_invoice_line
+                    #  amount_untaxed |     -200.0       |  1000.0
+                    "amount_untaxed",
+                    "financial_total_gross",
+                    # price_gross -200.0 <class 'float'> 1000.0
+                    "price_gross",
+                    # Evitar o caso de Devolução/Refund onde os campos
+                    # não são iguais
+                    "ipi_cst_code",
+                    "cofins_cst_id",
+                    "cfop_id",
+                    "pis_cst_code",
+                    "fiscal_operation_line_id",
+                    "fiscal_operation_id",
+                    "pis_cst_id",
+                    "fiscal_operation_type",
+                    "icms_origin",
+                ]
+
+                common_fields = list(
+                    set(acl_fields) & set(sol_fields) - set(skipped_fields)
+                )
+                values_prepare_inv_line = moves.sale_line_id._prepare_invoice_line(
+                    moves.product_qty
+                )
+                for field in common_fields:
+
+                    # Verifica os casos em que não há nada a fazer
+                    if not values_prepare_inv_line.get(field):
+                        continue
+                    elif type(values_prepare_inv_line.get(field)) is list:
+                        if not values_prepare_inv_line.get(field)[0][2]:
+                            # Exemplo Lista vazia [(6, 0, [])]
+                            continue
+                    elif self._get_invoice_type() == "out_refund":
+                        # Caso de Devolução os valores não são iguais
+                        # TODO Deveria chamar algum metodo?
+                        continue
+
+                    # Verifica os casos de diferenças
+                    # entre os valores nos dicionarios
+                    if not values.get(field) and values_prepare_inv_line.get(field):
+                        # Campo está vazio no values mas não no _prepare_invoice_line
+                        values[field] = values_prepare_inv_line.get(field)
+
+                    elif (
+                        values.get(field)
+                        and type(values_prepare_inv_line.get(field)) is list
+                    ):
+                        # O campo tem valor mas é uma lista vazia
+                        if (
+                            values[field][0][2]
+                            != values_prepare_inv_line.get(field)[0][2]
+                        ):
+                            # Caso lista vazia mas tem valor
+                            # no _prepare_invoice_line exemplo:
+                            # field =>agents
+                            # values.get(field) =>[(6, 0, [])]
+                            # values_prepare_inv_line.get(field) =>
+                            # [(0, 0, {'agent': 75, 'commission': 1})]
+                            values[field] = values_prepare_inv_line.get(field)
+
+                    elif values.get(field) != values_prepare_inv_line.get(field):
+                        # Valor do campo é diferente do valor do _prepare_invoice_line
+                        values[field] = values_prepare_inv_line.get(field)
+
+                # Associção entre a Fatura é o Pedido de Venda
                 values["sale_line_ids"] = [(6, 0, moves.sale_line_id.ids)]
 
         return values


### PR DESCRIPTION
Others modules can overwriting the method _prepare_invoice_line from sale.order to included new values in the creation of Invoice, when the creation from stock.picking this values should be consider.

Outros módulos podem sobre escrever o método _prepare_invoice_line do objeto sale_order_line para incluir novos campos exemplo:
* Modulo sale_commission inclui a comissão https://github.com/OCA/commission/blob/12.0/sale_commission/models/sale_order.py#L95 

Isso funciona quando a Fatura account.invoice é criada a partir do sale.order, mas quando é criada a partir do stock.picking essa informação não existe e sem o código desse PR ( provavelmente existe uma forma melhor de resolver, por enquanto foi a que encontrei ) a account.invoice é criada sem essa informação, .

Um forma de testar e instalar tanto o l10n_br_sale_stock quanto o l10n_br_sale_commission https://github.com/OCA/l10n-brazil/pull/1830 existe um Pedido de Vendas de teste com Comissão, ao validar será criado o stock.picking e a partir dali ao criar a Fatura/account.invoice o campo da Comissão também dever existir.

Esse problema pode acontecer em outros casos onde são adicionados campos no _prepare_invoice_line do objeto sale_order_line e a Invoice deve ser criada a partir do stock.picking.

Não inclui testes porque nenhum desses módulos tem uma dependência direta.

cc @renatonlima @rvalyi @marcelsavegnago @mileo @netosjb @felipemotter @gabrielcardoso21 
