### PR TITLE
[12.0] l10n_br_nfe: Remove conversão do campo modBCST para float na importação

### DIFF
--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -1048,7 +1048,7 @@ class NFeLine(spec_models.StackedModel):
                     # ICMS ST fields
                     # TODO map icmsst_tax_id
                     if hasattr(icms, "modBCST") and icms.modBCST is not None:
-                        icms_vals["icmsst_base_type"] = float(icms.modBCST)
+                        icms_vals["icmsst_base_type"] = icms.modBCST
                     if hasattr(icms, "pMVAST") and icms.pMVAST is not None:
                         icms_vals["icmsst_mva_percent"] = float(icms.pMVAST)
                     if hasattr(icms, "pRedBCST") and icms.pRedBCST is not None:


### PR DESCRIPTION
O campo nfe40_modBCST é do tipo selection, logo durante a importação o valor de modBCST não deve ser convertido para float, assim como pode ser visto para o campo modBC:
https://github.com/OCA/l10n-brazil/blob/d0f753121647b8cd949694d87199bdd79e363278/l10n_br_nfe/models/document_line.py#L1024-L1025