### PR TITLE
[14.0][FIX] payment_order: campos obrigatórios apenas quando for cobrança.

### DIFF
--- a/l10n_br_account_payment_order/models/account_payment_mode.py
+++ b/l10n_br_account_payment_order/models/account_payment_mode.py
@@ -110,7 +110,11 @@ class AccountPaymentMode(models.Model):
                     % field
                 )
 
-            if self.bank_code_bc == "341" and not self.boleto_wallet:
+            if (
+                self.bank_code_bc == "341"
+                and self.payment_type == "inbound"
+                and not self.boleto_wallet
+            ):
                 raise ValidationError(_("Carteira no banco Itaú é obrigatória"))
 
     def get_own_number_sequence(self, inv, numero_documento):

--- a/l10n_br_account_payment_order/views/account_payment_mode.xml
+++ b/l10n_br_account_payment_order/views/account_payment_mode.xml
@@ -44,7 +44,7 @@
                                 <field
                                     name="own_number_sequence_id"
                                     attrs="{'invisible': [('own_number_type', '!=', '2')],
-                                 'required': [('own_number_type', '==', '2'), ('payment_order_ok', '==', True)]}"
+                                 'required': [('own_number_type', '==', '2'), ('payment_order_ok', '==', True), ('payment_type', '==', 'inbound')]}"
                                 />
                                 <field name="boleto_wallet" />
                                 <field name="boleto_modality" />


### PR DESCRIPTION
Módulo: [l10n_br_account_payment_order](https://github.com/OCA/l10n-brazil/tree/14.0/l10n_br_account_payment_order)

A sequência do nosso número e a carteira não devem ser campos obrigatórios quando o modo de pagamento for do tipo "outbound" ( pagamentos) apenas quando for do tipo "inbound" (cobrança)

