### PR TITLE
[14.0][FIX] l10n_br_account_nfe: o meio de pagamento (tPag) deve ser obrigatório em um faturamento normal

### DIFF
--- a/l10n_br_account_nfe/models/document_workflow.py
+++ b/l10n_br_account_nfe/models/document_workflow.py
@@ -60,11 +60,11 @@ class DocumentWorkflow(models.AbstractModel):
                     count += 1
                 record.nfe40_dup = [(6, 0, duplicatas.ids)]
 
-                # TAG - Pagamento
-                if (
-                    record.move_ids.payment_mode_id
-                    and not record.move_ids.payment_mode_id.fiscal_payment_mode
-                ):
+                if not record.move_ids.payment_mode_id:
+                    raise UserError(
+                        _("Payment Mode cannot be empty for this NF-e/NFC-e")
+                    )
+                if not record.move_ids.payment_mode_id.fiscal_payment_mode:
                     raise UserError(
                         _(
                             "Payment Mode {} should has Fiscal Payment Mode"
@@ -81,6 +81,7 @@ class DocumentWorkflow(models.AbstractModel):
                 )
                 v_pag = record.amount_financial_total
 
+            # TAG - Pagamento
             pagamentos = record.env["nfe.40.detpag"].create(
                 {
                     "nfe40_indPag": ind_pag,


### PR DESCRIPTION
Atualmente na localização se por descuido alguém que está emitindo uma nota fiscal esquecer de informar o Modo de Pagamento vai receber esse erro na validação da mesma:

> Schema XML: 225 - Rejeicao: Falha no Schema XML da NFe The element 'detPag' in namespace 'http://www.portalfiscal.inf.br/nfe' has invalid child element 'vPag' in namespace 'http://www.portalfiscal.inf.br/nfe'. List of possible elements expected: 'tPag' in namespace 'http://www.portalfiscal.inf.br/nfe'.

Isso acontece porque o tPag (meio de pagamento) é um campo obrigatório e deve ser sempre ser informado, com exceção dos casos onde a finalidade da nota seja Ajuste ou Devolução.
![image](https://user-images.githubusercontent.com/634278/206607165-81ae34b8-9335-4749-be45-94c3e64337d9.png)

Esta PR altera o código para que exiba um aviso de erro caso não seja informado o modo de pagamento nos casos normais.
