### PR TITLE
[12.0][FIX] Missing 1 required positional argument in get_brcobranca_api_url

### DIFF
--- a/l10n_br_account_payment_brcobranca/models/account_move_line.py
+++ b/l10n_br_account_payment_brcobranca/models/account_move_line.py
@@ -184,7 +184,7 @@ class AccountMoveLine(models.Model):
         boleto_data = self._prepare_boleto_cnab_vals()
         bank = boleto_data.pop("bank")
         data = json.dumps(boleto_data, separators=(",", ":"))
-        brcobranca_api_url = get_brcobranca_api_url()
+        brcobranca_api_url = get_brcobranca_api_url(self.env)
         brcobranca_service_url = brcobranca_api_url + "/api/boleto/nosso_numero"
         res = requests.get(brcobranca_service_url, params={"bank": bank, "data": data})
         if str(res.status_code)[0] == "2":


### PR DESCRIPTION
Ao tentar imprimir um boleto esta sendo gerado um erro:

```
  interval.own_number_boleto = interval.generate_own_number_boleto()
 File "/odoo/external-src/l10n-brazil/l10n_br_account_payment_brcobranca/models/account_move_line.py", line 198, in generate_own_number_boleto
   brcobranca_api_url = get_brcobranca_api_url()
TypeError: get_brcobranca_api_url() missing 1 required positional argument: 'env'
```

O problema acontece porque no PR #2054 faltou informar o argumento env na chamada do método get_brcobranca_api_url() no arquivo account_move_line.py, Esse PR adicionar o argumento faltante.
