### PR TITLE
[14.0][IMP] l10n_br_fiscal, l10n_br_nfe: atualização do parâmetro do tipo de emissão na geração da chave edoc

### DIFF
--- a/l10n_br_fiscal/constants/fiscal.py
+++ b/l10n_br_fiscal/constants/fiscal.py
@@ -526,3 +526,15 @@ FISCAL_PAYMENT_MODE = [
     ("90", "90 - Sem Pagamento"),
     ("99", "99 - Outros"),
 ]
+TRANSMISSIONS_TYPE = [
+    ("1", "Emissão Normal"),
+    ("2", "Contingência FS-IA"),
+    ("3", "Contingência SCAN"),
+    ("4", "Contingência EPEC"),
+    ("5", "Contingência FS-DA"),
+    ("6", "Contingência SVC-AN"),
+    ("7", "Contingência SVC-RS"),
+    ("9", "Contingência off-line da NFC-e"),
+]
+
+TRANSMISSION_TYPE_DEFAULT = "1"

--- a/l10n_br_fiscal/constants/fiscal.py
+++ b/l10n_br_fiscal/constants/fiscal.py
@@ -526,7 +526,7 @@ FISCAL_PAYMENT_MODE = [
     ("90", "90 - Sem Pagamento"),
     ("99", "99 - Outros"),
 ]
-TRANSMISSIONS_TYPE = [
+EDOC_TRANSMISSIONS = [
     ("1", "Emissão Normal"),
     ("2", "Contingência FS-IA"),
     ("3", "Contingência SCAN"),
@@ -537,4 +537,4 @@ TRANSMISSIONS_TYPE = [
     ("9", "Contingência off-line da NFC-e"),
 ]
 
-TRANSMISSION_TYPE_DEFAULT = "1"
+EDOC_TRANSMISSION_DEFAULT = "1"

--- a/l10n_br_fiscal/migrations/14.0.10.10.0/pre-migration.py
+++ b/l10n_br_fiscal/migrations/14.0.10.10.0/pre-migration.py
@@ -1,0 +1,18 @@
+# Copyright (C) 2023 - Ygor Carvalho - KMEE
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+_field_renames = [
+    (
+        "res.company",
+        "res_company",
+        "nfe_transmission",
+        "edoc_transmission",
+    ),
+]
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    openupgrade.rename_fields(env, _field_renames)

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -24,7 +24,7 @@ from ..constants.fiscal import (
     SITUACAO_EDOC_CANCELADA,
     SITUACAO_EDOC_DENEGADA,
     SITUACAO_EDOC_INUTILIZADA,
-    TRANSMISSIONS_TYPE,
+    EDOC_TRANSMISSIONS,
 )
 
 
@@ -188,11 +188,11 @@ class Document(models.Model):
         default=False,
     )
 
-    transmission_type = fields.Selection(
-        selection=TRANSMISSIONS_TYPE,
+    edoc_transmission = fields.Selection(
+        selection=EDOC_TRANSMISSIONS,
         string="NFe Transmission",
         copy=False,
-        default=lambda self: self.env.user.company_id.transmission_type,
+        default=lambda self: self.env.user.company_id.edoc_transmission,
     )
 
     @api.constrains("document_key")

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -24,6 +24,7 @@ from ..constants.fiscal import (
     SITUACAO_EDOC_CANCELADA,
     SITUACAO_EDOC_DENEGADA,
     SITUACAO_EDOC_INUTILIZADA,
+    TRANSMISSIONS_TYPE,
 )
 
 
@@ -185,6 +186,13 @@ class Document(models.Model):
         string="Subsequent documents generated?",
         compute="_compute_document_subsequent_generated",
         default=False,
+    )
+
+    transmission_type = fields.Selection(
+        selection=TRANSMISSIONS_TYPE,
+        string="NFe Transmission",
+        copy=False,
+        default=lambda self: self.env.user.company_id.transmission_type,
     )
 
     @api.constrains("document_key")

--- a/l10n_br_fiscal/models/document_workflow.py
+++ b/l10n_br_fiscal/models/document_workflow.py
@@ -258,7 +258,7 @@ class DocumentWorkflow(models.AbstractModel):
                         and record.company_state_id.ibge_code
                         or ""
                     ),
-                    forma_emissao=int(self.transmission_type),
+                    forma_emissao=int(self.edoc_transmission),
                     modelo_documento=record.document_type_id.code or "",
                     numero_documento=record.document_number or "",
                     numero_serie=record.document_serie or "",

--- a/l10n_br_fiscal/models/document_workflow.py
+++ b/l10n_br_fiscal/models/document_workflow.py
@@ -258,7 +258,7 @@ class DocumentWorkflow(models.AbstractModel):
                         and record.company_state_id.ibge_code
                         or ""
                     ),
-                    forma_emissao=1,  # TODO: Implementar campo no Odoo
+                    forma_emissao=int(self.transmission_type),
                     modelo_documento=record.document_type_id.code or "",
                     numero_documento=record.document_number or "",
                     numero_serie=record.document_serie or "",

--- a/l10n_br_fiscal/models/res_company.py
+++ b/l10n_br_fiscal/models/res_company.py
@@ -33,8 +33,8 @@ from ..constants.fiscal import (
     TAX_FRAMEWORK_NORMAL,
     TAX_FRAMEWORK_SIMPLES,
     TAX_FRAMEWORK_SIMPLES_ALL,
-    TRANSMISSION_TYPE_DEFAULT,
-    TRANSMISSIONS_TYPE,
+    EDOC_TRANSMISSION_DEFAULT,
+    EDOC_TRANSMISSIONS,
 )
 
 _logger = logging.getLogger(__name__)
@@ -323,10 +323,10 @@ class ResCompany(models.Model):
         default="line",
     )
 
-    transmission_type = fields.Selection(
-        selection=TRANSMISSIONS_TYPE,
+    edoc_transmission = fields.Selection(
+        selection=EDOC_TRANSMISSIONS,
         string="Transmission Type",
-        default=TRANSMISSION_TYPE_DEFAULT,
+        default=EDOC_TRANSMISSION_DEFAULT,
         help="1=Emissão normal (não em contingência);"
         "\n2=Contingência FS-IA, com impressão do DANFE em Formulário"
         " de Segurança - Impressor Autônomo;"

--- a/l10n_br_fiscal/models/res_company.py
+++ b/l10n_br_fiscal/models/res_company.py
@@ -33,6 +33,8 @@ from ..constants.fiscal import (
     TAX_FRAMEWORK_NORMAL,
     TAX_FRAMEWORK_SIMPLES,
     TAX_FRAMEWORK_SIMPLES_ALL,
+    TRANSMISSION_TYPE_DEFAULT,
+    TRANSMISSIONS_TYPE,
 )
 
 _logger = logging.getLogger(__name__)
@@ -319,6 +321,26 @@ class ResCompany(models.Model):
         help="Define if costs of Insurance, Freight and Other Costs"
         " should be informed by Line or by Total.",
         default="line",
+    )
+
+    transmission_type = fields.Selection(
+        selection=TRANSMISSIONS_TYPE,
+        string="Transmission Type",
+        default=TRANSMISSION_TYPE_DEFAULT,
+        help="1=Emissão normal (não em contingência);"
+        "\n2=Contingência FS-IA, com impressão do DANFE em Formulário"
+        " de Segurança - Impressor Autônomo;"
+        "\n3=Contingência SCAN (Sistema de Contingência do Ambiente Nacional);"
+        " *Desativado * NT 2015/002"
+        "\n4=Contingência EPEC (Evento Prévio da Emissão em Contingência);"
+        "\n5=Contingência FS-DA, com impressão do DANFE em Formulário "
+        "de Segurança - Documento Auxiliar;"
+        "\n6=Contingência SVC-AN (SEFAZ Virtual de Contingência do AN);"
+        "\n7=Contingência SVC-RS (SEFAZ Virtual de Contingência do RS);"
+        "\n9=Contingência off-line da NFC-e;"
+        "\nObservação: Para a NFC-e somente é válida a opção de contingência:"
+        "\n9-Contingência Off-Line e, a critério da UF, opção "
+        "4-Contingência EPEC. (NT 2015/002)",
     )
 
     anonymous_partner_id = fields.Many2one(

--- a/l10n_br_fiscal/models/res_config_settings.py
+++ b/l10n_br_fiscal/models/res_config_settings.py
@@ -51,3 +51,9 @@ class ResConfigSettings(models.TransientModel):
     delivery_costs = fields.Selection(
         related="company_id.delivery_costs", readonly=False
     )
+
+    transmission_type = fields.Selection(
+        string="NFe Transmission",
+        related="company_id.transmission_type",
+        readonly=False,
+    )

--- a/l10n_br_fiscal/models/res_config_settings.py
+++ b/l10n_br_fiscal/models/res_config_settings.py
@@ -52,8 +52,8 @@ class ResConfigSettings(models.TransientModel):
         related="company_id.delivery_costs", readonly=False
     )
 
-    transmission_type = fields.Selection(
+    edoc_transmission = fields.Selection(
         string="NFe Transmission",
-        related="company_id.transmission_type",
+        related="company_id.edoc_transmission",
         readonly=False,
     )

--- a/l10n_br_fiscal/views/res_company_view.xml
+++ b/l10n_br_fiscal/views/res_company_view.xml
@@ -115,11 +115,7 @@
                                         domain="{'3': [('tax_group_id', '=', %(l10n_br_fiscal.tax_group_icms)d)]}.get(tax_framework, [('tax_group_id', '=', %(l10n_br_fiscal.tax_group_icmssn)d)])"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
-                                      <field
-                                        name="icms_regulation_id"
-                                        attrs="{'invisible': [('tax_framework', '!=', '3')], 'required': [('tax_framework', '=', '3')]}"
-                                        options="{'no_create': True, 'no_create_edit': True}"
-                                    />
+                                      <field name="icms_regulation_id" />
                                   </group>
                                   <group name="issqn_taxes" string="ISSQN">
                                       <field name="tax_issqn_id" />
@@ -168,6 +164,9 @@
                                     />
                                 </group>
                                 <group />
+                                <group>
+                                    <field name="transmission_type" />
+                                </group>
                             </group>
                         </page>
                     </notebook>

--- a/l10n_br_fiscal/views/res_company_view.xml
+++ b/l10n_br_fiscal/views/res_company_view.xml
@@ -165,7 +165,7 @@
                                 </group>
                                 <group />
                                 <group>
-                                    <field name="transmission_type" />
+                                    <field name="edoc_transmission" />
                                 </group>
                             </group>
                         </page>

--- a/l10n_br_fiscal/views/res_config_settings_view.xml
+++ b/l10n_br_fiscal/views/res_config_settings_view.xml
@@ -147,11 +147,11 @@
                         <div class="content-group">
                             <div class="mt16 row">
                                 <label
-                                    for="transmission_type"
+                                    for="edoc_transmission"
                                     class="col-4 col-lg-4 o_light_label"
                                 />
                                 <field
-                                    name="transmission_type"
+                                    name="edoc_transmission"
                                     class="oe_inline"
                                     required="1"
                                 />

--- a/l10n_br_fiscal/views/res_config_settings_view.xml
+++ b/l10n_br_fiscal/views/res_config_settings_view.xml
@@ -144,6 +144,22 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="content-group">
+                            <div class="mt16 row">
+                                <label
+                                    for="transmission_type"
+                                    class="col-4 col-lg-4 o_light_label"
+                                />
+                                <field
+                                    name="transmission_type"
+                                    class="oe_inline"
+                                    required="1"
+                                />
+                                <div class="text-muted">
+                                    Define the transmission type for Brazilian eletronic invoice.
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </xpath>

--- a/l10n_br_nfe/constants/nfe.py
+++ b/l10n_br_nfe/constants/nfe.py
@@ -13,21 +13,6 @@ NFE_ENVIRONMENTS = [("1", "Produção"), ("2", "Homologação")]
 NFE_ENVIRONMENT_DEFAULT = "2"
 
 
-NFE_TRANSMISSIONS = [
-    ("1", "Emissão Normal"),
-    ("2", "Contingência FS-IA"),
-    ("3", "Contingência SCAN"),
-    ("4", "Contingência EPEC"),
-    ("5", "Contingência FS-DA"),
-    ("6", "Contingência SVC-AN"),
-    ("7", "Contingência SVC-RS"),
-    ("9", "Contingência off-line da NFC-e"),
-]
-
-
-NFE_TRANSMISSION_DEFAULT = "1"
-
-
 NFE_DANFE_LAYOUTS = [
     ("0", "Sem geração de DANFE;"),
     ("1", "DANFE normal, Retrato;"),

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -243,7 +243,7 @@ class NFe(spec_models.StackedModel):
     )
 
     nfe40_tpEmis = fields.Selection(
-        related="transmission_type"
+        related="edoc_transmission"
     )  # TODO no caso de entrada
 
     nfe_transmission = fields.Selection(
@@ -284,7 +284,7 @@ class NFe(spec_models.StackedModel):
     # Compute Methods
     ##########################
 
-    @api.depends("fiscal_operation_type", "transmission_type")
+    @api.depends("fiscal_operation_type", "edoc_transmission")
     def _compute_ide_data(self):
         """Set schema data which are not just related fields"""
         for record in self:
@@ -353,7 +353,7 @@ class NFe(spec_models.StackedModel):
     def _inverse_nfe40_tpEmis(self):
         for doc in self:
             if doc.nfe40_tpEmis:
-                doc.transmission_type = doc.nfe40_tpEmis
+                doc.edoc_transmission = doc.nfe40_tpEmis
 
     def _inverse_nfe40_dhSaiEnt(self):
         for doc in self:

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -57,7 +57,6 @@ from ..constants.nfe import (
     NFCE_DANFE_LAYOUTS,
     NFE_DANFE_LAYOUTS,
     NFE_ENVIRONMENTS,
-    NFE_TRANSMISSIONS,
     NFE_VERSIONS,
 )
 
@@ -244,7 +243,7 @@ class NFe(spec_models.StackedModel):
     )
 
     nfe40_tpEmis = fields.Selection(
-        related="nfe_transmission"
+        related="transmission_type"
     )  # TODO no caso de entrada
 
     nfe_transmission = fields.Selection(
@@ -285,7 +284,7 @@ class NFe(spec_models.StackedModel):
     # Compute Methods
     ##########################
 
-    @api.depends("fiscal_operation_type", "nfe_transmission")
+    @api.depends("fiscal_operation_type", "transmission_type")
     def _compute_ide_data(self):
         """Set schema data which are not just related fields"""
         for record in self:
@@ -354,7 +353,7 @@ class NFe(spec_models.StackedModel):
     def _inverse_nfe40_tpEmis(self):
         for doc in self:
             if doc.nfe40_tpEmis:
-                doc.nfe_transmission = doc.nfe40_tpEmis
+                doc.transmission_type = doc.nfe40_tpEmis
 
     def _inverse_nfe40_dhSaiEnt(self):
         for doc in self:

--- a/l10n_br_nfe/models/res_company.py
+++ b/l10n_br_nfe/models/res_company.py
@@ -13,8 +13,6 @@ from ..constants.nfe import (
     NFE_DANFE_LAYOUTS,
     NFE_ENVIRONMENT_DEFAULT,
     NFE_ENVIRONMENTS,
-    NFE_TRANSMISSION_DEFAULT,
-    NFE_TRANSMISSIONS,
     NFE_VERSION_DEFAULT,
     NFE_VERSIONS,
 )
@@ -95,26 +93,6 @@ class ResCompany(spec_models.SpecModel):
         ),
     )
 
-    nfe_transmission = fields.Selection(
-        selection=NFE_TRANSMISSIONS,
-        string="Transmission Type",
-        default=NFE_TRANSMISSION_DEFAULT,
-        help="1=Emissão normal (não em contingência);"
-        "\n2=Contingência FS-IA, com impressão do DANFE em Formulário"
-        " de Segurança - Impressor Autônomo;"
-        "\n3=Contingência SCAN (Sistema de Contingência do Ambiente Nacional);"
-        " *Desativado * NT 2015/002"
-        "\n4=Contingência EPEC (Evento Prévio da Emissão em Contingência);"
-        "\n5=Contingência FS-DA, com impressão do DANFE em Formulário "
-        "de Segurança - Documento Auxiliar;"
-        "\n6=Contingência SVC-AN (SEFAZ Virtual de Contingência do AN);"
-        "\n7=Contingência SVC-RS (SEFAZ Virtual de Contingência do RS);"
-        "\n9=Contingência off-line da NFC-e;"
-        "\nObservação: Para a NFC-e somente é válida a opção de contingência:"
-        "\n9-Contingência Off-Line e, a critério da UF, opção "
-        "4-Contingência EPEC. (NT 2015/002)",
-    )
-
     nfe_danfe_layout = fields.Selection(
         selection=NFE_DANFE_LAYOUTS,
         string="NFe Layout",
@@ -142,6 +120,20 @@ class ResCompany(spec_models.SpecModel):
         string="Include Technical Support Partner data in persons authorized to "
         "download NFe XML",
         default=False,
+    )
+
+    nfce_csc_token = fields.Char(
+        string="NFC-e ID Token",
+    )
+
+    nfce_csc_code = fields.Char(
+        string="NFC-e CSC Code",
+    )
+
+    nfce_qrcode_version = fields.Selection(
+        selection=[("1", "1.00"), ("2", "2.00")],
+        string="NFC-e QR-Code Version",
+        default="2",
     )
 
     nfce_qrcode_version = fields.Selection(

--- a/l10n_br_nfe/models/res_config_settings.py
+++ b/l10n_br_nfe/models/res_config_settings.py
@@ -19,12 +19,6 @@ class ResConfigSettings(models.TransientModel):
         readonly=False,
     )
 
-    nfe_transmission = fields.Selection(
-        string="NFe Transmission",
-        related="company_id.nfe_transmission",
-        readonly=False,
-    )
-
     nfe_enable_sync_transmission = fields.Boolean(
         related="company_id.nfe_enable_sync_transmission",
         readonly=False,

--- a/l10n_br_nfe/views/res_company_view.xml
+++ b/l10n_br_nfe/views/res_company_view.xml
@@ -12,7 +12,6 @@
                       <group>
                           <field name="nfe_version" required="1" />
                           <field name="nfe_environment" required="1" />
-                          <field name="nfe_transmission" required="1" />
                             <field
                                 name="nfe_enable_sync_transmission"
                                 string="Enable Sync Transmission"

--- a/l10n_br_nfe/views/res_config_settings_view.xml
+++ b/l10n_br_nfe/views/res_config_settings_view.xml
@@ -84,19 +84,6 @@
                               <div class="text-muted">
                                   Set nf-e default transmission type used to create new NF-e documents
                               </div>
-                              <div class="content-group">
-                                  <div class="mt16 row">
-                                      <label
-                                            for="nfe_transmission"
-                                            class="col-4 col-lg-4 o_light_label"
-                                        />
-                                      <field
-                                            name="nfe_transmission"
-                                            class="oe_inline"
-                                            required="1"
-                                        />
-                                  </div>
-                              </div>
                           </div>
                         </div>
                         <div class="col-12 col-lg-6 o_setting_box">


### PR DESCRIPTION
Fiz isso momentaneamente para conseguir fazer o processo da emissão da NFC-e em contingência sem nenhum problema, considerando que há outras formas de tipos de emissão no documento fiscal. Entretanto, eu acabei inserindo esse campo que é adicionado através do módulo l10n_br_nfe para o preenchimento.

A ideia é que nos próximos dias eu implemente esse campo e remova esse TODO presente no código, deixando o código o mais correto possível.