### PR TITLE
[FIX] certificate datetime test error

### DIFF
--- a/l10n_br_fiscal/models/certificate.py
+++ b/l10n_br_fiscal/models/certificate.py
@@ -112,7 +112,7 @@ class Certificate(models.Model):
                     c.type and c.type.upper() or "",
                     c.subtype and c.subtype.upper() or "",
                     c.owner_name or "",
-                    format_date(self.env, c.date_expiration),
+                    format_date(self.env, c.date_expiration.date()),
                 )
                 c.file_name = c.name + ".p12"
             else:


### PR DESCRIPTION
Dependendo do horário do testes e o horário do servidor o teste do fiscal falha pois estava considerando a hora do certificado no name_get do teste do certificado.

![image](https://user-images.githubusercontent.com/1975978/197651300-84e6ef0f-0c3b-4fe7-81be-9dd509c32f27.png)


