### PR TITLE
[14.0][l10n_br_fiscal][l10n_br_account][REF] faster tests with SavepointCase

### DIFF
--- a/l10n_br_account/tests/__init__.py
+++ b/l10n_br_account/tests/__init__.py
@@ -1,8 +1,11 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from . import test_account_taxes
-from . import test_customer_invoice_dummy
-from . import test_supplier_invoice_dummy
-from . import test_invoice_refund
-from . import test_company_fiscal_dummy
-from . import test_invoice_general_cases
+from . import (
+    test_account_taxes,
+    test_company_fiscal_dummy,
+    test_customer_invoice_dummy,
+    test_document_date,
+    test_invoice_refund,
+    test_move_discount,
+    test_supplier_invoice_dummy,
+)

--- a/l10n_br_account/tests/test_account_taxes.py
+++ b/l10n_br_account/tests/test_account_taxes.py
@@ -1,19 +1,18 @@
 # Copyright (C) 2020  Renato Lima - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo.tests.common import TransactionCase
+from odoo.tests import SavepointCase
 
 
-class TestAccountTaxes(TransactionCase):
-    def setUp(self):
-        super().setUp()
-
-        self.l10n_br_company = self.env["res.company"].create(
+class TestAccountTaxes(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.l10n_br_company = cls.env["res.company"].create(
             {"name": "Empresa Teste do Plano de Contas Simplificado"}
         )
-
-        self.env.user.company_ids += self.l10n_br_company
-        self.env.company = self.l10n_br_company
+        cls.env.user.company_ids += cls.l10n_br_company
+        cls.env.company = cls.l10n_br_company
 
     def test_account_taxes(self):
         """Test if account taxes are related with fiscal taxes"""

--- a/l10n_br_account/tests/test_company_fiscal_dummy.py
+++ b/l10n_br_account/tests/test_company_fiscal_dummy.py
@@ -2,14 +2,15 @@
 
 from psycopg2 import IntegrityError
 
-from odoo.tests.common import TransactionCase
+from odoo.tests import SavepointCase
 from odoo.tools import mute_logger
 
 
-class TestCompanyFiscalDummy(TransactionCase):
-    def setUp(self):
-        super().setUp()
-        self.company = self.env["res.company"].create(
+class TestCompanyFiscalDummy(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env["res.company"].create(
             {
                 "name": "Company Test",
             }

--- a/l10n_br_account/tests/test_document_date.py
+++ b/l10n_br_account/tests/test_document_date.py
@@ -1,0 +1,149 @@
+# Copyright (C) 2023-Today - Engenere (<https://engenere.one>).
+# @author Felipe Motter Pereira <felipe@engenere.one>
+
+from datetime import datetime, time, timedelta
+
+from pytz import UTC, timezone
+
+from odoo.tests import SavepointCase
+
+from odoo.addons.l10n_br_fiscal.constants.fiscal import DOCUMENT_ISSUER_PARTNER
+
+
+class TestInvoiceDiscount(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.company = cls.env.ref("l10n_br_base.empresa_lucro_presumido")
+
+        # set default user company
+        companies = cls.env["res.company"].search([])
+        cls.env.user.company_ids = [(6, 0, companies.ids)]
+        cls.env.user.company_id = cls.company
+
+        cls.invoice_account_id = cls.env["account.account"].create(
+            {
+                "company_id": cls.company.id,
+                "user_type_id": cls.env.ref("account.data_account_type_receivable").id,
+                "code": "RECTEST",
+                "name": "Test receivable account",
+                "reconcile": True,
+            }
+        )
+
+        cls.invoice_journal = cls.env["account.journal"].create(
+            {
+                "company_id": cls.company.id,
+                "name": "Invoice Journal - (test)",
+                "code": "INVTEST",
+                "type": "sale",
+            }
+        )
+
+        cls.invoice_line_account_id = cls.env["account.account"].create(
+            {
+                "company_id": cls.company.id,
+                "user_type_id": cls.env.ref("account.data_account_type_revenue").id,
+                "code": "705070",
+                "name": "Product revenue account (test)",
+            }
+        )
+
+        cls.fiscal_operation_id = cls.env.ref("l10n_br_fiscal.fo_venda")
+        cls.fiscal_operation_id.deductible_taxes = True
+
+        product_id = cls.env.ref("product.product_product_7")
+
+        invoice_line_vals = [
+            (
+                0,
+                0,
+                {
+                    "account_id": cls.invoice_line_account_id.id,
+                    "product_id": product_id.id,
+                    "quantity": 1,
+                    "price_unit": 1000.0,
+                    "discount_value": 100.0,
+                },
+            )
+        ]
+
+        cls.move_id = (
+            cls.env["account.move"]
+            .with_context({"check_move_validity": False})
+            .create(
+                {
+                    "company_id": cls.company.id,
+                    "document_serie_id": cls.env.ref(
+                        "l10n_br_fiscal.empresa_lc_document_55_serie_1"
+                    ).id,
+                    "journal_id": cls.invoice_journal.id,
+                    "invoice_user_id": cls.env.user.id,
+                    "fiscal_operation_id": cls.fiscal_operation_id,
+                    "move_type": "out_invoice",
+                    "currency_id": cls.company.currency_id.id,
+                    "invoice_line_ids": invoice_line_vals,
+                }
+            )
+        )
+
+    def test_document_date(self):
+        self.move_id.issuer = DOCUMENT_ISSUER_PARTNER
+        user_tz = timezone(self.env.user.tz or "UTC")
+        original_date = datetime.combine(datetime.now().date(), time.min)
+        # Convert the original_date to the user's timezone and remove the time for comparison
+        original_date_in_user_tz = (
+            user_tz.localize(original_date).astimezone(UTC).replace(tzinfo=None)
+        )
+        original_date_without_time = original_date_in_user_tz.date()
+
+        self.move_id.invoice_date = original_date.date()
+        self.move_id.fiscal_document_id._compute_document_date()
+
+        self.assertEqual(
+            self.move_id.fiscal_document_id.document_date.date(),
+            original_date_without_time,
+            "Computed document date is incorrect",
+        )
+
+    def test_inverse_document_date(self):
+        self.move_id.issuer = DOCUMENT_ISSUER_PARTNER
+        new_date = datetime.now() - timedelta(days=2)
+        self.move_id.fiscal_document_id.document_date = new_date
+        self.move_id.fiscal_document_id._inverse_document_date()
+
+        self.assertEqual(
+            self.move_id.invoice_date,
+            new_date.date(),
+            "Inverse computed invoice date is incorrect",
+        )
+
+    def test_date_in_out(self):
+        self.move_id.issuer = DOCUMENT_ISSUER_PARTNER
+        user_tz = timezone(self.env.user.tz or "UTC")
+        original_date = datetime.combine(datetime.now().date(), time.min)
+        # Convert the original_date to the user's timezone and remove the time for comparison
+        original_date_in_user_tz = (
+            user_tz.localize(original_date).astimezone(UTC).replace(tzinfo=None)
+        )
+        original_date_without_time = original_date_in_user_tz.date()
+        self.move_id.date = original_date.date()
+        self.move_id.fiscal_document_id._compute_date_in_out()
+
+        self.assertEqual(
+            self.move_id.fiscal_document_id.date_in_out.date(),
+            original_date_without_time,
+            "Computed date in out is incorrect",
+        )
+
+    def test_inverse_date_in_out(self):
+        self.move_id.issuer = DOCUMENT_ISSUER_PARTNER
+        new_date = datetime.now() - timedelta(days=2)
+        self.move_id.fiscal_document_id.date_in_out = new_date
+        self.move_id.fiscal_document_id._inverse_date_in_out()
+        self.assertEqual(
+            self.move_id.date,
+            new_date.date(),
+            "Inverse computed account date is incorrect",
+        )

--- a/l10n_br_account/tests/test_invoice_refund.py
+++ b/l10n_br_account/tests/test_invoice_refund.py
@@ -3,49 +3,50 @@
 
 from odoo import fields
 from odoo.exceptions import UserError
-from odoo.tests.common import TransactionCase
+from odoo.tests import SavepointCase
 
 
-class TestInvoiceRefund(TransactionCase):
-    def setUp(self):
-        super().setUp()
+class TestInvoiceRefund(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
-        self.sale_account = self.env["account.account"].create(
+        cls.sale_account = cls.env["account.account"].create(
             dict(
                 code="X1020",
                 name="Product Refund Sales - (test)",
-                user_type_id=self.env.ref("account.data_account_type_revenue").id,
+                user_type_id=cls.env.ref("account.data_account_type_revenue").id,
             )
         )
 
-        self.refund_journal = self.env["account.journal"].create(
+        cls.refund_journal = cls.env["account.journal"].create(
             dict(
                 name="Refund Journal - (test)",
                 code="TREJ",
                 type="sale",
                 refund_sequence=True,
-                default_account_id=self.sale_account.id,
+                default_account_id=cls.sale_account.id,
             )
         )
 
-        self.reverse_vals = {
+        cls.reverse_vals = {
             "date": fields.Date.from_string("2019-02-01"),
             "reason": "no reason",
             "refund_method": "refund",
-            "journal_id": self.refund_journal.id,
+            "journal_id": cls.refund_journal.id,
         }
 
-        self.invoice = self.env["account.move"].create(
+        cls.invoice = cls.env["account.move"].create(
             dict(
                 name="Test Refund Invoice",
                 move_type="out_invoice",
-                invoice_payment_term_id=self.env.ref(
+                invoice_payment_term_id=cls.env.ref(
                     "account.account_payment_term_advance"
                 ).id,
-                partner_id=self.env.ref("l10n_br_base.res_partner_cliente1_sp").id,
-                journal_id=self.refund_journal.id,
-                document_type_id=self.env.ref("l10n_br_fiscal.document_55").id,
-                document_serie_id=self.env.ref(
+                partner_id=cls.env.ref("l10n_br_base.res_partner_cliente1_sp").id,
+                journal_id=cls.refund_journal.id,
+                document_type_id=cls.env.ref("l10n_br_fiscal.document_55").id,
+                document_serie_id=cls.env.ref(
                     "l10n_br_fiscal.empresa_lc_document_55_serie_1"
                 ).id,
                 invoice_line_ids=[
@@ -53,30 +54,30 @@ class TestInvoiceRefund(TransactionCase):
                         0,
                         0,
                         {
-                            "product_id": self.env.ref("product.product_product_6").id,
+                            "product_id": cls.env.ref("product.product_product_6").id,
                             "quantity": 1.0,
                             "price_unit": 100.0,
-                            "account_id": self.env["account.account"]
+                            "account_id": cls.env["account.account"]
                             .search(
                                 [
                                     (
                                         "user_type_id",
                                         "=",
-                                        self.env.ref(
+                                        cls.env.ref(
                                             "account.data_account_type_revenue"
                                         ).id,
                                     ),
                                     (
                                         "company_id",
                                         "=",
-                                        self.env.company.id,
+                                        cls.env.company.id,
                                     ),
                                 ],
                                 limit=1,
                             )
                             .id,
                             "name": "Refund Test",
-                            "uom_id": self.env.ref("uom.product_uom_unit").id,
+                            "uom_id": cls.env.ref("uom.product_uom_unit").id,
                         },
                     )
                 ],

--- a/l10n_br_account/tests/test_move_discount.py
+++ b/l10n_br_account/tests/test_move_discount.py
@@ -1,13 +1,7 @@
 # Copyright (C) 2023-Today - Engenere (<https://engenere.one>).
 # @author Felipe Motter Pereira <felipe@engenere.one>
 
-from datetime import datetime, time, timedelta
-
-from pytz import UTC, timezone
-
 from odoo.tests import TransactionCase
-
-from odoo.addons.l10n_br_fiscal.constants.fiscal import DOCUMENT_ISSUER_PARTNER
 
 
 class TestInvoiceDiscount(TransactionCase):
@@ -94,63 +88,3 @@ class TestInvoiceDiscount(TransactionCase):
         self.assertEqual(self.move_id.invoice_line_ids.discount, 10)
         self.move_id.invoice_line_ids._onchange_price_subtotal()
         self.assertEqual(self.move_id.invoice_line_ids.price_subtotal, 900)
-
-    def test_document_date(self):
-        self.move_id.issuer = DOCUMENT_ISSUER_PARTNER
-        user_tz = timezone(self.env.user.tz or "UTC")
-        original_date = datetime.combine(datetime.now().date(), time.min)
-        # Convert the original_date to the user's timezone and remove the time for comparison
-        original_date_in_user_tz = (
-            user_tz.localize(original_date).astimezone(UTC).replace(tzinfo=None)
-        )
-        original_date_without_time = original_date_in_user_tz.date()
-
-        self.move_id.invoice_date = original_date.date()
-        self.move_id.fiscal_document_id._compute_document_date()
-
-        self.assertEqual(
-            self.move_id.fiscal_document_id.document_date.date(),
-            original_date_without_time,
-            "Computed document date is incorrect",
-        )
-
-    def test_inverse_document_date(self):
-        self.move_id.issuer = DOCUMENT_ISSUER_PARTNER
-        new_date = datetime.now() - timedelta(days=2)
-        self.move_id.fiscal_document_id.document_date = new_date
-        self.move_id.fiscal_document_id._inverse_document_date()
-
-        self.assertEqual(
-            self.move_id.invoice_date,
-            new_date.date(),
-            "Inverse computed invoice date is incorrect",
-        )
-
-    def test_date_in_out(self):
-        self.move_id.issuer = DOCUMENT_ISSUER_PARTNER
-        user_tz = timezone(self.env.user.tz or "UTC")
-        original_date = datetime.combine(datetime.now().date(), time.min)
-        # Convert the original_date to the user's timezone and remove the time for comparison
-        original_date_in_user_tz = (
-            user_tz.localize(original_date).astimezone(UTC).replace(tzinfo=None)
-        )
-        original_date_without_time = original_date_in_user_tz.date()
-        self.move_id.date = original_date.date()
-        self.move_id.fiscal_document_id._compute_date_in_out()
-
-        self.assertEqual(
-            self.move_id.fiscal_document_id.date_in_out.date(),
-            original_date_without_time,
-            "Computed date in out is incorrect",
-        )
-
-    def test_inverse_date_in_out(self):
-        self.move_id.issuer = DOCUMENT_ISSUER_PARTNER
-        new_date = datetime.now() - timedelta(days=2)
-        self.move_id.fiscal_document_id.date_in_out = new_date
-        self.move_id.fiscal_document_id._inverse_date_in_out()
-        self.assertEqual(
-            self.move_id.date,
-            new_date.date(),
-            "Inverse computed account date is incorrect",
-        )

--- a/l10n_br_base/tests/test_partner_bank.py
+++ b/l10n_br_base/tests/test_partner_bank.py
@@ -3,15 +3,16 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.exceptions import UserError
-from odoo.tests import TransactionCase
+from odoo.tests import SavepointCase
 
 
-class PartnerBankTest(TransactionCase):
-    def setUp(self):
-        super().setUp()
-        self.partner_bank_model = self.env["res.partner.bank"]
-        self.partner_id = self.env.ref("l10n_br_base.res_partner_amd")
-        self.bank_id = self.env.ref("l10n_br_base.res_bank_001")
+class PartnerBankTest(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner_bank_model = cls.env["res.partner.bank"]
+        cls.partner_id = cls.env.ref("l10n_br_base.res_partner_amd")
+        cls.bank_id = cls.env.ref("l10n_br_base.res_bank_001")
 
     def test_ok_transactional_acc_type(self):
         ok_bank_vals = {

--- a/l10n_br_base/tests/test_valid_pix.py
+++ b/l10n_br_base/tests/test_valid_pix.py
@@ -5,17 +5,18 @@
 from psycopg2 import IntegrityError
 
 from odoo.exceptions import ValidationError
-from odoo.tests import TransactionCase
+from odoo.tests import SavepointCase
 from odoo.tools import mute_logger
 
 
-class ValidCreatePIXTest(TransactionCase):
+class ValidCreatePIXTest(SavepointCase):
     """Test if ValidationError is raised well during create({})"""
 
-    def setUp(self):
-        super().setUp()
-        self.res_partner_pix_model = self.env["res.partner.pix"]
-        self.partner_id = self.env.ref("l10n_br_base.res_partner_amd")
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.res_partner_pix_model = cls.env["res.partner.pix"]
+        cls.partner_id = cls.env.ref("l10n_br_base.res_partner_amd")
 
     def test_invalid_pix_cnpj_too_big(self):
         pix_vals = {

--- a/l10n_br_cnpj_search/tests/common.py
+++ b/l10n_br_cnpj_search/tests/common.py
@@ -1,15 +1,14 @@
 # Copyright 2022 KMEE
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from odoo.tests import SavepointCase
 
-from odoo.tests.common import TransactionCase
 
-
-class TestCnpjCommon(TransactionCase):
-    def setUp(self):
-        super(TestCnpjCommon, self).setUp()
-
-        self.model = self.env["res.partner"]
+class TestCnpjCommon(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.model = cls.env["res.partner"]
 
     def set_param(self, param_name, param_value):
         (

--- a/l10n_br_crm/tests/test_crm_lead.py
+++ b/l10n_br_crm/tests/test_crm_lead.py
@@ -2,22 +2,23 @@
 #   Clément Mombereau <clement.mombereau@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo.tests.common import TransactionCase
+from odoo.tests import SavepointCase
 
 
-class CrmLeadTest(TransactionCase):
+class CrmLeadTest(SavepointCase):
     """Test basic operations on Lead"""
 
-    def setUp(self):
-        super(CrmLeadTest, self).setUp()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
         # Create lead with simple details
-        self.crm_lead_company = self.env["crm.lead"].create(
+        cls.crm_lead_company = cls.env["crm.lead"].create(
             {
                 "name": "Test Company Lead",
                 "legal_name": "Teste Empresa",
                 "cnpj": "56.647.352/0001-98",
-                "stage_id": self.env.ref("crm.stage_lead1").id,
+                "stage_id": cls.env.ref("crm.stage_lead1").id,
                 "partner_name": "Test Partner",
                 "inscr_est": "079.798.013.363",
                 "inscr_mun": "99999999",
@@ -25,33 +26,33 @@ class CrmLeadTest(TransactionCase):
         )
 
         # Create lead for a person/contact
-        self.crm_lead_contact = self.env["crm.lead"].create(
+        cls.crm_lead_contact = cls.env["crm.lead"].create(
             {
                 "name": "Test Contact",
                 "cpf": "70531160505",
                 "rg": "99.888.777-1",
-                "stage_id": self.env.ref("crm.stage_lead1").id,
+                "stage_id": cls.env.ref("crm.stage_lead1").id,
                 "contact_name": "Test Contact",
             }
         )
 
         # Create lead with a valid Inscr. Estadual
-        self.crm_lead_company_1 = self.env["crm.lead"].create(
+        cls.crm_lead_company_1 = cls.env["crm.lead"].create(
             {
                 "name": "Test Company Lead IE",
                 "legal_name": "Teste Empresa 1",
                 "cnpj": "57.240.310/0001-09",
-                "stage_id": self.env.ref("crm.stage_lead1").id,
+                "stage_id": cls.env.ref("crm.stage_lead1").id,
                 "partner_name": "Test Partner 1",
                 "inscr_est": "041.092.540.590",
                 "inscr_mun": "99999999",
-                "country_id": self.env.ref("base.br").id,
-                "state_id": self.env.ref("base.state_br_sp").id,
+                "country_id": cls.env.ref("base.br").id,
+                "state_id": cls.env.ref("base.state_br_sp").id,
             }
         )
 
         # Create a Partner
-        self.partner_id_01 = self.env["res.partner"].create(
+        cls.partner_id_01 = cls.env["res.partner"].create(
             {
                 "name": "Test Lead Partner",
                 "legal_name": "Test Lead Partner",
@@ -61,7 +62,7 @@ class CrmLeadTest(TransactionCase):
                 "suframa": "99999999",
                 "street_number": "1225",
                 "district": "centro",
-                "city_id": self.env.ref("l10n_br_base.city_4205407").id,
+                "city_id": cls.env.ref("l10n_br_base.city_4205407").id,
                 "is_company": True,
             }
         )

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -1,16 +1,18 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from . import test_cnae
-from . import test_service_type
-from . import test_partner_profile
-from . import test_certificate
-from . import test_ibpt_product
-from . import test_ibpt_service
-from . import test_fiscal_tax
-from . import test_workflow
-from . import test_fiscal_document_generic
-from . import test_subsequent_operation
-from . import test_uom_uom
-from . import test_fiscal_document_nfse
-from . import test_icms_regulation
-from . import test_ncm
+from . import (
+    test_certificate,
+    test_cnae,
+    test_fiscal_document_generic,
+    test_fiscal_document_nfse,
+    test_fiscal_tax,
+    test_ibpt_product,
+    test_ibpt_service,
+    test_icms_regulation,
+    test_ncm,
+    test_partner_profile,
+    test_service_type,
+    test_subsequent_operation,
+    test_uom_uom,
+    test_workflow,
+)

--- a/l10n_br_fiscal/tests/test_certificate.py
+++ b/l10n_br_fiscal/tests/test_certificate.py
@@ -7,61 +7,63 @@ from erpbrasil.assinatura import misc
 
 from odoo import fields
 from odoo.exceptions import ValidationError
-from odoo.tests import common
+from odoo.tests import SavepointCase
 from odoo.tools.misc import format_date
 
 
-class TestCertificate(common.TransactionCase):
-    def setUp(self):
-        super().setUp()
+class TestCertificate(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company_model = cls.env["res.company"]
+        cls.certificate_model = cls.env["l10n_br_fiscal.certificate"]
+        cls.company = cls._create_compay()
+        cls._switch_user_company(cls.env.user, cls.company)
 
-        self.company_model = self.env["res.company"]
-        self.certificate_model = self.env["l10n_br_fiscal.certificate"]
-        self.company = self._create_compay()
-        self._switch_user_company(self.env.user, self.company)
-
-        self.cert_country = "BR"
-        self.cert_issuer_a = "EMISSOR A TESTE"
-        self.cert_issuer_b = "EMISSOR B TESTE"
-        self.cert_subject_valid = "CERTIFICADO VALIDO TESTE"
-        self.cert_date_exp = fields.Datetime.today() + timedelta(days=365)
-        self.cert_subject_invalid = "CERTIFICADO INVALIDO TESTE"
-        self.cert_passwd = "123456"
-        self.cert_name = "{} - {} - {} - Valid: {}".format(
+        cls.cert_country = "BR"
+        cls.cert_issuer_a = "EMISSOR A TESTE"
+        cls.cert_issuer_b = "EMISSOR B TESTE"
+        cls.cert_subject_valid = "CERTIFICADO VALIDO TESTE"
+        cls.cert_date_exp = fields.Datetime.today() + timedelta(days=365)
+        cls.cert_subject_invalid = "CERTIFICADO INVALIDO TESTE"
+        cls.cert_passwd = "123456"
+        cls.cert_name = "{} - {} - {} - Valid: {}".format(
             "NF-E",
             "A1",
-            self.cert_subject_valid,
-            format_date(self.env, self.cert_date_exp),
+            cls.cert_subject_valid,
+            format_date(cls.env, cls.cert_date_exp),
         )
 
-        self.certificate_valid = misc.create_fake_certificate_file(
+        cls.certificate_valid = misc.create_fake_certificate_file(
             valid=True,
-            passwd=self.cert_passwd,
-            issuer=self.cert_issuer_a,
-            country=self.cert_country,
-            subject=self.cert_subject_valid,
+            passwd=cls.cert_passwd,
+            issuer=cls.cert_issuer_a,
+            country=cls.cert_country,
+            subject=cls.cert_subject_valid,
         )
-        self.certificate_invalid = misc.create_fake_certificate_file(
+        cls.certificate_invalid = misc.create_fake_certificate_file(
             valid=False,
-            passwd=self.cert_passwd,
-            issuer=self.cert_issuer_b,
-            country=self.cert_country,
-            subject=self.cert_subject_invalid,
+            passwd=cls.cert_passwd,
+            issuer=cls.cert_issuer_b,
+            country=cls.cert_country,
+            subject=cls.cert_subject_invalid,
         )
 
-    def _create_compay(self):
+    @classmethod
+    def _create_compay(cls):
         """Creating a company"""
-        company = self.env["res.company"].create(
+        company = cls.env["res.company"].create(
             {
                 "name": "Company Test Fiscal BR",
                 "cnpj_cpf": "42.245.642/0001-09",
-                "country_id": self.env.ref("base.br").id,
-                "state_id": self.env.ref("base.state_br_sp").id,
+                "country_id": cls.env.ref("base.br").id,
+                "state_id": cls.env.ref("base.state_br_sp").id,
             }
         )
         return company
 
-    def _switch_user_company(self, user, company):
+    @classmethod
+    def _switch_user_company(cls, user, company):
         """Add a company to the user's allowed & set to current."""
         user.write(
             {

--- a/l10n_br_fiscal/tests/test_fiscal_tax.py
+++ b/l10n_br_fiscal/tests/test_fiscal_tax.py
@@ -1,17 +1,14 @@
 # Copyright 2020 Akretion - Renato Lima <renato.lima@akretion.com.br>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo.tests import common
+from odoo.tests import SavepointCase
 from odoo.tools import float_compare
 
 from ..constants.fiscal import FINAL_CUSTOMER_NO, FINAL_CUSTOMER_YES
 from ..constants.icms import ICMS_ORIGIN_DEFAULT
 
 
-class TestFiscalTax(common.TransactionCase):
-    def setUp(self):
-        super().setUp()
-
+class TestFiscalTax(SavepointCase):
     def _check_compute_taxes_result(self, test_result, compute_result, currency):
         for tax_domain in test_result["taxes"]:
             for tax_field in test_result["taxes"][tax_domain]:

--- a/l10n_br_fiscal/tests/test_icms_regulation.py
+++ b/l10n_br_fiscal/tests/test_icms_regulation.py
@@ -1,25 +1,24 @@
-from odoo.tests import tagged
-from odoo.tests.common import TransactionCase
+from odoo.tests import SavepointCase, tagged
 
 from ..constants.fiscal import FINAL_CUSTOMER_NO, FINAL_CUSTOMER_YES
 
 
 @tagged("icms")
-class TestICMSRegulation(TransactionCase):
-    def setUp(self):
-        super().setUp()
+class TestICMSRegulation(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env.ref("l10n_br_base.res_partner_akretion")
+        cls.company = cls.env.ref("base.main_company")
+        cls.product = cls.env.ref("product.product_product_1")
+        cls.nbm = cls.env["l10n_br_fiscal.nbm"]
+        cls.icms_regulation = cls.env.ref("l10n_br_fiscal.tax_icms_regulation")
 
-        self.partner = self.env.ref("l10n_br_base.res_partner_akretion")
-        self.company = self.env.ref("base.main_company")
-        self.product = self.env.ref("product.product_product_1")
-        self.nbm = self.env["l10n_br_fiscal.nbm"]
-        self.icms_regulation = self.env.ref("l10n_br_fiscal.tax_icms_regulation")
-
-        self.sc_state_id = self.env.ref("base.state_br_sc")
-        self.sp_state_id = self.env.ref("base.state_br_sp")
-        self.venda_operation_line_id = self.env.ref("l10n_br_fiscal.fo_venda_venda")
-        self.ncm_48191000_id = self.env.ref("l10n_br_fiscal.ncm_48191000")
-        self.ncm_energia_id = self.env.ref("l10n_br_fiscal.ncm_27160000")
+        cls.sc_state_id = cls.env.ref("base.state_br_sc")
+        cls.sp_state_id = cls.env.ref("base.state_br_sp")
+        cls.venda_operation_line_id = cls.env.ref("l10n_br_fiscal.fo_venda_venda")
+        cls.ncm_48191000_id = cls.env.ref("l10n_br_fiscal.ncm_48191000")
+        cls.ncm_energia_id = cls.env.ref("l10n_br_fiscal.ncm_27160000")
 
     def test_icms_sc_sc_ind_final_yes_default(self):
         tax_icms = self.find_icms_tax(

--- a/l10n_br_fiscal/tests/test_ncm.py
+++ b/l10n_br_fiscal/tests/test_ncm.py
@@ -3,26 +3,25 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo.exceptions import AccessError
-from odoo.tests.common import TransactionCase
+from odoo.tests import SavepointCase
 
 
-class TestNcm(TransactionCase):
-    def setUp(self):
-        super(TestNcm, self).setUp()
+class TestNcm(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
         # Create a test user with manager rights
-        self.test_user_manager = self.env["res.users"].create(
+        cls.test_user_manager = cls.env["res.users"].create(
             {
                 "name": "Test User Manager",
                 "login": "test_user_manager",
-                "groups_id": [
-                    (6, 0, [self.env.ref("l10n_br_fiscal.group_manager").id])
-                ],
+                "groups_id": [(6, 0, [cls.env.ref("l10n_br_fiscal.group_manager").id])],
             }
         )
 
         # Create a test user without manager rights
-        self.test_user = self.env["res.users"].create(
+        cls.test_user = cls.env["res.users"].create(
             {
                 "name": "Test User",
                 "login": "test_user",
@@ -30,7 +29,7 @@ class TestNcm(TransactionCase):
         )
 
         # Fetch an existing record
-        self.test_record = self.env.ref("l10n_br_fiscal.ncm_00000000")
+        cls.test_record = cls.env.ref("l10n_br_fiscal.ncm_00000000")
 
     def test_action_archive_manager(self):
         self.test_record.with_user(self.test_user_manager).action_archive()

--- a/l10n_br_hr/tests/test_hr_employee_dependent.py
+++ b/l10n_br_hr/tests/test_hr_employee_dependent.py
@@ -2,20 +2,21 @@ from dateutil.relativedelta import relativedelta
 
 from odoo.exceptions import ValidationError
 from odoo.fields import Date
-from odoo.tests import TransactionCase
+from odoo.tests import SavepointCase
 
 
-class TestHrEmployeeDependent(TransactionCase):
-    def setUp(self):
-        super(TestHrEmployeeDependent, self).setUp()
+class TestHrEmployeeDependent(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
-        self.employee = self.env["hr.employee"]
-        self.employee = self.employee.create(
+        cls.employee = cls.env["hr.employee"]
+        cls.employee = cls.employee.create(
             {
-                "address_id": self.env["res.partner"].search([]).company_id.id,
-                "company_id": self.env["res.partner"].search([]).company_id.id,
-                "department_id": self.env["hr.department"],
-                "civil_certificate_type_id": self.env["hr.civil.certificate.type"],
+                "address_id": cls.env["res.partner"].search([]).company_id.id,
+                "company_id": cls.env["res.partner"].search([]).company_id.id,
+                "department_id": cls.env["hr.department"],
+                "civil_certificate_type_id": cls.env["hr.civil.certificate.type"],
                 "deficiency_id": 1,
                 "deficiency_description": "Deficiency in index finger",
                 "name": "l10n brazil demo employee",
@@ -24,21 +25,21 @@ class TestHrEmployeeDependent(TransactionCase):
             }
         )
 
-        self.employee_dependent = self.env["hr.employee.dependent"]
-        self.employee_dependent = self.employee_dependent.create(
+        cls.employee_dependent = cls.env["hr.employee.dependent"]
+        cls.employee_dependent = cls.employee_dependent.create(
             {
-                "employee_id": self.employee.id,
+                "employee_id": cls.employee.id,
                 "name": "Dependent 01",
                 "dependent_dob": "2019-01-01",
                 "inscr_est": "49.365.539-6",
                 "cnpj_cpf": "417.668.850-55",
-                "dependent_type_id": self.env["hr.dependent.type"].search([])[0].id,
+                "dependent_type_id": cls.env["hr.dependent.type"].search([])[0].id,
             }
         )
 
-        self.employee._check_dependents()
-        self.assertTrue(self.employee, "Error on create a l10n_br employee")
-        self.assertTrue(self.employee_dependent, "Error on create a employee dependent")
+        cls.employee._check_dependents()
+        cls.assertTrue(cls.employee, "Error on create a l10n_br employee")
+        cls.assertTrue(cls.employee_dependent, "Error on create a employee dependent")
 
     def test_invalid_hr_employee_dependent_cpf(self):
         try:

--- a/l10n_br_hr/tests/test_l10n_br_hr.py
+++ b/l10n_br_hr/tests/test_l10n_br_hr.py
@@ -1,18 +1,19 @@
 from odoo.exceptions import ValidationError
-from odoo.tests import TransactionCase
+from odoo.tests import SavepointCase
 
 
-class TestL10nBr(TransactionCase):
-    def setUp(self):
-        super(TestL10nBr, self).setUp()
+class TestL10nBr(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
-        self.employee = self.env["hr.employee"]
-        self.employee = self.employee.create(
+        cls.employee = cls.env["hr.employee"]
+        cls.employee = cls.employee.create(
             {
-                "address_id": self.env["res.partner"].search([]).company_id.id,
-                "company_id": self.env["res.partner"].search([]).company_id.id,
-                "department_id": self.env["hr.department"],
-                "civil_certificate_type_id": self.env["hr.civil.certificate.type"],
+                "address_id": cls.env["res.partner"].search([]).company_id.id,
+                "company_id": cls.env["res.partner"].search([]).company_id.id,
+                "department_id": cls.env["hr.department"],
+                "civil_certificate_type_id": cls.env["hr.civil.certificate.type"],
                 "deficiency_id": 1,
                 "deficiency_description": "Deficiency in index finger",
                 "name": "l10n brazil demo employee",
@@ -21,7 +22,7 @@ class TestL10nBr(TransactionCase):
             }
         )
 
-        self.assertTrue(self.employee, "Error on create a l10n_br employee")
+        cls.assertTrue(cls.employee, "Error on create a l10n_br employee")
 
     def test_invalid_hr_employee_cpf(self):
         try:

--- a/l10n_br_nfe/tests/test_account_customer_nfe.py
+++ b/l10n_br_nfe/tests/test_account_customer_nfe.py
@@ -3,19 +3,20 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 
-from odoo.tests.common import TransactionCase
+from odoo.tests import SavepointCase
 
 
-class TestCustomerNFe(TransactionCase):
-    def setUp(self):
-        super(TestCustomerNFe, self).setUp()
-        self.invoice_same_state = self.env.ref(
+class TestCustomerNFe(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.invoice_same_state = cls.env.ref(
             "l10n_br_account_product.demo_nfe_same_state"
         )
-        self.invoice_other_costs = self.env.ref(
+        cls.invoice_other_costs = cls.env.ref(
             "l10n_br_account_product.demo_nfe_other_costs"
         )
-        self.invoice_difal = self.env.ref("l10n_br_account_product.demo_nfe_difal")
+        cls.invoice_difal = cls.env.ref("l10n_br_account_product.demo_nfe_difal")
 
     def test_customer_nfe_same_state(self):
         """Test customer NFe same state 'Contribuinte'"""

--- a/l10n_br_pos/tests/test_l10n_br_pos_config.py
+++ b/l10n_br_pos/tests/test_l10n_br_pos_config.py
@@ -1,9 +1,10 @@
 # Copyright 2022 KMEE
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo.tests.common import TransactionCase
+from odoo.tests import TransactionCase
 
 
+# for some reason conversion to SavepointCase fails
 class TestL10nBrPosConfig(TransactionCase):
     def setUp(self):
         super().setUp()

--- a/l10n_br_pos/tests/test_l10n_br_pos_order.py
+++ b/l10n_br_pos/tests/test_l10n_br_pos_order.py
@@ -4,16 +4,17 @@
 from datetime import datetime
 
 from odoo import fields
-from odoo.tests.common import TransactionCase
+from odoo.tests import SavepointCase
 
 
-class TestL10nBrPosOrder(TransactionCase):
-    def setUp(self):
-        super().setUp()
-        self.env.company = self.env.ref("l10n_br_base.empresa_lucro_presumido")
-        self.pos_config = self.env.ref("l10n_br_pos.pos_config_presumido")
-        self.cash_payment_method = self.env.ref("l10n_br_pos.presumido_dinheiro")
-        self.led_lamp = self.env["product.product"].create(
+class TestL10nBrPosOrder(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.company = cls.env.ref("l10n_br_base.empresa_lucro_presumido")
+        cls.pos_config = cls.env.ref("l10n_br_pos.pos_config_presumido")
+        cls.cash_payment_method = cls.env.ref("l10n_br_pos.presumido_dinheiro")
+        cls.led_lamp = cls.env["product.product"].create(
             {
                 "name": "LED Lamp",
                 "available_in_pos": True,

--- a/l10n_br_pos/tests/test_l10n_br_pos_partner.py
+++ b/l10n_br_pos/tests/test_l10n_br_pos_partner.py
@@ -1,13 +1,14 @@
 # Copyright 2023 KMEE
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo.tests.common import TransactionCase
+from odoo.tests import SavepointCase
 
 
-class TestL10nBrPosPartner(TransactionCase):
-    def setUp(self):
-        super().setUp()
-        self.pos_config = self.env.ref("point_of_sale.pos_config_main")
+class TestL10nBrPosPartner(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.pos_config = cls.env.ref("point_of_sale.pos_config_main")
 
     def test_create_partner_from_ui_l10n_brazil(self):
 

--- a/l10n_br_resource/tests/test_resource_calendar.py
+++ b/l10n_br_resource/tests/test_resource_calendar.py
@@ -5,6 +5,7 @@ import odoo.tests.common as test_common
 from odoo import fields
 
 
+# for some reason conversion to SavepointCase fails
 class TestResourceCalendar(test_common.SingleTransactionCase):
     def setUp(self):
         super(TestResourceCalendar, self).setUp()

--- a/l10n_br_resource/tests/test_resource_calendar_2.py
+++ b/l10n_br_resource/tests/test_resource_calendar_2.py
@@ -1,25 +1,25 @@
 from datetime import date, datetime
 
-from odoo.tests import common
+from odoo.tests import SavepointCase
 
 
-class TestResourceCalendar(common.TransactionCase):
-    def setUp(self):
-        super(TestResourceCalendar, self).setUp()
-        self.calendar = self.env["resource.calendar"].create({"name": "Test Calendar"})
+class TestResourceCalendar(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.calendar = cls.env["resource.calendar"].create({"name": "Test Calendar"})
 
-        self.env["resource.calendar.leaves"].create(
+        cls.env["resource.calendar.leaves"].create(
             {
                 "name": "Christmas",
                 "date_from": date(2023, 12, 25),
                 "date_to": date(2023, 12, 25),
                 "leave_type": "F",
-                "calendar_id": self.calendar.id,
+                "calendar_id": cls.calendar.id,
             }
         )
 
     def test_data_eh_feriado(self):
-
         holiday_date = datetime(2023, 12, 25)
         result = self.calendar.data_eh_feriado(holiday_date)
         expected_result = True
@@ -73,7 +73,6 @@ class TestResourceCalendar(common.TransactionCase):
         )
 
     def test_data_eh_feriado_emendado(self):
-
         reference_data = datetime(2023, 9, 7, 15, 0, 0)
         expected_result = False
 

--- a/l10n_br_zip/tests/test_l10n_br_zip_res_company.py
+++ b/l10n_br_zip/tests/test_l10n_br_zip_res_company.py
@@ -4,37 +4,38 @@
 
 from unittest import mock
 
-from odoo.tests.common import TransactionCase
+from odoo.tests import SavepointCase
 
 _module_ns = "odoo.addons.l10n_br_zip"
 _provider_class = _module_ns + ".models.l10n_br_zip" + ".L10nBrZip"
 
 
-class L10nBRZipTest(TransactionCase):
-    def setUp(self):
-        super(L10nBRZipTest, self).setUp()
+class L10nBRZipTest(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
-        self.zip_obj = self.env["l10n_br.zip"]
-        self.zip_1 = self.zip_obj.create(
+        cls.zip_obj = cls.env["l10n_br.zip"]
+        cls.zip_1 = cls.zip_obj.create(
             dict(
                 zip_code="01310923",
-                city_id=self.env.ref("l10n_br_base.city_3550308").id,
-                state_id=self.env.ref("base.state_br_sp").id,
-                country_id=self.env.ref("base.br").id,
+                city_id=cls.env.ref("l10n_br_base.city_3550308").id,
+                state_id=cls.env.ref("base.state_br_sp").id,
+                country_id=cls.env.ref("base.br").id,
                 street_name="Avenida Paulista 1842",
                 street_type="Avenida",
                 district="Bela Vista",
             )
         )
-        self.company = self.env.ref("base.main_company")
-        self.company_1 = self.env["res.company"].create(
+        cls.company = cls.env.ref("base.main_company")
+        cls.company_1 = cls.env["res.company"].create(
             dict(
                 name="teste",
                 street_name="paulista",
                 district="Bela Vista",
-                country_id=self.env.ref("base.br").id,
-                state_id=self.env.ref("base.state_br_sp").id,
-                city_id=self.env.ref("l10n_br_base.city_3550308").id,
+                country_id=cls.env.ref("base.br").id,
+                state_id=cls.env.ref("base.state_br_sp").id,
+                city_id=cls.env.ref("l10n_br_base.city_3550308").id,
             )
         )
 

--- a/l10n_br_zip/tests/test_l10n_br_zip_res_partner.py
+++ b/l10n_br_zip/tests/test_l10n_br_zip_res_partner.py
@@ -4,37 +4,38 @@
 
 from unittest import mock
 
-from odoo.tests.common import TransactionCase
+from odoo.tests import SavepointCase
 
 _module_ns = "odoo.addons.l10n_br_zip"
 _provider_class = _module_ns + ".models.l10n_br_zip" + ".L10nBrZip"
 
 
-class L10nBRZipTest(TransactionCase):
-    def setUp(self):
-        super().setUp()
+class L10nBRZipTest(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
-        self.zip_obj = self.env["l10n_br.zip"]
-        self.zip_1 = self.zip_obj.create(
+        cls.zip_obj = cls.env["l10n_br.zip"]
+        cls.zip_1 = cls.zip_obj.create(
             dict(
                 zip_code="01310923",
-                city_id=self.env.ref("l10n_br_base.city_3550308").id,
-                state_id=self.env.ref("base.state_br_sp").id,
-                country_id=self.env.ref("base.br").id,
+                city_id=cls.env.ref("l10n_br_base.city_3550308").id,
+                state_id=cls.env.ref("base.state_br_sp").id,
+                country_id=cls.env.ref("base.br").id,
                 street_name="Avenida Paulista 1842",
                 street_type="Avenida",
                 district="Bela Vista",
             )
         )
-        self.res_partner = self.env.ref("l10n_br_base.res_partner_akretion")
-        self.res_partner_1 = self.env["res.partner"].create(
+        cls.res_partner = cls.env.ref("l10n_br_base.res_partner_akretion")
+        cls.res_partner_1 = cls.env["res.partner"].create(
             dict(
                 name="teste",
                 street_name="paulista",
                 district="Bela Vista",
-                country_id=self.env.ref("base.br").id,
-                state_id=self.env.ref("base.state_br_sp").id,
-                city_id=self.env.ref("l10n_br_base.city_3550308").id,
+                country_id=cls.env.ref("base.br").id,
+                state_id=cls.env.ref("base.state_br_sp").id,
+                city_id=cls.env.ref("l10n_br_base.city_3550308").id,
             )
         )
 


### PR DESCRIPTION
já que estamos adicionando mais tests https://github.com/OCA/l10n-brazil/pull/2551 e que vamos adicionar mais ainda, è bom deixar os testes rápidos. Para isso é essencial usar o SavePointCase que tem um savepoint e não precisa refazer o setup a cada execução, isso salva milhares de queries. Na versão 16.0 o TransactionPointCase virou um SavePointCase mas isso não é o caso ainda na 14.0 então é importante fazer essa mudança para SavePoint aqui.

Vale a pena dizer que o SavePointCase so tem um ganho quando ha varios testes no arquivo. Senão vale até mais a pena deixar um TransactionCase para minimizar o diff com a v16 onde tera que ser TransactionCase sempre (que é a mesma coisa então que um SavePointCase na v16).

@felipemotter eu dividi seu l10n_br_account/tests/test_invoice_general_cases.py em 2 tests arquivos mais explicitos:

- l10n_br_account/tests/test_document_date.py
- e l10n_br_account/tests/test_move_discount.py

Esse ultimo porem não funcionou de usar um SavePointcase. Eu deixei como TransactionCase, ja que ele é o único do arquivo não faz diferença.