### PR TITLE
[14.0][FIX] l10n_br_nfse: check provider before serializing

### DIFF
--- a/l10n_br_nfse/models/document.py
+++ b/l10n_br_nfse/models/document.py
@@ -125,23 +125,26 @@ class Document(models.Model):
     def _document_export(self, pretty_print=True):
         super(Document, self)._document_export()
         for record in self.filtered(filter_processador_edoc_nfse):
-            edoc = record.serialize()[0]
-            processador = record._processador_erpbrasil_nfse()
-            xml_file = processador._generateds_to_string_etree(
-                edoc, pretty_print=pretty_print
-            )[0]
-            event_id = self.event_ids.create_event_save_xml(
-                company_id=self.company_id,
-                environment=(
-                    EVENT_ENV_PROD if self.nfse_environment == "1" else EVENT_ENV_HML
-                ),
-                event_type="0",
-                xml_file=xml_file,
-                document_id=self,
-            )
-            _logger.debug(xml_file)
-            record.authorization_event_id = event_id
-            record.make_pdf()
+            if record.company_id.provedor_nfse:
+                edoc = record.serialize()[0]
+                processador = record._processador_erpbrasil_nfse()
+                xml_file = processador._generateds_to_string_etree(
+                    edoc, pretty_print=pretty_print
+                )[0]
+                event_id = self.event_ids.create_event_save_xml(
+                    company_id=self.company_id,
+                    environment=(
+                        EVENT_ENV_PROD
+                        if self.nfse_environment == "1"
+                        else EVENT_ENV_HML
+                    ),
+                    event_type="0",
+                    xml_file=xml_file,
+                    document_id=self,
+                )
+                _logger.debug(xml_file)
+                record.authorization_event_id = event_id
+                record.make_pdf()
 
     def _prepare_dados_servico(self):
         # TODO: Migration 14.0: Acredito que fiscal_line_ids


### PR DESCRIPTION
Verifica se tem provedor antes de tentar serializar o documento. Desta forma o lançamento é postado porém o documento ainda fica como a ser enviado. 