### PR TITLE
[14.0][FIX] l10n_br_account: workaround https://github.com/oca/ocb/commit/1…

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -103,3 +103,15 @@ class AccountMove(models.Model):
         # retidos associada a essa fatura e cancela-las também.
         self._withholding_validate()
         return super().button_cancel()
+
+    # TODO: Por ora esta solução contorna o problema
+    #  AttributeError: 'Boolean' object has no attribute 'depends_context'
+    #  Este erro está relacionado com o campo active implementado via localização
+    #  nos modelos account.move.line e l10n_br_fiscal.document.line
+    #  Este problema começou após este commit:
+    #  https://github.com/oca/ocb/commit/1dcd071b27779e7d6d8f536c7dce7002d27212ba
+    def _get_integrity_hash_fields_and_subfields(self):
+        return self._get_integrity_hash_fields() + [
+            f"line_ids.{subfield}"
+            for subfield in self.env["account.move.line"]._get_integrity_hash_fields()
+        ]


### PR DESCRIPTION
https://github.com/OCA/OCB/commit/1dcd071b27779e7d6d8f536c7dce7002d27212ba

Em um dado momento quando chega nesta linha, ao tentar acessar self.line_ids recebemos esta mensagem de erro. 

AttributeError: 'Boolean' object has no attribute 'depends_context'

Este erro está relacionado com o campo active

Não que a solução proposta (mesmo que temporariamente) seja melhor.. mas aqui esta o link de um jeito tosco de tratar a questão https://github.com/OCA/l10n-brazil/pull/2353

Ref. https://github.com/OCA/l10n-brazil/issues/2350