### PR TITLE
[14.0][IMP] l10n_br_account_due_list: create payment from move line

### DIFF
--- a/l10n_br_account_due_list/__manifest__.py
+++ b/l10n_br_account_due_list/__manifest__.py
@@ -12,6 +12,7 @@
     "depends": ["account_due_list"],
     "data": [
         "views/account_invoice_view.xml",
+        "views/account_move_line.xml",
     ],
     "installable": True,
     "auto_install": True,

--- a/l10n_br_account_due_list/models/__init__.py
+++ b/l10n_br_account_due_list/models/__init__.py
@@ -1,1 +1,2 @@
 from . import account_move
+from . import account_move_line

--- a/l10n_br_account_due_list/models/account_move_line.py
+++ b/l10n_br_account_due_list/models/account_move_line.py
@@ -1,0 +1,24 @@
+# Copyright (C) 2023 - Felipe Motter Pereira - Engenere.one
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import _, models
+
+
+class AccountInvoice(models.Model):
+    _inherit = "account.move.line"
+
+    def action_register_payment(self):
+        """Open the account.payment.register wizard to pay the selected journal entries.
+        :return: An action opening the account.payment.register wizard.
+        """
+        return {
+            "name": _("Register Payment"),
+            "res_model": "account.payment.register",
+            "view_mode": "form",
+            "context": {
+                "active_model": "account.move.line",
+                "active_ids": self.ids,
+            },
+            "target": "new",
+            "type": "ir.actions.act_window",
+        }

--- a/l10n_br_account_due_list/views/account_move_line.xml
+++ b/l10n_br_account_due_list/views/account_move_line.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2023 Engenere.one
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.ui.view" id="account_move_line_form_view">
+        <field name="name">account.move.line.form</field>
+        <field name="model">account.move.line</field>
+        <field name="inherit_id" ref="account.view_move_line_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//sheet" position="before">
+                <header>
+                    <field name="parent_state" invisible="1" />
+                    <field name="reconciled" invisible="1" />
+                    <field name="account_internal_type" invisible="1" />
+                    <button
+                        name="action_register_payment"
+                        id="account_invoice_payment_btn"
+                        type="object"
+                        class="oe_highlight"
+                        attrs="{'invisible': ['|', '|', ('parent_state', '!=', 'posted'), ('reconciled', '=', True), ('account_internal_type', 'not in', ('receivable', 'payable'))]}"
+                        context="{'dont_redirect_to_payments': True}"
+                        string="Register Payment"
+                        groups="account.group_account_invoice"
+                    />
+                </header>
+            </xpath>
+        </field>
+    </record>
+
+
+    <record model="ir.ui.view" id="account_move_line_tree_view">
+        <field name="name">account.move.line.tree</field>
+        <field name="model">account.move.line</field>
+        <field name="inherit_id" ref="account_due_list.view_payments_tree" />
+        <field name="arch" type="xml">
+            <field name="date" position="before">
+                <header>
+                    <button
+                        name="action_register_payment"
+                        type="object"
+                        string="Register Payment"
+                        groups="account.group_account_user"
+                    />
+                </header>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Seguindo a lógica do módulo, de permitir o gerenciamento financeiro com base nos `account.move.line`, ess PR permite que o usuário faça um pagamento diretamente pelos vencimentos e não seja obrigado a ir até a visão da fatura.