### PR TITLE
[14.0][REF] l10n_br_account: document_type repetido

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -99,12 +99,6 @@ class AccountMove(models.Model):
         ondelete="cascade",
     )
 
-    document_type = fields.Char(
-        related="document_type_id.code",
-        string="Document Code",
-        store=True,
-    )
-
     fiscal_operation_type = fields.Selection(
         selection=FISCAL_IN_OUT_ALL,
         related=None,


### PR DESCRIPTION
Essa PR remove a definição do  `document_type` no  `account.move`.
O mesmo já é definido no modelo herdado `l10n_br_fiscal.document`:

https://github.com/OCA/l10n-brazil/blob/9a32283fb58e75233fb654a489b99b57e3d515c0/l10n_br_fiscal/models/document.py#L189-L192




