### PR TITLE
[12.0][FIX] indicador do consumidor final no account.invoice.

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -462,6 +462,11 @@ class AccountInvoice(models.Model):
                         tax_grouped[key]["base"] += round_curr(val["base"])
         return tax_grouped
 
+    @api.onchange("partner_id")
+    def _onchange_partner_id(self):
+        if self.partner_id:
+            self.ind_final = self.partner_id.ind_final
+
     @api.onchange("fiscal_operation_id")
     def _onchange_fiscal_operation_id(self):
         super()._onchange_fiscal_operation_id()

--- a/l10n_br_account/tests/test_customer_invoice_dummy.py
+++ b/l10n_br_account/tests/test_customer_invoice_dummy.py
@@ -9,6 +9,7 @@ class TestCustomerInvoice(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.account_account_type_model = cls.env["account.account.type"]
         cls.sale_account = cls.env["account.account"].create(
             dict(
                 code="X1020",
@@ -16,6 +17,20 @@ class TestCustomerInvoice(SavepointCase):
                 user_type_id=cls.env.ref("account.data_account_type_revenue").id,
                 reconcile=True,
             )
+        )
+        cls.account_type_receivable = cls.account_account_type_model.create(
+            {
+                "name": "Test Receivable",
+                "type": "receivable",
+            }
+        )
+        cls.account_receivable = cls.env["account.account"].create(
+            {
+                "name": "Test Receivable",
+                "code": "TEST_CR",
+                "user_type_id": cls.account_type_receivable.id,
+                "reconcile": True,
+            }
         )
         cls.sale_journal = cls.env["account.journal"].create(
             dict(
@@ -33,6 +48,7 @@ class TestCustomerInvoice(SavepointCase):
                 payment_term_id=cls.env.ref("account.account_payment_term_advance").id,
                 partner_id=cls.env.ref("base.res_partner_3").id,
                 journal_id=cls.sale_journal.id,
+                account_id=cls.account_receivable.id,
                 invoice_line_ids=[
                     (
                         0,
@@ -101,6 +117,7 @@ class TestCustomerInvoice(SavepointCase):
                 payment_term_id=cls.env.ref("account.account_payment_term_advance").id,
                 partner_id=cls.env.ref("base.res_partner_3").id,
                 journal_id=cls.sale_journal.id,
+                account_id=cls.account_receivable.id,
                 invoice_line_ids=[
                     (
                         0,
@@ -161,6 +178,7 @@ class TestCustomerInvoice(SavepointCase):
                 currency_id=cls.env.ref("base.EUR").id,
                 partner_id=cls.env.ref("base.res_partner_3").id,
                 journal_id=cls.sale_journal.id,
+                account_id=cls.account_receivable.id,
                 invoice_line_ids=[
                     (
                         0,

--- a/l10n_br_account/tests/test_invoice_refund.py
+++ b/l10n_br_account/tests/test_invoice_refund.py
@@ -8,7 +8,7 @@ from odoo.tests.common import TransactionCase
 class TestInvoiceRefund(TransactionCase):
     def setUp(self):
         super().setUp()
-
+        self.account_account_type_model = self.env["account.account.type"]
         self.sale_account = self.env["account.account"].create(
             dict(
                 code="X1020",
@@ -17,7 +17,20 @@ class TestInvoiceRefund(TransactionCase):
                 reconcile=True,
             )
         )
-
+        self.account_type_receivable = self.account_account_type_model.create(
+            {
+                "name": "Test Receivable",
+                "type": "receivable",
+            }
+        )
+        self.account_receivable = self.env["account.account"].create(
+            {
+                "name": "Test Receivable",
+                "code": "TEST_CR",
+                "user_type_id": self.account_type_receivable.id,
+                "reconcile": True,
+            }
+        )
         self.refund_journal = self.env["account.journal"].create(
             dict(
                 name="Refund Journal - (test)",
@@ -36,6 +49,7 @@ class TestInvoiceRefund(TransactionCase):
                 payment_term_id=self.env.ref("account.account_payment_term_advance").id,
                 partner_id=self.env.ref("l10n_br_base.res_partner_cliente1_sp").id,
                 journal_id=self.refund_journal.id,
+                account_id=self.account_receivable.id,
                 document_type_id=self.env.ref("l10n_br_fiscal.document_55").id,
                 document_serie_id=self.env.ref(
                     "l10n_br_fiscal.empresa_lc_document_55_serie_1"

--- a/l10n_br_account/tests/test_supplier_invoice_dummy.py
+++ b/l10n_br_account/tests/test_supplier_invoice_dummy.py
@@ -8,6 +8,7 @@ from odoo.tests.common import TransactionCase
 class TestSupplierInvoice(TransactionCase):
     def setUp(self):
         super(TestSupplierInvoice, self).setUp()
+        self.account_account_type_model = self.env["account.account.type"]
         self.purchase_account = self.env["account.account"].create(
             dict(
                 code="X1020",
@@ -15,7 +16,20 @@ class TestSupplierInvoice(TransactionCase):
                 user_type_id=self.env.ref("account.data_account_type_revenue").id,
             )
         )
-
+        self.account_type_receivable = self.account_account_type_model.create(
+            {
+                "name": "Test Receivable",
+                "type": "receivable",
+            }
+        )
+        self.account_receivable = self.env["account.account"].create(
+            {
+                "name": "Test Receivable",
+                "code": "TEST_CR",
+                "user_type_id": self.account_type_receivable.id,
+                "reconcile": True,
+            }
+        )
         self.purchase_journal = self.env["account.journal"].create(
             dict(
                 name="Purchase Journal - (test)",
@@ -32,6 +46,7 @@ class TestSupplierInvoice(TransactionCase):
                 payment_term_id=self.env.ref("account.account_payment_term_advance").id,
                 partner_id=self.env.ref("base.res_partner_3").id,
                 journal_id=self.purchase_journal.id,
+                account_id=self.account_receivable.id,
                 invoice_line_ids=[
                     (
                         0,

--- a/l10n_br_account/views/account_invoice_view.xml
+++ b/l10n_br_account/views/account_invoice_view.xml
@@ -100,7 +100,6 @@
                 />
                 <field
                     name="ind_final"
-                    requied="0"
                     attrs="{'invisible': ['|', ('document_type_id', '=', False), ('issuer', '=', 'partner')], 'required': [('issuer', '=', 'company'), ('document_type_id', '!=', False)], 'readonly': [('state', '!=', 'draft')]}"
                 />
                 <field
@@ -109,12 +108,10 @@
                 />
                 <field
                     name="document_serie_id"
-                    requied="0"
                     attrs="{'invisible': ['|', ('document_type_id', '=', False), ('issuer', '=', 'partner')], 'required': [('issuer', '=', 'company'), ('document_type_id', '!=', False)], 'readonly': [('state', '!=', 'draft')]}"
                 />
                 <field
                     name="document_serie"
-                    requied="0"
                     attrs="{'invisible': ['|', ('document_type_id', '=', False), ('issuer', '=', 'company')], 'required': [('issuer', '=', 'partner'), ('document_type_id', '!=', False)], 'readonly': [('state', '!=', 'draft')]}"
                 />
                 <field

--- a/l10n_br_account/views/account_invoice_view.xml
+++ b/l10n_br_account/views/account_invoice_view.xml
@@ -83,7 +83,6 @@
                     <field name="fiscal_operation_type" invisible="1" />
                     <field name="number" invisible="1" />
                     <field name="edoc_purpose" invisible="1" />
-                    <field name="ind_final" invisible="1" />
                     <field name="ind_pres" invisible="1" />
                     <field name="fiscal_document_id" required="0" invisible="1" />
                     <field name="create_date" invisible="1" />
@@ -98,6 +97,11 @@
                 <field
                     name="fiscal_operation_id"
                     attrs="{'invisible': [('document_type_id', '=', False)], 'required': [('document_type_id', '!=', False)], 'readonly': [('state', '!=', 'draft')]}"
+                />
+                <field
+                    name="ind_final"
+                    requied="0"
+                    attrs="{'invisible': ['|', ('document_type_id', '=', False), ('issuer', '=', 'partner')], 'required': [('issuer', '=', 'company'), ('document_type_id', '!=', False)], 'readonly': [('state', '!=', 'draft')]}"
                 />
                 <field
                     name="issuer"


### PR DESCRIPTION
Ao alterar o cliente na fatura, o campo ind_final ( indicador de consumidor final ) não estava sendo atualizado.

No documento fiscal já existia um onchange para esse fim, porém no account ele não funciona, o motivo é por causa do inherit**s** do documento fiscal no account.invoice. A ORM do Odoo não saber lidar com esses casos onde o mesmo field existe implementado no modelo pai e também no modelo filho, é o caso do campo partner_id ele existe na invoice e no fiscal.document.
Nessa caso a ORM não chama o onchange do partner que está no documento fiscal, só chama o onchange se ele estiver implementando explicitamente em alguma classe que herda o account.invoice (diretamente)

por esse motivo, repliquei o código do onchange que está no fiscal.document para o account.invoice.

Obs: esses campos que repetem nos dois modelos tem que ter um cuidado especial, os campo são esses:
```
    "name",
    "partner_id",
    "company_id",
    "currency_id",
    "product_id",
    "uom_id",
    "quantity",
    "price_unit",
    "discount_value",
```



