### PR TITLE
[14.0][FIX] Calculo dos Valores Totais na Fatura e a divergência desses valores com os Pedidos de Vendas e Compras e os Lançamentos Contábeis com Dedutíveis 

### DIFF
--- a/l10n_br_account/models/account_invoice_line.py
+++ b/l10n_br_account/models/account_invoice_line.py
@@ -486,3 +486,26 @@ class AccountMoveLine(models.Model):
 
                 # Define o campo para considerar os valores brasileiros
                 line.price_total = line.amount_total
+
+    @api.onchange(
+        "fiscal_price",
+        "discount_value",
+        "insurance_value",
+        "other_value",
+        "freight_value",
+        "fiscal_quantity",
+        "amount_tax_not_included",
+        "amount_tax_included",
+        "amount_tax_withholding",
+        "uot_id",
+        "product_id",
+        "partner_id",
+        "company_id",
+        "price_unit",
+        "quantity",
+    )
+    def _onchange_price_subtotal(self):
+        # Necessário adicionar os outros campos dentro no onchange
+        # para que os Lançamentos Contábeis seja calculados
+        # corretamente.
+        return super()._onchange_price_subtotal()

--- a/l10n_br_account/models/account_invoice_line.py
+++ b/l10n_br_account/models/account_invoice_line.py
@@ -327,6 +327,19 @@ class AccountMoveLine(models.Model):
         price_subtotal = line_discount_price_unit * quantity
         price_total = price_subtotal + add_to_amount - rm_to_amount + self.amount_tax
 
+        # Caso sem Lançamentos Contábeis de Impostos de Dedutiveis
+        if not self.move_id.fiscal_operation_id.deductible_taxes:
+            price_total = (
+                price_subtotal
+                + add_to_amount
+                - rm_to_amount
+                + self.amount_tax
+                - self.icms_value
+                - self.ipi_value
+                - self.pis_value
+                - self.cofins_value
+            )
+
         result = {"price_total": price_total, "price_subtotal": price_subtotal}
 
         return result

--- a/l10n_br_account/tests/test_invoice_general_cases.py
+++ b/l10n_br_account/tests/test_invoice_general_cases.py
@@ -81,6 +81,11 @@ class TestInvoiceDiscount(TransactionCase):
             )
         )
 
+        for line in self.move_id.invoice_line_ids:
+            # Metodos onchange precisam ser
+            # chamados no Testes
+            line._compute_amounts()
+
     def test_discount(self):
         self.assertEqual(self.move_id.invoice_line_ids.price_unit, 1000)
         self.assertEqual(self.move_id.invoice_line_ids.quantity, 1)

--- a/l10n_br_account/views/account_invoice_view.xml
+++ b/l10n_br_account/views/account_invoice_view.xml
@@ -124,11 +124,48 @@
             </field>
             <field name="amount_untaxed" position="after">
                 <field string="(-) Discount" name="amount_discount_value" />
+                <field name="delivery_costs" invisible="1" />
+                <field name="force_compute_delivery_costs_by_total" invisible="1" />
+                <field
+                    name="amount_freight_value"
+                    widget='monetary'
+                    options="{'currency_field': 'currency_id'}"
+                    attrs="{'readonly': [('delivery_costs', '=', 'line'),('force_compute_delivery_costs_by_total', '=', False)]}"
+                />
+                <field
+                    name="amount_insurance_value"
+                    widget='monetary'
+                    options="{'currency_field': 'currency_id'}"
+                    attrs="{'readonly': [('delivery_costs', '=', 'line'),('force_compute_delivery_costs_by_total', '=', False)]}"
+                />
+                <field
+                    name="amount_other_value"
+                    widget='monetary'
+                    options="{'currency_field': 'currency_id'}"
+                    attrs="{'readonly': [('delivery_costs', '=', 'line'),('force_compute_delivery_costs_by_total', '=', False)]}"
+                />
+                <field
+                    name="amount_tax"
+                    string="Impostos"
+                    widget='monetary'
+                    options="{'currency_field': 'currency_id'}"
+                    attrs="{'readonly': [('delivery_costs', '=', 'line'),('force_compute_delivery_costs_by_total', '=', False)]}"
+                />
             </field>
             <field name="amount_total" position="after">
                 <field string="(-) Tax Withholding" name="amount_tax_withholding" />
             </field>
 
+            <xpath
+                expr="//field[hasclass('oe_subtotal_footer_separator')]"
+                position="after"
+            >
+                <field
+                    name="amount_financial_total"
+                    widget='monetary'
+                    options="{'currency_field': 'currency_id'}"
+                />
+            </xpath>
 
             <!-- invoice_line_ids tree (Invoice Lines) -->
             <xpath expr="//field[@name='invoice_line_ids']/tree" position="attributes">

--- a/l10n_br_purchase/models/purchase_order.py
+++ b/l10n_br_purchase/models/purchase_order.py
@@ -91,7 +91,22 @@ class PurchaseOrder(models.Model):
 
     @api.depends("order_line")
     def _compute_amount(self):
-        return super()._compute_amount()
+        for record in self:
+            if not record.fiscal_operation_id:
+                # Caso não tenha uma Operação Fiscal,
+                # o caso do Brasil, retorna o super
+                return super()._compute_amount()
+
+            super()._compute_amount()
+            for line in record.order_line:
+                # TODO para os valores price_subtotal e price_total ficarem corretos
+                #  é necessário chamar o metodo _compute_amount aqui, apesar dele
+                #  existir tanto nas Linhas desse modulo quanto do purchase.
+                #  Reavaliar na v16 ou versão superior.
+                line._compute_amount()
+
+            values = record.compute_br_amounts()
+            record.update(values)
 
     @api.depends("order_line.price_total")
     def _amount_all(self):

--- a/l10n_br_purchase/tests/test_l10n_br_purchase.py
+++ b/l10n_br_purchase/tests/test_l10n_br_purchase.py
@@ -225,6 +225,60 @@ class L10nBrPurchaseBaseTest(SavepointCase):
                 " dictionary from Purchase Order.",
             )
 
+            # Valida os Totais
+            self.assertEqual(
+                order.amount_total,
+                invoice.amount_total,
+                "Error field Amount Total in Invoice"
+                " are different from Purchase Order.",
+            )
+
+            self.assertEqual(
+                order.amount_tax,
+                invoice.amount_tax,
+                "Error field Amount Tax in Invoice are"
+                " different from Purchase Order.",
+            )
+            self.assertEqual(
+                order.amount_untaxed,
+                invoice.amount_untaxed,
+                "Error field Amount Untaxed in Invoice"
+                " are different from Purchase Order.",
+            )
+            self.assertEqual(
+                order.amount_price_gross,
+                invoice.amount_price_gross,
+                "Error field Amount Price Gross in Invoice"
+                " are different from Purchase Order.",
+            )
+            self.assertEqual(
+                order.amount_financial_total,
+                invoice.amount_financial_total,
+                "Error field Amount Financial Total in Invoice"
+                " are different from Purchase Order.",
+            )
+            self.assertEqual(
+                order.amount_financial_total_gross,
+                invoice.amount_financial_total_gross,
+                "Error field Amount Financial Total Gross in Invoice"
+                " are different from Purchase Order.",
+            )
+            self.assertEqual(
+                order.amount_freight_value,
+                invoice.amount_freight_value,
+                "Error field Amount Freight in Invoice are different from Purchase Order.",
+            )
+            self.assertEqual(
+                order.amount_insurance_value,
+                invoice.amount_insurance_value,
+                "Error field Amount Insurance in Invoice are different from Purchase Order.",
+            )
+            self.assertEqual(
+                order.amount_other_value,
+                invoice.amount_other_value,
+                "Error field Amount Other Values in Invoice are different from Purchase Order.",
+            )
+
             for line in invoice.invoice_line_ids:
                 self.assertTrue(
                     line.fiscal_operation_line_id,

--- a/l10n_br_sale/tests/test_l10n_br_sale.py
+++ b/l10n_br_sale/tests/test_l10n_br_sale.py
@@ -178,6 +178,60 @@ class L10nBrSaleBaseTest(SavepointCase):
                 " dictionary from Sale Order.",
             )
 
+            # Testa se os Valores Totais estão iguais entre o Pedido e Fatura
+            self.assertEqual(
+                sale_order.amount_total,
+                invoice.amount_total,
+                "Error field Amount Total in Invoice" " are different from Sale Order.",
+            )
+            self.assertEqual(
+                sale_order.amount_tax,
+                invoice.amount_tax,
+                "Error field Amount Tax in Invoice" " are different from Sale Order.",
+            )
+            self.assertEqual(
+                sale_order.amount_untaxed,
+                invoice.amount_untaxed,
+                "Error field Amount Untaxed in Invoice"
+                " are different from Sale Order.",
+            )
+            self.assertEqual(
+                sale_order.amount_price_gross,
+                invoice.amount_price_gross,
+                "Error field Amount Price Gross in Invoice"
+                " are different from Sale Order.",
+            )
+            self.assertEqual(
+                sale_order.amount_financial_total,
+                invoice.amount_financial_total,
+                "Error field Amount Financial Total in "
+                "Invoice are different from Sale Order.",
+            )
+            self.assertEqual(
+                sale_order.amount_financial_total_gross,
+                invoice.amount_financial_total_gross,
+                "Error field Amount Financial Total Gross"
+                " in Invoice are different from Sale Order.",
+            )
+            self.assertEqual(
+                sale_order.amount_freight_value,
+                invoice.amount_freight_value,
+                "Error field Amount Freight in Invoice"
+                " are different from Sale Order.",
+            )
+            self.assertEqual(
+                sale_order.amount_insurance_value,
+                invoice.amount_insurance_value,
+                "Error field Amount Insurance in Invoice"
+                " are different from Sale Order.",
+            )
+            self.assertEqual(
+                sale_order.amount_other_value,
+                invoice.amount_other_value,
+                "Error field Amount Other Values in Invoice"
+                " are different from Sale Order.",
+            )
+
             for line in invoice.invoice_line_ids:
                 self.assertTrue(
                     line.fiscal_operation_line_id,


### PR DESCRIPTION
Fixed the amount total calculation in Invoice and the divergence between this values and the values in Sale, Purchase Order and Picking.

Correção do calculo dos Valores Totais na Fatura e a divergência desses valores com os Pedidos de Vendas, Compras e Picking.

Pelo o que entendi o problema era causado porque no objeto account.move quando o método _compute_amount chamava o super acabava chamando apenas o do ADDONS e ignorava o que existe no objeto https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py#L146 além disso o método _get_price_total_and_subtotal_model https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_account/models/account_invoice_line.py#L294 está retornando valores errados 

Na Fatura ao alterar para o Preço Unitário 10
![image](https://user-images.githubusercontent.com/6341149/229207816-48ea2ecd-c3d0-4a83-99f4-498a108cfbd1.png)

Ao Salvar o documento
![image](https://user-images.githubusercontent.com/6341149/229207929-efeb0ee2-f6f3-4772-8f68-58be6d386001.png)

O que fiz para resolver foi criar um novo método _compute_br_amounts, para evitar o problema do super acabar não chamando o método da localização e assim não ter os valores Brasileiros sendo considerados no calculo dos Totais além disso foi necessário recalcular os campos amount_residual, amount_untaxed_signed, amount_tax_signed, amount_total_signed e amount_residual_signed por eles serem usados na visão tree 

![image](https://user-images.githubusercontent.com/6341149/229209053-fa7e40b8-7fd5-4d69-a228-c27e3101a1d7.png)
Por algum motivo que não entendi não foi possível fazer os calculos da mesma forma que o metodo original porque os valores acabavam negativos como o caso da primeira linha, deixei um TODO.
Também alterei no Form os totais para ficarem parecidos com os do Pedido de Vendas.

Testei a alteração das Linhas, os cálculos dos Totais e a criação da Fatura/account.move no Pedido de Vendas, Compras e Movimentação de Estoque/Picking:

OBS.: Adicionei o campo price_total nas Linhas apenas para visualizar os valores mas acredito que pode ser debatido se esse campo não deveriam estar presente na visão.

- l10n_br_sale
Pedido de Venda
![image](https://user-images.githubusercontent.com/6341149/229210101-96904a95-c96a-47f3-92b7-d3d5a0943232.png)
Fatura
![image](https://user-images.githubusercontent.com/6341149/229210247-d69b008e-a9d2-4efb-8d4f-1b6dde57f86b.png)

- l10n_br_purchase
Pedido de Compra 
![image](https://user-images.githubusercontent.com/6341149/229210407-d9011e34-1fc9-4581-9d0c-3e3d420adc64.png)

Fatura
![image](https://user-images.githubusercontent.com/6341149/229210572-e9194fed-e0ab-4c8e-8f9f-9cdb066efc73.png)

- l10n_br_stock_account

Hoje existe um Bug nesse modulo que sem esse PR não está sendo possível alterar o Preço unitário o programa está alterando o valor sempre para zero.

Nesse modulo eu fiz uma alteração que é usar o Preço Unitário informado no stock.move para criar a Linha da Fatura, o que acontecia antes era que o programa forçava esse campo para ser igual ao Preço Padrão do Produto, mas pensando sobre essa questão isso não parece o certo porque a prioridade deve ser o valor que é informado pelo usuário e não uma decisão do código, além disso pode causar uma confusão ao usuário já que ele via um valor no Picking e outro na Fatura, e nos casos de virem mais de um Valor eu estou usando o Menor valor para os casos Sem financeiro ex.:  Simples Remessa e Bonificação e etc. 

Inclui na visão Form a aba de Totais para permitir visualizar esses valores antes de criar a Fatura.

Picking
![image](https://user-images.githubusercontent.com/6341149/229212300-38fbb996-efba-49cd-945f-93f11efd2614.png)
  
Fatura
![image](https://user-images.githubusercontent.com/6341149/229212502-286cc7cf-0ae2-4ee8-99b1-172263b5f3b2.png)

Nesses três módulos foram incluídos testes para verificar se os principais valores Totais desses objetos estão iguais aos valores totais das Faturas criadas.

O PR pode ter algum erro ou algum caso que faltou considerar e que deve ter um valor diferente porém da forma que o código está permite a alteração desses cálculos sem precisar editar ou sobre escrever algum método estrutural e pode ajudar a entender melhor o problema, isso parece resolver pelo menos em partes os Issues https://github.com/OCA/l10n-brazil/issues/2313 https://github.com/OCA/l10n-brazil/issues/2346 https://github.com/OCA/l10n-brazil/issues/2373 https://github.com/OCA/l10n-brazil/issues/2409 e pode ajudar nos PRs https://github.com/OCA/l10n-brazil/pull/2347 https://github.com/OCA/l10n-brazil/pull/2363 é preciso verificar a questão dos Lançamentos Contábeis se estão corretos. 

cc @rvalyi @renatonlima @marcelsavegnago @mileo @felipemotter 