### PR TITLE
[14.0][FIX] l10n_br_base: changing one of the fields resets the value of the other (state_id and inscr_est)

### DIFF
--- a/l10n_br_base/models/res_company.py
+++ b/l10n_br_base/models/res_company.py
@@ -42,12 +42,15 @@ class Company(models.Model):
         for company in self:
             company.partner_id.cnpj_cpf = company.cnpj_cpf
 
+    def _inverse_inscr_est(self):
+        """Write the l10n_br specific functional fields."""
+        for company in self:
+            company.partner_id.inscr_est = company.inscr_est
+
     def _inverse_state(self):
         """Write the l10n_br specific functional fields."""
         for company in self:
-            company.partner_id.write(
-                {"state_id": company.state_id.id, "inscr_est": company.inscr_est}
-            )
+            company.partner_id.state_id = company.state_id
 
     def _inverse_state_tax_number_ids(self):
         """Write the l10n_br specific functional fields."""
@@ -97,7 +100,7 @@ class Company(models.Model):
 
     inscr_est = fields.Char(
         compute="_compute_address",
-        inverse="_inverse_state",
+        inverse="_inverse_inscr_est",
     )
 
     state_tax_number_ids = fields.One2many(
@@ -138,3 +141,11 @@ class Company(models.Model):
                 raise e
 
         return result
+
+    @api.onchange("state_id")
+    def _onchange_state_id(self):
+        for record in self:
+            super()._onchange_state_id()
+            record.inscr_est = False
+            record.partner_id.inscr_est = False
+            record.partner_id.state_id = record.state_id

--- a/l10n_br_fiscal/tests/test_icms_regulation.py
+++ b/l10n_br_fiscal/tests/test_icms_regulation.py
@@ -1,3 +1,6 @@
+# Copyright 2019 Akretion - Renato Lima <renato.lima@akretion.com.br>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo.tests import SavepointCase, tagged
 
 from ..constants.fiscal import FINAL_CUSTOMER_NO, FINAL_CUSTOMER_YES, TAX_DOMAIN_ICMS
@@ -59,6 +62,8 @@ class TestICMSRegulation(SavepointCase):
     def find_icms_tax(self, in_state_id, out_state_id, ncm_id, ind_final):
 
         self.partner.state_id = in_state_id
+        self.company.partner_id.inscr_est = False
+        self.company.inscr_est = False
         self.company.state_id = out_state_id
         self.product.ncm_id = ncm_id
 


### PR DESCRIPTION
No momento ao alterar o campo inscr_est do cadastro da empresa o valor de state_id é zerado e quando altera o valor de state_id o campo inscrição estadual é zerado.

Não sei o impacto já que o state_id fica sem inverse neste caso.

cc @augustodinizl 