### PR TITLE
[12.0][FIX] spec_driven_model _export_float_monetary

### DIFF
--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -616,17 +616,6 @@ class NFeLine(spec_models.StackedModel):
 
         return super()._export_many2one(field_name, xsd_required, class_obj)
 
-    def _export_float_monetary(self, field_name, member_spec, class_obj, xsd_required):
-        if not self[field_name] and not xsd_required:
-            if not (
-                class_obj._name == "nfe.40.imposto" and field_name == "nfe40_vTotTrib"
-            ) and not (class_obj._name == "nfe.40.fat"):
-                self[field_name] = False
-                return False
-        return super()._export_float_monetary(
-            field_name, member_spec, class_obj, xsd_required
-        )
-
     def _build_attr(self, node, fields, vals, path, attr):
         key = "nfe40_%s" % (attr.get_name(),)  # TODO schema wise
         value = getattr(node, attr.get_name())

--- a/spec_driven_model/models/spec_export.py
+++ b/spec_driven_model/models/spec_export.py
@@ -142,6 +142,8 @@ class AbstractSpecMixin(models.AbstractModel):
 
     def _export_float_monetary(self, field_name, member_spec, class_obj, xsd_required):
         self.ensure_one()
+        if not self[field_name] and not xsd_required:
+            return False
         if member_spec.data_type[0]:
             TDec = "".join(filter(lambda x: x.isdigit(), member_spec.data_type[0]))[-2:]
             my_format = "%.{}f".format(TDec)


### PR DESCRIPTION
No módulo NF-e é herdado o método _export_float_monetary para tratar os campos que não são xsd_required mas estavam sendo exportados para o XML.
Na verdade o correto seria na classe spec.mixin onde é implementado o método _export_float_monetary deveria ser tratado os casos gerais onde ser um campo não tem o xsd_required=True e ele não tem valor definido (seja Falso ou 0.00) ele não deve ser exportado.