### PR TITLE
[WIP][12.0][FIX] l10n_br_account: Fix recalculation of all invoices linked to dummy

### DIFF
--- a/l10n_br_account/models/account_invoice_line.py
+++ b/l10n_br_account/models/account_invoice_line.py
@@ -133,7 +133,6 @@ class AccountInvoiceLine(models.Model):
         "invoice_id.company_id",
         "invoice_id.date_invoice",
         "invoice_id.date",
-        "fiscal_tax_ids",
     )
     def _compute_price(self):
         """Compute the amounts of the SO line."""


### PR DESCRIPTION
Em uma base de cliente por algum motivo está forçando o recalculo de todas as faturas vinculadas ao dummy. Ao depurar percebi que o sistema assumia que deveria recalcular todas as linhas das faturas quando chegava neste momento.

![image](https://user-images.githubusercontent.com/3595132/208168924-4091eeb5-6a66-46e2-bdee-5497c2fbd1e5.png)

Removendo o campo fiscal_tax_ids do método _compute_price rodou bonitinho mas não avaliei ainda o impacto de remover este campo do depends