### PR TITLE
[14.0] workaround tests

### DIFF
--- a/l10n_br_fiscal/models/document_workflow.py
+++ b/l10n_br_fiscal/models/document_workflow.py
@@ -251,7 +251,7 @@ class DocumentWorkflow(models.AbstractModel):
             ):
                 chave_edoc = ChaveEdoc(
                     ano_mes=record.document_date.strftime("%y%m").zfill(4),
-                    cnpj_emitente=record.company_cnpj_cpf,
+                    cnpj_cpf_emitente=record.company_cnpj_cpf,
                     codigo_uf=(
                         record.company_state_id
                         and record.company_state_id.ibge_code

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 vcrpy  # Needed by payment_pagseguro
 odoo-test-helper  # Needed by spec_driven_model
 signxml<3.1.0
+odoo14-addon-account-payment-order<14.0.2.0.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
 vcrpy  # Needed by payment_pagseguro
 odoo-test-helper  # Needed by spec_driven_model
+signxml<3.1.0


### PR DESCRIPTION
- [x] limita a versão signxml<3.1.0 para contornar erros como https://github.com/OCA/l10n-brazil/pull/2282#issuecomment-1372464976
- [x] limita a versão do accounrt_payment_order antes desse recfator https://github.com/OCA/bank-payment/pull/979 até que os modulos l10n_br_account_payment_order e l10n_br_account_payment_brcobranca sejam adaptados
- [x] inclusão de https://github.com/OCA/l10n-brazil/pull/2288 para evitar erro na geraçao de chave de NFe

cc @renatonlima @marcelsavegnago @felipemotter @antoniospneto 