### PR TITLE
[12.0] Permitir informar o campo nfe40_cProd se o product_id não é informado

### DIFF
--- a/l10n_br_nfe/__manifest__.py
+++ b/l10n_br_nfe/__manifest__.py
@@ -24,6 +24,7 @@
         # Views
         "views/res_company_view.xml",
         "views/nfe_document_view.xml",
+        "views/nfe_document_line_view.xml",
         "views/res_config_settings_view.xml",
         # Wizards
         "wizards/import_document.xml",

--- a/l10n_br_nfe/views/nfe_document_line_view.xml
+++ b/l10n_br_nfe/views/nfe_document_line_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="nfe_document_line_form" model="ir.ui.view">
+        <field name="name">l10n_br_nfe.document.line.form</field>
+        <field name="model">l10n_br_fiscal.document.line</field>
+        <field name="priority">5</field>
+        <field name="inherit_id" ref="l10n_br_fiscal.document_line_form" />
+        <field name="arch" type="xml">
+            <field name="product_id" position="after">
+                <field name="nfe40_cProd" string="Code" attrs="{'invisible': [('product_id', '!=', False)], 'required': [('product_id', '=', False)]}"/>
+            </field>
+        </field>
+  </record>
+
+</odoo>


### PR DESCRIPTION
Em alguns casos pode ser necessário criar uma linha de NF-e sem um produto, esse PR insere o campo para ser preenchido caso o product_id não seja informado.