### PR TITLE
[12.0][l10n_br_nfe][FIX] Troca campo nfe40_nFat de related para computed

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -560,11 +560,15 @@ class NFe(spec_models.StackedModel):
     ##########################
     # NF-e tag: fat
     ##########################
-    nfe40_nFat = fields.Char(related="document_number")
+    nfe40_nFat = fields.Char(compute="_compute_nfe40_nfat")
 
     nfe40_vOrig = fields.Monetary(related="amount_financial_total_gross")
 
     nfe40_vLiq = fields.Monetary(related="amount_financial_total")
+
+    def _compute_nfe40_nfat(self):
+        for record in self:
+            record.nfe40_nFat = record.document_number
 
     ##########################
     # NF-e tag: infRespTec


### PR DESCRIPTION
Apesar de no Odoo os campos nNF e nFat serem sempre iguais, este não é o caso para todas as notas fiscais.

O fato do campo nfe40_nFat ser related com document_number esta causando problema na importação de notas fiscais que tem os campos nNF e nFat diferentes. Quando isso acontece, a nota esta sendo importada com o valor do campo nFat no document_number, isso é um problema pois multiplas notas do mesmo emissor podem conter um valor igual nesse campo.

Com essa mudança a nota é importada com o valor do campo nNF no campo document number.