### PR TITLE
[14.0][l10n_br_account][FIX] removed invalid @api.onchange fields

### DIFF
--- a/l10n_br_account/models/account_invoice_line.py
+++ b/l10n_br_account/models/account_invoice_line.py
@@ -499,8 +499,6 @@ class AccountMoveLine(models.Model):
 
     @api.onchange(
         "move_id",
-        "move_id.move_type",
-        "move_id.fiscal_operation_id",
         "amount_untaxed",
         "amount_tax_included",
         "amount_tax_not_included",


### PR DESCRIPTION
algo que foi extrapolado no PR https://github.com/OCA/l10n-brazil/pull/2347
api.onchange não é igual ao api.depends, e so aceita campos e não campos indireitos.

Antes a gente pegava esse warning:

```
2023-05-24 00:38:57,113 300 WARNING db odoo.models: @api.onchange('move_id', 'move_id.move_type', 'move_id.fiscal_operation_id', 'amount_untaxed', 'amount_tax_included', 'amount_tax_not_included', 'amount_taxed', 'currency_id', 'company_currency_id', 'company_id', 'date', 'quantity', 'discount', 'price_unit', 'tax_ids') parameters must be field names -> not valid: ['move_id.move_type', 'move_id.fiscal_operation_id'] 
```

isso remove o warning e funciona igual.

cc @felipemotter @antoniospneto 