### PR TITLE
[14.0][FIX] Incoterms definido na fatura para o documento fiscal.

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -111,6 +111,10 @@ class AccountMove(models.Model):
         compute="_compute_fiscal_operation_type",
     )
 
+    # override the incoterm inherited by the fiscal document
+    # to have the same value as the native incoterm of the invoice.
+    incoterm_id = fields.Many2one(related="invoice_incoterm_id")
+
     def _compute_fiscal_operation_type(self):
         for inv in self:
             if inv.move_type == "entry":

--- a/l10n_br_delivery_nfe/models/document.py
+++ b/l10n_br_delivery_nfe/models/document.py
@@ -18,6 +18,7 @@ class Document(models.Model):
 
     nfe40_modFrete = fields.Selection(
         compute=_compute_nfe40_modFrete,
+        store=True,
     )
 
     nfe40_transporta = fields.Many2one(


### PR DESCRIPTION
Ao criar uma fatura de um documento fiscal, o valor do incoterms definido na fatura não era replicado para o modelo do documento fiscal.

também alterei o campo da modalide do frete para ser store=true, importante para fazer o SPED pelo SQL.