### PR TITLE
[12.0] Cancelar uma NF-e que não foi emitida pela empresa

### DIFF
--- a/l10n_br_fiscal/models/document_workflow.py
+++ b/l10n_br_fiscal/models/document_workflow.py
@@ -337,7 +337,6 @@ class DocumentWorkflow(models.AbstractModel):
 
     def _document_cancel(self, justificative):
         self.ensure_one()
-        self.cancel_reason = justificative
         if self._change_state(SITUACAO_EDOC_CANCELADA):
             self.cancel_reason = justificative
 

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -957,13 +957,13 @@ class NFe(spec_models.StackedModel):
         return etree.tostring(new_root)
 
     def _document_cancel(self, justificative):
-        super(NFe, self)._document_cancel(justificative)
-        online_event = self.filtered(filter_processador_edoc_nfe)
-        if online_event:
-            online_event._nfe_cancel()
+        self.ensure_one()
+        super()._document_cancel(justificative)
+        edoc = self.filtered(filter_processador_edoc_nfe)
+        if edoc.filtered(lambda r: r.issuer == DOCUMENT_ISSUER_COMPANY):
+            edoc._nfe_cancel()
 
     def _nfe_cancel(self):
-        self.ensure_one()
         processador = self._processador()
 
         if not self.authorization_protocol:


### PR DESCRIPTION
Permite cancelar uma NF-e emitida pelo por um parceiro