### PR TITLE
[14.0][FIX] l10n_br_account: recompute taxes after ind final

### DIFF
--- a/l10n_br_account/models/account_invoice.py
+++ b/l10n_br_account/models/account_invoice.py
@@ -265,6 +265,8 @@ class AccountMove(models.Model):
     @api.onchange("ind_final")
     def _onchange_ind_final(self):
         """Trigger the recompute of the taxes when the ind_final is changed"""
+        for line in self.invoice_line_ids:
+            line._onchange_fiscal_operation_id()
         return self._recompute_dynamic_lines(recompute_all_taxes=True)
 
     @api.model


### PR DESCRIPTION
Em Santa Catarina o icms para uso final é de 17% enquanto para o restante é 12%. VIsto isso, se um usuário troca o ind_final depois de já ter colocado os produtos na fatura, os valores do icms ficarão errados. Esta PR resolve isto.