### PR TITLE
[14.0][FIX] l10n_br_account: Carregamento da modalidade do frete na NF-e

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -108,10 +108,6 @@ class AccountMove(models.Model):
         compute="_compute_fiscal_operation_type",
     )
 
-    # override the incoterm inherited by the fiscal document
-    # to have the same value as the native incoterm of the invoice.
-    incoterm_id = fields.Many2one(related="invoice_incoterm_id")
-
     def _compute_fiscal_operation_type(self):
         for inv in self:
             if inv.move_type == "entry":

--- a/l10n_br_account/models/fiscal_document.py
+++ b/l10n_br_account/models/fiscal_document.py
@@ -43,6 +43,10 @@ class FiscalDocument(models.Model):
         copy=False,
     )
 
+    # For some reason, perhaps limitation of _inhertis,
+    # the related directly in the account.move does not work correctly.
+    incoterm_id = fields.Many2one(related="move_ids.invoice_incoterm_id")
+
     document_date = fields.Datetime(
         compute="_compute_document_date", inverse="_inverse_document_date", store=True
     )


### PR DESCRIPTION
Essa PR tem o objetivo de corrigir o carregamento do campo nfe40_modFrete ( Modalidade do Frete), campo da NF-e.

O mesmo não estava sendo alterado ao alterar o incoterm na fatura (`invoice_incoterm_id`)

O problema estava na verdade no campo `incoterm_id` do documento fiscal, que no módulo l10n_br_account ele é extendido para ser um related ao `invoice_incoterm_id`.

Porém por alguma limitação do inherits a forma como estava sendo feito o override não tava funcionando.

Alterei para que o override ficasse no próprio documento fiscal ao invés de ser na fatura (account.move)
