### PR TITLE
[14.0][RFC] l10n_br_contract: add brazilian fiscal data on contract line form

### DIFF
--- a/l10n_br_contract/models/contract_contract.py
+++ b/l10n_br_contract/models/contract_contract.py
@@ -11,6 +11,7 @@ class ContractContract(models.Model):
     currency_id = fields.Many2one(
         readonly=False,
     )
+    country_id = fields.Many2one(related="company_id.country_id", store=True)
 
     @api.model
     def _fiscal_operation_domain(self):

--- a/l10n_br_contract/models/contract_contract.py
+++ b/l10n_br_contract/models/contract_contract.py
@@ -13,6 +13,11 @@ class ContractContract(models.Model):
     )
     country_id = fields.Many2one(related="company_id.country_id", store=True)
 
+    contract_recalculate_taxes_before_invoice = fields.Boolean(
+        string="Recalculate taxes before invoicing",
+        default="company.contract_recalculate_taxes_before_invoice",
+    )
+
     @api.model
     def _fiscal_operation_domain(self):
         domain = [("state", "=", "approved")]

--- a/l10n_br_contract/models/contract_line.py
+++ b/l10n_br_contract/models/contract_line.py
@@ -13,6 +13,7 @@ class ContractLine(models.Model):
     company_id = fields.Many2one(
         related="contract_id.company_id",
     )
+    country_id = fields.Many2one(related="company_id.country_id", store=True)
 
     fiscal_tax_ids = fields.Many2many(
         comodel_name="l10n_br_fiscal.tax",

--- a/l10n_br_contract/models/contract_line.py
+++ b/l10n_br_contract/models/contract_line.py
@@ -1,7 +1,7 @@
 # Copyright 2020 KMEE INFORMATICA LTDA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
+from odoo import fields, models
 
 from ...l10n_br_fiscal.constants.fiscal import TAX_FRAMEWORK
 
@@ -77,11 +77,3 @@ class ContractLine(models.Model):
             invoice_line_vals["quantity"] = quantity
             invoice_line_vals["tax_ids"] = tax_ids.ids
         return invoice_line_vals
-
-    @api.model
-    def create(self, values):
-        res = super().create(values)
-        if res.contract_id.fiscal_operation_id and not res.fiscal_operation_id:
-            res.fiscal_operation_id = res.contract_id.fiscal_operation_id
-            res._onchange_fiscal_operation_id()
-        return res

--- a/l10n_br_contract/models/contract_line.py
+++ b/l10n_br_contract/models/contract_line.py
@@ -50,7 +50,8 @@ class ContractLine(models.Model):
 
         contract = self.contract_id
 
-        self._onchange_fiscal_operation_id()
+        if contract.contract_recalculate_taxes_before_invoice:
+            self._onchange_fiscal_operation_id()
 
         invoice_line_vals = super()._prepare_invoice_line(move_form)
 

--- a/l10n_br_contract/models/res_company.py
+++ b/l10n_br_contract/models/res_company.py
@@ -19,3 +19,7 @@ class ResCompany(models.Model):
         string="Default Contract Purchase Fiscal Operation",
         required=False,
     )
+
+    contract_recalculate_taxes_before_invoice = fields.Boolean(
+        string="Dafault recalculate taxes before invoicing", default=True
+    )

--- a/l10n_br_contract/views/contract_line.xml
+++ b/l10n_br_contract/views/contract_line.xml
@@ -1,22 +1,98 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright 2020 KMEE
+     Copyright 2021 - TODAY, Escodoo
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
     <record id="contract_line_form_view" model="ir.ui.view">
-        <field name="name">contract.line form view (in contract)</field>
+        <field
+            name="name"
+        >contract.contract.line form view (in l10n_br_contract)</field>
         <field name="model">contract.line</field>
         <field name="inherit_id" ref="contract.contract_line_form_view" />
         <field name="arch" type="xml">
              <xpath expr="//field[@name='discount']/.." position="after">
-                 <group name="fiscal">
-                     <field name="fiscal_operation_id" />
-                     <field name="fiscal_operation_line_id" readonly="1" />
-                     <field
-                        name="fiscal_tax_ids"
-                        widget="many2many_tags"
-                        readonly="1"
+                 <group name="fiscal_fields" invisible="1">
+                     <field name="fiscal_operation_type" invisible="1" readonly="1" />
+                     <field name="fiscal_genre_code" invisible="1" />
+                     <field name="tax_framework" invisible="1" />
+                     <field name="tax_icms_or_issqn" invisible="1" />
+                </group>
+                 <group
+                    name="fiscal"
+                    attrs="{'invisible': ['|', ('display_type', '=', 'line_section'), '&amp;', ('display_type', '=', 'line_note'), ('note_invoicing_mode', '!=', 'custom')]}"
+                >
+                    <field
+                        name="fiscal_operation_id"
+                        options="{'no_create': True}"
+                        attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
+                    />
+                    <field
+                        name="fiscal_operation_line_id"
+                        options="{'no_create': True}"
+                        attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
+                    />
+                    <field
+                        name="cfop_id"
+                        options="{'no_create': True}"
+                        attrs="{'invisible': ['|', ('tax_icms_or_issqn', '=', 'issqn'), ('country_id', '!=', %(base.br)d)]}"
+                    />
+                    <field
+                        name="service_type_id"
+                        options="{'no_create': True}"
+                        attrs="{'invisible': ['|', ('tax_icms_or_issqn', '=', 'icms'), ('country_id', '!=', %(base.br)d)]}"
+                    />
+                    <field
+                        name="city_taxation_code_id"
+                        attrs="{'invisible': ['|', ('tax_icms_or_issqn', '=', 'icms'), ('country_id', '!=', %(base.br)d)]}"
+                        options="{'no_create': True}"
+                    />
+                    <field
+                        name="cnae_id"
+                        attrs="{'invisible': ['|', ('tax_icms_or_issqn', '=', 'icms'), ('country_id', '!=', %(base.br)d)]}"
+                        options="{'no_create': True}"
                     />
                  </group>
+            </xpath>
+            <xpath expr="//sheet" position="inside">
+                <field name="country_id" invisible="1" />
+                <notebook
+                    attrs="{'invisible': ['|', ('display_type', '=', 'line_section'), '&amp;', ('display_type', '=', 'line_note'), ('note_invoicing_mode', '!=', 'custom')]}"
+                >
+                    <page
+                        name="fiscal_taxes"
+                        string="Taxes"
+                        attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
+                    />
+                    <page
+                        name="amounts"
+                        string="Amounts"
+                        attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
+                    >
+                        <group>
+                            <group>
+                                <field name="amount_untaxed" />
+                                <field name="amount_fiscal" />
+                                <field name="amount_tax" />
+                                <field name="estimate_tax" readonly="1" />
+                            </group>
+                            <group>
+                                <field name="amount_total" />
+                                <field name="amount_tax_withholding" readonly="1" />
+                                <field name="amount_taxed" />
+                            </group>
+                        </group>
+                    </page>
+                    <page
+                        name="fiscal_line_extra_info"
+                        string="Extra Info"
+                        attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
+                    />
+                </notebook>
+            </xpath>
+            <xpath expr="//group[@name='recurrence_info']" position="attributes">
+                <attribute name="attrs">
+                    {'invisible': ['|','|', ('display_type', '=', 'line_section'), ('parent.line_recurrence', '!=', True), '&amp;', ('display_type', '=', 'line_note'), ('note_invoicing_mode', '!=', 'custom')]}
+                </attribute>
             </xpath>
         </field>
     </record>

--- a/l10n_br_contract/views/contract_view.xml
+++ b/l10n_br_contract/views/contract_view.xml
@@ -15,6 +15,10 @@
                     options="{'no_create': True}"
                     attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
                 />
+                <field
+                    name="contract_recalculate_taxes_before_invoice"
+                    attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
+                />
             </field>
             <xpath
                 expr="//field[@name='contract_line_fixed_ids']"

--- a/l10n_br_contract/views/contract_view.xml
+++ b/l10n_br_contract/views/contract_view.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2020 KMEE
+     Copyright 2021 - TODAY, Escodoo
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
     <record id="contract_contract_form_view" model="ir.ui.view">
         <field name="name">contract.contract form view (in l10n_br_contract)</field>
@@ -6,7 +9,12 @@
         <field name="inherit_id" ref="contract.contract_contract_form_view" />
         <field name="arch" type="xml">
             <field name="fiscal_position_id" position="after">
-                <field name="fiscal_operation_id" />
+                <field name="country_id" invisible="1" />
+                <field
+                    name="fiscal_operation_id"
+                    options="{'no_create': True}"
+                    attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
+                />
             </field>
             <xpath
                 expr="//field[@name='contract_line_fixed_ids']"
@@ -21,34 +29,38 @@
                     name="context"
                 >{'default_fiscal_operation_id': fiscal_operation_id, 'default_partner_id': partner_id, 'default_company_id': company_id}</attribute>
             </xpath>
-
+            <xpath
+                expr="//field[@name='contract_line_fixed_ids']/tree"
+                position="attributes"
+            >
+                <attribute name="editable" />
+            </xpath>
             <xpath
                 expr="//field[@name='contract_line_fixed_ids']/tree/button"
                 position="before"
             >
-                <field name="fiscal_operation_id" readonly="1" optional="hide" />
-                <field name="fiscal_operation_line_id" readonly="1" optional="hide" />
+                <field name="country_id" invisible="1" />
                 <field
                     name="fiscal_tax_ids"
                     widget="many2many_tags"
-                    readonly="1"
+                    options="{'no_create': True}"
                     optional="hide"
+                    attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
                 />
             </xpath>
             <xpath
                 expr="//field[@name='contract_line_ids']/tree/button"
                 position="before"
             >
-                <field name="fiscal_operation_id" readonly="1" optional="hide" />
-                <field name="fiscal_operation_line_id" readonly="1" optional="hide" />
+                <field name="country_id" invisible="1" />
                 <field
                     name="fiscal_tax_ids"
                     widget="many2many_tags"
-                    readonly="1"
+                    options="{'no_create': True}"
                     optional="hide"
+                    attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
                 />
             </xpath>
-
         </field>
     </record>
 </odoo>

--- a/l10n_br_contract/views/res_company.xml
+++ b/l10n_br_contract/views/res_company.xml
@@ -14,6 +14,7 @@
                         <group>
                             <field name="contract_sale_fiscal_operation_id" />
                             <field name="contract_purchase_fiscal_operation_id" />
+                            <field name="contract_recalculate_taxes_before_invoice" />
                         </group>
                     </group>
                 </page>


### PR DESCRIPTION
Pessoal.. fiz algumas mudanças..

Removi o recalculo da operação fiscal que implementei recentemente no método de preparação dos dados para a invoice e buscando maior controle adicionei os dados fiscais no form da linha do contrato e mudei a inclusão de linha de contrato para ser via form já que hoje os dados fiscais são injetados no form e não na tree (algo que podemos avaliar futuramente conforme sugerido pelo @rvalyi nesta issue #1678)