### PR TITLE
[14.0][IMP] l10n_br_fiscal: adds field to define anonymous consumer

### DIFF
--- a/l10n_br_fiscal/models/res_company.py
+++ b/l10n_br_fiscal/models/res_company.py
@@ -321,6 +321,12 @@ class ResCompany(models.Model):
         default="line",
     )
 
+    anonymous_partner_id = fields.Many2one(
+        comodel_name="res.partner",
+        string="Anonymous Partner",
+        help="Partner used to create anonymous fiscal documents",
+    )
+
     def _del_tax_definition(self, tax_domain):
         tax_def = self.tax_definition_ids.filtered(
             lambda d: d.tax_group_id.tax_domain != tax_domain

--- a/l10n_br_fiscal/models/res_partner.py
+++ b/l10n_br_fiscal/models/res_partner.py
@@ -96,6 +96,11 @@ class ResPartner(models.Model):
         tracking=True,
     )
 
+    is_anonymous_consumer = fields.Boolean(
+        tracking=True,
+        string="Anonymous Consumer",
+    )
+
     def _inverse_fiscal_profile(self):
         for p in self:
             p._onchange_fiscal_profile_id()

--- a/l10n_br_fiscal/views/res_company_view.xml
+++ b/l10n_br_fiscal/views/res_company_view.xml
@@ -162,6 +162,10 @@
                                     <field name="processador_edoc" />
                                     <field name="document_save_disk" />
                                     <field name="document_type_id" />
+                                    <field
+                                        name="anonymous_partner_id"
+                                        domain="[('is_anonymous_consumer', '=', True)]"
+                                    />
                                 </group>
                                 <group />
                             </group>

--- a/l10n_br_fiscal/views/res_partner_view.xml
+++ b/l10n_br_fiscal/views/res_partner_view.xml
@@ -33,6 +33,7 @@
                         options="{'no_create': True, 'no_create_edit': True}"
                     />
                     <field name="ind_final" />
+                    <field name="is_anonymous_consumer" />
                 </group>
             </group>
         </field>


### PR DESCRIPTION
Não é uma regra, mas em alguns casos, como na NFC-e, pode ser possível que o consumidor não seja identificado. Dessa forma, não é emitido a tag `dest` e/ou `entrega`. Apesar de existir alguns dados com "Consumidor Anônimo" já cadastrado no sistema, para não ficar algo hardcoded, eu adicionei essa flag na aba fiscal do `res.partner` pra ficar mais fácil de conseguir lidar com isso.