### PR TITLE
[14.0][REF] Alteração do método que retorna os Impostos e ou Dedutíveis para ser chamado apenas uma vez

### DIFF
--- a/l10n_br_account/models/account_invoice_line.py
+++ b/l10n_br_account/models/account_invoice_line.py
@@ -437,20 +437,16 @@ class AccountMoveLine(models.Model):
         """Ao alterar o campo fiscal_tax_ids que contém os impostos fiscais,
         são atualizados os impostos contábeis relacionados"""
         result = super()._onchange_fiscal_tax_ids()
-        user_type = "sale"
 
         # Atualiza os impostos contábeis relacionados aos impostos fiscais
+        user_type = "sale"
         if self.move_id.move_type in ("in_invoice", "in_refund"):
             user_type = "purchase"
-        self.tax_ids |= self.fiscal_tax_ids.account_taxes(user_type=user_type)
 
-        # Caso a operação fiscal esteja definida para usar o impostos
-        # dedutíveis os impostos contáveis deduvíveis são adicionados na linha
-        # da movimentação/fatura.
-        if self.fiscal_operation_id and self.fiscal_operation_id.deductible_taxes:
-            self.tax_ids |= self.fiscal_tax_ids.account_taxes(
-                user_type=user_type, deductible=True
-            )
+        self.tax_ids = self.fiscal_tax_ids.account_taxes(
+            user_type=user_type, fiscal_operation=self.fiscal_operation_id
+        )
+
         return result
 
     @api.onchange(

--- a/l10n_br_contract/models/contract_line.py
+++ b/l10n_br_contract/models/contract_line.py
@@ -61,14 +61,10 @@ class ContractLine(models.Model):
         self._onchange_fiscal_tax_ids()
         quantity = invoice_line_vals.get("quantity")
 
-        tax_ids = self.fiscal_tax_ids.account_taxes(user_type=contract.contract_type)
-        if (
-            contract.fiscal_operation_id
-            and contract.fiscal_operation_id.deductible_taxes
-        ):
-            tax_ids |= self.fiscal_tax_ids.account_taxes(
-                user_type=contract.contract_type, deductible=True
-            )
+        tax_ids = self.fiscal_tax_ids.account_taxes(
+            user_type=contract.contract_type,
+            fiscal_operation=contract.fiscal_operation_id,
+        )
 
         if invoice_line_vals:
             invoice_line_vals.update(self._prepare_br_fiscal_dict())

--- a/l10n_br_purchase/models/purchase_order_line.py
+++ b/l10n_br_purchase/models/purchase_order_line.py
@@ -117,24 +117,20 @@ class PurchaseOrderLine(models.Model):
         return result
 
     def _compute_tax_id(self):
-        result = super()._compute_tax_id()
         for line in self:
-            line.taxes_id |= line.fiscal_tax_ids.account_taxes(user_type="purchase")
-            if line.order_id.fiscal_operation_id.deductible_taxes:
-                line.taxes_id |= line.fiscal_tax_ids.account_taxes(
-                    user_type="purchase", deductible=True
+            if line.fiscal_operation_line_id:
+                super()._compute_tax_id()
+                line.taxes_id = line.fiscal_tax_ids.account_taxes(
+                    user_type="purchase", fiscal_operation=line.fiscal_operation_id
                 )
-        return result
 
     @api.onchange("fiscal_tax_ids")
     def _onchange_fiscal_tax_ids(self):
-        result = super()._onchange_fiscal_tax_ids()
-        self.taxes_id |= self.fiscal_tax_ids.account_taxes(user_type="purchase")
-        if self.order_id.fiscal_operation_id.deductible_taxes:
-            self.taxes_id |= self.fiscal_tax_ids.account_taxes(
-                user_type="purchase", deductible=True
+        if self.fiscal_operation_line_id:
+            super()._onchange_fiscal_tax_ids()
+            self.taxes_id = self.fiscal_tax_ids.account_taxes(
+                user_type="purchase", fiscal_operation=self.fiscal_operation_id
             )
-        return result
 
     def _prepare_account_move_line(self, move=False):
         values = super()._prepare_account_move_line(move)

--- a/l10n_br_purchase/tests/test_l10n_br_purchase.py
+++ b/l10n_br_purchase/tests/test_l10n_br_purchase.py
@@ -28,6 +28,8 @@ class L10nBrPurchaseBaseTest(SavepointCase):
         # cls.po_prod_srv = cls.env.ref(
         #     'l10n_br_purchase.main_po_product_service')
         cls.fsc_op_purchase = cls.env.ref("l10n_br_fiscal.fo_compras")
+        # Testa os Impostos Dedutiveis
+        cls.fsc_op_purchase.deductible_taxes = True
         cls.fsc_op_line_purchase = cls.env.ref("l10n_br_fiscal.fo_compras_compras")
         cls.fsc_op_line_purchase_resale = cls.env.ref(
             "l10n_br_fiscal.fo_compras_compras_comercializacao"

--- a/l10n_br_repair/models/fiscal_line_mixin.py
+++ b/l10n_br_repair/models/fiscal_line_mixin.py
@@ -67,13 +67,11 @@ class FiscalLineMixin(models.AbstractModel):
 
     @api.onchange("fiscal_tax_ids")
     def _onchange_fiscal_tax_ids(self):
-        result = super()._onchange_fiscal_tax_ids()
-        self.tax_id |= self.fiscal_tax_ids.account_taxes(user_type="sale")
-        if self.repair_id.fiscal_operation_id.deductible_taxes:
-            self.tax_id |= self.fiscal_tax_ids.account_taxes(
-                user_type="sale", deductible=True
+        if self.product_id and self.fiscal_operation_line_id:
+            super()._onchange_fiscal_tax_ids()
+            self.tax_id = self.fiscal_tax_ids.account_taxes(
+                user_type="sale", fiscal_operation=self.fiscal_operation_id
             )
-        return result
 
     @api.onchange("product_uom", "product_uom_qty")
     def _onchange_product_uom(self):

--- a/l10n_br_repair/tests/test_l10n_br_repair.py
+++ b/l10n_br_repair/tests/test_l10n_br_repair.py
@@ -25,6 +25,8 @@ class L10nBrRepairBaseTest(SavepointCase):
         cls.so_services = cls.env.ref("l10n_br_repair.main_so_only_services")
         cls.so_prod_srv = cls.env.ref("l10n_br_repair.main_so_product_service")
         cls.fsc_op_sale = cls.env.ref("l10n_br_fiscal.fo_venda")
+        # Testa os Impostos Dedutiveis
+        cls.fsc_op_sale.deductible_taxes = True
         cls.fsc_op_line_sale = cls.env.ref("l10n_br_fiscal.fo_venda_venda")
         cls.fsc_op_line_sale_non_contr = cls.env.ref(
             "l10n_br_fiscal.fo_venda_venda_nao_contribuinte"

--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -259,13 +259,11 @@ class SaleOrderLine(models.Model):
 
     @api.onchange("fiscal_tax_ids")
     def _onchange_fiscal_tax_ids(self):
-        result = super()._onchange_fiscal_tax_ids()
-        self.tax_id |= self.fiscal_tax_ids.account_taxes(user_type="sale")
-        if self.order_id.fiscal_operation_id.deductible_taxes:
-            self.tax_id |= self.fiscal_tax_ids.account_taxes(
-                user_type="sale", deductible=True
+        if self.product_id and self.fiscal_operation_line_id:
+            super()._onchange_fiscal_tax_ids()
+            self.tax_id = self.fiscal_tax_ids.account_taxes(
+                user_type="sale", fiscal_operation=self.fiscal_operation_id
             )
-        return result
 
     def _get_product_price(self):
         self.ensure_one()

--- a/l10n_br_sale/tests/test_l10n_br_sale.py
+++ b/l10n_br_sale/tests/test_l10n_br_sale.py
@@ -25,6 +25,8 @@ class L10nBrSaleBaseTest(SavepointCase):
         cls.so_services = cls.env.ref("l10n_br_sale.lc_so_only_services")
         cls.so_product_service = cls.env.ref("l10n_br_sale.lc_so_product_service")
         cls.fsc_op_sale = cls.env.ref("l10n_br_fiscal.fo_venda")
+        # Testa os Impostos Dedutiveis
+        cls.fsc_op_sale.deductible_taxes = True
         cls.fsc_op_line_sale = cls.env.ref("l10n_br_fiscal.fo_venda_venda")
         cls.fsc_op_line_sale_non_contr = cls.env.ref(
             "l10n_br_fiscal.fo_venda_venda_nao_contribuinte"

--- a/l10n_br_stock_account/tests/test_invoicing_picking.py
+++ b/l10n_br_stock_account/tests/test_invoicing_picking.py
@@ -44,6 +44,8 @@ class InvoicingPickingTest(SavepointCase):
         """Test Invoicing Picking"""
         self._change_user_company(self.company)
 
+        # Testa os Impostos Dedutiveis
+        self.stock_picking_sp.fiscal_operation_id.deductible_taxes = True
         nb_invoice_before = self.invoice_model.search_count([])
         self._run_fiscal_onchanges(self.stock_picking_sp)
 


### PR DESCRIPTION
Altered the method to get Taxes and Deductibles to be possible just call the method once.

Alteração simples mas que permite chamar apenas uma vez o método que retorna os Impostos e ou os Impostos Dedutíveis, também retirei os "return result" porque o método _onchange_fiscal_tax_ids não retorna nada https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py#L810 e como os métodos onchange são chamados logo ao criar uma nova Linha quando não tem nenhum campo além dos defaults inclui uma verificação para não fazer nada quando a Linha não ter o Produto( exceção a Linha de Compras porque o campo não está como obrigatório ) e a Linha de Operação Fiscal, os módulos alterados além l10n_br_account:

- l10n_br_purchase, o método _compute_tax_id também não retorna nada https://github.com/odoo/odoo/blob/14.0/addons/purchase/models/purchase.py#L292 por isso também removi o 'return result' e nos testes eu defino que a Operação Fiscal tem Dedutíveis para testar esse caso. 

- l10n_br_repair aqui seria importante saber porque a inclusão do _onchange_fiscal_tax_ids foi feita diretamente no objeto "l10n_br_repair.fiscal.line.mixin" ao invés do repair.line, o que foi feito nos outros objetos, alguém sabe o motivo?

- l10n_br_sale, nos testes eu defino que a Operação Fiscal tem Dedutíveis para testar esse caso. 

- l10n_br_stock_account, aqui também é uma correção porque não estava sendo considerado o caso "user_type=purchase", nos testes eu defino que a Operação Fiscal tem Dedutíveis para testar esse caso.

cc @renatonlima @rvalyi @marcelsavegnago @mileo @felipemotter 