### PR TITLE
[12.0][l10n_br_payment_order][backport] payment order cleanup

### DIFF
--- a/l10n_br_account_payment_order/models/l10n_br_cnab_boleto_fields.py
+++ b/l10n_br_account_payment_order/models/l10n_br_cnab_boleto_fields.py
@@ -9,7 +9,7 @@ from odoo.addons import decimal_precision as dp
 from ..constants import BOLETO_ESPECIE
 
 
-class L10nBrCNABBoletoFields(models.Model):
+class L10nBrCNABBoletoFields(models.AbstractModel):
     _name = "l10n_br_cnab.boleto.fields"
     _description = "CNAB - Boleto Fields."
 

--- a/l10n_br_account_payment_order/models/l10n_br_cnab_payment_fields.py
+++ b/l10n_br_account_payment_order/models/l10n_br_cnab_payment_fields.py
@@ -11,7 +11,7 @@ from ..constants import (
 )
 
 
-class L10nBrCNABPaymentFields(models.Model):
+class L10nBrCNABPaymentFields(models.AbstractModel):
     _name = "l10n_br_cnab.payment.fields"
     _description = "CNAB - Payment Fields."
 

--- a/l10n_br_account_payment_order/views/account_payment_order.xml
+++ b/l10n_br_account_payment_order/views/account_payment_order.xml
@@ -46,8 +46,14 @@
                     name="release_form"
                     attrs="{'invisible': [('payment_method_code', '!=', '240')]}"
                 />
-                <field name="code_convetion" />
-                <field name="code_convenio_lider" />
+                <field
+                    name="code_convetion"
+                    attrs="{'invisible': [('payment_type', '=', 'outbound')]}"
+                />
+                <field
+                    name="code_convenio_lider"
+                    attrs="{'invisible': [('payment_type', '=', 'outbound')]}"
+                />
             </field>
             <field name="company_id" position="after">
                 <field


### PR DESCRIPTION
Fica para debate e de acordo com necessidade e disposição quais PR da 14.0 devem ou não ter um backport para a v12. Mas neste caso se trata de coisas simples que podem ser corrigidas na 12.0, deixando o codigo mais proximo da 14.0.

- [x] https://github.com/OCA/l10n-brazil/pull/2139
- [x] https://github.com/OCA/l10n-brazil/pull/1953 (apenas 1 dos 3 commits)

cc @renatonlima @mbcosta @felipemotter @netosjb @marcelsavegnago 