### PR TITLE
[REF] brcobranca: state abbreviation in address

### DIFF
--- a/l10n_br_account_payment_brcobranca/models/account_move_line.py
+++ b/l10n_br_account_payment_brcobranca/models/account_move_line.py
@@ -47,16 +47,16 @@ class AccountMoveLine(models.Model):
                 "valor": str("%.2f" % move_line.debit),
                 "cedente": move_line.company_id.partner_id.legal_name,
                 "cedente_endereco": (move_line.company_id.partner_id.street_name or "")
-                + ", "
+                + " "
                 + (move_line.company_id.partner_id.street_number or "")
-                + " - "
+                + ", "
                 + (move_line.company_id.partner_id.district or "")
-                + " - "
+                + ", "
                 + (move_line.company_id.partner_id.city_id.name or "")
                 + " - "
-                + ("CEP:" + move_line.company_id.partner_id.zip or "")
-                + " - "
-                + (move_line.company_id.partner_id.state_id.code or ""),
+                + (move_line.company_id.partner_id.state_id.code or "")
+                + " "
+                + ("CEP:" + move_line.company_id.partner_id.zip or ""),
                 "documento_cedente": move_line.company_id.cnpj_cpf,
                 "sacado": move_line.partner_id.legal_name,
                 "sacado_documento": move_line.partner_id.cnpj_cpf,
@@ -74,13 +74,15 @@ class AccountMoveLine(models.Model):
                 "moeda": DICT_BRCOBRANCA_CURRENCY["R$"],
                 "aceite": move_line.payment_mode_id.boleto_accept,
                 "sacado_endereco": (move_line.partner_id.street_name or "")
-                + ", "
-                + (move_line.partner_id.street_number or "")
                 + " "
+                + (move_line.partner_id.street_number or "")
+                + ", "
+                + (move_line.partner_id.district or "")
+                + ", "
                 + (move_line.partner_id.city_id.name or "")
                 + " - "
-                + (move_line.partner_id.state_id.name or "")
-                + " - "
+                + (move_line.partner_id.state_id.code or "")
+                + " "
                 + ("CEP:" + move_line.partner_id.zip or ""),
                 "data_processamento": move_line.move_id.invoice_date.strftime(
                     "%Y/%m/%d"


### PR DESCRIPTION
Mais um pequeno refactor na formatação do endereço que é impresso nos boletos.

Antes:
![181937215-052e7b53-b655-4b06-9d67-11e678cce65e](https://user-images.githubusercontent.com/634278/182031809-0c903603-e308-4019-85ad-68b180e79aa5.png)

Depois:
![2022-07-31_11-39](https://user-images.githubusercontent.com/634278/182031826-d47c7fea-f32d-42d4-8a94-5e69d43c3370.png)

1) Alterado estado para a forma abreviada.
2)  Adicionado o bairro.

