### PR TITLE
[12.0][FIX] payment_order / brcobranca: adiciona o código do convênio líder.

### DIFF
--- a/l10n_br_account_payment_brcobranca/models/account_payment_order.py
+++ b/l10n_br_account_payment_brcobranca/models/account_payment_order.py
@@ -35,6 +35,7 @@ class PaymentOrder(models.Model):
             {
                 "convenio": int(self.payment_mode_id.code_convetion),
                 "variacao_carteira": self.payment_mode_id.boleto_variation.zfill(3),
+                "convenio_lider": self.payment_mode_id.code_convenio_lider.zfill(7),
                 "carteira": str(self.payment_mode_id.boleto_wallet).zfill(2),
             }
         )

--- a/l10n_br_account_payment_order/demo/account_payment_mode.xml
+++ b/l10n_br_account_payment_order/demo/account_payment_mode.xml
@@ -873,6 +873,7 @@
         />
         <!-- O campo do convenio varia de acordo com o tamanho da sequencia own_number_sequence_id -->
         <field name="code_convetion">1234</field>
+        <field name="code_convenio_lider">7654321</field>
         <field
             name="cnab_liq_return_move_code_ids"
             eval="[(6,0,[ref('brasil_400_return_05'), ref('brasil_400_return_06'),

--- a/l10n_br_account_payment_order/models/account_payment_order.py
+++ b/l10n_br_account_payment_order/models/account_payment_order.py
@@ -58,6 +58,10 @@ class AccountPaymentOrder(models.Model):
         help="Campo G007 do CNAB",
     )
 
+    code_convenio_lider = fields.Char(
+        string="Convênio Líder", related="payment_mode_id.code_convenio_lider"
+    )
+
     indicative_form_payment = fields.Selection(
         selection=INDICATIVO_FORMA_PAGAMENTO,
         string="Indicativo de Forma de Pagamento",

--- a/l10n_br_account_payment_order/models/l10n_br_cnab_boleto_fields.py
+++ b/l10n_br_account_payment_order/models/l10n_br_cnab_boleto_fields.py
@@ -26,6 +26,13 @@ class L10nBrCNABBoletoFields(models.Model):
         track_visibility="always",
     )
 
+    code_convenio_lider = fields.Char(
+        string="Convênio Líder",
+        size=7,
+        help="Código do Convênio Líder, exclusivo para o Banco do Brasil",
+        track_visibility="always",
+    )
+
     condition_issuing_paper = fields.Selection(
         selection=[
             ("1", "Banco emite e Processa"),

--- a/l10n_br_account_payment_order/views/account_payment_mode.xml
+++ b/l10n_br_account_payment_order/views/account_payment_mode.xml
@@ -21,10 +21,11 @@
                     col="4"
                     attrs="{'invisible': [('payment_method_code', 'not in', ('240','400', '500', 'manual_test') )]}"
                 >
-                    <notebook colspan="4" name="l10n_br_account_payment_order">
+                    <notebook name="l10n_br_account_payment_order">
                         <page string="Geral">
                             <group name="l10n_br_account_payment_order-geral">
                                 <field name="code_convetion" />
+                                <field name="code_convenio_lider" />
                                 <field name="instructions" />
                                 <field name="invoice_print" />
                                 <field name="condition_issuing_paper" />

--- a/l10n_br_account_payment_order/views/account_payment_order.xml
+++ b/l10n_br_account_payment_order/views/account_payment_order.xml
@@ -47,6 +47,7 @@
                     attrs="{'invisible': [('payment_method_code', '!=', '240')]}"
                 />
                 <field name="code_convetion" />
+                <field name="code_convenio_lider" />
             </field>
             <field name="company_id" position="after">
                 <field


### PR DESCRIPTION
Adicionado o campo para informar o código do convênio líder, o mesmo foi requisitado pelo Banco do Brasil no processo de homologação.


![image](https://user-images.githubusercontent.com/634278/178158839-8b54a73a-071f-48a2-a311-9bb38703e608.png)
![image](https://user-images.githubusercontent.com/634278/178158849-a7d2f561-baa4-41c5-b317-e2454e3629c5.png)
![image](https://user-images.githubusercontent.com/634278/178158943-38daae2a-6865-4ec6-b0d2-a501b9cf69c5.png)



