### PR TITLE
[14.0][l10n_br_acount][IMP] 30% performance improvement

### DIFF
--- a/l10n_br_account/models/fiscal_document.py
+++ b/l10n_br_account/models/fiscal_document.py
@@ -23,6 +23,22 @@ class FiscalDocument(models.Model):
         string="Invoices",
     )
 
+    # proxy fields to enable writing the related (shadowed) fields
+    # to the fiscal document from the account.move through the _inherits system
+    # despite they have the same names.
+    fiscal_partner_id = fields.Many2one(related="partner_id", readonly=False)
+    fiscal_company_id = fields.Many2one(related="company_id", readonly=False)
+    fiscal_currency_id = fields.Many2one(related="currency_id", readonly=False)
+    fiscal_partner_shipping_id = fields.Many2one(
+        related="partner_shipping_id", readonly=False
+    )
+    fiscal_user_id = fields.Many2one(related="user_id", readonly=False)
+
+    # commented out because of badly written TestInvoiceDiscount.test_date_in_out
+    #    def write(self, vals):
+    #        if self.document_type_id:
+    #            return super().write(vals)
+
     fiscal_line_ids = fields.One2many(
         copy=False,
     )

--- a/l10n_br_account/models/fiscal_document_line.py
+++ b/l10n_br_account/models/fiscal_document_line.py
@@ -14,6 +14,15 @@ class FiscalDocumentLine(models.Model):
         string="Invoice Lines",
     )
 
+    # proxy fields to enable writing the related (shadowed) fields
+    # to the fiscal doc line from the aml through the _inherits system
+    # despite they have the same names.
+    fiscal_name = fields.Text(related="name", readonly=False)
+    fiscal_product_id = fields.Many2one(related="product_id", readonly=False)
+    fiscal_uom_id = fields.Many2one(related="uom_id", readonly=False)
+    fiscal_quantity = fields.Float(related="quantity", readonly=False)
+    fiscal_price_unit = fields.Float(related="price_unit", readonly=False)
+
     def modified(self, fnames, create=False, before=False):
         """
         Modifying a dummy fiscal document (no document_type_id) line should not recompute

--- a/l10n_br_delivery/models/fiscal_document_mixin.py
+++ b/l10n_br_delivery/models/fiscal_document_mixin.py
@@ -20,6 +20,8 @@ class FiscalDocumentMixin(models.AbstractModel):
         " transactions.",
     )
 
+    fiscal_incoterm_id = fields.Many2one(related="incoterm_id")
+
     carrier_id = fields.Many2one(
         comodel_name="delivery.carrier",
         string="Carrier",


### PR DESCRIPTION
Performance ao rodar os tests no modulo l10n_br_account:
antes:
Module l10n_br_account loaded in 22.26s (incl. 19.38s test), 1272 queries (+**9497** test)
depois:
ver nos comentários em baixo...

Segue a explicação em inglês da mensagem de commit:

Some fields have the same names in the fiscal.document(.line) and the account.move(.line). We call them the "shadowed fields".

It's important they have the same name for onchanges and other inherited method to behave as expected.
But the _inherits system prevent writing these fields through the account.move(.line) objects, hence the name "shadowed".

Before this commit, we were writing the shadowed fields after the 1st create/write. This was doing unecessary UPDATE SQL queries and mostly was triggering computed fields again.

With this commit we write these fields through new fiscal_* related fields so they are written at the same time as the other fields with now extra UPDATE query nor re-compute.