### PR TITLE
[14.0][l10n_br_account] remessa fix com fix dos totais

### DIFF
--- a/l10n_br_account/models/account_invoice_line.py
+++ b/l10n_br_account/models/account_invoice_line.py
@@ -572,8 +572,35 @@ class AccountMoveLine(models.Model):
                     is_stock_only = True
 
         if not is_stock_only:
-            # NOTE that we will fix the case for an empty recordset in a next commit
-            amount_currency = self.price_total * sign
+            if self.price_total:  # recordset with one line
+                amount_currency = self.price_total * sign
+
+            elif self._context.get("create_vals_list") and hasattr(
+                type(self), "_create_vals_line_counter"
+            ):
+                vals = self._context["create_vals_list"][
+                    type(self)._create_vals_line_counter
+                ]
+                partner = self.env["res.partner"].browse(vals.get("partner_id"))
+                taxes = self.new({"tax_ids": vals.get("tax_ids", [])}).tax_ids
+                tax_ids = set(taxes.ids)
+                taxes = self.env["account.tax"].browse(tax_ids)
+                result = self._get_price_total_and_subtotal_model(
+                    vals.get("price_unit", 0.0),
+                    vals.get("quantity", 0.0),
+                    vals.get("discount", 0.0),
+                    currency,
+                    self.env["product.product"].browse(vals.get("product_id")),
+                    partner,
+                    taxes,
+                    move_type,
+                )
+                price_total = result["price_total"]
+                amount_currency = price_total * sign
+                # NOTE this is different from the native:
+                # price_subtotal * sign
+                # to properly account for the tax included price we have in Brazil,
+                # see https://github.com/OCA/l10n-brazil/pull/2303
 
         balance = currency._convert(
             amount_currency,

--- a/l10n_br_account/models/account_invoice_line.py
+++ b/l10n_br_account/models/account_invoice_line.py
@@ -213,9 +213,6 @@ class AccountMoveLine(models.Model):
         self.clear_caches()
         return result
 
-    # TODO As the accounting behavior of taxes in Brazil is completely different,
-    # for now the method for companies in Brazil brings an empty result.
-    # You can correctly map this behavior later.
     @api.model
     def _get_fields_onchange_balance_model(
         self,
@@ -228,7 +225,33 @@ class AccountMoveLine(models.Model):
         price_subtotal,
         force_computation=False,
     ):
-        return {}
+        """
+        This method is used to recompute the values of 'quantity', 'discount',
+        'price_unit' due to a change made
+        in some accounting fields such as 'balance'.
+        """
+        if self._context.get("create_vals_list") and hasattr(
+            type(self), "_should_increment_line_counter"
+        ):
+            # incrementing the counter will discriminate next method calls
+            type(self)._should_increment_line_counter = True
+
+        if self.fiscal_operation_line_id:
+            # TODO As the accounting behavior of taxes in Brazil is completely different,
+            # for now the method for companies in Brazil brings an empty result.
+            # You can correctly map this behavior later.
+            return {}
+        else:
+            return super()._get_fields_onchange_balance_model(
+                quantity=quantity,
+                discount=discount,
+                amount_currency=amount_currency,
+                move_type=move_type,
+                currency=currency,
+                taxes=taxes,
+                price_subtotal=price_subtotal,
+                force_computation=force_computation,
+            )
 
     def _get_price_total_and_subtotal(
         self,


### PR DESCRIPTION
Tentativa de resolver a questão dos totais financeiros, junto com o fix das remessas ja que mexe no mesmo codigo.

Eh um código bem porco SIM. POREM, eu duvido que da para fazer algo menos porco que ainda acerta os totais. O que eh porco eh que a gente enfia no contexto parametros que o Odoo não passa em alguns metodos chamados no create_multi. E tem tambem um contador de linhas do create bem porco que usa variáveis "thread local" no type(self) que fica incrementado de forma bem estratégica para conseguir saber de qual linha desse create multi se trata e pegar os valores que a localização precisa do contexto... Se alguém quiser bater nos caras da Odoo SA até eles pararem de fazer métodos gigantescos que não dam opção para acrescentar parâmetros nos métodos chamados, eu apoio ta (até onde eu vi na v16 não precisaria mais dessa gambiarra porem, o código do create do account.move.line ficou mais limpo). Até la, eu acho que da para resolver assim...

![2023-03-02_04-32](https://user-images.githubusercontent.com/16926/222361524-f2eb00e8-f2ca-46b7-991c-7ed038c6e206.png)

