### PR TITLE
[14.0][FIX] indicador do consumidor final no account.move

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -422,6 +422,17 @@ class AccountMove(models.Model):
     #     return new_mv_lines_dict
     #
 
+    @api.onchange("partner_id")
+    def _onchange_partner_id(self):
+        # Even having this method in the l10n_br_fiscal.document.mixin.methods, the ORM
+        # seems to have some limitation with inherits when the parent model and the
+        # child model have the same field (in this case partner_id). This override was
+        # done to ensure that final_ind is set.
+        result = super()._onchange_partner_id()
+        if self.partner_id:
+            self.ind_final = self.partner_id.ind_final
+        return result
+
     @api.onchange("fiscal_operation_id")
     def _onchange_fiscal_operation_id(self):
         result = super()._onchange_fiscal_operation_id()

--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -103,3 +103,15 @@ class AccountMove(models.Model):
         # retidos associada a essa fatura e cancela-las também.
         self._withholding_validate()
         return super().button_cancel()
+
+    # TODO: Por ora esta solução contorna o problema
+    #  AttributeError: 'Boolean' object has no attribute 'depends_context'
+    #  Este erro está relacionado com o campo active implementado via localização
+    #  nos modelos account.move.line e l10n_br_fiscal.document.line
+    #  Este problema começou após este commit:
+    #  https://github.com/oca/ocb/commit/1dcd071b27779e7d6d8f536c7dce7002d27212ba
+    def _get_integrity_hash_fields_and_subfields(self):
+        return self._get_integrity_hash_fields() + [
+            f"line_ids.{subfield}"
+            for subfield in self.env["account.move.line"]._get_integrity_hash_fields()
+        ]

--- a/l10n_br_account/views/account_invoice_view.xml
+++ b/l10n_br_account/views/account_invoice_view.xml
@@ -69,7 +69,6 @@
                     <field name="fiscal_operation_type" invisible="1" />
                     <field name="name" invisible="1" />
                     <field name="edoc_purpose" invisible="1" />
-                    <field name="ind_final" invisible="1" />
                     <field name="ind_pres" invisible="1" />
                     <field name="fiscal_document_id" required="0" invisible="1" />
                     <field name="create_date" invisible="1" />
@@ -94,6 +93,10 @@
                 />
                 <field
                     name="fiscal_operation_id"
+                    attrs="{'invisible': [('document_type_id', '=', False)], 'required': [('document_type_id', '!=', False)], 'readonly': [('state', '!=', 'draft')]}"
+                />
+                <field
+                    name="ind_final"
                     attrs="{'invisible': [('document_type_id', '=', False)], 'required': [('document_type_id', '!=', False)], 'readonly': [('state', '!=', 'draft')]}"
                 />
                 <field

--- a/l10n_br_account/views/account_invoice_view.xml
+++ b/l10n_br_account/views/account_invoice_view.xml
@@ -102,12 +102,10 @@
                 />
                 <field
                     name="document_serie_id"
-                    requied="0"
                     attrs="{'invisible': ['|', ('document_type_id', '=', False), ('issuer', '=', 'partner')], 'required': [('issuer', '=', 'company'), ('document_type_id', '!=', False)], 'readonly': [('state', '!=', 'draft')]}"
                 />
                 <field
                     name="document_serie"
-                    requied="0"
                     attrs="{'invisible': ['|', ('document_type_id', '=', False), ('issuer', '=', 'company')], 'required': [('issuer', '=', 'partner'), ('document_type_id', '!=', False)], 'readonly': [('state', '!=', 'draft')]}"
                 />
                 <field


### PR DESCRIPTION
Mesmo que a PR #2014, com alguns pequenos ajustes. Na época não entrou porque estava tendo um outro erro na localização que estava inpedindo o merge.

Usei o commit da PR #2357 para ignorar o problema do hash.