### PR TITLE
[14.0][REF] l10n_br_account_payment_order/brcobranca: Valor do Desconto

### DIFF
--- a/l10n_br_account_payment_brcobranca/models/account_move_line.py
+++ b/l10n_br_account_payment_brcobranca/models/account_move_line.py
@@ -136,19 +136,16 @@ class AccountMoveLine(models.Model):
                 )
 
             # Instrução Desconto
-            if move_line.payment_mode_id.boleto_discount_perc > 0.0:
+            if move_line.boleto_discount_perc > 0.0:
                 valor_desconto = round(
-                    move_line.debit
-                    * (move_line.payment_mode_id.boleto_discount_perc / 100),
+                    move_line.debit * (move_line.boleto_discount_perc / 100),
                     precision_account,
                 )
                 instrucao_desconto_vencimento = (
                     "CONCEDER ABATIMENTO PERCENTUAL DE" + " %s %% "
                     "ATÉ O VENCIMENTO EM %s ( R$ %s )"
                     % (
-                        (
-                            "%.2f" % move_line.payment_mode_id.boleto_discount_perc
-                        ).replace(".", ","),
+                        ("%.2f" % move_line.boleto_discount_perc).replace(".", ","),
                         move_line.date_maturity.strftime("%d/%m/%Y"),
                         ("%.2f" % valor_desconto).replace(".", ","),
                     )

--- a/l10n_br_account_payment_brcobranca/models/bank_payment_line.py
+++ b/l10n_br_account_payment_brcobranca/models/bank_payment_line.py
@@ -54,7 +54,7 @@ class BankPaymentLine(models.Model):
 
         linhas_pagamentos["numero"] = doc_number
 
-        if payment_mode_id.boleto_discount_perc:
+        if self.discount_value:
             linhas_pagamentos["cod_desconto"] = "1"
 
     def _prepare_bank_line_banco_brasil(self, payment_mode_id, linhas_pagamentos):
@@ -116,12 +116,9 @@ class BankPaymentLine(models.Model):
                         "valor_mora"
                     ] = payment_mode_id.boleto_interest_perc
 
-            if payment_mode_id.boleto_discount_perc:
+            if self.discount_value:
                 linhas_pagamentos["data_desconto"] = self.date.strftime("%Y/%m/%d")
-                linhas_pagamentos["valor_desconto"] = round(
-                    self.amount_currency * (payment_mode_id.boleto_discount_perc / 100),
-                    precision_account,
-                )
+                linhas_pagamentos["valor_desconto"] = self.discount_value
 
             # Protesto
             if payment_mode_id.boleto_protest_code:

--- a/l10n_br_account_payment_order/models/account_move_line.py
+++ b/l10n_br_account_payment_order/models/account_move_line.py
@@ -70,6 +70,13 @@ class AccountMoveLine(models.Model):
         default="inicial",
     )
 
+    boleto_discount_perc = fields.Float(
+        string="Desconto de pontualidade",
+        digits="Account",
+        help="Percentual de Desconto até a Data de Vencimento",
+        related="payment_mode_id.boleto_discount_perc",
+    )
+
     instructions = fields.Text(
         string="Instruções de cobrança",
         readonly=True,
@@ -140,6 +147,7 @@ class AccountMoveLine(models.Model):
             vals["partner_pix_id"] = self.partner_id.pix_key_ids[0].id
         # Preenchendo apenas nos casos CNAB
         if self.payment_mode_id.payment_method_code in BR_CODES_PAYMENT_ORDER:
+            digits = self.env["decimal.precision"].precision_get("Account")
             vals.update(
                 {
                     "own_number": self.own_number,
@@ -156,6 +164,9 @@ class AccountMoveLine(models.Model):
                     "ml_maturity_date": self.date_maturity,
                     "move_id": self.move_id.id,
                     "service_type": self._get_default_service_type(),
+                    "discount_value": round(
+                        self.amount_currency * (self.boleto_discount_perc / 100), digits
+                    ),
                 }
             )
 

--- a/l10n_br_account_payment_order/views/account_move_line.xml
+++ b/l10n_br_account_payment_order/views/account_move_line.xml
@@ -48,6 +48,7 @@
                     <field name="own_number" readonly="1" />
                     <field name="document_number" readonly="1" />
                     <field name="mov_instruction_code_id" readonly="1" />
+                    <field name="boleto_discount_perc" />
                     <field name="company_title_identification" readonly="1" />
                     <field name="instructions" />
                 </group>


### PR DESCRIPTION
O valor do desconto do boleto era calculado somente dentro do arquivo de remessa, alterei para que ele seja calculado antes, já na criação do payment.line, dessa forma é possível visualizar o valor do desconto  já na linha da ordem de pagamento:
![image](https://user-images.githubusercontent.com/634278/214206496-ed524f5c-2a43-4c42-aaed-613ebfa6411f.png)
