### PR TITLE
[14.0][l10n_br_fiscal][l10n_br_nfe][l10n_br_nfse] cleanup dependencies

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -107,9 +107,4 @@
     "installable": True,
     "application": True,
     "auto_install": False,
-    "external_dependencies": {
-        "python": [
-            "erpbrasil.assinatura",
-        ]
-    },
 }

--- a/l10n_br_fiscal/models/certificate.py
+++ b/l10n_br_fiscal/models/certificate.py
@@ -22,8 +22,9 @@ try:
 except ImportError:
     _logger.error(
         _(
-            "Python Library erpbrasil.assinatura not installed, "
-            "please install ex: pip install erpbrasil.assinatura."
+            "Python Library erpbrasil.assinatura not installed!"
+            "It doesn't matter much until you want to send NFe or NFSe documents."
+            "You can install it later with: pip install erpbrasil.assinatura."
         )
     )
 

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -1,9 +1,10 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+import logging
+from odoo import _
 from . import test_cnae
 from . import test_service_type
 from . import test_partner_profile
-from . import test_certificate
 from . import test_ibpt_product
 from . import test_ibpt_service
 from . import test_fiscal_tax
@@ -14,3 +15,16 @@ from . import test_uom_uom
 from . import test_fiscal_document_nfse
 from . import test_icms_regulation
 from . import test_ncm
+
+try:
+    from erpbrasil.assinatura import certificado
+    from . import test_certificate
+except ModuleNotFoundError:
+    _logger = logging.getLogger(__name__)
+    _logger.error(
+        _(
+            "Python Library erpbrasil.assinatura not installed, "
+            "test_certificate will be skipped."
+            "You can install it later with: pip install erpbrasil.assinatura."
+        )
+    )

--- a/l10n_br_fiscal/tools/misc.py
+++ b/l10n_br_fiscal/tools/misc.py
@@ -5,14 +5,24 @@
 import logging
 import os
 
-from erpbrasil.assinatura import misc
 from erpbrasil.base.misc import punctuation_rm
 
+from odoo import _
 from odoo.tools import config
 
 from ..constants.fiscal import CERTIFICATE_TYPE_NFE, EVENT_ENV_HML, EVENT_ENV_PROD
 
 _logger = logging.getLogger(__name__)
+
+try:
+    from erpbrasil.assinatura import misc
+except ImportError:
+    _logger.error(
+        _(
+            "Python Library erpbrasil.assinatura not installed!"
+            "You can install it with: pip install erpbrasil.assinatura."
+        )
+    )
 
 
 def domain_field_codes(

--- a/l10n_br_nfe/__manifest__.py
+++ b/l10n_br_nfe/__manifest__.py
@@ -37,6 +37,7 @@
     "external_dependencies": {
         "python": [
             "nfelib",
+            "erpbrasil.assinatura>=1.7.0",
             "erpbrasil.transmissao",
             "erpbrasil.edoc",
             "erpbrasil.edoc.pdf",

--- a/l10n_br_nfse/__manifest__.py
+++ b/l10n_br_nfse/__manifest__.py
@@ -12,10 +12,10 @@
     "website": "https://github.com/OCA/l10n-brazil",
     "external_dependencies": {
         "python": [
-            "erpbrasil.edoc",
-            "erpbrasil.assinatura",
-            "erpbrasil.transmissao",
             "erpbrasil.base>=2.3.0",
+            "erpbrasil.edoc",
+            "erpbrasil.assinatura>=1.7.0",
+            "erpbrasil.transmissao",
         ],
     },
     "depends": [

--- a/l10n_br_nfse_paulistana/__manifest__.py
+++ b/l10n_br_nfse_paulistana/__manifest__.py
@@ -13,12 +13,12 @@
     "website": "https://github.com/OCA/l10n-brazil",
     "external_dependencies": {
         "python": [
-            "erpbrasil.edoc",
-            "erpbrasil.assinatura",
-            "erpbrasil.transmissao",
-            "erpbrasil.base>=2.3.0",
-            "nfselib.paulistana",
             "unidecode",
+            "erpbrasil.base>=2.3.0",
+            "erpbrasil.edoc",
+            "erpbrasil.assinatura>=1.7.0",
+            "erpbrasil.transmissao",
+            "nfselib.paulistana",
         ],
     },
     "depends": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # generated from manifests external_dependencies
 email-validator
-erpbrasil.assinatura
+erpbrasil.assinatura>=1.7.0
 erpbrasil.base>=2.3.0
 erpbrasil.edoc
 erpbrasil.edoc.pdf


### PR DESCRIPTION
Simplifica as dependências.

- [x] o erpbrasil.assinatura não ta mais obrigatorio no modulo l10n_br_fiscal. Pois ja da para fazer muita coisa com os modulos da localização sem o erpbrasil.assinatura. So pega para transmitir NFe ou NFSe, então so vira dependencies pros modulos l10n_br_nfe e l10n_br_nfse. Do restante das uns warning se não tiver, assim como é op caso com alguns modulos Odoo se vc não tiver tal ou tal pacote instalado. Eh comum o erpbrasil.assinatura sempre dar trabalho para instalar, as vezes o cara ta no Windows descobrindo o Odoo, as vezes o cara ta com uma versão de signxml ou de pyopenssl incompativel... Pro cara iniciante, pode levar 1 ou 2 anos de estudo do Odoo até ele de fato emitir alguma NFe ou NFSe em produção, então fica ruim travar ele logo com esse tipo de dificuldade que ele pode resolver la na frente.
- [x] nos modulos 10n_br_nfe e l10n_br_nfse exige a versão 1.7.0 do erpbrasil.assinatura que foi publicada recentemente e que resolve muitos pepinos comuns que apareceram recentemente (namespace na assinatura, incompatibilidade com signxml...)
- [x] simplifica as dependências transitivas para não ter que ficar repetindo as versões dos pacotes (na medida do possível).