### PR TITLE
[12.0][FIX] If you create NF-e without payment_mode_id

### DIFF
--- a/l10n_br_account_nfe/models/document_workflow.py
+++ b/l10n_br_account_nfe/models/document_workflow.py
@@ -38,6 +38,9 @@ class DocumentWorkflow(models.AbstractModel):
         for record in self.filtered(filter_nfe):
             record.nfe40_dup = [(5,)]
             record.nfe40_detPag = [(5,)]
+            ind_pag = "0"
+            fiscal_payment_mode = "90"
+            v_pag = 0.00
             if (
                 record.amount_financial_total
                 and record.edoc_purpose != EDOC_PURPOSE_DEVOLUCAO
@@ -57,7 +60,10 @@ class DocumentWorkflow(models.AbstractModel):
                 record.nfe40_dup = [(6, 0, duplicatas.ids)]
 
                 # TAG - Pagamento
-                if not record.invoice_ids.payment_mode_id.fiscal_payment_mode:
+                if (
+                    record.invoice_ids.payment_mode_id
+                    and not record.invoice_ids.payment_mode_id.fiscal_payment_mode
+                ):
                     raise UserError(
                         _(
                             "Payment Mode {} should has Fiscal Payment Mode"
@@ -75,10 +81,6 @@ class DocumentWorkflow(models.AbstractModel):
                     record.invoice_ids.payment_mode_id.fiscal_payment_mode
                 )
                 v_pag = record.amount_financial_total
-            else:
-                ind_pag = "0"
-                fiscal_payment_mode = "90"
-                v_pag = 0.00
 
             pagamentos = record.env["nfe.40.detpag"].create(
                 {

--- a/l10n_br_account_nfe/models/document_workflow.py
+++ b/l10n_br_account_nfe/models/document_workflow.py
@@ -10,6 +10,7 @@ from odoo.exceptions import UserError
 
 from odoo.addons.l10n_br_fiscal.constants.fiscal import (
     DOCUMENT_ISSUER_COMPANY,
+    EDOC_PURPOSE_AJUSTE,
     EDOC_PURPOSE_DEVOLUCAO,
     MODELO_FISCAL_NFCE,
     MODELO_FISCAL_NFE,
@@ -41,9 +42,9 @@ class DocumentWorkflow(models.AbstractModel):
             ind_pag = "0"
             fiscal_payment_mode = "90"
             v_pag = 0.00
-            if (
-                record.amount_financial_total
-                and record.edoc_purpose != EDOC_PURPOSE_DEVOLUCAO
+            if record.amount_financial_total and record.edoc_purpose not in (
+                EDOC_PURPOSE_DEVOLUCAO,
+                EDOC_PURPOSE_AJUSTE,
             ):
                 # TAG - Cobrança
                 duplicatas = record.env["nfe.40.dup"]


### PR DESCRIPTION
# Esse PR faz duas correções

## Caso não seja preenchido o campo Modo de pagamento (payment_mode_id)

Quando não é informado nenhum modo de pagamento deve ser gerado a tag 90=Sem Pagamento

## Em NF-e e NFC-e de devolução ou ajuste

Segundo a NT deve ser informado o código 90=Sem Pagamento

![image](https://user-images.githubusercontent.com/211005/181093249-c7a20b53-88d7-49ef-9c88-3d649a57aec6.png)