### PR TITLE
[14.0][IMP] l10n_br_fiscal: add event print feature

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -88,6 +88,9 @@
         #        "views/dfe/dfe_views.xml",
         "views/operation_dashboard_view.xml",
         "views/document_event_view.xml",
+        # Reports
+        "views/document_event_report.xml",
+        "views/document_event_template.xml",
         # Wizards
         "wizards/document_cancel_wizard.xml",
         "wizards/document_correction_wizard.xml",

--- a/l10n_br_fiscal/models/document_event.py
+++ b/l10n_br_fiscal/models/document_event.py
@@ -377,3 +377,8 @@ class Event(models.Model):
         event_id = self.create(vals)
         event_id._save_event_file(xml_file, "xml")
         return event_id
+
+    def print_document_event(self):
+        return self.env.ref(
+            "l10n_br_fiscal.action_report_document_event"
+        ).report_action(self)

--- a/l10n_br_fiscal/views/document_event_report.xml
+++ b/l10n_br_fiscal/views/document_event_report.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <data>
+        <record id="action_report_document_event" model="ir.actions.report">
+            <field name="name">Document Event</field>
+            <field name="model">l10n_br_fiscal.event</field>
+            <field name="report_type">qweb-pdf</field>
+            <field name="report_name">l10n_br_fiscal.main_report_document_event</field>
+            <field name="report_file">l10n_br_fiscal.report_document_event</field>
+            <field
+                name="print_report_name"
+            >dict(object.fields_get(allfields=['type'])['type']['selection'])[object.type]</field>
+            <field name="binding_model_id" ref="model_l10n_br_fiscal_event" />
+            <field name="binding_type">report</field>
+        </record>
+    </data>
+</odoo>

--- a/l10n_br_fiscal/views/document_event_template.xml
+++ b/l10n_br_fiscal/views/document_event_template.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+<data>
+<template id="report_document_event">
+    <t t-set="o" t-value="doc" />
+        <t t-set="o" t-value="o.with_context(lang=o.document_id.partner_id.lang)" />
+        <div class="page" style="font-size:16px;">
+            <style type="text/css">
+.col-1,
+.col-2,
+.col-3,
+.col-4,
+.col-5,
+.col-6,
+.col-7,
+.col-8,
+.col-9,
+.col-10,
+.col-11,
+.col-12 {
+    padding: 5px 5px 5px 5px;
+}
+.bt {
+    border-top: 1px solid black;
+}
+.bb {
+    border-bottom: 1px solid black;
+}
+.bl {
+    border-left: 1px solid black;
+}
+.br {
+    border-right: 1px solid black;
+}
+row {
+    cols: 10;
+}
+                </style>
+
+        <div class="oe_structure" />
+
+        <div id="header" class="row bt bb bl br">
+            <div class="col-12" style="text-align: center; font-size: 36px;">
+                <span t-field="o.type" />
+            </div>
+        </div>
+        <div class="row bb bl br">
+              <div id="document_key" class="col-6">
+                  <strong style="font-size:18px;">Document Key:</strong>
+                  <p t-field="o.document_id.document_key" />
+              </div>
+              <div id="company_cnpj_cpf" class="col-6 bl">
+                  <strong style="font-size:18px;">CNPJ:</strong>
+                  <p t-field="o.document_id.company_cnpj_cpf" />
+              </div>
+        </div>
+        <div class="row bb bl br">
+              <div id="document_number" class="col-3">
+                  <strong style="font-size:18px;">Document Number:</strong>
+                  <p t-field="o.document_number" />
+              </div>
+              <div id="document_serie_code" class="col-3 bl">
+                  <strong style="font-size:18px;">Document Serie:</strong>
+                  <p t-field="o.document_serie_id.code" />
+              </div>
+              <div id="environment" class="col-6 bl">
+                  <strong style="font-size:18px;">Environment:</strong>
+                  <p t-field="o.environment" />
+              </div>
+        </div>
+        <div class="row bb bl br">
+              <div id="protocol_number" class="col-6">
+                  <strong style="font-size:18px;">Protocol Number:</strong>
+                  <p t-field="o.protocol_number" />
+              </div>
+               <div id="protocol_date" class="col-6 bl">
+                  <strong style="font-size:18px;">Protocol Date:</strong>
+                  <p t-field="o.protocol_date" />
+              </div>
+        </div>
+        <div id="justification" class="row bb bl br">
+              <div class="col-12" t-if="o.justification">
+                  <strong style="font-size:18px;">Justification:</strong>
+                  <p t-field="o.justification" />
+              </div>
+        </div>
+        <div id="cce_notes" class="row bb bl br">
+              <div class="col-12" style="font-size:10px;" t-if="o.type == '14'">
+                  A Carta de Correção é disciplinada pelo parágrafo 1o-A do artigo 7o do Convênio S/N, de 15 de dezembro de 1970 e pode ser utilizada para regularização de erro ocorrido na emissão de documento fiscal, desde que o erro não seja relacionado com:<br
+                        />
+                  <br />
+                  I - as variáveis que determinam o valor do imposto tais como: base de cálculo, alíquota, diferença de preço, quantidade, valor da operação ou da prestação;<br
+                        />
+                  II - a correção de dados cadastrais que impliquem mudança do remetente ou do destinatário;<br
+                        />
+                  III - a data de emissão ou de saída.<br />
+              </div>
+        </div>
+    </div>
+</template>
+
+<template id="main_report_document_event">
+    <t t-call="web.html_container">
+        <div class="article">
+            <t t-foreach="docs" t-as="doc">
+                <t
+                            t-call="l10n_br_fiscal.report_document_event"
+                            t-lang="doc.document_id.partner_id.lang"
+                        />
+            </t>
+        </div>
+    </t>
+</template>
+
+</data>
+</odoo>

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -415,6 +415,11 @@
                                 <field name="justification" />
                                 <field name="create_date" />
                                 <field name="state" />
+                                <button
+                                                name="print_document_event"
+                                                icon="fa-print"
+                                                type="object"
+                                            />
                             </tree>
                         </field>
                     </group>


### PR DESCRIPTION
Adicionando recurso para impressão de eventos do documento fiscal. No caso adicionei o botão de impressão apenas nos eventos de Carta de Correção mas poderia ser utilizado para imprimir detalhes de qualquer evento. 

Obs. Se for o caso pensei em implementar isso em um módulo chamado l10n_br_fiscal_report que poderia servir inclusive para agum outro relatório e desta forma não sobrecarregar ainda mais o módulo fiscal.

![image](https://user-images.githubusercontent.com/3595132/207777003-06f91b07-523b-4ce3-91a7-532bb4ed05c8.png)

![image](https://user-images.githubusercontent.com/3595132/207777059-bcfcf260-a0b5-4b97-b490-60ceaa09479a.png)

