### PR TITLE
[14.0][l10n_br_nfe] nfelib versão 2.0, com os bindings legacy (sem xsdata)

### DIFF
--- a/l10n_br_nfe/__manifest__.py
+++ b/l10n_br_nfe/__manifest__.py
@@ -36,7 +36,7 @@
     "auto_install": False,
     "external_dependencies": {
         "python": [
-            "nfelib",
+            "nfelib>=2.0.0",
             "erpbrasil.transmissao",
             "erpbrasil.edoc",
             "erpbrasil.edoc.pdf",

--- a/l10n_br_nfe/hooks.py
+++ b/l10n_br_nfe/hooks.py
@@ -30,18 +30,15 @@ def post_init_hook(cr, registry):
     is_demo = cr.fetchone()[0]
     if is_demo:
         res_items = (
-            "..",
-            "tests",
             "nfe",
-            "v4_00",
+            "samples",
+            "v4_0",
             "leiauteNFe",
             "35180834128745000152550010000474491454651420-nfe.xml",
         )
         resource_path = "/".join(res_items)
         nfe_stream = pkg_resources.resource_stream(nfelib.__name__, resource_path)
 
-        # nfe_stream = pkg_resources.resource_stream('nfelib',
-        # '../tests/nfe/v4_00/leiauteNFe/35180803102452000172550010000474491454651420-nfe.xml')
         nfe_binding = nfe_sub.parse(nfe_stream, silence=True)
         document_number = nfe_binding.infNFe.ide.nNF
         existing_nfes = env["l10n_br_fiscal.document"].search(

--- a/l10n_br_nfe/tests/test_nfe_import.py
+++ b/l10n_br_nfe/tests/test_nfe_import.py
@@ -20,10 +20,9 @@ class NFeImportTest(SavepointCase):
             "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00",
         )
         res_items = (
-            "..",
-            "tests",
             "nfe",
-            "v4_00",
+            "samples",
+            "v4_0",
             "leiauteNFe",
             "35180834128745000152550010000474281920007498-nfe.xml",
         )
@@ -46,10 +45,9 @@ class NFeImportTest(SavepointCase):
             "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00",
         )
         res_items = (
-            "..",
-            "tests",
             "nfe",
-            "v4_00",
+            "samples",
+            "v4_0",
             "leiauteNFe",
             "35180834128745000152550010000474281920007498-nfe.xml",
         )

--- a/l10n_br_nfe_spec/__manifest__.py
+++ b/l10n_br_nfe_spec/__manifest__.py
@@ -6,11 +6,6 @@
     "category": "Accounting",
     "summary": "nfe spec",
     "depends": ["base"],
-    "external_dependencies": {
-        "python": [
-            "nfelib",  # (only for tests)
-        ],
-    },
     "installable": True,
     "application": False,
     "development_status": "Production/Stable",

--- a/l10n_br_nfe_spec/tests/test_nfe_import.py
+++ b/l10n_br_nfe_spec/tests/test_nfe_import.py
@@ -103,10 +103,9 @@ spec_models.NfeSpecMixin.match_or_create_m2o_fake = match_or_create_m2o_fake
 class NFeImportTest(SavepointCase):
     def test_import_nfe1(self):
         res_items = (
-            "..",
-            "tests",
             "nfe",
-            "v4_00",
+            "samples",
+            "v4_0",
             "leiauteNFe",
             "26180875335849000115550010000016871192213331-nfe.xml",
         )
@@ -120,10 +119,9 @@ class NFeImportTest(SavepointCase):
 
     def test_import_nfe2(self):
         res_items = (
-            "..",
-            "tests",
             "nfe",
-            "v4_00",
+            "samples",
+            "v4_0",
             "leiauteNFe",
             "35180834128745000152550010000476491552806942-nfe.xml",
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ erpbrasil.base>=2.3.0
 erpbrasil.edoc
 erpbrasil.edoc.pdf
 erpbrasil.transmissao
-nfelib
+nfelib>=2.0.0
 nfselib.paulistana
 num2words
 phonenumbers


### PR DESCRIPTION
Este é um PR que usa a futura versão 2.0 da nfelib onde tem os bindings generateDS legacy na pasta nfelib/v4_00 (no mesmo caminho do que antes). Jà tem os bindings xsdata na nfelib 2.0 mas esses não estão sendo utilizados neste PR. Foi adaptado tb os caminhos dos arquivos de demo para resolver esse problema na nfelib 1.x https://github.com/akretion/nfelib/issues/62

Este PR é um sub-pedaço de PRs maiores como:

- https://github.com/OCA/l10n-brazil/pull/2474
- ou https://github.com/OCA/l10n-brazil/pull/2371

Ele poderia receber um merge antes. Principalmente eu estou testando o backport deste PR na v12.0 https://github.com/OCA/l10n-brazil/pull/2542 onde provavelmente não teremos um backport de https://github.com/OCA/l10n-brazil/pull/2371 (de acordo com o que pensam os outros mantenedores ativos na v12). Este PR simples tem tb como proposito de validar a compatibilidade backward da nfelib 2.x.