### PR TITLE
[FIX+IMP] l10n_br_account_nfe: Demo Data e incluído teste para o caso sem Modo de Pagto

### DIFF
--- a/l10n_br_account_nfe/demo/account_invoice_sn_demo.xml
+++ b/l10n_br_account_nfe/demo/account_invoice_sn_demo.xml
@@ -77,4 +77,39 @@
         })]"
         />
     </record>
+
+    <!-- Faturas/Invoices de Teste não deve gerar TAG Cobrança -->
+    <record id="demo_nfe_sem_dados_de_cobranca" model="account.move">
+        <field name="name">Teste NFe Sem Dados de Cobrança</field>
+        <field name="company_id" ref="l10n_br_base.empresa_simples_nacional" />
+        <field name="journal_id" ref="l10n_br_coa_simple.sale_journal_empresa_sn" />
+        <field name="partner_id" ref="l10n_br_base.res_partner_akretion" />
+        <field name="move_type">out_invoice</field>
+        <field name="user_id" ref="base.user_admin" />
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_bonificacao" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
+        <field
+            name="document_serie_id"
+            ref="l10n_br_fiscal.empresa_sn_document_55_serie_1"
+        />
+        <field name="document_serie">1</field>
+        <field name="fiscal_operation_type">out</field>
+        <field
+            name="invoice_line_ids"
+            eval="[
+        (0, 0, {
+            'product_id': ref('product.product_product_5'),
+            'quantity': 1,
+            'price_unit': 1000,
+            'company_id': ref('l10n_br_base.empresa_simples_nacional'),
+            'partner_id': ref('l10n_br_base.res_partner_akretion'),
+            'uom_id': ref('uom.product_uom_unit'),
+            'fiscal_operation_id': ref('l10n_br_fiscal.fo_bonificacao'),
+            'fiscal_operation_line_id': ref('l10n_br_fiscal.fo_bonificacao_bonificacao'),
+            'cfop_id': ref('l10n_br_fiscal.cfop_5910'),
+            'ncm_id': ref('l10n_br_fiscal.ncm_84714900'),
+        })]"
+        />
+    </record>
+
 </odoo>

--- a/l10n_br_account_nfe/hooks.py
+++ b/l10n_br_account_nfe/hooks.py
@@ -34,6 +34,20 @@ def load_simples_nacional_demo(env, registry):
             kind="demo",
         )
 
+        # É necessário rodar os onchanges fiscais para
+        # preencher os campos referentes aos Impostos
+        invoice_tag_cobranca = env.ref("l10n_br_account_nfe.demo_nfe_dados_de_cobranca")
+        for line in invoice_tag_cobranca.invoice_line_ids:
+            line._onchange_fiscal_operation_line_id()
+            line._onchange_fiscal_tax_ids()
+
+        invoice_sem_tag_cobranca = env.ref(
+            "l10n_br_account_nfe.demo_nfe_sem_dados_de_cobranca"
+        )
+        for line in invoice_sem_tag_cobranca.invoice_line_ids:
+            line._onchange_fiscal_operation_line_id()
+            line._onchange_fiscal_tax_ids()
+
     # back to the main company as the next modules to be installed
     # expect this to be the default company.
     env.user.company_id = env.ref("base.main_company")


### PR DESCRIPTION
In the Demo Data need to run onchanges methods to get Taxes values, included Test to case when Invoice don't has Payment Mode.

Nos dados de demonstração do l10n_br_account_nfe é preciso rodar os onchanges Fiscais para preencher os campos dos Impostos se não ficam vazios e ao Confirmar a Fatura retorna o erro 

![image](https://user-images.githubusercontent.com/6341149/188512442-9ea4671f-96d5-4a0d-bdc1-e4d329ce62f8.png)
 
Inclui também tanto o dado de demonstração ( existia na v12 mas havia sido removido na v14 ) quanto o teste do caso da Fatura que não tem Modo de Pagamento, no exemplo uma Bonificação, que nesse caso deve ter na TAG detPag o campo nfe40_tPag com 90 - Sem Pagamento

cc @renatonlima @rvalyi @marcelsavegnago @netosjb @mileo 