### PR TITLE
[14.0][DOC] proper module dependencies

### DIFF
--- a/l10n_br_base/readme/INSTALL.rst
+++ b/l10n_br_base/readme/INSTALL.rst
@@ -1,1 +1,6 @@
-Este módulo depende do pacote Python erpbrasil.base https://github.com/erpbrasil/erpbrasil.base
+Este módulo depende dos pacotes Python:
+
+* `erpbrasil.base <https://github.com/erpbrasil/erpbrasil.base>`_
+* num2words
+* phonenumbers
+* email_validator


### PR DESCRIPTION
Ainda um PR para facilitar para iniciante: lista exatamente os pacotes Python usados como dependência no README (teve o caso recentemente de alguem que bateu a cabeça com isso). De uma forma geral eu sou contra ficar repetindo detalhadamente informações do `__manifest__.py` dentro do README se não for uma dependência super notável. Mas esse modulo l10n_br_base é a porta de entrada do projeto, o primeiro modulo que o cara vai instalar, então eu tb acho legal tentar ajudar.