### PR TITLE
[14.0][FIX] l10n_br_account: detalhes fiscais exigindo permissão de administrador

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -431,11 +431,12 @@ class AccountMove(models.Model):
 
     def open_fiscal_document(self):
         if self.env.context.get("move_type", "") == "out_invoice":
-            action = self.env.ref("l10n_br_account.fiscal_invoice_out_action").read()[0]
+            xmlid = "l10n_br_account.fiscal_invoice_out_action"
         elif self.env.context.get("move_type", "") == "in_invoice":
-            action = self.env.ref("l10n_br_account.fiscal_invoice_in_action").read()[0]
+            xmlid = "l10n_br_account.fiscal_invoice_in_action"
         else:
-            action = self.env.ref("l10n_br_account.fiscal_invoice_all_action").read()[0]
+            xmlid = "l10n_br_account.fiscal_invoice_all_action"
+        action = self.env["ir.actions.act_window"]._for_xml_id(xmlid)
         form_view = [(self.env.ref("l10n_br_account.fiscal_invoice_form").id, "form")]
         if "views" in action:
             action["views"] = form_view + [


### PR DESCRIPTION
Da forma que está hoje o sistema está exigindo que o usuário tenha permissão de administrador do sistema para ver os detalhes fiscais através do botão na fatura.

Botão:
![tela fatura](https://user-images.githubusercontent.com/6812128/216777593-941bcefd-3981-4331-9f25-2a273442f8f8.png)

Erro de permissão:
![permissao acr view](https://user-images.githubusercontent.com/6812128/216777607-7ed158c4-05a1-4a90-ac8c-579a73f1ef36.png)

Com a correção um usuário com as permissões FISCAIS esperadas já não tem mais problema.