### PR TITLE
[14.0][l10n_br_fiscal][CI] only run IBPT tests certain days

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,5 @@
 [run]
 omit =
     l10n_br_currency_rate_update/tests/test_currency_rate_update_bcb.py
+    l10n_br_fiscal/tests/test_ibpt_service.py
+    l10n_br_fiscal/tests/test_ibpt_product.py

--- a/l10n_br_fiscal/tests/test_ibpt.py
+++ b/l10n_br_fiscal/tests/test_ibpt.py
@@ -1,6 +1,11 @@
 # Copyright 2019 Akretion - Renato Lima <renato.lima@akretion.com.br>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+import logging
+from datetime import datetime
+from os import environ
+
+from decorator import decorate
 from erpbrasil.base import misc
 
 from odoo.tests import SavepointCase
@@ -11,11 +16,72 @@ from odoo.addons.l10n_br_fiscal.models.ibpt import (
     get_ibpt_service,
 )
 
+_logger = logging.getLogger(__name__)
+
+
+def _not_every_day_test(method, self, modulo=7, remaining=0):
+    if datetime.now().day % modulo == remaining or environ.get("CI_FORCE_IBPT"):
+        return method(self)
+    else:
+        return lambda: _logger.info(
+            "Skipping test today because datetime.now().day %% %s != %s"
+            % (modulo, remaining)
+        )
+
+
+def not_every_day_test(method):
+    """
+    Decorate test methods to query the IBPT only
+    1 day out of 7 and skip tests otherwise.
+    Indeed the IBPT webservice often returns errors and it sucks
+    to crash the entire l10n-brazil test suite because of this.
+    the CI_FORCE_IBPT env var can be set to force the test anyhow.
+    """
+    return decorate(method, _not_every_day_test)
+
+
+def mocked_requests_get(*args, **kwargs):
+    class MockResponse:
+        def __init__(self, json_data, status_code):
+            self.json_data = json_data
+            self.status_code = status_code
+
+        def ok(self):
+            return True
+
+        def json(self):
+            return self.json_data
+
+    # the same as rates during 2 days:
+    return MockResponse(
+        {
+            "Codigo": "85030010",
+            "UF": "ES",
+            "EX": 0,
+            "Descricao": "Partes de motores/geradores de pot<=75kva",
+            "Nacional": 16.67,
+            "Estadual": 25.0,
+            "Importado": 23.98,
+            "Municipal": 0.0,
+            "Tipo": "0",
+            "VigenciaInicio": "20/05/2023",
+            "VigenciaFim": "30/06/2023",
+            "Chave": "FADD79",
+            "Versao": "23.1.F",
+            "Fonte": "IBPT/empresometro.com.br",
+            "Valor": 0.0,
+            "ValorTributoNacional": 0.0,
+            "ValorTributoEstadual": 0.0,
+            "ValorTributoImportado": 0.0,
+            "ValorTributoMunicipal": 0.0,
+        },
+        200,
+    )
+
 
 class TestIbpt(SavepointCase):
     @classmethod
     def setUpClass(cls):
-
         super().setUpClass()
         cls.company = cls._create_compay()
         cls._switch_user_company(cls.env.user, cls.company)
@@ -37,7 +103,6 @@ class TestIbpt(SavepointCase):
     @classmethod
     def _check_ibpt_api(cls, company, ncm_nbs):
         """Check if IBPT API Webservice is online"""
-
         result = False
         try:
             config = DeOlhoNoImposto(
@@ -81,13 +146,11 @@ class TestIbpt(SavepointCase):
     @classmethod
     def _create_product_tmpl(cls, name, ncm):
         """Create products related with NCM"""
-
         product = cls.product_tmpl_model.create({"name": name, "ncm_id": ncm.id})
         return product
 
     @classmethod
     def _create_service_tmpl(cls, name, nbs):
         """Create services related with NBS"""
-
         product = cls.product_tmpl_model.create({"name": name, "nbs_id": nbs.id})
         return product

--- a/l10n_br_fiscal/tests/test_ibpt_service.py
+++ b/l10n_br_fiscal/tests/test_ibpt_service.py
@@ -1,13 +1,14 @@
 # Copyright 2019 Akretion - Renato Lima <renato.lima@akretion.com.br>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from .test_ibpt import TestIbpt
+from unittest import mock
+
+from .test_ibpt import TestIbpt, mocked_requests_get, not_every_day_test
 
 
 class TestIbptService(TestIbpt):
     @classmethod
     def setUpClass(cls):
-
         super().setUpClass()
         cls.nbs_115069000 = cls.env.ref("l10n_br_fiscal.nbs_115069000")
         cls.nbs_124043300 = cls.env.ref("l10n_br_fiscal.nbs_124043300")
@@ -24,6 +25,14 @@ class TestIbptService(TestIbpt):
             name="Product Test 3 - With NBS: 1.2404.33.00", nbs=cls.nbs_124043300
         )
 
+    @mock.patch("requests.get", side_effect=mocked_requests_get)
+    def test_mock(self, mock_get):
+        api_status = self.env.company.ibpt_api
+        self.env.company.ibpt_api = True  # force to run the mocked query
+        self.nbs_115069000.action_ibpt_inquiry()
+        self.env.company.ibpt_api = api_status
+
+    @not_every_day_test
     def test_update_ibpt_service(self):
         """Check tax estimate update"""
 
@@ -40,6 +49,7 @@ class TestIbptService(TestIbpt):
             [("nbs_id", "in", (self.nbs_115069000.id, self.nbs_124043300.id))]
         ).unlink()
 
+    @not_every_day_test
     def test_nbs_count_product_template(self):
         """Check product template relation with NBS"""
 
@@ -49,6 +59,7 @@ class TestIbptService(TestIbpt):
         self.assertEqual(self.nbs_115069000.product_tmpl_qty, 2)
         self.assertEqual(self.nbs_124043300.product_tmpl_qty, 1)
 
+    @not_every_day_test
     def test_update_scheduled(self):
         """Check NBS update scheduled"""
 


### PR DESCRIPTION
semelhante ao https://github.com/OCA/l10n-brazil/pull/2506 mas com o serviço fiscal do IBPT.

Eu mudei os dias de testes para 8, 15, 22 e 29 para não existir apenas um dia desgraçado que tentar rodar os testes do BCB e do IBPT ao mesmo tempo (igual hoje).

Os outros dias, roda um teste mocked vagabundo so para não matar o coverage.

Ainda é possivel forçar o teste com `export CI_FORCE_IBPT=1` antes de iniciar os testes se for preciso, por examplo se tiver um PR pro modulo.

cc @antoniospneto @felipemotter @marcelsavegnago @renatonlima 