### PR TITLE
[14.0][IMP] l10n_br_account: allow edit invoice line account_id

### DIFF
--- a/l10n_br_account/views/account_invoice_view.xml
+++ b/l10n_br_account/views/account_invoice_view.xml
@@ -337,6 +337,7 @@
                 expr="//field[@name='invoice_line_ids']/form/sheet/group/field[@name='account_id']"
                 position="attributes"
             >
+                <attribute name="readonly">0</attribute>
                 <attribute name="groups">account.group_account_readonly</attribute>
                 <attribute
                     name="domain"


### PR DESCRIPTION
Alteração para manter o comportamento padrão do odoo que é permitir a editar a conta da linha da fatura.