### PR TITLE
[12.0][l10n_br_nfe] Inverte importação dos campos emit e dest para notas emitidas pela empresa

### DIFF
--- a/l10n_br_nfe/models/res_company.py
+++ b/l10n_br_nfe/models/res_company.py
@@ -113,7 +113,12 @@ class ResCompany(spec_models.SpecModel):
     )
 
     def _build_attr(self, node, fields, vals, path, attr):
-        if attr.get_name() == "enderEmit" and self.env.context.get("edoc_type") == "in":
+        if (
+            attr.get_name() == "enderEmit" and self.env.context.get("edoc_type") == "in"
+        ) or (
+            attr.get_name() == "enderDest"
+            and self.env.context.get("edoc_type") == "out"
+        ):
             # we don't want to try build a related partner_id for enderEmit
             # when importing an NFe
             # instead later the emit tag will be imported as the


### PR DESCRIPTION
Altera o método build_many2one para suportar importação de documentos nos quais a empresa é o emissor, como em notas de importação, por exemplo.