### PR TITLE
[14.0][l10n_br_base][l10n_br_fiscal][l10n_br_account] create multi support

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -246,8 +246,8 @@ class AccountMove(models.Model):
         return vals_list
 
     @api.model_create_multi
-    def create(self, values):
-        invoice = super().create(values)
+    def create(self, vals_list):
+        invoice = super().create(vals_list)
         invoice._write_shadowed_fields()
         return invoice
 

--- a/l10n_br_account/models/fiscal_tax.py
+++ b/l10n_br_account/models/fiscal_tax.py
@@ -57,9 +57,9 @@ class FiscalTax(models.Model):
             else:
                 account_taxes.write({"fiscal_tax_ids": [(4, fiscal_tax.id)]})
 
-    @api.model
-    def create(self, values):
-        fiscal_taxes = super().create(values)
+    @api.model_create_multi
+    def create(self, vals_list):
+        fiscal_taxes = super().create(vals_list)
         fiscal_taxes._create_account_tax()
         return fiscal_taxes
 

--- a/l10n_br_account/tests/test_account_taxes.py
+++ b/l10n_br_account/tests/test_account_taxes.py
@@ -6,7 +6,7 @@ from odoo.tests.common import TransactionCase
 
 class TestAccountTaxes(TransactionCase):
     def setUp(self):
-        super(TestAccountTaxes, self).setUp()
+        super().setUp()
 
         self.l10n_br_company = self.env["res.company"].create(
             {"name": "Empresa Teste do Plano de Contas Simplificado"}

--- a/l10n_br_account/tests/test_company_fiscal_dummy.py
+++ b/l10n_br_account/tests/test_company_fiscal_dummy.py
@@ -8,7 +8,7 @@ from odoo.tools import mute_logger
 
 class TestCompanyFiscalDummy(TransactionCase):
     def setUp(self):
-        super(TestCompanyFiscalDummy, self).setUp()
+        super().setUp()
         self.company = self.env["res.company"].create(
             {
                 "name": "Company Test",

--- a/l10n_br_base/models/res_partner_pix.py
+++ b/l10n_br_base/models/res_partner_pix.py
@@ -129,10 +129,11 @@ class PartnerPix(models.Model):
                 ) from e
         return key
 
-    @api.model
-    def create(self, vals):
-        self.check_vals(vals)
-        return super(PartnerPix, self).create(vals)
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            self.check_vals(vals)
+        return super(PartnerPix, self).create(vals_list)
 
     def write(self, vals):
         self.check_vals(vals)

--- a/l10n_br_fiscal/models/certificate.py
+++ b/l10n_br_fiscal/models/certificate.py
@@ -135,10 +135,11 @@ class Certificate(models.Model):
             if c.date_expiration:
                 c.is_valid = c.date_expiration >= fields.Datetime.now()
 
-    @api.model
-    def create(self, values):
-        values = self.update_certificate_data(values)
-        return super().create(values)
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            self.update_certificate_data(vals)
+        return super().create(vals_list)
 
     def write(self, values):
         values = self.update_certificate_data(values)

--- a/l10n_br_fiscal/models/certificate.py
+++ b/l10n_br_fiscal/models/certificate.py
@@ -138,8 +138,8 @@ class Certificate(models.Model):
     @api.model
     def create(self, values):
         values = self.update_certificate_data(values)
-        return super(Certificate, self).create(values)
+        return super().create(values)
 
     def write(self, values):
         values = self.update_certificate_data(values)
-        return super(Certificate, self).write(values)
+        return super().write(values)

--- a/l10n_br_fiscal/models/cest.py
+++ b/l10n_br_fiscal/models/cest.py
@@ -44,11 +44,10 @@ class Cest(models.Model):
         string="Tax Definition",
     )
 
-    @api.model
-    def create(self, values):
-        create_super = super().create(values)
-        if "ncms" in values.keys():
-            create_super.with_context(do_not_write=True).action_search_ncms()
+    @api.model_create_multi
+    def create(self, vals_list):
+        create_super = super().create(vals_list)
+        create_super.with_context(do_not_write=True).action_search_ncms()
         return create_super
 
     def write(self, values):

--- a/l10n_br_fiscal/models/cest.py
+++ b/l10n_br_fiscal/models/cest.py
@@ -46,13 +46,13 @@ class Cest(models.Model):
 
     @api.model
     def create(self, values):
-        create_super = super(Cest, self).create(values)
+        create_super = super().create(values)
         if "ncms" in values.keys():
             create_super.with_context(do_not_write=True).action_search_ncms()
         return create_super
 
     def write(self, values):
-        write_super = super(Cest, self).write(values)
+        write_super = super().write(values)
         do_not_write = self.env.context.get("do_not_write")
         if "ncms" in values.keys() and not do_not_write:
             self.with_context(do_not_write=True).action_search_ncms()

--- a/l10n_br_fiscal/models/data_ncm_nbs_abstract.py
+++ b/l10n_br_fiscal/models/data_ncm_nbs_abstract.py
@@ -178,10 +178,7 @@ class DataNcmNbsAbstract(models.AbstractModel):
     def fields_view_get(
         self, view_id=None, view_type="form", toolbar=False, submenu=False
     ):
-        res = super(DataNcmNbsAbstract, self).fields_view_get(
-            view_id, view_type, toolbar, submenu
-        )
-
+        res = super().fields_view_get(view_id, view_type, toolbar, submenu)
         if view_type == "form":
             xml = etree.XML(res["arch"])
             xml_button = xml.xpath("//button[@name='action_ibpt_inquiry']")

--- a/l10n_br_fiscal/models/document_eletronic.py
+++ b/l10n_br_fiscal/models/document_eletronic.py
@@ -156,7 +156,7 @@ class DocumentEletronic(models.AbstractModel):
         to update the state of the transmited document,
 
         def _eletronic_document_send(self):
-            super(DocumentEletronic, self)._document_send()
+            super()._document_send()
             for record in self.filtered(myfilter):
                 Do your transmission stuff
                 [...]

--- a/l10n_br_fiscal/models/document_serie.py
+++ b/l10n_br_fiscal/models/document_serie.py
@@ -75,7 +75,7 @@ class DocumentSerie(models.Model):
         this field is null"""
         if not values.get("internal_sequence_id"):
             values.update({"internal_sequence_id": self._create_sequence(values)})
-        return super(DocumentSerie, self).create(values)
+        return super().create(values)
 
     def name_get(self):
         return [(r.id, "{}".format(r.name)) for r in self]

--- a/l10n_br_fiscal/models/document_serie.py
+++ b/l10n_br_fiscal/models/document_serie.py
@@ -69,13 +69,14 @@ class DocumentSerie(models.Model):
             sequence["company_id"] = values["company_id"]
         return self.env["ir.sequence"].create(sequence).id
 
-    @api.model
-    def create(self, values):
+    @api.model_create_multi
+    def create(self, vals_list):
         """Overwrite method to create a new ir.sequence if
         this field is null"""
-        if not values.get("internal_sequence_id"):
-            values.update({"internal_sequence_id": self._create_sequence(values)})
-        return super().create(values)
+        for vals in vals_list:
+            if not vals.get("internal_sequence_id"):
+                vals.update({"internal_sequence_id": self._create_sequence(vals)})
+        return super().create(vals_list)
 
     def name_get(self):
         return [(r.id, "{}".format(r.name)) for r in self]

--- a/l10n_br_fiscal/models/icms_regulation.py
+++ b/l10n_br_fiscal/models/icms_regulation.py
@@ -1236,9 +1236,7 @@ class ICMSRegulation(models.Model):
         self, view_id=None, view_type="form", toolbar=False, submenu=False
     ):
 
-        view_super = super(ICMSRegulation, self).fields_view_get(
-            view_id, view_type, toolbar, submenu
-        )
+        view_super = super().fields_view_get(view_id, view_type, toolbar, submenu)
 
         if view_type == "form":
             doc = etree.fromstring(view_super.get("arch"))

--- a/l10n_br_fiscal/models/nbm.py
+++ b/l10n_br_fiscal/models/nbm.py
@@ -41,13 +41,13 @@ class Nbm(models.Model):
 
     @api.model
     def create(self, values):
-        create_super = super(Nbm, self).create(values)
+        create_super = super().create(values)
         if "ncms" in values.keys():
             create_super.with_context(do_not_write=True).action_search_ncms()
         return create_super
 
     def write(self, values):
-        write_super = super(Nbm, self).write(values)
+        write_super = super().write(values)
         do_not_write = self.env.context.get("do_not_write")
         if "ncms" in values.keys() and not do_not_write:
             self.with_context(do_not_write=True).action_search_ncms()

--- a/l10n_br_fiscal/models/nbm.py
+++ b/l10n_br_fiscal/models/nbm.py
@@ -39,11 +39,10 @@ class Nbm(models.Model):
         string="Tax Definition",
     )
 
-    @api.model
-    def create(self, values):
-        create_super = super().create(values)
-        if "ncms" in values.keys():
-            create_super.with_context(do_not_write=True).action_search_ncms()
+    @api.model_create_multi
+    def create(self, vals_list):
+        create_super = super().create(vals_list)
+        create_super.with_context(do_not_write=True).action_search_ncms()
         return create_super
 
     def write(self, values):

--- a/l10n_br_fiscal/models/operation.py
+++ b/l10n_br_fiscal/models/operation.py
@@ -164,7 +164,7 @@ class Operation(models.Model):
         operations = self.filtered(lambda l: l.state == "approved")
         if operations:
             raise UserError(_("You cannot delete an Operation which is not draft !"))
-        return super(Operation, self).unlink()
+        return super().unlink()
 
     def get_document_serie(self, company, document_type):
         self.ensure_one()

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -309,7 +309,7 @@ class OperationLine(models.Model):
             raise UserError(
                 _("You cannot delete an Operation Line which is not draft !")
             )
-        return super(OperationLine, self).unlink()
+        return super().unlink()
 
     @api.onchange("fiscal_operation_id")
     def _onchange_fiscal_operation_id(self):

--- a/l10n_br_fiscal/models/res_company.py
+++ b/l10n_br_fiscal/models/res_company.py
@@ -78,8 +78,8 @@ class ResCompany(models.Model):
             "fiscal_line_ids": [(0, 0, {"name": "dummy", "company_id": self.id})],
         }
 
-    @api.model
-    def create(self, vals):
+    @api.model_create_multi
+    def create(self, vals_list):
         """
         to satisfy the not-null constraint of the fiscal_dummy_id field,
         the fiscal dummy is passed without a company_id and updated
@@ -90,8 +90,9 @@ class ResCompany(models.Model):
             .sudo()
             .create(self._prepare_create_fiscal_dummy_doc())
         )
-        vals.update({"fiscal_dummy_id": dummy_doc.id})
-        company = super().create(vals)
+        for vals in vals_list:
+            vals.update({"fiscal_dummy_id": dummy_doc.id})
+        company = super().create(vals_list)
         dummy_doc.company_id = company
         dummy_doc.fiscal_line_ids.company_id = company
         return company

--- a/l10n_br_fiscal/models/subsequent_document.py
+++ b/l10n_br_fiscal/models/subsequent_document.py
@@ -165,7 +165,7 @@ class SubsequentDocument(models.Model):
                     "subsequent document has already been "
                     "generated."
                 )
-        return super(SubsequentDocument, self).unlink()
+        return super().unlink()
 
     def _confirms_document_generation(self):
         """We check if we can generate the subsequent document

--- a/l10n_br_fiscal/models/tax_definition.py
+++ b/l10n_br_fiscal/models/tax_definition.py
@@ -253,7 +253,7 @@ class TaxDefinition(models.Model):
             raise UserError(
                 _("You cannot delete an Tax Definition which is not draft !")
             )
-        return super(TaxDefinition, self).unlink()
+        return super().unlink()
 
     def action_search_ncms(self):
         ncm = self.env["l10n_br_fiscal.ncm"]
@@ -314,7 +314,7 @@ class TaxDefinition(models.Model):
 
     @api.model
     def create(self, values):
-        create_super = super(TaxDefinition, self).create(values)
+        create_super = super().create(values)
         ncm_fields_list = ("ncms", "not_in_ncms", "ncm_exception")
         if set(ncm_fields_list).intersection(values.keys()):
             create_super.with_context(do_not_write=True).action_search_ncms()
@@ -328,7 +328,7 @@ class TaxDefinition(models.Model):
         return create_super
 
     def write(self, values):
-        write_super = super(TaxDefinition, self).write(values)
+        write_super = super().write(values)
         ncm_fields_list = ("ncms", "not_in_ncms", "ncm_exception")
         do_not_write = self.env.context.get("do_not_write")
         if set(ncm_fields_list).intersection(values.keys()) and not do_not_write:

--- a/l10n_br_fiscal/models/tax_definition.py
+++ b/l10n_br_fiscal/models/tax_definition.py
@@ -315,9 +315,16 @@ class TaxDefinition(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         create_super = super().create(vals_list)
-        create_super.with_context(do_not_write=True).action_search_ncms()
-        create_super.with_context(do_not_write=True).action_search_cests()
-        create_super.with_context(do_not_write=True).action_search_nbms()
+        ncm_fields_list = ("ncms", "not_in_ncms", "ncm_exception")
+        for index, values in enumerate(vals_list):
+            if set(ncm_fields_list).intersection(values.keys()):
+                create_super[index].with_context(do_not_write=True).action_search_ncms()
+            if "cests" in values.keys():
+                create_super[index].with_context(
+                    do_not_write=True
+                ).action_search_cests()
+            if "nbms" in values.keys():
+                create_super[index].with_context(do_not_write=True).action_search_nbms()
         return create_super
 
     def write(self, values):

--- a/l10n_br_fiscal/models/uom_uom.py
+++ b/l10n_br_fiscal/models/uom_uom.py
@@ -36,4 +36,4 @@ class Uom(models.Model):
     def search(self, domain, *args, **kwargs):
         for sub_domain in list(filter(lambda x: x[0] == "code", domain)):
             domain = self._get_code_domain(sub_domain, domain)
-        return super(Uom, self).search(domain, *args, **kwargs)
+        return super().search(domain, *args, **kwargs)

--- a/l10n_br_fiscal/tests/test_subsequent_operation.py
+++ b/l10n_br_fiscal/tests/test_subsequent_operation.py
@@ -6,7 +6,7 @@ from odoo.tests.common import TransactionCase
 
 class TestSubsequentOperation(TransactionCase):
     def setUp(self):
-        super(TestSubsequentOperation, self).setUp()
+        super().setUp()
 
         self.nfe_simples_faturamento = self.env.ref(
             "l10n_br_fiscal.demo_nfe_so_simples_faturamento"


### PR DESCRIPTION
- support sistemático do @api.model_create_multi que temos na v14 e adiante (lembrando se continuar a chamar create({...}) vai continuar funcionado, pois é exatamente o trabalho do @api.model_create_multi de enfiar o dicionario num list neste caso. Mas ainda assim o support do create_multi vale a pena para permitir melhor performances e ter um código "future proof" jà.
- aproveitei para dar uma limpa nos super() e separei os commits para facilitar um eventual backport disso na 12.0 (para minimizar o diff v12/v14)