### PR TITLE
[12.0][FIX] l10n_br_sale_invoice_plan: fix price_unit on invoice.line

### DIFF
--- a/l10n_br_sale_invoice_plan/models/sale_invoice_plan.py
+++ b/l10n_br_sale_invoice_plan/models/sale_invoice_plan.py
@@ -16,5 +16,7 @@ class SaleInvoicePlan(models.Model):
         if invoice:
             for line in invoice.invoice_line_ids:
                 line.write({"fiscal_quantity": line.quantity})
+                price_unit = line.price_unit
                 line._onchange_fiscal_tax_ids()
+                line.write({"price_unit": price_unit})
             invoice._onchange_invoice_line_ids()


### PR DESCRIPTION
Quando chama o método _onchange_fiscal_tax_ids() o preço unitário é alterado buscando o preço de venda do produto. 