### PR TITLE
[14.0][l10n_br_account][FIX] fix critical dummy doc compute chain shortcut bug

### DIFF
--- a/l10n_br_account/hooks.py
+++ b/l10n_br_account/hooks.py
@@ -34,7 +34,7 @@ def pre_init_hook(cr):
         if coa_modules:
             raise UserError(
                 _(
-                    """It looks like your database %s(database) is running with demo
+                    """It looks like your database %s is running with demo
                    data. But the l10n_br_account module will need you to install the
                    l10n_br_coa_simple and l10n_br_coa_generic
                    chart of accounts modules first to load l10n_br_account demo data
@@ -44,7 +44,7 @@ def pre_init_hook(cr):
                    Please install the l10n_br_coa_simple and l10n_br_coa_generic modules
                    first and try installing the l10n_br_account module again.
                 """,
-                    database=cr.dbname,
+                    cr.dbname,
                 )
             )
 

--- a/l10n_br_account/models/fiscal_document.py
+++ b/l10n_br_account/models/fiscal_document.py
@@ -18,21 +18,23 @@ class FiscalDocument(models.Model):
 
     def modified(self, fnames, create=False, before=False):
         """
-        Modifying a dummy fiscal document should not recompute
+        Modifying a dummy fiscal document (no document_type_id) should not recompute
         any account.move related to the same dummy fiscal document.
         """
-        if not self.document_type_id:
-            return
-        return super().modified(fnames, create, before)
+        filtered = self.filtered(
+            lambda rec: isinstance(rec.id, models.NewId) or rec.document_type_id
+        )
+        return super(FiscalDocument, filtered).modified(fnames, create, before)
 
     def _modified_triggers(self, tree, create=False):
         """
-        Modifying a dummy fiscal document should not recompute
+        Modifying a dummy fiscal document (no document_type_id) should not recompute
         any account.move related to the same dummy fiscal document.
         """
-        if not self.document_type_id:
-            return []
-        return super()._modified_triggers(tree, create)
+        filtered = self.filtered(
+            lambda rec: isinstance(rec.id, models.NewId) or rec.document_type_id
+        )
+        return super(FiscalDocument, filtered)._modified_triggers(tree, create)
 
     fiscal_line_ids = fields.One2many(
         copy=False,

--- a/l10n_br_account/models/fiscal_document_line.py
+++ b/l10n_br_account/models/fiscal_document_line.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2021 - TODAY Gabriel Cardoso de Faria - Kmee
+# Copyright (C) 2023 - TODAY Raphaël Valyi - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from odoo import fields, models
@@ -15,18 +16,24 @@ class FiscalDocumentLine(models.Model):
 
     def modified(self, fnames, create=False, before=False):
         """
-        Modifying a dummy fiscal document line should not recompute
+        Modifying a dummy fiscal document (no document_type_id) line should not recompute
         any account.move.line related to the same dummy fiscal document line.
         """
-        if not self.document_id.document_type_id:
-            return
-        return super().modified(fnames, create, before)
+        filtered = self.filtered(
+            lambda rec: isinstance(rec.id, models.NewId)
+            or not rec.document_id  # document_id might exist and be computed later
+            or rec.document_id.document_type_id
+        )
+        return super(FiscalDocumentLine, filtered).modified(fnames, create, before)
 
     def _modified_triggers(self, tree, create=False):
         """
-        Modifying a dummy fiscal document line should not recompute
+        Modifying a dummy fiscal document (no document_type_id) line should not recompute
         any account.move.line related to the same dummy fiscal document line.
         """
-        if not self.document_id.document_type_id:
-            return []
-        return super()._modified_triggers(tree, create)
+        filtered = self.filtered(
+            lambda rec: isinstance(rec.id, models.NewId)
+            or not rec.document_id  # document_id might exist and be computed later
+            or rec.document_id.document_type_id
+        )
+        return super(FiscalDocumentLine, filtered)._modified_triggers(tree, create)

--- a/l10n_br_account_nfe/tests/test_nfe_generate_tags_cobr_dup_pag.py
+++ b/l10n_br_account_nfe/tests/test_nfe_generate_tags_cobr_dup_pag.py
@@ -114,6 +114,7 @@ class TestGeneratePaymentInfo(SavepointCase):
             {
                 "account_id": cls.invoice_line_account_id.id,
                 "quantity": 1,
+                "uom_id": cls.env.ref("uom.product_uom_unit").id,
                 "price_unit": 450.0,
                 "name": "Product - Invoice Line Test",
                 "fiscal_operation_line_id": cls.env.ref(
@@ -208,3 +209,15 @@ class TestGeneratePaymentInfo(SavepointCase):
                 "90",
                 "Error in nfe40_tPag field, should be 90 - Sem Pagamento.",
             )
+
+    def test_valid_nfe_xml(self):
+        """
+        Test that NFe XML is valid. This in fact tests that NFe computed fields are
+        properly computed.
+        In fact this tests this bug with dummy documents(lines) compute triggers
+        https://github.com/OCA/l10n-brazil/issues/2451
+        is fixed.
+        """
+        invoice = self.invoice
+        invoice.fiscal_document_id._document_export()
+        self.assertEqual(invoice.fiscal_document_id.xml_error_message, False)


### PR DESCRIPTION
resolve a regressão critica: https://github.com/OCA/l10n-brazil/issues/2451

@antoniospneto vc pode verificar, o novo teste quebra com o código atual (bug semelhante a https://github.com/OCA/l10n-brazil/issues/2451) mas passa com esse fix. Basicamente como eu expliquei, dentro de um form, a linhas são registros new NewId e vao pegar um document_id e um document_type_id so depois dentro da cadeia de computes. Nisso eu tava cortando cedo demais e nao passava nos compute nesta situação. Agora eu tou me assegurando que os registros estão persistidos e ja tem um document_id antes de cortar a cadeia de computes caso for uma linha de documento fiscal dummy (ou seja um account.move puramente contábil ou invoice que não tem um verdadeiro documento fiscal brasileiro para quem ta pegando isso agora).

(Eu tb aproveitei para resolver essa cagadinha https://github.com/OCA/l10n-brazil/pull/2466#issuecomment-1536335378)

cc @marcelsavegnago @felipemotter @renatonlima @mbcosta 