### PR TITLE
[12.0] l10n_br_fiscal: Aplicação de ST para produtos com origem de ICMS estrangeira

### DIFF
--- a/l10n_br_fiscal/data/l10n_br_fiscal.tax.csv
+++ b/l10n_br_fiscal/data/l10n_br_fiscal.tax.csv
@@ -84,6 +84,7 @@
 "tax_icms_12_red_41_67","ICMS 12% Com Red. 41,67%","percent","12.00","41.67","tax_group_icms","cst_icms_20","cst_icms_20",,,,,"0","4",,
 "tax_icms_12_red_53_33","ICMS 12% Com Red. 53,33%","percent","12.00","53.33","tax_group_icms","cst_icms_20","cst_icms_20",,,,,"0","4",,
 "tax_icms_18_red_68_89","ICMS 18% Com Red. 68,89%","percent","18.00","68.89","tax_group_icms","cst_icms_20","cst_icms_20",,,,,"0","4",,
+"tax_icms_4_st","ICMS 4% c/ ST","percent","4.00","0.00","tax_group_icms","cst_icms_10","cst_icms_10",,,,,"0","4",,
 "tax_icmsst_29_43","ICMS MVA 29,43%","percent","18.00","0.00","tax_group_icmsst",,,,,,,"0","4","29.43",
 "tax_icmsst_40","ICMS MVA 40%","percent","18.00","0.00","tax_group_icmsst",,,,,,,"0","4","40",
 "tax_icmsst_42_73","ICMS MVA 42,73%","percent","18.00","0.00","tax_group_icmsst",,,,,,,"0","4","42.73",

--- a/l10n_br_fiscal/data/l10n_br_fiscal_tax_icms_data.xml
+++ b/l10n_br_fiscal/data/l10n_br_fiscal_tax_icms_data.xml
@@ -5,6 +5,7 @@
   <record id="tax_icms_regulation" model="l10n_br_fiscal.icms.regulation">
     <field name="name">Regulamento do ICMS</field>
     <field name="icms_imported_tax_id" ref="l10n_br_fiscal.tax_icms_4" />
+    <field name="icms_imported_with_st_tax_id" ref="l10n_br_fiscal.tax_icms_4_st" />
   </record>
 
   <!-- ICMS - Simples Faturamento -->

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -6,6 +6,7 @@ from . import test_partner_profile
 from . import test_certificate
 from . import test_ibpt_product
 from . import test_ibpt_service
+from . import test_icms_regulation
 from . import test_workflow
 from . import test_fiscal_document_generic
 from . import test_fiscal_closing

--- a/l10n_br_fiscal/tests/test_icms_regulation.py
+++ b/l10n_br_fiscal/tests/test_icms_regulation.py
@@ -1,0 +1,53 @@
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("icms")
+class TestICMSRegulation(TransactionCase):
+    def setUp(self):
+        super().setUp()
+
+        self.env["l10n_br_fiscal.tax.definition"].create(
+            {
+                "icms_regulation_id": self.env.ref(
+                    "l10n_br_fiscal.tax_icms_regulation"
+                ).id,
+                "ncms": "7323.99.00",
+                "state_from_id": self.env.ref("base.state_br_sp").id,
+                "state_to_ids": [(6, 0, [self.env.ref("base.state_br_mg").id])],
+                "is_taxed": True,
+                "is_debit_credit": True,
+                "tax_id": self.env.ref("l10n_br_fiscal.tax_icmsst_57").id,
+                "tax_group_id": self.env.ref("l10n_br_fiscal.tax_group_icmsst").id,
+                "state": "approved",
+            }
+        )
+
+        self.nbm = self.env["l10n_br_fiscal.nbm"]
+        self.cst_icms_00 = self.env.ref("l10n_br_fiscal.cst_icms_00")
+        self.cst_icms_10 = self.env.ref("l10n_br_fiscal.cst_icms_10")
+        self.icms_regulation = self.env.ref("l10n_br_fiscal.tax_icms_regulation")
+        self.venda_operation_line_id = self.env.ref("l10n_br_fiscal.fo_venda_venda")
+
+    def test_icms_imported_with_st(self):
+        self.partner = self.env.ref("l10n_br_base.res_partner_cliente9_mg")
+        self.company = self.env.ref("base.main_company")
+        self.product = self.env.ref("product.product_product_9")
+        tax_icms = self.find_icms_tax()
+        self.assertEqual(tax_icms.cst_out_id, self.cst_icms_10)
+
+    def test_icms_imported_without_st(self):
+        self.partner = self.env.ref("l10n_br_base.res_partner_cliente7_rs")
+        self.company = self.env.ref("base.main_company")
+        self.product = self.env.ref("product.product_product_9")
+        tax_icms = self.find_icms_tax()
+        self.assertEqual(tax_icms.cst_out_id, self.cst_icms_00)
+
+    def find_icms_tax(self):
+        return self.icms_regulation.map_tax_icms(
+            company=self.company,
+            partner=self.partner,
+            product=self.product,
+            nbm=self.nbm,
+            operation_line=self.venda_operation_line_id,
+        )

--- a/l10n_br_fiscal/views/icms_regulation_view.xml
+++ b/l10n_br_fiscal/views/icms_regulation_view.xml
@@ -30,6 +30,7 @@
               <group>
                 <field name="name" required="1" />
                 <field name="icms_imported_tax_id" required="1" />
+                <field name="icms_imported_with_st_tax_id" required="1" />
               </group>
               <notebook>
               </notebook>


### PR DESCRIPTION
   Atualmente o sistema não suporta a aplicação de substituição tributária para produtos com origem do ICMS estrangeira.
   Quando um produto com uma destas origens de ICMS é selecionado em uma venda, o registro selecionado em icms_imported_tax_id do Regulamento ICMS é selecionado automaticamente. Porém esta definição de imposto está atrelada com o CST '00 - Tributado integralmente'.
   Este PR adiciona um novo campo ao Regulamento de ICMS, onde pode ser inserida a definição de imposto a ser utilizada quando o produto importado estiver sujeito a ST, além da lógica necessária para que este registro seja selecionado e de um registro padrão para o campo.

![Screenshot from 2022-08-03 10-36-45](https://user-images.githubusercontent.com/63242917/182622598-25c280c1-2097-4b28-884f-a515f1120dc6.png)
Novo campo no Regulamento ICMS

![Screenshot from 2022-08-03 10-36-58](https://user-images.githubusercontent.com/63242917/182622709-4397eb71-f4f2-49c6-bf70-a4dd2a161d97.png)
Registro padrão do novo campo

![Screenshot from 2022-08-03 10-37-36](https://user-images.githubusercontent.com/63242917/182622799-d5e6dea1-3529-4e1d-a619-65831bec8da1.png)
Produto usado no exemplo abaixo

![Screenshot from 2022-08-03 10-38-12](https://user-images.githubusercontent.com/63242917/182622909-d4a83073-d2c4-4ef1-8457-d8591cd1b917.png)
Exemplo de criação de order_line para produto importado sujeito a ST





