### PR TITLE
[14.0][l10n_br_account] fixes OCA#1813 skip bad recomputes

### DIFF
--- a/l10n_br_account/__init__.py
+++ b/l10n_br_account/__init__.py
@@ -1,6 +1,35 @@
+# Copyright (C) 2023 - TODAY Raphaël Valyi - Akretion
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
 from .hooks import pre_init_hook
 from .hooks import post_init_hook
 
 from . import models
 from . import wizards
 from . import report
+
+from odoo.api import Environment
+from odoo.models import NewId
+
+
+def add_to_compute(self, field, records):
+    """
+    Mark ``field`` to be computed on ``records``.
+    Monkey patched to avoid recomputing account.move
+    and account.move.line linked to the same dummy records
+    used in non fiscal account moves.
+    """
+    if records and self.context.get(
+        "recompute_%s_after_id" % (records._name.replace(".", "_"),)
+    ):
+        records = records.filtered(
+            lambda rec: isinstance(rec.id, NewId)
+            or rec.id
+            > self.context["recompute_%s_after_id" % (records._name.replace(".", "_"),)]
+        )
+
+    return Environment.add_to_compute._original_method(self, field, records)
+
+
+add_to_compute._original_method = Environment.add_to_compute
+Environment.add_to_compute = add_to_compute

--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -251,9 +251,13 @@ class AccountMove(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        invoice = super().create(vals_list)
-        invoice._write_shadowed_fields()
-        return invoice
+        recompute_inv_after_id = self.search([], order="id DESC", limit=1).id
+        invoices = super(
+            AccountMove,
+            self.with_context(recompute_account_move_after_id=recompute_inv_after_id),
+        ).create(vals_list)
+        invoices._write_shadowed_fields()
+        return invoices
 
     def write(self, values):
         result = super().write(values)

--- a/l10n_br_account/models/account_invoice_line.py
+++ b/l10n_br_account/models/account_invoice_line.py
@@ -174,7 +174,14 @@ class AccountMoveLine(models.Model):
                 )
             )
 
-        lines = super().create(vals_list)
+        recompute_line_after_id = self.search([], order="id DESC", limit=1).id
+        lines = super(
+            AccountMoveLine,
+            self.with_context(
+                recompute_account_move_line_after_id=recompute_line_after_id
+            ),
+        ).create(vals_list)
+
         for line in lines.filtered(lambda l: l.fiscal_document_line_id != dummy_line):
             shadowed_fiscal_vals = line._prepare_shadowed_fields_dict()
             doc_id = line.move_id.fiscal_document_id.id

--- a/l10n_br_account/tests/test_customer_invoice_dummy.py
+++ b/l10n_br_account/tests/test_customer_invoice_dummy.py
@@ -33,6 +33,12 @@ class TestCustomerInvoice(SavepointCase):
             )
         )
 
+        cls.init_number_of_fiscal_docs = cls.env[
+            "l10n_br_fiscal.document"
+        ].search_count([])
+        cls.init_number_of_fiscal_doc_lines = cls.env[
+            "l10n_br_fiscal.document.line"
+        ].search_count([])
         cls.invoice_1 = cls.env["account.move"].create(
             dict(
                 name="Test Customer Invoice 1",
@@ -218,6 +224,22 @@ class TestCustomerInvoice(SavepointCase):
                     )
                 ],
             )
+        )
+
+    def test_dummy_doc_usage(self):
+        self.assertEqual(
+            self.init_number_of_fiscal_docs,
+            self.env["l10n_br_fiscal.document"].search_count([]),
+            "Non fiscal invoices should not create fiscal documents"
+            "They should use the company dummy document instead.",
+        )
+
+    def test_dummy_doc_line_usage(self):
+        self.assertEqual(
+            self.init_number_of_fiscal_doc_lines,
+            self.env["l10n_br_fiscal.document.line"].search_count([]),
+            "Non fiscal invoices should not create fiscal document lines"
+            "They should use the company dummy document line instead.",
         )
 
     def test_state(self):

--- a/l10n_br_account/tests/test_supplier_invoice_dummy.py
+++ b/l10n_br_account/tests/test_supplier_invoice_dummy.py
@@ -33,6 +33,12 @@ class TestSupplierInvoice(SavepointCase):
             )
         )
 
+        cls.init_number_of_fiscal_docs = cls.env[
+            "l10n_br_fiscal.document"
+        ].search_count([])
+        cls.init_number_of_fiscal_doc_lines = cls.env[
+            "l10n_br_fiscal.document.line"
+        ].search_count([])
         cls.invoice_1 = cls.env["account.move"].create(
             dict(
                 name="Test Supplier Invoice 1",
@@ -73,6 +79,22 @@ class TestSupplierInvoice(SavepointCase):
                     )
                 ],
             )
+        )
+
+    def test_dummy_doc_usage(self):
+        self.assertEqual(
+            self.init_number_of_fiscal_docs,
+            self.env["l10n_br_fiscal.document"].search_count([]),
+            "Non fiscal invoices should not create fiscal documents"
+            "They should use the company dummy document instead.",
+        )
+
+    def test_dummy_doc_line_usage(self):
+        self.assertEqual(
+            self.init_number_of_fiscal_doc_lines,
+            self.env["l10n_br_fiscal.document.line"].search_count([]),
+            "Non fiscal invoices should not create fiscal document lines"
+            "They should use the company dummy document line instead.",
         )
 
     def test_state(self):

--- a/l10n_br_account/tests/test_supplier_invoice_dummy.py
+++ b/l10n_br_account/tests/test_supplier_invoice_dummy.py
@@ -3,71 +3,72 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import fields
-from odoo.tests.common import TransactionCase
+from odoo.tests import SavepointCase
 
 
-class TestSupplierInvoice(TransactionCase):
+class TestSupplierInvoice(SavepointCase):
     """
     This is a simple test for ensuring l10n_br_account doesn't break the basic
     account module behavior with supplier invoices.
     """
 
-    def setUp(self):
-        super().setUp()
-        self.purchase_account = self.env["account.account"].create(
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.purchase_account = cls.env["account.account"].create(
             dict(
                 code="X1020",
                 name="Product Purchase - (test)",
-                user_type_id=self.env.ref("account.data_account_type_revenue").id,
+                user_type_id=cls.env.ref("account.data_account_type_revenue").id,
             )
         )
 
-        self.purchase_journal = self.env["account.journal"].create(
+        cls.purchase_journal = cls.env["account.journal"].create(
             dict(
                 name="Purchase Journal - (test)",
                 code="TPJ",
                 type="purchase",
                 refund_sequence=True,
-                default_account_id=self.purchase_account.id,
+                default_account_id=cls.purchase_account.id,
             )
         )
 
-        self.invoice_1 = self.env["account.move"].create(
+        cls.invoice_1 = cls.env["account.move"].create(
             dict(
                 name="Test Supplier Invoice 1",
                 move_type="in_invoice",
                 invoice_date=fields.Date.today(),
-                partner_id=self.env.ref("base.res_partner_3").id,
-                journal_id=self.purchase_journal.id,
+                partner_id=cls.env.ref("base.res_partner_3").id,
+                journal_id=cls.purchase_journal.id,
                 invoice_line_ids=[
                     (
                         0,
                         0,
                         {
-                            "product_id": self.env.ref("product.product_product_5").id,
+                            "product_id": cls.env.ref("product.product_product_5").id,
                             "quantity": 10.0,
                             "price_unit": 450.0,
-                            "account_id": self.env["account.account"]
+                            "account_id": cls.env["account.account"]
                             .search(
                                 [
                                     (
                                         "user_type_id",
                                         "=",
-                                        self.env.ref(
+                                        cls.env.ref(
                                             "account.data_account_type_revenue"
                                         ).id,
                                     ),
                                     (
                                         "company_id",
                                         "=",
-                                        self.env.company.id,
+                                        cls.env.company.id,
                                     ),
                                 ],
                                 limit=1,
                             )
                             .id,
                             "name": "product test 5",
-                            "uom_id": self.env.ref("uom.product_uom_unit").id,
+                            "uom_id": cls.env.ref("uom.product_uom_unit").id,
                         },
                     )
                 ],

--- a/l10n_br_account/tests/test_supplier_invoice_dummy.py
+++ b/l10n_br_account/tests/test_supplier_invoice_dummy.py
@@ -1,8 +1,11 @@
-# @ 2018 Akretion - www.akretion.com.br -
-#   Magno Costa <magno.costa@akretion.com.br>
+# Copyright (C) 2018 - Magno Costa - Akretion
+# Copyright (C) 2023 - TODAY Raphaël Valyi - Akretion
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+import mock
+
 from odoo import fields
+from odoo.models import NewId
 from odoo.tests import SavepointCase
 
 
@@ -96,6 +99,91 @@ class TestSupplierInvoice(SavepointCase):
             "Non fiscal invoices should not create fiscal document lines"
             "They should use the company dummy document line instead.",
         )
+
+    def test_create_dont_recompute_existing_moves(self):
+        with mock.patch.object(
+            self.env.__class__.add_to_compute, "_original_method", wraps=None
+        ) as mocked_env:
+            invoice = self.env["account.move"].create(
+                dict(
+                    name="Test Supplier Invoice 1",
+                    move_type="in_invoice",
+                    invoice_date=fields.Date.today(),
+                    partner_id=self.env.ref("base.res_partner_3").id,
+                    journal_id=self.purchase_journal.id,
+                    invoice_line_ids=[
+                        (
+                            0,
+                            0,
+                            {
+                                "product_id": self.env.ref(
+                                    "product.product_product_5"
+                                ).id,
+                                "quantity": 10.0,
+                                "price_unit": 450.0,
+                                "account_id": self.env["account.account"]
+                                .search(
+                                    [
+                                        (
+                                            "user_type_id",
+                                            "=",
+                                            self.env.ref(
+                                                "account.data_account_type_revenue"
+                                            ).id,
+                                        ),
+                                        (
+                                            "company_id",
+                                            "=",
+                                            self.env.company.id,
+                                        ),
+                                    ],
+                                    limit=1,
+                                )
+                                .id,
+                                "name": "product test 5",
+                                "uom_id": self.env.ref("uom.product_uom_unit").id,
+                            },
+                        )
+                    ],
+                )
+            )
+            for mock_call in mocked_env.mock_calls:
+                if (
+                    str(mock_call.args[1]).split(".")[:-1] == ["account", "move"]
+                    and mock_call.args[2]
+                    and not isinstance(mock_call.args[2][0].id, NewId)
+                ):
+                    self.assertEqual(mock_call.args[2], invoice)
+                elif (
+                    str(mock_call.args[1]).split(".")[:-1]
+                    == ["account", "move", "line"]
+                    and mock_call.args[2]
+                    and not isinstance(mock_call.args[2][0].id, NewId)
+                ):
+                    for line in mock_call.args[2]:
+                        self.assertIn(line, invoice.line_ids)
+
+    def test_write_dont_recompute_existing_moves(self):
+        with mock.patch.object(
+            self.env.__class__.add_to_compute, "_original_method", wraps=None
+        ) as mocked_env:
+            self.invoice_1.invoice_line_ids[0].write({"quantity": 20})
+
+            for mock_call in mocked_env.mock_calls:
+                if (
+                    str(mock_call.args[1]).split(".")[:-1] == ["account", "move"]
+                    and mock_call.args[2]
+                    and not isinstance(mock_call.args[2][0].id, NewId)
+                ):
+                    self.assertEqual(mock_call.args[2], self.invoice_1)
+                elif (
+                    str(mock_call.args[1]).split(".")[:-1]
+                    == ["account", "move", "line"]
+                    and mock_call.args[2]
+                    and not isinstance(mock_call.args[2][0].id, NewId)
+                ):
+                    for line in mock_call.args[2]:
+                        self.assertIn(line, self.invoice_1.line_ids)
 
     def test_state(self):
         self.assertEqual(


### PR DESCRIPTION
mesmo fix do que https://github.com/OCA/l10n-brazil/pull/1816 para resolver os problemas de lentidão devido aos recompute dos registros account.move e account.move.line ligados aos registros dummy nos account.move não fiscais.

Na v14.0 foi necessario fazer um monkey patch do api.Environment porque o método add_to_compute não pertence mais do models.

cc @antoniospneto @felipemotter @renatonlima @marcelsavegnago 