### PR TITLE
[14.0][l10n_br_account] fix document refund

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -12,6 +12,7 @@ from odoo.addons.l10n_br_fiscal.constants.fiscal import (
     DOCUMENT_ISSUER_PARTNER,
     FISCAL_IN_OUT_ALL,
     FISCAL_OUT,
+    MODELO_FISCAL_NFE,
     SITUACAO_EDOC_CANCELADA,
     SITUACAO_EDOC_EM_DIGITACAO,
 )
@@ -608,14 +609,14 @@ class AccountMove(models.Model):
                 )
                 line._onchange_fiscal_operation_id()
 
-            # Migrar para v14.0 .. talvez nao precise mais disso.
-            # Nao ficou claro o objetivo deste trecho
-            # refund_inv_id = record.reversal_move_id
-            #
-            # if record.refund_move_id.document_type_id:
-            #     record.fiscal_document_id._document_reference(
-            #         refund_inv_id.fiscal_document_id
-            #     )
+            # Adds the related document to the NF-e.
+            # this is required for correct xml validation
+            if record.document_type_id and record.document_type_id.code in (
+                MODELO_FISCAL_NFE
+            ):
+                record.fiscal_document_id._document_reference(
+                    record.reversed_entry_id.fiscal_document_id
+                )
 
         return new_moves
 

--- a/l10n_br_account/models/fiscal_document.py
+++ b/l10n_br_account/models/fiscal_document.py
@@ -34,6 +34,10 @@ class FiscalDocument(models.Model):
             return []
         return super()._modified_triggers(tree, create)
 
+    fiscal_line_ids = fields.One2many(
+        copy=False,
+    )
+
     def unlink(self):
         non_draft_documents = self.filtered(
             lambda d: d.state != SITUACAO_EDOC_EM_DIGITACAO

--- a/l10n_br_account/views/account_invoice_view.xml
+++ b/l10n_br_account/views/account_invoice_view.xml
@@ -72,6 +72,8 @@
                     <field name="ind_pres" invisible="1" />
                     <field name="fiscal_document_id" required="0" invisible="1" />
                     <field name="create_date" invisible="1" />
+                    <field name="operation_name" invisible="1" />
+                    <field name="comment_ids" invisible="1" />
                 </group>
             </xpath>
             <field name="ref" position="after">

--- a/l10n_br_account_nfe/models/document.py
+++ b/l10n_br_account_nfe/models/document.py
@@ -30,6 +30,7 @@ class DocumentNfe(models.Model):
         comodel_name="nfe.40.dup",
         compute="_compute_nfe40_dup",
         store=True,
+        copy=False,
         readonly=False,
     )
 


### PR DESCRIPTION
esse é um rebase de https://github.com/OCA/l10n-brazil/pull/2374 pois me parecia facil de deixar OK; é um "low hanging fruit" e como a Engenere ainda não atualizou pro HEAD da 14.0 nos clientes dela não faz rebase da branch dela. Porem eu acho tranquilo ja matar esse.

Porem eu fiz um amend do pénultimo commit onde eu removi essa parte no inicio do override do `_onchange_fiscal_operation_id`:

```
        # /!\ Inherits limitation ?
        # hack so that the onchange of the fiscal_document_line model is also called
        self.fiscal_document_id._onchange_fiscal_operation_id()
```

Pois até onde eu testei o _onchange_fiscal_operation_id do `l10n_br_fiscal.document.mixin.methods` já é corretamente chamado e altera o account.move da forma esperada. O que estava acontecendo neste caso porem é que no forma do account.move da v14 não tinha os campos que esse _onchange_fiscal_operation_id original alterava (operation_name e comment_ids), por isso na hora de salvar, o Odoo não salvava. Essa é uma pegadinha clássica e não tem nada ver com os _inherits.

E alias eu corrigi tb o onchange_partner_id de cima onde vcs tinham mexido num PR anterior, eu fiz esse PR especifico https://github.com/OCA/l10n-brazil/pull/2442

cc @felipemotter @antoniospneto @marcelsavegnago @renatonlima @mbcosta 