### PR TITLE
[14.0][FIX] l10n_br_contract: add onchange_fiscal_operation before prepare invoice line

### DIFF
--- a/l10n_br_contract/models/contract_line.py
+++ b/l10n_br_contract/models/contract_line.py
@@ -49,6 +49,8 @@ class ContractLine(models.Model):
 
         contract = self.contract_id
 
+        self._onchange_fiscal_operation_id()
+
         invoice_line_vals = super()._prepare_invoice_line(move_form)
 
         # Por algum motivo com a localização o campo company_currency_id

--- a/l10n_br_contract/views/contract_line.xml
+++ b/l10n_br_contract/views/contract_line.xml
@@ -10,7 +10,12 @@
              <xpath expr="//field[@name='discount']/.." position="after">
                  <group name="fiscal">
                      <field name="fiscal_operation_id" />
-                     <field name="fiscal_operation_line_id" />
+                     <field name="fiscal_operation_line_id" readonly="1" />
+                     <field
+                        name="fiscal_tax_ids"
+                        widget="many2many_tags"
+                        readonly="1"
+                    />
                  </group>
             </xpath>
         </field>

--- a/l10n_br_contract/views/contract_view.xml
+++ b/l10n_br_contract/views/contract_view.xml
@@ -8,6 +8,14 @@
             <field name="fiscal_position_id" position="after">
                 <field name="fiscal_operation_id" />
             </field>
+            <xpath
+                expr="//field[@name='contract_line_fixed_ids']"
+                position="attributes"
+            >
+                <attribute
+                    name="context"
+                >{'default_fiscal_operation_id': fiscal_operation_id, 'default_partner_id': partner_id, 'default_company_id': company_id}</attribute>
+            </xpath>
             <xpath expr="//field[@name='contract_line_ids']" position="attributes">
                 <attribute
                     name="context"

--- a/l10n_br_contract/views/contract_view.xml
+++ b/l10n_br_contract/views/contract_view.xml
@@ -21,6 +21,34 @@
                     name="context"
                 >{'default_fiscal_operation_id': fiscal_operation_id, 'default_partner_id': partner_id, 'default_company_id': company_id}</attribute>
             </xpath>
+
+            <xpath
+                expr="//field[@name='contract_line_fixed_ids']/tree/button"
+                position="before"
+            >
+                <field name="fiscal_operation_id" readonly="1" optional="hide" />
+                <field name="fiscal_operation_line_id" readonly="1" optional="hide" />
+                <field
+                    name="fiscal_tax_ids"
+                    widget="many2many_tags"
+                    readonly="1"
+                    optional="hide"
+                />
+            </xpath>
+            <xpath
+                expr="//field[@name='contract_line_ids']/tree/button"
+                position="before"
+            >
+                <field name="fiscal_operation_id" readonly="1" optional="hide" />
+                <field name="fiscal_operation_line_id" readonly="1" optional="hide" />
+                <field
+                    name="fiscal_tax_ids"
+                    widget="many2many_tags"
+                    readonly="1"
+                    optional="hide"
+                />
+            </xpath>
+
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Na 14.0 as faturas sempre eram geradas com os impostos que foram calculados no momento da criação da linha.

oq faz mais sentido no caso de contratos ? permitir e chumbar a configuracao dos impostos no cadastro ou recalcular a cada fatura gerada ?

- [x] Chamar o método _onchange_fiscal_operation antes de preparar os dados de faturamento de cada linha de contrato
- [x] Incluir na tree contract_line_ids e contract_line_fixed_ids as colunas fiscal_operation_id, fiscal_operation_line_id e fiscal_tax_ids... opcionais e somente leitura
- [x] Incluir as taxas que foram calculadas e deixar o campo fiscal_operation_line_id readonly no form de inclusão de linha de contrato. Como eh executado o _onchange_fiscal_operation_id a cada faturamento, não faz sentido que estes campos sejam editaveis. 

O objetivo maior foi permitir visualizar no contrato os impostos que serão considerados no faturamento e permitir que o comportamento original da 12 fosse mantido (rodar o change da operacao fiscal antes de cada faturamento)
