### PR TITLE
[14.0][REF] l10n_br_nfse: Usabilidade do código de verificação (NFS-e)

### DIFF
--- a/l10n_br_nfse/models/document.py
+++ b/l10n_br_nfse/models/document.py
@@ -61,7 +61,6 @@ class Document(models.Model):
         default="1",
     )
     verify_code = fields.Char(
-        readonly=True,
         copy=False,
     )
     nfse_environment = fields.Selection(

--- a/l10n_br_nfse/views/document_view.xml
+++ b/l10n_br_nfse/views/document_view.xml
@@ -23,17 +23,15 @@
                     name="nfse_info"
                     attrs="{'invisible': [('document_type', '!=', 'SE')]}"
                 >
+                    <field
+                        name="verify_code"
+                        attrs="{'invisible': [('document_type', '!=', 'SE')]}"
+                    />
                     <field name="rps_number" force_save="1" readonly="1" />
                     <field name="rps_type" />
                     <field name="nfse_environment" readonly="1" />
                 </group>
             </group>
-            <field name="authorization_protocol" position="after">
-                <field
-                    name="verify_code"
-                    attrs="{'invisible': [('document_type', '!=', 'SE')]}"
-                />
-            </field>
         </field>
     </record>
 


### PR DESCRIPTION
O código de verificação de uma NFS-e é um campo importante, por isso movi a sua exibição para o cabeçario do formulário do documento fiscal.

Também foi habilitado a edição para que o usuário  possa informalo no caso da digitação de uma NFS-e recebida (emitida por terceiros)