### PR TITLE
[14.0][IMP] l10n_br_nfe: validação para o ambiente de homologação

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -729,6 +729,7 @@ class NFe(spec_models.StackedModel):
     def _processador(self):
         if not self.company_id.certificate_nfe_id:
             raise UserError(_("Certificado não encontrado"))
+        self._check_nfe_environment()
 
         certificado = cert.Certificado(
             arquivo=self.company_id.certificate_nfe_id.file,
@@ -743,6 +744,18 @@ class NFe(spec_models.StackedModel):
             versao=self.nfe_version,
             ambiente=self.nfe_environment,
         )
+
+    def _check_nfe_environment(self):
+        self.ensure_one()
+        company_nfe_environment = self.company_id.nfe_environment
+        if self.nfe_environment != company_nfe_environment:
+            raise UserError(
+                _(
+                    f"Nf-e environment: {self.nfe_environment}"
+                    " cannot be different from what is configured "
+                    f"in the company: {company_nfe_environment}"
+                )
+            )
 
     def _document_export(self, pretty_print=True):
         result = super()._document_export()

--- a/l10n_br_nfe/views/nfe_document_view.xml
+++ b/l10n_br_nfe/views/nfe_document_view.xml
@@ -7,6 +7,16 @@
       <field name="priority">5</field>
       <field name="inherit_id" ref="l10n_br_fiscal.document_form" />
       <field name="arch" type="xml">
+        <xpath expr="//sheet" position="before">
+            <div
+                    class="alert alert-warning"
+                    role="alert"
+                    attrs="{'invisible': [('nfe_environment','!=','2')]}"
+                >
+            Nf-e Environment: <strong><field name="nfe_environment" /></strong>
+            </div>
+        </xpath>
+
           <page name="delivery" position="inside">
               <group
                     name="nfe_transport"
@@ -89,6 +99,12 @@
                 <field name="nfe40_autXML" widget="many2many" />
               </group>
           </page>
+            <xpath
+                expr="//page[@name='others']//group//field[@name='status_description']"
+                position="after"
+            >
+                <field name="nfe_environment" />
+            </xpath>
       </field>
   </record>
 


### PR DESCRIPTION
Hoje na localização é fácil se confundir e transmitir uma nota fiscal no ambiente de produção quando a intenção era na verdade o ambiente de homologação. 

Isso pode acontecer facilmente pois o sistema guarda a informação individualmente em cada nota fiscal, a informação do ambiente é pego da configuração da empresa no momento que se inicia a digitação da nota fiscal, então se alterar o amebite de produção para homologação depois de já ter inciado a digitação da nota, o ambiente na nota irá permanecer como produção, se por descuido transmitir essa nota, ela será transmitida no ambiente em produção e não em homologação, mesmo que a configuração do sistema/empresa esteja como homologação.

Para evitar isso fiz algumas alterações: 

Exibe um aviso quando o ambiente de homologação está ativo:
![image](https://user-images.githubusercontent.com/634278/196052845-a851c229-7025-4327-b518-1d90503b5d71.png)

Impede a transmissão da nota fiscal caso o ambiente configurado dentro do documento esteja diferente do configurado na empresa.
![image](https://user-images.githubusercontent.com/634278/196054080-0198f94f-fb8c-4779-a302-e4fdd7af1aa1.png)

Adiciona o campo do ambiente na visualização do documento fiscal, na aba "Others"
![image](https://user-images.githubusercontent.com/634278/196054116-45825cfc-9d0b-4634-b000-b4c74a4927f6.png)
