### PR TITLE
[14.0][FIX] l10n_br_stock: wrong table name for stock_picking

### DIFF
--- a/l10n_br_fiscal/demo/product_demo.xml
+++ b/l10n_br_fiscal/demo/product_demo.xml
@@ -509,7 +509,7 @@
     </record>
 
     <!-- DESK0004 - Customizable Desk -->
-    <record id="product.product_product_4d" model="product.product">
+    <record id="product.product_product_4c" model="product.product">
         <field name="ncm_id" ref="l10n_br_fiscal.ncm_94033000" />
         <field name="fiscal_genre_id" ref="l10n_br_fiscal.product_genre_94" />
         <field name="fiscal_type">04</field>

--- a/l10n_br_nfe/tests/test_nfe_xml_validation.py
+++ b/l10n_br_nfe/tests/test_nfe_xml_validation.py
@@ -36,7 +36,7 @@ class TestXMLValidation(TransactionCase):
                 "partner_id": document.partner_id.id,
                 "fiscal_operation_type": document.fiscal_operation_type,
                 "fiscal_operation_id": document.fiscal_operation_id.id,
-                "product_id": self.env.ref("product.product_product_4d").id,
+                "product_id": self.env.ref("product.product_product_4c").id,
             }
         )
         line._onchange_product_id_fiscal()

--- a/l10n_br_stock/migrations/14.0.2.0.0/pre-migration.py
+++ b/l10n_br_stock/migrations/14.0.2.0.0/pre-migration.py
@@ -5,7 +5,7 @@
 from openupgradelib import openupgrade
 
 _column_renames = {
-    "stock.picking": [("ie", "inscr_est")],
+    "stock_picking": [("ie", "inscr_est")],
 }
 
 


### PR DESCRIPTION
Fix para corrigir o nome da tabela no script de migração do l10n_br_stock.
resolve a issue #2174 