### PR TITLE
[12.0][l10n_br_account][spec_model_driven] several hook fixes

### DIFF
--- a/l10n_br_account/__init__.py
+++ b/l10n_br_account/__init__.py
@@ -1,4 +1,4 @@
-# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from .hooks import pre_init_hook
 from .hooks import post_init_hook
 
 from . import models

--- a/l10n_br_account/__manifest__.py
+++ b/l10n_br_account/__manifest__.py
@@ -44,6 +44,7 @@
     "demo": [
         "demo/res_users_demo.xml",
     ],
+    "pre_init_hook": "pre_init_hook",
     "post_init_hook": "post_init_hook",
     "installable": True,
     "auto_install": False,

--- a/l10n_br_account/hooks.py
+++ b/l10n_br_account/hooks.py
@@ -1,8 +1,14 @@
 # Copyright (C) 2019 - Raphaël Valyi Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import SUPERUSER_ID, api
+import logging
+import sys
+
+from odoo import SUPERUSER_ID, api, registry as odoo_registry
+from odoo.modules import loading
 from odoo.tools.sql import column_exists, create_column
+
+_logger = logging.getLogger(__name__)
 
 
 def pre_init_hook(cr):
@@ -17,6 +23,48 @@ def pre_init_hook(cr):
     that we use to fill these new foreign keys.
     """
     env = api.Environment(cr, SUPERUSER_ID, {})
+
+    cr.execute("select demo from ir_module_module where name='l10n_br_account';")
+    is_demo = cr.fetchone()[0]
+    if is_demo:
+        # load convenient COAs that are used in demos and tests
+        # without a hard dependency (you don't need all COAs for production)
+        coa_modules = env["ir.module.module"].search(
+            [
+                ("name", "in", ("l10n_br_coa_generic", "l10n_br_coa_simple")),
+                ("state", "=", "uninstalled"),
+            ]
+        )
+
+        if coa_modules:
+            registry = odoo_registry(cr.dbname)
+
+            # this xmlids hack is required to avoid deletion records
+            # just installed before this hook and before loaded_xmlids would
+            # be reset by load_modules.
+            loaded_xmlids = registry.loaded_xmlids.copy()
+
+            # without this, these modules would be installed twice
+            to_install = env["ir.module.module"].search([("state", "=", "to install")])
+            to_upgrade = env["ir.module.module"].search([("state", "=", "to upgrade")])
+            (to_install + to_upgrade).write({"state": "uninstalled"})
+
+            # strangely setting coa_modules as 'to install' would fail
+            coa_modules.write({"state": "to upgrade"})
+            # we need to commit so load_modules can see it.
+            # load_modules would commit soon after anyway.
+            cr.commit()  # pylint: disable=E8102
+            _logger.info("installing charts of accounts for demo context...")
+            loading.load_modules(registry._db, force_demo=True)
+            # this 2nd commit is required to be able to call the post_init_hook
+            cr.commit()  # pylint: disable=E8102
+            for mod in coa_modules:
+                py_module = sys.modules["odoo.addons.%s" % (mod.name,)]
+                py_module.post_init_hook(cr, registry)
+
+            to_install.write({"state": "to install"})
+            to_upgrade.write({"state": "to upgrade"})
+            registry.loaded_xmlids = loaded_xmlids.union(registry.loaded_xmlids)
 
     # Create fiscal_document_id fields
     if not column_exists(cr, "account_invoice", "fiscal_document_id"):

--- a/l10n_br_account/hooks.py
+++ b/l10n_br_account/hooks.py
@@ -2,6 +2,55 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from odoo import SUPERUSER_ID, api
+from odoo.tools.sql import column_exists, create_column
+
+
+def pre_init_hook(cr):
+    """
+    account.move and account.move.line inherits from
+    l10n_br_account.fiscal_document and l10n_br_account.fiscal_document.line
+    respectively.
+    But the problem is that you may have existing invoice and lines (like demo
+    data or because you were using Odoo before installing this module or because
+    you use your Odoo instance for other countries than Brazil) so we should
+    make the Odoo ORM happy for these records and we do that with dummy records
+    that we use to fill these new foreign keys.
+    """
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
+    # Create fiscal_document_id fields
+    if not column_exists(cr, "account_invoice", "fiscal_document_id"):
+        create_column(cr, "account_invoice", "fiscal_document_id", "INTEGER")
+
+    # Create fiscal_document_line_id fields
+    if not column_exists(cr, "account_invoice_line", "fiscal_document_line_id"):
+        create_column(cr, "account_invoice_line", "fiscal_document_line_id", "INTEGER")
+
+    companies = env["res.company"].search([])
+    for company in companies:
+        cr.execute(
+            """
+            UPDATE
+                account_invoice
+            SET fiscal_document_id=%s
+            WHERE
+                company_id=%s
+            AND
+                fiscal_document_id IS NULL;""",
+            (company.fiscal_dummy_id.id, company.id),
+        )
+        cr.execute(
+            """
+            UPDATE
+                account_invoice_line
+            SET
+                fiscal_document_line_id=%s
+            WHERE
+                company_id=%s
+            AND
+                fiscal_document_line_id IS NULL;""",
+            (company.fiscal_dummy_id.line_ids[0].id, company.id),
+        )
 
 
 def load_fiscal_taxes(env, l10n_br_coa_chart):
@@ -35,38 +84,3 @@ def post_init_hook(cr, registry):
 
     for l10n_br_coa_chart in l10n_br_coa_charts:
         load_fiscal_taxes(env, l10n_br_coa_chart)
-
-    # account.invoice and account.invoice.line inherits from
-    # l10n_br_account.fiscal_document and l10n_br_account.fiscal_document.line
-    # respectively.
-    # But the problem is that you may have existing invoice and lines (like demo
-    # data or because you were using Odoo before installing this module or because
-    # you use your Odoo instance for other countries than Brazil) so we should
-    # make the Odoo ORM happy for these records and we do that with dummy records
-    # that we use to fill these new foreign keys.
-
-    companies = env["res.company"].search([])
-    for company in companies:
-        cr.execute(
-            """
-            UPDATE
-                account_invoice
-            SET fiscal_document_id=%s
-            WHERE
-                company_id=%s
-            AND
-                fiscal_document_id IS NULL;""",
-            (company.fiscal_dummy_id.id, company.id),
-        )
-        cr.execute(
-            """
-            UPDATE
-                account_invoice_line
-            SET
-                fiscal_document_line_id=%s
-            WHERE
-                company_id=%s
-            AND
-                fiscal_document_line_id IS NULL;""",
-            (company.fiscal_dummy_id.line_ids[0].id, company.id),
-        )

--- a/spec_driven_model/hooks.py
+++ b/spec_driven_model/hooks.py
@@ -86,10 +86,15 @@ def get_remaining_spec_models(cr, registry, module_name, spec_module):
         # 1st classic Odoo classes
         if hasattr(base_class, "_inherit"):
             injected_models.add(base_class._name)
-            if isinstance(base_class._inherit, list):
-                injected_models = injected_models.union(set(base_class._inherit))
-            elif base_class._inherit is not None:
-                injected_models.add(base_class._inherit)
+            for cls in base_class.mro():
+                if hasattr(cls, "_inherit") and cls._inherit:
+                    if isinstance(cls._inherit, list):
+                        inherit_list = cls._inherit
+                    else:
+                        inherit_list = [cls._inherit]
+                    for inherit in inherit_list:
+                        if inherit.startswith("spec.mixin."):
+                            injected_models.add(cls._name)
 
     # visit_stack will now need the associated spec classes
     injected_classes = set()

--- a/spec_driven_model/models/spec_models.py
+++ b/spec_driven_model/models/spec_models.py
@@ -192,12 +192,9 @@ class SpecModel(models.AbstractModel):
 
     def _register_hook(self):
         res = super(SpecModel, self)._register_hook()
-        load_key = "_%s_loaded" % (self._spec_module,)
-        if not hasattr(self.env.registry, load_key):
-            from .. import hooks  # importing here avoids loop
+        from .. import hooks  # importing here avoids loop
 
-            hooks.register_hook(self.env, self._odoo_module, self._spec_module)
-            self.env.registry.load_key = True
+        hooks.register_hook(self.env, self._odoo_module, self._spec_module)
         return res
 
 


### PR DESCRIPTION
Pela ordem dos commits:

- [x] resolve a regressão https://github.com/OCA/l10n-brazil/issues/1911 com o backport de https://github.com/akretion/l10n-brazil/commit/cb2fff388439bceb3caf032f71be971f058b85cd assim o codigo tb fica mais igual da v14 para manter
- [x] resolve problemas como https://github.com/OCA/l10n-brazil/pull/2014#issuecomment-1182661379 e https://github.com/OCA/l10n-brazil/pull/2005#issuecomment-1181005362 acontece que nos dados de testes e demo atuais temos dependencias implicitas aos planos de contas l10n_br_coa_simple e l10n_br_coa_generic. Eh normal a gente nao ter uma dependencia dura. Tambem se vc tiver uma SO ou PO para a empresa de demo do simples ou do lucro presumido, se vc seguir ate as faturas sem ter os respeitivos COAs instalados isso vai criar problemas/dados zoados. Da mesma forma tem testes que de forma implicita precisam desses COAs como https://github.com/OCA/l10n-brazil/blob/12.0/l10n_br_account_nfe/demo/account_invoice_demo.xml#L58 . E eh claro que os testes tem mais valores usando esses planos, principalemente com os impostos deles. Por outro lado nao seria razoavel cada modulo de venda, compra, contrato etc depender desses planos... A forma como eu resolvi (depois de muito trabalho!) foi de dizer que no pre_init_hook do l10n_br_account se o contexto for de demo ou test, a gente puxa a instalaçao dos planos l10n_br_coa_simple e l10n_br_coa_generic. No Travis/Github Action s/Runboat geralmente funcionava porque todos modulos eram instalados antes do testes. Mas se alguem fizer `odoo -i l10n_br_account_nfe` do zero, dava pau mesmo https://gist.github.com/rvalyi/7c3800c3bff88d44a93351bd5d754775 . Agora esse tipo de coisa funciona de forma determinista.
- [x] o register_hook do spec_model_driven deve ser chamado ou apenas uma vez no fim quando todos modulos que podem injectar mixins de spec xsd tiverem carregados (assim o mapping fica dinamico sem matar a modularidade do Odoo) ou entao se tiver forçado, como é o caso nos testes antes de importar algum XML de NFe para frisar o mapping. Mas o problema é que a deteçao de se o register_hook ja tinha sido chamado ou não era quebrada. Nisso era chamado VARIAS vezes de bobeira criando um problema de **performance** importante nos testes e na hora de iniciar o servidor.
- [x] por fim o ultimo commit so serve caso vc forçar o register_hook de novo num outro modulo, por examplo l10n_br_account_nfe. Quando alguma class que injectava algum mixin era herdada de novo, o _inherit visto pelo hook nao identificava os mixins de spec xsd e podia perder alguns. Assim o spec_model_driven podia tentar tornar concreto mixins como nfe.40.tlocal que na vdd ja tinha sido injectado no res.partner no modulo l10n_br_nfe. Agora essa deteção fica robusta usando o mro() em vez do _inherit do objeto usado no modulo.


cc @netosjb @renatonlima @marcelsavegnago 