### PR TITLE
[14.0][l10n_br_account] onchange was shadowed by invoice onchange

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -420,17 +420,6 @@ class AccountMove(models.Model):
     #     return new_mv_lines_dict
     #
 
-    @api.onchange("partner_id")
-    def _onchange_partner_id(self):
-        # Even having this method in the l10n_br_fiscal.document.mixin.methods, the ORM
-        # seems to have some limitation with inherits when the parent model and the
-        # child model have the same field (in this case partner_id). This override was
-        # done to ensure that final_ind is set.
-        result = super()._onchange_partner_id()
-        if self.partner_id:
-            self.ind_final = self.partner_id.ind_final
-        return result
-
     @api.onchange("fiscal_operation_id")
     def _onchange_fiscal_operation_id(self):
         result = super()._onchange_fiscal_operation_id()

--- a/l10n_br_fiscal/models/document_fiscal_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin_methods.py
@@ -88,7 +88,7 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
             d.fiscal_line_ids._document_comment()
 
     @api.onchange("partner_id")
-    def _onchange_partner_id(self):
+    def _onchange_partner_id_fiscal(self):
         if self.partner_id:
             self.ind_final = self.partner_id.ind_final
 


### PR DESCRIPTION
revisando melhor https://github.com/OCA/l10n-brazil/pull/2374 eu achei estranho essas colocações sobre limitaçoês dos _inherits... (tinha sido feito pelo @felipemotter nesta PR https://github.com/OCA/l10n-brazil/pull/2358 ) 

1. Eu botei um print("in account") no  _onchange_partner_id do account/models/account_move.py
2. e um outro print("in fiscal")no on _onchange_partner_id no l10n_br_fiscal/models/document_fiscal_mixin_methods.py

E realmente vi que apenas o metodo onchange do modulo account estava sendo chamado quando alterava o partner_id na tela do account.move (invoice). Isso porque fazemos uma **herança multiplia**, dos 2 objetos, então apenas o primeiro metodo encontrado pelo Method Resolution Order do Python vai ser chamado, o _onchange_partner_id do account/models/account_move.py no caso.

A solução foi simplesmente de mudar o nome do onchange no  l10n_br_fiscal/models/document_fiscal_mixin_methods.py. Eu tb  verifiquei que ele não estava sendo chamado explicitamente em nenhum outro lugar. Se vcs botam print, vão ver que os 2 onchange estão sendo devidamente chamados.

Alem disso, caso alguem fizer um override do onchange do partner_id no fiscal, é importante que ele seja chamado tb, então realemente evitar o conflito de nome é evitar problemas futuros.

Eu tb fiz um grep sistematico do metodos nessas duas classes e das linhas para me assegurar que era o unico conflito que tinhamos.
No caso das linhas das faturas eu já tive que fazer esse mesmo tipo de mudança (método **_onchange_product_id_fiscal**) 2 anos atras quando eu migrei o modulo l10n_br_fiscal para a v14: https://github.com/OCA/l10n-brazil/commit/69d4382932a6172e6b710b26574d06f8effdb645

cc @felipemotter @antoniospneto @renatonlima @marcelsavegnago @mbcosta 