### PR TITLE
[14.0][FIX] l10n_br_nfse: Valor correto dos serviços quando a quantidade maior que um.

### DIFF
--- a/l10n_br_nfse/models/document_line.py
+++ b/l10n_br_nfse/models/document_line.py
@@ -70,7 +70,7 @@ class DocumentLine(models.Model):
 
     def prepare_line_servico(self):
         return {
-            "valor_servicos": round(self.fiscal_price, 2),
+            "valor_servicos": round(self.fiscal_price * self.fiscal_quantity, 2),
             "valor_deducoes": round(self.fiscal_deductions_value, 2),
             "valor_pis": round(self.pis_value, 2) or round(self.pis_wh_value, 2),
             "valor_pis_retido": round(self.pis_wh_value, 2),


### PR DESCRIPTION
O campo valor dos serviços da nota fiscal deve contemplar o valor total dos serviços.
O valor estava ficando errado quando a quantidade do produto(serviço) estava diferente de 1.

@marcelsavegnago  @mileo 

