### PR TITLE
[14.0][IMP] l10n_br_fiscal: add icms difal regulation

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -30,6 +30,7 @@
         "data/res_partner_data.xml",
         "data/l10n_br_fiscal.tax.group.csv",
         "data/l10n_br_fiscal.icms.relief.csv",
+        "data/l10n_br_fiscal_icms_difal_definition_data.xml",
         "data/l10n_br_fiscal.document.type.csv",
         "data/l10n_br_fiscal.product.genre.csv",
         "data/l10n_br_fiscal.cst.csv",

--- a/l10n_br_fiscal/constants/icms.py
+++ b/l10n_br_fiscal/constants/icms.py
@@ -105,41 +105,6 @@ ICMS_DIFAL_PARTITION = {
 }
 
 
-ICMS_DIFAL_UNIQUE_BASE = [
-    "DF",
-    "ES",
-    "MA",
-    "MS",
-    "PE",
-    "RJ",
-    "RN",
-    "RR",
-]
-
-
-ICMS_DIFAL_DOUBLE_BASE = [
-    "AC",
-    "AL",
-    "AP",
-    "AM",
-    "BA",
-    "CE",
-    "GO",
-    "MG",
-    "MT",
-    "PA",
-    "PB",
-    "PI",
-    "PR",
-    "RO",
-    "RS",
-    "SC",
-    "SE",
-    "SP",
-    "TO",
-]
-
-
 ICSM_CST_CSOSN_ST_BASE = ["10", "30", "70", "90", "201", "202", "203", "900"]
 
 ICMS_CST_RELIEF = ["20", "30", "40", "41", "50", "70", "90"]

--- a/l10n_br_fiscal/data/l10n_br_fiscal_icms_difal_definition_data.xml
+++ b/l10n_br_fiscal/data/l10n_br_fiscal_icms_difal_definition_data.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="True">
+    <record id="tax_icms_difal_regulation" model="l10n_br_fiscal.icms.difal.regulation">
+        <field name="name">Regulamento do ICMS Difal</field>
+        <field
+            name="unique_base_state_ids"
+            eval="[(6, 0, [
+                ref('base.state_br_ac'),
+                ref('base.state_br_al'),
+                ref('base.state_br_am'),
+                ref('base.state_br_ap'),
+                ref('base.state_br_ba'),
+                ref('base.state_br_ce'),
+                ref('base.state_br_df'),
+                ref('base.state_br_es'),
+                ref('base.state_br_go'),
+                ref('base.state_br_ma'),
+                ref('base.state_br_mg'),
+                ref('base.state_br_ms'),
+                ref('base.state_br_mt'),
+                ref('base.state_br_pa'),
+                ref('base.state_br_pb'),
+                ref('base.state_br_pe'),
+                ref('base.state_br_pi'),
+                ref('base.state_br_pr'),
+                ref('base.state_br_rj'),
+                ref('base.state_br_rn'),
+                ref('base.state_br_ro'),
+                ref('base.state_br_rr'),
+                ref('base.state_br_rs'),
+                ref('base.state_br_sc'),
+                ref('base.state_br_se'),
+                ref('base.state_br_sp'),
+                ref('base.state_br_to')
+            ])]"
+        />
+    </record>
+
+</odoo>

--- a/l10n_br_fiscal/demo/company_demo.xml
+++ b/l10n_br_fiscal/demo/company_demo.xml
@@ -108,6 +108,7 @@
         <field name="is_industry" eval="True" />
         <field name="ripi" eval="True" />
         <field name="icms_regulation_id" ref="tax_icms_regulation" />
+        <field name="icms_difal_regulation_id" ref="tax_icms_difal_regulation" />
         <field name="cnae_main_id" ref="l10n_br_fiscal.cnae_3101200" />
         <field name="piscofins_id" ref="l10n_br_fiscal.tax_pis_cofins_columativo" />
         <field name="document_type_id" ref="l10n_br_fiscal.document_55" />

--- a/l10n_br_fiscal/models/__init__.py
+++ b/l10n_br_fiscal/models/__init__.py
@@ -44,6 +44,7 @@ from . import tax_definition_operation_line
 from . import tax_definition_partner_profile
 from . import icms_regulation
 from . import icms_relief
+from . import icms_difal_regulation
 from . import document_type
 from . import document_serie
 from . import product_genre

--- a/l10n_br_fiscal/models/icms_difal_regulation.py
+++ b/l10n_br_fiscal/models/icms_difal_regulation.py
@@ -1,0 +1,37 @@
+# Copyright (C) 2023  Felipe Motter Pereira - Akretion <felipe@engenere.one>
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class ICMSDifalRegulation(models.Model):
+    _name = "l10n_br_fiscal.icms.difal.regulation"
+    _description = "ICMS Difal Regulation"
+
+    name = fields.Text(required=True, index=True)
+
+    unique_base_state_ids = fields.Many2many(
+        comodel_name="res.country.state",
+        relation="icms_difal_regulation_unique_base_state_rel",
+        column1="icms_difal_regulation",
+        column2="state_id",
+        string="States with Unique Base",
+        domain=[("country_id.code", "=", "BR")],
+    )
+
+    double_base_state_ids = fields.Many2many(
+        comodel_name="res.country.state",
+        relation="icms_difal_regulation_double_base_state_rel",
+        column1="icms_difal_regulation",
+        column2="state_id",
+        string="States with Double Base",
+        domain=[("country_id.code", "=", "BR")],
+    )
+
+    @api.constrains("unique_base_state_ids", "double_base_state_ids")
+    def _check_duplicity(self):
+        for state in self.unique_base_state_ids:
+            if state in self.double_base_state_ids:
+                raise UserError(_("You cannot have two bases for same state."))
+        return True

--- a/l10n_br_fiscal/models/res_company.py
+++ b/l10n_br_fiscal/models/res_company.py
@@ -251,6 +251,11 @@ class ResCompany(models.Model):
         comodel_name="l10n_br_fiscal.icms.regulation", string="ICMS Regulation"
     )
 
+    icms_difal_regulation_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.icms.difal.regulation",
+        string="ICMS Difal Regulation",
+    )
+
     tax_issqn_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",
         string="Default ISSQN",

--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -1,7 +1,8 @@
 # Copyright (C) 2013  Renato Lima - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 from odoo.tools import float_is_zero
 
 from ..constants.fiscal import (
@@ -22,9 +23,7 @@ from ..constants.icms import (
     ICMS_BASE_TYPE,
     ICMS_BASE_TYPE_DEFAULT,
     ICMS_CST_RELIEF,
-    ICMS_DIFAL_DOUBLE_BASE,
     ICMS_DIFAL_PARTITION,
-    ICMS_DIFAL_UNIQUE_BASE,
     ICMS_ORIGIN_TAX_IMPORTED,
     ICMS_SN_CST_WITH_CREDIT,
     ICMS_ST_BASE_TYPE,
@@ -396,7 +395,10 @@ class Tax(models.Model):
             or operation_line.fiscal_operation_id.fiscal_type == "return_in"
             and operation_line.fiscal_operation_type == FISCAL_IN
         ):
-            icms_tax_difal, _ = company.icms_regulation_id.map_tax_def_icms_difal(
+            (
+                icms_tax_difal,
+                tax_definitions,
+            ) = company.icms_regulation_id.map_tax_def_icms_difal(
                 company, partner, product, ncm, nbm, cest, operation_line, ind_final
             )
             icmsfcp_tax_difal = taxes_dict.get("icmsfcp", {})
@@ -424,10 +426,16 @@ class Tax(models.Model):
             # Difal - ICMS Dest Value
             icms_dest_value = currency.round(icms_base * (icms_dest_perc / 100))
 
-            if partner.state_id.code in ICMS_DIFAL_UNIQUE_BASE:
+            icms_difal_regulation = company.icms_difal_regulation_id
+            if not icms_difal_regulation:
+                raise UserError(
+                    _("The company '%s' don't have a ICMS Difal Regulation defined.")
+                    % (company.name)
+                )
+            if partner.state_id in icms_difal_regulation.unique_base_state_ids:
                 difal_icms_base = icms_base
 
-            if partner.state_id.code in ICMS_DIFAL_DOUBLE_BASE:
+            elif partner.state_id in icms_difal_regulation.double_base_state_ids:
                 difal_icms_base = currency.round(
                     (icms_base - icms_origin_value)
                     / (1 - ((icms_dest_perc + icmsfcp_perc) / 100))
@@ -435,6 +443,14 @@ class Tax(models.Model):
 
                 icms_dest_value = currency.round(
                     difal_icms_base * (icms_dest_perc / 100)
+                )
+            else:
+                raise UserError(
+                    _(
+                        "The state of partner '%s' does not have a defined "
+                        "base in the icms difal regulation."
+                    )
+                    % (partner.state_id.code)
                 )
 
             difal_value = icms_dest_value - icms_origin_value

--- a/l10n_br_fiscal/security/ir.model.access.csv
+++ b/l10n_br_fiscal/security/ir.model.access.csv
@@ -10,6 +10,8 @@
 "l10n_br_fiscal_cst_maintenance","Fiscal CST for Maintenance","model_l10n_br_fiscal_cst","l10n_br_fiscal.group_data_maintenance",1,1,1,1
 "l10n_br_fiscal_tax_group_user","Fiscal Tax Group for User","model_l10n_br_fiscal_tax_group","l10n_br_fiscal.group_user",1,0,0,0
 "l10n_br_fiscal_tax_group_manager","Fiscal Tax Group for Manager","model_l10n_br_fiscal_tax_group","l10n_br_fiscal.group_manager",1,1,1,1
+"l10n_br_fiscal_icms_difal_regulation_user","Fiscal Tax ICMS Difal Regulation for User","model_l10n_br_fiscal_icms_difal_regulation","l10n_br_fiscal.group_user",1,0,0,0
+"l10n_br_fiscal_icms_difal_regulation_manager","Fiscal Tax ICMS Difal Regulation for Manager","model_l10n_br_fiscal_icms_difal_regulation","l10n_br_fiscal.group_manager",1,1,1,1
 "l10n_br_fiscal_icms_regulation_user","Fiscal Tax ICMS Regulation for User","model_l10n_br_fiscal_icms_regulation","l10n_br_fiscal.group_user",1,0,0,0
 "l10n_br_fiscal_icms_regulation_manager","Fiscal Tax ICMS Regulation for Manager","model_l10n_br_fiscal_icms_regulation","l10n_br_fiscal.group_manager",1,1,1,1
 "l10n_br_fiscal_icms_relief_user","Fiscal Tax ICMS Relief for User","model_l10n_br_fiscal_icms_relief","l10n_br_fiscal.group_user",1,0,0,0

--- a/l10n_br_fiscal/tests/test_icms_regulation.py
+++ b/l10n_br_fiscal/tests/test_icms_regulation.py
@@ -1,6 +1,7 @@
 # Copyright 2019 Akretion - Renato Lima <renato.lima@akretion.com.br>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from odoo.exceptions import UserError
 from odoo.tests import SavepointCase, tagged
 
 from ..constants.fiscal import FINAL_CUSTOMER_NO, FINAL_CUSTOMER_YES, TAX_DOMAIN_ICMS
@@ -75,3 +76,16 @@ class TestICMSRegulation(SavepointCase):
             ind_final=ind_final,
         )
         return tax_icms.filtered(lambda t: t.tax_domain == TAX_DOMAIN_ICMS)
+
+    def test_state_difal_base_duplicity(self):
+
+        demo_state = self.env.ref("base.state_br_sc")
+
+        with self.assertRaises(UserError):
+            self.env["l10n_br_fiscal.icms.difal.regulation"].create(
+                {
+                    "name": "Difal Test",
+                    "unique_base_state_ids": [(4, demo_state.id, 0)],
+                    "double_base_state_ids": [(4, demo_state.id, 0)],
+                }
+            )

--- a/l10n_br_fiscal/views/l10n_br_fiscal_action.xml
+++ b/l10n_br_fiscal/views/l10n_br_fiscal_action.xml
@@ -100,6 +100,22 @@
         </field>
     </record>
 
+    <!-- Tax ICMS Difal Regulation -->
+    <record id="tax_icms_difal_regulation_action" model="ir.actions.act_window">
+        <field name="name">ICMS Difal Regulation</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">l10n_br_fiscal.icms.difal.regulation</field>
+        <field name="view_mode">tree,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+              Add a new ICMS Difal Regulation
+            </p><p>
+              A ICMS Difal Regulation is necessary to calc
+              ICMS Difal values on document lines.
+            </p>
+        </field>
+    </record>
+
     <!-- Tax ICMS Regulation -->
     <record id="tax_icms_regulation_action" model="ir.actions.act_window">
         <field name="name">ICMS Regulation</field>

--- a/l10n_br_fiscal/views/l10n_br_fiscal_menu.xml
+++ b/l10n_br_fiscal/views/l10n_br_fiscal_menu.xml
@@ -408,6 +408,15 @@
         sequence="20"
     />
 
+    <!-- Tax ICMS Difal Regulation -->
+    <menuitem
+        id="tax_icms_difal_regulation_menu"
+        action="tax_icms_difal_regulation_action"
+        groups="l10n_br_fiscal.group_manager"
+        parent="tax_icms_config_menu"
+        sequence="30"
+    />
+
     <!-- Tax ISSQN Settings -->
     <menuitem
         id="tax_issqn_config_menu"

--- a/l10n_br_fiscal/views/res_company_view.xml
+++ b/l10n_br_fiscal/views/res_company_view.xml
@@ -120,6 +120,11 @@
                                         attrs="{'invisible': [('tax_framework', '!=', '3')], 'required': [('tax_framework', '=', '3')]}"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
+                                    <field
+                                        name="icms_difal_regulation_id"
+                                        attrs="{'invisible': [('tax_framework', '!=', '3')], 'required': [('tax_framework', '=', '3')]}"
+                                        options="{'no_create': True, 'no_create_edit': True}"
+                                    />
                                   </group>
                                   <group name="issqn_taxes" string="ISSQN">
                                       <field name="tax_issqn_id" />


### PR DESCRIPTION
Atualmente, usamos constantes no código para definir os tipos de base para o DIFAL, mas isso pode causar algumas complicações.

Depois que o Convênio ICMS 236/2021 (https://www.confaz.fazenda.gov.br/legislacao/convenios/2021/CV236_21) entrou em vigor no ano passado, as bases para vendas em todos os estados deveriam ser simples e únicas. No entanto, no nosso código, ainda temos estados com bases simples e outros com bases duplas. Não tenho certeza se as empresas ainda seguem esse padrão ou se o nosso sistema está desatualizado.

Além disso, há algumas exceções. Conforme explicado pela nossa contadora, em Minas Gerais, mesmo tendo assinado o acordo, em certas inspeções fiscais eles exigem que o cálculo do DIFAL seja feito com base dupla.

Resumindo, não estamos totalmente seguros sobre o que é certo ou errado nesse caso. Por isso, decidimos permitir que cada empresa ajuste a configuração de acordo com suas necessidades e diretrizes.

Fiz uma atualização para definir todas as bases dos estados como simples, seguindo o convênio citado, mas não estabeleci isso como padrão. Acreditamos que cada empresa deve verificar e decidir se essa é a melhor forma de trabalhar para ela.