### PR TITLE
[14.0][REF][FIX] l10n_br_base: remove código desnecessário envolvendo o endereço.

### DIFF
--- a/l10n_br_base/demo/l10n_br_base_demo.xml
+++ b/l10n_br_base/demo/l10n_br_base_demo.xml
@@ -463,7 +463,7 @@
     <record id="res_partner_exterior" model="res.partner">
         <field name="name">Cliente Exterior</field>
         <field name="is_company">1</field>
-        <field name="street_name">3404  Edgewood Road</field>
+        <field name="street">3404  Edgewood Road</field>
         <field name="city">Jonesboro</field>
         <field
             name="state_id"


### PR DESCRIPTION
Remove os métodos:

**_get_street_fields** : O override não é mais necessário, pois não precisamos adicionar o "street" no dict.

 **_set_street**:  Esse método não existe mais no 14.0 o nome mudou para _inverse_street_data, de qualquer forma não precisamos mais fazer o override, a finalidade era pra corrigir um bug que existia na 12.0,  porém o mesmo já foi corrigido diretamente no Odoo a partir da versão 13.0.

Fix no dados de demostração:

O field do endereço computado o correto é **street** e não **street_name**, o testes locais estavam quebrando por causa disso, só não entendi muito bem por que isso não acusou no Travis antes.. 

