### PR TITLE
[12.0][FIX] added ind_final in purchase order form

### DIFF
--- a/l10n_br_purchase/views/purchase_view.xml
+++ b/l10n_br_purchase/views/purchase_view.xml
@@ -22,6 +22,7 @@
           <field name="arch" type="xml">
               <xpath expr="//field[@name='company_id']" position="after">
                   <field name="fiscal_operation_id" required="1" />
+                  <field name="ind_final" />
               </xpath>
               <xpath expr="//field[@name='order_line']" position="attributes">
                   <attribute


### PR DESCRIPTION
Adicionado o campo ind_final na visão do purchase.order pois esse campo é atualizado com o valor no cadastro do parceiro  no onchange do partner_id, mas como o campo não esta na visão, esse campo não estava sendo preenchido no onchange.