### PR TITLE
[12.0][FIX] ignore case sensitive in res.city search

### DIFF
--- a/l10n_br_zip/models/l10n_br_zip.py
+++ b/l10n_br_zip/models/l10n_br_zip.py
@@ -147,7 +147,7 @@ class L10nBrZip(models.Model):
 
             # search city with name and state
             city = self.env["res.city"].search(
-                [("name", "=", cep.get("cidade")), ("state_id.id", "=", state.id)],
+                [("name", "ilike", cep.get("cidade")), ("state_id.id", "=", state.id)],
                 limit=1,
             )
 


### PR DESCRIPTION
Ao consultar o CEP: 36309-632 é gerado o seguinte erro:


![WhatsApp Image 2023-03-08 at 17 49 15](https://user-images.githubusercontent.com/211005/223846931-3618e7ff-0009-400e-b934-9cc8c115c88f.jpeg)

Isso ocorre porque o nome do municipio na busca de CEP esta "São João Del Rei"

![Screenshot from 2023-03-08 17-44-47](https://user-images.githubusercontent.com/211005/223847284-90841a14-cb9f-455f-9a17-08911f61c45d.png)

Mas no cadastro de municio do IBGE está "São João del Rei"

![Screenshot from 2023-03-08 17-50-02](https://user-images.githubusercontent.com/211005/223847653-217a2775-7a31-4137-962b-e86a4520e538.png)

Para resolver esse problema foi alterado a busca do res.city para ignorar o case sensitive