### PR TITLE
[14.0][IMP] Adiciona a opção de informar a base do ICMS manualmente.

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -371,6 +371,8 @@ class AccountMove(models.Model):
             icms_origin=base_line.icms_origin,
             ind_final=base_line.ind_final,
             icms_base_manual=base_line.icms_base_manual,
+            icmsst_base_manual=base_line.icmsst_base_manual,
+            icmsst_value_manual=base_line.icmsst_value_manual,
         )
 
         return balance_taxes_res

--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -370,6 +370,7 @@ class AccountMove(models.Model):
             icmssn_range=base_line.icmssn_range_id,
             icms_origin=base_line.icms_origin,
             ind_final=base_line.ind_final,
+            icms_base_manual=base_line.icms_base_manual,
         )
 
         return balance_taxes_res

--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -335,6 +335,7 @@ class AccountMoveLine(models.Model):
                 icmssn_range=self.icmssn_range_id,
                 icms_origin=self.icms_origin,
                 ind_final=self.ind_final,
+                icms_base_manual=self.icms_base_manual,
             ),
         )._get_price_total_and_subtotal(
             price_unit=price_unit or self.price_unit,
@@ -410,6 +411,7 @@ class AccountMoveLine(models.Model):
                 icmssn_range=self.env.context.get("icmssn_range"),
                 icms_origin=self.env.context.get("icms_origin"),
                 ind_final=self.env.context.get("ind_final"),
+                icms_base_manual=self.env.context.get("icms_base_manual"),
             )
 
             result["price_subtotal"] = taxes_res["total_excluded"]

--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -336,6 +336,8 @@ class AccountMoveLine(models.Model):
                 icms_origin=self.icms_origin,
                 ind_final=self.ind_final,
                 icms_base_manual=self.icms_base_manual,
+                icmsst_base_manual=self.icmsst_base_manual,
+                icmsst_value_manual=self.icmsst_value_manual,
             ),
         )._get_price_total_and_subtotal(
             price_unit=price_unit or self.price_unit,
@@ -412,6 +414,8 @@ class AccountMoveLine(models.Model):
                 icms_origin=self.env.context.get("icms_origin"),
                 ind_final=self.env.context.get("ind_final"),
                 icms_base_manual=self.env.context.get("icms_base_manual"),
+                icmsst_base_manual=self.env.context.get("icmsst_base_manual"),
+                icmsst_value_manual=self.env.context.get("icmsst_value_manual"),
             )
 
             result["price_subtotal"] = taxes_res["total_excluded"]

--- a/l10n_br_account/models/account_tax.py
+++ b/l10n_br_account/models/account_tax.py
@@ -42,6 +42,7 @@ class AccountTax(models.Model):
         icmssn_range=None,
         icms_origin=None,
         ind_final=FINAL_CUSTOMER_NO,
+        icms_base_manual=None,
     ):
         """Returns all information required to apply taxes
             (in self + their children in case of a tax goup).
@@ -113,6 +114,7 @@ class AccountTax(models.Model):
             icmssn_range=icmssn_range,
             icms_origin=icms_origin or product.icms_origin,
             ind_final=ind_final,
+            icms_base_manual=icms_base_manual,
         )
 
         taxes_results["amount_tax_included"] = fiscal_taxes_results["amount_included"]

--- a/l10n_br_account/models/account_tax.py
+++ b/l10n_br_account/models/account_tax.py
@@ -43,6 +43,8 @@ class AccountTax(models.Model):
         icms_origin=None,
         ind_final=FINAL_CUSTOMER_NO,
         icms_base_manual=None,
+        icmsst_base_manual=None,
+        icmsst_value_manual=None,
     ):
         """Returns all information required to apply taxes
             (in self + their children in case of a tax goup).
@@ -115,6 +117,8 @@ class AccountTax(models.Model):
             icms_origin=icms_origin or product.icms_origin,
             ind_final=ind_final,
             icms_base_manual=icms_base_manual,
+            icmsst_base_manual=icmsst_base_manual,
+            icmsst_value_manual=icmsst_value_manual,
         )
 
         taxes_results["amount_tax_included"] = fiscal_taxes_results["amount_included"]

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin.py
@@ -339,6 +339,12 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         selection=ICMS_ORIGIN, string="ICMS Origin", default=ICMS_ORIGIN_DEFAULT
     )
 
+    icms_base_manual = fields.Monetary(
+        string="Manual ICMS Base",
+        help="Value of the ICMS Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
     # vBC - Valor da base de cálculo do ICMS
     icms_base = fields.Monetary(string="ICMS Base")
 

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin.py
@@ -385,6 +385,18 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         default=ICMS_ST_BASE_TYPE_DEFAULT,
     )
 
+    icmsst_base_manual = fields.Monetary(
+        string="Manual ICMS ST Base",
+        help="Value of the ICMS ST Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    icmsst_value_manual = fields.Monetary(
+        string="Manual ICMS ST Value",
+        help="Value of the ICMS ST Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
     # pMVAST - Percentual da margem de valor Adicionado do ICMS ST
     icmsst_mva_percent = fields.Float(string="ICMS ST MVA %")
 

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -211,6 +211,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             icmssn_range=self.icmssn_range_id,
             icms_origin=self.icms_origin,
             icms_cst_id=self.icms_cst_id,
+            icms_base_manual=self.icms_base_manual,
             ind_final=self.ind_final,
         )
 
@@ -774,6 +775,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         "insurance_value",
         "other_value",
         "freight_value",
+        "icms_base_manual",
     )
     def _onchange_fiscal_taxes(self):
         self._update_fiscal_tax_ids(self._get_all_tax_id_fields())

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -212,6 +212,8 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             icms_origin=self.icms_origin,
             icms_cst_id=self.icms_cst_id,
             icms_base_manual=self.icms_base_manual,
+            icmsst_base_manual=self.icmsst_base_manual,
+            icmsst_value_manual=self.icmsst_value_manual,
             ind_final=self.ind_final,
         )
 
@@ -776,6 +778,8 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         "other_value",
         "freight_value",
         "icms_base_manual",
+        "icmsst_base_manual",
+        "icmsst_value_manual",
     )
     def _onchange_fiscal_taxes(self):
         self._update_fiscal_tax_ids(self._get_all_tax_id_fields())

--- a/l10n_br_fiscal/tests/test_fiscal_tax.py
+++ b/l10n_br_fiscal/tests/test_fiscal_tax.py
@@ -101,6 +101,7 @@ class TestFiscalTax(common.TransactionCase):
             "icmssn_range": False,
             "icms_origin": ICMS_ORIGIN_DEFAULT,
             "ind_final": FINAL_CUSTOMER_YES,
+            "icms_base_manual": 0.00,
         }
 
     def test_compute_taxes_01(self):

--- a/l10n_br_fiscal/tests/test_fiscal_tax.py
+++ b/l10n_br_fiscal/tests/test_fiscal_tax.py
@@ -102,6 +102,8 @@ class TestFiscalTax(common.TransactionCase):
             "icms_origin": ICMS_ORIGIN_DEFAULT,
             "ind_final": FINAL_CUSTOMER_YES,
             "icms_base_manual": 0.00,
+            "icmsst_base_manual": 0.00,
+            "icmsst_value_manual": 0.00,
         }
 
     def test_compute_taxes_01(self):

--- a/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
@@ -202,6 +202,10 @@
                                             attrs="{'readonly': [('icmssn_tax_id', '!=', False)], 'invisible': [('tax_framework', '=', '3')]}"
                                         />
                         <field
+                                            name="icms_base_manual"
+                                            attrs="{'invisible': ['|', ('tax_framework', '=', '2'), ('icms_cst_code', 'not in', ('00', '10', '20', '30', '40', '41', '50', '51', '60', '70', '90', '900'))]}"
+                                        />
+                        <field
                                             name="icms_base"
                                             force_save="1"
                                             attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': ['|', ('tax_framework', '=', '2'), ('icms_cst_code', 'not in', ('00', '10', '20', '30', '40', '41', '50', '51', '60', '70', '90', '900'))]}"

--- a/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
@@ -286,9 +286,19 @@
                                             attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('icms_cst_code', 'in', ('60', '500'))]}"
                                         />
                         <field
+                                            name="icmsst_base_manual"
+                                            force_save="1"
+                                            attrs="{'invisible': [('icms_cst_code', 'in', ('60', '500'))]}"
+                                        />
+                        <field
                                             name="icmsst_base"
                                             force_save="1"
                                             attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('icms_cst_code', 'in', ('60', '500'))]}"
+                                        />
+                        <field
+                                            name="icmsst_value_manual"
+                                            force_save="1"
+                                            attrs="{'invisible': [('icms_cst_code', 'in', ('60', '500'))]}"
                                         />
                         <field
                                             name="icmsst_value"


### PR DESCRIPTION
A proposta desta PR é adicionar a possibilidade de informar a base do ICMS calculada manualmente.
Isso é interessante no caso da digitação de uma nota fiscal de importação, que normalmente o cálculo da base é bem complexa e o usuário prefere informar conforme vem descrito na declaração de importação.

![Peek 2023-06-22 23-52](https://github.com/OCA/l10n-brazil/assets/634278/705b62d5-ecab-462e-9dc3-e67589183d84)



Ainda em testes, não é uma proposta final, por isso em rascunho.

- [ ] adicionar testes
- [ ] fazer o mesmo para os outros impostos?


