### PR TITLE
[14.0][spec_driven_model][l10n_br_nfe] fix dry run import

### DIFF
--- a/l10n_br_nfe/hooks.py
+++ b/l10n_br_nfe/hooks.py
@@ -53,7 +53,7 @@ def post_init_hook(cr, registry):
             nfe = (
                 env["nfe.40.infnfe"]
                 .with_context(tracking_disable=True, edoc_type="in", lang="pt_BR")
-                .build(nfe_binding.infNFe)
+                .build_from_binding(nfe_binding.infNFe)
             )
             _logger.info(nfe.nfe40_emit.nfe40_CNPJ)
         except ValidationError:

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -378,8 +378,12 @@ class NFeLine(spec_models.StackedModel):
                 record.nfe40_choice10 = "nfe40_ISSQN"
 
     @api.model
-    def _prepare_import_dict(self, values, model=None, parent_dict=None):
-        values = super()._prepare_import_dict(values, model, parent_dict)
+    def _prepare_import_dict(
+        self, values, model=None, parent_dict=None, defaults_model=None
+    ):
+        values = super()._prepare_import_dict(
+            values, model, parent_dict, defaults_model
+        )
         if not values.get("name"):
             values["name"] = values.get("nfe40_xProd")
             if values.get("product_id"):
@@ -772,7 +776,7 @@ class NFeLine(spec_models.StackedModel):
                         ).id
                         # TODO search + log if not found
                     if hasattr(icms, "modBC") and icms.modBC is not None:
-                        icms_vals["icms_base_type"] = float(icms.modBC)
+                        icms_vals["icms_base_type"] = icms.modBC
                     if hasattr(icms, "orig"):
                         icms_vals["icms_origin"] = icms.orig
                     if hasattr(icms, "vBC") and icms.vBC is not None:

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -77,7 +77,7 @@ class NFeLine(spec_models.StackedModel):
     # So a part of the mapping is done
     # in the fiscal document line:
     # from Odoo -> XML by using related fields/_compute
-    # from XML -> Odoo by overriding the product create method
+    # from XML -> Odoo by overriding the product default_get method
     nfe40_cProd = fields.Char(
         related="product_id.default_code",
     )
@@ -378,8 +378,8 @@ class NFeLine(spec_models.StackedModel):
                 record.nfe40_choice10 = "nfe40_ISSQN"
 
     @api.model
-    def _prepare_import_dict(self, values, model=None):
-        values = super()._prepare_import_dict(values, model)
+    def _prepare_import_dict(self, values, model=None, parent_dict=None):
+        values = super()._prepare_import_dict(values, model, parent_dict)
         if not values.get("name"):
             values["name"] = values.get("nfe40_xProd")
             if values.get("product_id"):

--- a/l10n_br_nfe/models/res_company.py
+++ b/l10n_br_nfe/models/res_company.py
@@ -123,12 +123,14 @@ class ResCompany(spec_models.SpecModel):
         return super()._build_attr(node, fields, vals, path, attr)
 
     @api.model
-    def _prepare_import_dict(self, values, model=None, parent_dict=None):
+    def _prepare_import_dict(
+        self, values, model=None, parent_dict=None, defaults_model=None
+    ):
         # we disable enderEmit related creation with dry_run=True
         context = self._context.copy()
         context["dry_run"] = True
         values = super(ResCompany, self.with_context(context))._prepare_import_dict(
-            values, model, parent_dict
+            values, model, parent_dict, defaults_model
         )
         if not values.get("name"):
             values["name"] = values.get("nfe40_xFant") or values.get("nfe40_xNome")

--- a/l10n_br_nfe/models/res_company.py
+++ b/l10n_br_nfe/models/res_company.py
@@ -123,12 +123,12 @@ class ResCompany(spec_models.SpecModel):
         return super()._build_attr(node, fields, vals, path, attr)
 
     @api.model
-    def _prepare_import_dict(self, values, model=None):
+    def _prepare_import_dict(self, values, model=None, parent_dict=None):
         # we disable enderEmit related creation with dry_run=True
         context = self._context.copy()
         context["dry_run"] = True
         values = super(ResCompany, self.with_context(context))._prepare_import_dict(
-            values, model
+            values, model, parent_dict
         )
         if not values.get("name"):
             values["name"] = values.get("nfe40_xFant") or values.get("nfe40_xNome")

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -36,8 +36,12 @@ class ResPartner(spec_models.SpecModel):
     _nfe_search_keys = ["nfe40_CNPJ", "nfe40_CPF", "nfe40_xNome"]
 
     @api.model
-    def _prepare_import_dict(self, values, model=None, parent_dict=None):
-        values = super()._prepare_import_dict(values, model, parent_dict)
+    def _prepare_import_dict(
+        self, values, model=None, parent_dict=None, defaults_model=None
+    ):
+        values = super()._prepare_import_dict(
+            values, model, parent_dict, defaults_model
+        )
         if not values.get("name") and values.get("legal_name"):
             values["name"] = values["legal_name"]
         return values

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -36,8 +36,8 @@ class ResPartner(spec_models.SpecModel):
     _nfe_search_keys = ["nfe40_CNPJ", "nfe40_CPF", "nfe40_xNome"]
 
     @api.model
-    def _prepare_import_dict(self, values, model=None):
-        values = super()._prepare_import_dict(values, model)
+    def _prepare_import_dict(self, values, model=None, parent_dict=None):
+        values = super()._prepare_import_dict(values, model, parent_dict)
         if not values.get("name") and values.get("legal_name"):
             values["name"] = values["legal_name"]
         return values

--- a/l10n_br_nfe/tests/test_nfe_import.py
+++ b/l10n_br_nfe/tests/test_nfe_import.py
@@ -35,7 +35,7 @@ class NFeImportTest(SavepointCase):
         nfe = (
             self.env["nfe.40.infnfe"]
             .with_context(tracking_disable=True, edoc_type="in", lang="pt_BR")
-            .build(nfe_binding.infNFe, dry_run=True)
+            .build_from_binding(nfe_binding.infNFe, dry_run=True)
         )
         assert isinstance(nfe.id, NewId)
         self.assertEqual(nfe.partner_id.name, "Alimentos Saudaveis")
@@ -62,7 +62,7 @@ class NFeImportTest(SavepointCase):
         nfe = (
             self.env["nfe.40.infnfe"]
             .with_context(tracking_disable=True, edoc_type="in", lang="pt_BR")
-            .build(nfe_binding.infNFe)
+            .build_from_binding(nfe_binding.infNFe)
         )
         assert isinstance(nfe.id, int)
         self.assertEqual(type(nfe)._name, "l10n_br_fiscal.document")

--- a/spec_driven_model/models/spec_import.py
+++ b/spec_driven_model/models/spec_import.py
@@ -26,7 +26,7 @@ class AbstractSpecMixin(models.AbstractModel):
     _inherit = "spec.mixin"
 
     @api.model
-    def build(self, node, dry_run=False):
+    def build_from_binding(self, node, dry_run=False):
         """
         Builds an instance of an Odoo Model from a pre-populated
         Python binding object. Binding object such as the ones generated using

--- a/spec_driven_model/models/spec_import.py
+++ b/spec_driven_model/models/spec_import.py
@@ -50,7 +50,7 @@ class AbstractSpecMixin(models.AbstractModel):
             return model.create(attrs)
 
     @api.model
-    def build_attrs(self, node, path=""):
+    def build_attrs(self, node, path="", defaults_model=None):
         """
         Builds a new odoo model instance from a Python binding element or
         sub-element. Iterates over the binding fields to populate the Odoo fields.
@@ -58,7 +58,7 @@ class AbstractSpecMixin(models.AbstractModel):
         vals = {}
         for attr in node.member_data_items_:
             self._build_attr(node, self._fields, vals, path, attr)
-        vals = self._prepare_import_dict(vals)
+        vals = self._prepare_import_dict(vals, defaults_model=defaults_model)
         return vals
 
     @api.model
@@ -123,7 +123,9 @@ class AbstractSpecMixin(models.AbstractModel):
                 # o2m
                 lines = []
                 for line in [li for li in value if li]:
-                    line_vals = comodel.build_attrs(line, path=child_path)
+                    line_vals = comodel.build_attrs(
+                        line, path=child_path, defaults_model=comodel
+                    )
                     lines.append((0, 0, line_vals))
                 vals[key] = lines
 
@@ -169,7 +171,9 @@ class AbstractSpecMixin(models.AbstractModel):
         return key_vals
 
     @api.model
-    def _prepare_import_dict(self, vals, model=None, parent_dict=None):
+    def _prepare_import_dict(
+        self, vals, model=None, parent_dict=None, defaults_model=False
+    ):
         """
         Set non computed field values based on XML values if required.
         NOTE: this is debatable if we could use an api multi with values in
@@ -178,6 +182,8 @@ class AbstractSpecMixin(models.AbstractModel):
         """
         if model is None:
             model = self
+
+        vals = {k: v for k, v in vals.items() if k in self._fields.keys()}
 
         related_many2ones = {}
         fields = model._fields
@@ -212,23 +218,22 @@ class AbstractSpecMixin(models.AbstractModel):
             else:  # search res.country with Brasil for instance
                 vals[related_m2o] = model.match_or_create_m2o(sub_val, vals, comodel)
 
-        defaults = model.with_context(
-            record_dict=vals,
-            parent_dict=parent_dict,
-        ).default_get(
-            [
-                f
-                for f, v in model._fields.items()
-                if v.type not in ["binary", "integer", "float", "monetary"]
-                and v.name not in vals.keys()
-            ]
-        )
-        vals.update(defaults)
-        # NOTE: also eventually load default values from the context?
+        if defaults_model is not None:
+            defaults = defaults_model.with_context(
+                record_dict=vals,
+                parent_dict=parent_dict,
+            ).default_get(
+                [
+                    f
+                    for f, v in defaults_model._fields.items()
+                    if v.type not in ["binary", "integer", "float", "monetary"]
+                    and v.name not in vals.keys()
+                ]
+            )
+            vals.update(defaults)
+            # NOTE: also eventually load default values from the context?
 
-        # NOTE: is this filtering still useful?
-        filtered_vals = {k: v for k, v in vals.items() if k in self._fields.keys()}
-        return filtered_vals
+        return vals
 
     @api.model
     def _verify_related_many2ones(self, related_many2ones):
@@ -254,14 +259,17 @@ class AbstractSpecMixin(models.AbstractModel):
             if rec_dict.get(key):
                 # TODO enable to build criteria using parent_dict
                 # such as state_id when searching for a city
-                if hasattr(model, "_nfe_extra_domain"):
+                if hasattr(model, "_nfe_extra_domain"):  # FIXME make generic
                     domain = model._nfe_extra_domain + [(key, "=", rec_dict.get(key))]
                 else:
                     domain = [(key, "=", rec_dict.get(key))]
                 match_ids = model.search(domain)
                 if match_ids:
                     if len(match_ids) > 1:
-                        _logger.warning("!! WARNING more than 1 record found!!")
+                        _logger.warning(
+                            "!! WARNING more than 1 record found!! model: %s, domain: %s"
+                            % (model, domain)
+                        )
                     return match_ids[0].id
         return False
 
@@ -284,18 +292,18 @@ class AbstractSpecMixin(models.AbstractModel):
         else:
             rec_id = self.match_record(rec_dict, parent_dict, model)
         if not rec_id:
-            create_dict = self._prepare_import_dict(
-                rec_dict, model=model, parent_dict=parent_dict
+            vals = self._prepare_import_dict(
+                rec_dict, model=model, parent_dict=parent_dict, defaults_model=model
             )
             if self._context.get("dry_run"):
-                rec_id = model.new(create_dict).id
+                rec_id = model.new(vals).id
             else:
                 rec_id = (
                     model.with_context(
                         parent_dict=parent_dict,
                         lang="en_US",
                     )
-                    .create(create_dict)
+                    .create(vals)
                     .id
                 )
         return rec_id

--- a/spec_driven_model/models/spec_import.py
+++ b/spec_driven_model/models/spec_import.py
@@ -55,27 +55,9 @@ class AbstractSpecMixin(models.AbstractModel):
         Builds a new odoo model instance from a Python binding element or
         sub-element. Iterates over the binding fields to populate the Odoo fields.
         """
-        fields = self._fields
-        # no default image for easier debugging
-        vals = self.default_get(
-            [
-                f
-                for f, v in fields.items()
-                if v.type not in ["binary", "integer", "float", "monetary"]
-            ]
-        )
-        # TODO deal with default values but take them from self._context
-        # if path == '':
-        #    vals.update(defaults)
-        # we sort attrs to be able to define m2o related values
-        sorted_attrs = sorted(
-            node.member_data_items_,
-            key=lambda a: a.get_container() in [0, 1],
-            reverse=True,
-        )
-        for attr in sorted_attrs:
-            self._build_attr(node, fields, vals, path, attr)
-
+        vals = {}
+        for attr in node.member_data_items_:
+            self._build_attr(node, self._fields, vals, path, attr)
         vals = self._prepare_import_dict(vals)
         return vals
 
@@ -187,7 +169,7 @@ class AbstractSpecMixin(models.AbstractModel):
         return key_vals
 
     @api.model
-    def _prepare_import_dict(self, vals, model=None):
+    def _prepare_import_dict(self, vals, model=None, parent_dict=None):
         """
         Set non computed field values based on XML values if required.
         NOTE: this is debatable if we could use an api multi with values in
@@ -196,6 +178,7 @@ class AbstractSpecMixin(models.AbstractModel):
         """
         if model is None:
             model = self
+
         related_many2ones = {}
         fields = model._fields
         for k, v in fields.items():
@@ -228,7 +211,24 @@ class AbstractSpecMixin(models.AbstractModel):
                 vals[related_m2o] = comodel.match_or_create_m2o(sub_val, vals)
             else:  # search res.country with Brasil for instance
                 vals[related_m2o] = model.match_or_create_m2o(sub_val, vals, comodel)
-        return vals
+
+        defaults = model.with_context(
+            record_dict=vals,
+            parent_dict=parent_dict,
+        ).default_get(
+            [
+                f
+                for f, v in model._fields.items()
+                if v.type not in ["binary", "integer", "float", "monetary"]
+                and v.name not in vals.keys()
+            ]
+        )
+        vals.update(defaults)
+        # NOTE: also eventually load default values from the context?
+
+        # NOTE: is this filtering still useful?
+        filtered_vals = {k: v for k, v in vals.items() if k in self._fields.keys()}
+        return filtered_vals
 
     @api.model
     def _verify_related_many2ones(self, related_many2ones):
@@ -284,10 +284,9 @@ class AbstractSpecMixin(models.AbstractModel):
         else:
             rec_id = self.match_record(rec_dict, parent_dict, model)
         if not rec_id:
-            rec_dict = self._prepare_import_dict(rec_dict, model)
-            create_dict = {
-                k: v for k, v in rec_dict.items() if k in self._fields.keys()
-            }
+            create_dict = self._prepare_import_dict(
+                rec_dict, model=model, parent_dict=parent_dict
+            )
             if self._context.get("dry_run"):
                 rec_id = model.new(create_dict).id
             else:

--- a/spec_driven_model/models/spec_models.py
+++ b/spec_driven_model/models/spec_models.py
@@ -96,7 +96,7 @@ class SpecModel(models.AbstractModel):
                         )
 
                     cls._map_concrete(parent, cls._name)
-                    if not hasattr(pool[parent], "build"):  # FIXME BRITTLE
+                    if not hasattr(pool[parent], "build_from_binding"):
                         pool[parent]._inherit = super_parents + ["spec.mixin"]
                         pool[parent].__bases__ = (pool["spec.mixin"],) + pool[
                             parent

--- a/spec_driven_model/tests/test_spec_model.py
+++ b/spec_driven_model/tests/test_spec_model.py
@@ -132,13 +132,13 @@ class TestSpecModel(SavepointCase, FakeModelLoader):
 
         # 3rd we import an Odoo PO from this binding object
         # first we will do a dry run import:
-        imported_po_dry_run = self.env["fake.purchase.order"].build(
+        imported_po_dry_run = self.env["fake.purchase.order"].build_from_binding(
             po_binding, dry_run=True
         )
         assert isinstance(imported_po_dry_run.id, NewId)
 
         # now a real import:
-        imported_po = self.env["fake.purchase.order"].build(po_binding)
+        imported_po = self.env["fake.purchase.order"].build_from_binding(po_binding)
         self.assertEqual(imported_po.partner_id.name, "Wood Corner")
         self.assertEqual(
             imported_po.partner_id.id, self.env.ref("base.res_partner_1").id


### PR DESCRIPTION
como o PR https://github.com/OCA/l10n-brazil/pull/2073 ficou bem grande e que a questão da importação dry-run tava mal resolvida, eu decidi tirar os commits do dry-run do PR #2073 e joguei aqui com 3 commits adicionais que resolvem o problema.

Primeiro a importação de XML não funciona legal com dry_run=True (opção para ver o que seria criado no Odoo sem chamar create de nada). Como não chama o create (o teste atual com dry_run só passa porque importamos uma NFe de demo antes que cria o mesmo produto antes), não instanciava alguns campos, em especial os do product.product onde a gente pegava valores da linha pelo contexto no create. Eu arrumei para setar esses campos no default_get et pro default_get ser chamado nos lugares certos. Em especial, o wizard de importação contribuido pelo @hirokibastos no https://github.com/OCA/l10n-brazil/pull/1985 deveria usar o dry_run=True inicialmente. Depois de fazer merge dessa PR @hirokibastos vc poderia ver isso melhor...

@hirokibastos o problema do default_get que vc levantou aqui https://github.com/OCA/l10n-brazil/pull/2073#pullrequestreview-1066682206 eu resolvi nos ultimos commits. Basicamente o problema era na hora de montar os campos m2o que estão como "stacked" no documento fiscal. Acabava chamando varias vezes o default_get e sobre-escrevia alguns campos com valor padrão como o nfe40_modFrete no caso onde a tag XML stacked no documento não tinha o valor.

Agora eu chamo esse default_get apenas no objeto certo e apenas na hora de montar o objeto final no match_or_create ou quando se trata de um elemento de o2m (como as linhas de det) onde o match_or_create não seria chamado.
Eu acrescentei um test que funciona testando o nfe40_modFrete.

Eu também refatorei bastante o teste de importaçao para que seja testado a mesma coisa na hora de uma importação dry-run. No caso do dry run tem alguns detalhe de arredondamento ou de formatação de CNPJ, mas nada de muito importante. Eu anotei e podemos ver isso depois (não regrediu pelo contrario).