### PR TITLE
[14.0][l10n_br_fiscal][l10n_br_account] fix commercial partner

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -44,7 +44,6 @@ MOVE_TAX_USER_TYPE = {
 }
 
 SHADOWED_FIELDS = [
-    "partner_id",
     "company_id",
     "currency_id",
     "partner_shipping_id",
@@ -118,6 +117,7 @@ class AccountMove(models.Model):
     def _prepare_shadowed_fields_dict(self, default=False):
         self.ensure_one()
         vals = self._convert_to_write(self.read(self._shadowed_fields())[0])
+        vals["partner_id"] = self.partner_id.commercial_partner_id.id
         if default:  # in case you want to use new rather than write later
             return {"default_%s" % (k,): vals[k] for k in vals.keys()}
         return vals

--- a/l10n_br_account/models/account_invoice_line.py
+++ b/l10n_br_account/models/account_invoice_line.py
@@ -14,7 +14,6 @@ from odoo.exceptions import UserError
 # where they are injected.
 SHADOWED_FIELDS = [
     "name",
-    "partner_id",
     "company_id",
     "currency_id",
     "product_id",
@@ -127,6 +126,7 @@ class AccountMoveLine(models.Model):
     def _prepare_shadowed_fields_dict(self, default=False):
         self.ensure_one()
         vals = self._convert_to_write(self.read(self._shadowed_fields())[0])
+        vals["partner_id"] = self.partner_id.commercial_partner_id.id
         if default:  # in case you want to use new rather than write later
             return {"default_%s" % (k,): vals[k] for k in vals.keys()}
         return vals

--- a/l10n_br_fiscal/models/document_fiscal_invoice_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_invoice_mixin.py
@@ -16,101 +16,101 @@ class FiscalDocumentInvoiceMixin(models.AbstractModel):
 
     partner_legal_name = fields.Char(
         string="Legal Name",
-        related="partner_id.legal_name",
+        related="partner_id.commercial_partner_id.legal_name",
     )
 
     partner_name = fields.Char(
         string="Partner Name",
-        related="partner_id.name",
+        related="partner_id.commercial_partner_id.name",
     )
 
     partner_cnpj_cpf = fields.Char(
         string="CNPJ",
-        related="partner_id.cnpj_cpf",
+        related="partner_id.commercial_partner_id.cnpj_cpf",
     )
 
     partner_inscr_est = fields.Char(
         string="State Tax Number",
-        related="partner_id.inscr_est",
+        related="partner_id.commercial_partner_id.inscr_est",
     )
 
     partner_ind_ie_dest = fields.Selection(
         string="Contribuinte do ICMS",
-        related="partner_id.ind_ie_dest",
+        related="partner_id.commercial_partner_id.ind_ie_dest",
     )
 
     partner_inscr_mun = fields.Char(
         string="Municipal Tax Number",
-        related="partner_id.inscr_mun",
+        related="partner_id.commercial_partner_id.inscr_mun",
     )
 
     partner_suframa = fields.Char(
         string="Suframa",
-        related="partner_id.suframa",
+        related="partner_id.commercial_partner_id.suframa",
     )
 
     partner_cnae_main_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.cnae",
         string="Main CNAE",
-        related="partner_id.cnae_main_id",
+        related="partner_id.commercial_partner_id.cnae_main_id",
     )
 
     partner_tax_framework = fields.Selection(
         string="Tax Framework",
-        related="partner_id.tax_framework",
+        related="partner_id.commercial_partner_id.tax_framework",
     )
 
     partner_street = fields.Char(
         string="Partner Street",
-        related="partner_id.street",
+        related="partner_id.commercial_partner_id.street",
     )
 
     partner_number = fields.Char(
         string="Partner Number",
-        related="partner_id.street_number",
+        related="partner_id.commercial_partner_id.street_number",
     )
 
     partner_street2 = fields.Char(
         string="Partner Street2",
-        related="partner_id.street2",
+        related="partner_id.commercial_partner_id.street2",
     )
 
     partner_district = fields.Char(
         string="Partner District",
-        related="partner_id.district",
+        related="partner_id.commercial_partner_id.district",
     )
 
     partner_country_id = fields.Many2one(
         comodel_name="res.country",
         string="Partner Country",
-        related="partner_id.country_id",
+        related="partner_id.commercial_partner_id.country_id",
     )
 
     partner_state_id = fields.Many2one(
         comodel_name="res.country.state",
         string="Partner State",
-        related="partner_id.state_id",
+        related="partner_id.commercial_partner_id.state_id",
     )
 
     partner_city_id = fields.Many2one(
         comodel_name="res.city",
         string="Partner City",
-        related="partner_id.city_id",
+        related="partner_id.commercial_partner_id.city_id",
     )
 
     partner_zip = fields.Char(
         string="Partner Zip",
-        related="partner_id.zip",
+        related="partner_id.commercial_partner_id.zip",
     )
 
     partner_phone = fields.Char(
         string="Partner Phone",
-        related="partner_id.phone",
+        related="partner_id.commercial_partner_id.phone",
     )
 
     partner_is_company = fields.Boolean(
         string="Partner Is Company?",
-        related="partner_id.is_company",
+        related="partner_id.commercial_partner_id.is_company",
     )
 
     company_id = fields.Many2one(

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -179,7 +179,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         self.ensure_one()
         return taxes.compute_taxes(
             company=self.company_id,
-            partner=self.partner_id,
+            partner=self.partner_id.commercial_partner_id,
             product=self.product_id,
             price_unit=self.price_unit,
             quantity=self.quantity,
@@ -315,7 +315,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             self._onchange_commercial_quantity()
             self.fiscal_operation_line_id = self.fiscal_operation_id.line_definition(
                 company=self.company_id,
-                partner=self.partner_id,
+                partner=self.partner_id.commercial_partner_id,
                 product=self.product_id,
             )
             self._onchange_fiscal_operation_line_id()
@@ -327,7 +327,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         if self.fiscal_operation_line_id:
             mapping_result = self.fiscal_operation_line_id.map_fiscal_taxes(
                 company=self.company_id,
-                partner=self.partner_id,
+                partner=self.partner_id.commercial_partner_id,
                 product=self.product_id,
                 ncm=self.ncm_id,
                 nbm=self.nbm_id,

--- a/l10n_br_fiscal/models/document_fiscal_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin_methods.py
@@ -80,7 +80,7 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
     @api.onchange("partner_id")
     def _onchange_partner_id(self):
         if self.partner_id:
-            self.ind_final = self.partner_id.ind_final
+            self.ind_final = self.partner_id.commercial_partner_id.ind_final
 
     @api.onchange("fiscal_operation_id")
     def _onchange_fiscal_operation_id(self):

--- a/l10n_br_fiscal/tests/test_fiscal_document_generic.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_generic.py
@@ -37,6 +37,21 @@ class TestFiscalDocumentGeneric(SavepointCase):
     def test_nfe_same_state(self):
         """Test NFe same state."""
 
+        # First we will create a fiscal document for a contact
+        # in a different state but related to a partner in the same state
+        # In the fiscal document we expect only "commercial partners"
+        # but this will test what can happen with a SO/PO or invoice
+        # using a contact different from the "commercial partner".
+        contact_other_state = self.nfe_other_state.partner_id.copy(
+            default={
+                "parent_id": self.nfe_same_state.partner_id.id,
+                "is_company": False,
+                "cnpj_cpf": False,
+            },
+        )
+        # yes for some reason we need to specify the state again:
+        contact_other_state.state_id = self.nfe_other_state.partner_id.state_id.id
+        self.nfe_same_state.partner_id = contact_other_state.id
         self.nfe_same_state._onchange_document_serie_id()
         self.nfe_same_state._onchange_fiscal_operation_id()
 

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -301,7 +301,11 @@
             </page>
             <page name="recipient" string="Recipient">
               <group name="partner">
-                <field name="partner_id" />
+                <field
+                                    name="partner_id"
+                                    domain="['|', ('is_company', '=', True), ('parent_id', '=', False)]"
+                                    required="1"
+                                />
               </group>
               <group>
                 <group name="partner_left">


### PR DESCRIPTION
fix para https://github.com/OCA/l10n-brazil/issues/2071

**Caso do documento fiscal**
para consistencia é esperado que o partner_id do documento fiscal seja o destinatario real e nao um contato do destinatario (ou emitente real e nao contato do emitente) como permite um pedido de venda ou invoice do Odoo por examplo. Se espera que na tabela do documento fiscal, vc ve a mesma coisa do que numa NFe e que seja consistente com o SPED por examplo, sem ter que fazer gambiarras SQL para saber se o partner_id é um contato ou o "parceiro commercial" mesmo. Por isso acrescentei a restrição na visao do documento fiscal "puro".

**Caso da NFe**
A NFe se basea no documento fiscal e com esse commit vai então usar o parceiro commercial tambem.

**Uso em mixins, por examplo Vendas, Compras...**
Esses mixins herdam de `l10n_br_fiscal.document.mixin`e `l10n_br_fiscal.document.mixin.methods`. Nisso eles nao criam documentos fiscais. Isso so acontece depois quando um invoice é criado. Nisso não é grave se o partner_id dos pedidos de venda ou de compram apontam pro contato do parceiro e nao o parceiro commercial. A unica coisa que importa é que os mixins se baseam no commercial_partner_id na logica deles, por examplo para saber se uma venda é do mesmo estado ou não. Por isso eu acrescentei o commercial_partner_id nos mixins.

**Caso dos Invoices**
O caso do invoice é semelhante ao uso em Vendas ou Compras onde o Odoo permite que partner_id seja um contato.
Mas os invoice tb herda do mixin `l10n_br_fiscal.document.invoice.mixin`. Esse mixin é usado pelo `l10n_br.fiscal_document` tambem e permite que vc enxerga um documento fiscal atraves das views dos account.move/invoice pelo sistema do _inherits. Por isso eu acrescentei o commercial_partner_id nesse mixin tb apesar que quando esse mixin é usado dentro do documento fiscal o partner_id ja sera o proprio commercial_partner_id,

Agora quando o documento fiscal é criado ou escrito atraves do create ou write do Invoice/Invoice line, em vez de passar o mesmo partner_id do que no invoice, a gente cuida agora de passar o commercial_partner_id nor documento fiscal. Nisso ele pode ser diferente entre o fiscal document e o invoice, mas sendo o commercial_partner_id no documento fiscal tudo vai funcionar como esperado.

cc @marcelsavegnago @renatonlima @mbcosta @netosjb @felipemotter 

