### PR TITLE
[14.0][ADD] test-requirements.txt

### DIFF
--- a/payment_pagseguro/__manifest__.py
+++ b/payment_pagseguro/__manifest__.py
@@ -20,9 +20,4 @@
     ],
     "demo": [],
     "uninstall_hook": "uninstall_hook",
-    "external_dependencies": {
-        "python": [
-            "vcrpy",  # (only for tests)
-        ],
-    },
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,7 @@ erpbrasil.edoc.pdf
 erpbrasil.transmissao
 nfelib
 num2words
-odoo_test_helper
 phonenumbers
 pycep_correios
-vcrpy
 workalendar
 xmldiff

--- a/spec_driven_model/__manifest__.py
+++ b/spec_driven_model/__manifest__.py
@@ -11,11 +11,6 @@
     "author": "Akretion,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-brazil",
     "depends": [],
-    "external_dependencies": {
-        "python": [
-            "odoo_test_helper",  # (only for tests)
-        ],
-    },
     "data": [],
     "demo": [],
     "development_status": "Beta",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,2 @@
+vcrpy  # Needed by payment_pagseguro
+odoo-test-helper  # Needed by spec_driven_model


### PR DESCRIPTION
port da parte relevante de https://github.com/OCA/l10n-brazil/pull/2238

Isso limpa os módulos das dependências que servem apenas pŕos testes e tb vamos logo precisar desse test-requirements.txt para poder compartilhar uns PRs no repo antes de publicar os pacotes no pypi, principalemente para avanços com NFe ou NFSe (pois a partir da v13 nao da mais para mexer no requirements.txt para especificar branches pros pacotes Python, pois o requirements.txt fica gerido).

Veja um examplo aqui onde eu uso uma branch do @antoniospneto do erpbrasil.edoc para testar a NFe com xsdata: https://github.com/OCA/l10n-brazil/pull/1979/commits/2a28e628fdb02bf9c2e92dd302e46ce0b421255f