### PR TITLE
[14.0][IMP] Ajustes na criação de documento fiscal.

### DIFF
--- a/l10n_br_account/models/fiscal_document.py
+++ b/l10n_br_account/models/fiscal_document.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2009 - TODAY Renato Lima - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import _, fields, models
+from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 from odoo.addons.l10n_br_fiscal.constants.fiscal import SITUACAO_EDOC_EM_DIGITACAO
@@ -26,3 +26,15 @@ class FiscalDocument(models.Model):
                 _("You cannot delete a fiscal document " "which is not draft state.")
             )
         return super().unlink()
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        # OVERRIDE
+        # force creation of fiscal_document_line only when creating an AML record
+        # In order not to affect the creation of the dummy document, a test was included
+        # that verifies that the ACTIVE field is not False. As the main characteristic
+        # of the dummy document is the ACTIVE field is False
+        for values in vals_list:
+            if values.get("fiscal_line_ids") and values.get("active") is not False:
+                values.update({"fiscal_line_ids": False})
+        return super().create(vals_list)

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -360,11 +360,12 @@ class Document(models.Model):
     def _compute_amount(self):
         return super()._compute_amount()
 
-    @api.model
-    def create(self, values):
-        if not values.get("document_date"):
-            values["document_date"] = self._date_server_format()
-        return super().create(values)
+    @api.model_create_multi
+    def create(self, vals_list):
+        for values in vals_list:
+            if not values.get("document_date"):
+                values["document_date"] = self._date_server_format()
+        return super().create(vals_list)
 
     def unlink(self):
         forbidden_states_unlink = [


### PR DESCRIPTION
Fazendo alguns testes com a criação de Notas de Crédito através de uma fatura do tipo fiscal percebi que o método de criação de linha de documento fiscal era acionado antes de passar pelo método de criação da linha da fatura. Com isso o sistema estava gerando 2 linhas de documento fiscal sendo apenas a segunda criação (acionada pelo create da linha da fatura) vinculada a uma linha de fatura e a outra ficando perdida na tabela de documentos fiscais e impactando a criação do xml já que no XML as duas linhas do documento fiscal eram enviadas.

Enfim. Como na criação de documento dummy os dados de linha são enviados.. criei um parametro para incluir no contexto desta chamada e não impactar o funcionamento da mesma.