### PR TITLE
[12.0][l10n_br_nfe][FIX]  xFant same label warning

### DIFF
--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -65,7 +65,7 @@ class ResPartner(spec_models.SpecModel):
 
     # nfe.40.dest
     nfe40_xNome = fields.Char(related="legal_name")
-    nfe40_xFant = fields.Char(related="name")
+    nfe40_xFant = fields.Char(related="name", string="Nome Fantasia")
     nfe40_enderDest = fields.Many2one(
         comodel_name="res.partner", compute="_compute_nfe40_enderDest"
     )


### PR DESCRIPTION
backport de https://github.com/OCA/l10n-brazil/pull/2025

o @renatonlima tinha tb feito o fix no PR de cleanup da NFe rascunho https://github.com/OCA/l10n-brazil/pull/2000
porem fica mais limpo se o PR se esse backport esta separado do PR de refator para ter o port do PR de cleanup mais alinhado entre a 12 e a 14.