### PR TITLE
[14.0][l10n_br_nfe][FIX] fix #2035 inconsistent/spurious translations

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -390,7 +390,10 @@ class NFe(spec_models.StackedModel):
     # TODO  Verificar as operações de bonificação se o desconto sai correto
     # nfe40_vDesc = fields.Monetary(related="amount_financial_discount_value")
     # nfe40_vDesc = fields.Monetary(related="amount_discount_value")
-    nfe40_vDesc = fields.Monetary(related="amount_discount_value")
+    nfe40_vDesc = fields.Monetary(
+        string="Montante de Desconto",
+        related="amount_discount_value",
+    )
 
     nfe40_vII = fields.Monetary(related="amount_ii_value")
 
@@ -406,7 +409,10 @@ class NFe(spec_models.StackedModel):
         string="valor do COFINS (NFe)", related="amount_cofins_value"
     )
 
-    nfe40_vOutro = fields.Monetary(related="amount_other_value")
+    nfe40_vOutro = fields.Monetary(
+        string="Outros Custos",
+        related="amount_other_value",
+    )
 
     nfe40_vNF = fields.Monetary(related="amount_total")
 


### PR DESCRIPTION
Resolve https://github.com/OCA/l10n-brazil/issues/2035

o problema é que no Odoo quando um campo è sobrecarregado em varios mixins injectados num modelo e que são mixins de um mesmo modulo (aqui l10n_br_nfe_spec), a gente não tem certeza da ordem na qual esses mixins podem redefinir o mesmo attributo (aqui `string`) caso sobrecarregam o mesmo campo. O caso é raro, mas ainda temos esses 2 casos com a NFe:

`nfe40_vOutro = fields.Monetary(related="amount_other_value")`
Pelos mixins xsd fiscais do l10n_br_nfe_spec, esse campo tb pode pegar o string dele pelos mixins:
'nfe.40.icmstot'
https://github.com/OCA/l10n-brazil/blob/12.0/l10n_br_nfe_spec/models/v4_00/leiauteNFe.py#L1844
'nfe.40.issqntot'
https://github.com/OCA/l10n-brazil/blob/12.0/l10n_br_nfe_spec/models/v4_00/leiauteNFe.py#L2203
De acordo com o modulo l10n_br_fiscal, foi colocado de forma genérica: string="Outros Custos"

`nfe40_vDesc = fields.Monetary(related="amount_discount_value")`
Pelos mixins xsd fiscais do l10n_br_nfe_spec, esse campo tb pode pegar o string dele pelos mixins:
'nfe.40.icmstot'
https://github.com/OCA/l10n-brazil/blob/12.0/l10n_br_nfe_spec/models/v4_00/leiauteNFe.py#L1813
'nfe.40.fat'
https://github.com/OCA/l10n-brazil/blob/12.0/l10n_br_nfe_spec/models/v4_00/leiauteNFe.py#L3629
De acordo com o modulo l10n_br_fiscal, foi colocado de forma genérica: string="Montante de Desconto"

cc @renatonlima @marcelsavegnago @netosjb @felipemotter @mileo 