### PR TITLE
[14.0][FIX] l10n_br_fiscal: ignore canceled document key on constrains

### DIFF
--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -241,6 +241,7 @@ class Document(models.Model):
                             MODELO_FISCAL_NFSE,
                         ),
                     ),
+                    ("state", "!=", "cancelada"),
                 ]
             )
 


### PR DESCRIPTION
Para melhorar a usabilidade do usuário, acredito que a constrains para que a chave seja unica deve levar em consideração apenas os documentos não cancelados.