### PR TITLE
[14.0] [FIX] l10n_br_account: generate all move line in general test invoice

### DIFF
--- a/l10n_br_account/tests/test_invoice_general_cases.py
+++ b/l10n_br_account/tests/test_invoice_general_cases.py
@@ -48,6 +48,20 @@ class TestInvoiceDiscount(TransactionCase):
 
         product_id = self.env.ref("product.product_product_7")
 
+        invoice_line_vals = [
+            (
+                0,
+                0,
+                {
+                    "account_id": self.invoice_line_account_id.id,
+                    "product_id": product_id.id,
+                    "quantity": 1,
+                    "price_unit": 1000.0,
+                    "discount_value": 100.0,
+                },
+            )
+        ]
+
         self.move_id = (
             self.env["account.move"]
             .with_context({"check_move_validity": False})
@@ -62,25 +76,15 @@ class TestInvoiceDiscount(TransactionCase):
                     "fiscal_operation_id": self.fiscal_operation_id,
                     "move_type": "out_invoice",
                     "currency_id": self.company.currency_id.id,
+                    "invoice_line_ids": invoice_line_vals,
                 }
             )
         )
 
-        self.line_id = self.env["account.move.line"].create(
-            {
-                "move_id": self.move_id.id,
-                "account_id": self.invoice_line_account_id.id,
-                "product_id": product_id.id,
-                "quantity": 1,
-                "price_unit": 1000.0,
-                "discount_value": 100.0,
-            }
-        )
-
     def test_discount(self):
-        self.assertEqual(self.line_id.price_unit, 1000)
-        self.assertEqual(self.line_id.quantity, 1)
-        self.assertEqual(self.line_id.discount_value, 100)
-        self.assertEqual(self.line_id.discount, 10)
+        self.assertEqual(self.move_id.invoice_line_ids.price_unit, 1000)
+        self.assertEqual(self.move_id.invoice_line_ids.quantity, 1)
+        self.assertEqual(self.move_id.invoice_line_ids.discount_value, 100)
+        self.assertEqual(self.move_id.invoice_line_ids.discount, 10)
         self.move_id.invoice_line_ids._onchange_price_subtotal()
-        self.assertEqual(self.line_id.price_subtotal, 900)
+        self.assertEqual(self.move_id.invoice_line_ids.price_subtotal, 900)


### PR DESCRIPTION
Arrumando os testes que fiz na #2401 . No fim, não estava gerando todas as linhas, ficando apenas a invoice line e gerando um move desbalanceado. Não estava dando sempre o erro, só fui perceber dando um force na #2347.