### PR TITLE
[12.0][FIX] account.invoice.tax create

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -231,6 +231,7 @@ class AccountInvoice(models.Model):
         else:
             invoice = super().create(values)
         invoice._write_shadowed_fields()
+        invoice.compute_taxes()
         return invoice
 
     def _recompute_todo(self, field):


### PR DESCRIPTION
Quando a fatura é duplicada os totais das linhas account.invoice.tax não estavam sendo atualizadas.