### PR TITLE
Pylint raise missing

### DIFF
--- a/.pylintrc-mandatory
+++ b/.pylintrc-mandatory
@@ -89,8 +89,8 @@ enable=anomalous-backslash-in-string,
     xml-attribute-translatable,
     xml-deprecated-qweb-directive,
     xml-deprecated-tree-attribute,
-    external-request-timeout
-
+    external-request-timeout,
+    raise-missing-from
 
 [REPORTS]
 msg-template={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}

--- a/l10n_br_account_payment_brcobranca/models/account_journal.py
+++ b/l10n_br_account_payment_brcobranca/models/account_journal.py
@@ -225,7 +225,7 @@ class AccountJournal(models.Model):
             except UserError:
                 # "Clean" exception, raise as such
                 raise
-            except Exception:
+            except Exception as e:
                 error_type, error_value, trbk = sys.exc_info()
                 st = "Error: %s\nDescription: %s\nTraceback:" % (
                     error_type.__name__,
@@ -235,6 +235,6 @@ class AccountJournal(models.Model):
                 raise ValidationError(
                     _("Statement import error " "The statement cannot be created: %s")
                     % st
-                )
+                ) from e
 
         return moves

--- a/l10n_br_base/models/res_partner_pix.py
+++ b/l10n_br_base/models/res_partner_pix.py
@@ -60,8 +60,8 @@ class PartnerPix(models.Model):
                 email,
                 check_deliverability=False,
             )
-        except EmailSyntaxError:
-            raise ValidationError(_(f"{email.strip()} is an invalid email"))
+        except EmailSyntaxError as e:
+            raise ValidationError(_(f"{email.strip()} is an invalid email")) from e
         normalized_email = result["local"].lower() + "@" + result["domain_i18n"]
         if len(normalized_email) > 77:
             raise ValidationError(
@@ -69,22 +69,22 @@ class PartnerPix(models.Model):
                     f"The email is too long, "
                     f"a maximum of 77 characters is allowed: \n{email.strip()}"
                 )
-            )
+            ) from None
         return normalized_email
 
     def _normalize_phone(self, phone):
         try:
             phonenumber = phonenumbers.parse(phone, "BR")
         except phonenumbers.phonenumberutil.NumberParseException as e:
-            raise ValidationError(_(f"Unable to parse {phone}: {str(e)}"))
+            raise ValidationError(_(f"Unable to parse {phone}: {str(e)}")) from e
         if not phonenumbers.is_possible_number(phonenumber):
             raise ValidationError(
                 _(f"Impossible number {phone}: probably invalid number of digits.")
-            )
+            ) from None
         if not phonenumbers.is_valid_number(phonenumber):
             raise ValidationError(
                 _(f"Invalid number {phone}: probably incorrect prefix.")
-            )
+            ) from None
         phone = phonenumbers.format_number(
             phonenumber, phonenumbers.PhoneNumberFormat.E164
         )
@@ -120,13 +120,13 @@ class PartnerPix(models.Model):
         for block in blocks:
             try:
                 int(block, 16)
-            except ValueError:
+            except ValueError as e:
                 raise ValidationError(
                     _(
                         f"Invalid Random Key: {key} \nthe block {block} "
                         f"is not a valid hexadecimal format."
                     )
-                )
+                ) from e
         return key
 
     @api.model

--- a/l10n_br_fiscal/models/certificate.py
+++ b/l10n_br_fiscal/models/certificate.py
@@ -77,7 +77,9 @@ class Certificate(models.Model):
             try:
                 cert = certificado.Certificado(cert_file, cert_password)
             except Exception as e:
-                raise ValidationError(_("Cannot load Certificate ! \n\n {}").format(e))
+                raise ValidationError(
+                    _("Cannot load Certificate ! \n\n {}").format(e)
+                ) from e
 
             if cert:
                 values["issuer_name"] = cert.emissor

--- a/l10n_br_fiscal/models/closing.py
+++ b/l10n_br_fiscal/models/closing.py
@@ -261,12 +261,12 @@ class FiscalClosing(models.Model):
                 )
                 for attachment in attachment_ids:
                     self._save_tempfile(path, attachment, temp_dir)
-            except OSError:
-                raise RedirectWarning(_("Error!"), _("I/O Error"))
-            except PermissionError:
+            except OSError as e:
+                raise RedirectWarning(_("Error!"), _("I/O Error")) from e
+            except PermissionError as e:
                 raise RedirectWarning(
                     _("Error!"), _("Check write permissions in your system temp folder")
-                )
+                ) from e
 
         for document in documents:
             attachment_ids = document.authorization_event_id.mapped("file_response_id")
@@ -283,12 +283,12 @@ class FiscalClosing(models.Model):
 
                 for attachment in attachment_ids:
                     self._save_tempfile(document_path, attachment, temp_dir)
-            except OSError:
-                raise RedirectWarning(_("Error!"), _("I/O Error"))
-            except PermissionError:
+            except OSError as e:
+                raise RedirectWarning(_("Error!"), _("I/O Error")) from e
+            except PermissionError as e:
                 raise RedirectWarning(
                     _("Error!"), _("Check write permissions in your system temp folder")
-                )
+                ) from e
             except Exception:
                 _logger.error(
                     _(

--- a/l10n_br_fiscal/models/document_event.py
+++ b/l10n_br_fiscal/models/document_event.py
@@ -235,7 +235,7 @@ class Event(models.Model):
             if not os.path.exists(save_dir):
                 os.makedirs(save_dir)
             f = open(file_path, "w")
-        except IOError:
+        except IOError as e:
             raise UserError(
                 _("Erro!"),
                 _(
@@ -243,7 +243,7 @@ class Event(models.Model):
                     em disco, verifique as permissões de escrita
                     e o caminho da pasta"""
                 ),
-            )
+            ) from e
         else:
             f.write(arquivo)
             f.close()

--- a/l10n_br_fiscal/models/ibpt/taxes.py
+++ b/l10n_br_fiscal/models/ibpt/taxes.py
@@ -40,7 +40,7 @@ def _request(ws_url, params):
         elif response.status_code == requests.codes.service_unavailable:
             raise UserError(_("IBPT Service Unavailable - {!r}").format(ws_url))
     except Exception as e:
-        raise UserError(_("Error in the request: {}").format(e))
+        raise UserError(_("Error in the request: {}").format(e)) from e
 
 
 def get_ibpt_product(

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -705,7 +705,7 @@ class NFe(spec_models.StackedModel):
                 except Exception as e:
                     raise ValidationError(
                         _("{}:\n {}").format(record.document_type_id.name, e)
-                    )
+                    ) from e
         return result
 
     def _serialize(self, edocs):

--- a/l10n_br_zip/models/l10n_br_zip.py
+++ b/l10n_br_zip/models/l10n_br_zip.py
@@ -135,7 +135,7 @@ class L10nBrZip(models.Model):
                 zip_str, webservice=cep_ws_providers.get(cep_ws_provide)
             )
         except Exception as e:
-            raise UserError(_("Error in PyCEP-Correios: ") + str(e))
+            raise UserError(_("Error in PyCEP-Correios: ") + str(e)) from e
 
         values = {}
         if cep and any(cep.values()):
@@ -177,7 +177,7 @@ class L10nBrZip(models.Model):
                 zip_code=obj.zip,
             )
         except AttributeError as e:
-            raise UserError(_("Error loading attribute: ") + str(e))
+            raise UserError(_("Error loading attribute: ") + str(e)) from e
 
         zips = self.search(domain)
 


### PR DESCRIPTION
Atualmente essa regra é checada na v16 pelo flake8 e não pelo pylint.... Eu passei um tempo tentando decobrir como ativar isso via flake8 e acabei ativando via pylint, mais fácil.

Essa creio que seja a ultima regra que falta para v14 e 16 ficarem com as mesmas validações.