### PR TITLE
[14.0][FIX] Criação dos Lançamentos Contábeis de Impostos e Dedutíveis a partir do Pedido de Vendas, Compras e Picking 

### DIFF
--- a/l10n_br_account/models/account_invoice_line.py
+++ b/l10n_br_account/models/account_invoice_line.py
@@ -376,20 +376,23 @@ class AccountMoveLine(models.Model):
         """Ao alterar o campo fiscal_tax_ids que contém os impostos fiscais,
         são atualizados os impostos contábeis relacionados"""
         result = super()._onchange_fiscal_tax_ids()
-        user_type = "sale"
 
         # Atualiza os impostos contábeis relacionados aos impostos fiscais
+        user_type = "sale"
         if self.move_id.move_type in ("in_invoice", "in_refund"):
             user_type = "purchase"
-        self.tax_ids |= self.fiscal_tax_ids.account_taxes(user_type=user_type)
 
         # Caso a operação fiscal esteja definida para usar o impostos
         # dedutíveis os impostos contáveis deduvíveis são adicionados na linha
         # da movimentação/fatura.
+        deductible = False
         if self.fiscal_operation_id and self.fiscal_operation_id.deductible_taxes:
-            self.tax_ids |= self.fiscal_tax_ids.account_taxes(
-                user_type=user_type, deductible=True
-            )
+            deductible = True
+
+        self.tax_ids |= self.fiscal_tax_ids.account_taxes(
+            user_type=user_type, deductible=deductible
+        )
+
         return result
 
     @api.onchange(

--- a/l10n_br_account/models/fiscal_tax.py
+++ b/l10n_br_account/models/fiscal_tax.py
@@ -11,11 +11,22 @@ class FiscalTax(models.Model):
         account_taxes = self.env["account.tax"]
         for fiscal_tax in self:
             taxes = fiscal_tax._account_taxes()
+            # Atualiza os impostos contábeis relacionados aos impostos fiscais
             account_taxes |= taxes.filtered(
                 lambda t: t.type_tax_use == user_type
                 and t.active
-                and t.deductible == deductible
+                and t.deductible is False
             )
+            # Caso a operação fiscal esteja definida para usar o impostos
+            # dedutíveis os impostos contáveis dedutíveis são adicionados na linha
+            # da movimentação/fatura.
+            if deductible:
+                account_taxes |= taxes.filtered(
+                    lambda t: t.type_tax_use == user_type
+                    and t.active
+                    and t.deductible == deductible
+                )
+
         return account_taxes
 
     def _account_taxes(self):

--- a/l10n_br_purchase/models/purchase_order_line.py
+++ b/l10n_br_purchase/models/purchase_order_line.py
@@ -146,4 +146,26 @@ class PurchaseOrderLine(models.Model):
             fiscal_values.update(values)
             values.update(fiscal_values)
 
+            # Atualiza os impostos contábeis relacionados aos impostos fiscais.
+            # TODO: Ver possibilidade de incluir o preenchimento do tax_ids
+            #  no metodo _prepare_br_fiscal_dict, seria possível?
+
+            # Caso a operação fiscal esteja definida para usar o impostos
+            # dedutíveis os impostos contáveis dedutíveis são adicionados na linha
+            # da movimentação/fatura.
+            deductible = False
+            if self.fiscal_operation_id and self.fiscal_operation_id.deductible_taxes:
+                deductible = True
+
+            values["tax_ids"] = [
+                (
+                    6,
+                    0,
+                    self.env["l10n_br_fiscal.tax"]
+                    .browse(values["fiscal_tax_ids"])
+                    .account_taxes(user_type="purchase", deductible=deductible)
+                    .ids,
+                )
+            ]
+
         return values

--- a/l10n_br_purchase/tests/test_l10n_br_purchase.py
+++ b/l10n_br_purchase/tests/test_l10n_br_purchase.py
@@ -165,6 +165,9 @@ class L10nBrPurchaseBaseTest(SavepointCase):
     def _invoice_purchase_order(self, order):
         order.with_context(tracking_disable=True).button_confirm()
 
+        # Testa os Impostos Dedutiveis
+        order.fiscal_operation_id.deductible_taxes = True
+
         invoice_values = {
             "partner_id": order.partner_id.id,
             "move_type": "in_invoice",

--- a/l10n_br_sale/tests/test_l10n_br_sale.py
+++ b/l10n_br_sale/tests/test_l10n_br_sale.py
@@ -161,6 +161,9 @@ class L10nBrSaleBaseTest(SavepointCase):
     def _invoice_sale_order(self, sale_order):
         sale_order.action_confirm()
 
+        # Testa os Impostos Dedutiveis
+        sale_order.fiscal_operation_id.deductible_taxes = True
+
         # Create and check invoice
         sale_order._create_invoices(final=True)
 

--- a/l10n_br_stock_account/tests/test_invoicing_picking.py
+++ b/l10n_br_stock_account/tests/test_invoicing_picking.py
@@ -44,6 +44,9 @@ class InvoicingPickingTest(SavepointCase):
         """Test Invoicing Picking"""
         self._change_user_company(self.company)
 
+        # Testa os Impostos Dedutiveis
+        self.stock_picking_sp.fiscal_operation_id.deductible_taxes = True
+
         nb_invoice_before = self.invoice_model.search_count([])
         self._run_fiscal_onchanges(self.stock_picking_sp)
 


### PR DESCRIPTION
Fix Taxes Journal Entries when Invoice are create from Sale, Purchase and Picking.

Corrigido os Lançamentos Contábeis dos Impostos e Dedutíveis quando a Fatura/account.move está sendo criada a partir do Pedido de Vendas, Compras e Picking, precisei alterar a logica do metodo account_taxes para facilitar o uso dele nos objetos que criam a Fatura.

Abaixo é possível ver nas imagens os resultados que se tem hoje e o que a alteração faz e com a opção de Dedutíveis marcada nas Operações Fiscais, importante destacar que existe um problema com o Calculo dos Totais e que se está buscando resolver em mais de um PR, aqui estou usando o PR https://github.com/OCA/l10n-brazil/pull/2412 para fazer os calculos  ( é preciso fazer um rebase desse PR porque os commits recentes alteraram a logica e não está sendo mais possível chamar o super no metodo _compute_amount estou vendo de contornar o problema mas devo fazer o rebase mesmo com essa questão nas próximas horas ) apesar disso acredito que não existe uma dependência direta com esse PR já que aqui o objetivo é apenas fazer com que a criação da Fatura a partir de outros objetos tenha o mesmo comportamento de quando se cria diretamente uma Fatura.

- l10n_br_sale
antes
![image](https://user-images.githubusercontent.com/6341149/229871236-afea2db0-4b12-4c0a-b20a-764e8a9c1c19.png)

depois
![image](https://user-images.githubusercontent.com/6341149/229871338-efe93103-c95f-4b73-9e37-bd7cfa06010a.png)

- l10n_br_purchase
antes
![image](https://user-images.githubusercontent.com/6341149/229871538-05f8d9a5-5620-4b03-8a0b-b247a9b5efd7.png)

depois
![image](https://user-images.githubusercontent.com/6341149/229871646-9272b0ca-c832-43d6-8d5b-d66a2d578279.png)

- l10n_br_stock_account
Antes, era feito parcialmente mas também não identificava quando era "sale" ou "purchase"
![image](https://user-images.githubusercontent.com/6341149/229872200-42ff00cc-8847-4f27-a02a-26534f87dd72.png)

depois
![image](https://user-images.githubusercontent.com/6341149/229872302-5f8a4cd9-90f6-44ad-8f89-09f13fbfc48a.png)

- l10n_br_account
Essse caso já funcionava e junto com o l10n_br_stock_account foi a base para entender melhor o problema, pode ser testado com uma Nova Fatura mesmo antes de Salvar o documento já deve carregar os lançamentos, mas como foi alterada a logica do metodo para poder usa-lo nos casos anteriores vou colocar as imagens para conferencia.
antes
![image](https://user-images.githubusercontent.com/6341149/229872892-e0e6babd-dfa0-4f83-bd95-98030a2b3d39.png)

depois
![image](https://user-images.githubusercontent.com/6341149/229872988-cd256368-a3b9-4a90-ba5f-044d9f4fa9eb.png)

O PR parece resolver ou ajudar partes do issue https://github.com/OCA/l10n-brazil/issues/2346 e do PR https://github.com/OCA/l10n-brazil/pull/2347 

cc @renatonlima @rvalyi @marcelsavegnago @mileo @felipemotter 