### PR TITLE
[12.0][FIX] l10n_br_contract: fix contract form view

### DIFF
--- a/l10n_br_contract/views/contract_line.xml
+++ b/l10n_br_contract/views/contract_line.xml
@@ -89,11 +89,6 @@
                     />
                 </notebook>
             </xpath>
-            <xpath expr="//group[@name='recurrence_info']" position="attributes">
-                <attribute name="attrs">
-                    {'invisible': ['|','|', ('display_type', '=', 'line_section'), ('parent.line_recurrence', '!=', True), '&amp;', ('display_type', '=', 'line_note'), ('note_invoicing_mode', '!=', 'custom')]}
-                </attribute>
-            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Acabou passando um trecho que não precisa na 12.0 e está impactando na inclusão de uma linha no contrato.