### PR TITLE
[14.0][l10n_br_account] fix bad recompute final

### DIFF
--- a/l10n_br_account/__init__.py
+++ b/l10n_br_account/__init__.py
@@ -1,35 +1,6 @@
-# Copyright (C) 2023 - TODAY Raphaël Valyi - Akretion
-# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
-
 from .hooks import pre_init_hook
 from .hooks import post_init_hook
 
 from . import models
 from . import wizards
 from . import report
-
-from odoo.api import Environment
-from odoo.models import NewId
-
-
-def add_to_compute(self, field, records):
-    """
-    Mark ``field`` to be computed on ``records``.
-    Monkey patched to avoid recomputing account.move
-    and account.move.line linked to the same dummy records
-    used in non fiscal account moves.
-    """
-    if records and self.context.get(
-        "recompute_%s_after_id" % (records._name.replace(".", "_"),)
-    ):
-        records = records.filtered(
-            lambda rec: isinstance(rec.id, NewId)
-            or rec.id
-            > self.context["recompute_%s_after_id" % (records._name.replace(".", "_"),)]
-        )
-
-    return Environment.add_to_compute._original_method(self, field, records)
-
-
-add_to_compute._original_method = Environment.add_to_compute
-Environment.add_to_compute = add_to_compute

--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -251,13 +251,9 @@ class AccountMove(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        recompute_inv_after_id = self.search([], order="id DESC", limit=1).id
-        invoices = super(
-            AccountMove,
-            self.with_context(recompute_account_move_after_id=recompute_inv_after_id),
-        ).create(vals_list)
-        invoices._write_shadowed_fields()
-        return invoices
+        invoice = super().create(vals_list)
+        invoice._write_shadowed_fields()
+        return invoice
 
     def write(self, values):
         result = super().write(values)

--- a/l10n_br_account/models/account_invoice_line.py
+++ b/l10n_br_account/models/account_invoice_line.py
@@ -174,14 +174,7 @@ class AccountMoveLine(models.Model):
                 )
             )
 
-        recompute_line_after_id = self.search([], order="id DESC", limit=1).id
-        lines = super(
-            AccountMoveLine,
-            self.with_context(
-                recompute_account_move_line_after_id=recompute_line_after_id
-            ),
-        ).create(vals_list)
-
+        lines = super().create(vals_list)
         for line in lines.filtered(lambda l: l.fiscal_document_line_id != dummy_line):
             shadowed_fiscal_vals = line._prepare_shadowed_fields_dict()
             doc_id = line.move_id.fiscal_document_id.id

--- a/l10n_br_account/models/fiscal_document.py
+++ b/l10n_br_account/models/fiscal_document.py
@@ -16,6 +16,24 @@ class FiscalDocument(models.Model):
         string="Invoices",
     )
 
+    def modified(self, fnames, create=False, before=False):
+        """
+        Modifying a dummy fiscal document should not recompute
+        any account.move related to the same dummy fiscal document.
+        """
+        if not self.document_type_id:
+            return
+        return super().modified(fnames, create, before)
+
+    def _modified_triggers(self, tree, create=False):
+        """
+        Modifying a dummy fiscal document should not recompute
+        any account.move related to the same dummy fiscal document.
+        """
+        if not self.document_type_id:
+            return []
+        return super()._modified_triggers(tree, create)
+
     def unlink(self):
         non_draft_documents = self.filtered(
             lambda d: d.state != SITUACAO_EDOC_EM_DIGITACAO

--- a/l10n_br_account/models/fiscal_document_line.py
+++ b/l10n_br_account/models/fiscal_document_line.py
@@ -12,3 +12,21 @@ class FiscalDocumentLine(models.Model):
         inverse_name="fiscal_document_line_id",
         string="Invoice Lines",
     )
+
+    def modified(self, fnames, create=False, before=False):
+        """
+        Modifying a dummy fiscal document line should not recompute
+        any account.move.line related to the same dummy fiscal document line.
+        """
+        if not self.document_id.document_type_id:
+            return
+        return super().modified(fnames, create, before)
+
+    def _modified_triggers(self, tree, create=False):
+        """
+        Modifying a dummy fiscal document line should not recompute
+        any account.move.line related to the same dummy fiscal document line.
+        """
+        if not self.document_id.document_type_id:
+            return []
+        return super()._modified_triggers(tree, create)

--- a/l10n_br_account/tests/test_customer_invoice_dummy.py
+++ b/l10n_br_account/tests/test_customer_invoice_dummy.py
@@ -247,7 +247,7 @@ class TestCustomerInvoice(SavepointCase):
 
     def test_create_dont_recompute_existing_moves(self):
         with mock.patch.object(
-            self.env.__class__.add_to_compute, "_original_method", wraps=None
+            self.env.__class__, "add_to_compute", wraps=None
         ) as mocked_env:
             invoice = self.env["account.move"].create(
                 dict(
@@ -293,40 +293,40 @@ class TestCustomerInvoice(SavepointCase):
             )
             for mock_call in mocked_env.mock_calls:
                 if (
-                    str(mock_call.args[1]).split(".")[:-1] == ["account", "move"]
-                    and mock_call.args[2]
-                    and not isinstance(mock_call.args[2][0].id, NewId)
+                    str(mock_call.args[0]).split(".")[:-1] == ["account", "move"]
+                    and mock_call.args[1]
+                    and not isinstance(mock_call.args[1][0].id, NewId)
                 ):
-                    self.assertEqual(mock_call.args[2], invoice)
+                    self.assertEqual(mock_call.args[1], invoice)
                 elif (
-                    str(mock_call.args[1]).split(".")[:-1]
+                    str(mock_call.args[0]).split(".")[:-1]
                     == ["account", "move", "line"]
-                    and mock_call.args[2]
-                    and not isinstance(mock_call.args[2][0].id, NewId)
+                    and mock_call.args[1]
+                    and not isinstance(mock_call.args[1][0].id, NewId)
                 ):
-                    for line in mock_call.args[2]:
+                    for line in mock_call.args[1]:
                         self.assertIn(line, invoice.line_ids)
 
     def test_write_dont_recompute_existing_moves(self):
         with mock.patch.object(
-            self.env.__class__.add_to_compute, "_original_method", wraps=None
+            self.env.__class__, "add_to_compute", wraps=None
         ) as mocked_env:
             self.invoice_1.invoice_line_ids[0].write({"quantity": 20})
 
             for mock_call in mocked_env.mock_calls:
                 if (
-                    str(mock_call.args[1]).split(".")[:-1] == ["account", "move"]
-                    and mock_call.args[2]
-                    and not isinstance(mock_call.args[2][0].id, NewId)
+                    str(mock_call.args[0]).split(".")[:-1] == ["account", "move"]
+                    and mock_call.args[1]
+                    and not isinstance(mock_call.args[1][0].id, NewId)
                 ):
-                    self.assertEqual(mock_call.args[2], self.invoice_1)
+                    self.assertEqual(mock_call.args[1], self.invoice_1)
                 elif (
-                    str(mock_call.args[1]).split(".")[:-1]
+                    str(mock_call.args[0]).split(".")[:-1]
                     == ["account", "move", "line"]
-                    and mock_call.args[2]
-                    and not isinstance(mock_call.args[2][0].id, NewId)
+                    and mock_call.args[1]
+                    and not isinstance(mock_call.args[1][0].id, NewId)
                 ):
-                    for line in mock_call.args[2]:
+                    for line in mock_call.args[1]:
                         self.assertIn(line, self.invoice_1.line_ids)
 
     def test_state(self):

--- a/l10n_br_account/tests/test_supplier_invoice_dummy.py
+++ b/l10n_br_account/tests/test_supplier_invoice_dummy.py
@@ -102,7 +102,7 @@ class TestSupplierInvoice(SavepointCase):
 
     def test_create_dont_recompute_existing_moves(self):
         with mock.patch.object(
-            self.env.__class__.add_to_compute, "_original_method", wraps=None
+            self.env.__class__, "add_to_compute", wraps=None
         ) as mocked_env:
             invoice = self.env["account.move"].create(
                 dict(
@@ -149,40 +149,40 @@ class TestSupplierInvoice(SavepointCase):
             )
             for mock_call in mocked_env.mock_calls:
                 if (
-                    str(mock_call.args[1]).split(".")[:-1] == ["account", "move"]
-                    and mock_call.args[2]
-                    and not isinstance(mock_call.args[2][0].id, NewId)
+                    str(mock_call.args[0]).split(".")[:-1] == ["account", "move"]
+                    and mock_call.args[1]
+                    and not isinstance(mock_call.args[1][0].id, NewId)
                 ):
-                    self.assertEqual(mock_call.args[2], invoice)
+                    self.assertEqual(mock_call.args[1], invoice)
                 elif (
-                    str(mock_call.args[1]).split(".")[:-1]
+                    str(mock_call.args[0]).split(".")[:-1]
                     == ["account", "move", "line"]
-                    and mock_call.args[2]
-                    and not isinstance(mock_call.args[2][0].id, NewId)
+                    and mock_call.args[1]
+                    and not isinstance(mock_call.args[1][0].id, NewId)
                 ):
-                    for line in mock_call.args[2]:
+                    for line in mock_call.args[1]:
                         self.assertIn(line, invoice.line_ids)
 
     def test_write_dont_recompute_existing_moves(self):
         with mock.patch.object(
-            self.env.__class__.add_to_compute, "_original_method", wraps=None
+            self.env.__class__, "add_to_compute", wraps=None
         ) as mocked_env:
             self.invoice_1.invoice_line_ids[0].write({"quantity": 20})
 
             for mock_call in mocked_env.mock_calls:
                 if (
-                    str(mock_call.args[1]).split(".")[:-1] == ["account", "move"]
-                    and mock_call.args[2]
-                    and not isinstance(mock_call.args[2][0].id, NewId)
+                    str(mock_call.args[0]).split(".")[:-1] == ["account", "move"]
+                    and mock_call.args[1]
+                    and not isinstance(mock_call.args[1][0].id, NewId)
                 ):
-                    self.assertEqual(mock_call.args[2], self.invoice_1)
+                    self.assertEqual(mock_call.args[1], self.invoice_1)
                 elif (
-                    str(mock_call.args[1]).split(".")[:-1]
+                    str(mock_call.args[0]).split(".")[:-1]
                     == ["account", "move", "line"]
-                    and mock_call.args[2]
-                    and not isinstance(mock_call.args[2][0].id, NewId)
+                    and mock_call.args[1]
+                    and not isinstance(mock_call.args[1][0].id, NewId)
                 ):
-                    for line in mock_call.args[2]:
+                    for line in mock_call.args[1]:
                         self.assertIn(line, self.invoice_1.line_ids)
 
     def test_state(self):

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -304,7 +304,7 @@ class NFeLine(spec_models.StackedModel):
         if not self.cofinsst_value:
             xsd_fields.remove("nfe40_COFINSST")
 
-        if not self.ii_value:
+        if not self.ii_value and "nfe40_II" in xsd_fields:
             xsd_fields.remove("nfe40_II")
 
     ##################################################

--- a/l10n_br_purchase_stock/wizards/stock_invocing_onshipping.py
+++ b/l10n_br_purchase_stock/wizards/stock_invocing_onshipping.py
@@ -4,6 +4,8 @@
 
 from odoo import fields, models
 
+from odoo.addons.l10n_br_fiscal.constants.fiscal import DOCUMENT_ISSUER_PARTNER
+
 
 class StockInvoiceOnshipping(models.TransientModel):
     _inherit = "stock.invoice.onshipping"
@@ -19,6 +21,7 @@ class StockInvoiceOnshipping(models.TransientModel):
         pick = fields.first(pickings)
         if pick.purchase_id:
             values["purchase_id"] = pick.purchase_id.id
+            values["issuer"] = DOCUMENT_ISSUER_PARTNER
 
             if pick.purchase_id.payment_term_id.id != values.get(
                 "invoice_payment_term_id"


### PR DESCRIPTION
Esse PR resolve de forma limpa o problema de performance em bancos com muitos account.move sem tipo de documento fiscal (e então ligados a (linhas de) documentos fiscais "dummy") que teve origem https://github.com/OCA/l10n-brazil/pull/1816 com essa primeira tentativa de resolução na 14 https://github.com/OCA/l10n-brazil/pull/2370 mas que não foi suficiente como ilustrado aqui https://github.com/OCA/l10n-brazil/pull/2414.

No final a solução foi simples: dizer que (linhas de) documentos fiscais "dummy" que podem ser compartilhados com milhares de account.move(.line) não devem propagar nenhum recalculo a partir deles quando são modificados. Nisso eu pude tirar o primeiro fix, apenas adaptei os testes.

Eu deixei os 2 PRs com o testes de criação de 1000 account.move/10 000 account.move.line para ilustrar melhor que resolveu mesmo: 

- criação de 1000 account.move não fiscais sem commit https://github.com/OCA/l10n-brazil/pull/2419: acaba ficando um pouco mais lento sim (tipo 3x mais lento no fim), mas isso não tem nada ver com o uso de dummy como eu pude verificar sobrecarregando o _browse do account.move.line e botando um raise logo que tem mais de 1000 ids. Isso acontece quando chega a 100 account.move de 10 linhas cada um, pelo simples fato do que todos registros estão na memoria como marcado para recalcular e o browse desse "NewId" acontece de qualquer forma (a partir da memoria apenas, mas ainda assim gera alguma carga de processamento Python que vai aumentando). Se criar so account.move.line apenas com o modulo account, sem nada de dummy, aconteceria do mesmo jeito. Mas tb, por varios motivos, na vida real mesmo se a gente tiver um job que cria 10000 account.move.line, a gente daria commit, sei la de 50 em 50, no minimo para evitar "transaction isolation error" que poderiam acontecer.
- criação de 1000 account.move não fiscais com commit depois de cada account.move https://github.com/OCA/l10n-brazil/pull/2420: o tempo fica constante e bastante curto.

cc @marcelsavegnago @antoniospneto @felipemotter @renatonlima @mbcosta @mileo 

agora sim podem sentar o dedo no approve.