### PR TITLE
[14.0] l10n_br_base, l10n_br_account: Cadastro de chaves PIX no Parceiro.

### DIFF
--- a/l10n_br_account/__manifest__.py
+++ b/l10n_br_account/__manifest__.py
@@ -40,6 +40,7 @@
         "views/l10n_br_account_menu.xml",
         # Report
         #        "report/account_invoice_report_view.xml",
+        "views/res_partner_view.xml",
     ],
     "demo": [
         "demo/res_users_demo.xml",

--- a/l10n_br_account/views/res_partner_view.xml
+++ b/l10n_br_account/views/res_partner_view.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <!--
+        Partners Extension
+    -->
+    <record id="l10n_br_account_partner_form" model="ir.ui.view">
+        <field name="name">l10n_br_account.res.partner.form</field>
+        <field name="model">res.partner</field>
+        <field name="priority">99</field>
+        <field name="inherit_id" ref="account.view_partner_property_form" />
+        <field name="arch" type="xml">
+            <group position="after" name="banks">
+                <div />
+                <group
+                    string="Brazilian Instant Payment Keys (PIX)"
+                    name="pix_keys"
+                    groups="account.group_account_invoice,account.group_account_readonly"
+                    attrs="{'invisible': [('show_l10n_br', '=', False)]}"
+                >
+                    <field name="show_l10n_br" invisible="1" />
+                    <field name="pix_key_ids" nolabel="1">
+                        <tree editable="bottom">
+                            <field name="partner_id" invisible="1" />
+                            <field name="sequence" widget="handle" />
+                            <field name="key_type" />
+                            <field name="key" />
+                            <field name="partner_bank_id" />
+                        </tree>
+                    </field>
+                </group>
+            </group>
+        </field>
+    </record>
+</odoo>

--- a/l10n_br_base/__manifest__.py
+++ b/l10n_br_base/__manifest__.py
@@ -32,9 +32,12 @@
         "demo/res_partner_demo.xml",
         "demo/res_company_demo.xml",
         "demo/res_users_demo.xml",
+        "demo/res_partner_pix_demo.xml",
     ],
     "installable": True,
     "pre_init_hook": "pre_init_hook",
     "development_status": "Mature",
-    "external_dependencies": {"python": ["num2words", "erpbrasil.base"]},
+    "external_dependencies": {
+        "python": ["num2words", "erpbrasil.base", "phonenumbers", "email_validator"]
+    },
 }

--- a/l10n_br_base/demo/res_partner_pix_demo.xml
+++ b/l10n_br_base/demo/res_partner_pix_demo.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <!--
+    Resource: res.partner.pix
+    Partner: AMD do Brasil
+    -->
+    <record id="res_partner_amd_pix_cnpj" model="res.partner.pix">
+        <field name="partner_id" ref="res_partner_amd" />
+        <field name="key_type">cnpj_cpf</field>
+        <field name="key">62228384000151</field>
+    </record>
+
+    <record id="res_partner_amd_pix_phone" model="res.partner.pix">
+        <field name="partner_id" ref="res_partner_amd" />
+        <field name="key_type">phone</field>
+        <field name="key">1144576060</field>
+    </record>
+
+    <record id="res_partner_amd_pix_email" model="res.partner.pix">
+        <field name="partner_id" ref="res_partner_amd" />
+        <field name="key_type">email</field>
+        <field name="key">amdteste@amdteste.com.br</field>
+    </record>
+
+    <record id="res_partner_amd_evp" model="res.partner.pix">
+        <field name="partner_id" ref="res_partner_amd" />
+        <field name="key_type">evp</field>
+        <field name="key">123e4567-e12b-12d1-a456-426655440000</field>
+    </record>
+
+</odoo>

--- a/l10n_br_base/models/__init__.py
+++ b/l10n_br_base/models/__init__.py
@@ -12,3 +12,4 @@ from . import res_partner
 from . import state_tax_numbers
 from . import res_company
 from . import res_config_settings
+from . import res_partner_pix

--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -34,6 +34,18 @@ class Partner(models.Model):
 
     union_entity_code = fields.Char(string="Union Entity code")
 
+    pix_key_ids = fields.One2many(
+        string="Pix Keys",
+        comodel_name="res.partner.pix",
+        inverse_name="partner_id",
+        help="Keys for Brazilian instant payment (pix)",
+    )
+
+    show_l10n_br = fields.Boolean(
+        compute="_compute_show_l10n_br",
+        help="Indicates if Brazilian localization fields should be displayed.",
+    )
+
     @api.constrains("cnpj_cpf", "inscr_est")
     def _check_cnpj_inscr_est(self):
         for record in self:
@@ -176,3 +188,13 @@ class Partner(models.Model):
     @api.onchange("city_id")
     def _onchange_city_id(self):
         self.city = self.city_id.name
+
+    def _compute_show_l10n_br(self):
+        """
+        Defines when Brazilian localization fields should be displayed.
+        """
+        for rec in self:
+            if rec.company_id and rec.company_id.country_id != self.env.ref("base.br"):
+                rec.show_l10n_br = False
+            else:
+                rec.show_l10n_br = True

--- a/l10n_br_base/models/res_partner_pix.py
+++ b/l10n_br_base/models/res_partner_pix.py
@@ -1,0 +1,150 @@
+import phonenumbers
+from email_validator import EmailSyntaxError, validate_email
+from erpbrasil.base.fiscal import cnpj_cpf
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class PartnerPix(models.Model):
+    _name = "res.partner.pix"
+    _description = "Brazilian instant payment ecosystem (Pix)"
+    _order = "sequence, id"
+    _rec_name = "key"
+
+    _sql_constraints = [
+        (
+            "partner_pix_key_unique",
+            "unique(key_type, key, partner_id)",
+            "A Pix Key with this values already exists in this partner.",
+        )
+    ]
+
+    KEY_TYPES = [
+        ("cnpj_cpf", _("CPF or CNPJ")),
+        ("phone", _("Phone Number")),
+        ("email", _("E-mail")),
+        ("evp", _("Random Key")),
+    ]
+
+    partner_id = fields.Many2one(
+        comodel_name="res.partner",
+        string="Partner",
+        ondelete="cascade",
+        required=True,
+    )
+    sequence = fields.Integer(default=10)
+    key_type = fields.Selection(
+        selection=KEY_TYPES,
+        string="Type",
+        required=True,
+    )
+    key = fields.Char(
+        help="PIX Addressing key",
+        required=True,
+    )
+
+    partner_bank_id = fields.Many2one(
+        comodel_name="res.partner.bank",
+        string="Bank Account",
+        domain="[('partner_id', '=', partner_id)]",
+    )
+
+    def _normalize_email(self, email):
+        try:
+            result = validate_email(
+                email,
+                check_deliverability=False,
+            )
+        except EmailSyntaxError:
+            raise ValidationError(_(f"{email.strip()} is an invalid email"))
+        normalized_email = result["local"].lower() + "@" + result["domain_i18n"]
+        if len(normalized_email) > 77:
+            raise ValidationError(
+                _(
+                    f"The email is too long, "
+                    f"a maximum of 77 characters is allowed: \n{email.strip()}"
+                )
+            )
+        return normalized_email
+
+    def _normalize_phone(self, phone):
+        try:
+            phonenumber = phonenumbers.parse(phone, "BR")
+        except phonenumbers.phonenumberutil.NumberParseException as e:
+            raise ValidationError(_(f"Unable to parse {phone}: {str(e)}"))
+        if not phonenumbers.is_possible_number(phonenumber):
+            raise ValidationError(
+                _(f"Impossible number {phone}: probably invalid number of digits.")
+            )
+        if not phonenumbers.is_valid_number(phonenumber):
+            raise ValidationError(
+                _(f"Invalid number {phone}: probably incorrect prefix.")
+            )
+        phone = phonenumbers.format_number(
+            phonenumber, phonenumbers.PhoneNumberFormat.E164
+        )
+        return phone
+
+    def _normalize_cnpj_cpf(self, doc_number):
+        doc_number = "".join(char for char in doc_number if char.isdigit())
+        if not 11 <= len(doc_number) <= 14:
+            raise ValidationError(
+                _(
+                    f"Invalid Document Number {doc_number}: "
+                    f"\nThe CPF must have 11 digits and the CNPJ 14 digits."
+                )
+            )
+        is_valid = cnpj_cpf.validar(doc_number)
+        if not is_valid:
+            raise ValidationError(_(f"Invalid Document Number: {doc_number}"))
+        return doc_number
+
+    def _normalize_evp(self, key):
+        # EVP: Endereço Virtual de Pagamento (chave aleatória)
+        # ex: 123e4567-e12b-12d1-a456-426655440000
+        key = "".join(key.split())
+        if len(key) != 36:
+            raise ValidationError(
+                _(f"Invalid Random Key: {key}, cannot be longer than 35 characters")
+            )
+        blocks = key.split("-")
+        if len(blocks) != 5:
+            raise ValidationError(
+                _(f"Invalid Random Key: {key}, the key must consist of five blocks.")
+            )
+        for block in blocks:
+            try:
+                int(block, 16)
+            except ValueError:
+                raise ValidationError(
+                    _(
+                        f"Invalid Random Key: {key} \nthe block {block} "
+                        f"is not a valid hexadecimal format."
+                    )
+                )
+        return key
+
+    @api.model
+    def create(self, vals):
+        self.check_vals(vals)
+        return super(PartnerPix, self).create(vals)
+
+    def write(self, vals):
+        self.check_vals(vals)
+        return super(PartnerPix, self).write(vals)
+
+    def check_vals(self, vals):
+        key_type = vals.get("key_type") or self.key_type
+        key = vals.get("key") or self.key
+        if not key or not key_type:
+            return
+        if key_type == "email":
+            key = self._normalize_email(key)
+        elif key_type == "phone":
+            key = self._normalize_phone(key)
+        elif key_type == "cnpj_cpf":
+            key = self._normalize_cnpj_cpf(key)
+        elif key_type == "evp":
+            key = self._normalize_evp(key)
+        vals["key"] = key

--- a/l10n_br_base/readme/CONTRIBUTORS.rst
+++ b/l10n_br_base/readme/CONTRIBUTORS.rst
@@ -1,4 +1,13 @@
-* Renato Lima <renato.lima@akretion.com.br>
-* Raphaël Valyi <raphael.valyi@akretion.com.br>
-* Luis Felipe Mileo <mileo@kmee.com.br>
-* Michell Stuttgart <michell.stuttgart@kmee.com.br>
+* `Akretion <https://www.akretion.com/pt-BR>`_:
+
+  * Renato Lima <renato.lima@akretion.com.br>
+  * Raphaël Valyi <raphael.valyi@akretion.com.br>
+
+* `KMEE <https://www.kmee.com.br>`_:
+
+  * Luis Felipe Mileo <mileo@kmee.com.br>
+  * Michell Stuttgart <michell.stuttgart@kmee.com.br>
+
+* `Engenere <https://engenere.one>`_:
+
+  * Antônio S. Pereira Neto <neto@engenere.one>

--- a/l10n_br_base/readme/DESCRIPTION.rst
+++ b/l10n_br_base/readme/DESCRIPTION.rst
@@ -1,4 +1,4 @@
-Este é o módulo raiz da localização brasileira. Ele traz adaptações nos modelos do módulo ``base`` do Odoo como Parceiros, Empresas e Endereços:
+Este é o módulo 'raiz' da localização brasileira. Ele traz adaptações nos modelos do módulo ``base`` do Odoo como Parceiros, Empresas e Endereços:
 
 * Campo CNPJ e CPF com formatação e validação destes campos;
 * Campo de Inscrição Estadual com validação;
@@ -6,6 +6,7 @@ Este é o módulo raiz da localização brasileira. Ele traz adaptações nos mo
 * Código do Banco Central e Siscomex para países;
 * Código do IBGE para estados e municípios;
 * Lista dos Bancos brasileiros;
+* Contas bancarias e chaves PIX dos parceiros;
 * Lista dos municípios brasileiros.
 
 Se trata de um módulo muito simples e maduro. Existem alguns outros módulos simples que dependem apenas desse módulo ou quase como ``l10n_br_crm`` ou ``l10n_br_portal``.

--- a/l10n_br_base/security/ir.model.access.csv
+++ b/l10n_br_base/security/ir.model.access.csv
@@ -1,3 +1,5 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
 "state_tax_numbers_user","State Tax Numbers for User","model_state_tax_numbers","base.group_user",1,0,0,0
 "state_tax_numbers_manager","State Tax Numbers for Manager","model_state_tax_numbers","base.group_system",1,1,1,1
+"res_partner_pix_user","Partner PIX for User","model_res_partner_pix","base.group_user",1,0,0,0
+"res_partner_pix_manager","Partner PIX for Partner Manager","model_res_partner_pix","base.group_partner_manager",1,1,1,1

--- a/l10n_br_base/tests/__init__.py
+++ b/l10n_br_base/tests/__init__.py
@@ -8,3 +8,5 @@ from . import test_amount_to_text
 from . import test_valid_createid
 from . import test_base_onchange
 from . import test_other_ie
+from . import test_valid_pix
+from . import test_partner_bank

--- a/l10n_br_base/tests/test_partner_bank.py
+++ b/l10n_br_base/tests/test_partner_bank.py
@@ -1,0 +1,36 @@
+from odoo.exceptions import UserError
+from odoo.tests import TransactionCase
+
+
+class PartnerBankTest(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.partner_bank_model = self.env["res.partner.bank"]
+        self.partner_id = self.env.ref("l10n_br_base.res_partner_amd")
+        self.bank_id = self.env.ref("l10n_br_base.res_bank_001")
+
+    def test_ok_transactional_acc_type(self):
+        ok_bank_vals = {
+            "partner_id": self.partner_id.id,
+            "transactional_acc_type": "checking",
+            "bank_id": self.bank_id.id,
+            "bra_number": "1020",
+            "acc_number": "102030",
+            "acc_number_dig": "9",
+        }
+        ok_acc_bank = self.partner_bank_model.with_context(
+            tracking_disable=True
+        ).create(ok_bank_vals)
+        self.assertTrue(ok_acc_bank.exists())
+
+    def test_wrong_transactional_acc_type(self):
+        wrong_bank_vals = {
+            "partner_id": self.partner_id.id,
+            "transactional_acc_type": "checking",
+            "bra_number": "1020",
+            "acc_number_dig": "9",
+        }
+        with self.assertRaises(UserError):
+            self.partner_bank_model.with_context(tracking_disable=True).create(
+                wrong_bank_vals
+            )

--- a/l10n_br_base/tests/test_valid_pix.py
+++ b/l10n_br_base/tests/test_valid_pix.py
@@ -1,0 +1,114 @@
+from psycopg2 import IntegrityError
+
+from odoo.exceptions import ValidationError
+from odoo.tests import TransactionCase
+from odoo.tools import mute_logger
+
+
+class ValidCreatePIXTest(TransactionCase):
+    """Test if ValidationError is raised well during create({})"""
+
+    def setUp(self):
+        super().setUp()
+        self.res_partner_pix_model = self.env["res.partner.pix"]
+        self.partner_id = self.env.ref("l10n_br_base.res_partner_amd")
+
+    def test_invalid_pix_cnpj_too_big(self):
+        pix_vals = {
+            "partner_id": self.partner_id.id,
+            "key_type": "cnpj_cpf",
+            "key": "0296089500013199",
+        }
+        self.check_validation_error_on_create(pix_vals)
+
+    def test_invalid_pix_cnpj_too_less(self):
+        pix_vals = {
+            "partner_id": self.partner_id.id,
+            "key_type": "cnpj_cpf",
+            "key": "950001319",
+        }
+        self.check_validation_error_on_create(pix_vals)
+
+    def test_invalid_pix_cnpj_wrong_value(self):
+        pix_vals = {
+            "partner_id": self.partner_id.id,
+            "key_type": "cnpj_cpf",
+            "key": "12345897560234",
+        }
+        self.check_validation_error_on_create(pix_vals)
+
+    def test_invalid_pix_phone_wrong_value(self):
+        pix_vals = {
+            "partner_id": self.partner_id.id,
+            "key_type": "phone",
+            "key": "1103252020",
+        }
+        self.check_validation_error_on_create(pix_vals)
+
+    def test_invalid_pix_phone_wrong_country_code(self):
+        pix_vals = {
+            "partner_id": self.partner_id.id,
+            "key_type": "phone",
+            "key": "0119991123456789",
+        }
+        self.check_validation_error_on_create(pix_vals)
+
+    def test_invalid_pix_email_wrong_value(self):
+        pix_vals = {
+            "partner_id": self.partner_id.id,
+            "key_type": "email",
+            "key": "teste#teste.com",
+        }
+        self.check_validation_error_on_create(pix_vals)
+
+    def test_invalid_pix_email_too_long(self):
+        pix_vals = {
+            "partner_id": self.partner_id.id,
+            "key_type": "email",
+            "key": "toooooooolooooooooooongemaaaaaailllllll@teeeeeeeee"
+            "eeeeeeeeeeeeeeeeeeeest.com.br",
+        }
+        self.check_validation_error_on_create(pix_vals)
+
+    def test_invalid_pix_EVP_wrong_value(self):
+        pix_vals = {
+            "partner_id": self.partner_id.id,
+            "key_type": "evp",
+            "key": "nmmnaasa-qwhjwqhjk-2112",
+        }
+        self.check_validation_error_on_create(pix_vals)
+
+    def test_invalid_pix_EVP_wrong_blocks(self):
+        pix_vals = {
+            "partner_id": self.partner_id.id,
+            "key_type": "evp",
+            "key": "123e4567-e12b-12d1-a456-426655-40000",
+        }
+        self.check_validation_error_on_create(pix_vals)
+
+    def test_invalid_pix_EVP_wrong_hex(self):
+        pix_vals = {
+            "partner_id": self.partner_id.id,
+            "key_type": "evp",
+            "key": "123*4567-e12b-12d1-a456-426655440000",
+        }
+        self.check_validation_error_on_create(pix_vals)
+
+    def check_validation_error_on_create(self, pix_vals):
+        with self.assertRaises(ValidationError):
+            self.res_partner_pix_model.with_context(tracking_disable=True).create(
+                pix_vals
+            )
+
+    def test_repeated_pix_key(self):
+        pix_vals = {
+            "partner_id": self.partner_id.id,
+            "key_type": "phone",
+            "key": "+50372424737",
+        }
+        self.res_partner_pix_model.with_context(tracking_disable=True).create(pix_vals)
+        with mute_logger("odoo.sql_db"):
+            with self.assertRaisesRegex(IntegrityError, "partner_pix_key_unique"):
+                self.res_partner_pix_model.with_context(tracking_disable=True).create(
+                    pix_vals
+                )

--- a/l10n_br_base/views/res_partner_bank_view.xml
+++ b/l10n_br_base/views/res_partner_bank_view.xml
@@ -25,6 +25,26 @@
                     <field name="bra_bank_bic" class="oe_inline" />
                 </div>
             </field>
+            <xpath expr="//form/sheet/group" position="inside">
+                <group
+                    name="pix"
+                    string="Brazilian Instant Payment Keys (PIX)"
+                    attrs="{'invisible': [('company_country_id', '!=', %(base.br)d)]}"
+                >
+                    <field name="company_country_id" invisible="1" />
+                    <field name="transactional_acc_type" />
+                    <field
+                        name="partner_pix_ids"
+                        context="{'default_partner_id': partner_id}"
+                    >
+                        <tree editable="bottom">
+                            <field name="partner_id" invisible="1" />
+                            <field name="key_type" />
+                            <field name="key" />
+                        </tree>
+                    </field>
+                </group>
+            </xpath>
         </field>
     </record>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # generated from manifests external_dependencies
+email_validator
 erpbrasil.assinatura
 erpbrasil.base
 erpbrasil.edoc
@@ -7,6 +8,7 @@ erpbrasil.transmissao
 nfelib
 num2words
 odoo_test_helper
+phonenumbers
 pycep_correios
 workalendar
 xmldiff


### PR DESCRIPTION
Permite o cadastro de chaves PIX no Parceiro.

![image](https://user-images.githubusercontent.com/634278/189511948-8058ed11-db09-4feb-b320-cd2cef272715.png)
O cadastro fica dentro do cadastro do Parceiro, na aba invoicing a baixo do cadastro das contas bancárias.

As chaves são tratadas e validadas conforme o seu tipo.
