### PR TITLE
[14.0][FIX] fiscal dummy in new companies

### DIFF
--- a/l10n_br_fiscal/tests/test_fiscal_document_generic.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_generic.py
@@ -1045,6 +1045,19 @@ class TestFiscalDocumentGeneric(SavepointCase):
         with self.assertRaises(UserError):
             dummy_line.unlink()
 
+    def test_create_company_fiscal_dummy(self):
+        """Check Company Consistency in Fiscal Dummy"""
+        company = self.env["res.company"].create(
+            {
+                "name": "Company Test Fiscal BR",
+                "cnpj_cpf": "42.245.642/0001-09",
+                "country_id": self.env.ref("base.br").id,
+                "state_id": self.env.ref("base.state_br_sp").id,
+            }
+        )
+        self.assertEqual(company.fiscal_dummy_id.company_id, company)
+        self.assertEqual(company.fiscal_dummy_id.fiscal_line_ids[0].company_id, company)
+
     def test_nfe_comments(self):
         self.nfe_not_taxpayer._document_comment()
         additional_data = self.nfe_not_taxpayer.fiscal_line_ids[0].additional_data


### PR DESCRIPTION
Quando uma company é criada depois de o fiscal já estar instalado, ela não consegue identificar a empresa sendo criada e acaba colocando no fiscal_dummy a empresa em que o usuário está ativo. 

Como eles são requisitos um para o outro e são criados juntamente,  essa foi a forma que encontrei de contornar a situação.

![erro](https://user-images.githubusercontent.com/6812128/181650546-b73d84e5-c562-44cd-a5b5-80bbf8e8bc3e.png)
