### PR TITLE
[14.0][l10n_br_account] multi-localizations tests

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -149,7 +149,9 @@ class AccountMove(models.Model):
         self, view_id=None, view_type="form", toolbar=False, submenu=False
     ):
         invoice_view = super().fields_view_get(view_id, view_type, toolbar, submenu)
-        if view_type == "form":
+        if self.env.company.country_id.code != "BR":
+            return invoice_view
+        elif view_type == "form":
             view = self.env["ir.ui.view"]
 
             if view_id == self.env.ref("l10n_br_account.fiscal_invoice_form").id:
@@ -232,9 +234,7 @@ class AccountMove(models.Model):
         "ind_final",
     )
     def _compute_amount(self):
-        if self.company_id.country_id.code != "BR":
-            return super()._compute_amount()
-        for move in self:
+        for move in self.filtered(lambda m: m.company_id.country_id.code == "BR"):
             for line in move.line_ids:
                 if (
                     move.is_invoice(include_receipts=True)
@@ -243,7 +243,7 @@ class AccountMove(models.Model):
                     line._update_taxes()
 
         result = super()._compute_amount()
-        for move in self:
+        for move in self.filtered(lambda m: m.company_id.country_id.code == "BR"):
             if move.move_type == "entry" or move.is_outbound():
                 sign = -1
             else:

--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -300,6 +300,18 @@ class AccountMoveLine(models.Model):
         price_subtotal,
         force_computation=False,
     ):
+        if self.env.company.country_id.code != "BR":
+            return super()._get_fields_onchange_balance_model(
+                quantity=quantity,
+                discount=discount,
+                amount_currency=amount_currency,
+                move_type=move_type,
+                currency=currency,
+                taxes=taxes,
+                price_subtotal=price_subtotal,
+                force_computation=force_computation,
+            )
+
         return {}
 
     def _get_price_total_and_subtotal(
@@ -504,7 +516,7 @@ class AccountMoveLine(models.Model):
         # completely new onchange, even if the name is not totally consistent with the
         # fields declared in the api.onchange.
         if self.company_id.country_id.code != "BR":
-            return super(AccountMoveLine, self)._onchange_price_subtotal()
+            return super()._onchange_price_subtotal()
         for line in self:
             if not line.move_id.is_invoice(include_receipts=True):
                 continue

--- a/l10n_br_account/tests/__init__.py
+++ b/l10n_br_account/tests/__init__.py
@@ -1,11 +1,10 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from . import (
-    test_account_taxes,
-    test_company_fiscal_dummy,
-    test_customer_invoice_dummy,
-    test_document_date,
-    test_invoice_refund,
-    test_move_discount,
-    test_supplier_invoice_dummy,
-)
+from . import test_account_taxes
+from . import test_company_fiscal_dummy
+from . import test_customer_invoice_dummy
+from . import test_document_date
+from . import test_invoice_refund
+from . import test_move_discount
+from . import test_supplier_invoice_dummy
+from . import test_multi_localizations_invoice

--- a/l10n_br_account/tests/test_multi_localizations_invoice.py
+++ b/l10n_br_account/tests/test_multi_localizations_invoice.py
@@ -1,0 +1,199 @@
+# Copyright (C) 2023 - TODAY Raphaël Valyi - Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import logging
+
+from odoo.tests.common import OdooSuite, tagged
+
+_logger = logging.getLogger(__name__)
+
+
+# flake8: noqa: B950  - line too long
+def addTest(self, test):
+    """
+    This monkey patch is required to avoid triggering all the tests from
+    TestAccountMoveOutInvoiceOnchanges when it is imported.
+    see https://stackoverflow.com/questions/69091760/how-can-i-import-a-testclass-properly-to-inherit-from-without-it-being-run-as-a
+    """
+    if type(test).__name__ == "MultiLocalizationsInvoice":
+        if test._testMethodName.startswith("test_force_"):
+            # in our MultiLocalizationInvoice class tests should start
+            # with test_force_ to be enabled in the test suite.
+            return OdooSuite.addTest._original_method(self, test)
+
+    elif type(test).__name__ != "TestAccountMoveOutInvoiceOnchanges":
+        return OdooSuite.addTest._original_method(self, test)
+
+
+addTest._original_method = OdooSuite.addTest
+OdooSuite.addTest = addTest
+
+
+# flake8: noqa: E402  - module level import not at top of file
+from odoo.addons.account.tests.test_account_move_out_invoice import (
+    TestAccountMoveOutInvoiceOnchanges,
+)
+
+
+@tagged("post_install", "-at_install")
+class MultiLocalizationsInvoice(TestAccountMoveOutInvoiceOnchanges):
+    """
+    This is a simple test for ensuring l10n_br_account doesn't break the basic
+    account module behavior with customer invoices.
+    """
+
+    @classmethod
+    def setup_company_data(cls, company_name, chart_template=None, **kwargs):
+        usa = cls.env.ref("base.us").id  # would be Brazil by default otherwise
+        return super().setup_company_data(
+            company_name, chart_template, country_id=usa, **kwargs
+        )
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref)
+        # FIXME the following line should not be required but as for
+        # now if we don't add this group, creating a refund will result
+        # in an attempt to create a l10n_br_fiscal.subsequent.document record.
+        cls.env.user.groups_id |= cls.env.ref("l10n_br_fiscal.group_manager")
+
+    # The following tests list is taken with
+    # cat addons/account/tests/test_account_move_out_invoice.py | grep "def test_"
+    # then the following script will format the lines:
+    # for line in lines.splitlines():
+    #     print(line.replace("def test_", "def test_force_"))
+    #     print(line.replace("def ", "    super().").replace("(self):", "()") + "\n")
+    #
+    # ideally they should made to pass for a True multi-localizations compatibility
+
+    def test_force_out_invoice_onchange_invoice_date(self):
+        super().test_out_invoice_onchange_invoice_date()
+
+    def test_force_out_invoice_line_onchange_product_1(self):
+        super().test_out_invoice_line_onchange_product_1()
+
+    def test_force_out_invoice_line_onchange_product_2_with_fiscal_pos_1(self):
+        super().test_out_invoice_line_onchange_product_2_with_fiscal_pos_1()
+
+    def test_force_out_invoice_line_onchange_product_2_with_fiscal_pos_2(self):
+        super().test_out_invoice_line_onchange_product_2_with_fiscal_pos_2()
+
+    #    def test_force_out_invoice_line_onchange_business_fields_1(self):
+    #        FIXME
+    #        super().test_out_invoice_line_onchange_business_fields_1()
+
+    #    def test_force_out_invoice_line_onchange_accounting_fields_1(self):
+    #        FIXME this test works with most of the l10n-brazil modules
+    #        but fails because of _order = "date desc, date_maturity ASC, id desc"
+    #        inside l10n_br_account_payment_order/models/account_move_line.py
+    #        super().test_out_invoice_line_onchange_accounting_fields_1()
+
+    def test_force_out_invoice_line_onchange_partner_1(self):
+        super().test_out_invoice_line_onchange_partner_1()
+
+    def test_force_out_invoice_line_onchange_taxes_1(self):
+        super().test_out_invoice_line_onchange_taxes_1()
+
+    def test_force_out_invoice_line_onchange_rounding_price_subtotal_1(self):
+        super().test_out_invoice_line_onchange_rounding_price_subtotal_1()
+
+    def test_force_out_invoice_line_onchange_rounding_price_subtotal_2(self):
+        super().test_out_invoice_line_onchange_rounding_price_subtotal_2()
+
+    def test_force_out_invoice_line_onchange_taxes_2_price_unit_tax_included(self):
+        super().test_out_invoice_line_onchange_taxes_2_price_unit_tax_included()
+
+    def test_force_out_invoice_line_onchange_analytic(self):
+        super().test_out_invoice_line_onchange_analytic()
+
+    def test_force_out_invoice_line_onchange_analytic_2(self):
+        super().test_out_invoice_line_onchange_analytic_2()
+
+    def test_force_out_invoice_line_onchange_cash_rounding_1(self):
+        super().test_out_invoice_line_onchange_cash_rounding_1()
+
+    def test_force_out_invoice_line_onchange_currency_1(self):
+        super().test_out_invoice_line_onchange_currency_1()
+
+    #    def test_force_out_invoice_line_tax_fixed_price_include_free_product(self):
+    #        FIXME
+    #        super().test_out_invoice_line_tax_fixed_price_include_free_product()
+
+    #    def test_force_out_invoice_line_taxes_fixed_price_include_free_product(self):
+    #        FIXME
+    #        super().test_out_invoice_line_taxes_fixed_price_include_free_product()
+
+    def test_force_out_invoice_create_refund(self):
+        super().test_out_invoice_create_refund()
+
+    def test_force_out_invoice_create_refund_multi_currency(self):
+        super().test_out_invoice_create_refund_multi_currency()
+
+    def test_force_out_invoice_create_refund_auto_post(self):
+        super().test_out_invoice_create_refund_auto_post()
+
+    def test_force_out_invoice_create_1(self):
+        super().test_out_invoice_create_1()
+
+    def test_force_out_invoice_create_child_partner(self):
+        super().test_out_invoice_create_child_partner()
+
+    def test_force_out_invoice_write_1(self):
+        super().test_out_invoice_write_1()
+
+    def test_force_out_invoice_write_2(self):
+        super().test_out_invoice_write_2()
+
+    def test_force_out_invoice_post_1(self):
+        super().test_out_invoice_post_1()
+
+    def test_force_out_invoice_post_2(self):
+        super().test_out_invoice_post_2()
+
+    def test_force_out_invoice_switch_out_refund_1(self):
+        super().test_out_invoice_switch_out_refund_1()
+
+    def test_force_out_invoice_switch_out_refund_2(self):
+        super().test_out_invoice_switch_out_refund_2()
+
+    def test_force_out_invoice_reverse_move_tags(self):
+        super().test_out_invoice_reverse_move_tags()
+
+    def test_force_out_invoice_change_period_accrual_1(self):
+        super().test_out_invoice_change_period_accrual_1()
+
+    def test_force_out_invoice_multi_date_change_period_accrual(self):
+        super().test_out_invoice_multi_date_change_period_accrual()
+
+    def test_force_out_invoice_filter_zero_balance_lines(self):
+        super().test_out_invoice_filter_zero_balance_lines()
+
+    def test_force_out_invoice_recomputation_receivable_lines(self):
+        super().test_out_invoice_recomputation_receivable_lines()
+
+    def test_force_out_invoice_rounding_recomputation_receivable_lines(self):
+        super().test_out_invoice_rounding_recomputation_receivable_lines()
+
+    def test_force_out_invoice_multi_company(self):
+        super().test_out_invoice_multi_company()
+
+    def test_force_out_invoice_multiple_switch_payment_terms(self):
+        super().test_out_invoice_multiple_switch_payment_terms()
+
+    def test_force_out_invoice_copy_custom_date(self):
+        super().test_out_invoice_copy_custom_date()
+
+    def test_force_select_specific_product_account(self):
+        super().test_select_specific_product_account()
+
+    def test_force_out_invoice_note_and_tax_partner_is_set(self):
+        super().test_out_invoice_note_and_tax_partner_is_set()
+
+    def test_force_out_invoice_reverse_caba(self):
+        super().test_out_invoice_reverse_caba()
+
+    def test_force_out_invoice_duplicate_currency_rate(self):
+        super().test_out_invoice_duplicate_currency_rate()
+
+    def test_force_out_invoice_depreciated_account(self):
+        super().test_out_invoice_depreciated_account()

--- a/l10n_br_account_payment_order/models/account_move_line.py
+++ b/l10n_br_account_payment_order/models/account_move_line.py
@@ -21,7 +21,7 @@ class AccountMoveLine(models.Model):
     # Data de Vencimentos/date_maturity senão ficam fora de ordem:
     #  ex.: own_number 201 31/12/2020, own_number 202 18/11/2020
     #  Isso causa confusão pois a primeira parcela fica como sendo a segunda.
-    _order = "date desc, date_maturity ASC, id desc"
+    _order = "date desc, date_maturity asc, move_name desc, id"
 
     cnab_state = fields.Selection(
         selection=ESTADOS_CNAB,
@@ -280,7 +280,6 @@ class AccountMoveLine(models.Model):
                     )
 
     def reconcile(self):
-
         res = super().reconcile()
         for record in self:
             # Verificar Casos de CNAB

--- a/l10n_br_account_payment_order/models/l10n_br_cnab_change_methods.py
+++ b/l10n_br_account_payment_order/models/l10n_br_cnab_change_methods.py
@@ -160,17 +160,14 @@ class L10nBrCNABChangeMethods(models.Model):
         )
 
     def _cnab_already_start(self):
-
         result = False
         # Se existir uma Ordem já gerada, exportada ou concluída
         # significa que o processo desse CNAB já foi iniciado no Banco
         cnab_already_start = self.payment_line_ids.filtered(
             lambda t: t.order_id.state in ("generated", "uploaded", "done")
         )
-
         if cnab_already_start:
             result = True
-
         return result
 
     def update_cnab_for_cancel_invoice(self):
@@ -518,7 +515,6 @@ class L10nBrCNABChangeMethods(models.Model):
         )
 
     def create_payment_outside_cnab(self, amount_payment):
-
         if self.amount_residual == 0.0:
             reason_write_off = (
                 "Movement Instruction Code Updated for"

--- a/l10n_br_base/__init__.py
+++ b/l10n_br_base/__init__.py
@@ -26,7 +26,11 @@ def _auto_install_l10n_br_generic_module(env):
         # Load all l10n_br COA in Demo
         if not tools.config["without_demo"]:
             module_name_domain = [
-                ("name", "in", ("l10n_br_coa_simple", "l10n_br_coa_generic"))
+                (
+                    "name",
+                    "in",
+                    ("l10n_br_coa_simple", "l10n_br_coa_generic", "l10n_generic_coa"),
+                )
             ]
 
         module_ids = env["ir.module.module"].search(

--- a/l10n_br_purchase/tests/test_l10n_br_purchase.py
+++ b/l10n_br_purchase/tests/test_l10n_br_purchase.py
@@ -20,7 +20,6 @@ class L10nBrPurchaseBaseTest(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.main_company = cls.env.ref("base.main_company")
         cls.company = cls.env.ref("l10n_br_base.empresa_lucro_presumido")
         cls.po_products = cls.env.ref("l10n_br_purchase.lp_po_only_products")
         # cls.po_services = cls.env.ref(
@@ -433,7 +432,6 @@ class L10nBrPurchaseBaseTest(SavepointCase):
             )
 
         self._invoice_purchase_order(self.po_products)
-        self._change_user_company(self.main_company)
 
     def test_fields_view_get(self):
         """Test Purchase Order fields_view_get."""
@@ -536,4 +534,3 @@ class L10nBrPurchaseBaseTest(SavepointCase):
                     13.34,
                     "Unexpected value for the field Other Values in Purchase Order.",
                 )
-        self._change_user_company(self.main_company)

--- a/l10n_br_repair/tests/test_l10n_br_repair.py
+++ b/l10n_br_repair/tests/test_l10n_br_repair.py
@@ -19,7 +19,6 @@ class L10nBrRepairBaseTest(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.main_company = cls.env.ref("base.main_company")
         cls.company = cls.env.ref("base.main_company")
         cls.so_products = cls.env.ref("l10n_br_repair.main_so_only_products")
         cls.so_services = cls.env.ref("l10n_br_repair.main_so_only_services")
@@ -338,8 +337,6 @@ class L10nBrRepairBaseTest(SavepointCase):
         self.assertEqual(action_created_invoice["type"], "ir.actions.act_window")
         self.assertEqual(action_created_invoice["view_mode"], "form")
 
-        self._change_user_company(self.company)
-
     def test_l10n_br_repair_services(self):
         """Test brazilian Repair Order with only Services."""
         self._change_user_company(self.company)
@@ -459,8 +456,6 @@ class L10nBrRepairBaseTest(SavepointCase):
         action_created_invoice = self.so_services.action_created_invoice()
         self.assertEqual(action_created_invoice["type"], "ir.actions.act_window")
         self.assertEqual(action_created_invoice["view_mode"], "form")
-
-        self._change_user_company(self.company)
 
     def test_l10n_br_repair_products_services(self):
         """Test brazilian Repair Order with Product and Services."""
@@ -700,8 +695,6 @@ class L10nBrRepairBaseTest(SavepointCase):
         action_created_invoice = self.so_prod_srv.action_created_invoice()
         self.assertEqual(action_created_invoice["type"], "ir.actions.act_window")
         self.assertEqual(action_created_invoice["view_mode"], "tree,form")
-
-        self._change_user_company(self.main_company)
 
     def test_action_views(self):
         act1 = self.so_services.action_created_invoice()

--- a/l10n_br_sale/tests/test_l10n_br_sale.py
+++ b/l10n_br_sale/tests/test_l10n_br_sale.py
@@ -390,7 +390,6 @@ class L10nBrSaleBaseTest(SavepointCase):
             )
 
         self._invoice_sale_order(self.so_products)
-        self._change_user_company(self.main_company)
 
     def test_l10n_br_sale_services(self):
         """Test brazilian Sale Order with only Services."""
@@ -507,7 +506,6 @@ class L10nBrSaleBaseTest(SavepointCase):
             )
 
         self._invoice_sale_order(self.so_services)
-        self._change_user_company(self.main_company)
 
     def test_l10n_br_sale_product_service(self):
         """Test brazilian Sale Order with Product and Service."""
@@ -521,7 +519,6 @@ class L10nBrSaleBaseTest(SavepointCase):
         self.so_product_service._create_invoices(final=True)
         # Devem existir duas Faturas/Documentos Fiscais
         self.assertEqual(2, self.so_product_service.invoice_count)
-        self._change_user_company(self.main_company)
 
     def test_fields_freight_insurance_other_costs(self):
         """Test fields Freight, Insurance and Other Costs when
@@ -615,4 +612,3 @@ class L10nBrSaleBaseTest(SavepointCase):
                     11.43,
                     "Unexpected value for the field Other Values in Sale line.",
                 )
-        self._change_user_company(self.main_company)


### PR DESCRIPTION
Este PR injecta os principais testes do module account nativo do Odoo para verificar que o modulo l10n_br_account não quebra nada para uma empresa que não fosse do Brasil. Esse teste é bem importante para garantir a empresas multi-nacionais que tem interesse na localização que apesar do malabarismo que fazemos nos objetos account.move e account.move.line, a principio as coisas vão continuar funcionando para filial ou matriz que não estiver dentro do Brasil. Alem disso garante tb que a localização não quebra algumas funcionalidades básicas.

No momento 3 testes dos 42 tiveram que ser desativados (coisas ligadas a discount e produtos gratuitos), fica para melhorar no futuro.

O teste acrescenta algo como 1'30 de tempo de teste. Mas enfim eu acho que vale a cobertura. Por outro lado eu acho um trade-off razoável de não tentar injetar outros testes nativos sendo que se as coisas do invoice de cliente funcionam, é bem provável que os mesmos overrides sejam desativados para que as coisas de fatura de fornecedor funcionam tb. E sendo que é principalmente nos account.move e account.move.line que fazemos malabarismo, nos outros objetos do core é bem mais suave.

Tb eu acho que é importante ter esse tipo de teste antes de jogar o modulo para ser migrado na 15 ou na 16.