### PR TITLE
[14.0][FIX] l10n_br_delivery: fix free shipping compute

### DIFF
--- a/l10n_br_delivery/models/delivery_carrier.py
+++ b/l10n_br_delivery/models/delivery_carrier.py
@@ -17,3 +17,37 @@ class Carrier(models.Model):
         inverse_name="carrier_id",
         string="Vehicles",
     )
+
+    # FIXME: For now we are going to overwrite this method but this needs
+    # to be evaluated further.
+    def _get_price_available(self, order):
+        self.ensure_one()
+        self = self.sudo()
+        order = order.sudo()
+        total = weight = volume = quantity = 0
+        total_delivery = 0.0
+        for line in order.order_line:
+            if line.state == "cancel":
+                continue
+            if line.is_delivery:
+                total_delivery += line.price_total
+            if not line.product_id or line.is_delivery:
+                continue
+            if line.product_id.type == "service":
+                continue
+            qty = line.product_uom._compute_quantity(
+                line.product_uom_qty, line.product_id.uom_id
+            )
+            weight += (line.product_id.weight or 0.0) * qty
+            volume += (line.product_id.volume or 0.0) * qty
+            quantity += qty
+        total = (order.amount_total or 0.0) - total_delivery
+
+        # Solves free shipping calculation problem when deducting
+        # the shipping value from the total amount
+        if order.company_id.country_id.code == "BR":
+            total = (order.amount_total or 0.0) - order.amount_freight_value
+
+        total = self._compute_currency(order, total, "pricelist_to_company")
+
+        return self._get_price_from_picking(total, weight, volume, quantity)

--- a/l10n_br_delivery/models/sale_order.py
+++ b/l10n_br_delivery/models/sale_order.py
@@ -55,3 +55,14 @@ class SaleOrder(models.Model):
             for line in record.order_line:
                 amount_volume += line.product_qty * line.product_id.volume
             record.amount_volume = amount_volume
+
+    def _compute_amount_total_without_delivery(self):
+        self.ensure_one()
+        result = super()._compute_amount_total_without_delivery()
+        if self.company_id.country_id.code == "BR":
+            result = self.env["delivery.carrier"]._compute_currency(
+                self,
+                self.amount_total - self.amount_freight_value,
+                "pricelist_to_company",
+            )
+        return result

--- a/l10n_br_delivery/models/sale_order.py
+++ b/l10n_br_delivery/models/sale_order.py
@@ -42,6 +42,12 @@ class SaleOrder(models.Model):
                 order.delivery_costs = "line"
         return True
 
+    def _remove_delivery_line(self):
+        super()._remove_delivery_line()
+        for order in self:
+            if order.company_id.country_id.code == "BR":
+                order.amount_freight_value = 0
+
     def _compute_amount_gross_weight(self):
         for record in self:
             amount_gross_weight = 0.0


### PR DESCRIPTION
Por enquanto foi necessário sobreescrever o método _get_price_available porque o valor total não usa um método especifico para calcular o valor total sem frete. Pretendo fazer isso de forma mais limpa mas para teste funcional já dá para avaliar.

Ref. https://github.com/OCA/l10n-brazil/issues/2323