### PR TITLE
[FIX] Remoção Tax Id quando BR

### DIFF
--- a/l10n_br_base/views/res_company_view.xml
+++ b/l10n_br_base/views/res_company_view.xml
@@ -8,6 +8,11 @@
         <field name="model">res.company</field>
         <field name="inherit_id" ref="base.view_company_form" />
         <field name="arch" type="xml">
+            <xpath expr="//field[@name='vat']" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'invisible': [('country_id', '=', %(base.br)d)]}</attribute>
+            </xpath>
             <field name="company_registry" position="after">
                 <field
                     name="legal_name"


### PR DESCRIPTION
Alteração no módulo l10n_br_base, na qual faz o field Tax Id (vat) invisível quando o country_id é do Brasil.