### PR TITLE
[FIX][14.0] l10n_br_pos_cfe: Tradução dos campos no JavaScript

### DIFF
--- a/l10n_br_pos_cfe/static/src/js/PaymentScreen/PaymentScreen.js
+++ b/l10n_br_pos_cfe/static/src/js/PaymentScreen/PaymentScreen.js
@@ -15,7 +15,10 @@ odoo.define("l10n_br_pos_cfe.PaymentScreen", function (require) {
     const L10nBrPosCfePaymentScreen = (PaymentScreen) =>
         class extends PaymentScreen {
             async validateOrder(isForceValidate) {
-                if (this.env.pos.config.iface_fiscal_via_proxy) {
+                if (
+                    this.env.pos.config.iface_fiscal_via_proxy ||
+                    this.env.pos.config.simplified_document_type !== "59"
+                ) {
                     super.validateOrder(isForceValidate);
                 } else {
                     this.showPopup("ErrorPopup", {

--- a/l10n_br_pos_cfe/static/src/js/fiscal_cfe.js
+++ b/l10n_br_pos_cfe/static/src/js/fiscal_cfe.js
@@ -212,11 +212,11 @@ odoo.define("l10n_br_pos_cfe.FiscalDocumentCFe", function (require) {
             });
             this.cfe_config = {
                 sat_path: pos.config.sat_path,
-                codigo_ativacao: pos.config.cod_ativacao,
-                impressora: pos.config.impressora,
+                codigo_ativacao: pos.config.activation_code,
+                impressora: pos.config.printer,
                 printer_params: pos.config.printer_params,
                 fiscal_printer_type: pos.config.fiscal_printer_type,
-                assinatura: pos.config.assinatura_sat,
+                assinatura: pos.config.signature_sat,
             };
             const hw_fiscal = this.pos.proxy.get("status").drivers.hw_fiscal;
             if (hw_fiscal && hw_fiscal.status !== "connect") {

--- a/l10n_br_pos_cfe/static/src/js/models.js
+++ b/l10n_br_pos_cfe/static/src/js/models.js
@@ -57,13 +57,13 @@ odoo.define("l10n_br_pos_cfe.models", function (require) {
             json.company.inscr_mun = pos_company.inscr_mun;
             json.rounding = this.pos.currency.rounding;
 
-            if (pos_company.environment_sat === AMBIENTE_PRODUCAO) {
+            if (pos_company.sat_environment === AMBIENTE_PRODUCAO) {
                 json.company.cnpj = pos_company.cnpj_cpf;
                 json.company.ie = pos_company.inscr_est;
                 json.company.cnpj_software_house = pos_config.cnpj_software_house;
             } else {
-                json.company.cnpj = pos_config.cnpj_homologacao;
-                json.company.ie = pos_config.ie_homologacao;
+                json.company.cnpj = pos_config.cnpj_homologation;
+                json.company.ie = pos_config.ie_homologation;
                 json.company.cnpj_software_house = pos_config.cnpj_software_house;
             }
 
@@ -78,9 +78,9 @@ odoo.define("l10n_br_pos_cfe.models", function (require) {
             json.configs_sat = {};
             json.configs_sat.cnpj_software_house = json.company.cnpj_software_house;
             json.configs_sat.sat_path = pos_config.sat_path;
-            json.configs_sat.numero_caixa = pos_config.numero_caixa;
-            json.configs_sat.cod_ativacao = pos_config.cod_ativacao;
-            json.configs_sat.impressora = pos_config.impressora;
+            json.configs_sat.numero_caixa = pos_config.cashier_number;
+            json.configs_sat.cod_ativacao = pos_config.activation_code;
+            json.configs_sat.impressora = pos_config.printer;
             json.configs_sat.printer_params = pos_config.printer_params;
         },
         export_for_printing: function () {
@@ -209,8 +209,8 @@ odoo.define("l10n_br_pos_cfe.models", function (require) {
     models.Paymentline = models.Paymentline.extend({
         _prepare_fiscal_json: function (json) {
             _super_payment_line._prepare_fiscal_json.apply(this, arguments);
-            json.sat_payment_mode = this.payment_method.sat_payment_mode;
-            json.sat_card_acquirer = this.payment_method.sat_card_acquirer;
+            json.sat_payment_mode = this.payment_method.sat_payment_mode || "";
+            json.sat_card_accrediting = this.payment_method.sat_card_acquirer || "";
         },
         export_for_printing: function () {
             var json = _super_payment_line.export_for_printing.apply(this, arguments);


### PR DESCRIPTION
Como os campos referentes a CFe foram atualizadas no módulo pai (`l10n_br_pos`), houve um erro na hora de aplicar essa tradução nos campos pertencentes a esse modelo. Dessa forma, ao se iniciar uma sessão no PDV, não está sendo possível que o sistema consiga se resolver com essas discrepâncias e acaba bloqueando o fluxo da emissão da CFe pelo frontend.