### PR TITLE
[12.0][l10n_br_nfe] nfelib versão 2.0, com os bindings legacy (sem xsdata)

### DIFF
--- a/l10n_br_nfe/__manifest__.py
+++ b/l10n_br_nfe/__manifest__.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2019  Renato Lima - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-
 {
     "name": "NF-e",
     "summary": "Brazilian Eletronic Invoice NF-e .",

--- a/l10n_br_nfe/hooks.py
+++ b/l10n_br_nfe/hooks.py
@@ -30,18 +30,15 @@ def post_init_hook(cr, registry):
     is_demo = cr.fetchone()[0]
     if is_demo:
         res_items = (
-            "..",
-            "tests",
             "nfe",
-            "v4_00",
+            "samples",
+            "v4_0",
             "leiauteNFe",
             "35180834128745000152550010000474491454651420-nfe.xml",
         )
         resource_path = "/".join(res_items)
         nfe_stream = pkg_resources.resource_stream(nfelib.__name__, resource_path)
 
-        # nfe_stream = pkg_resources.resource_stream('nfelib',
-        # '../tests/nfe/v4_00/leiauteNFe/35180803102452000172550010000474491454651420-nfe.xml')
         nfe_binding = nfe_sub.parse(nfe_stream, silence=True)
         document_number = nfe_binding.infNFe.ide.nNF
         existing_nfes = env["l10n_br_fiscal.document"].search(

--- a/l10n_br_nfe/tests/test_nfe_import.py
+++ b/l10n_br_nfe/tests/test_nfe_import.py
@@ -20,10 +20,9 @@ class NFeImportTest(SavepointCase):
             "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00",
         )
         res_items = (
-            "..",
-            "tests",
             "nfe",
-            "v4_00",
+            "samples",
+            "v4_0",
             "leiauteNFe",
             "35180834128745000152550010000474281920007498-nfe.xml",
         )
@@ -46,10 +45,9 @@ class NFeImportTest(SavepointCase):
             "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00",
         )
         res_items = (
-            "..",
-            "tests",
             "nfe",
-            "v4_00",
+            "samples",
+            "v4_0",
             "leiauteNFe",
             "35180834128745000152550010000474281920007498-nfe.xml",
         )

--- a/l10n_br_nfe_spec/tests/test_nfe_import.py
+++ b/l10n_br_nfe_spec/tests/test_nfe_import.py
@@ -103,10 +103,9 @@ spec_models.NfeSpecMixin.match_or_create_m2o_fake = match_or_create_m2o_fake
 class NFeImportTest(SavepointCase):
     def test_import_nfe1(self):
         res_items = (
-            "..",
-            "tests",
             "nfe",
-            "v4_00",
+            "samples",
+            "v4_0",
             "leiauteNFe",
             "26180875335849000115550010000016871192213331-nfe.xml",
         )
@@ -120,10 +119,9 @@ class NFeImportTest(SavepointCase):
 
     def test_import_nfe2(self):
         res_items = (
-            "..",
-            "tests",
             "nfe",
-            "v4_00",
+            "samples",
+            "v4_0",
             "leiauteNFe",
             "35180834128745000152550010000476491552806942-nfe.xml",
         )


### PR DESCRIPTION
backport de https://github.com/OCA/l10n-brazil/pull/2541