### PR TITLE
[14.0][IMP] l10n_br_account_payment_brcobranca: adding other ways to set brcobranca_api_url value

### DIFF
--- a/l10n_br_account_payment_brcobranca/constants/br_cobranca.py
+++ b/l10n_br_account_payment_brcobranca/constants/br_cobranca.py
@@ -9,6 +9,7 @@ from collections import namedtuple
 
 from odoo import _
 from odoo.exceptions import UserError
+from odoo.tools import config
 
 DICT_BRCOBRANCA_CNAB_TYPE = {
     "240": "cnab240",
@@ -56,8 +57,12 @@ def get_brcobranca_bank(bank_account_id, payment_method_code):
     return bank_name_brcobranca
 
 
-def get_brcobranca_api_url():
-    brcobranca_api_url = os.environ.get("BRCOBRANCA_API_URL")
+def get_brcobranca_api_url(env):
+    brcobranca_api_url = (
+        os.environ.get("BRCOBRANCA_API_URL")
+        or config.get("brcobranca_api_url")
+        or env["ir.config_parameter"].sudo().get_param("brcobranca_api_url")
+    )
 
     if not brcobranca_api_url:
         raise UserError(

--- a/l10n_br_account_payment_brcobranca/models/account_move.py
+++ b/l10n_br_account_payment_brcobranca/models/account_move.py
@@ -73,7 +73,7 @@ class AccountMove(models.Model):
         f.close()
         files = {"data": open(f.name, "rb")}
 
-        brcobranca_api_url = get_brcobranca_api_url()
+        brcobranca_api_url = get_brcobranca_api_url(self.env)
         brcobranca_service_url = brcobranca_api_url + "/api/boleto/multi"
         logger.info(
             "Connecting to %s to get Boleto of invoice %s",

--- a/l10n_br_account_payment_brcobranca/models/account_payment_order.py
+++ b/l10n_br_account_payment_brcobranca/models/account_payment_order.py
@@ -172,7 +172,7 @@ class PaymentOrder(models.Model):
         f.close()
         files = {"data": open(f.name, "rb")}
 
-        brcobranca_api_url = get_brcobranca_api_url()
+        brcobranca_api_url = get_brcobranca_api_url(self.env)
         # EX.: "http://boleto_cnab_api:9292/api/remessa"
         brcobranca_service_url = brcobranca_api_url + "/api/remessa"
         logger.info(

--- a/l10n_br_account_payment_brcobranca/parser/cnab_file_parser.py
+++ b/l10n_br_account_payment_brcobranca/parser/cnab_file_parser.py
@@ -78,7 +78,7 @@ class CNABFileParser(FileParser):
     def _get_brcobranca_retorno(self, files):
 
         bank_name_brcobranca = dict_brcobranca_bank[self.bank.code_bc]
-        brcobranca_api_url = get_brcobranca_api_url()
+        brcobranca_api_url = get_brcobranca_api_url(self.env)
         # Ex.: "http://boleto_cnab_api:9292/api/retorno"
         brcobranca_service_url = brcobranca_api_url + "/api/retorno"
         logger.info(


### PR DESCRIPTION
Sabendo que hoje a unica forma de configurar o valor da variavel brcobranca_api_url é através de uma variavel de sistema, fiz algumas modicações para permitir configurar também no arquivo de configuração do odoo como também nos parametros do sistema. 

Neste caso, considerei que primeiro verifica se tem parametro do sistema, depois se tem parametro no arquivo de configuracao e em seguida verifica se tem valor de brcobranca_api_url em uma variavel de sistema. Se for o caso podemos inverter a ordem.. aceito sugestões :D