### PR TITLE
[14.0][l10n_br_fiscal][l10n_br_nfe][FIX] in Odoo aml product_id should be optional

### DIFF
--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -26,8 +26,6 @@ from ..constants.fiscal import (
     SITUACAO_EDOC_INUTILIZADA,
 )
 
-PRODUCT_CODE_FISCAL_DOCUMENT_TYPES = ["55", "01"]
-
 
 class Document(models.Model):
     """Implementação base dos documentos fiscais
@@ -219,22 +217,6 @@ class Document(models.Model):
         compute="_compute_document_subsequent_generated",
         default=False,
     )
-
-    @api.constrains("document_type", "state_edoc", "fiscal_line_ids")
-    def _check_product_default_code(self):
-        for rec in self:
-            if (
-                rec.document_type in PRODUCT_CODE_FISCAL_DOCUMENT_TYPES
-                and rec.state_edoc == "a_enviar"
-            ):
-                for line in rec.fiscal_line_ids:
-                    if not line.product_id.default_code:
-                        raise ValidationError(
-                            _(
-                                f"The product {line.product_id.display_name} "
-                                f"must have a default code."
-                            )
-                        )
 
     @api.constrains("document_key")
     def _check_key(self):

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -55,6 +55,8 @@ from ..constants.nfe import (
     NFE_VERSIONS,
 )
 
+PRODUCT_CODE_FISCAL_DOCUMENT_TYPES = ["55", "01"]
+
 _logger = logging.getLogger(__name__)
 
 
@@ -681,6 +683,23 @@ class NFe(spec_models.StackedModel):
     ################################
     # Business Model Methods
     ################################
+
+    @api.constrains("document_type", "state_edoc", "fiscal_line_ids")
+    def _check_product_default_code(self):
+        for rec in self:
+            if (
+                rec.document_type in PRODUCT_CODE_FISCAL_DOCUMENT_TYPES
+                and rec.state_edoc == "a_enviar"
+            ):
+                for line in rec.fiscal_line_ids:
+                    if not line.product_id.default_code and not line.nfe40_cProd:
+                        raise ValidationError(
+                            _(
+                                f"The product {line.product_id.display_name} "
+                                f"must have a default code or the product code"
+                                f"line field (nfe40_cProd) should be filled."
+                            )
+                        )
 
     def _document_number(self):
         # TODO: Criar campos no fiscal para codigo aleatorio e digito verificador,


### PR DESCRIPTION
Eu não me liguei na hora de aprovar o PR https://github.com/OCA/l10n-brazil/pull/2453 mas não tava correto, pois no Odoo o produto é optional nas linhas de account.move.line e é bom que continue assim na localização. Nisso o check tem que ser feito apenas no l10n_br_nfe e permitir de preencher o campo nfe40_cProd na linha se não tiver product_id.

cc @renatonlima @felipemotter @antoniospneto @marcelsavegnago 