### PR TITLE
[16.0][REM] pylint missing-files

### DIFF
--- a/.pylintrc-mandatory
+++ b/.pylintrc-mandatory
@@ -69,7 +69,7 @@ enable=anomalous-backslash-in-string,
     deprecated-openerp-xml-node,
     duplicate-po-message-definition,
     except-pass,
-    file-not-used,
+    # file-not-used, Removed because l10n_br_fiscal has many files only on hook
     invalid-commit,
     manifest-maintainers-list,
     missing-newline-extrafiles,


### PR DESCRIPTION
Remove a checagem de arquivos não declarados no manifesto pois o módulo fiscal tem vários arquivos que só são importados no hook.
