### PR TITLE
[14.0][FIX] l10n_br_sale: Amarrar lógica de descontos

### DIFF
--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -130,21 +130,6 @@ class SaleOrder(models.Model):
 
         return order_view
 
-    @api.onchange("discount_rate")
-    def onchange_discount_rate(self):
-        for order in self:
-            for line in order.order_line:
-                if line.discount_fixed:
-                    continue
-                if self.env.user.has_group("l10n_br_sale.group_discount_per_value"):
-                    line.discount_value = (line.product_uom_qty * line.price_unit) * (
-                        order.discount_rate / 100
-                    )
-                    line._onchange_discount_value()
-                else:
-                    line.discount = order.discount_rate
-                    line._onchange_discount_percent()
-
     @api.onchange("fiscal_operation_id")
     def _onchange_fiscal_operation_id(self):
         result = super()._onchange_fiscal_operation_id()

--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -104,6 +104,31 @@ class SaleOrderLine(models.Model):
     price_tax = fields.Monetary(compute_sudo=True)
     price_total = fields.Monetary(compute_sudo=True)
 
+    user_total_discount = fields.Boolean(compute="_compute_user_total_discount")
+    user_discount_value = fields.Boolean(compute="_compute_user_discount_value")
+
+    # Depends of price_unit because we need an field to force compute in new records
+    # not created yet. This field is necessary to compute readonly condition for
+    # discount/discount value.
+    @api.depends("price_unit")
+    def _compute_user_total_discount(self):
+        for rec in self:
+            if self.env.user.has_group("l10n_br_sale.group_total_discount"):
+                rec.user_total_discount = True
+            else:
+                rec.user_total_discount = False
+
+    # Depends of price_unit because we need an field to force compute in new records
+    # not created yet. This field is necessary to compute readonly condition for
+    # discount/discount value.
+    @api.depends("price_unit")
+    def _compute_user_discount_value(self):
+        for rec in self:
+            if self.env.user.has_group("l10n_br_sale.group_discount_per_value"):
+                rec.user_discount_value = True
+            else:
+                rec.user_discount_value = False
+
     @api.model
     def _cnae_domain(self):
         company = self.env.company

--- a/l10n_br_sale/readme/CONTRIBUTORS.rst
+++ b/l10n_br_sale/readme/CONTRIBUTORS.rst
@@ -1,4 +1,18 @@
-* Renato Lima <renato.lima@akretion.com.br>
-* Raphaël Valyi <raphael.valyi@akretion.com.br>
-* Luis Felipe Mileo <mileo@kmee.com.br>
-* Michell Stuttgart <michell.stuttgart@kmee.com.br>
+* `AKRETION <https://akretion.com/pt-BR/>`_:
+
+  * Raphaël Valyi <raphael.valyi@akretion.com.br>
+  * Renato Lima <renato.lima@akretion.com.br>
+  * Magno Costa <magno.costa@akretion.com.br>
+
+* `KMEE <https://kmee.com.br>`_:
+
+  * Luis Felipe Mileo <mileo@kmee.com.br>
+  * Michell Stuttgart <michell.stuttgart@kmee.com.br>
+
+* `ESCODOO <https://escodoo.com.br>`_:
+
+  * Marcel Savegnago <marcel.savegnago@escodoo.com.br>
+
+* `ENGENERE <https://engenere.one>`_:
+
+  * Felipe Motter Pereira <felipe@engenere.one>

--- a/l10n_br_sale/tests/__init__.py
+++ b/l10n_br_sale/tests/__init__.py
@@ -1,5 +1,6 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from . import test_l10n_br_sale
+from . import test_l10n_br_sale_discount
 from . import test_l10n_br_sale_sn
 from . import test_l10n_br_sale_lc

--- a/l10n_br_sale/tests/test_l10n_br_sale.py
+++ b/l10n_br_sale/tests/test_l10n_br_sale.py
@@ -151,14 +151,12 @@ class L10nBrSaleBaseTest(SavepointCase):
         sale_order.onchange_partner_id()
         sale_order.onchange_partner_shipping_id()
         sale_order._onchange_fiscal_operation_id()
-        sale_order.onchange_discount_rate()
 
     def _run_sale_line_onchanges(self, sale_line):
         sale_line._onchange_product_id_fiscal()
         sale_line._onchange_fiscal_operation_id()
         sale_line._onchange_fiscal_operation_line_id()
         sale_line._onchange_fiscal_taxes()
-        sale_line._onchange_discount_percent()
 
     def _invoice_sale_order(self, sale_order):
         sale_order.action_confirm()

--- a/l10n_br_sale/tests/test_l10n_br_sale_discount.py
+++ b/l10n_br_sale/tests/test_l10n_br_sale_discount.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2022-Today - Engenere (<https://engenere.one>).
+# @author Felipe Motter Pereira <felipe@engenere.one>
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
 from odoo.tests import Form, SavepointCase
 
 

--- a/l10n_br_sale/tests/test_l10n_br_sale_discount.py
+++ b/l10n_br_sale/tests/test_l10n_br_sale_discount.py
@@ -1,0 +1,163 @@
+from odoo.tests import Form, SavepointCase
+
+
+class L10nBrSaleDiscount(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.ref("base.main_company")
+        cls.group_total_discount_id = cls.env.ref(
+            "l10n_br_sale.group_total_discount"
+        ).id
+        cls.group_discount_per_value_id = cls.env.ref(
+            "l10n_br_sale.group_discount_per_value"
+        ).id
+
+        sale_manager_user = cls.env.ref("sales_team.group_sale_manager")
+        fiscal_user = cls.env.ref("l10n_br_fiscal.group_user")
+        user_groups = [sale_manager_user.id, fiscal_user.id]
+        cls.user = (
+            cls.env["res.users"]
+            .with_user(cls.env.user)
+            .with_context(no_reset_password=True)
+            .create(
+                {
+                    "name": "Test User",
+                    "login": "test_user",
+                    "email": "test@oca.com",
+                    "company_id": cls.company.id,
+                    "company_ids": [(4, cls.company.id)],
+                    "groups_id": [(6, 0, user_groups)],
+                }
+            )
+        )
+
+        cls.env = cls.env(user=cls.user)
+        cls.cr = cls.env.cr
+
+        cls.partner = cls.env["res.partner"].create({"name": "Test"})
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "test_product",
+                "type": "service",
+                "list_price": 1000,
+            }
+        )
+        cls.order = Form(cls.env["sale.order"])
+        cls.order.partner_id = cls.partner
+        cls.order.fiscal_operation_id = cls.env.ref("l10n_br_fiscal.fo_venda")
+        cls.order = cls.order.save()
+
+        cls.order_line = cls.env["sale.order.line"].create(
+            {
+                "name": cls.product.name,
+                "product_id": cls.product.id,
+                "product_uom_qty": 1,
+                "product_uom": cls.product.uom_id.id,
+                "price_unit": 1000.00,
+                "order_id": cls.order.id,
+                "fiscal_operation_id": cls.env.ref("l10n_br_fiscal.fo_venda").id,
+                "fiscal_operation_line_id": cls.env.ref(
+                    "l10n_br_fiscal.fo_venda_venda"
+                ).id,
+            },
+        )
+
+        cls.sales_view_id = "l10n_br_sale.l10n_br_sale_order_form"
+
+    def test_l10n_br_sale_discount_value(self):
+        self.user.groups_id = [(4, self.group_discount_per_value_id)]
+
+        self.assertTrue(self.order_line.user_discount_value)
+        self.assertFalse(self.order_line.user_total_discount)
+        self.assertFalse(self.order_line.need_change_discount_value())
+
+        order = Form(self.order)
+        with order.order_line.edit(0) as line:
+            line.discount_value = 450
+            self.assertEqual(line.discount, 45)
+            line.price_unit = 2000
+            self.assertEqual(line.discount, 22.5)
+            with self.assertRaises(AssertionError):
+                line.discount = 20
+
+    def test_l10n_br_sale_discount_value_with_total(self):
+        self.user.groups_id = [(4, self.group_discount_per_value_id)]
+        self.user.groups_id = [(4, self.group_total_discount_id)]
+
+        self.assertTrue(self.order_line.user_discount_value)
+        self.assertTrue(self.order_line.user_total_discount)
+        self.assertTrue(self.order_line.need_change_discount_value())
+        self.order_line.discount_fixed = True
+        self.assertFalse(self.order_line.need_change_discount_value())
+        self.order_line.discount_fixed = False
+
+        order = Form(self.order)
+        order.discount_rate = 10
+        with order.order_line.edit(0) as line:
+            self.assertEqual(line.discount, 10)
+            self.assertEqual(line.discount_value, 100)
+            with self.assertRaises(AssertionError):
+                line.discount = 20
+            with self.assertRaises(AssertionError):
+                line.discount_value = 20
+            line.discount_fixed = True
+            line.discount_value = 450
+            self.assertEqual(line.discount, 45)
+            with self.assertRaises(AssertionError):
+                line.discount = 20
+        order.discount_rate = 15
+        with order.order_line.edit(0) as line:
+            self.assertEqual(line.discount, 45)
+            self.assertEqual(line.discount_value, 450)
+            line.discount_fixed = False
+            self.assertEqual(line.discount, 15)
+            self.assertEqual(line.discount_value, 150)
+
+    def test_l10n_br_sale_discount_percent(self):
+
+        self.assertFalse(self.order_line.user_discount_value)
+        self.assertFalse(self.order_line.user_total_discount)
+        self.assertTrue(self.order_line.need_change_discount_value())
+
+        order = Form(self.order)
+        with order.order_line.edit(0) as line:
+            line.discount = 33
+            self.assertEqual(line.discount_value, 330)
+            line.price_unit = 2000
+            self.assertEqual(line.discount_value, 660)
+            with self.assertRaises(AssertionError):
+                line.discount_value = 20
+
+    def test_l10n_br_sale_discount_percent_with_total(self):
+
+        self.user.groups_id = [(4, self.group_total_discount_id)]
+
+        self.assertFalse(self.order_line.user_discount_value)
+        self.assertTrue(self.order_line.user_total_discount)
+        self.assertTrue(self.order_line.need_change_discount_value())
+        self.order_line.discount_fixed = True
+        self.assertTrue(self.order_line.need_change_discount_value())
+        self.order_line.discount_fixed = False
+
+        order = Form(self.order)
+        order.discount_rate = 15
+        with order.order_line.edit(0) as line:
+            self.assertEqual(line.discount, 15)
+            self.assertEqual(line.discount_value, 150)
+            with self.assertRaises(AssertionError):
+                line.discount = 20
+            with self.assertRaises(AssertionError):
+                line.discount_value = 20
+            line.discount_fixed = True
+            line.discount = 50
+            self.assertEqual(line.discount_value, 500)
+            with self.assertRaises(AssertionError):
+                line.discount_value = 20
+        order.discount_rate = 35
+        with order.order_line.edit(0) as line:
+            self.assertEqual(line.discount, 50)
+            self.assertEqual(line.discount_value, 500)
+            line.discount_fixed = False
+            self.assertEqual(line.discount, 35)
+            self.assertEqual(line.discount_value, 350)

--- a/l10n_br_sale/views/sale_view.xml
+++ b/l10n_br_sale/views/sale_view.xml
@@ -293,38 +293,35 @@
                 </notebook>
             </xpath>
             <xpath
-                expr="//field[@name='order_line']/form//div[@name='discount']"
-                position="attributes"
-            >
-                <attribute
-                    name="groups"
-                >!l10n_br_sale.group_discount_per_value</attribute>
-            </xpath>
-            <xpath
                 expr="//field[@name='order_line']/form//label[@for='discount']"
-                position="attributes"
-            >
-                <attribute
-                    name="groups"
-                >!l10n_br_sale.group_discount_per_value</attribute>
-            </xpath>
-            <xpath
-                expr="//field[@name='order_line']/form//div[@name='discount']"
-                position="after"
+                position="before"
             >
                 <field
                     name="discount_fixed"
                     groups="l10n_br_sale.group_total_discount"
                 />
-                <label
-                    for="discount_value"
-                    groups="l10n_br_sale.group_discount_per_value"
-                />
-                <div
-                    name="discount_value"
-                    groups="l10n_br_sale.group_discount_per_value"
-                >
-                    <field name="discount_value" class="oe_inline" />
+                <field name="user_discount_value" invisible="1" />
+                <field name="user_total_discount" invisible="1" />
+            </xpath>
+            <xpath
+                expr="//field[@name='order_line']/form//field[@name='discount']"
+                position="attributes"
+            >
+                <attribute
+                    name="attrs"
+                >{'readonly':['|',['user_discount_value','=',True],'&amp;',['user_total_discount','=',True],['discount_fixed','=',False]]}</attribute>
+            </xpath>
+            <xpath
+                expr="//field[@name='order_line']/form//div[@name='discount']"
+                position="after"
+            >
+                <label for="discount_value" />
+                <div name="discount_value">
+                    <field
+                        name="discount_value"
+                        class="oe_inline"
+                        attrs="{'readonly':['|',['user_discount_value','=',False],'&amp;',['user_total_discount','=',True],['discount_fixed','=',False]]}"
+                    />
                 </div>
             </xpath>
             <xpath expr="//group[@name='sale_total']" position="after">


### PR DESCRIPTION
### PROBLEMA:

Hoje a localização tem um comportamento bem dinâmico com relação a descontos, indo de desconto geral para todo o pedido, a escolha por usuário de trabalhar com desconto na linha por valor ou por percentagem. 

As permissões envolvidas no usuário são: **_Allow Amount Discount on Sales Orders_** para permitir o usuário trabalhar com descontos gerais no pedido e **_Discount in Sales Orders per Value_** para por valores nas linhas ao invés de %.
![image](https://user-images.githubusercontent.com/6812128/204419633-ea97ef8f-72ce-4608-9526-33bd0f25b2a8.png)

Em um geral, não existe um erro gritante, mas por ele ser extremamente dinâmico ele abre certas brechas para enganos se o usuário não estiver atento. E estamos falando de dinheiro, o que pode gerar grandes problemas para a empresa.

Fiz 3 gifs para demonstrar os maiores problemas que vejo hoje e que podem induzir o usuário ao erro:
1) Se você utilizar o usuário com permissão para trabalhar com descontos em % nas linhas, se após dar o desconto o valor da linha alterar, o desconto em valores ficará errado(e o pior, não é possível notar na tela do pedido que ele está errado, pois está invisível). Como o que é transmitido para fatura é apenas o campo discount_value, teremos valores indesejaveis ao cliente. GIF a seguir:
![comportamento 3 (2)](https://user-images.githubusercontent.com/6812128/204411177-54387259-5ca9-4756-9176-b5790e07b92b.gif)
Descrição: Uma linha com 1 item a R$1.000 e desconto de 10%, totalizando R$100 de desconto. Logo após o preço é alterado para R$500. Como não é possível ver no pedido, foi criado uma fatura e nela é possível ver que o discount_value continua de R$100 e não R$50 que seria o correto.

2) Ao trabalhar com desconto por valor nas linhas + o desconto geral no pedido, o comportamento se torna um pouco confuso. Por exemplo, se o usuário coloca um desconto geral no pedido, ao alterar os valores totais da linha, o desconto desejado (em percentual geral) não é persistido no valor do desconto. Também mesmo não marcado como desconto fixo na linha, está sendo possível alterar o desconto na linha para não bater com o geral).
![comportamento 2](https://user-images.githubusercontent.com/6812128/204411382-bf4b5cb1-4fdd-4039-bb22-e6f4f6670945.gif)
Descrição: Um pedido com desconto de 5% e uma linha com 1 item a R$1.000, totalizando um desconto de R$50 na linha. O desconto fixo não está ativo e mesmo alterando o valor do item para R$5.000, o valor de desconto permanece R$50. 

3) Se existe um desconto geral no pedido, linhas novas de pedido não puxarão esse desconto por padrão, sendo ele apenas aplicado às linhas existentes no momento da alteração do discount_rate.
GIF: 
![comportamento 1](https://user-images.githubusercontent.com/6812128/204412222-580ac8bf-59ce-4566-8893-6fd077990b7e.gif)

Em suma, os problemas que induzem ao erro são:
1) Não está sendo mostrado os dois valores (% e valor) ao mesmo tempo na view, o que impede do usuário visualizar um possível erro;
2) A alteração de preço e quantidade não está atualizando os valores em % e R$ dos descontos conforme necessário;
3) O comportamento do desconto geral não está sendo permanente, está parecendo um wizard, alterando apenas os valores naquele exato momento da alteração do valor. Principalmente não sendo levado as linhas novas.
4) Não acho que se o desconto geral está ativo, seja interessante liberar a alteração do desconto nas linhas sem o discount_fixed é True, justamente para deixar o comportamento explícito.


### PROPOSTA

**CAMPOS DESCONTOS COM READONLY:**
Primeiro, a alteração da view para que sempre esteja visível tanto o discount(em %) e o discount_value(em valor). Ao invés de usar o invisible, optei pelo reandyonly para os casos que não se pode alterar o campo. 

1) O campo descount (%) só será editável se:
- Não tiver a permissão de desconto por valor na linha e a permissão do disconto geral estiver desativada
- Não tiver a permissão de desconto por valor na linha, a permissão do desconto geral estiver ativa e o discount_fixed estiver ativo também.
2) O campo descount_value ($) só será editável se:
- Tiver a permissão de desconto por valor na linha e a permissão do disconto geral estiver desativada
- Tiver a permissão de desconto por valor na linha, a permissão do desconto geral estiver ativa e o discount_fixed estiver ativo também.

Dessa forma o comportamento fica mais explícito e o usuário pode notar qualquer problema de lógica com mais facilidade.

**ALTERAÇÃO DA LÓGICA GERAL**
Primeiro achei necessário fazer um mapeamento de quando a alteração precisaria ser no campo discount_value e quando a alteração precisaria ser no discount_value, isso levando em consideração:
1) O usuário está com permissão de desconto por valor na linha?
2) O usuário está com permissão para dar desconto geral?
3) Se o usuário está com desconto geral permitido, o campo discount_fixed está ativo?

A tabela a seguir foi usada para implementar toda a lógica de onchange quando campos de interesse são alterados:
![image](https://user-images.githubusercontent.com/6812128/204416871-215b9290-d58f-430d-ace1-07bb370efbc4.png)

Para deixar mais completo, mapeei outros capos importantes que podem alterar com o desconto(price, qt, discount_fixed) e também me preocupei bastante em criar testes para o máximo de situações que consegui imaginar.

Deixar os dois campos de desconto do line(% e $) bem amarrados, pode ajudar a resolver de forma concreta o problema da issue #1878 no futuro. (Aqui ainda não é o foco)

### PROBLEMA AINDA EM ABERTO
O problema de não trazer o discount_rate(desconto geral) para as linhs novas eu ainda não resolvi porque queria saber a opinião da comunidade, hoje já existe um módulo que cria todo esse comportamento de uma forma mais completa e testada. https://github.com/OCA/sale-workflow/tree/14.0/sale_order_general_discount

Eu não consegui saber proque, mas a localização não é 100% compatível com esse código, mas talvez não seria interessante substituir o nosso atual discount_rate por esse addon? Só porque a opção de ativação/desativação passaria a não depender das permissões do usuário e sim da instalação deste.

A minha ideia seria o l10n_br_sale não depender do módulo, sendo a adaptação para localização feita em um módulo a parte (junto com a lógica do discount_fixed).

edit: no fim eu corrigi o problema das linhas novas também, mas a ideia de usar o modulo general_discount continuo achando legal.
