### PR TITLE
[14.0][FIX] l10n_br_sale: sale onchange product fiscal price with price list

### DIFF
--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -266,3 +266,25 @@ class SaleOrderLine(models.Model):
                 user_type="sale", deductible=True
             )
         return result
+
+    def _get_product_price(self):
+        self.ensure_one()
+
+        if (
+            self.fiscal_operation_id.default_price_unit == "sale_price"
+            and self.order_id.pricelist_id
+            and self.order_id.partner_id
+        ):
+            self.price_unit = self.product_id._get_tax_included_unit_price(
+                self.company_id,
+                self.order_id.currency_id,
+                self.order_id.date_order,
+                "sale",
+                fiscal_position=self.order_id.fiscal_position_id,
+                product_price_unit=self._get_display_price(self.product_id),
+                product_currency=self.order_id.currency_id,
+            )
+        elif self.fiscal_operation_id.default_price_unit == "cost_price":
+            self.price_unit = self.product_id.standard_price
+        else:
+            self.price_unit = 0.00

--- a/l10n_br_sale/tests/__init__.py
+++ b/l10n_br_sale/tests/__init__.py
@@ -4,3 +4,4 @@ from . import test_l10n_br_sale
 from . import test_l10n_br_sale_discount
 from . import test_l10n_br_sale_sn
 from . import test_l10n_br_sale_lc
+from . import test_l10n_br_sale_pricelist

--- a/l10n_br_sale/tests/test_l10n_br_sale_pricelist.py
+++ b/l10n_br_sale/tests/test_l10n_br_sale_pricelist.py
@@ -1,0 +1,81 @@
+from odoo.tests import tagged
+from odoo.tests.common import Form
+
+from odoo.addons.sale.tests.common import TestSaleCommon
+
+
+@tagged("post_install", "-at_install")
+class TestSaleOrderPriceList(TestSaleCommon):
+    @classmethod
+    def setUpClass(
+        cls, chart_template_ref="l10n_br_coa_generic.l10n_br_coa_generic_template"
+    ):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        cls.env.user.groups_id |= cls.env.ref("l10n_br_fiscal.group_manager")
+
+        Pricelist = cls.env["product.pricelist"]
+        PricelistItem = cls.env["product.pricelist.item"]
+        SaleOrder = cls.env["sale.order"].with_context(tracking_disable=True)
+
+        # Create a pricelist with especial price for partner_a
+        cls.pricelist_partner_a = Pricelist.create(
+            {
+                "name": "Pricelist Partner A",
+                "company_id": cls.company_data["company"].id,
+            }
+        )
+        PricelistItem.create(
+            {
+                "pricelist_id": cls.pricelist_partner_a.id,
+                "applied_on": "1_product",
+                "product_tmpl_id": cls.company_data[
+                    "product_order_no"
+                ].product_tmpl_id.id,
+                "compute_price": "fixed",
+                "fixed_price": 10,
+            }
+        )
+
+        cls.partner_a.with_company(
+            cls.company_data["company"]
+        ).property_product_pricelist = cls.pricelist_partner_a
+
+        sale_form = Form(SaleOrder)
+        sale_form.partner_id = cls.partner_a
+        sale_form.partner_invoice_id = cls.partner_a
+        sale_form.partner_shipping_id = cls.partner_a
+        sale_form.fiscal_operation_id = cls.env.ref("l10n_br_fiscal.fo_venda")
+
+        with sale_form.order_line.new() as line_form:
+            line_form.name = cls.company_data["product_order_no"].name
+            line_form.product_id = cls.company_data["product_order_no"]
+            line_form.fiscal_operation_line_id = cls.env.ref(
+                "l10n_br_fiscal.fo_venda_revenda"
+            )
+
+        cls.sale_order = sale_form.save()
+
+    def test_pricelist_onchange_product(self):
+        """Test pricelist onchange product_id"""
+
+        # prices before product change.
+        price_before = self.sale_order.order_line[0].price_unit
+        fiscal_price_before = self.sale_order.order_line[0].fiscal_price
+
+        # change product name
+        with Form(self.sale_order) as sale_form:
+            with sale_form.order_line.edit(0) as line_form:
+                line_form.product_id.name = "Test Product - New Name"
+        self.sale_order = sale_form.save()
+
+        # onchange must be called to follow the same behavior as the view.
+        self.sale_order.order_line._onchange_product_id_fiscal()
+
+        # prices after product change.
+        price_after = self.sale_order.order_line[0].price_unit
+        fiscal_price_after = self.sale_order.order_line[0].fiscal_price
+
+        # check if prices are the same.
+        self.assertEqual(price_before, price_after)
+        self.assertEqual(fiscal_price_before, fiscal_price_after)


### PR DESCRIPTION
O calculo do fiscal_price está sendo feito erroneamente ao editar um produto após ele já estar na linha do pedido de venda.
Como reproduzir o erro:

1) A empresa precisa estar com as listas de preços habilitadas
2) Crie uma cotação com alguma lista de preços específica
3) Ao criar uma linha garanta que o preço no cadastro do produto seja diferente na lista de preços
4) acesse o produto direto pela linha da cotação, altere algum campo e salve a alteração do mesmo
ERRO: O fiscal_price agora será igual ao do cadastro do produto e não ao da lista de preços. Por consequencia, impostos e todo resto do fiscal estará errado.
![WhatsApp Image 2023-02-23 at 15 42 27](https://user-images.githubusercontent.com/6812128/221065636-1dcf2e80-765c-4837-85d4-974e11ec6698.jpeg)

Para corrigir, fizemos um overrido do método _get_product_price do mixin fiscal para fazer com que, ao ter uma operação fiscal que utilize o preço de venda, o cálculo do preço seja feito exatamente da mesma forma que é no sale nativo.

Pode ser que o correto seria o _get_product_price já trabalhar com o _get_tax_included_unit_price, pois é um método feito para padronizaçao do unit_price em diversos modelos(account, sale e purchase), mas exigiria um pouco mais de modificação e complexidade que talvez não valheria a pena. É bom ficar registrado caso surjam comportamentos estranhos.

Em breve o @antoniospneto vai subir testes.

