### PR TITLE
[14.0][FIX] l10n_br_account_payment_brcobranca: Flag de desconto BRCobrança

### DIFF
--- a/l10n_br_account_payment_brcobranca/parser/cnab_file_parser.py
+++ b/l10n_br_account_payment_brcobranca/parser/cnab_file_parser.py
@@ -436,9 +436,14 @@ class CNABFileParser(FileParser):
                 str(linha_cnab["data_credito"]), date_format
             ).date()
 
-        # Valor Desconto
-        if linha_cnab.get("desconto"):
-            valor_desconto = self.cnab_str_to_float(linha_cnab["desconto"])
+        # Na própria lib o desconto é tratado com duas keys diferentes
+        # dependendo do banco e do formato. Também há um erro de escrita que foi tratado
+        # aqui porque uma alteração da lib poderia quebrar outras implementações.
+        desconto_linha = linha_cnab.get("desconto") or linha_cnab.get(
+            "desconto_concedito"
+        )
+        if desconto_linha:
+            valor_desconto = self.cnab_str_to_float(desconto_linha)
             if valor_desconto > 0.0:
                 row_list.append(
                     {


### PR DESCRIPTION
O BRCobrança não segue um padrão do flag desconto, no CNAB400 eles costumam usar 'desconto' e para CNAB240 'desconto_concedito' (sim, com erro gramatical). Pode até ter outras diferentes, mas no geral foi o que mapeamos.

Com isso, o desconto não é encontrado, o valor total fica menor e por isso o pagamento fica parcial.

Para evitar mexer no BRCobrança e acabar conflitando com outras implementações, preferi lidar com isso diretamente no modulo. Testei com e sem desconto, e ficou tudo certo.