### PR TITLE
[14.0][FIX] l10n_br_account: Correção para emissão da nota de devolução.

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -12,6 +12,7 @@ from odoo.addons.l10n_br_fiscal.constants.fiscal import (
     DOCUMENT_ISSUER_PARTNER,
     FISCAL_IN_OUT_ALL,
     FISCAL_OUT,
+    MODELO_FISCAL_NFE,
     SITUACAO_EDOC_CANCELADA,
     SITUACAO_EDOC_EM_DIGITACAO,
 )
@@ -440,6 +441,11 @@ class AccountMove(models.Model):
     @api.onchange("fiscal_operation_id")
     def _onchange_fiscal_operation_id(self):
         result = super()._onchange_fiscal_operation_id()
+
+        # /!\ Inherits limitation ?
+        # hack so that the onchange of the fiscal_document_line model is also called
+        self.fiscal_document_id._onchange_fiscal_operation_id()
+
         if self.fiscal_operation_id and self.fiscal_operation_id.journal_id:
             self.journal_id = self.fiscal_operation_id.journal_id
         return result
@@ -614,14 +620,14 @@ class AccountMove(models.Model):
                 )
                 line._onchange_fiscal_operation_id()
 
-            # Migrar para v14.0 .. talvez nao precise mais disso.
-            # Nao ficou claro o objetivo deste trecho
-            # refund_inv_id = record.reversal_move_id
-            #
-            # if record.refund_move_id.document_type_id:
-            #     record.fiscal_document_id._document_reference(
-            #         refund_inv_id.fiscal_document_id
-            #     )
+            # Adds the related document to the NF-e.
+            # this is required for correct xml validation
+            if record.document_type_id and record.document_type_id.code in (
+                MODELO_FISCAL_NFE
+            ):
+                record.fiscal_document_id._document_reference(
+                    record.reversed_entry_id.fiscal_document_id
+                )
 
         return new_moves
 

--- a/l10n_br_account/models/fiscal_document.py
+++ b/l10n_br_account/models/fiscal_document.py
@@ -16,23 +16,9 @@ class FiscalDocument(models.Model):
         string="Invoices",
     )
 
-    def modified(self, fnames, create=False, before=False):
-        """
-        Modifying a dummy fiscal document should not recompute
-        any account.move related to the same dummy fiscal document.
-        """
-        if not self.document_type_id:
-            return
-        return super().modified(fnames, create, before)
-
-    def _modified_triggers(self, tree, create=False):
-        """
-        Modifying a dummy fiscal document should not recompute
-        any account.move related to the same dummy fiscal document.
-        """
-        if not self.document_type_id:
-            return []
-        return super()._modified_triggers(tree, create)
+    fiscal_line_ids = fields.One2many(
+        copy=False,
+    )
 
     def unlink(self):
         non_draft_documents = self.filtered(

--- a/l10n_br_account_nfe/models/document.py
+++ b/l10n_br_account_nfe/models/document.py
@@ -30,6 +30,7 @@ class DocumentNfe(models.Model):
         comodel_name="nfe.40.dup",
         compute="_compute_nfe40_dup",
         store=True,
+        copy=False,
         readonly=False,
     )
 


### PR DESCRIPTION
Essa PR tem a finalidade de corrigir a criação de uma nota fiscal (NF-e) a partir da funcionalidade de reembolso (Credit Note) nativa do módulo Account.

1) Fiz um override no `fiscal_line_ids` para que no módulo l10n_br_account ficasse com o `copy=False`
No account não precisamos copiar as linhas fiscais pois elas são criadas automaticamente junto com as linhas da própria invoice.

2) Foi colocado copy=False para o campo nfe40_dup. Não precisamos copiar esses valores da nota original, caso seja preciso o sistema irá computar essas informações novamente.

3) No processo de criação da nota de devolução no método `_reverse_moves` é chamado o método `_onchange_fiscal_operation_id() ` porém não não chega a chamar o que está definido no documento fiscal.
Forcei a chamada, dentro do onchange que está no account_invoice.

4)  Adicionei no processo de criação da nota de devolução, para que adicione também a nota fiscal referenciada, que é um requisito para a NF-e.



