### PR TITLE
[FIX] brcobranca: add cep in sacado_endereco

### DIFF
--- a/l10n_br_account_payment_brcobranca/models/account_move_line.py
+++ b/l10n_br_account_payment_brcobranca/models/account_move_line.py
@@ -79,7 +79,9 @@ class AccountMoveLine(models.Model):
                 + " "
                 + (move_line.partner_id.city_id.name or "")
                 + " - "
-                + (move_line.partner_id.state_id.name or ""),
+                + (move_line.partner_id.state_id.name or "")
+                + " - "
+                + ("CEP:" + move_line.partner_id.zip or ""),
                 "data_processamento": move_line.move_id.invoice_date.strftime(
                     "%Y/%m/%d"
                 ),


### PR DESCRIPTION
No processo de homologação do banco do brasil, foi informado que faltava informar o CEP do Pagador na impressão do Boleto.
![image](https://user-images.githubusercontent.com/634278/181130270-99b12525-1105-450f-8aee-6e021ad20892.png)

