### PR TITLE
[12.0] l10n_br_fiscal: Arruma condição para aplicação do Difal

### DIFF
--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -361,7 +361,6 @@ class Tax(models.Model):
             company.state_id != partner.state_id
             and operation_line.fiscal_operation_type == FISCAL_OUT
             and partner.ind_ie_dest == NFE_IND_IE_DEST_9
-            and not partner.is_company
             and tax_dict.get("tax_value")
         ):
             tax_icms_difal = company.icms_regulation_id.map_tax_icms_difal(


### PR DESCRIPTION
Em #1963 foi incluida a condição abaixo para a aplicação do ICMS Difal. 

https://github.com/OCA/l10n-brazil/blob/dec4442f6d97eacd44447d33de16de564ddaf65c/l10n_br_fiscal/models/tax.py#L362

Ela já havia sido questionada pelo @marcelsavegnago aqui 
https://github.com/OCA/l10n-brazil/pull/1519#discussion_r708681703

Esta condição está incorreta, estamos com um caso agora onde é feita uma venda para um cliente que é uma empresa e não é contribuinte do icms, e o difal deve ser aplicado.