### PR TITLE
[12.0][IMP] l10n_br_account: add company filter in _account_taxes

### DIFF
--- a/l10n_br_account/models/account_tax.py
+++ b/l10n_br_account/models/account_tax.py
@@ -71,9 +71,20 @@ class AccountTax(models.Model):
 
         product = product or self.env["product.product"]
 
-        # FIXME Should get company from document?
+        if len(self) == 0:
+            company = self.env.user.company_id
+            if self.env.context.get("default_company_id") or self.env.context.get(
+                "allowed_company_ids"
+            ):
+                company = self.env["res.company"].browse(
+                    self.env.context.get("default_company_id")
+                    or self.env.context.get("allowed_company_ids")[0]
+                )
+        else:
+            company = self[0].company_id
+
         fiscal_taxes_results = fiscal_taxes.compute_taxes(
-            company=self.env.user.company_id,
+            company=company,
             partner=partner,
             product=product,
             price_unit=price_unit,

--- a/l10n_br_account/models/fiscal_tax.py
+++ b/l10n_br_account/models/fiscal_tax.py
@@ -21,8 +21,20 @@ class FiscalTax(models.Model):
     def _account_taxes(self):
         self.ensure_one()
         account_tax_group = self.tax_group_id.account_tax_group()
+        company = self.env.user.company_id
+        if self.env.context.get("default_company_id") or self.env.context.get(
+            "allowed_company_ids"
+        ):
+            company = self.env["res.company"].browse(
+                self.env.context.get("default_company_id")
+                or self.env.context.get("allowed_company_ids")[0]
+            )
         return self.env["account.tax"].search(
-            [("tax_group_id", "=", account_tax_group.id), ("active", "=", True)]
+            [
+                ("tax_group_id", "=", account_tax_group.id),
+                ("active", "=", True),
+                ("company_id", "=", company.id),
+            ]
         )
 
     def _create_account_tax(self):

--- a/l10n_br_purchase_stock/tests/test_l10n_br_purchase_stock.py
+++ b/l10n_br_purchase_stock/tests/test_l10n_br_purchase_stock.py
@@ -13,6 +13,7 @@ class L10nBrPurchaseStockBase(test_l10n_br_purchase.L10nBrPurchaseBaseTest):
         self.invoice_wizard = self.env["stock.invoice.onshipping"]
         self.stock_return_picking = self.env["stock.return.picking"]
         self.stock_picking = self.env["stock.picking"]
+        self.company = self.env.ref("l10n_br_base.empresa_lucro_presumido")
 
     def _picking_purchase_order(self, order):
         self.assertEqual(
@@ -85,7 +86,7 @@ class L10nBrPurchaseStockBase(test_l10n_br_purchase.L10nBrPurchaseBaseTest):
         )
         wizard = wizard_obj.create(wizard_values)
         wizard.onchange_group()
-        wizard.action_generate()
+        wizard.with_context(default_company_id=self.company.id).action_generate()
         domain = [("picking_ids", "in", (picking_1.id, picking_2.id))]
         invoice = self.invoice_model.search(domain)
         # Fatura Agrupada
@@ -160,7 +161,7 @@ class L10nBrPurchaseStockBase(test_l10n_br_purchase.L10nBrPurchaseBaseTest):
         wizard_values = wizard_obj.default_get(fields_list)
         wizard = wizard_obj.create(wizard_values)
         wizard.onchange_group()
-        wizard.action_generate()
+        wizard.with_context(default_company_id=self.company.id).action_generate()
         domain = [("picking_ids", "=", picking_devolution.id)]
         invoice_devolution = self.invoice_model.search(domain)
         # Confirmando a Fatura

--- a/l10n_br_sale_stock/tests/test_sale_stock.py
+++ b/l10n_br_sale_stock/tests/test_sale_stock.py
@@ -14,6 +14,7 @@ class TestSaleStock(SavepointCase):
         cls.invoice_wizard = cls.env["stock.invoice.onshipping"]
         cls.stock_return_picking = cls.env["stock.return.picking"]
         cls.stock_picking = cls.env["stock.picking"]
+        cls.company = cls.env.ref("l10n_br_base.empresa_lucro_presumido")
 
         # TODO: Em uma instalção direta do modulo
         #  $ odoo -d test -i l10n_br_sale_stock --stop-after-init
@@ -299,7 +300,7 @@ class TestSaleStock(SavepointCase):
         wizard_values = wizard_obj.default_get(fields_list)
         wizard = wizard_obj.create(wizard_values)
         wizard.onchange_group()
-        wizard.action_generate()
+        wizard.with_context(default_company_id=self.company.id).action_generate()
         domain = [("picking_ids", "=", picking_devolution.id)]
         invoice_devolution = self.invoice_model.search(domain)
         # Confirmando a Fatura
@@ -358,7 +359,7 @@ class TestSaleStock(SavepointCase):
         )
         wizard = wizard_obj.create(wizard_values)
         wizard.onchange_group()
-        wizard.action_generate()
+        wizard.with_context(default_company_id=self.company.id).action_generate()
         domain = [("picking_ids", "in", (picking.id, picking2.id))]
         invoice = self.invoice_model.search(domain)
         # Fatura Agrupada

--- a/l10n_br_stock_account/tests/test_invoicing_picking.py
+++ b/l10n_br_stock_account/tests/test_invoicing_picking.py
@@ -75,7 +75,7 @@ class InvoicingPickingTest(SavepointCase):
         wizard_values = wizard_obj.default_get(fields_list)
         wizard = wizard_obj.create(wizard_values)
         wizard.onchange_group()
-        wizard.action_generate()
+        wizard.with_context(default_company_id=self.company.id).action_generate()
         domain = [("picking_ids", "=", self.stock_picking_sp.id)]
         invoice = self.invoice_model.search(domain)
 
@@ -215,7 +215,7 @@ class InvoicingPickingTest(SavepointCase):
         )
         wizard = wizard_obj.create(wizard_values)
         wizard.onchange_group()
-        wizard.action_generate()
+        wizard.with_context(default_company_id=self.company.id).action_generate()
         domain = [("picking_ids", "=", picking.id)]
         invoice = self.invoice_model.search(domain)
         self.assertEqual(len(invoice), 1)
@@ -289,7 +289,7 @@ class InvoicingPickingTest(SavepointCase):
         )
         wizard = wizard_obj.create(wizard_values)
         wizard.onchange_group()
-        wizard.action_generate()
+        wizard.with_context(default_company_id=self.company.id).action_generate()
         domain = [("picking_ids", "in", (picking.id, picking2.id))]
         invoicies = self.invoice_model.search(domain)
         self.assertEqual(len(invoicies), 2)


### PR DESCRIPTION
Ainda cabe analisar melhor isto mas tive dois problemas:
1o A empresa do usuário que do usuário que está rodando o job afeta a geração da fatura por nao encontrar o icms.regulation da empresa 1 (base demo)
2o Ao gerar a fatura por algum motivo o sistema preenche o campo invoice_line_tax_ids da linha da invoice com o mesmo imposto multiplicado pela quantidade de empresas existentes.

obs. por ora estou registrando esta PR mas ainda pretendo avaliar melhor.. porém como demorei para chegar aqui achei melhor deixar registrado hehehe

Ref. #2088