### PR TITLE
[14.0][IMP] l10n_br_nfe: add accountant cnpj_cpf on autXML tag

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -514,6 +514,29 @@ class NFe(spec_models.StackedModel):
         related="company_id.technical_support_id",
     )
 
+    ##########################
+    # NF-e tag: autXML
+    # Compute Methods
+    ##########################
+
+    def _default_nfe40_autxml(self):
+        company = self.env.company
+        authorized_partners = []
+        if company.accountant_id and company.nfe_authorize_accountant_download_xml:
+            authorized_partners.append(company.accountant_id.id)
+        if (
+            company.technical_support_id
+            and company.nfe_authorize_technical_download_xml
+        ):
+            authorized_partners.append(company.technical_support_id.id)
+        return authorized_partners
+
+    ##########################
+    # NF-e tag: autXML
+    ##########################
+
+    nfe40_autXML = fields.One2many(default=_default_nfe40_autxml)
+
     ################################
     # Framework Spec model's methods
     ################################

--- a/l10n_br_nfe/models/res_company.py
+++ b/l10n_br_nfe/models/res_company.py
@@ -100,6 +100,18 @@ class ResCompany(spec_models.SpecModel):
         string="NF-e Default Serie",
     )
 
+    nfe_authorize_accountant_download_xml = fields.Boolean(
+        string="Include Accountant Partner data in persons authorized to "
+        "download NFe XML",
+        default=False,
+    )
+
+    nfe_authorize_technical_download_xml = fields.Boolean(
+        string="Include Technical Support Partner data in persons authorized to "
+        "download NFe XML",
+        default=False,
+    )
+
     def _build_attr(self, node, fields, vals, path, attr):
         if attr.get_name() == "enderEmit" and self.env.context.get("edoc_type") == "in":
             # we don't want to try build a related partner_id for enderEmit

--- a/l10n_br_nfe/models/res_config_settings.py
+++ b/l10n_br_nfe/models/res_config_settings.py
@@ -41,3 +41,17 @@ class ResConfigSettings(models.TransientModel):
         string="NFe Proc Version",
         config_parameter="l10n_br_nfe.version.name",
     )
+
+    nfe_authorize_accountant_download_xml = fields.Boolean(
+        string="Include Accountant Partner data in persons authorized to "
+        "download NFe XML",
+        related="company_id.nfe_authorize_accountant_download_xml",
+        readonly=False,
+    )
+
+    nfe_authorize_technical_download_xml = fields.Boolean(
+        string="Include Technical Support Partner data in persons authorized to "
+        "download NFe XML",
+        related="company_id.nfe_authorize_technical_download_xml",
+        readonly=False,
+    )

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -30,6 +30,7 @@ class ResPartner(spec_models.SpecModel):
         "nfe.40.dest",
         "nfe.40.tenderemi",
         "nfe.40.tinfresptec",
+        "nfe.40.autxml",
     ]
     _nfe_search_keys = ["nfe40_CNPJ", "nfe40_CPF", "nfe40_xNome"]
 
@@ -96,6 +97,11 @@ class ResPartner(spec_models.SpecModel):
         compute="_compute_nfe_data",
         compute_sudo=True,
         string="CNPJ/CPF/idEstrangeiro",
+    )
+
+    nfe40_choice8 = fields.Selection(
+        selection=[("nfe40_CNPJ", "CNPJ"), ("nfe40_CPF", "CPF")],
+        string="CNPJ/CPF do Parceiro Autorizado",
     )
 
     def _compute_nfe40_xEnder(self):

--- a/l10n_br_nfe/views/nfe_document_view.xml
+++ b/l10n_br_nfe/views/nfe_document_view.xml
@@ -37,6 +37,14 @@
                   <field name="nfe40_detPag" />
               </group>
           </page>
+          <page name="others" position="inside">
+              <group
+                    name="nfe_autxml"
+                    attrs="{'invisible': [('document_type', 'not in', ['55', '65'])]}"
+                >
+                <field name="nfe40_autXML" widget="many2many" />
+              </group>
+          </page>
       </field>
   </record>
 

--- a/l10n_br_nfe/views/res_company_view.xml
+++ b/l10n_br_nfe/views/res_company_view.xml
@@ -19,6 +19,8 @@
                                 name="nfe_default_serie_id"
                                 domain="[('document_type_id', '=', %(l10n_br_fiscal.document_55)d)]"
                             />
+                          <field name="nfe_authorize_accountant_download_xml" />
+                          <field name="nfe_authorize_technical_download_xml" />
                       </group>
                   </group>
               </page>


### PR DESCRIPTION
Em alguns estados é exigido a informação do cnpj do contador na tag autXML. Acredito que neste caberia também informar o cnpj do responsável técnico também. 

Implementei um compute no campo  nfe40_autXML que por ora atenderia e tentei ser o menos intrusivo possível. 

@rvalyi se puder dar uma olhada e criticar, eu agradeço :)

