### PR TITLE
[12.0][FIX] Correções para o Boleto Santander.

### DIFF
--- a/l10n_br_account_payment_brcobranca/models/account_move_line.py
+++ b/l10n_br_account_payment_brcobranca/models/account_move_line.py
@@ -80,6 +80,14 @@ class AccountMoveLine(models.Model):
                 "instrucao1": move_line.payment_mode_id.instructions or "",
             }
 
+            # No Santander a carteira impressa no boleto é diferente da remessa.
+            if bank_account_id.bank_id.code_bc in ("033"):
+                boleto_cnab_api_data.update(
+                    {
+                        "carteira": str(move_line.payment_mode_id.boleto_wallet2),
+                    }
+                )
+
             # Instrução de Juros
             if move_line.payment_mode_id.boleto_interest_perc > 0.0:
                 valor_juros = round(

--- a/l10n_br_account_payment_brcobranca/models/account_move_line.py
+++ b/l10n_br_account_payment_brcobranca/models/account_move_line.py
@@ -21,166 +21,150 @@ class AccountMoveLine(models.Model):
     # brcobranca/boleto/itau_spec.rb
 
     def send_payment(self):
-
-        # super(AccountMoveLine, self).send_payment()
         wrapped_boleto_list = []
-
         for move_line in self:
-
-            bank_account_id = move_line.payment_mode_id.fixed_journal_id.bank_account_id
-            bank_name_brcobranca = get_brcobranca_bank(
-                bank_account_id, move_line.payment_mode_id.payment_method_code
-            )
-            precision = self.env["decimal.precision"]
-            precision_account = precision.precision_get("Account")
-
-            boleto_cnab_api_data = {
-                "bank": bank_name_brcobranca[0],
-                "valor": str("%.2f" % move_line.debit),
-                "cedente": move_line.company_id.partner_id.legal_name,
-                "cedente_endereco": (move_line.company_id.partner_id.street_name or "")
-                + ", "
-                + (move_line.company_id.partner_id.street_number or "")
-                + " - "
-                + (move_line.company_id.partner_id.district or "")
-                + " - "
-                + (move_line.company_id.partner_id.city_id.name or "")
-                + " - "
-                + ("CEP:" + move_line.company_id.partner_id.zip or "")
-                + " - "
-                + (move_line.company_id.partner_id.state_id.code or ""),
-                "documento_cedente": move_line.company_id.cnpj_cpf,
-                "sacado": move_line.partner_id.legal_name,
-                "sacado_documento": move_line.partner_id.cnpj_cpf,
-                "agencia": bank_account_id.bra_number,
-                "conta_corrente": bank_account_id.acc_number,
-                "convenio": move_line.payment_mode_id.code_convetion,
-                "carteira": str(move_line.payment_mode_id.boleto_wallet),
-                "nosso_numero": int(
-                    "".join(i for i in move_line.own_number if i.isdigit())
-                ),
-                "documento_numero": move_line.document_number,
-                "data_vencimento": move_line.date_maturity.strftime("%Y/%m/%d"),
-                "data_documento": move_line.invoice_id.date_invoice.strftime(
-                    "%Y/%m/%d"
-                ),
-                "especie": move_line.payment_mode_id.boleto_species,
-                "moeda": DICT_BRCOBRANCA_CURRENCY["R$"],
-                "aceite": move_line.payment_mode_id.boleto_accept,
-                "sacado_endereco": (move_line.partner_id.street_name or "")
-                + ", "
-                + (move_line.partner_id.street_number or "")
-                + " "
-                + (move_line.partner_id.city_id.name or "")
-                + " - "
-                + (move_line.partner_id.state_id.name or ""),
-                "data_processamento": move_line.invoice_id.date_invoice.strftime(
-                    "%Y/%m/%d"
-                ),
-                "instrucao1": move_line.payment_mode_id.instructions or "",
-            }
-
-            # No Santander a carteira impressa no boleto é diferente da remessa.
-            if bank_account_id.bank_id.code_bc in ("033"):
-                boleto_cnab_api_data.update(
-                    {
-                        "carteira": str(move_line.payment_mode_id.boleto_wallet2),
-                    }
-                )
-
-            # Instrução de Juros
-            if move_line.payment_mode_id.boleto_interest_perc > 0.0:
-                valor_juros = round(
-                    move_line.debit
-                    * ((move_line.payment_mode_id.boleto_interest_perc / 100) / 30),
-                    precision_account,
-                )
-                instrucao_juros = (
-                    "APÓS VENCIMENTO COBRAR PERCENTUAL"
-                    + " DE %s %% AO MÊS ( R$ %s AO DIA )"
-                    % (
-                        (
-                            "%.2f" % move_line.payment_mode_id.boleto_interest_perc
-                        ).replace(".", ","),
-                        ("%.2f" % valor_juros).replace(".", ","),
-                    )
-                )
-                boleto_cnab_api_data.update(
-                    {
-                        "instrucao3": instrucao_juros,
-                    }
-                )
-
-            # Instrução Multa
-            if move_line.payment_mode_id.boleto_fee_perc > 0.0:
-                valor_multa = round(
-                    move_line.debit * (move_line.payment_mode_id.boleto_fee_perc / 100),
-                    precision_account,
-                )
-                instrucao_multa = (
-                    "APÓS VENCIMENTO COBRAR MULTA"
-                    + " DE %s %% ( R$ %s )"
-                    % (
-                        ("%.2f" % move_line.payment_mode_id.boleto_fee_perc).replace(
-                            ".", ","
-                        ),
-                        ("%.2f" % valor_multa).replace(".", ","),
-                    )
-                )
-                boleto_cnab_api_data.update(
-                    {
-                        "instrucao4": instrucao_multa,
-                    }
-                )
-
-            # Instrução Desconto
-            if move_line.payment_mode_id.boleto_discount_perc > 0.0:
-                valor_desconto = round(
-                    move_line.debit
-                    * (move_line.payment_mode_id.boleto_discount_perc / 100),
-                    precision_account,
-                )
-                instrucao_desconto_vencimento = (
-                    "CONCEDER ABATIMENTO PERCENTUAL DE" + " %s %% "
-                    "ATÉ O VENCIMENTO EM %s ( R$ %s )"
-                    % (
-                        (
-                            "%.2f" % move_line.payment_mode_id.boleto_discount_perc
-                        ).replace(".", ","),
-                        move_line.date_maturity.strftime("%d/%m/%Y"),
-                        ("%.2f" % valor_desconto).replace(".", ","),
-                    )
-                )
-                boleto_cnab_api_data.update(
-                    {
-                        "instrucao5": instrucao_desconto_vencimento,
-                    }
-                )
-
-            bank_account = move_line.payment_mode_id.fixed_journal_id.bank_account_id
-            if bank_account_id.bank_id.code_bc in ("021", "004"):
-                boleto_cnab_api_data.update(
-                    {
-                        "digito_conta_corrente": bank_account.acc_number_dig,
-                    }
-                )
-
-            # Fields used in Sicredi and Sicoob Banks
-            if bank_account_id.bank_id.code_bc in ("748", "756"):
-                boleto_cnab_api_data.update(
-                    {
-                        "byte_idt": move_line.payment_mode_id.boleto_byte_idt,
-                        "posto": move_line.payment_mode_id.boleto_post,
-                    }
-                )
-            # Campo usado no Unicred
-            if bank_account_id.bank_id.code_bc == "136":
-                boleto_cnab_api_data.update(
-                    {
-                        "conta_corrente_dv": bank_account.acc_number_dig,
-                    }
-                )
-
+            boleto_cnab_api_data = move_line._prepare_boleto_cnab_vals()
             wrapped_boleto_list.append(boleto_cnab_api_data)
-
         return wrapped_boleto_list
+
+    def _prepare_boleto_cnab_vals(self):
+        self.ensure_one()
+        bank_account_id = self.payment_mode_id.fixed_journal_id.bank_account_id
+        bank_name_brcobranca = get_brcobranca_bank(
+            bank_account_id, self.payment_mode_id.payment_method_code
+        )
+        precision = self.env["decimal.precision"]
+        precision_account = precision.precision_get("Account")
+
+        boleto_cnab_api_data = {
+            "bank": bank_name_brcobranca[0],
+            "valor": str("%.2f" % self.debit),
+            "cedente": self.company_id.partner_id.legal_name,
+            "cedente_endereco": (self.company_id.partner_id.street_name or "")
+            + ", "
+            + (self.company_id.partner_id.street_number or "")
+            + " - "
+            + (self.company_id.partner_id.district or "")
+            + " - "
+            + (self.company_id.partner_id.city_id.name or "")
+            + " - "
+            + ("CEP:" + self.company_id.partner_id.zip or "")
+            + " - "
+            + (self.company_id.partner_id.state_id.code or ""),
+            "documento_cedente": self.company_id.cnpj_cpf,
+            "sacado": self.partner_id.legal_name,
+            "sacado_documento": self.partner_id.cnpj_cpf,
+            "agencia": bank_account_id.bra_number,
+            "conta_corrente": bank_account_id.acc_number,
+            "convenio": self.payment_mode_id.code_convetion,
+            "carteira": str(self.payment_mode_id.boleto_wallet),
+            "nosso_numero": int("".join(i for i in self.own_number if i.isdigit())),
+            "documento_numero": self.document_number,
+            "data_vencimento": self.date_maturity.strftime("%Y/%m/%d"),
+            "data_documento": self.invoice_id.date_invoice.strftime("%Y/%m/%d"),
+            "especie": self.payment_mode_id.boleto_species,
+            "moeda": DICT_BRCOBRANCA_CURRENCY["R$"],
+            "aceite": self.payment_mode_id.boleto_accept,
+            "sacado_endereco": (self.partner_id.street_name or "")
+            + ", "
+            + (self.partner_id.street_number or "")
+            + " "
+            + (self.partner_id.city_id.name or "")
+            + " - "
+            + (self.partner_id.state_id.name or ""),
+            "data_processamento": self.invoice_id.date_invoice.strftime("%Y/%m/%d"),
+            "instrucao1": self.payment_mode_id.instructions or "",
+        }
+
+        # Instrução de Juros
+        if self.payment_mode_id.boleto_interest_perc > 0.0:
+            valor_juros = round(
+                self.debit * ((self.payment_mode_id.boleto_interest_perc / 100) / 30),
+                precision_account,
+            )
+            instrucao_juros = (
+                "APÓS VENCIMENTO COBRAR PERCENTUAL"
+                + " DE %s %% AO MÊS ( R$ %s AO DIA )"
+                % (
+                    ("%.2f" % self.payment_mode_id.boleto_interest_perc).replace(
+                        ".", ","
+                    ),
+                    ("%.2f" % valor_juros).replace(".", ","),
+                )
+            )
+            boleto_cnab_api_data.update(
+                {
+                    "instrucao3": instrucao_juros,
+                }
+            )
+
+        # Instrução Multa
+        if self.payment_mode_id.boleto_fee_perc > 0.0:
+            valor_multa = round(
+                self.debit * (self.payment_mode_id.boleto_fee_perc / 100),
+                precision_account,
+            )
+            instrucao_multa = "APÓS VENCIMENTO COBRAR MULTA" + " DE %s %% ( R$ %s )" % (
+                ("%.2f" % self.payment_mode_id.boleto_fee_perc).replace(".", ","),
+                ("%.2f" % valor_multa).replace(".", ","),
+            )
+            boleto_cnab_api_data.update(
+                {
+                    "instrucao4": instrucao_multa,
+                }
+            )
+
+        # Instrução Desconto
+        if self.payment_mode_id.boleto_discount_perc > 0.0:
+            valor_desconto = round(
+                self.debit * (self.payment_mode_id.boleto_discount_perc / 100),
+                precision_account,
+            )
+            instrucao_desconto_vencimento = (
+                "CONCEDER ABATIMENTO PERCENTUAL DE" + " %s %% "
+                "ATÉ O VENCIMENTO EM %s ( R$ %s )"
+                % (
+                    ("%.2f" % self.payment_mode_id.boleto_discount_perc).replace(
+                        ".", ","
+                    ),
+                    self.date_maturity.strftime("%d/%m/%Y"),
+                    ("%.2f" % valor_desconto).replace(".", ","),
+                )
+            )
+            boleto_cnab_api_data.update(
+                {
+                    "instrucao5": instrucao_desconto_vencimento,
+                }
+            )
+
+        if bank_account_id.bank_id.code_bc in ("021", "004"):
+            boleto_cnab_api_data.update(
+                {
+                    "digito_conta_corrente": bank_account_id.acc_number_dig,
+                }
+            )
+
+        # Fields used in Sicredi and Sicoob Banks
+        if bank_account_id.bank_id.code_bc in ("748", "756"):
+            boleto_cnab_api_data.update(
+                {
+                    "byte_idt": self.payment_mode_id.boleto_byte_idt,
+                    "posto": self.payment_mode_id.boleto_post,
+                }
+            )
+        # Campo usado no Unicred
+        if bank_account_id.bank_id.code_bc == "136":
+            boleto_cnab_api_data.update(
+                {
+                    "conta_corrente_dv": bank_account_id.acc_number_dig,
+                }
+            )
+        # Particularidades Santander
+        if bank_account_id.bank_id.code_bc in ("033"):
+            boleto_cnab_api_data.update(
+                {
+                    # A carteira impressa no boleto é diferente da remessa.
+                    "carteira": str(self.payment_mode_id.boleto_wallet2),
+                }
+            )
+        return boleto_cnab_api_data

--- a/l10n_br_account_payment_brcobranca/models/account_payment_order.py
+++ b/l10n_br_account_payment_brcobranca/models/account_payment_order.py
@@ -40,6 +40,17 @@ class PaymentOrder(models.Model):
             }
         )
 
+    def _prepare_remessa_santander_400(self, remessa_values):
+        remessa_values.update(
+            {
+                "codigo_carteira": str(self.payment_mode_id.boleto_wallet),
+                "codigo_transmissao": self.payment_mode_id.transmission_code,
+                "conta_corrente": misc.punctuation_rm(
+                    self.journal_id.bank_account_id.acc_number
+                ),
+            }
+        )
+
     def _prepare_remessa_caixa_240(self, remessa_values):
         remessa_values.update(
             {

--- a/l10n_br_account_payment_brcobranca/tests/test_payment_order.py
+++ b/l10n_br_account_payment_brcobranca/tests/test_payment_order.py
@@ -8,7 +8,11 @@ from unittest import mock
 
 from odoo.exceptions import UserError
 from odoo.modules import get_resource_path
-from odoo.tests import SavepointCase, tagged
+from odoo.tests import tagged
+
+from odoo.addons.l10n_br_account_payment_order.tests.test_base_class import (
+    TestL10nBrAccountPaymentOder,
+)
 
 _module_ns = "odoo.addons.l10n_br_account_payment_brcobranca"
 _provider_class_pay_order = (
@@ -18,7 +22,7 @@ _provider_class_acc_invoice = _module_ns + ".models.account_invoice" + ".Account
 
 
 @tagged("post_install", "-at_install")
-class TestPaymentOrder(SavepointCase):
+class TestPaymentOrder(TestL10nBrAccountPaymentOder):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -39,7 +43,8 @@ class TestPaymentOrder(SavepointCase):
         )
         cls.partner_akretion = cls.env.ref("l10n_br_base.res_partner_akretion")
         # I validate invoice by creating on
-        cls.invoice_cef.action_invoice_open()
+        with cls.mock_own_number_boleto:
+            cls.invoice_cef.action_invoice_open()
 
         payment_order = cls.env["account.payment.order"].search(
             [("payment_mode_id", "=", cls.invoice_cef.payment_mode_id.id)]
@@ -87,7 +92,8 @@ class TestPaymentOrder(SavepointCase):
     def _run_boleto_remessa(self, invoice, boleto_file, remessa_file):
 
         # I validate invoice
-        invoice.action_invoice_open()
+        with self.mock_own_number_boleto:
+            invoice.action_invoice_open()
 
         # I check that the invoice state is "Open"
         self.assertEqual(invoice.state, "open")
@@ -218,7 +224,8 @@ class TestPaymentOrder(SavepointCase):
             "l10n_br_account_payment_order.demo_invoice_payment_order_itau_cnab240"
         )
         # I validate invoice
-        invoice.action_invoice_open()
+        with self.mock_own_number_boleto:
+            invoice.action_invoice_open()
 
         # I check that the invoice state is "Open"
         self.assertEqual(invoice.state, "open")
@@ -707,7 +714,8 @@ class TestPaymentOrder(SavepointCase):
         """
         self.partner_akretion = self.env.ref("l10n_br_base.res_partner_akretion")
         # I validate invoice by creating on
-        self.invoice_cef.action_invoice_open()
+        with self.mock_own_number_boleto:
+            self.invoice_cef.action_invoice_open()
 
         payment_order = self.env["account.payment.order"].search(
             [("payment_mode_id", "=", self.invoice_cef.payment_mode_id.id)]

--- a/l10n_br_account_payment_brcobranca/tests/test_return_import.py
+++ b/l10n_br_account_payment_brcobranca/tests/test_return_import.py
@@ -10,7 +10,11 @@ from unittest import mock
 
 from odoo import tools
 from odoo.modules import get_resource_path
-from odoo.tests import SavepointCase, tagged
+from odoo.tests import tagged
+
+from odoo.addons.l10n_br_account_payment_order.tests.test_base_class import (
+    TestL10nBrAccountPaymentOder,
+)
 
 _module_ns = "odoo.addons.l10n_br_account_payment_brcobranca"
 _provider_class_pay_order = (
@@ -20,7 +24,7 @@ _provider_class = _module_ns + ".parser.cnab_file_parser" + ".CNABFileParser"
 
 
 @tagged("post_install", "-at_install")
-class TestReturnImport(SavepointCase):
+class TestReturnImport(TestL10nBrAccountPaymentOder):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -58,9 +62,10 @@ class TestReturnImport(SavepointCase):
         cls.journal = cls.env.ref("l10n_br_account_payment_order.unicred_journal")
 
         # I validate invoice by creating on
-        cls.invoice_unicred_1.action_invoice_open()
-        cls.invoice_unicred_2.action_invoice_open()
-        cls.invoice_ailos_1.action_invoice_open()
+        with cls.mock_own_number_boleto:
+            cls.invoice_unicred_1.action_invoice_open()
+            cls.invoice_unicred_2.action_invoice_open()
+            cls.invoice_ailos_1.action_invoice_open()
 
         # Para evitar erros nos testes de variação da Sequencia do
         # Nosso Numero/own_number quando se roda mais de uma vez ou

--- a/l10n_br_account_payment_order/models/account_invoice.py
+++ b/l10n_br_account_payment_order/models/account_invoice.py
@@ -85,6 +85,7 @@ class AccountInvoice(models.Model):
                 interval.own_number = (
                     sequence if interval.payment_mode_id.generate_own_number else "0"
                 )
+                interval.own_number_boleto = interval.generate_own_number_boleto()
                 interval.document_number = numero_documento
                 interval.company_title_identification = hex(interval.id).upper()
                 instructions = ""

--- a/l10n_br_account_payment_order/models/l10n_br_cnab_boleto_fields.py
+++ b/l10n_br_account_payment_order/models/l10n_br_cnab_boleto_fields.py
@@ -52,6 +52,21 @@ class L10nBrCNABBoletoFields(models.Model):
         track_visibility="always",
     )
 
+    boleto_wallet2 = fields.Char(
+        string="Carteira Boleto",
+        help="Código da carteira para ser impresso no boleto, "
+        "quando o mesmo for diferente do impresso na remessa.",
+        size=3,
+        track_visibility="always",
+    )
+
+    transmission_code = fields.Char(
+        string="Código de Transmissão",
+        help="Informação cedida pelo banco que identifica o arquivo remessa do cliente",
+        size=20,
+        track_visibility="always",
+    )
+
     boleto_modality = fields.Char(
         string="Modalidade",
         size=2,

--- a/l10n_br_account_payment_order/tests/test_base_class.py
+++ b/l10n_br_account_payment_order/tests/test_base_class.py
@@ -2,6 +2,8 @@
 #   Luis Felipe Mileo <mileo@kmee.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
+from unittest import mock
+
 from odoo.exceptions import UserError
 from odoo.fields import Date
 from odoo.tests import SavepointCase, tagged
@@ -17,6 +19,13 @@ class TestL10nBrAccountPaymentOder(SavepointCase):
 
         cls.chance_view_id = (
             "l10n_br_account_payment_order." "account_move_line_cnab_change_form_view"
+        )
+
+        cls.mock_own_number_boleto = mock.patch.object(
+            cls.env["account.move.line"].__class__,
+            "generate_own_number_boleto",
+            autospec=True,
+            side_effect=lambda move_line: move_line.own_number,
         )
 
     def _payment_order_all_workflow(self, payment_order_id):

--- a/l10n_br_account_payment_order/tests/test_invoice_manual_workflow.py
+++ b/l10n_br_account_payment_order/tests/test_invoice_manual_workflow.py
@@ -18,7 +18,8 @@ class TestPaymentOrderManualWorkflow(TestL10nBrAccountPaymentOder):
         )
 
     def _invoice_confirm_flow(self):
-        self.invoice_manual_test.action_invoice_open()
+        with self.mock_own_number_boleto:
+            self.invoice_manual_test.action_invoice_open()
 
         # I check that the invoice state is "Open"
         self.assertEqual(self.invoice_manual_test.state, "open")

--- a/l10n_br_account_payment_order/tests/test_invoice_normal_workflow.py
+++ b/l10n_br_account_payment_order/tests/test_invoice_normal_workflow.py
@@ -2,11 +2,13 @@
 #   Luis Felipe Mileo <mileo@kmee.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
-from odoo.tests import SavepointCase, tagged
+from odoo.tests import tagged
+
+from .test_base_class import TestL10nBrAccountPaymentOder
 
 
 @tagged("post_install", "-at_install")
-class TestPaymentOrder(SavepointCase):
+class TestPaymentOrder(TestL10nBrAccountPaymentOder):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -17,7 +19,8 @@ class TestPaymentOrder(SavepointCase):
 
     def test_cancel_invoice_no_payment_mode_pay(self):
         """Test Pay Invoice without payment mode in cash"""
-        self.invoice_customer_without_paymeny_mode.action_invoice_open()
+        with self.mock_own_number_boleto:
+            self.invoice_customer_without_paymeny_mode.action_invoice_open()
 
         # I check that the invoice state is "Open"
         self.assertEqual(self.invoice_customer_without_paymeny_mode.state, "open")

--- a/l10n_br_account_payment_order/tests/test_payment_order.py
+++ b/l10n_br_account_payment_order/tests/test_payment_order.py
@@ -3,11 +3,13 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from odoo.exceptions import ValidationError
-from odoo.tests import SavepointCase, tagged
+from odoo.tests import tagged
+
+from .test_base_class import TestL10nBrAccountPaymentOder
 
 
 @tagged("post_install", "-at_install")
-class TestPaymentOrder(SavepointCase):
+class TestPaymentOrder(TestL10nBrAccountPaymentOder):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -20,7 +22,8 @@ class TestPaymentOrder(SavepointCase):
         """Test Invoice when Payment Mode not generate Payment Order."""
         self.invoice_cheque._onchange_payment_mode_id()
         # I validate invoice by creating on
-        self.invoice_cheque.action_invoice_open()
+        with self.mock_own_number_boleto:
+            self.invoice_cheque.action_invoice_open()
         # I check that the invoice state is "Open"
         self.assertEqual(self.invoice_cheque.state, "open")
         payment_order = self.env["account.payment.order"].search(

--- a/l10n_br_account_payment_order/tests/test_payment_order_change.py
+++ b/l10n_br_account_payment_order/tests/test_payment_order_change.py
@@ -19,7 +19,8 @@ class TestPaymentOrderChange(TestL10nBrAccountPaymentOder):
             "l10n_br_account_payment_order." "demo_invoice_automatic_test"
         )
         if cls.invoice_auto.state == "draft":
-            cls.invoice_auto.action_invoice_open()
+            with cls.mock_own_number_boleto:
+                cls.invoice_auto.action_invoice_open()
 
         assert cls.invoice_auto.move_id, "Move not created for open invoice"
 

--- a/l10n_br_account_payment_order/tests/test_payment_order_inbound.py
+++ b/l10n_br_account_payment_order/tests/test_payment_order_inbound.py
@@ -7,11 +7,13 @@
 import time
 
 from odoo.exceptions import UserError
-from odoo.tests import SavepointCase, tagged
+from odoo.tests import tagged
+
+from .test_base_class import TestL10nBrAccountPaymentOder
 
 
 @tagged("post_install", "-at_install")
-class TestPaymentOrderInbound(SavepointCase):
+class TestPaymentOrderInbound(TestL10nBrAccountPaymentOder):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -49,7 +51,8 @@ class TestPaymentOrderInbound(SavepointCase):
         self.assertEqual(self.invoice_cef.state, "draft")
 
         # I validate invoice by creating on
-        self.invoice_cef.action_invoice_open()
+        with self.mock_own_number_boleto:
+            self.invoice_cef.action_invoice_open()
 
         # I check that the invoice state is "Open"
         self.assertEqual(self.invoice_cef.state, "open")
@@ -150,7 +153,8 @@ class TestPaymentOrderInbound(SavepointCase):
         apagar as linhas de pagamentos.
         """
         # I validate invoice by creating on
-        self.invoice_unicred.action_invoice_open()
+        with self.mock_own_number_boleto:
+            self.invoice_unicred.action_invoice_open()
 
         payment_order = self.env["account.payment.order"].search(
             [("payment_mode_id", "=", self.invoice_unicred.payment_mode_id.id)]
@@ -185,7 +189,8 @@ class TestPaymentOrderInbound(SavepointCase):
         gerar erro por ter uma Instrução CNAB a ser enviada.
         """
         # I validate invoice by creating on
-        self.invoice_unicred.action_invoice_open()
+        with self.mock_own_number_boleto:
+            self.invoice_unicred.action_invoice_open()
 
         payment_order = self.env["account.payment.order"].search(
             [("payment_mode_id", "=", self.invoice_unicred.payment_mode_id.id)]
@@ -217,7 +222,8 @@ class TestPaymentOrderInbound(SavepointCase):
         """Test Cancel Invoice when Payment Order Draft."""
 
         # I validate invoice by creating on
-        self.invoice_unicred.action_invoice_open()
+        with self.mock_own_number_boleto:
+            self.invoice_unicred.action_invoice_open()
         payment_order = self.env["account.payment.order"].search(
             [("payment_mode_id", "=", self.invoice_unicred.payment_mode_id.id)]
         )
@@ -236,7 +242,8 @@ class TestPaymentOrderInbound(SavepointCase):
         """
         self.partner_akretion = self.env.ref("l10n_br_base.res_partner_akretion")
         # I validate invoice by creating on
-        self.invoice_cef.action_invoice_open()
+        with self.mock_own_number_boleto:
+            self.invoice_cef.action_invoice_open()
 
         payment_order = self.env["account.payment.order"].search(
             [("payment_mode_id", "=", self.invoice_cef.payment_mode_id.id)]
@@ -279,7 +286,8 @@ class TestPaymentOrderInbound(SavepointCase):
         self.assertEqual(self.demo_invoice_auto.state, "draft")
 
         # I validate invoice by creating on
-        self.demo_invoice_auto.action_invoice_open()
+        with self.mock_own_number_boleto:
+            self.demo_invoice_auto.action_invoice_open()
 
         # I check that the invoice state is "Open"
         self.assertEqual(self.demo_invoice_auto.state, "open")
@@ -336,7 +344,8 @@ class TestPaymentOrderInbound(SavepointCase):
         self.assertEqual(self.demo_invoice_auto.state, "draft")
 
         # I validate invoice by creating on
-        self.demo_invoice_auto.action_invoice_open()
+        with self.mock_own_number_boleto:
+            self.demo_invoice_auto.action_invoice_open()
 
         # I check that the invoice state is "Open"
         self.assertEqual(self.demo_invoice_auto.state, "open")
@@ -396,7 +405,8 @@ class TestPaymentOrderInbound(SavepointCase):
         self.assertEqual(self.demo_invoice_auto.state, "draft")
 
         # I validate invoice by creating on
-        self.demo_invoice_auto.action_invoice_open()
+        with self.mock_own_number_boleto:
+            self.demo_invoice_auto.action_invoice_open()
 
         # I check that the invoice state is "Open"
         self.assertEqual(self.demo_invoice_auto.state, "open")

--- a/l10n_br_account_payment_order/views/account_move_line.xml
+++ b/l10n_br_account_payment_order/views/account_move_line.xml
@@ -45,6 +45,7 @@
                     <field name="cnab_state" readonly="1" />
                     <field name="payment_situation" readonly="1" />
                     <field name="own_number" readonly="1" />
+                    <field name="own_number_boleto" readonly="1" />
                     <field name="document_number" readonly="1" />
                     <field name="mov_instruction_code_id" readonly="1" />
                     <field name="company_title_identification" readonly="1" />

--- a/l10n_br_account_payment_order/views/account_payment_mode.xml
+++ b/l10n_br_account_payment_order/views/account_payment_mode.xml
@@ -47,8 +47,10 @@
                                  'required': [('own_number_type', '==', '2'), ('payment_order_ok', '==', True)]}"
                                 />
                                 <field name="boleto_wallet" />
+                                <field name="boleto_wallet2" />
                                 <field name="boleto_modality" />
                                 <field name="boleto_variation" />
+                                <field name="transmission_code" />
                                 <field name="boleto_accept" />
                                 <field name="boleto_species" />
                                 <field name="payment_method_code" invisible="1" />


### PR DESCRIPTION
Adiciona dois novos campos para atender a homologação do banco Santander.

o código de transmissão, e o código da carteira exclusivo para ser impresso no Boleto, pois pra eles não é o mesmo que vai no arquivo de remessa.