### PR TITLE
[14.0][FIX] l10n_br_fiscal: Acrescenta campo type em document_type_tree

### DIFF
--- a/l10n_br_fiscal/views/document_type_view.xml
+++ b/l10n_br_fiscal/views/document_type_view.xml
@@ -9,6 +9,7 @@
                 <field name="code" />
                 <field name="name" />
                 <field name="electronic" />
+                <field name="type" />                
             </tree>
         </field>
     </record>


### PR DESCRIPTION
Para que seja possível a criação de um documento fiscal.
Pois esse campo é obrigatório, mas não está aparecendo do form de criação.

Para solução do #2140