### PR TITLE
[14.0][IMP] l10n_br_account_nfe: Not export dup, fat in NFCe xml

### DIFF
--- a/l10n_br_account_nfe/models/document.py
+++ b/l10n_br_account_nfe/models/document.py
@@ -115,6 +115,7 @@ class DocumentNfe(models.Model):
             self._need_compute_nfe_tags()
             and self.amount_financial_total > 0
             and self.nfe40_tpNF == NFE_OUT
+            and self.document_type != "65"
         ):
             return True
         else:


### PR DESCRIPTION
O Sefaz não permite que a NFC-e contenha as tags de duplicata e fatura no XML. Com essa pequena condição, essas tags não são exportadas e é possível realizar o processo de autorização da NFC-e.