### PR TITLE
[14.0][REF] l10n_br_pos: Atualização nas referências para o CPF/CNPJ

### DIFF
--- a/l10n_br_pos/__manifest__.py
+++ b/l10n_br_pos/__manifest__.py
@@ -17,6 +17,7 @@
         "l10n_br_zip",
         "l10n_br_base",
         "point_of_sale",
+        "pos_crm",
         # TODO: Check this files after alpha version
         #   "queue_job",
         #   "l10n_br_stock_account",

--- a/l10n_br_pos/models/pos_order.py
+++ b/l10n_br_pos/models/pos_order.py
@@ -323,7 +323,9 @@ class PosOrder(models.Model):
         order_fields["document_type_id"] = ui_order.get("document_type_id")
         order_fields["document_type"] = ui_order.get("document_type")
 
-        order_fields["cnpj_cpf"] = ui_order.get("cnpj_cpf")
+        order_fields["cnpj_cpf"] = ui_order.get("cnpj_cpf") or ui_order.get(
+            "customer_tax_id"
+        )
 
         order_fields["additional_data"] = ui_order.get("additional_data")
 

--- a/l10n_br_pos/static/src/js/Screens/PaymentScreen/PaymentScreen.js
+++ b/l10n_br_pos/static/src/js/Screens/PaymentScreen/PaymentScreen.js
@@ -19,7 +19,7 @@ odoo.define("l10n_br_pos.PaymentScreen", function (require) {
     const L10nBrPosPaymentScreen = (PaymentScreen) =>
         class extends PaymentScreen {
             checkValidCpfCnpj(currentOrder) {
-                if (!currentOrder.customer_tax_id) {
+                if (!currentOrder.customer_tax_id && !currentOrder.get_client()) {
                     return true;
                 }
 
@@ -38,9 +38,9 @@ odoo.define("l10n_br_pos.PaymentScreen", function (require) {
 
             async _isOrderValid(isForceValidate) {
                 var result = super._isOrderValid(isForceValidate);
-                var currentOrder = this.env.pos.get_order();
-                if (this.checkValidCpfCnpj(currentOrder)) {
-                    result = await currentOrder.document_send(this);
+                var order = this.env.pos.get_order();
+                if (this.checkValidCpfCnpj(order)) {
+                    result = await order.document_send(this);
                     return result;
                 }
                 Gui.showPopup("ErrorPopup", {

--- a/l10n_br_pos/static/src/js/Screens/PaymentScreen/PaymentScreen.js
+++ b/l10n_br_pos/static/src/js/Screens/PaymentScreen/PaymentScreen.js
@@ -19,6 +19,10 @@ odoo.define("l10n_br_pos.PaymentScreen", function (require) {
     const L10nBrPosPaymentScreen = (PaymentScreen) =>
         class extends PaymentScreen {
             checkValidCpfCnpj(currentOrder) {
+                if (!currentOrder.customer_tax_id) {
+                    return true;
+                }
+
                 const client = currentOrder.get_client();
                 if (!client) {
                     return util.validate_cnpj_cpf(currentOrder.customer_tax_id);

--- a/l10n_br_pos/static/src/js/Screens/PaymentScreen/PaymentScreen.js
+++ b/l10n_br_pos/static/src/js/Screens/PaymentScreen/PaymentScreen.js
@@ -28,7 +28,12 @@ odoo.define("l10n_br_pos.PaymentScreen", function (require) {
                     return util.validate_cnpj_cpf(currentOrder.customer_tax_id);
                 }
 
-                const cnpj_cpf = client.cnpj_cpf || client.name;
+                const cnpj_cpf = client.cnpj_cpf;
+
+                if (!cnpj_cpf) {
+                    return true;
+                }
+
                 const result = util.validate_cnpj_cpf(cnpj_cpf);
                 if (!result) {
                     currentOrder.set_client(null);

--- a/l10n_br_pos/static/src/js/models.js
+++ b/l10n_br_pos/static/src/js/models.js
@@ -579,18 +579,9 @@ odoo.define("l10n_br_pos.models", function (require) {
 
     models.PosModel = models.PosModel.extend({
         initialize: function (session, attributes) {
-            this.cnpj_cpf = null;
-
             this.last_document_session_number = null;
 
             return _super_posmodel.initialize.call(this, session, attributes);
-        },
-        get_cnpj_cpf: function () {
-            var order = this.get_order();
-            if (order) {
-                return order.get_cnpj_cpf();
-            }
-            return null;
         },
     });
 });

--- a/l10n_br_pos/static/src/js/models.js
+++ b/l10n_br_pos/static/src/js/models.js
@@ -325,11 +325,11 @@ odoo.define("l10n_br_pos.models", function (require) {
             return false;
         },
         get_cnpj_cpf: function () {
-            var partner_vat = null;
+            let partner_vat = "";
             if (this.get_client() && this.get_client().vat) {
                 partner_vat = this.get_client().vat;
             }
-            return this.cnpj_cpf || partner_vat;
+            return this.cnpj_cpf || this.customer_tax_id || partner_vat;
         },
         get_taxes_and_percentages: function (order) {
             var taxes = {


### PR DESCRIPTION
Nesse PR estão incluídos:

- Adição da dependência do módulo `pos_crm`, que é responsável por perguntar sobre o CPF/CNPJ na nota
- Atualização das referências da variável após as atualizações que foram feitos no módulo `pos_crm`
- Melhorias na função de validação do CPF/CNPJ visando a manutenção e legibilidade