### PR TITLE
[14.0][IMP] l10n_br_sale: fiscal operation optional

### DIFF
--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -9,8 +9,6 @@ class SaleOrderLine(models.Model):
     _name = "sale.order.line"
     _inherit = [_name, "l10n_br_fiscal.document.line.mixin"]
 
-    country_id = fields.Many2one(related="company_id.country_id", store=True)
-
     @api.model
     def _default_fiscal_operation(self):
         return self.env.company.sale_fiscal_operation_id
@@ -19,6 +17,12 @@ class SaleOrderLine(models.Model):
     def _fiscal_operation_domain(self):
         domain = [("state", "=", "approved")]
         return domain
+
+    company_country_id = fields.Many2one(related="company_id.country_id", store=True)
+
+    order_fiscal_operation_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.operation", related="order_id.fiscal_operation_id"
+    )
 
     fiscal_operation_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.operation",

--- a/l10n_br_sale/views/sale_view.xml
+++ b/l10n_br_sale/views/sale_view.xml
@@ -65,9 +65,21 @@
                 />
             </field>
             <field name="validity_date" position="after">
-                <field name="fiscal_operation_id" required="True" />
-                <field name="ind_final" required="True" />
-                <field name="ind_pres" required="True" />
+                <field name="company_country_id" invisible="1" />
+                <field
+                    name="fiscal_operation_id"
+                    attrs="{'invisible': [('company_country_id', '!=', %(base.br)d)]}"
+                />
+                <field
+                    name="ind_final"
+                    required="0"
+                    attrs="{'invisible': [('fiscal_operation_id', '=', False)],'required': [('fiscal_operation_id', '!=', False)]}"
+                />
+                <field
+                    name="ind_pres"
+                    required="0"
+                    attrs="{'invisible': [('fiscal_operation_id', '=', False)],'required': [('fiscal_operation_id', '!=', False)]}"
+                />
             </field>
             <field name="note" position="replace">
                 <group>
@@ -151,36 +163,38 @@
                 expr="//field[@name='order_line']/form//label[@for='customer_lead']"
                 position="before"
             >
+                <field name="order_fiscal_operation_id" invisible="1" />
+                <field name="company_country_id" invisible="1" />
                 <field
                     name="fiscal_operation_id"
                     options="{'no_create': True}"
-                    attrs="{'readonly': [('state', 'in', ('sale', 'done', 'cancel'))], 'required': [('display_type', '=', False)], 'invisible': [('country_id', '!=', %(base.br)d)]}"
+                    attrs="{'readonly': [('state', 'in', ('sale', 'done', 'cancel'))], 'required': [('order_fiscal_operation_id', '!=', False),('display_type', '=', False)], 'invisible': [('company_country_id', '!=', %(base.br)d)]}"
                 />
                 <field
                     name="fiscal_operation_line_id"
                     options="{'no_create': True}"
-                    attrs="{'readonly': [('state', 'in', ('sale', 'done', 'cancel'))], 'required': [('display_type', '=', False)], 'invisible': [('country_id', '!=', %(base.br)d)]}"
+                    attrs="{'readonly': [('state', 'in', ('sale', 'done', 'cancel'))], 'required': [('order_fiscal_operation_id', '!=', False),('display_type', '=', False)], 'invisible': [('company_country_id', '!=', %(base.br)d)]}"
                 />
                 <field
                     name="cfop_id"
                     options="{'no_create': True}"
-                    attrs="{'invisible': ['|', ('tax_icms_or_issqn', '=', 'issqn'), ('country_id', '!=', %(base.br)d)]}"
+                    attrs="{'invisible': ['|', ('tax_icms_or_issqn', '=', 'issqn'), ('company_country_id', '!=', %(base.br)d)]}"
                 />
                 <field name="price_total" invisible="1" />
                 <field name="price_subtotal" invisible="1" />
                 <field
                     name="service_type_id"
                     options="{'no_create': True}"
-                    attrs="{'invisible': ['|', ('tax_icms_or_issqn', '=', 'icms'), ('country_id', '!=', %(base.br)d)]}"
+                    attrs="{'invisible': ['|', ('tax_icms_or_issqn', '=', 'icms'), ('company_country_id', '!=', %(base.br)d)]}"
                 />
                 <field
                     name="city_taxation_code_id"
-                    attrs="{'invisible': ['|', ('tax_icms_or_issqn', '=', 'icms'), ('country_id', '!=', %(base.br)d)]}"
+                    attrs="{'invisible': ['|', ('tax_icms_or_issqn', '=', 'icms'), ('company_country_id', '!=', %(base.br)d)]}"
                     options="{'no_create': True}"
                 />
                 <field
                     name="cnae_id"
-                    attrs="{'invisible': ['|', ('tax_icms_or_issqn', '=', 'icms'), ('country_id', '!=', %(base.br)d)]}"
+                    attrs="{'invisible': ['|', ('tax_icms_or_issqn', '=', 'icms'), ('company_country_id', '!=', %(base.br)d)]}"
                     options="{'no_create': True}"
                 />
             </xpath>
@@ -199,9 +213,9 @@
                 <label
                     for="fiscal_quantity"
                     string="Fiscal Quantity"
-                    attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
+                    attrs="{'invisible': [('company_country_id', '!=', %(base.br)d)]}"
                 />
-                <div attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}">
+                <div attrs="{'invisible': [('company_country_id', '!=', %(base.br)d)]}">
                     <field
                         context="{'partner_id':parent.partner_id, 'quantity':fiscal_quantity, 'pricelist':parent.pricelist_id, 'uom':uot_id, 'uom_qty_change':True, 'company_id': parent.company_id}"
                         name="fiscal_quantity"
@@ -217,19 +231,20 @@
                 </div>
                 <field
                     name="fiscal_price"
-                    attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
+                    attrs="{'invisible': [('company_country_id', '!=', %(base.br)d)]}"
                 />
             </xpath>
             <xpath
                 expr="//field[@name='order_line']/form/field[@name='name']"
                 position="after"
             >
-                <field name="country_id" invisible="1" />
-                <notebook attrs="{'invisible': [('display_type', '!=', False)]}">
+                <notebook
+                    attrs="{'invisible': [('company_country_id', '!=', %(base.br)d)]}"
+                >
                     <page
                         name="fiscal_taxes"
                         string="Taxes"
-                        attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
+                        attrs="{'invisible': [('display_type', '!=', False)]}"
                     />
                     <page
                         string="Invoice Lines"


### PR DESCRIPTION
Oi pessoal,

Fizemos algumas mudanças no Pedido de Vendas.

Primeiro, fizemos um ajuste na obrigatoriedade da operação fiscal. Percebemos que, em alguns casos, como no aluguel de equipamentos de um dos nossos clientes, não é necessário um documento fiscal. Por isso, decidimos tornar a operação opcional nestas situações.

Em segundo lugar, trabalhamos na localização para torná-la mais compatível com empresas que têm filiais em outros países. 

Então, para resumir:

1) No Pedido de Vendas, a operação fiscal agora é opcional em algumas circunstâncias;
2) Melhoramos a compatibilidade com empresas estrangeiras.

Como sempre, qualquer feedback é bem-vindo!