### PR TITLE
[14.0][IMP] l10n_br_account_payment_order: add barcode field on account.payment.line

### DIFF
--- a/l10n_br_account_payment_order/models/account_payment_line.py
+++ b/l10n_br_account_payment_order/models/account_payment_line.py
@@ -47,6 +47,10 @@ class AccountPaymentLine(models.Model):
         string="Número documento",
     )
 
+    barcode = fields.Char(
+        string="Barcode", help="This field is used in the payment of supplier slips"
+    )
+
     company_title_identification = fields.Char(
         string="Identificação Titulo Empresa",
     )

--- a/l10n_br_account_payment_order/models/bank_payment_line.py
+++ b/l10n_br_account_payment_order/models/bank_payment_line.py
@@ -125,6 +125,10 @@ class BankPaymentLine(models.Model):
         string="Número documento",
     )
 
+    barcode = fields.Char(
+        string="Barcode", readonly=True, related="payment_line_ids.barcode"
+    )
+
     company_title_identification = fields.Char(
         string="Identificação Titulo Empresa",
     )

--- a/l10n_br_account_payment_order/views/account_move_line.xml
+++ b/l10n_br_account_payment_order/views/account_move_line.xml
@@ -11,6 +11,7 @@
         <field name="arch" type="xml">
             <field name="name" position="after">
                 <field name="mov_instruction_code_id" />
+                <field name="barcode" optional="hide" />
             </field>
         </field>
     </record>

--- a/l10n_br_account_payment_order/views/account_payment_line.xml
+++ b/l10n_br_account_payment_order/views/account_payment_line.xml
@@ -81,6 +81,11 @@
                 <group name="cnab" string="Informações do CNAB">
                     <field name="own_number" readonly="1" />
                     <field name="document_number" readonly="1" />
+                    <field name="payment_mode_domain" invisible="1" />
+                    <field
+                        name="barcode"
+                        attrs="{'required': [('payment_type', '=', 'outbound'),('payment_mode_domain', '=', 'boleto')]}"
+                    />
                     <field name="company_title_identification" readonly="1" />
                     <field
                         name="movement_type"

--- a/l10n_br_account_payment_order/views/bank_payment_line.xml
+++ b/l10n_br_account_payment_order/views/bank_payment_line.xml
@@ -11,6 +11,7 @@
                 <group>
                     <field name="own_number" readonly="1" />
                     <field name="document_number" readonly="1" />
+                    <field name="barcode" readonly="1" />
                     <field name="company_title_identification" readonly="1" />
                     <field name="last_cnab_state" invisible="1" />
                     <field name="mov_instruction_code_id" readonly="1" />


### PR DESCRIPTION
Pessoal.. para atender o cnab de pagamento na modalidade boleto vamos precisar do código de barras do boleto do fornecedor e por ora entendo que se faz necessário incluir o campo barcode no modelo account.payment.line

cc @mbcosta @antoniospneto @douglascstd @felipemotter 