### PR TITLE
[12.0] l10n_br_fiscal: Arruma calculo da base do ICMS ST

### DIFF
--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -192,10 +192,11 @@ class Tax(models.Model):
         insurance_value = kwargs.get("insurance_value", 0.00)
         freight_value = kwargs.get("freight_value", 0.00)
         other_value = kwargs.get("other_value", 0.00)
+        add_to_base = kwargs.get("add_to_base", 0.00)
 
         if tax.tax_group_id.base_with_additional_values:
             tax_dict["add_to_base"] += sum(
-                [freight_value, insurance_value, other_value]
+                [add_to_base, freight_value, insurance_value, other_value]
             )
         tax_dict["remove_from_base"] += sum([discount_value])
 


### PR DESCRIPTION
No calculo do valor do ICMS ST é adicionado o campo 'add_to_base' ao kwargs. Porém este valor é ignorado no método _compute_tax_base.

https://github.com/OCA/l10n-brazil/blob/709397bd6f6a8042b26d2297c7df927f3bc9e207/l10n_br_fiscal/models/tax.py#L487-L492

https://github.com/OCA/l10n-brazil/blob/709397bd6f6a8042b26d2297c7df927f3bc9e207/l10n_br_fiscal/models/tax.py#L182-L197

Este PR adiciona este valor na soma da base de cálculo do imposto.

