### PR TITLE
[12.0] spec_driven_model do not export fields monetary xsd_required=False and value 0.00

### DIFF
--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000012062777161.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000012062777161.xml
@@ -78,7 +78,6 @@
                 <indTot>1</indTot>
             </prod>
             <imposto>
-                <vTotTrib>0.00</vTotTrib>
                 <ICMS>
                     <ICMSSN101>
                         <orig>0</orig>
@@ -116,9 +115,6 @@
                 <vBC>0.00</vBC>
                 <vICMS>0.00</vICMS>
                 <vICMSDeson>0.00</vICMSDeson>
-                <vFCPUFDest>0.00</vFCPUFDest>
-                <vICMSUFDest>0.00</vICMSUFDest>
-                <vICMSUFRemet>0.00</vICMSUFRemet>
                 <vFCP>0.00</vFCP>
                 <vBCST>0.00</vBCST>
                 <vST>0.00</vST>
@@ -135,7 +131,6 @@
                 <vCOFINS>0.00</vCOFINS>
                 <vOutro>0.00</vOutro>
                 <vNF>14.00</vNF>
-                <vTotTrib>0.00</vTotTrib>
             </ICMSTot>
         </total>
         <transp>
@@ -147,7 +142,6 @@
                 <tPag>01</tPag>
                 <vPag>14.00</vPag>
             </detPag>
-            <vTroco>0.00</vTroco>
         </pag>
         <infAdic>
             <infAdFisco>Documento emitido por: Marc Demo</infAdFisco>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000022062777169.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000022062777169.xml
@@ -77,7 +77,6 @@
                 <indTot>1</indTot>
             </prod>
             <imposto>
-                <vTotTrib>0.00</vTotTrib>
                 <ICMS>
                     <ICMS20>
                         <orig>0</orig>
@@ -118,9 +117,6 @@
                 <vBC>953.36</vBC>
                 <vICMS>171.60</vICMS>
                 <vICMSDeson>0.00</vICMSDeson>
-                <vFCPUFDest>0.00</vFCPUFDest>
-                <vICMSUFDest>0.00</vICMSUFDest>
-                <vICMSUFRemet>0.00</vICMSUFRemet>
                 <vFCP>0.00</vFCP>
                 <vBCST>0.00</vBCST>
                 <vST>0.00</vST>
@@ -137,7 +133,6 @@
                 <vCOFINS>58.50</vCOFINS>
                 <vOutro>0.00</vOutro>
                 <vNF>1950.00</vNF>
-                <vTotTrib>0.00</vTotTrib>
             </ICMSTot>
         </total>
         <transp>
@@ -149,7 +144,6 @@
                 <tPag>01</tPag>
                 <vPag>1950.00</vPag>
             </detPag>
-            <vTroco>0.00</vTroco>
         </pag>
         <infAdic>
             <infAdFisco>Documento emitido por: Marc Demo</infAdFisco>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000032062777166.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000032062777166.xml
@@ -80,7 +80,6 @@
                 <indTot>1</indTot>
             </prod>
             <imposto>
-                <vTotTrib>0.00</vTotTrib>
                 <ICMS>
                     <ICMS00>
                         <orig>2</orig>
@@ -120,9 +119,6 @@
                 <vBC>94.00</vBC>
                 <vICMS>3.76</vICMS>
                 <vICMSDeson>0.00</vICMSDeson>
-                <vFCPUFDest>0.00</vFCPUFDest>
-                <vICMSUFDest>0.00</vICMSUFDest>
-                <vICMSUFRemet>0.00</vICMSUFRemet>
                 <vFCP>0.00</vFCP>
                 <vBCST>0.00</vBCST>
                 <vST>0.00</vST>
@@ -139,7 +135,6 @@
                 <vCOFINS>2.82</vCOFINS>
                 <vOutro>0.00</vOutro>
                 <vNF>94.00</vNF>
-                <vTotTrib>0.00</vTotTrib>
             </ICMSTot>
         </total>
         <transp>
@@ -151,7 +146,6 @@
                 <tPag>01</tPag>
                 <vPag>94.00</vPag>
             </detPag>
-            <vTroco>0.00</vTroco>
         </pag>
         <infAdic>
             <infAdFisco>Documento emitido por: Marc Demo</infAdFisco>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200181583054000129550010000000052062777166.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200181583054000129550010000000052062777166.xml
@@ -79,7 +79,7 @@
             <prod>
                 <cProd>E-COM11</cProd>
                 <cEAN>SEM GTIN</cEAN>
-                <xProd>[E-COM11] Cabinet with Doors</xProd>
+                <xProd>Cabinet with Doors</xProd>
                 <NCM>94033000</NCM>
                 <CFOP>5102</CFOP>
                 <uCom>UNID</uCom>
@@ -93,7 +93,6 @@
                 <indTot>1</indTot>
             </prod>
             <imposto>
-                <vTotTrib>0.00</vTotTrib>
                 <ICMS>
                     <ICMSSN101>
                         <orig>0</orig>
@@ -131,9 +130,6 @@
                 <vBC>0.00</vBC>
                 <vICMS>0.00</vICMS>
                 <vICMSDeson>0.00</vICMSDeson>
-                <vFCPUFDest>0.00</vFCPUFDest>
-                <vICMSUFDest>0.00</vICMSUFDest>
-                <vICMSUFRemet>0.00</vICMSUFRemet>
                 <vFCP>0.00</vFCP>
                 <vBCST>0.00</vBCST>
                 <vST>0.00</vST>
@@ -150,7 +146,6 @@
                 <vCOFINS>0.00</vCOFINS>
                 <vOutro>0.00</vOutro>
                 <vNF>14.00</vNF>
-                <vTotTrib>0.00</vTotTrib>
             </ICMSTot>
         </total>
         <transp>
@@ -162,7 +157,6 @@
                 <tPag>01</tPag>
                 <vPag>14.00</vPag>
             </detPag>
-            <vTroco>0.00</vTroco>
         </pag>
         <infAdic>
             <infAdFisco>Documento emitido por: Marc Demo</infAdFisco>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200681583054000129550010000000012760018057-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200681583054000129550010000000012760018057-nf-e.xml
@@ -176,9 +176,6 @@
         <vBC>4147.25</vBC>
         <vICMS>497.67</vICMS>
         <vICMSDeson>0.00</vICMSDeson>
-        <vFCPUFDest>0.00</vFCPUFDest>
-        <vICMSUFDest>0.00</vICMSUFDest>
-        <vICMSUFRemet>0.00</vICMSUFRemet>
         <vFCP>0.00</vFCP>
         <vBCST>0.00</vBCST>
         <vST>0.00</vST>
@@ -195,7 +192,6 @@
         <vCOFINS>118.95</vCOFINS>
         <vOutro>0.00</vOutro>
         <vNF>4147.25</vNF>
-        <vTotTrib>0.00</vTotTrib>
       </ICMSTot>
     </total>
     <transp>

--- a/spec_driven_model/models/spec_export.py
+++ b/spec_driven_model/models/spec_export.py
@@ -160,6 +160,9 @@ class AbstractSpecMixin(models.AbstractModel):
     ):
         self.ensure_one()
         field_data = export_value or self[field_name]
+        # TODO check xsd_required for all fields to export?
+        if not field_data and not xsd_required:
+            return False
         if member_spec.data_type[0]:
             TDec = "".join(filter(lambda x: x.isdigit(), member_spec.data_type[0]))[-2:]
             my_format = "%.{}f".format(TDec)


### PR DESCRIPTION
Essa alteração é para não exporta campos do tipo monetários que são xsd_required=False e tem valor 0.00.