### PR TITLE
[14.0][REF] pay_order: hide fields for outbound payments

### DIFF
--- a/l10n_br_account_payment_order/views/account_payment_order.xml
+++ b/l10n_br_account_payment_order/views/account_payment_order.xml
@@ -46,8 +46,14 @@
                     name="release_form"
                     attrs="{'invisible': [('payment_method_code', '!=', '240')]}"
                 />
-                <field name="code_convetion" />
-                <field name="code_convenio_lider" />
+                <field
+                    name="code_convetion"
+                    attrs="{'invisible': [('payment_type', '=', 'outbound')]}"
+                />
+                <field
+                    name="code_convenio_lider"
+                    attrs="{'invisible': [('payment_type', '=', 'outbound')]}"
+                />
             </field>
             <field name="company_id" position="after">
                 <field


### PR DESCRIPTION
Os campos code_convetion e code_convenio_lider fazem sentido apenas para cobranças, por isso o invisible em casos de pagamentos. 

