### PR TITLE
[14.0][FIX] l10n_br_account: copy invoice with fiscal dummy

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -322,15 +322,6 @@ class AccountMove(models.Model):
         self.clear_caches()
         return result
 
-    @api.returns("self", lambda value: value.id)
-    def copy(self, default=None):
-        default = default or {}
-        if self.document_type_id:
-            default["fiscal_line_ids"] = False
-        else:
-            default["fiscal_line_ids"] = self.line_ids[0]
-        return super().copy(default)
-
     @api.model
     def _serialize_tax_grouping_key(self, grouping_dict):
         return "-".join(str(v) for v in grouping_dict.values())


### PR DESCRIPTION
Proposta para resolver o problema de copiar faturas, talvez não precise mais dessa extensão do método copy.
