### PR TITLE
[FIX][14.0] l10n_br_pos: correção no nome do método e da chave de retorno

### DIFF
--- a/l10n_br_pos/models/pos_order.py
+++ b/l10n_br_pos/models/pos_order.py
@@ -373,8 +373,8 @@ class PosOrder(models.Model):
         return res
 
     def _populate_cancel_order_fields(self, order_vals):
-        self.cancel_document_key = order_vals["key_cfe"]
-        self.cancel_document_session_number = order_vals["sessionNum"]
+        self.cancel_document_key = order_vals["chave_cfe"]
+        self.cancel_document_session_number = order_vals["numSessao"]
         self.state_edoc = "cancelada"
         self.cancel_file = order_vals["xml"]
 

--- a/l10n_br_pos/static/src/js/models.js
+++ b/l10n_br_pos/static/src/js/models.js
@@ -485,7 +485,7 @@ odoo.define("l10n_br_pos.models", function (require) {
             try {
                 this.pos.rpc({
                     model: "pos.order",
-                    method: "cancelar_order",
+                    method: "cancel_order",
                     args: [result.response],
                 });
             } catch (error) {

--- a/l10n_br_pos/tests/test_l10n_br_pos_order.py
+++ b/l10n_br_pos/tests/test_l10n_br_pos_order.py
@@ -129,8 +129,8 @@ class TestL10nBrPosOrder(TransactionCase):
 
         order_data = {
             "order_id": order.id,
-            "sessionNum": 123456,
-            "key_cfe": "Cfe35181104113837000100590001128550021551657445",
+            "numSessao": 123456,
+            "chave_cfe": "Cfe35181104113837000100590001128550021551657445",
             "xml": "dGVzdGVfY2FuY2VsX2Zsb3c=",
         }
         order.cancel_order(order_data)


### PR DESCRIPTION
Durante o processo de tradução dos campos, a função de cancelamento foi atualizada no Python, mas não no JavaScript; e para a criação dos campos, as chaves foram traduzidas para o inglês, mas nesse caso está baseada na mensagem de retorno e, por isso, não é possível aplicar esse tipo de tradução.