### PR TITLE
[14.0][FIX] l10n_br_sale: Série para diferentes documentos fiscais em faturas do mesmo pedido

### DIFF
--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -263,8 +263,9 @@ class SaleOrder(models.Model):
                                 order_line.invoice_lines = invoice.invoice_line_ids
                             invoice_id.invoice_line_ids -= inv_line
 
+            # set the document serie for original invoice
             invoice_created_by_super.document_serie_id = (
-                fiscal_document_type.get_document_serie(
+                invoice_created_by_super.document_type_id.get_document_serie(
                     invoice_created_by_super.company_id,
                     invoice_created_by_super.fiscal_operation_id,
                 )


### PR DESCRIPTION
Corrigir a definição da série do documento fiscal ao criar faturas com diferentes tipos de documentos a partir de um mesmo pedido. Por exemplo, uma Nota Fiscal de Venda (NF-e) e uma Nota Fiscal de Serviço (NFS-e) geradas a partir do mesmo pedido.

Antes dessa correção, estava ocorrendo a atribuição incorreta da mesma série (`document_serie_id`) para os dois tipos de documentos fiscais. Por exemplo, a série da NF-e (55) estava sendo erroneamente atribuída ao documento NFS-e (SE) ou vice-versa, dependendo da ordem em que os itens eram preenchidos no pedido.