### PR TITLE
[14.0][RFC] l10n_br_website_sale: refactor /shop/address view

### DIFF
--- a/l10n_br_website_sale/controllers/main.py
+++ b/l10n_br_website_sale/controllers/main.py
@@ -11,6 +11,9 @@ from odoo.addons.website_sale.controllers.main import WebsiteSale
 
 
 class L10nBrWebsiteSale(WebsiteSale):
+    def _get_country_code(self, country_id):
+        return request.env["res.country"].browse(country_id).code
+
     # overwrite confirm_order
     @http.route(
         ["/shop/confirm_order"], type="http", auth="public", website=True, sitemap=False
@@ -32,8 +35,10 @@ class L10nBrWebsiteSale(WebsiteSale):
         req = super()._get_mandatory_fields_billing(country_id)
         company_country_code = request.website.company_id.country_id.code
         if country_id:
-            partner_country_code = request.env["res.country"].browse(country_id).code
-            if partner_country_code == "BR" and company_country_code == "BR":
+            if (
+                self._get_country_code(country_id) == "BR"
+                and company_country_code == "BR"
+            ):
                 req.remove("city")
                 req.remove("street")
                 extension = [
@@ -45,7 +50,6 @@ class L10nBrWebsiteSale(WebsiteSale):
                     "city_id",
                     "zip",
                     "cnpj_cpf",
-                    "company_type",
                 ]
                 req.extend(extension)
         return req
@@ -54,8 +58,10 @@ class L10nBrWebsiteSale(WebsiteSale):
         req = super()._get_mandatory_fields_shipping(country_id)
         company_country_code = request.website.company_id.country_id.code
         if country_id:
-            partner_country_code = request.env["res.country"].browse(country_id).code
-            if partner_country_code == "BR" and company_country_code == "BR":
+            if (
+                self._get_country_code(country_id) == "BR"
+                and company_country_code == "BR"
+            ):
                 req.remove("city")
                 req.remove("street")
                 extension = [
@@ -108,35 +114,43 @@ class L10nBrWebsiteSale(WebsiteSale):
         new_values, errors, error_msg = super().values_postprocess(
             order, mode, values, errors, error_msg
         )
-        if "country_id" in new_values and new_values["country_id"] != "31":
-            if "state_id" in errors:
-                errors.pop("state_id", None)
-            if "city_id" in errors:
-                errors.pop("city_id", None)
-            if "cnpj_cpf" in errors:
-                errors.pop("city_id", None)
 
-        if "city_id" in values:
-            new_values["city_id"] = values["city_id"]
-        if "cnpj_cpf" in values and "cnpj_cpf" not in errors:
-            new_values["cnpj_cpf"] = values["cnpj_cpf"]
-        if "company_type" in values and "company_type" not in errors:
-            new_values["company_type"] = values["company_type"]
-        if "street_name" in values:
-            new_values["street_name"] = values["street_name"]
-        if "street_number" in values:
-            new_values["street_number"] = values["street_number"]
-        if "district" in values:
-            new_values["district"] = values["district"]
+        # Check if the current country is not Brazil and remove specific errors
+        if self._get_country_code(new_values.get("country_id")) != "BR":
+            error_fields = ["state_id", "city_id", "cnpj_cpf", "inscr_est", "inscr_mun"]
+            for field in error_fields:
+                errors.pop(field, None)
+
+        # Expected fields that may be updated in new_values if not present in errors
+        expected_fields = [
+            "city_id",
+            "cnpj_cpf",
+            "company_type",
+            "street_name",
+            "street_number",
+            "district",
+            "mobile",
+            "inscr_est",
+            "inscr_mun",
+            "vat",
+        ]
+
+        # Update new_values for each expected field if it exists in values and not in errors
+        for field in expected_fields:
+            if field in values and field not in errors:
+                new_values[field] = values[field]
+
         return new_values, errors, error_msg
 
     def checkout_form_validate(self, mode, all_form_values, data):
         error, error_message = super().checkout_form_validate(
             mode, all_form_values, data
         )
-
         if "cnpj_cpf" in data:
-            if "country_id" in data and data["country_id"] == "31":
+            if (
+                "country_id" in data
+                and self._get_country_code(data["country_id"]) == "BR"
+            ):
                 order = request.website.sale_get_order()
                 if order.partner_id.is_company:
                     if not cnpj_cpf.validar(data["cnpj_cpf"]):
@@ -148,6 +162,16 @@ class L10nBrWebsiteSale(WebsiteSale):
 
                 if "cnpj_cpf" not in error:
                     all_form_values["cnpj_cpf"] = data["cnpj_cpf"]
+        if "vat" in data and data["vat"]:
+            if (
+                "country_id" in data
+                and self._get_country_code(data["country_id"]) == "BR"
+            ):
+                if not cnpj_cpf.validar(data["vat"]):
+                    error["cnpj_cpf"] = "error"
+                    error_message.append("VAT Inválido")
+            if "vat" not in error:
+                all_form_values["vat"] = data["vat"]
 
         return error, error_message
 

--- a/l10n_br_website_sale/static/src/js/l10n_br_address.js
+++ b/l10n_br_website_sale/static/src/js/l10n_br_address.js
@@ -12,22 +12,38 @@ odoo.define("l10n_br_website_sale.l10n_br_address", function (require) {
         return $.Deferred().reject("DOM doesn't contain '.checkout_autoformat'");
     }
 
-    if ($("#input_cnpj_cpf").length) {
-        var cpf_cleave = new Cleave("#input_cnpj_cpf", {
-            blocks: [2, 3, 3, 4, 2],
-            delimiters: [".", ".", "-"],
-            numericOnly: true,
-            onValueChanged: function (e) {
-                if (e.target.rawValue.length > 11) {
-                    this.properties.blocks = [2, 3, 3, 4, 2];
-                    this.properties.delimiters = [".", ".", "/", "-"];
-                } else {
-                    this.properties.blocks = [3, 3, 3, 3];
-                    this.properties.delimiters = [".", ".", "-"];
-                }
-            },
-        });
+    function formatCpfCnpj(inputValue) {
+        // Remove non-numeric characters
+        let value = inputValue.replace(/\D/g, "");
+
+        // Truncate the value to 11 digits if it's more than 11 and less than 14
+        if (value.length > 11 && value.length < 14) {
+            value = value.substring(0, 11);
+        }
+        // Truncate the value to 14 digits if it's 14 or more
+        else if (value.length >= 14) {
+            value = value.substring(0, 14);
+        }
+
+        if (value.length <= 11) {
+            // Format as CPF
+            value = value.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, "$1.$2.$3-$4");
+        } else {
+            // Format as CNPJ
+            value = value.replace(
+                /(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/,
+                "$1.$2.$3/$4-$5"
+            );
+        }
+
+        return value;
     }
+
+    $("#input_cnpj_cpf").on("blur", function () {
+        var value = $(this).val();
+        var formattedValue = formatCpfCnpj(value);
+        $(this).val(formattedValue);
+    });
 
     var zip_cleave = new Cleave(".input-zipcode", {
         blocks: [5, 3],
@@ -46,13 +62,15 @@ odoo.define("l10n_br_website_sale.l10n_br_address", function (require) {
                     mode: $("#country_id").attr("mode"),
                 }).then(function (data) {
                     if (data.country_code) {
-                        if (data.country_code === "BR") {
-                            $("input[name='city']").parent("div").hide();
-                            $("select[name='city_id']").parent("div").show();
-                        } else {
-                            $("select[name='city_id']").parent("div").hide();
-                            $("input[name='city']").parent("div").show();
-                        }
+                        setTimeout(() => {
+                            if (data.country_code === "BR") {
+                                $("input[name='city']").parent("div").hide();
+                                $("select[name='city_id']").parent("div").show();
+                            } else {
+                                $("select[name='city_id']").parent("div").hide();
+                                $("input[name='city']").parent("div").show();
+                            }
+                        }, 1000);
                     }
                 });
             }
@@ -61,66 +79,52 @@ odoo.define("l10n_br_website_sale.l10n_br_address", function (require) {
             "change",
             "select[name='state_id']",
             function () {
-                var state_id_selector = $("#state_id");
-                if (!state_id_selector.val()) {
+                var state_id = $("#state_id").val();
+                if (!state_id) {
                     return;
                 }
-                ajax.jsonRpc(
-                    "/shop/state_infos/" + state_id_selector.val(),
-                    "call"
-                ).then(function (data) {
-                    // Populate states and display
+                ajax.jsonRpc("/shop/state_infos/" + state_id, "call").then(function (
+                    data
+                ) {
                     var city_id_selector = $("select[name='city_id']");
-                    var selectCities = city_id_selector;
-                    var zip_city = city_id_selector[0].val;
-                    // Dont reload state at first loading (done in qweb)
-                    if (
-                        selectCities.data("init") === 0 ||
-                        selectCities.find("option").length === 1
-                    ) {
-                        if (data.cities.length) {
-                            _.each(data.cities, function (x) {
-                                var opt = $("<option>")
-                                    .text(x[1])
-                                    .attr("value", x[0])
-                                    .attr("data-code", x[2]);
-                                selectCities.append(opt);
-                            });
-                            selectCities.parent("div").show();
-                            $("input[name='city']").parent("div").hide();
-                            city_id_selector.val(zip_city);
-                        } else {
-                            selectCities.val("").parent("div").hide();
-                            $("input[name='city']").parent("div").show();
-                        }
-                        selectCities.data("init", 0);
+                    city_id_selector.empty();
+                    if (data.cities.length) {
+                        data.cities.forEach(function (city) {
+                            city_id_selector.append(
+                                new Option(city[1], city[0], false, false)
+                            );
+                        });
+                        city_id_selector.parent("div").show();
+                        $("input[name='city']").parent("div").hide();
                     } else {
-                        selectCities.data("init", 0);
+                        city_id_selector.parent("div").hide();
+                        $("input[name='city']").parent("div").show();
                     }
                 });
             }
         );
         $checkout_autoformat_selector.on("change", "input[name='zip']", function () {
             var vals = {zipcode: $('input[name="zip"]').val()};
-            console.log("Changing ZIP");
-            $('a:contains("Next")').attr("display: none !important;");
+            console.log("Changing ZIP code");
+            $('a:contains("Next")').css("display", "none");
             ajax.jsonRpc("/l10n_br/zip_search_public", "call", vals).then(function (
                 data
             ) {
                 if (data.error) {
-                    // Todo: Retornar nos campos error e error_message
-                    console.log("Falha ao consultar cep");
+                    console.log("Failed to query zip code");
                 } else {
-                    var city_id_selector = $('select[name="city_id"]');
                     var state_id_selector = $('select[name="state_id"]');
+                    var city_id_selector = $('select[name="city_id"]');
+                    // Set the district and street name based on the ZIP code data
                     $('input[name="district"]').val(data.district);
                     $('input[name="street_name"]').val(data.street_name);
-                    city_id_selector.val(data.city_id);
-                    city_id_selector.change();
-                    city_id_selector[0].val = data.city_id;
-                    state_id_selector.val(data.state_id);
-                    state_id_selector.change();
-                    $('a:contains("Next")').attr("display: block !important;");
+                    // Set the value of the state selector and trigger its change event
+                    state_id_selector.val(data.state_id).change();
+                    // Wait for the city selector to be populated, then set its value and trigger its change event
+                    setTimeout(() => {
+                        city_id_selector.val(data.city_id).change();
+                    }, 1000);
+                    $('a:contains("Next")').css("display", "block");
                 }
             });
         });

--- a/l10n_br_website_sale/templates/portal_templates.xml
+++ b/l10n_br_website_sale/templates/portal_templates.xml
@@ -3,319 +3,245 @@
 <!-- oca-hooks:disable=xml-dangerous-qweb-replace-low-priority  -->
 <odoo>
 
-    <template id="portal_address" inherit_id="website_sale.address">
-        <form action="/shop/address" position="replace">
-            <form action="/shop/address" method="post" class="checkout_autoformat">
-                <div class="form-row">
-                    <div
-                        t-attf-class="form-group #{error.get('company_type') and 'o_has_error' or ''} col-xl-12 div_type"
-                    >
-                        <label class="col-form-label" for="person_type">Tipo de
-                            Pessoa: </label>
-                        <br />
-                        <div class="form-check form-check-inline">
-                            <input
-                                type="radio"
-                                name="company_type"
-                                id="radioCompany"
-                                value="company"
-                                t-attf-class="#{error.get('company_type') and 'is-invalid' or ''}"
-                                t-att-checked="'company_type' in checkout and checkout['company_type'] == 'company'"
-                            />
-                            Pessoa Jurídica </div>
-                        <div class="form-check form-check-inline">
-                            <input
-                                type="radio"
-                                name="company_type"
-                                id="radioPerson"
-                                value="person"
-                                t-attf-class="#{error.get('company_type') and 'is-invalid' or ''}"
-                                t-att-checked="'company_type' in checkout and checkout['company_type'] == 'person'"
-                            />
-                            Pessoa Física </div>
-                    </div>
+    <template
+        id="portal_address"
+        name="Address Management in (l10n_br_website_sale)"
+        inherit_id="website_sale.address"
+    >
+        <xpath expr="//div[@id='div_email']" position="after">
+            <div
+                t-attf-class="form-group #{error.get('cnpj_cpf') and 'o_has_error' or ''} col-xl-6"
+                id="cnpj_cpf"
+            >
+                <label class="col-form-label" for="contact_name">
+                    CPF</label>
+                <input
+                    type="text"
+                    id="input_cnpj_cpf"
+                    name="cnpj_cpf"
+                    t-attf-class="form-control #{error.get('cnpj_cpf') and 'is-invalid' or ''}"
+                    t-att-value="'cnpj_cpf' in checkout and checkout['cnpj_cpf']"
+                />
+            </div>
+        </xpath>
 
-                    <div
-                        t-attf-class="form-group #{error.get('name') and 'o_has_error' or ''} col-lg-12 div_name"
-                    >
-                        <label class="col-form-label" for="name">Name</label>
-                        <input
-                            type="text"
-                            name="name"
-                            t-attf-class="form-control #{error.get('name') and 'is-invalid' or ''}"
-                            t-att-value="'name' in checkout and checkout['name']"
-                        />
-                    </div>
-                    <div class="w-100" />
-                    <t t-if="mode[1] == 'billing'">
-                        <div
-                            t-attf-class="form-group #{error.get('email') and 'o_has_error' or ''} col-lg-6"
-                            id="div_email"
-                        >
-                            <label class="col-form-label" for="email">
-                                Email</label>
-                            <input
-                                type="email"
-                                name="email"
-                                t-attf-class="form-control #{error.get('email') and 'is-invalid' or ''}"
-                                t-att-value="'email' in checkout and checkout['email']"
-                            />
-                        </div>
+        <xpath expr="//div[@id='div_phone']" position="before">
+            <div
+                t-attf-class="form-group #{error.get('mobile') and 'o_has_error' or ''} col-lg-6"
+                id="div_mobile"
+            >
+                <label class="col-form-label" for="mobile">Mobile</label>
+                <input
+                    type="tel"
+                    name="mobile"
+                    t-attf-class="form-control #{error.get('mobile') and 'is-invalid' or ''}"
+                    t-att-value="'mobile' in checkout and checkout['mobile']"
+                />
+            </div>
+        </xpath>
 
-                        <div
-                            t-attf-class="form-group #{error.get('cnpj_cpf') and 'o_has_error' or ''} col-xl-6"
-                            id="cnpj_cpf"
-                        >
-                            <label class="col-form-label" for="contact_name">
-                                CPF/CNPJ</label>
-                            <input
-                                type="text"
-                                id="input_cnpj_cpf"
-                                name="cnpj_cpf"
-                                t-attf-class="form-control #{error.get('cnpj_cpf') and 'is-invalid' or ''}"
-                                t-att-value="'cnpj_cpf' in checkout and checkout['cnpj_cpf']"
-                            />
-                        </div>
-                    </t>
-                    <div
-                        t-attf-class="form-group #{error.get('phone') and 'o_has_error' or ''} col-lg-6"
-                        id="div_phone"
-                    >
-                        <label class="col-form-label" for="phone">Phone</label>
-                        <input
-                            type="tel"
-                            name="phone"
-                            t-attf-class="form-control #{error.get('phone') and 'is-invalid' or ''}"
-                            t-att-value="'phone' in checkout and checkout['phone']"
-                        />
-                    </div>
+        <xpath expr="//div[contains(@t-attf-class, 'div_street')]" position="before">
+            <xpath
+                expr="//div[contains(@t-attf-class, 'div_country')]"
+                position="move"
+            />
+            <xpath expr="//t[contains(@t-set,'zip_city')]" position="move" />
+            <xpath
+                expr="//t[contains(@t-if,'zip_city and zip_city')]"
+                position="move"
+            />
 
-                    <div class="w-100" />
-                    <t
-                        t-set='zip_city'
-                        t-value='country and [x for x in country.get_address_fields() if x in ["zip", "city"]] or ["city", "zip"]'
+            <div class="w-100" />
+            <div
+                t-attf-class="form-group #{error.get('street_name') and 'o_has_error' or ''} col-lg-8"
+            >
+                <label class="col-form-label" for="street_name">
+                    Street</label>
+                <input
+                    type="text"
+                    name="street_name"
+                    t-attf-class="form-control #{error.get('street_name') and 'is-invalid' or ''}"
+                    t-att-value="'street_name' in checkout and checkout['street_name']"
+                />
+            </div>
+            <div
+                t-attf-class="form-group #{error.get('street_number') and 'o_has_error' or ''} col-lg-4"
+            >
+                <label class="col-form-label" for="street_number">
+                    Nº</label>
+                <input
+                    type="text"
+                    name="street_number"
+                    t-attf-class="form-control #{error.get('street_number') and 'is-invalid' or ''}"
+                    t-att-value="'street_number' in checkout and checkout['street_number']"
+                />
+            </div>
+            <xpath
+                expr="//div[contains(@t-attf-class, 'div_street2')]"
+                position="move"
+            />
+            <div
+                t-attf-class="form-group #{error.get('district') and 'o_has_error' or ''} col-lg-12 div_disctrict"
+            >
+                <label class="col-form-label" for="district">
+                    District</label>
+                <input
+                    type="text"
+                    name="district"
+                    t-attf-class="form-control #{error.get('district') and 'is-invalid' or ''}"
+                    t-att-value="'district' in checkout and checkout['district']"
+                />
+            </div>
+        </xpath>
+
+        <xpath
+            expr="//div[contains(concat(' ', normalize-space(@t-attf-class), ' '), ' div_street ')]"
+            position="attributes"
+        >
+            <attribute name="hidden">true</attribute>
+        </xpath>
+
+        <xpath expr="//t[contains(@t-if,'zip_city and zip_city')]" position="replace">
+            <t t-if="'zip' in zip_city">
+                <div
+                    t-attf-class="form-group #{error.get('zip') and 'o_has_error' or ''} col-lg-6 div_zip"
+                >
+                    <label class="col-form-label" for="zip">
+                        Zip Code</label>
+                    <input
+                        type="text"
+                        name="zip"
+                        t-attf-class="input-zipcode form-control #{error.get('zip') and 'is-invalid' or ''}"
+                        t-att-value="'zip' in checkout and checkout['zip']"
                     />
-                    <t t-if="'zip' in zip_city">
-                        <div
-                            t-attf-class="form-group #{error.get('zip') and 'o_has_error' or ''} col-md-6 div_zip"
-                        >
-                            <label class="col-form-label" for="zip">
-                                Zip Code</label>
-                            <input
-                                type="text"
-                                name="zip"
-                                t-attf-class="input-zipcode form-control #{error.get('zip') and 'is-invalid' or ''}"
-                                t-att-value="'zip' in checkout and checkout['zip']"
-                            />
-                        </div>
-                    </t>
-                    <div
-                        t-attf-class="form-group #{error.get('street_name') and 'o_has_error' or ''} col-md-6 div_street"
-                    >
-                        <label class="col-form-label" for="street_name">
-                            Street</label>
-                        <input
-                            type="text"
-                            name="street_name"
-                            t-attf-class="form-control #{error.get('street_name') and 'is-invalid' or ''}"
-                            t-att-value="'street_name' in checkout and checkout['street_name']"
-                        />
-                    </div>
-                    <div class="w-100" />
-                    <div
-                        t-attf-class="form-group #{error.get('street_number') and 'o_has_error' or ''} col-xl-6"
-                    >
-                        <label class="col-form-label" for="street_number">
-                            Nº</label>
-                        <input
-                            type="text"
-                            name="street_number"
-                            t-attf-class="form-control #{error.get('street_number') and 'is-invalid' or ''}"
-                            t-att-value="'street_number' in checkout and checkout['street_number']"
-                        />
-                    </div>
-                    <div
-                        t-attf-class="form-group #{error.get('district') and 'o_has_error' or ''} col-xl-6"
-                    >
-                        <label class="col-form-label" for="district">
-                            Bairro</label>
-                        <input
-                            type="text"
-                            name="district"
-                            t-attf-class="form-control #{error.get('district') and 'is-invalid' or ''}"
-                            t-att-value="'district' in checkout and checkout['district']"
-                        />
-                    </div>
-                    <div class="w-100" />
-                    <div
-                        t-attf-class="form-group #{error.get('street2') and 'o_has_error' or ''} col-md-6 div_street2"
-                    >
-                        <label class="col-form-label label-optional" for="street2">
-                            Complemento</label>
-                        <input
-                            type="text"
-                            name="street2"
-                            t-attf-class="form-control #{error.get('street2') and 'is-invalid' or ''}"
-                            t-att-value="'street2' in checkout and checkout['street2']"
-                        />
-                    </div>
-                    <div
-                        t-attf-class="form-group #{error.get('country_id') and 'o_has_error' or ''} col-lg-6 div_country"
-                    >
-                        <label class="col-form-label" for="country_id">
-                            Country</label>
-                        <select
-                            id="country_id"
-                            name="country_id"
-                            t-attf-class="form-control #{error.get('country_id') and 'is-invalid' or ''}"
-                            t-att-mode="mode[1]"
-                        >
-                            <option value="">Country...</option>
-                            <t t-foreach="countries" t-as="c">
-                                <option
-                                    t-att-value="c.id"
-                                    t-att-selected="c.id == (country and country.id or -1)"
-                                >
-                                    <t t-esc="c.name" />
-                                </option>
-                            </t>
-                        </select>
-                    </div>
-                    <div
-                        id="div_state"
-                        t-attf-class="form-group #{error.get('state_id') and 'o_has_error' or ''} col-lg-6 div_state"
-                        t-att-style="(not country or not country.state_ids) and 'display: none'"
-                    >
-                        <label class="col-form-label" for="state_id">State /
-                            Province</label>
-                        <select
-                            id="state_id"
-                            name="state_id"
-                            t-attf-class="form-control #{error.get('state_id') and 'is-invalid' or ''}"
-                            data-init="1"
-                        >
-                            <option value="">State / Province...</option>
-                            <t t-foreach="country and country.state_ids or []" t-as="s">
-                                <option
-                                    t-att-value="s.id"
-                                    t-att-selected="s.id == ('state_id' in checkout and country and checkout['state_id'] != '' and int(checkout['state_id']))"
-                                >
-                                    <t t-esc="s.name" />
-                                </option>
-                            </t>
-                        </select>
-                    </div>
-
-                    <div
-                        t-attf-class="form-group #{error.get('city_id') and 'o_has_error' or ''} col-xl-6"
-                        t-att-style="(not country or not country.state_ids) and 'display: none'"
-                    >
-                        <label
-                            class="col-form-label"
-                            for="city_id"
-                            t-att-style="(not country or not country.state_ids) and 'display: none'"
-                        >
-                            Cidade</label>
-                        <select
-                            name="city_id"
-                            id="city_id"
-                            t-attf-class="form-control #{error.get('city_id') and 'is-invalid' or ''}"
-                            t-att-style="(not country or not country.state_ids) and 'display: none'"
-                        >
-                            <option value="">select...</option>
-                            <t t-foreach="cities or []" t-as="citie">
-                                <option
-                                    t-att-value="citie.id"
-                                    style="display:none;"
-                                    t-att-data-state_id="citie.state_id.id"
-                                    t-att-selected="citie.id == ('city_id' in checkout and checkout['city_id'] != '' and int(checkout['city_id']))"
-                                >
-                                    <t t-esc="citie.name" />
-                                </option>
-                            </t>
-                        </select>
-
-                    </div>
-
-                    <div
-                        t-attf-class="form-group #{error.get('city') and 'o_has_error' or ''} col-lg-6"
-                        t-att-style="(country and not country.state_ids) and 'display: none'"
-                    >
-                        <label class="col-form-label" for="city">
-                            City</label>
-                        <input
-                            type="text"
-                            name="city"
-                            id="city"
-                            t-attf-class="form-control #{error.get('city') and 'is-invalid' or ''}"
-                            t-att-value="'city' in checkout and checkout['city']"
-                        />
-                    </div>
-
-                    <div class="w-100" />
-                    <t t-if="mode == ('new', 'billing') and not only_services">
-                        <div class="col-lg-12">
-                            <div class="checkbox">
-                                <label>
-                                    <input
-                                        type="checkbox"
-                                        id='shipping_use_same'
-                                        class="mr8"
-                                        name='use_same'
-                                        value="1"
-                                        checked='checked'
-                                    />
-                                    Ship to the same address
-                                    <span
-                                        class='ship_to_other text-muted'
-                                        style="display: none"
-                                    >
-                                        &amp;nbsp;(<i>Your shipping address
-                                        will be requested later) </i></span>
-                                </label>
-                            </div>
-                        </div>
-                    </t>
                 </div>
-                    <input
-                    type="hidden"
-                    name="csrf_token"
-                    t-att-value="request.csrf_token()"
-                />
-                    <input type="hidden" name="submitted" value="1" />
-                    <input
-                    type="hidden"
-                    name="partner_id"
-                    t-att-value="partner_id or '0'"
-                />
-                    <input type="hidden" name="callback" t-att-value="callback" />
-                    <!-- Example -->
-                    <input
-                    type="hidden"
-                    name="field_required"
-                    t-att-value="'phone,name'"
-                />
+            </t>
+        </xpath>
 
-                    <div class="d-flex justify-content-between">
-                        <a
-                        role="button"
-                        t-att-href="mode == ('new', 'billing') and '/shop/cart' or '/shop/checkout'"
-                        class="btn btn-secondary mb32"
-                    >
-                            <i class="fa fa-chevron-left" />
-                            <span>Back</span>
-                        </a>
-                        <a
-                        role="button"
-                        href="#"
-                        class="btn btn-primary mb32 a-submit a-submit-disable a-submit-loading"
-                    >
-                            <span>Next</span>
-                            <i class="fa fa-chevron-right" />
-                        </a>
-                    </div>
-            </form>
-        </form>
+        <xpath expr="//div[contains(@t-attf-class, 'div_state')]" position="replace">
+            <div
+                id="div_state"
+                t-attf-class="form-group #{error.get('state_id') and 'o_has_error' or ''} col-lg-6 div_state"
+                t-att-style="(not country or not country.state_ids) and 'display: none'"
+            >
+                <label class="col-form-label" for="state_id">State /
+                    Province</label>
+                <select
+                    id="state_id"
+                    name="state_id"
+                    t-attf-class="form-control #{error.get('state_id') and 'is-invalid' or ''}"
+                    data-init="1"
+                >
+                    <option value="">State / Province...</option>
+                    <t t-foreach="country and country.state_ids or []" t-as="s">
+                        <option
+                            t-att-value="s.id"
+                            t-att-selected="s.id == ('state_id' in checkout and country and checkout['state_id'] != '' and int(checkout['state_id']))"
+                        >
+                            <t t-esc="s.name" />
+                        </option>
+                    </t>
+                </select>
+            </div>
+        </xpath>
+
+        <xpath expr="//div[contains(@t-attf-class, 'div_state')]" position="after">
+            <div
+                t-attf-class="form-group #{error.get('city_id') and 'o_has_error' or ''} col-xl-6"
+                t-att-style="(not country or not country.state_ids) and 'display: none'"
+            >
+                <label
+                    class="col-form-label"
+                    for="city_id"
+                    t-att-style="(not country or not country.state_ids) and 'display: none'"
+                >
+                    Cidade</label>
+                <select
+                    name="city_id"
+                    id="city_id"
+                    t-attf-class="form-control #{error.get('city_id') and 'is-invalid' or ''}"
+                    t-att-style="(not country or not country.state_ids) and 'display: none'"
+                >
+                    <option value="">select...</option>
+                    <t t-foreach="cities or []" t-as="citie">
+                        <option
+                            t-att-value="citie.id"
+                            style="display:none;"
+                            t-att-data-state_id="citie.state_id.id"
+                            t-att-selected="citie.id == ('city_id' in checkout and checkout['city_id'] != '' and int(checkout['city_id']))"
+                        >
+                            <t t-esc="citie.name" />
+                        </option>
+                    </t>
+                </select>
+            </div>
+            <xpath expr="//div[contains(@t-attf-class, 'div_city')]" position="move" />
+        </xpath>
+
+        <xpath expr="//div[contains(@t-attf-class, 'div_city')]" position="replace">
+            <div
+                t-attf-class="form-group #{error.get('city') and 'o_has_error' or ''} col-lg-6"
+                t-att-style="(country and not country.state_ids) and 'display: none'"
+            >
+                <label class="col-form-label" for="city">
+                    City</label>
+                <input
+                    type="text"
+                    name="city"
+                    id="city"
+                    t-attf-class="form-control #{error.get('city') and 'is-invalid' or ''}"
+                    t-att-value="'city' in checkout and checkout['city']"
+                />
+            </div>
+        </xpath>
+    </template>
+
+    <template
+        id="address_b2b"
+        name="Show b2b fields in (l10n_br_website_sale)"
+        inherit_id="website_sale.address_b2b"
+    >
+        <xpath expr="//div[contains(@t-attf-class, 'div_vat')]" position="after">
+            <div class="w-100" />
+            <div
+                t-attf-class="form-group #{error.get('inscr_est') and 'o_has_error' or ''} col-lg-6 div_inscr_est"
+            >
+                <label
+                    class="col-form-label font-weight-normal label-optional"
+                    for="inscr_est"
+                >State Tax Number</label>
+                <t
+                    t-set="vat_not_editable_message"
+                >Changing State Tax number is not allowed once document(s) have been issued for your account. Please contact us directly for this operation.</t>
+                <input
+                    type="text"
+                    name="inscr_est"
+                    t-attf-class="form-control #{error.get('inscr_est') and 'is-invalid' or ''}"
+                    t-att-value="'inscr_est' in checkout and checkout['inscr_est']"
+                    t-att-readonly="'1' if 'inscr_est' in checkout and checkout['inscr_est'] and not can_edit_vat else None"
+                    t-att-title="vat_not_editable_message if 'inscr_est' in checkout and checkout['inscr_est'] and not can_edit_vat else None"
+                />
+            </div>
+            <div
+                t-attf-class="form-group #{error.get('inscr_mun') and 'o_has_error' or ''} col-lg-6 div_inscr_mun"
+            >
+                <label
+                    class="col-form-label font-weight-normal label-optional"
+                    for="inscr_mun"
+                >State Tax Number</label>
+                <t
+                    t-set="vat_not_editable_message"
+                >Changing Municipal Tax number is not allowed once document(s) have been issued for your account. Please contact us directly for this operation.</t>
+                <input
+                    type="text"
+                    name="inscr_mun"
+                    t-attf-class="form-control #{error.get('inscr_mun') and 'is-invalid' or ''}"
+                    t-att-value="'inscr_mun' in checkout and checkout['inscr_mun']"
+                    t-att-readonly="'1' if 'inscr_mun' in checkout and checkout['inscr_mun'] and not can_edit_vat else None"
+                    t-att-title="vat_not_editable_message if 'inscr_mun' in checkout and checkout['inscr_mun'] and not can_edit_vat else None"
+                />
+            </div>
+        </xpath>
     </template>
 
 </odoo>


### PR DESCRIPTION
depende de parte da PR #2030 já que para permitir o fluxo normal do sistema se faz necessário o preenchimento de campo além do CPF para a pessoa que está se cadastrando informe o CNPJ/VAT da empresa que atua.

Fiz esta alteração com o objetivo de remover a sobreescrita de um longo trecho do código original e fiz a inclusão do campo inscrição estadual e inscrição municipal. 

Buscando manter o formulário mais padronizado com o nativo eu removi a definição do tipo de empresa. Analisando o fluxo faz sentido o cadastro do contato para em seguida cadastrar a empresa.

- [X] Na consulta do endereço via portal o campo city aparece ao invés do campo city_id e somente quando altera o Estado o campo city_id substitui o campo city