### PR TITLE
[14.0][FIX] exibição do campo "document_type_id" no acocunt.move

### DIFF
--- a/l10n_br_account/views/account_invoice_view.xml
+++ b/l10n_br_account/views/account_invoice_view.xml
@@ -62,20 +62,6 @@
                     name="attrs"
                 >{'invisible': [('document_type_id', '!=', False)]}</attribute>
             </xpath>
-            <xpath expr="//form/sheet/div/h1[1]" position="after">
-                <h1 class="mt0">
-                    <div attrs="{'invisible': [('document_type_id', '=', False)]}">
-                        <span class="oe_inline">
-                            <field readonly="1" name="document_type_id" />:
-                            <field
-                                name="document_number"
-                                readonly="1"
-                                attrs="{'invisible': [('state','in',('draft',))]}"
-                            />
-                        </span>
-                    </div>
-                </h1>
-            </xpath>
             <xpath expr="//form/sheet/group" position="after">
                 <group name="l10n_br_fiscal">
                     <field name="id" invisible="1" />

--- a/l10n_br_account/views/account_invoice_view.xml
+++ b/l10n_br_account/views/account_invoice_view.xml
@@ -79,7 +79,18 @@
                 <field name="document_type" invisible="1" />
                 <field
                     name="document_type_id"
-                    attrs="{'invisible': [('create_date', '!=', False), ('document_type_id', '=', False)], 'readonly': [('state', '!=', 'draft')]}"
+                    attrs="{
+                    'invisible': [
+                            '|',
+                            '&amp;',
+                            '|',
+                            ('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')),
+                            ('create_date', '=', True),
+                            ('document_type_id', '=', False),
+                            ('currency_id', '!=',  %(base.BRL)d),
+                        ],
+                    'readonly': [('state', '!=', 'draft')]
+                }"
                 />
                 <field
                     name="fiscal_operation_id"


### PR DESCRIPTION
O campo "document_type_id" deve ser exibido apenas quando o account.move for uma invoice. Antes estava sendo exibido sempre.

Resolve o #1949 