### PR TITLE
[14.0][FIX] l10n_br_nfe, l10n_br_base: CNPJ, CFP e IE (Produtor Rural)

### DIFF
--- a/l10n_br_base/views/res_partner_view.xml
+++ b/l10n_br_base/views/res_partner_view.xml
@@ -80,20 +80,9 @@
                         attrs="{'invisible': [('is_company','=', True)]}"
                     />
                     <div class="oe_edit_only" name="inscr_est">
-                        <label
-                            for="inscr_est"
-                            name="inscr_est"
-                            string="State Tax Number"
-                            attrs="{'invisible': [('is_company','!=', True)]}"
-                        />
+                        <label for="inscr_est" name="inscr_est" string="IE" />
                     </div>
-                    <field
-                        colspan="4"
-                        name="inscr_est"
-                        nolabel="1"
-                        placeholder="Para ISENTO deixe vazio ou escreva 'ISENTO'"
-                        attrs="{'invisible': [('is_company','!=', True)]}"
-                    />
+                    <field colspan="4" name="inscr_est" nolabel="1" />
                 </group>
             </xpath>
             <page position="after" name="sales_purchases">

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -156,6 +156,7 @@ class ResPartner(spec_models.SpecModel):
                     rec.nfe40_choice8 = "nfe40_CNPJ"
                     rec.nfe40_choice19 = "nfe40_CNPJ"
                     rec.nfe40_CNPJ = cnpj_cpf
+                    rec.nfe40_CPF = None
                 else:
                     rec.nfe40_choice2 = "nfe40_CPF"
                     rec.nfe40_choice6 = "nfe40_CPF"
@@ -163,8 +164,9 @@ class ResPartner(spec_models.SpecModel):
                     rec.nfe40_choice8 = "nfe40_CPF"
                     rec.nfe40_choice19 = "nfe40_CPF"
                     rec.nfe40_CPF = cnpj_cpf
+                    rec.nfe40_CNPJ = None
 
-            if rec.inscr_est and rec.is_company:
+            if rec.inscr_est:
                 rec.nfe40_IE = punctuation_rm(rec.inscr_est)
             else:
                 rec.nfe40_IE = None


### PR DESCRIPTION
**l10n_br_nfe**: Implementada correção para zerar o campo CPF quando o CNPJ for preenchido e vice-versa. Sem esta correção, os dois campos acabavam sendo enviados para o XML da NF-e, resultando em falha de validação. Para identificar o erro, é necessário alternar o cadastro de um parceiro entre pessoa física e jurídica, e alterar o CNPJ/CPF.

**l10n_br_base**: Modificado o campo da Inscrição Estadual (IE) para que seja visível também para cadastros de pessoa física. Esta alteração é necessária para cadastros de Produtores Rurais, que apesar de não possuírem CNPJ, possuem uma Inscrição Estadual.