### PR TITLE
[14.0][IMP] l10n_br_fiscal: ajustando estado do edoc quando o emissor é o parceiro e não a empresa

### DIFF
--- a/l10n_br_fiscal/demo/fiscal_document_demo.xml
+++ b/l10n_br_fiscal/demo/fiscal_document_demo.xml
@@ -837,4 +837,58 @@
         <value eval="[ref('demo_nfe_line_so_simples_faturamento_7-1')]" />
     </function>
 
+    <!-- NFe Compras Test - Empresa Contribuinte - Mesmo Estado -->
+    <record id="demo_nfe_purchase_same_state" model="l10n_br_fiscal.document">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+        <field name="document_serie">1</field>
+        <field name="document_number">123</field>
+        <field name="issuer">partner</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_akretion" />
+        <field name="user_id" ref="base.user_demo" />
+        <field name="fiscal_operation_type">in</field>
+    </record>
+
+    <record
+        id="demo_nfe_purchase_line_same_state_1-1"
+        model="l10n_br_fiscal.document.line"
+    >
+        <field name="document_id" ref="demo_nfe_purchase_same_state" />
+        <field name="name">Purchase Test</field>
+        <field name="product_id" ref="product.product_product_6" />
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="price_unit">100</field>
+        <field name="quantity">1</field>
+        <field name="fiscal_operation_type">in</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_compras_compras"
+        />
+    </record>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('demo_nfe_purchase_line_same_state_1-1')]" />
+    </function>
+
+    <record
+        id="demo_nfe_purchase_line_same_state_1-1"
+        model="l10n_br_fiscal.document.line"
+    >
+        <field name="price_unit">100</field>
+    </record>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('demo_nfe_purchase_line_same_state_1-1')]" />
+    </function>
+
+    <function
+        model="l10n_br_fiscal.document.line"
+        name="_onchange_fiscal_operation_line_id"
+    >
+        <value eval="[ref('demo_nfe_purchase_line_same_state_1-1')]" />
+    </function>
+
+
 </odoo>

--- a/l10n_br_fiscal/models/document_workflow.py
+++ b/l10n_br_fiscal/models/document_workflow.py
@@ -303,6 +303,8 @@ class DocumentWorkflow(models.AbstractModel):
                 if not line.comment_ids and line.fiscal_operation_line_id.comment_ids:
                     line.comment_ids |= line.fiscal_operation_line_id.comment_ids
             self._change_state(SITUACAO_EDOC_A_ENVIAR)
+        else:
+            self._change_state(SITUACAO_EDOC_AUTORIZADA)
 
     def action_document_confirm(self):
         to_confirm = self.filtered(lambda inv: inv.state_edoc != SITUACAO_EDOC_A_ENVIAR)

--- a/l10n_br_fiscal/models/document_workflow.py
+++ b/l10n_br_fiscal/models/document_workflow.py
@@ -332,7 +332,10 @@ class DocumentWorkflow(models.AbstractModel):
     def action_document_back2draft(self):
         self.xml_error_message = False
         self.file_report_id = False
-        self._change_state(SITUACAO_EDOC_EM_DIGITACAO)
+        if self.issuer == DOCUMENT_ISSUER_COMPANY:
+            self._change_state(SITUACAO_EDOC_EM_DIGITACAO)
+        else:
+            self.state_edoc = SITUACAO_EDOC_EM_DIGITACAO
 
     def _document_cancel(self, justificative):
         self.ensure_one()

--- a/l10n_br_fiscal/models/document_workflow.py
+++ b/l10n_br_fiscal/models/document_workflow.py
@@ -345,11 +345,14 @@ class DocumentWorkflow(models.AbstractModel):
 
     def action_document_cancel(self):
         self.ensure_one()
-        if self.state_edoc == SITUACAO_EDOC_AUTORIZADA:
-            result = self.env["ir.actions.act_window"]._for_xml_id(
-                "l10n_br_fiscal.document_cancel_wizard_action"
-            )
-            return result
+        if self.issuer == DOCUMENT_ISSUER_COMPANY:
+            if self.state_edoc == SITUACAO_EDOC_AUTORIZADA:
+                result = self.env["ir.actions.act_window"]._for_xml_id(
+                    "l10n_br_fiscal.document_cancel_wizard_action"
+                )
+                return result
+        else:
+            self.state_edoc = SITUACAO_EDOC_CANCELADA
 
     def action_document_invalidate(self):
         self.ensure_one()


### PR DESCRIPTION
Proposta para tratar a situação do edoc quano o emissor é o parceiro.

- [x] mudar o status do documento fiscal para Autorizado quando o movimento contábil é confirmado.
- [x] mudar o status do documento fiscal para Em Digitação quando o movimento contábil volta para rascunho.
- [x] mudar o status do documento fiscal para Cancelado quando o movimento contábil é cancelado.

Ref. https://github.com/OCA/l10n-brazil/issues/2275
