### PR TITLE
[14.0][FIX] payment_order: payment_mode na linha de pagamento deve ser related

### DIFF
--- a/l10n_br_account_payment_order/models/account_move_line.py
+++ b/l10n_br_account_payment_order/models/account_move_line.py
@@ -134,7 +134,6 @@ class AccountMoveLine(models.Model):
                     "own_number": self.own_number,
                     "document_number": self.document_number,
                     "company_title_identification": self.company_title_identification,
-                    "payment_mode_id": self.payment_mode_id.id,
                     # Codigo de Instrução do Movimento
                     "mov_instruction_code_id": self.mov_instruction_code_id.id,
                     "communication_type": "cnab",

--- a/l10n_br_account_payment_order/models/account_payment_line.py
+++ b/l10n_br_account_payment_order/models/account_payment_line.py
@@ -89,6 +89,7 @@ class AccountPaymentLine(models.Model):
 
     payment_mode_id = fields.Many2one(
         comodel_name="account.payment.mode",
+        related="order_id.payment_mode_id",
     )
 
     # Campo não usado no BRCobranca


### PR DESCRIPTION
A forma de pagamento da linha de pagamento não pode ser diferente da ordem de pagamento.
por isso removi a inserção manual e alterei o campo para ser um related.

