### PR TITLE
[12.0][REF] l10n_br_fiscal: move a geração do certificado fake para a lib erpbrasil.assinatura.

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -112,7 +112,6 @@
         "python": [
             "erpbrasil.base",
             "erpbrasil.assinatura",
-            "OpenSSL",
         ]
     },
 }

--- a/l10n_br_fiscal/tests/test_certificate.py
+++ b/l10n_br_fiscal/tests/test_certificate.py
@@ -3,12 +3,12 @@
 
 from datetime import timedelta
 
+from erpbrasil.assinatura import misc
+
 from odoo import fields
 from odoo.exceptions import ValidationError
 from odoo.tests import common
 from odoo.tools.misc import format_date
-
-from ..tools import misc
 
 
 class TestCertificate(common.TransactionCase):

--- a/l10n_br_fiscal/tools/misc.py
+++ b/l10n_br_fiscal/tools/misc.py
@@ -4,10 +4,9 @@
 
 import logging
 import os
-from base64 import b64encode
 
+from erpbrasil.assinatura import misc
 from erpbrasil.base.misc import punctuation_rm
-from OpenSSL import crypto
 
 from odoo.tools import config
 
@@ -58,52 +57,10 @@ def prepare_fake_certificate_vals(
         "type": cert_type,
         "subtype": "a1",
         "password": passwd,
-        "file": create_fake_certificate_file(valid, passwd, issuer, country, subject),
+        "file": misc.create_fake_certificate_file(
+            valid, passwd, issuer, country, subject
+        ),
     }
-
-
-def create_fake_certificate_file(valid, passwd, issuer, country, subject):
-    """Creating a fake certificate
-
-        TODO: Move this method to erpbrasil
-
-    :param valid: True or False
-    :param passwd: Some password
-    :param issuer: Some string, like EMISSOR A TESTE
-    :param country: Some country: BR
-    :param subject: Some string: CERTIFICADO VALIDO TESTE
-    :return: base64 file
-    """
-    key = crypto.PKey()
-    key.generate_key(crypto.TYPE_RSA, 2048)
-
-    cert = crypto.X509()
-
-    cert.get_issuer().C = country
-    cert.get_issuer().CN = issuer
-
-    cert.get_subject().C = country
-    cert.get_subject().CN = subject
-
-    cert.set_serial_number(2009)
-
-    if valid:
-        time_before = 0
-        time_after = 365 * 24 * 60 * 60
-    else:
-        time_before = -1 * (365 * 24 * 60 * 60)
-        time_after = 0
-
-    cert.gmtime_adj_notBefore(time_before)
-    cert.gmtime_adj_notAfter(time_after)
-    cert.set_pubkey(key)
-    cert.sign(key, "md5")
-
-    p12 = crypto.PKCS12()
-    p12.set_privatekey(key)
-    p12.set_certificate(cert)
-
-    return b64encode(p12.export(passwd))
 
 
 def path_edoc_company(company_id):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 num2words==0.5.4
 pycep-correios==5.0.0
-workalendar==7.1.1
+workalendar
 erpbrasil.base==2.2.2
-erpbrasil.assinatura==1.2.0
+erpbrasil.assinatura
 erpbrasil.transmissao==1.0.0
 erpbrasil.edoc==2.2.1
 erpbrasil.edoc.pdf==1.0.1


### PR DESCRIPTION
port da pr #1843 

move geração do certificado fake para a lib erpbrasil.assinatura.

remove a dependência direta ao openssl.