### PR TITLE
[14.0][REF+IMP] l10n_br_stock_account: Na criação de uma Fatura usa o Preço Unitário informado ao inves do Preço Padrão do Produto

### DIFF
--- a/l10n_br_stock_account/models/stock_move.py
+++ b/l10n_br_stock_account/models/stock_move.py
@@ -130,6 +130,10 @@ class StockMove(models.Model):
     def _get_price_unit_invoice(self, inv_type, partner, qty=1):
 
         result = super()._get_price_unit_invoice(inv_type, partner, qty)
+        if not self.fiscal_operation_id:
+            # Caso não tenha a Operação Fiscal não é uma Fatura do Brasil
+            return result
+
         product = self.mapped("product_id")
         product.ensure_one()
 
@@ -155,6 +159,9 @@ class StockMove(models.Model):
     def _get_price_unit(self):
         """Returns the unit price to store on the quant"""
         result = super()._get_price_unit()
+        if not self.fiscal_operation_id:
+            # Caso não tenha a Operação Fiscal não é uma caso do Brasil
+            return result
 
         # No Brasil o caso de Ordens de Entrega com Operação Fiscal
         # de Saída precisam informar o Preço de Custo e não o de Venda

--- a/l10n_br_stock_account/models/stock_move.py
+++ b/l10n_br_stock_account/models/stock_move.py
@@ -79,7 +79,12 @@ class StockMove(models.Model):
         # No Brasil o caso de Ordens de Entrega com Operação Fiscal
         # de Saída precisam informar o Preço de Custo e não o de Venda
         # ex.: Simples Remessa, Remessa p/ Industrialiazação e etc.
-        if self.fiscal_operation_id.fiscal_operation_type == "out":
+        # Porém caso o campo seja preenchido pelo usuário o valor informado
+        # deve ter prioridade.
+        if (
+            self.fiscal_operation_id.fiscal_operation_type == "out"
+            and self.price_unit == 0.0
+        ):
             self.price_unit = self.product_id.standard_price
 
     def _get_new_picking_values(self):

--- a/l10n_br_stock_account/views/stock_account_view.xml
+++ b/l10n_br_stock_account/views/stock_account_view.xml
@@ -9,11 +9,11 @@
             <field name="invoice_state" position="after">
                 <field
                     name="fiscal_operation_id"
-                    attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"
+                    attrs="{'invisible': ['|', ('invoice_state', 'in', [False, 'none']), ('fiscal_operation_id', '=', False)], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"
                 />
                 <field
                     name="fiscal_operation_line_id"
-                    attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"
+                    attrs="{'invisible': ['|', ('invoice_state', 'in', [False, 'none']), ('fiscal_operation_id', '=', False)], 'required': [('fiscal_operation_id', '=', True)], 'readonly': [('invoice_state', '=', 'invoiced')]}"
                 />
             </field>
         </field>
@@ -50,22 +50,22 @@
                 <field name="fiscal_price" />
                 <field
                     name="fiscal_operation_id"
-                    attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"
+                    attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': [('invoice_state', 'in', [False, 'none'])], 'readonly': [('invoice_state', '=', 'invoiced')]}"
                 />
                 <field
                     name="fiscal_operation_line_id"
-                    attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"
+                    attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': ['|', ('invoice_state', 'in', [False, 'none']), ('fiscal_operation_id', '=', False)], 'readonly': [('invoice_state', '=', 'invoiced')]}"
                 />
                 <field
                     name="cfop_id"
-                    attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"
+                    attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': [('fiscal_operation_id', '=', True)], 'readonly': [('invoice_state', '=', 'invoiced')]}"
                 />
                 <field name="partner_id" invisible="1" />
                 <field name="company_id" invisible="1" />
             </field>
             <group name="invoice_lines" position="after">
                 <notebook
-                    attrs="{'invisible': [('invoice_state', '=', 'none')],'required': [('invoice_state', '=', '2binvoiced')],'readonly': [('invoice_state', '=', 'invoiced')]}"
+                    attrs="{'invisible': ['|', ('invoice_state', 'in', [False, 'none']), ('fiscal_operation_id', '=', False)], 'readonly': [('invoice_state', '=', 'invoiced')]}"
                 >
                     <group name="fiscal_fields" invisible="1">
                         <field

--- a/l10n_br_stock_account/views/stock_picking.xml
+++ b/l10n_br_stock_account/views/stock_picking.xml
@@ -10,7 +10,7 @@
             <field name="picking_type_id" position="after">
                 <field
                     name="fiscal_operation_id"
-                    attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"
+                    attrs="{'invisible': [('invoice_state', '=', 'none')], 'readonly': [('invoice_state', '=', 'invoiced')]}"
                 />
             </field>
             <field name="invoice_state" position="attributes">
@@ -42,11 +42,11 @@
             >
                 <field
                     name="fiscal_operation_id"
-                    attrs="{'column_invisible': [('parent.invoice_state', '=', 'none')], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"
+                    attrs="{'column_invisible': ['|', ('parent.invoice_state', '=', 'none'), ('parent.fiscal_operation_id', '=', False)], 'readonly': [('invoice_state', '=', 'invoiced')]}"
                 />
                 <field
                     name="fiscal_operation_line_id"
-                    attrs="{'column_invisible': [('parent.invoice_state', '=', 'none')], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"
+                    attrs="{'column_invisible': ['|', ('parent.invoice_state', '=', 'none'), ('parent.fiscal_operation_id', '=', False)], 'readonly': [('invoice_state', '=', 'invoiced')]}"
                 />
             </xpath>
             <xpath
@@ -56,7 +56,7 @@
                 <group
                     name="fiscal"
                     string="Fiscal"
-                    attrs="{'invisible': [('invoice_state', 'in', [False, 'none'])]}"
+                    attrs="{'invisible': ['|', ('invoice_state', 'in', [False, 'none']), ('parent.fiscal_operation_id', '=', False)]}"
                     colspan="4"
                 >
                     <field name="invoice_state" readonly="1" force_save="1" />
@@ -80,22 +80,22 @@
                     <field name="fiscal_price" />
                     <field
                         name="fiscal_operation_id"
-                        attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"
+                        attrs="{'invisible': ['|', ('invoice_state', 'in', [False, 'none']), ('parent.fiscal_operation_id', '=', False)], 'readonly': [('invoice_state', '=', 'invoiced')]}"
                     />
                     <field
                         name="fiscal_operation_line_id"
-                        attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"
+                        attrs="{'invisible': ['|', ('invoice_state', 'in', [False, 'none']), ('parent.fiscal_operation_id', '=', False)], 'readonly': [('invoice_state', '=', 'invoiced')]}"
                     />
                     <field
                         name="cfop_id"
-                        attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"
+                        attrs="{'invisible': ['|', ('invoice_state', 'in', [False, 'none']), ('parent.fiscal_operation_id', '=', False)], 'required': [('fiscal_operation_id', '=', True)], 'readonly': [('invoice_state', '=', 'invoiced')]}"
                     />
                     <field name="partner_id" invisible="1" />
                     <field name="company_id" invisible="1" />
                 </group>
                 <group colspan="4">
                     <notebook
-                        attrs="{'invisible': [('invoice_state', '=', 'none')],'required': [('invoice_state', '=', '2binvoiced')],'readonly': [('invoice_state', '=', 'invoiced')]}"
+                        attrs="{'invisible': ['|', ('invoice_state', 'in', [False, 'none']), ('parent.fiscal_operation_id', '=', False)], 'readonly': [('invoice_state', '=', 'invoiced')]}"
                     >
                         <group name="fiscal_fields" invisible="1">
                             <field

--- a/l10n_br_stock_account/views/stock_picking.xml
+++ b/l10n_br_stock_account/views/stock_picking.xml
@@ -125,20 +125,26 @@
                             </group>
                         </page>
                         <page name="fiscal_line_extra_info" string="Extra Info" />
-                        <page name="accounting" string="Accounting" />
+                        <page name="accounting" string="Accounting">
+                            <group string="Taxes">
+                                <field name="fiscal_tax_ids" widget="many2many_tags" />
+                            </group>
+                            <group
+                                name="invoice_lines"
+                                string="Invoicing"
+                                colspan="4"
+                                groups="base.group_no_one"
+                                attrs="{'invisible': [('invoice_state', 'in', [False, 'none'])]}"
+                            >
+                                <field
+                                    name="invoice_line_ids"
+                                    readonly="1"
+                                    nolabel="1"
+                                />
+                            </group>
+                        </page>
                     </notebook>
                 </group>
-
-                <group
-                    name="invoice_lines"
-                    string="Invoicing"
-                    colspan="4"
-                    groups="base.group_no_one"
-                    attrs="{'invisible': [('invoice_state', 'in', [False, 'none'])]}"
-                >
-                    <field name="invoice_line_ids" readonly="1" nolabel="1" />
-                </group>
-
             </xpath>
             <xpath expr="//page[@name='extra']/group" position="inside">
                 <group name="delivery_costs" string="Delivery Costs">
@@ -164,6 +170,104 @@
 
                 </group>
             </xpath>
+
+            <notebook position="inside">
+
+                <page
+                    name="br_amounts"
+                    string="Amounts"
+                    attrs="{'invisible': [('fiscal_operation_id', '=', False)]}"
+                >
+                    <field name="delivery_costs" invisible="1" />
+                    <field name="force_compute_delivery_costs_by_total" invisible="1" />
+                    <group>
+                        <group>
+                            <group string="ICMS">
+                                <field name="amount_icms_base" />
+                                <field name="amount_icms_value" />
+                                <field name="amount_icmssn_credit_value" />
+                            </group>
+                            <group string="ICMS DIFAL">
+                                <field name="amount_icms_destination_value" />
+                                <field name="amount_icms_origin_value" />
+                                <field name="amount_icmsfcp_value" />
+                            </group>
+                            <group string="ICMS ST">
+                                <field name="amount_icmsst_base" />
+                                <field name="amount_icmsst_value" />
+                            </group>
+                            <group string="IPI">
+                                <field name="amount_ipi_base" />
+                                <field name="amount_ipi_value" />
+                            </group>
+                            <group string="ISSQN">
+                                <field name="amount_issqn_base" />
+                                <field name="amount_issqn_value" />
+                                <field name="amount_issqn_wh_base" />
+                                <field name="amount_issqn_wh_value" />
+                            </group>
+                            <group string="PIS">
+                                <field name="amount_pis_base" />
+                                <field name="amount_pis_value" />
+                                <field name="amount_pis_wh_base" />
+                                <field name="amount_pis_wh_value" />
+                            </group>
+                            <group string="COFINS">
+                                <field name="amount_cofins_base" />
+                                <field name="amount_cofins_value" />
+                                <field name="amount_cofins_wh_base" />
+                                <field name="amount_cofins_wh_value" />
+                            </group>
+                            <group string="CSLL">
+                                <field name="amount_csll_base" />
+                                <field name="amount_csll_value" />
+                                <field name="amount_csll_wh_base" />
+                                <field name="amount_csll_wh_value" />
+                            </group>
+                            <group string="IRPJ">
+                                <field name="amount_irpj_base" />
+                                <field name="amount_irpj_value" />
+                                <field name="amount_irpj_wh_base" />
+                                <field name="amount_irpj_wh_value" />
+                            </group>
+                            <group string="INSS">
+                                <field name="amount_inss_base" />
+                                <field name="amount_inss_value" />
+                                <field name="amount_inss_wh_base" />
+                                <field name="amount_inss_wh_value" />
+                            </group>
+                        </group>
+                        <group>
+                            <group string="Amounts">
+                                <field name="amount_price_gross" />
+                                <field name="amount_discount_value" />
+                                <field name="delivery_costs" invisible="1" />
+                                <field
+                                    name="amount_insurance_value"
+                                    attrs="{'readonly': [('delivery_costs', '=', 'line'),('force_compute_delivery_costs_by_total', '=', False)]}"
+                                />
+                                <field
+                                    name="amount_other_value"
+                                    attrs="{'readonly': [('delivery_costs', '=', 'line'),('force_compute_delivery_costs_by_total', '=', False)]}"
+                                />
+                                <field
+                                    name="amount_freight_value"
+                                    attrs="{'readonly': [('delivery_costs', '=', 'line'),('force_compute_delivery_costs_by_total', '=', False)]}"
+                                />
+                                <field name="amount_estimate_tax" />
+                                <field name="amount_tax" />
+                                <field name="amount_total" />
+                                <field name="amount_tax_withholding" />
+                                <field name="amount_financial_total" />
+                                <field name="amount_financial_total_gross" />
+                                <field name="amount_financial_discount_value" />
+                            </group>
+                        </group>
+                    </group>
+                </page>
+
+            </notebook>
+
         </field>
     </record>
 

--- a/l10n_br_stock_account/wizards/stock_invoice_onshipping.py
+++ b/l10n_br_stock_account/wizards/stock_invoice_onshipping.py
@@ -8,9 +8,25 @@ from odoo.exceptions import UserError
 class StockInvoiceOnshipping(models.TransientModel):
     _inherit = "stock.invoice.onshipping"
 
+    def _get_fiscal_operation_journal(self):
+        active_ids = self.env.context.get("active_ids", [])
+        if active_ids:
+            active_ids = active_ids[0]
+        pick_obj = self.env["stock.picking"]
+        picking = pick_obj.browse(active_ids)
+        if not picking or not picking.move_lines:
+            # Caso sem dados, apenas para evitar erro
+            return False
+        if not picking.fiscal_operation_id:
+            # Caso de Fatura Internacional, sem os dados Fiscais do Brasil
+            return False
+        else:
+            # Caso Brasileiro
+            return True
+
     fiscal_operation_journal = fields.Boolean(
         string="Account Jornal from Fiscal Operation",
-        default=True,
+        default=_get_fiscal_operation_journal,
     )
 
     group = fields.Selection(
@@ -43,6 +59,10 @@ class StockInvoiceOnshipping(models.TransientModel):
     def _build_invoice_values_from_pickings(self, pickings):
         invoice, values = super()._build_invoice_values_from_pickings(pickings)
         pick = fields.first(pickings)
+        if not pick.fiscal_operation_id:
+            # Caso de Fatura Internacional, sem os dados Fiscais do Brasil
+            return invoice, values
+
         fiscal_vals = pick._prepare_br_fiscal_dict()
 
         document_type = pick.company_id.document_type_id


### PR DESCRIPTION
Create Invoice based in Unit Price informed in moves instead of Product Standard Price, because the priority shall be what the value defined by user and not code decision.

Na criação de uma Fatura a partir de uma Movimentação de Estoque/picking o valor usado para informar o Preço Unitário que será usado deve ser o valor informado na Linha de Movimentação/stock.move e não o Preço Unitário Padrão do Produto, eu havia feito dessa forma na v12 porém reavaliando essa questão isso não parece estar certo porque a prioridade da informação deve ser o valor que o usuário define e não uma decisão do código, isso pode até confundir o usuário que vê um valor no Picking mas na Fatura está outro.

Caso venha mais de uma valor ao mapear os Preços Unitários, caso de Pickings Agrupados, o codigo no caso geral vai pegar o valor maior e se forem os casos out_invoice ou out_refund o valor menor. É possível alterar o código para não Agrupar quando houver diferentes Preços Unitários.

Também inclui a Aba de Valores Totais quando tiver uma Operação Fiscal e assim permitir visualizar esses valores antes de criar a Fatura. 

![image](https://user-images.githubusercontent.com/6341149/231276823-aab612ad-d872-4b32-b5a4-695df16b41b3.png)
 

Esse código estava inicialmente no PR https://github.com/OCA/l10n-brazil/pull/2412 mas achei melhor extrair para separar essas questões e facilitar a revisão.

cc @renatonlima @rvalyi @marcelsavegnago @mileo 