### PR TITLE
[14.0][FIX] l10n_br_account: Restringe a alteração do tipo do documento na fatura quando tiver dummy.

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -108,6 +108,27 @@ class AccountMove(models.Model):
         compute="_compute_fiscal_operation_type",
     )
 
+    has_fiscal_dummy = fields.Boolean(
+        compute="_compute_has_fiscal_dummy",
+    )
+
+    def _compute_has_fiscal_dummy(self):
+        for rec in self:
+            rec.has_fiscal_dummy = (
+                rec.fiscal_document_id.id == rec.company_id.fiscal_dummy_id.id
+            )
+
+    @api.constrains("fiscal_document_id", "document_type_id")
+    def _check_fiscal_document_type(self):
+        for rec in self:
+            has_fiscal_dummy = (
+                rec.fiscal_document_id.id == rec.company_id.fiscal_dummy_id.id
+            )
+            if has_fiscal_dummy and rec.document_type_id:
+                raise UserError(
+                    _("You can't set a document type to a fiscal dummy document.")
+                )
+
     def _compute_fiscal_operation_type(self):
         for inv in self:
             if inv.move_type == "entry":

--- a/l10n_br_account/tests/test_customer_invoice_dummy.py
+++ b/l10n_br_account/tests/test_customer_invoice_dummy.py
@@ -4,6 +4,7 @@
 
 import mock
 
+from odoo.exceptions import UserError
 from odoo.models import NewId
 from odoo.tests import SavepointCase
 
@@ -400,3 +401,13 @@ class TestCustomerInvoice(SavepointCase):
             )
 
         self.assertEqual(len(invoice_copy), 1)
+
+    def test_has_fiscal_dummy(self):
+        fiscal_dummy = self.invoice_1.company_id.fiscal_dummy_id
+        self.assertEqual(fiscal_dummy.id, self.invoice_1.fiscal_document_id.id)
+        self.assertTrue(self.invoice_1.has_fiscal_dummy)
+
+    def test_set_document_type_with_dummy(self):
+        self.assertTrue(self.invoice_1.has_fiscal_dummy)
+        with self.assertRaises(UserError):
+            self.invoice_1.document_type_id = self.env.ref("l10n_br_fiscal.document_55")

--- a/l10n_br_account/views/account_invoice_view.xml
+++ b/l10n_br_account/views/account_invoice_view.xml
@@ -74,6 +74,7 @@
                     <field name="create_date" invisible="1" />
                     <field name="operation_name" invisible="1" />
                     <field name="comment_ids" invisible="1" />
+                    <field name="has_fiscal_dummy" invisible="1" />
                 </group>
             </xpath>
             <field name="ref" position="after">
@@ -85,10 +86,12 @@
                             '|',
                             '&amp;',
                             '|',
+                            '|',
                             ('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')),
                             ('create_date', '=', True),
                             ('document_type_id', '=', False),
                             ('currency_id', '!=',  %(base.BRL)d),
+                            ('has_fiscal_dummy', '=', True),
                         ],
                     'readonly': [('state', '!=', 'draft')]
                 }"


### PR DESCRIPTION
Esta Pull Request implementa uma restrição à alteração do tipo de documento fiscal em uma fatura que já está associada a um documento fiscal dummy.

Essa restrição é essencial para prevenir inconsistências de dados e possíveis erros. No estado atual do sistema, se um usuário alterar o tipo de documento fiscal de uma fatura associada a um documento fiscal dummy, essa mudança será refletida em todas as outras faturas e lançamentos contábeis,  ligadas ao mesmo dummy. Isso resulta em dados inconsistentes e pode desencadear uma série de problemas.

Este ajuste é uma resposta à issue #2229.
