### PR TITLE
[14.0][l10n_br_base] erpbrasil.base>=2.3.0 e email-validator fix

### DIFF
--- a/l10n_br_base/__manifest__.py
+++ b/l10n_br_base/__manifest__.py
@@ -38,6 +38,11 @@
     "pre_init_hook": "pre_init_hook",
     "development_status": "Mature",
     "external_dependencies": {
-        "python": ["num2words", "erpbrasil.base", "phonenumbers", "email_validator"]
+        "python": [
+            "num2words",
+            "erpbrasil.base>=2.3.0",
+            "phonenumbers",
+            "email-validator",
+        ]
     },
 }

--- a/l10n_br_base/models/res_partner_pix.py
+++ b/l10n_br_base/models/res_partner_pix.py
@@ -62,7 +62,7 @@ class PartnerPix(models.Model):
             )
         except EmailSyntaxError as e:
             raise ValidationError(_(f"{email.strip()} is an invalid email")) from e
-        normalized_email = result.normalized
+        normalized_email = result.local_part + "@" + result.domain
         if len(normalized_email) > 77:
             raise ValidationError(
                 _(

--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -12,7 +12,6 @@
     "development_status": "Production/Stable",
     "version": "14.0.12.1.0",
     "depends": [
-        "uom",
         "product",
         "l10n_br_base",
     ],
@@ -110,7 +109,6 @@
     "auto_install": False,
     "external_dependencies": {
         "python": [
-            "erpbrasil.base",
             "erpbrasil.assinatura",
         ]
     },

--- a/l10n_br_hr/__manifest__.py
+++ b/l10n_br_hr/__manifest__.py
@@ -25,7 +25,6 @@
     ],
     "demo": ["demo/hr_employee_dependent_demo.xml"],
     "test": [],
-    "external_dependencies": {"python": ["erpbrasil.base"]},
     "installable": True,
     "auto_install": False,
     "license": "AGPL-3",

--- a/l10n_br_nfe/__manifest__.py
+++ b/l10n_br_nfe/__manifest__.py
@@ -37,12 +37,9 @@
     "external_dependencies": {
         "python": [
             "nfelib",
-            "erpbrasil.base",
-            "erpbrasil.assinatura",
             "erpbrasil.transmissao",
             "erpbrasil.edoc",
             "erpbrasil.edoc.pdf",
-            "xmldiff",
         ],
     },
 }

--- a/l10n_br_nfse/__manifest__.py
+++ b/l10n_br_nfse/__manifest__.py
@@ -15,7 +15,7 @@
             "erpbrasil.edoc",
             "erpbrasil.assinatura",
             "erpbrasil.transmissao",
-            "erpbrasil.base",
+            "erpbrasil.base>=2.3.0",
         ],
     },
     "depends": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # generated from manifests external_dependencies
-email_validator
+email-validator
 erpbrasil.assinatura
-erpbrasil.base
+erpbrasil.base>=2.3.0
 erpbrasil.edoc
 erpbrasil.edoc.pdf
 erpbrasil.transmissao

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,3 @@ pyyaml
 satcomum
 unidecode
 workalendar
-xmldiff

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 vcrpy  # Needed by payment_pagseguro
 odoo-test-helper  # Needed by spec_driven_model
 signxml<3.1.0
+xmldiff


### PR DESCRIPTION
varios fix de dependencias, o que tem como consequencia de concertar o Runboat!

EDIT:

- [x] erpbrasil.base>=2.3.0 para evitar https://github.com/OCA/l10n-brazil/discussions/2500
- [x] simplifica as dependencias indireitas para não ter que repetir as coisas como essa versão do erpbrasil.base
- [x] resolve o problema com email-validator. O problema é que no fix  https://github.com/OCA/l10n-brazil/pull/2495 eu usei o atributo `normalized` que so esta disponivel nas versões de menos de 1 mes do email-validator e sem release direito ainda. Para evitar o erro que temos no Runboat "'ValidatedEmail' object has no attribute 'normalized'" eu usei então atributos disponiveis na versão 1.3.x do email-validator.
- [x] isso tem como consequencia que concerta o Runboat, pois era esse problema com o email-validator que impedia de instalar dados de demo e quebrava a instalação de dados de demo subsequentes.