### PR TITLE
[14.0][FIX] l10n_br_account_payment_brcobranca: Texto da instrução de desconto

### DIFF
--- a/l10n_br_account_payment_brcobranca/models/account_move_line.py
+++ b/l10n_br_account_payment_brcobranca/models/account_move_line.py
@@ -143,7 +143,7 @@ class AccountMoveLine(models.Model):
                     precision_account,
                 )
                 instrucao_desconto_vencimento = (
-                    "CONCEDER ABATIMENTO PERCENTUAL DE" + " %s %% "
+                    "CONCEDER DESCONTO DE" + " %s %% "
                     "ATÉ O VENCIMENTO EM %s ( R$ %s )"
                     % (
                         (


### PR DESCRIPTION
Correção para a mensagem do "desconto até o vencimento"

Conforme foi solicitado no processo de homologação:
![image](https://user-images.githubusercontent.com/634278/214172007-f8111114-0eea-4f7f-a2c6-1229d2bea0f9.png)

Extraido da PR #2043