### PR TITLE
[14.0][l10n_br_nfe][FIX] xFant same label warning

### DIFF
--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -65,7 +65,7 @@ class ResPartner(spec_models.SpecModel):
 
     # nfe.40.dest
     nfe40_xNome = fields.Char(related="legal_name")
-    nfe40_xFant = fields.Char(related="name")
+    nfe40_xFant = fields.Char(related="name", string="Nome Fantasia")
     nfe40_enderDest = fields.Many2one(
         comodel_name="res.partner", compute="_compute_nfe40_enderDest"
     )


### PR DESCRIPTION
antes disso (e desde https://github.com/OCA/l10n-brazil/pull/1945)

```
2022-07-19 03:52:37,406 111 INFO db odoo.addons.spec_driven_model.models.spec_models: building StackedModel l10n_br_fiscal.document <class 'odoo.addons.l10n_br_nfe.models.document.NFe'> 
2022-07-19 03:52:37,410 111 INFO db odoo.addons.spec_driven_model.models.spec_models: building StackedModel l10n_br_fiscal.document.line <class 'odoo.addons.l10n_br_nfe.models.document_line.NFeLine'> 
2022-07-19 03:52:37,621 111 INFO db odoo.modules.registry: module l10n_br_nfe: creating or updating database tables 
2022-07-19 03:52:37,762 111 WARNING db odoo.addons.base.models.ir_model: Two fields (nfe40_xFant, name) of res.partner() have the same label: Name. 
2022-07-19 03:52:37,763 111 WARNING db odoo.addons.base.models.ir_model: Two fields (nfe40_xFant, name) of res.users() have the same label: Name. 
```

depois: não tem mais warning