### PR TITLE
[14.0][FIX] l10n_br_account: dummy multicompany

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -280,7 +280,11 @@ class AccountMove(models.Model):
         )._move_autocomplete_invoice_lines_create(vals_list)
         for vals in new_vals_list:
             if not vals.get("document_type_id"):
-                vals["fiscal_document_id"] = self.env.company.fiscal_dummy_id.id
+                if vals.get("company_id"):
+                    company_id = self.env["res.company"].browse(vals.get("company_id"))
+                else:
+                    company_id = self.env.company
+                vals["fiscal_document_id"] = company_id.fiscal_dummy_id.id
         return new_vals_list
 
     def _move_autocomplete_invoice_lines_values(self):
@@ -309,7 +313,7 @@ class AccountMove(models.Model):
                 continue
             if (
                 move.fiscal_document_id
-                and move.fiscal_document_id.id != self.env.company.fiscal_dummy_id.id
+                and move.fiscal_document_id.id != move.company_id.fiscal_dummy_id.id
             ):
                 unlink_documents |= move.fiscal_document_id
             unlink_moves |= move

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -377,7 +377,7 @@ class Document(models.Model):
         ]
 
         for record in self.filtered(
-            lambda d: d != self.env.company.fiscal_dummy_id
+            lambda d: d != d.company_id.fiscal_dummy_id
             and d.state_edoc in forbidden_states_unlink
         ):
             raise ValidationError(


### PR DESCRIPTION
Na forma atual, o 'dummy' inserido em um account.move sempre vem da empresa ativa naquele momento, e não daquela que corresponde ao próprio account.move. Mesmo que não seja uma prática recomendável, não há nada que impeça um usuário de editar um registro da empresa X enquanto a empresa Y está ativa. Portanto, é essencial estarmos preparados para tais situações errôneas, algo que já ocorreu com um de nossos clientes.

Lembrando que este é mais um problema associado ao 'dummy'. Nós aqui na Engenere acreditamos que, ultimamente, o 'dummy' vem causando mais complicações do que facilitando nosso trabalho. Estamos tentando dar uma chance para esta função recentemente, mas este tipo de problema é um dos muitos que enfrentamos e que está consumindo nosso tempo.

Já pensamos até em manter um 'fork' sem o 'dummy', mas percebemos que isso nos traria uma complexidade ainda maior para manter o código alinhado com esta localização, e acabaria nos distanciando da comunidade - algo que não desejamos.

Entendemos as razões para tentar utilizar o 'dummy', mas estamos começando a nos questionar sobre os reais benefícios do uso do 'inherits' e do 'dummy'. Parece que, ao invés de simplificar, essas ferramentas estão tornando tudo mais confuso, já que não impedem a duplicação de código e ainda introduzem uma série de comportamentos estranhos, sem mencionar os constantes erros do 'dummy'. Diante disso, não seria válido debatermos uma alternativa ao 'inherits' e ao 'dummy'?