### PR TITLE
[14.0][FIX] l10n_br_account: not show document_number for non-fiscal invoices

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -544,6 +544,16 @@ class AccountMove(models.Model):
         self.ensure_one()
         return self.fiscal_document_id.action_send_email()
 
+    @api.onchange("document_type_id")
+    def _onchange_document_type_id(self):
+        # We need to ensure that invoices without a fiscal document have the
+        # document_number blank, as all invoices without a fiscal document share this
+        # same field, they are linked to the same dummy fiscal document.
+        # Otherwise, in the tree view, this field will be displayed with the same value
+        # for all these invoices.
+        if not self.document_type_id:
+            self.document_number = ""
+
     # TODO FIXME migrate. refund method are very different in Odoo 13+
     # def _get_refund_common_fields(self):
     #     fields = super()._get_refund_common_fields()

--- a/l10n_br_account/views/account_invoice_view.xml
+++ b/l10n_br_account/views/account_invoice_view.xml
@@ -114,7 +114,7 @@
                     name="document_number"
                     readonly="0"
                     force_save="1"
-                    attrs="{'invisible': [('issuer', '=', 'company')], 'required': [('issuer', '=', 'partner'), ('document_type_id', '!=', False)], 'readonly': [('state', '!=', 'draft')]}"
+                    attrs="{'invisible': ['|', ('document_type_id', '=', False), ('issuer', '=', 'company')], 'required': [('issuer', '=', 'partner'), ('document_type_id', '!=', False)], 'readonly': [('state', '!=', 'draft')]}"
                 />
                 <field
                     name="document_key"


### PR DESCRIPTION
O campo **document_number** não deve ser exibido na fatura quando não informado o tipo de documento fiscal.
Pois se preenchido o valor será alterado em todas as faturas não fiscais:
![image](https://user-images.githubusercontent.com/634278/203876581-62a7f437-4ad3-4dfb-9879-b1c675a1b2b5.png)

Isso acontece pois o **document_number** é herdado do documento fiscal e as faturas não fiscais compartilham o mesmo documento fiscal  (**dummy**)