### PR TITLE
[12.0][FIX] nfe40_pICMSInter compute

### DIFF
--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -466,12 +466,11 @@ class NFeLine(spec_models.StackedModel):
 
     def _compute_nfe40_ICMSUFDest(self):
         for record in self:
-            if not record.icms_origin_percent and not record.icms_percent:
-                record.nfe40_pICMSInter = False
+            if record.icms_origin_percent:
+                record.nfe40_pICMSInter = str("%.02f" % record.icms_origin_percent)
             else:
-                record.nfe40_pICMSInter = str(
-                    "%.02f" % record.icms_origin_percent or record.icms_percent
-                )
+                record.nfe40_pICMSInter = False
+
             record.nfe40_pFCPUFDest = record.icmsfcp_percent
             record.nfe40_pICMSUFDest = record.icms_destination_percent
             record.nfe40_pICMSInterPart = record.icms_sharing_percent


### PR DESCRIPTION
O campo nfe40_pICMSInter é um selection que aceita os valores '12.0', '7.0' e '4.0' antes o compute estava pegando o valor icms_origin_percent ou icms_percent, o que não esta correto, pois deve pegar somente o valor do icms_origin_percent ou deixar como falso, pois se esse campo esta 0.00 é porque não tem incidência do DIFAL