### PR TITLE
[FIX] isort version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,7 +103,7 @@ repos:
       - id: pyupgrade
         args: ["--keep-percent-format"]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.5.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort except __init__.py


### PR DESCRIPTION
Problema de incompatibilidade na versão do isort ocasiona erro ao executar o pre-commit no repositório.

```
RuntimeError: The Poetry configuration is invalid:
            - [extras.pipfile_deprecated_finder.2] 'pip-shims<=0.3.4' does not match '^[a-zA-Z-_.0-9]+$'
```

Atualizando a versão do isort para 5.12.0, o problema é resolvido.

Referência da solução: #https://github.com/home-assistant/core/issues/86892