### PR TITLE
[FIX] l10n_br_fiscal: add missing depends on _compute_amounts

### DIFF
--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -130,10 +130,14 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         "freight_value",
         "fiscal_quantity",
         "amount_tax_not_included",
+        "amount_tax_included",
+        "amount_tax_withholding",
         "uot_id",
         "product_id",
         "partner_id",
         "company_id",
+        "price_unit",
+        "quantity",
     )
     def _compute_amounts(self):
         for record in self:


### PR DESCRIPTION
Alguns campos eram utilizados porém não estavam sendo declarados.