### PR TITLE
[14.0][l10n_br_nfe][FIX] make compute_sudo consistent with store=True

### DIFF
--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -64,10 +64,14 @@ class ResPartner(spec_models.SpecModel):
     nfe40_UF = fields.Char(related="state_id.code")
 
     # nfe.40.tendereco
-    nfe40_CEP = fields.Char(compute="_compute_nfe_data", inverse="_inverse_nfe40_CEP")
+    nfe40_CEP = fields.Char(
+        compute="_compute_nfe_data", inverse="_inverse_nfe40_CEP", compute_sudo=True
+    )
     nfe40_cPais = fields.Char(related="country_id.bc_code")
     nfe40_xPais = fields.Char(related="country_id.name")
-    nfe40_fone = fields.Char(compute="_compute_nfe_data", inverse="_inverse_nfe40_fone")
+    nfe40_fone = fields.Char(
+        compute="_compute_nfe_data", inverse="_inverse_nfe40_fone", compute_sudo=True
+    )
 
     # nfe.40.dest
     nfe40_xNome = fields.Char(related="legal_name")


### PR DESCRIPTION
fix para https://github.com/OCA/l10n-brazil/issues/2252
quando tem store=True tem um compute_sudo=True implicito. Ai como alguns campos calculados por _compute_nfe_data tem store=True e outros não dava warning porque sem compute_sudo unificado o cache não é compartilhado no ORM. Isso resolve o problema.

cc @marcelsavegnago 