### PR TITLE
[FIX] l10n_br_account: discount on subtotal

### DIFF
--- a/l10n_br_account/models/account_invoice_line.py
+++ b/l10n_br_account/models/account_invoice_line.py
@@ -117,6 +117,22 @@ class AccountMoveLine(models.Model):
         ondelete="restrict",
     )
 
+    discount = fields.Float(
+        compute="_compute_discounts",
+        store=True,
+    )
+
+    @api.depends(
+        "quantity",
+        "price_unit",
+        "discount_value",
+    )
+    def _compute_discounts(self):
+        for line in self:
+            line.discount = (line.discount_value * 100) / (
+                line.quantity * line.price_unit or 1
+            )
+
     @api.model
     def _shadowed_fields(self):
         """Returns the list of shadowed fields that are synchronized


### PR DESCRIPTION
Hoje o subtotal da fatura está sendo calculado errado em alguns casos porque o discount em nenhum momento é calculado neste modelo. Em outras palavras, ao alterar os campos discount_value, price_unit ou quantity, a variável discount não é afetada e acaba levando a erros ao computar o subtotal.

Exemplos:
1) Ao criar uma fatura a partir de um sales order, temos o desconto e o subtotal feitos corretamente, até ai sem problemas:
![fatura-sale-correto](https://user-images.githubusercontent.com/6812128/227611869-e1d241cf-b5d5-437a-ae73-0bb520c27fe5.png)

2) Agora nesta mesma fatura, feita a partir do sale order, se a gente alterar o descount value, o subtotal não irá considerar o novo valor, mas sim a % calculada e vinda do pedido:
![fatura-sale-alterado](https://user-images.githubusercontent.com/6812128/227612139-93eb3fec-8f03-4da6-99b1-0a9d84d9f57f.png)
Esse problema fica ainda pior, porque se for alterado preço ou quantidade o desconto será com base nesse novo valor total e a % que veio do pedido.

3) Agora o ultimo exemplo, é se a fatura for feita sozinha, sem vir do sale. Desta forma o desconto simplesmente não vai existir para o subtotal.
![fatura-direta](https://user-images.githubusercontent.com/6812128/227612482-e4e5bd90-2385-4b8a-9bd2-0dd302492767.png)
