### PR TITLE
[12.0] Remover as linhas de seção ou notas do documento fiscal

### DIFF
--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -375,6 +375,10 @@ class SaleOrder(models.Model):
 
                     # Update Invoice Line
                     for inv_line in invoice_created_by_super.invoice_line_ids:
+                        # remove display type lines in fiscal documents
+                        if inv_line.display_type or not inv_line.fiscal_operation_line_id:
+                            inv_line.unlink()
+                            continue
                         fiscal_document_type = (
                             inv_line.fiscal_operation_line_id.get_document_type(
                                 inv_line.invoice_id.company_id


### PR DESCRIPTION
Ao criar um pedido de venda com um produto tributado pelo ICMS e um serviço tributado pelo ISSQN, será gerado uma NF-e para o produto e uma NFS-e para o serviço, se esse pedido de venda tiver um alguma linha com o display_type do tipo section ou note, é gerado um erro.

Para resolver esse problema, na divisão das linhas das faturas para cada documento fiscal é verificado se a linha tem um display_type ou esta sem a linha da operação fiscal, que neste caso, a linha da fatura é removida.