### PR TITLE
[14.0][l10n_br_currency_rate_update][CI] only run BCB tests certain days

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit =
+    l10n_br_currency_rate_update/tests/test_currency_rate_update_bcb.py


### PR DESCRIPTION
os testes no l10n_br_currency_rate_update costumam falhar bastante por conta de falhas no servidor do Banco do Brasil.

O que eu fiz com isso é que a gente passa a rodar os testes apenas os dias 7, 14, 21 e 28 do mes. O restante não vai mais encher o saco. Assim a gente ainda testa o webservice de vez em quando mas o teste não atrasa mais a vida da gente.

Ainda é possivel forçar o teste com `export CI_FORCE_BCB=1` antes de iniciar os testes se for preciso, por examplo se tiver um PR pro modulo.

@antoniospneto @felipemotter @marcelsavegnago @renatonlima