### PR TITLE
[14.0][FIX] l10n_br_purchase_request:  Dependencia do repo purchase-workflow OCA.

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -7,3 +7,4 @@ account-reconcile
 mis-builder
 contract
 manufacture
+purchase-workflow


### PR DESCRIPTION
Missing OCA repository dependency.

PR bem simples, o modulo l10n_br_purchase_request foi incluído recentemente e possui a dependência purchase_request https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_purchase_request/__manifest__.py#L15 que está no repositório https://github.com/OCA/purchase-workflow https://github.com/OCA/purchase-workflow/tree/14.0/purchase_request

cc @marcelsavegnago @rvalyi @renatonlima @mileo 