### PR TITLE
[14.0][FIX] l10n_br_account: compute fiscal operation type for entry moves

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -114,6 +114,10 @@ class AccountMove(models.Model):
 
     def _compute_fiscal_operation_type(self):
         for inv in self:
+            if inv.move_type == "entry":
+                # if it is a Journal Entry there is nothing to do.
+                inv.fiscal_operation_type = False
+                continue
             if inv.fiscal_operation_id:
                 inv.fiscal_operation_type = (
                     inv.fiscal_operation_id.fiscal_operation_type


### PR DESCRIPTION
Correção urgente para resolver a regressão causada pela PR #2131. issue #2144

A computação não deve ser feita para lançamentos contábeis que não são faturas/recibos.