### PR TITLE
[14.0][FIX] l10n_br_purchase: ind final from order to move

### DIFF
--- a/l10n_br_purchase/models/purchase_order.py
+++ b/l10n_br_purchase/models/purchase_order.py
@@ -102,6 +102,7 @@ class PurchaseOrder(models.Model):
         invoice_vals = super()._prepare_invoice()
         invoice_vals.update(
             {
+                "ind_final": self.ind_final,
                 "fiscal_operation_id": self.fiscal_operation_id.id,
                 "document_type_id": self.company_id.document_type_id.id,
             }


### PR DESCRIPTION
A campo ind_final não estava sendo mapeado para a fatura.

Pedido de compra:
![compras](https://user-images.githubusercontent.com/6812128/228523849-a6fbe073-ebd3-4e2b-bd4c-0c78edff9e71.png)

Fatura que originou;
![fatura](https://user-images.githubusercontent.com/6812128/228523889-7e67d40b-722b-462d-986a-23676707bf5a.png)
