### PR TITLE
[14.0][HACK] Remove active field from account.move.line and l10n_br_fiscal.document.line

### DIFF
--- a/l10n_br_account/models/account_invoice_line.py
+++ b/l10n_br_account/models/account_invoice_line.py
@@ -30,12 +30,6 @@ class AccountMoveLine(models.Model):
     _inherit = [_name, "l10n_br_fiscal.document.line.mixin.methods"]
     _inherits = {"l10n_br_fiscal.document.line": "fiscal_document_line_id"}
 
-    # some account.move.line records _inherits from an fiscal.document.line that is
-    # disabled with active=False (dummy record) in the l10n_br_fiscal_document_line table.
-    # To make the invoice lines still visible, we set active=True
-    # in the account_move_line table.
-    active = fields.Boolean(default=True, depends_context=["move_id"])
-
     fiscal_document_line_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.document.line",
         string="Fiscal Document Line",

--- a/l10n_br_account/models/account_invoice_line.py
+++ b/l10n_br_account/models/account_invoice_line.py
@@ -34,9 +34,7 @@ class AccountMoveLine(models.Model):
     # disabled with active=False (dummy record) in the l10n_br_fiscal_document_line table.
     # To make the invoice lines still visible, we set active=True
     # in the account_move_line table.
-    active = fields.Boolean(
-        default=True,
-    )
+    active = fields.Boolean(default=True, depends_context=["move_id"])
 
     fiscal_document_line_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.document.line",

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -25,12 +25,6 @@ class DocumentLine(models.Model):
         ondelete="cascade",
     )
 
-    # used mostly to enable _inherits of account.invoice on fiscal_document
-    # when existing invoices have no fiscal document.
-    active = fields.Boolean(
-        default=True,
-    )
-
     name = fields.Text()
 
     company_id = fields.Many2one(


### PR DESCRIPTION
Provavelmente deve ter outra forma de resolver.. 

Tentei inserir nos campos active o depends_contex mas não rolou.. me pareceu um caminho...

    active = fields.Boolean(
        default=True,
        depends_context=['document_id']

    )