### PR TITLE
[14.0][IMP] payment_order: cnab processor

### DIFF
--- a/l10n_br_account_payment_brcobranca/__manifest__.py
+++ b/l10n_br_account_payment_brcobranca/__manifest__.py
@@ -24,5 +24,6 @@
     "demo": [
         "demo/account_journal_demo.xml",
         "demo/account_move_demo.xml",
+        "demo/account_payment_mode.xml",
     ],
 }

--- a/l10n_br_account_payment_brcobranca/__manifest__.py
+++ b/l10n_br_account_payment_brcobranca/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "L10n Br Account Payment BRCobranca",
-    "version": "14.0.1.3.3",
+    "version": "14.0.2.0.0",
     "license": "AGPL-3",
     "author": "Akretion, " "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-brazil",

--- a/l10n_br_account_payment_brcobranca/demo/account_payment_mode.xml
+++ b/l10n_br_account_payment_brcobranca/demo/account_payment_mode.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="True">
+
+    <!-- Bradesco CNAB 400 -->
+    <record
+        id="l10n_br_account_payment_order.payment_mode_cobranca_bradesco400"
+        model="account.payment.mode"
+    >
+        <field name="cnab_processor">brcobranca</field>
+    </record>
+
+    <!-- Modo de Pagamento cobrança Bradesco 240 -->
+    <record
+        id="l10n_br_account_payment_order.payment_mode_cobranca_bradesco240"
+        model="account.payment.mode"
+    >
+        <field name="cnab_processor">brcobranca</field>
+    </record>
+
+    <!-- Payment Mode Cobrança Unicred 400 -->
+    <record
+        id="l10n_br_account_payment_order.payment_mode_cobranca_unicred400"
+        model="account.payment.mode"
+    >
+        <field name="cnab_processor">brcobranca</field>
+    </record>
+
+    <!-- Payment Mode Cobrança Unicred 240 -->
+    <record
+        id="l10n_br_account_payment_order.payment_mode_cobranca_unicred240"
+        model="account.payment.mode"
+    >
+        <field name="cnab_processor">brcobranca</field>
+    </record>
+
+    <!-- Payment Mode Cobrança AILOS 240 -->
+    <record
+        id="l10n_br_account_payment_order.payment_mode_cobranca_ailos240"
+        model="account.payment.mode"
+    >
+        <field name="cnab_processor">brcobranca</field>
+    </record>
+
+    <!-- Modo de Pagamento cobrança Itau 240 -->
+    <record
+        id="l10n_br_account_payment_order.payment_mode_cobranca_itau240"
+        model="account.payment.mode"
+    >
+        <field name="cnab_processor">brcobranca</field>
+    </record>
+
+    <!-- Modo de Pagamento cobrança Itau 400 -->
+    <record
+        id="l10n_br_account_payment_order.payment_mode_cobranca_itau400"
+        model="account.payment.mode"
+    >
+        <field name="cnab_processor">brcobranca</field>
+    </record>
+
+    <!-- Modo de Pagamento cobrança Caixa Economica Federal 240 -->
+    <record
+        id="l10n_br_account_payment_order.payment_mode_cobranca_cef240"
+        model="account.payment.mode"
+    >
+        <field name="cnab_processor">brcobranca</field>
+    </record>
+
+    <!-- Modo de Pagamento cobrança Caixa Economica Federal 400 -->
+    <record
+        id="l10n_br_account_payment_order.payment_mode_cobranca_cef400"
+        model="account.payment.mode"
+    >
+        <field name="cnab_processor">brcobranca</field>
+    </record>
+
+    <!-- Modo de Pagamento Cobrança SICRED 240 -->
+    <record
+        id="l10n_br_account_payment_order.payment_mode_cobranca_sicredi240"
+        model="account.payment.mode"
+    >
+        <field name="cnab_processor">brcobranca</field>
+    </record>
+
+    <!-- Payment Mode Cobrança Banco do Brasil 400 -->
+    <record
+        id="l10n_br_account_payment_order.payment_mode_cobranca_bb400"
+        model="account.payment.mode"
+    >
+        <field name="cnab_processor">brcobranca</field>
+    </record>
+
+    <!-- Payment Mode Cobrança Banco do Brasil 240 -->
+    <record
+        id="l10n_br_account_payment_order.payment_mode_cobranca_bb240"
+        model="account.payment.mode"
+    >
+        <field name="cnab_processor">brcobranca</field>
+    </record>
+
+</odoo>

--- a/l10n_br_account_payment_brcobranca/migrations/14.0.2.0.0/post-migration.py
+++ b/l10n_br_account_payment_brcobranca/migrations/14.0.2.0.0/post-migration.py
@@ -1,0 +1,19 @@
+from openupgradelib import openupgrade
+
+
+def populate_cnab_processor(env):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE account_payment_mode
+        AS apm
+        SET cnab_processor='brcobranca'
+        WHERE apm.payment_method_code IN ('240', '400', '500')
+        AND apm.cnab_processor IN (NULL, 'none')
+        """,
+    )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    populate_cnab_processor(env)

--- a/l10n_br_account_payment_brcobranca/models/__init__.py
+++ b/l10n_br_account_payment_brcobranca/models/__init__.py
@@ -7,3 +7,4 @@ from . import account_move
 from . import account_payment_order
 from . import bank_payment_line
 from . import account_journal
+from . import account_payment_mode

--- a/l10n_br_account_payment_brcobranca/models/account_payment_mode.py
+++ b/l10n_br_account_payment_brcobranca/models/account_payment_mode.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2012-Today - KMEE (<http://kmee.com.br>).
+#  @author Luis Felipe Miléo - mileo@kmee.com.br
+#  @author Renato Lima - renato.lima@akretion.com.br
+# Copyright (C) 2021-Today - Akretion (<http://www.akretion.com>).
+# @author Magno Costa <magno.costa@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class AccountPaymentMode(models.Model):
+    """
+    Override Account Payment Mode
+    """
+
+    _inherit = "account.payment.mode"
+
+    cnab_processor = fields.Selection(
+        selection_add=[("brcobranca", "BRCobrança")],
+    )

--- a/l10n_br_account_payment_brcobranca/models/account_payment_order.py
+++ b/l10n_br_account_payment_brcobranca/models/account_payment_order.py
@@ -108,7 +108,10 @@ class PaymentOrder(models.Model):
         cnab_type = self.payment_mode_id.payment_method_code
 
         # Se não for um caso CNAB deve chamar o super
-        if cnab_type not in ("240", "400", "500"):
+        if (
+            cnab_type not in ("240", "400", "500")
+            or self.payment_mode_id.cnab_processor != "brcobranca"
+        ):
             return super().generate_payment_file()
 
         bank_account_id = self.journal_id.bank_account_id

--- a/l10n_br_account_payment_order/models/account_payment_mode.py
+++ b/l10n_br_account_payment_order/models/account_payment_mode.py
@@ -56,6 +56,8 @@ class AccountPaymentMode(models.Model):
         related="fixed_journal_id.company_id.own_number_type",
     )
 
+    cnab_processor = fields.Selection(selection=[("none", "None")], default="none")
+
     # Codigos de Retorno do Movimento
 
     # TODO: Campos many2many não estão sendo registrados pelo track_visibility.

--- a/l10n_br_account_payment_order/views/account_payment_mode.xml
+++ b/l10n_br_account_payment_order/views/account_payment_mode.xml
@@ -14,6 +14,12 @@
                 <separator />
                 <field name="auto_create_payment_order" />
             </field>
+            <field name="payment_type" position="after">
+                <field
+                    name="cnab_processor"
+                    attrs="{'invisible': [('payment_method_code', 'not in', ('240', '400', '500'))], 'required': [('payment_method_code', 'in', ('240', '400', '500'))]}"
+                />
+            </field>
             <xpath expr="//form/sheet/group[@name='note']" position="before">
                 <group
                     string="Configurações Brasileiras - CNAB"


### PR DESCRIPTION
Hoje na localização temos apenas o BRCobrança como processador de arquivos CNAB. Porém como alguns já sabem, estamos trabalhando em um módulo para fazer pagamentos automatizados e essa API não suportaria lidar com a questão.

Nessa PR estamos propondo adicionar a possibilidade do usuário escolher processadores CNAB diferentes para cada payment_mode.

Nessa semana ou na próxima queremos abrir um PR com a referida funcionalidade, o que fará essa proposta fazer mais sentido.
