### PR TITLE
[14.0][IMP] l10n_br_nfe: check document key date

### DIFF
--- a/l10n_br_fiscal/demo/fiscal_document_demo.xml
+++ b/l10n_br_fiscal/demo/fiscal_document_demo.xml
@@ -207,6 +207,7 @@
         <field name="document_serie">1</field>
         <field name="user_id" ref="base.user_demo" />
         <field name="document_key">26180812984794000154550010000016871192213339</field>
+        <field name="document_date">2018-08-18 00:00:00</field>
         <field name="document_number">19221333</field>
         <field name="partner_id" ref="base.res_partner_2" />
         <field name="fiscal_operation_type">out</field>
@@ -842,6 +843,7 @@
         />
         <field name="document_serie">1</field>
         <field name="document_key">35200497231608000169550010000000371161029083</field>
+        <field name="document_date">2020-04-18 00:00:00</field>
         <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
         <field name="user_id" ref="base.user_demo" />
         <field name="fiscal_operation_type">out</field>

--- a/l10n_br_fiscal_closing/tests/test_fiscal_closing.py
+++ b/l10n_br_fiscal_closing/tests/test_fiscal_closing.py
@@ -20,7 +20,6 @@ class TestFiscalClosing(TransactionCase):
         super(TestFiscalClosing, self).setUp()
 
         self.nfe_export = self.env.ref("l10n_br_fiscal.demo_nfe_export")
-        self.nfe_export.document_date = fields.Datetime.now()
         self.nfe_export.date_in_out = fields.Datetime.now()
         self.closing_all = self.env["l10n_br_fiscal.closing"].create(
             {
@@ -31,8 +30,8 @@ class TestFiscalClosing(TransactionCase):
         self.closing_period = self.env["l10n_br_fiscal.closing"].create(
             {
                 "export_type": "period",
-                "year": str(self.nfe_export.document_date.year),
-                "month": str(self.nfe_export.document_date.month),
+                "year": str(self.nfe_export.date_in_out.year),
+                "month": str(self.nfe_export.date_in_out.month),
             }
         )
 

--- a/l10n_br_nfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_nfe/demo/fiscal_document_demo.xml
@@ -76,6 +76,7 @@
         <field name="company_id" ref="l10n_br_base.empresa_simples_nacional" />
         <field name="document_number">1</field>
         <field name="document_key">35200159594315000157550010000000012062777161</field>
+        <field name="document_date">2020-01-09 12:00:00</field>
         <field name="document_serie">1</field>
         <field name="nfe_environment">2</field>
         <field name="processador_edoc">oca</field>
@@ -121,6 +122,7 @@
         <field name="document_number">2</field>
         <field name="document_serie">1</field>
         <field name="document_key">35200159594315000157550010000000022062777169</field>
+        <field name="document_date">2020-01-09 12:00:00</field>
         <field name="nfe_environment">2</field>
         <field name="processador_edoc">oca</field>
         <field name="partner_id" ref="l10n_br_base.res_partner_cliente11_sp" />
@@ -165,6 +167,7 @@
         <field name="document_number">3</field>
         <field name="document_serie">1</field>
         <field name="document_key">35200159594315000157550010000000032062777166</field>
+        <field name="document_date">2020-01-09 12:00:00</field>
         <field name="nfe_environment">2</field>
         <field name="processador_edoc">oca</field>
         <field name="partner_id" ref="l10n_br_base.res_partner_cliente4_am" />

--- a/l10n_br_nfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_nfe/demo/fiscal_document_demo.xml
@@ -76,7 +76,8 @@
         <field name="company_id" ref="l10n_br_base.empresa_simples_nacional" />
         <field name="document_number">1</field>
         <field name="document_key">35200159594315000157550010000000012062777161</field>
-        <field name="document_date">2020-01-09 12:00:00</field>
+        <field name="document_date">2020-01-01 11:00:00</field>
+        <field name="date_in_out">2020-01-01 11:00:00</field>
         <field name="document_serie">1</field>
         <field name="nfe_environment">2</field>
         <field name="processador_edoc">oca</field>
@@ -122,7 +123,8 @@
         <field name="document_number">2</field>
         <field name="document_serie">1</field>
         <field name="document_key">35200159594315000157550010000000022062777169</field>
-        <field name="document_date">2020-01-09 12:00:00</field>
+        <field name="document_date">2020-01-01 11:00:00</field>
+        <field name="date_in_out">2020-01-01 11:00:00</field>
         <field name="nfe_environment">2</field>
         <field name="processador_edoc">oca</field>
         <field name="partner_id" ref="l10n_br_base.res_partner_cliente11_sp" />
@@ -167,7 +169,8 @@
         <field name="document_number">3</field>
         <field name="document_serie">1</field>
         <field name="document_key">35200159594315000157550010000000032062777166</field>
-        <field name="document_date">2020-01-09 12:00:00</field>
+        <field name="document_date">2020-01-01 11:00:00</field>
+        <field name="date_in_out">2020-01-01 11:00:00</field>
         <field name="nfe_environment">2</field>
         <field name="processador_edoc">oca</field>
         <field name="partner_id" ref="l10n_br_base.res_partner_cliente4_am" />
@@ -209,6 +212,8 @@
         <field name="company_number">3</field>
         <field name="document_serie">1</field>
         <field name="document_key">33230807984267003800650040000000321935136447</field>
+        <field name="document_date">2023-08-01 11:00:00</field>
+        <field name="date_in_out">2023-08-01 11:00:00</field>
         <field name="nfe_environment">2</field>
         <field name="nfe_version">4.00</field>
         <field name="processador_edoc">oca</field>

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -773,6 +773,28 @@ class NFe(spec_models.StackedModel):
                             )
                         )
 
+    @api.constrains("document_date", "document_key", "state_edoc")
+    def _check_document_date_key(self):
+        for rec in self:
+            if rec.document_key:
+                key_date_str = rec.document_key[2:6]
+                key_date = datetime.strptime(key_date_str, "%y%m")
+
+                document_date = fields.Datetime.from_string(rec.document_date)
+                if (
+                    rec.document_type in ["55", "65"]
+                    and rec.state_edoc in ["a_enviar", "autorizada"]
+                    and (
+                        key_date.year != document_date.year
+                        or key_date.month != document_date.month
+                    )
+                ):
+                    raise ValidationError(
+                        _(
+                            "The document date does not match the date in the document key."
+                        )
+                    )
+
     def _document_number(self):
         # TODO: Criar campos no fiscal para codigo aleatorio e digito verificador,
         # pois outros modelos também precisam dessescampos: CT-e, MDF-e etc

--- a/l10n_br_nfe/tests/test_account_customer_nfe.py
+++ b/l10n_br_nfe/tests/test_account_customer_nfe.py
@@ -2,7 +2,7 @@
 #   Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-
+from odoo import exceptions
 from odoo.tests import SavepointCase
 
 
@@ -285,3 +285,12 @@ class TestCustomerNFe(SavepointCase):
             self.assertEqual(line.cofins_base, 1000.0, "COFINS BASE is not 1000.0")
             self.assertEqual(line.cofins_value, 30.0, "COFINS Value is not 30.0 ")
             self.assertEqual(line.cofins_percent, 3.0, "ICMS Percent is not 3.0 .")
+
+    def test_document_date_key_check(self):
+        document = self.env.ref("l10n_br_fiscal.demo_nfe_so_simples_faturamento")
+        with self.assertRaises(exceptions.ValidationError):
+            document.write(
+                {
+                    "document_date": "2023-05-18 00:00:00",
+                }
+            )

--- a/l10n_br_nfe/tests/test_nfe_serialize.py
+++ b/l10n_br_nfe/tests/test_nfe_serialize.py
@@ -4,7 +4,6 @@
 
 import logging
 import os
-from datetime import datetime
 
 from xmldiff import main
 
@@ -58,10 +57,6 @@ class TestNFeExport(TransactionCase):
             ),
         ]
         nfe.action_document_confirm()
-        nfe.document_date = datetime.strptime(
-            "2020-01-01T11:00:00", "%Y-%m-%dT%H:%M:%S"
-        )
-        nfe.date_in_out = datetime.strptime("2020-01-01T11:00:00", "%Y-%m-%dT%H:%M:%S")
         nfe.nfe40_cNF = "06277716"
         nfe.with_context(lang="pt_BR")._document_export()
 


### PR DESCRIPTION
Essa conferência é interessante principalmente por causa das notas emitidas pelo fornecedor. Como a importação de xml ainda não está funcional é legal criar mecanismos para que os dados fiquem corretos.


É bom entrar depois da #2480.