### PR TITLE
[14.0] dummy line fixes

### DIFF
--- a/l10n_br_account/hooks.py
+++ b/l10n_br_account/hooks.py
@@ -97,7 +97,12 @@ def pre_init_hook(cr):
                 company_id=%s
             AND
                 fiscal_document_line_id IS NULL;""",
-            (company.fiscal_dummy_id.fiscal_line_ids[0].id, company.id),
+            (
+                company.fiscal_dummy_id.with_context(active_test=False)
+                .fiscal_line_ids[0]
+                .id,
+                company.id,
+            ),
         )
 
 

--- a/l10n_br_account/models/account_invoice_line.py
+++ b/l10n_br_account/models/account_invoice_line.py
@@ -134,7 +134,9 @@ class AccountMoveLine(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         dummy_doc = self.env.company.fiscal_dummy_id
-        dummy_line = fields.first(dummy_doc.fiscal_line_ids)
+        dummy_line = fields.first(
+            dummy_doc.with_context(active_test=False).fiscal_line_ids
+        )
         for values in vals_list:
             fiscal_doc_id = (
                 self.env["account.move"].browse(values["move_id"]).fiscal_document_id.id
@@ -170,7 +172,9 @@ class AccountMoveLine(models.Model):
 
     def write(self, values):
         dummy_doc = self.env.company.fiscal_dummy_id
-        dummy_line = fields.first(dummy_doc.fiscal_line_ids)
+        dummy_line = fields.first(
+            dummy_doc.with_context(active_test=False).fiscal_line_ids
+        )
         non_dummy = self.filtered(lambda l: l.fiscal_document_line_id != dummy_line)
         if values.get("move_id") and len(non_dummy) == len(self):
             # we can write the document_id in all lines

--- a/l10n_br_fiscal/models/res_company.py
+++ b/l10n_br_fiscal/models/res_company.py
@@ -76,7 +76,9 @@ class ResCompany(models.Model):
             "fiscal_operation_type": "out",
             "partner_id": self.partner_id.id,
             "company_id": company,
-            "fiscal_line_ids": [(0, 0, {"name": "dummy", "company_id": self.id})],
+            "fiscal_line_ids": [
+                (0, 0, {"name": "dummy", "company_id": self.id, "active": False})
+            ],
         }
 
     @api.model

--- a/l10n_br_fiscal/tests/test_fiscal_document_generic.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_generic.py
@@ -1041,7 +1041,9 @@ class TestFiscalDocumentGeneric(SavepointCase):
 
     def test_unlink_dummy_document_line(self):
         """Test Dummy Fiscal Document Line Unlink Restrictions"""
-        dummy_line = self.env.company.fiscal_dummy_id.fiscal_line_ids[0]
+        dummy_line = self.env.company.fiscal_dummy_id.with_context(
+            active_test=False
+        ).fiscal_line_ids[0]
         with self.assertRaises(UserError):
             dummy_line.unlink()
 
@@ -1056,7 +1058,12 @@ class TestFiscalDocumentGeneric(SavepointCase):
             }
         )
         self.assertEqual(company.fiscal_dummy_id.company_id, company)
-        self.assertEqual(company.fiscal_dummy_id.fiscal_line_ids[0].company_id, company)
+        self.assertEqual(
+            company.fiscal_dummy_id.with_context(active_test=False)
+            .fiscal_line_ids[0]
+            .company_id,
+            company,
+        )
 
     def test_nfe_comments(self):
         self.nfe_not_taxpayer._document_comment()


### PR DESCRIPTION
as linhas de documento fiscal dummy servem apenas para satisfazer a chave estrangeira fiscal_document_line_id do account.move.line nos casos onde de fato não ha verdadeiramente um documento fiscal (multi empresa operando fora do Brasil, alguns bills).

Hoje as linhas de documento fiscal estão com active=True (padrão). Mas isso não é muito legal pro reporting. Eh possível botar active=False como nos documentos fiscais dummy, mas tem que fazer a adaptaçao desse PR para carregar as linhas dummy na hora de ler o o2m fiscal_line_ids.