### PR TITLE
[16.0][FIX] l10n_br_base and l10n_br_stock remove warnings

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,20 +1,21 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.12.0
+_commit: v1.14.1
 _src_path: gh:oca/oca-addons-repo-template
 ci: GitHub
 dependency_installation_mode: PIP
 generate_requirements_txt: true
 github_check_license: true
+github_ci_extra_env: {}
 github_enable_codecov: true
 github_enable_makepot: true
 github_enable_stale_action: true
 github_enforce_dev_status_compatibility: true
-include_wkhtmltopdf: false
+include_wkhtmltopdf: true
 odoo_version: 16.0
 org_name: Odoo Community Association (OCA)
 org_slug: OCA
 rebel_module_groups: []
-repo_description: 'TODO: add repo description.'
+repo_description: Odoo Brazilian localization
 repo_name: l10n-brazil
 repo_slug: l10n-brazil
 repo_website: https://github.com/OCA/l10n-brazil

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
               fi
           done
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ${{ matrix.container }}
     name: ${{ matrix.name }}
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -101,7 +101,7 @@ repos:
       - id: pyupgrade
         args: ["--keep-percent-format"]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort except __init__.py

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # l10n-brazil
 
-TODO: add repo description.
+Odoo Brazilian localization
 
 <!-- /!\ do not modify below this line -->
 

--- a/l10n_br_base/demo/res_users_demo.xml
+++ b/l10n_br_base/demo/res_users_demo.xml
@@ -43,7 +43,7 @@
         <field name="partner_id" ref="partner_demo_simples" />
         <field name="login">simples</field>
         <field name="password">simples</field>
-        <field name="signature" type="xml">
+        <field name="signature" type="html">
             <span>--<br />+Mr Simples
             </span>
         </field>
@@ -61,7 +61,7 @@
         <field name="partner_id" ref="partner_demo_presumido" />
         <field name="login">presumido</field>
         <field name="password">presumido</field>
-        <field name="signature" type="xml">
+        <field name="signature" type="html">
             <span>--<br />+Mr Presumido
             </span>
         </field>

--- a/l10n_br_base/models/res_partner_pix.py
+++ b/l10n_br_base/models/res_partner_pix.py
@@ -129,14 +129,15 @@ class PartnerPix(models.Model):
                 ) from e
         return key
 
-    @api.model
-    def create(self, vals):
-        self.check_vals(vals)
-        return super(PartnerPix, self).create(vals)
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            self.check_vals(vals)
+        return super().create(vals_list)
 
     def write(self, vals):
         self.check_vals(vals)
-        return super(PartnerPix, self).write(vals)
+        return super().write(vals)
 
     def check_vals(self, vals):
         key_type = vals.get("key_type") or self.key_type

--- a/l10n_br_base/tests/test_amount_to_text.py
+++ b/l10n_br_base/tests/test_amount_to_text.py
@@ -4,7 +4,7 @@
 
 import logging
 
-from odoo.tests import SavepointCase
+from odoo.tests import TransactionCase
 
 _logger = logging.getLogger(__name__)
 
@@ -14,7 +14,7 @@ except ImportError:
     _logger.info("Biblioteca Num2Words não instalada")
 
 
-class Num2WordsPTBRTest(SavepointCase):
+class Num2WordsPTBRTest(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/l10n_br_base/tests/test_base_onchange.py
+++ b/l10n_br_base/tests/test_base_onchange.py
@@ -2,10 +2,10 @@
 #   Clément Mombereau <clement.mombereau@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo.tests import SavepointCase
+from odoo.tests import TransactionCase
 
 
-class L10nBrBaseOnchangeTest(SavepointCase):
+class L10nBrBaseOnchangeTest(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/l10n_br_base/tests/test_other_ie.py
+++ b/l10n_br_base/tests/test_other_ie.py
@@ -4,13 +4,13 @@
 
 import logging
 
-from odoo.tests import SavepointCase
+from odoo.tests import TransactionCase
 from odoo.tools import mute_logger
 
 _logger = logging.getLogger(__name__)
 
 
-class OtherIETest(SavepointCase):
+class OtherIETest(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/l10n_br_base/tests/test_valid_createid.py
+++ b/l10n_br_base/tests/test_valid_createid.py
@@ -3,10 +3,10 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo.exceptions import ValidationError
-from odoo.tests import SavepointCase
+from odoo.tests import TransactionCase
 
 
-class ValidCreateIdTest(SavepointCase):
+class ValidCreateIdTest(TransactionCase):
     """Test if ValidationError is raised well during create({})"""
 
     @classmethod

--- a/l10n_br_stock/demo/stock_inventory_demo.xml
+++ b/l10n_br_stock/demo/stock_inventory_demo.xml
@@ -96,15 +96,6 @@
             eval="obj().env.ref('l10n_br_stock.wh_empresa_simples_nacional').lot_stock_id.id"
         />
         </record>
-        <record id="stock_inventory_sn_7d" model="stock.quant">
-            <field name="product_id" ref="product.product_product_4d" />
-            <field name="inventory_quantity">60.0</field>
-            <field
-            name="location_id"
-            model="stock.location"
-            eval="obj().env.ref('l10n_br_stock.wh_empresa_simples_nacional').lot_stock_id.id"
-        />
-        </record>
         <record id="stock_inventory_sn_11" model="stock.quant">
             <field name="product_id" ref="product.product_product_12" />
             <field name="inventory_quantity">10.0</field>
@@ -163,7 +154,6 @@
                                             ref('stock_inventory_sn_7'),
                                             ref('stock_inventory_sn_7b'),
                                             ref('stock_inventory_sn_7c'),
-                                            ref('stock_inventory_sn_7d'),
                                             ref('stock_inventory_sn_11'),
                                             ref('stock_inventory_sn_12'),
                                             ref('stock_inventory_sn_13'),
@@ -267,15 +257,6 @@
             eval="obj().env.ref('l10n_br_stock.wh_empresa_lucro_presumido').lot_stock_id.id"
         />
         </record>
-        <record id="stock_inventory_lp_7d" model="stock.quant">
-            <field name="product_id" ref="product.product_product_4d" />
-            <field name="inventory_quantity">60.0</field>
-            <field
-            name="location_id"
-            model="stock.location"
-            eval="obj().env.ref('l10n_br_stock.wh_empresa_lucro_presumido').lot_stock_id.id"
-        />
-        </record>
         <record id="stock_inventory_lp_11" model="stock.quant">
             <field name="product_id" ref="product.product_product_12" />
             <field name="inventory_quantity">10.0</field>
@@ -334,7 +315,6 @@
                                             ref('stock_inventory_lp_7'),
                                             ref('stock_inventory_lp_7b'),
                                             ref('stock_inventory_lp_7c'),
-                                            ref('stock_inventory_lp_7d'),
                                             ref('stock_inventory_lp_11'),
                                             ref('stock_inventory_lp_12'),
                                             ref('stock_inventory_lp_13'),

--- a/l10n_br_stock/hooks.py
+++ b/l10n_br_stock/hooks.py
@@ -86,11 +86,6 @@ def pre_init_hook(cr):
 
     if not tools.config["without_demo"]:
         _logger.info(_("Loading l10n_br_stock warehouse external ids..."))
-        with api.Environment.manage():
-            env = api.Environment(cr, SUPERUSER_ID, {})
-            set_stock_warehouse_external_ids(
-                env, "l10n_br_base.empresa_simples_nacional"
-            )
-            set_stock_warehouse_external_ids(
-                env, "l10n_br_base.empresa_lucro_presumido"
-            )
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        set_stock_warehouse_external_ids(env, "l10n_br_base.empresa_simples_nacional")
+        set_stock_warehouse_external_ids(env, "l10n_br_base.empresa_lucro_presumido")


### PR DESCRIPTION
Removed two warnings messages: 

WARNING db odoo.tools.convert: HTML field 'signature' is declared as `type="xml"`
WARNING db odoo.api.create: The model odoo.addons.l10n_br_base.models.res_partner_pix is not overriding the create method in batch