### PR TITLE
[14.0[l10n_br_account] fix l10n_br_account/hooks.py

### DIFF
--- a/l10n_br_account/hooks.py
+++ b/l10n_br_account/hooks.py
@@ -34,7 +34,7 @@ def pre_init_hook(cr):
         if coa_modules:
             raise UserError(
                 _(
-                    """It looks like your database %(database) is running with demo
+                    """It looks like your database %s(database) is running with demo
                    data. But the l10n_br_account module will need you to install the
                    l10n_br_coa_simple and l10n_br_coa_generic
                    chart of accounts modules first to load l10n_br_account demo data


### PR DESCRIPTION
pessoal eu acabei me embananando nesse meu ultimo PR https://github.com/OCA/l10n-brazil/pull/2425
inicialmente não tinha tradução da mensagem de erro e tava OK mas quando o pre-commit me pressionou para botar o `_(...)` eu acho que eu não verifiquei com no caso do raise. E Tava errado.

O problema atual se instalar o l10n_br_account com demo sem instar os modulos de COA antes:

```
Traceback (most recent call last):
  File "/odoo/src/odoo/tools/translate.py", line 451, in __call__
    return translation % (args or kwargs)
TypeError: %i format: a number is required, not str

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/odoo/src/odoo/service/server.py", line 1201, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/odoo/src/odoo/modules/registry.py", line 89, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/odoo/src/odoo/modules/loading.py", line 461, in load_modules
    loaded_modules, update_module, models_to_check)
  File "/odoo/src/odoo/modules/loading.py", line 349, in load_marked_modules
    perform_checks=perform_checks, models_to_check=models_to_check
  File "/odoo/src/odoo/modules/loading.py", line 186, in load_module_graph
    getattr(py_module, pre_init)(cr)
  File "/odoo/links/l10n_br_account/hooks.py", line 47, in pre_init_hook
    database=cr.dbname,
  File "/odoo/src/odoo/tools/translate.py", line 455, in __call__
    translation = source % (args or kwargs)
TypeError: %i format: a number is required, not str
2023-05-05 00:02:13,762 134 INFO db odoo.service.server: Stopping gracefully 
odoo@dev:/$ 
```

e depois desse fix:

```
2023-05-05 00:03:29,180 138 INFO db odoo.modules.loading: Loading module l10n_br_account (48/49) 
2023-05-05 00:03:29,329 138 WARNING db odoo.modules.loading: Transient module states were reset 
2023-05-05 00:03:29,332 138 ERROR db odoo.modules.registry: Failed to load registry 
2023-05-05 00:03:29,333 138 CRITICAL db odoo.service.server: Failed to initialize database `db`. 
Traceback (most recent call last):
  File "/odoo/src/odoo/service/server.py", line 1201, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/odoo/src/odoo/modules/registry.py", line 89, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/odoo/src/odoo/modules/loading.py", line 461, in load_modules
    loaded_modules, update_module, models_to_check)
  File "/odoo/src/odoo/modules/loading.py", line 349, in load_marked_modules
    perform_checks=perform_checks, models_to_check=models_to_check
  File "/odoo/src/odoo/modules/loading.py", line 186, in load_module_graph
    getattr(py_module, pre_init)(cr)
  File "/odoo/links/l10n_br_account/hooks.py", line 47, in pre_init_hook
    database=cr.dbname,
odoo.exceptions.UserError: It looks like your database {'database': 'db'}(database) is running with demo
                   data. But the l10n_br_account module will need you to install the
                   l10n_br_coa_simple and l10n_br_coa_generic
                   chart of accounts modules first to load l10n_br_account demo data
                   or run its tests properly (for production, these dependencies are not
                   required, that is why these are not usual explicit
                   module dependencies).
                   Please install the l10n_br_coa_simple and l10n_br_coa_generic modules
                   first and try installing the l10n_br_account module again.
```