### PR TITLE
[FIX][14.0] payment_order: Ignorar métodos do CNAB Cobrança, quando for Pagamentos.

### DIFF
--- a/l10n_br_account_payment_order/models/account_move.py
+++ b/l10n_br_account_payment_order/models/account_move.py
@@ -63,6 +63,9 @@ class AccountMove(models.Model):
         # Se não possui Modo de Pagto não há nada a ser feito
         if not self.payment_mode_id:
             return
+        # Se o Modo de Pagto é de saída (pgto fornecedor) não há nada a ser feito.
+        if self.payment_mode_id.payment_type == "outbound":
+            return
         # Se não gera Ordem de Pagto não há nada a ser feito
         if not self.payment_mode_id.payment_order_ok:
             return

--- a/l10n_br_account_payment_order/models/account_payment_mode.py
+++ b/l10n_br_account_payment_order/models/account_payment_mode.py
@@ -91,7 +91,10 @@ class AccountPaymentMode(models.Model):
     )
     def _check_cnab_restriction(self):
         for record in self:
-            if record.payment_method_code not in BR_CODES_PAYMENT_ORDER:
+            if (
+                record.payment_method_code not in BR_CODES_PAYMENT_ORDER
+                or self.payment_type == "outbound"
+            ):
                 return False
             fields_forbidden_cnab = []
             if record.group_lines:


### PR DESCRIPTION
Tanto o método load_cnab_info() do account_move quanto o _check_cnab_restriction() do payment_mode são métodos específicos para CNAB Cobrança (inbound). 
Essas regras não devem valer para quando o Payment Mode for do tipo Pagamentos (outbound)