### PR TITLE
[14.0][FIX] Busca a descrição correta para a linha da nota fiscal (Tag xProd)

### DIFF
--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -173,8 +173,12 @@ class NFeLine(spec_models.StackedModel):
         nfe40_cProd = self.product_id.default_code or self.nfe40_cProd or ""
         export_dict["cProd"] = nfe40_cProd
 
-        nfe40_xProd = self.product_id.name or self.name or ""
-        export_dict["xProd"] = nfe40_xProd[:120].replace("\n", "").strip()
+        nfe40_xProd = (
+            self.product_id.with_context(display_default_code=False).display_name
+            or self.name
+            or ""
+        )
+        export_dict["xProd"] = nfe40_xProd[:120].replace("\n", " ").strip()
 
         nfe40_cEAN = nfe40_cEANTrib = self.product_id.barcode or "SEM GTIN"
         export_dict["cEAN"] = export_dict["cEANTrib"] = nfe40_cEAN


### PR DESCRIPTION
O valor da descrição do item da nota fiscal não estava sendo carregado corretamente. Campo xProd na NF-e.

Do jeito que está na hora de gerar a o XML, o sistema estava pega a descrição diretamente do campo "name" de dentro do produto_id, isso é errado pois ignora toda a descrição que foi adicionada manualmente na linha da fatura e também ignora todas as regras de exibição do nome configurado nos produtos, muito utilizado nos casos de variantes, que o nome de exibição é gerado dinamicamente com base nas variações selecionadas.

O correto é primeiro buscar o valor de dentro do campo "name" da própria linha da fatura / documento fiscal que no caso é descrição / rótulo da item.
caso não exista, a segunda opção é pegar o "display_name" de dentro do produto.
