### PR TITLE
[12.0][IMP] l10n_br_contract: remove dead code

### DIFF
--- a/l10n_br_contract/models/contract_contract.py
+++ b/l10n_br_contract/models/contract_contract.py
@@ -1,7 +1,7 @@
 # Copyright 2020 KMEE INFORMATICA LTDA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 
 
 class ContractContract(models.Model):
@@ -167,19 +167,3 @@ class ContractContract(models.Model):
                     inv_vals[index]["invoice_line_ids"].append(inv_line)
 
         return inv_vals
-
-    def recurring_create_invoice(self):
-        """
-        override the contract method to allow posting for more than one invoice
-        """
-        invoices = self._recurring_create_invoice()
-        for invoice in invoices:
-            self.message_post(
-                body=_(
-                    "Contract manually invoiced: "
-                    '<a href="#" data-oe-model="%s" data-oe-id="%s">Invoice'
-                    "</a>"
-                )
-                % (invoice._name, invoice.id)
-            )
-        return invoices


### PR DESCRIPTION
Removendo a sobreescrita do método  recurring_create_invoice porque agora o mesmo comportamento já está implementado diretamente no módulo contract

https://github.com/OCA/contract/blob/32302960426b7433fc7f26c9a0bb122a1beba7ec/contract/models/contract.py#L622
