### PR TITLE
[12.0] spec_driven_model _export_fields dynamic dispatch

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -610,7 +610,7 @@ class NFe(spec_models.StackedModel):
     # Framework Spec model's methods
     ################################
 
-    def _export_field(self, xsd_field, class_obj, member_spec):
+    def _export_field(self, xsd_field, class_obj, member_spec, export_value=None):
         if xsd_field == "nfe40_tpAmb":
             self.env.context = dict(self.env.context)
             self.env.context.update({"tpAmb": self[xsd_field]})

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -509,7 +509,7 @@ class NFeLine(spec_models.StackedModel):
         return super()._export_fields(xsd_fields, class_obj, export_dict)
 
     # flake8: noqa: C901
-    def _export_field(self, xsd_field, class_obj, member_spec):
+    def _export_field(self, xsd_field, class_obj, member_spec, export_value=None):
         # ISSQN
         if xsd_field == "nfe40_cMunFG":
             return self.issqn_fg_city_id.ibge_code
@@ -620,7 +620,9 @@ class NFeLine(spec_models.StackedModel):
 
         return super()._export_many2one(field_name, xsd_required, class_obj)
 
-    def _export_float_monetary(self, field_name, member_spec, class_obj, xsd_required):
+    def _export_float_monetary(
+        self, field_name, member_spec, class_obj, xsd_required, export_value=None
+    ):
         if not self[field_name] and not xsd_required:
             if not (
                 class_obj._name == "nfe.40.imposto" and field_name == "nfe40_vTotTrib"

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -181,7 +181,7 @@ class ResPartner(spec_models.SpecModel):
             if rec.nfe40_fone:
                 rec.phone = rec.nfe40_fone
 
-    def _export_field(self, xsd_field, class_obj, member_spec):
+    def _export_field(self, xsd_field, class_obj, member_spec, export_value=None):
         # Se a NF-e é emitida em homologação altera o nome do destinatário
         if (
             xsd_field == "nfe40_xNome"

--- a/spec_driven_model/models/spec_export.py
+++ b/spec_driven_model/models/spec_export.py
@@ -87,7 +87,9 @@ class AbstractSpecMixin(models.AbstractModel):
                 # this can happen with a o2m generated foreign key for instance
                 continue
             member_spec = binding_class_spec[field_spec_name]
-            field_data = self._export_field(xsd_field, class_obj, member_spec)
+            field_data = self._export_field(
+                xsd_field, class_obj, member_spec, export_dict.get(field_spec_name)
+            )
             if xsd_field in self._stacking_points.keys():
                 if not field_data:
                     # stacked nested tags are skipped if empty
@@ -97,7 +99,7 @@ class AbstractSpecMixin(models.AbstractModel):
 
             export_dict[field_spec_name] = field_data
 
-    def _export_field(self, xsd_field, class_obj, member_spec):
+    def _export_field(self, xsd_field, class_obj, member_spec, export_value=None):
         """
         Maps a single Odoo field to a python binding value according to the
         kind of field.
@@ -125,7 +127,7 @@ class AbstractSpecMixin(models.AbstractModel):
             and self[xsd_field] is not False
         ):
             return self._export_float_monetary(
-                xsd_field, member_spec, class_obj, xsd_required
+                xsd_field, member_spec, class_obj, xsd_required, export_value
             )
         elif type(self[xsd_field]) == str:
             return self[xsd_field].strip()
@@ -153,12 +155,15 @@ class AbstractSpecMixin(models.AbstractModel):
             relational_data.append(field_data)
         return relational_data
 
-    def _export_float_monetary(self, field_name, member_spec, class_obj, xsd_required):
+    def _export_float_monetary(
+        self, field_name, member_spec, class_obj, xsd_required, export_value=None
+    ):
         self.ensure_one()
+        field_data = export_value or self[field_name]
         if member_spec.data_type[0]:
             TDec = "".join(filter(lambda x: x.isdigit(), member_spec.data_type[0]))[-2:]
             my_format = "%.{}f".format(TDec)
-            return str(my_format % self[field_name])
+            return str(my_format % field_data)
         else:
             raise NotImplementedError
 

--- a/spec_driven_model/models/spec_export.py
+++ b/spec_driven_model/models/spec_export.py
@@ -57,10 +57,23 @@ class AbstractSpecMixin(models.AbstractModel):
         that will later be injected as **kwargs in the proper XML Python
         binding constructors. Hence the value can either be simple values or
         sub binding instances already properly instanciated.
+
+        This method implements a dynamic dispatch checking if there is any
+        method called _export_fields_CLASS_NAME to update the xsd_fields
+        and export_dict variables, this way we allow controlling the
+        flow of fields to export or injecting specific values ​​in the
+        field export.
         """
         self.ensure_one()
         binding_class = self._get_binding_class(class_obj)
         binding_class_spec = {i.name: i for i in binding_class.member_data_items_}
+
+        class_name = class_obj._name.replace(".", "_")
+        export_method_name = "_export_fields_%s" % class_name
+        if hasattr(self, export_method_name):
+            xsd_fields = [i for i in xsd_fields]
+            export_method = getattr(self, export_method_name)
+            export_method(xsd_fields, class_obj, export_dict)
 
         for xsd_field in xsd_fields:
             if not xsd_field:


### PR DESCRIPTION
Proposta para alteração no módulo spec_driven_model para implementar um dynamic dispatch para métodos _export_fields_*

Hoje no módulo l10n_br_nfe é utilizado vários métodos _export_* para controlar o fluxo dos campos que serão exportados ou injetados valores para serem exportados. Fazendo o refatoramento do código l10n_br_nfe/models/document_line.py no PR #2000 com a finalidade de simplificar o código que hoje tem uma serie de [if e elif](https://github.com/OCA/l10n-brazil/blob/12.0/l10n_br_nfe/models/document_line.py#L514) e também utilizam alguns métodos _export_field, _export_many2one e _export_float_monetary. Eu implementei um dispatch dinamico dentro do método _export_fields que vai verificar se existe algum método **_export_fields_NOME_DA_CLASSE** permitindo atualizar as variaveis xsd_fields e  export_dict para controlar o fluxo de campos que será exportados ou injetar valores que devem ser exportados.

Por exemplo, hoje no método https://github.com/OCA/l10n-brazil/blob/12.0/l10n_br_nfe/models/document_line.py#L544:

É possível ver a quantidade excessiva de if, elif e else para controlar o fluxo de exportação dos campos e valores o que gera um grande problema para alterar o fluxo de novos campos ou manter implementação já que por para definir os valores das tags tipi, ipitrib e ipint estão fragmentada pelo código e dentro de vários if de outras tags de outros impostos.

Também eu não acho interessante sobreescrever os métodos específicos  _export_float_monetary e _export_many2one já que eles serão invocados em qualquer classe que herde o spec.export, hoje temos só o modulo l10n_br_nfe, mas futuramente podemos ter outros módulos para outros documentos fiscais como l10n_br_cte e etc...

![image](https://user-images.githubusercontent.com/211005/204558662-4ace17a5-b175-4770-9a7b-f75e5b1e628d.png)

Já com o código proposto é possível controlar o fluxo criando métodos que serão invocados quando o _export_fields for chamado para uma classe especifica o que simplifica a exportação dos campos:

![image](https://user-images.githubusercontent.com/211005/204557615-cb25d8c5-6be9-4948-8e8c-5aa97a752bf2.png)
