### PR TITLE
[14.0][REF] l10n_br_contract: O paramentro Selection é desnecessario quando existe o Related

### DIFF
--- a/l10n_br_contract/models/contract_line.py
+++ b/l10n_br_contract/models/contract_line.py
@@ -3,8 +3,6 @@
 
 from odoo import fields, models
 
-from ...l10n_br_fiscal.constants.fiscal import TAX_FRAMEWORK
-
 
 class ContractLine(models.Model):
     _name = "contract.line"
@@ -24,7 +22,6 @@ class ContractLine(models.Model):
     )
 
     tax_framework = fields.Selection(
-        selection=TAX_FRAMEWORK,
         related="contract_id.company_id.tax_framework",
         string="Tax Framework",
     )


### PR DESCRIPTION
Selection parameter unnecessary when has Related.

O paramentro Selection é desnecessario quando existe o Related, PR simples mas isso remove um WARNING do LOG

2022-09-06 19:11:02,279 95 WARNING test odoo.fields: contract.line.tax_framework: selection attribute will be ignored as the field is related

cc @renatonlima @rvalyi @marcelsavegnago @mileo 