### PR TITLE
[14.0][REF] l10n_br_account_payment_brcobranca: Model Check

### DIFF
--- a/l10n_br_account_payment_brcobranca/models/account_journal.py
+++ b/l10n_br_account_payment_brcobranca/models/account_journal.py
@@ -48,9 +48,9 @@ class AccountJournal(models.Model):
                 ftype=ftype,
             )
 
-            if len(result) > 1 or hasattr(result, "journal_id"):
+            if len(result) > 1 or result._name == "account.move":
                 res_move |= result
-            if hasattr(result, "filename"):
+            if result._name == "l10n_br_cnab.return.log":
                 res_cnab_log |= result
         if res_move:
             return res_move

--- a/l10n_br_account_payment_brcobranca/wizard/import_statement.py
+++ b/l10n_br_account_payment_brcobranca/wizard/import_statement.py
@@ -18,9 +18,9 @@ class CreditPartnerStatementImporter(models.TransientModel):
             result = journal.with_context(
                 file_name=importer.file_name
             ).multi_move_import(importer.input_statement, ftype.replace(".", ""))
-            if len(result) > 1 or hasattr(result, "journal_id"):
+            if len(result) > 1 or result._name == "account.move":
                 moves |= result
-            if hasattr(result, "filename"):
+            if result._name == "l10n_br_cnab.return.log":
                 cnab_logs |= result
 
         if moves:


### PR DESCRIPTION
Pequeno refactor para melhorar a comparação para descobrir se o modelo é um **account.move**

Antes a premissa era que se o modelo houvesse um atributo (campo) chamado **journal_id** ele seria considerado um **account.move**. Porém isso é pouco confiável, no momento que o outro modelo também implementar o campo **journal_id** vamos ter problema. Foi o que aconteceu no módulo **l10n_br_cnab_structure**, que o modelo **l10n_br_cnab.return.log** é estendido e adicionado o campo **journal_id**, no momento que instala o módulo os testes no **brcobranca** quebram.

Alterei a comparação para utilizar o próprio nome do modelo.


 

