### PR TITLE
[14.0][FIX] l10n_br_sale: required attribute for operation line

### DIFF
--- a/l10n_br_sale/views/sale_view.xml
+++ b/l10n_br_sale/views/sale_view.xml
@@ -159,7 +159,7 @@
                 <field
                     name="fiscal_operation_line_id"
                     options="{'no_create': True}"
-                    attrs="{'readonly': [('state', 'in', ('sale', 'done', 'cancel'))],'invisible': [('country_id', '!=', %(base.br)d)]}"
+                    attrs="{'readonly': [('state', 'in', ('sale', 'done', 'cancel'))], 'required': [('display_type', '=', False)], 'invisible': [('country_id', '!=', %(base.br)d)]}"
                 />
                 <field
                     name="cfop_id"


### PR DESCRIPTION
O campo operação fiscal da linha do pedido estava como não obrigatório:

![image](https://user-images.githubusercontent.com/634278/204407591-fe9e1e1b-820c-4ec8-93cc-55c1d84c94e0.png)

Caso um usuário tentasse criar uma fatura a partir do pedido sem essa informação preenchida o seguinte erro era exibido.
![image](https://user-images.githubusercontent.com/634278/204408051-21188ba1-7013-47ec-a1ab-db1e51b9dc29.png)

Para corrigir isso coloquei o campo fiscal_operation_line_id com o obrigatório, assim como era na versão 12.0

Acho que a informação foi apagada sem querer na migração da 14.0 nesse commit (linha 144): https://github.com/OCA/l10n-brazil/commit/03f74e13b1112dde43b9349bd9aa6773877937d3#diff-12651ac41fcb8582c5a21564a51ae93028e248c666a5147a3fd364ea4f68534eL144 


