### PR TITLE
[14.0][FIX] l10n_br_account: required invisible uot_id

### DIFF
--- a/l10n_br_account/views/account_invoice_view.xml
+++ b/l10n_br_account/views/account_invoice_view.xml
@@ -285,7 +285,7 @@
                         force_save="1"
                         groups="uom.group_uom"
                         class="oe_inline oe_no_button"
-                        attrs="{'required': [('display_type', '=', False)], 'invisible': [('document_type_id', '=', False)]}"
+                        attrs="{'required': [('display_type', '=', False),('document_type_id', '!=', False)], 'invisible': [('document_type_id', '=', False)]}"
                     />
                 </div>
                 <field


### PR DESCRIPTION
Em casos de lançamento de cupons simples de entrada(gasolina e outras despesas diversas que podem não gerar um documento fiscal para a empresa), é preciso que seja possível fazer uma fatura sem campos tributários.

Nesse sentido, ao salvar uma linha de uma fatura que não tem um documento fiscal, haverá um erro de campo inválido para o uot_id(por ele estar vazio), mesmo ele estando invisível. 