### PR TITLE
[14.0] l10n_br_account, l10n_br_fiscal: Possibilidade de informar os valores dos impostos manualmente.

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -422,7 +422,7 @@ class AccountMove(models.Model):
                 tax_type == "purchase" and base_line.credit
             )
             price_unit_wo_discount = base_line.amount_currency
-
+        manual_tax_values = base_line._prepare_br_manual_tax_dict()
         balance_taxes_res = base_line.tax_ids._origin.with_context(
             force_sign=move._get_tax_force_sign()
         ).compute_all(
@@ -451,6 +451,7 @@ class AccountMove(models.Model):
             icmssn_range=base_line.icmssn_range_id,
             icms_origin=base_line.icms_origin,
             ind_final=base_line.ind_final,
+            **manual_tax_values,
         )
         return balance_taxes_res
 

--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -5,6 +5,10 @@
 
 from odoo import api, fields, models
 
+from odoo.addons.l10n_br_fiscal.models.document_fiscal_line_mixin_methods import (
+    FISCAL_TAX_PREFIXES,
+)
+
 from .account_move import InheritsCheckMuteLogger
 
 # These fields have the same name in account.move.line
@@ -369,6 +373,10 @@ class AccountMoveLine(models.Model):
         move_type=None,
     ):
         self.ensure_one()
+
+        # get the dict with the values of the taxes entered manually.
+        manual_tax_values = self._prepare_br_manual_tax_dict()
+
         return super(
             AccountMoveLine,
             self.with_context(
@@ -391,6 +399,7 @@ class AccountMoveLine(models.Model):
                 icms_origin=self.icms_origin,
                 ind_final=self.ind_final,
                 icms_relief_value=self.icms_relief_value,
+                **manual_tax_values,
             ),
         )._get_price_total_and_subtotal(
             price_unit=price_unit or self.price_unit,
@@ -402,6 +411,17 @@ class AccountMoveLine(models.Model):
             taxes=taxes or self.tax_ids,
             move_type=move_type or self.move_id.move_type,
         )
+
+    def _get_manual_tax_values_from_context(self):
+        tax_values = {}
+        suffixes = ["_base_manual", "_value_manual"]
+
+        for tax_prefix in FISCAL_TAX_PREFIXES:
+            for suffix in suffixes:
+                attr_name = tax_prefix + suffix
+                tax_values[attr_name] = self.env.context.get(attr_name)
+
+        return tax_values
 
     @api.model
     def _get_price_total_and_subtotal_model(
@@ -444,6 +464,7 @@ class AccountMoveLine(models.Model):
             force_sign = (
                 -1 if move_type in ("out_invoice", "in_refund", "out_receipt") else 1
             )
+            manual_tax_values = self._get_manual_tax_values_from_context()
             taxes_res = taxes._origin.with_context(force_sign=force_sign).compute_all(
                 line_discount_price_unit,
                 currency=currency,
@@ -470,6 +491,7 @@ class AccountMoveLine(models.Model):
                 icmssn_range=self.env.context.get("icmssn_range"),
                 icms_origin=self.env.context.get("icms_origin"),
                 ind_final=self.env.context.get("ind_final"),
+                **manual_tax_values,
             )
 
             result["price_subtotal"] = taxes_res["total_excluded"]
@@ -497,7 +519,47 @@ class AccountMoveLine(models.Model):
             # override the default product uom (set by the onchange):
             self.product_uom_id = self.fiscal_document_line_id.uom_id.id
 
-    @api.onchange("fiscal_tax_ids")
+    @api.onchange(
+        "fiscal_tax_ids",
+        "icms_base_manual",
+        "icms_value_manual",
+        "icmsst_base_manual",
+        "icmsst_value_manual",
+        "issqn_base_manual",
+        "issqn_value_manual",
+        "issqn_wh_base_manual",
+        "issqn_wh_value_manual",
+        "icmsst_wh_base_manual",
+        "icmsst_wh_value_manual",
+        "ipi_base_manual",
+        "ipi_value_manual",
+        "ii_base_manual",
+        "ii_value_manual",
+        "cofins_base_manual",
+        "cofins_value_manual",
+        "cofinsst_base_manual",
+        "cofinsst_value_manual",
+        "cofins_wh_base_manual",
+        "cofins_wh_value_manual",
+        "pis_base_manual",
+        "pis_value_manual",
+        "pisst_base_manual",
+        "pisst_value_manual",
+        "pis_wh_base_manual",
+        "pis_wh_value_manual",
+        "csll_base_manual",
+        "csll_value_manual",
+        "csll_wh_base_manual",
+        "csll_wh_value_manual",
+        "irpj_base_manual",
+        "irpj_value_manual",
+        "irpj_wh_base_manual",
+        "irpj_wh_value_manual",
+        "inss_base_manual",
+        "inss_value_manual",
+        "inss_wh_base_manual",
+        "inss_wh_value_manual",
+    )
     def _onchange_fiscal_tax_ids(self):
         """Ao alterar o campo fiscal_tax_ids que contém os impostos fiscais,
         são atualizados os impostos contábeis relacionados"""

--- a/l10n_br_account/models/account_tax.py
+++ b/l10n_br_account/models/account_tax.py
@@ -44,6 +44,7 @@ class AccountTax(models.Model):
         icmssn_range=None,
         icms_origin=None,
         ind_final=FINAL_CUSTOMER_NO,
+        **kwargs,
     ):
         """Returns all information required to apply taxes
             (in self + their children in case of a tax goup).
@@ -117,6 +118,7 @@ class AccountTax(models.Model):
             icmssn_range=icmssn_range,
             icms_origin=icms_origin or product.icms_origin,
             ind_final=ind_final,
+            **kwargs,
         )
 
         taxes_results["amount_tax_included"] = fiscal_taxes_results["amount_included"]

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin.py
@@ -297,6 +297,18 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         default=ISSQN_INCENTIVE_DEFAULT,
     )
 
+    issqn_base_manual = fields.Monetary(
+        string="Manual ISSQN Base",
+        help="Value of the ISSQN Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    issqn_value_manual = fields.Monetary(
+        string="Manual ISSQN Value",
+        help="Value of the ISSQN Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
     issqn_base = fields.Monetary(string="ISSQN Base")
 
     issqn_percent = fields.Float(string="ISSQN %")
@@ -309,6 +321,18 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         comodel_name="l10n_br_fiscal.tax",
         string="Tax ISSQN RET",
         domain=[("tax_domain", "=", TAX_DOMAIN_ISSQN_WH)],
+    )
+
+    issqn_wh_base_manual = fields.Monetary(
+        string="Manual ISSQN RET Base",
+        help="Value of the ISSQN RET Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    issqn_wh_value_manual = fields.Monetary(
+        string="Manual ISSQN RET Value",
+        help="Value of the ISSQN RET Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
     )
 
     issqn_wh_base = fields.Monetary(string="ISSQN RET Base")
@@ -360,6 +384,18 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         selection=ICMS_ORIGIN, string="ICMS Origin", default=ICMS_ORIGIN_DEFAULT
     )
 
+    icms_base_manual = fields.Monetary(
+        string="Manual ICMS Base",
+        help="Value of the ICMS Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    icms_value_manual = fields.Monetary(
+        string="Manual ICMS Value",
+        help="Value of the ICMS Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
     # vBC - Valor da base de cálculo do ICMS
     icms_base = fields.Monetary(string="ICMS Base")
 
@@ -400,6 +436,18 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         default=ICMS_ST_BASE_TYPE_DEFAULT,
     )
 
+    icmsst_base_manual = fields.Monetary(
+        string="Manual ICMS ST Base",
+        help="Value of the ICMS ST Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    icmsst_value_manual = fields.Monetary(
+        string="Manual ICMS ST Value",
+        help="Value of the ICMS ST Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
     # pMVAST - Percentual da margem de valor Adicionado do ICMS ST
     icmsst_mva_percent = fields.Float(string="ICMS ST MVA %")
 
@@ -414,6 +462,18 @@ class FiscalDocumentLineMixin(models.AbstractModel):
 
     # vICMSST - Valor do ICMS ST
     icmsst_value = fields.Monetary(string="ICMS ST Value")
+
+    icmsst_wh_base_manual = fields.Monetary(
+        string="Manual ICMS ST RET Base",
+        help="Value of the ICMS ST RET Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    icmsst_wh_value_manual = fields.Monetary(
+        string="Manual ICMS ST RET Value",
+        help="Value of the ICMS ST RET Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
 
     # vBCSTRet - Valor da base de cálculo do ICMS ST retido
     icmsst_wh_base = fields.Monetary(string="ICMS ST WH Base")
@@ -549,6 +609,18 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         selection=TAX_BASE_TYPE, string="IPI Base Type", default=TAX_BASE_TYPE_PERCENT
     )
 
+    ipi_base_manual = fields.Monetary(
+        string="Manual IPI Base",
+        help="Value of the IPI Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    ipi_value_manual = fields.Monetary(
+        string="Manual IPI Value",
+        help="Value of the IPI Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
     ipi_base = fields.Monetary(string="IPI Base")
 
     ipi_percent = fields.Float(string="IPI %")
@@ -569,6 +641,18 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         comodel_name="l10n_br_fiscal.tax",
         string="Tax II",
         domain=[("tax_domain", "=", TAX_DOMAIN_II)],
+    )
+
+    ii_base_manual = fields.Monetary(
+        string="Manual II Base",
+        help="Value of the II Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    ii_value_manual = fields.Monetary(
+        string="Manual II Value",
+        help="Value of the II Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
     )
 
     ii_base = fields.Monetary(string="II Base")
@@ -605,6 +689,18 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         selection=TAX_BASE_TYPE,
         string="COFINS Base Type",
         default=TAX_BASE_TYPE_PERCENT,
+    )
+
+    cofins_base_manual = fields.Monetary(
+        string="Manual COFINS Base",
+        help="Value of the COFINS Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    cofins_value_manual = fields.Monetary(
+        string="Manual COFINS Value",
+        help="Value of the COFINS Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
     )
 
     cofins_base = fields.Monetary(string="COFINS Base")
@@ -648,6 +744,18 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         default=TAX_BASE_TYPE_PERCENT,
     )
 
+    cofinsst_base_manual = fields.Monetary(
+        string="Manual COFINS ST Base",
+        help="Value of the COFINS ST Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    cofinsst_value_manual = fields.Monetary(
+        string="Manual COFINS ST Value",
+        help="Value of the COFINS ST Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
     cofinsst_base = fields.Monetary(string="COFINS ST Base")
 
     cofinsst_percent = fields.Float(string="COFINS ST %")
@@ -666,6 +774,18 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         selection=TAX_BASE_TYPE,
         string="COFINS WH Base Type",
         default=TAX_BASE_TYPE_PERCENT,
+    )
+
+    cofins_wh_base_manual = fields.Monetary(
+        string="Manual COFINS RET Base",
+        help="Value of the COFINS RET Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    cofins_wh_value_manual = fields.Monetary(
+        string="Manual COFINS RET Value",
+        help="Value of the COFINS RET Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
     )
 
     cofins_wh_base = fields.Monetary(string="COFINS RET Base")
@@ -697,6 +817,18 @@ class FiscalDocumentLineMixin(models.AbstractModel):
 
     pis_base_type = fields.Selection(
         selection=TAX_BASE_TYPE, string="PIS Base Type", default=TAX_BASE_TYPE_PERCENT
+    )
+
+    pis_base_manual = fields.Monetary(
+        string="Manual PIS Base",
+        help="Value of the PIS Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    pis_value_manual = fields.Monetary(
+        string="Manual PIS Value",
+        help="Value of the PIS Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
     )
 
     pis_base = fields.Monetary(string="PIS Base")
@@ -740,6 +872,18 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         default=TAX_BASE_TYPE_PERCENT,
     )
 
+    pisst_base_manual = fields.Monetary(
+        string="Manual PIS ST Base",
+        help="Value of the PIS ST Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    pisst_value_manual = fields.Monetary(
+        string="Manual PIS ST Value",
+        help="Value of the PIS ST Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
     pisst_base = fields.Monetary(string="PIS ST Base")
 
     pisst_percent = fields.Float(string="PIS ST %")
@@ -760,6 +904,18 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         default=TAX_BASE_TYPE_PERCENT,
     )
 
+    pis_wh_base_manual = fields.Monetary(
+        string="Manual PIS RET Base",
+        help="Value of the PIS RET Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    pis_wh_value_manual = fields.Monetary(
+        string="Manual PIS RET Value",
+        help="Value of the PIS RET Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
     pis_wh_base = fields.Monetary(string="PIS RET Base")
 
     pis_wh_percent = fields.Float(string="PIS RET %")
@@ -773,6 +929,18 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         comodel_name="l10n_br_fiscal.tax",
         string="Tax CSLL",
         domain=[("tax_domain", "=", TAX_DOMAIN_CSLL)],
+    )
+
+    csll_base_manual = fields.Monetary(
+        string="Manual CSLL Base",
+        help="Value of the CSLL Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    csll_value_manual = fields.Monetary(
+        string="Manual CSLL Value",
+        help="Value of the CSLL Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
     )
 
     csll_base = fields.Monetary(string="CSLL Base")
@@ -789,6 +957,18 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         domain=[("tax_domain", "=", TAX_DOMAIN_CSLL_WH)],
     )
 
+    csll_wh_base_manual = fields.Monetary(
+        string="Manual CSLL RET Base",
+        help="Value of the CSLL RET Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    csll_wh_value_manual = fields.Monetary(
+        string="Manual CSLL RET Value",
+        help="Value of the CSLL RET Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
     csll_wh_base = fields.Monetary(string="CSLL RET Base")
 
     csll_wh_percent = fields.Float(string="CSLL RET %")
@@ -801,6 +981,18 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         comodel_name="l10n_br_fiscal.tax",
         string="Tax IRPJ",
         domain=[("tax_domain", "=", TAX_DOMAIN_IRPJ)],
+    )
+
+    irpj_base_manual = fields.Monetary(
+        string="Manual IRPJ Base",
+        help="Value of the IRPJ Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    irpj_value_manual = fields.Monetary(
+        string="Manual IRPJ Value",
+        help="Value of the IRPJ Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
     )
 
     irpj_base = fields.Monetary(string="IRPJ Base")
@@ -817,6 +1009,18 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         domain=[("tax_domain", "=", TAX_DOMAIN_IRPJ_WH)],
     )
 
+    irpj_wh_base_manual = fields.Monetary(
+        string="Manual IRPJ RET Base",
+        help="Value of the IRPJ RET Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    irpj_wh_value_manual = fields.Monetary(
+        string="Manual IRPJ RET Value",
+        help="Value of the IRPJ RET Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
     irpj_wh_base = fields.Monetary(string="IRPJ RET Base")
 
     irpj_wh_percent = fields.Float(string="IRPJ RET %")
@@ -831,6 +1035,18 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         domain=[("tax_domain", "=", TAX_DOMAIN_INSS)],
     )
 
+    inss_base_manual = fields.Monetary(
+        string="Manual INSS Base",
+        help="Value of the INSS Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    inss_value_manual = fields.Monetary(
+        string="Manual INSS Value",
+        help="Value of the INSS Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
     inss_base = fields.Monetary(string="INSS Base")
 
     inss_percent = fields.Float(string="INSS %")
@@ -843,6 +1059,18 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         comodel_name="l10n_br_fiscal.tax",
         string="Tax INSS RET",
         domain=[("tax_domain", "=", TAX_DOMAIN_INSS_WH)],
+    )
+
+    inss_wh_base_manual = fields.Monetary(
+        string="Manual INSS RET Base",
+        help="Value of the INSS RET Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    inss_wh_value_manual = fields.Monetary(
+        string="Manual INSS Value",
+        help="Value of the INSS Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
     )
 
     inss_wh_base = fields.Monetary(string="INSS RET Base")

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -44,6 +44,28 @@ FISCAL_CST_ID_FIELDS = [
     "cofinsst_cst_id",
 ]
 
+FISCAL_TAX_PREFIXES = [
+    "icms",
+    "icmsst",
+    "issqn",
+    "issqn_wh",
+    "icmsst_wh",
+    "ipi",
+    "ii",
+    "cofins",
+    "cofinsst",
+    "cofins_wh",
+    "pis",
+    "pisst",
+    "pis_wh",
+    "csll",
+    "csll_wh",
+    "irpj",
+    "irpj_wh",
+    "inss",
+    "inss_wh",
+]
+
 
 class FiscalDocumentLineMixinMethods(models.AbstractModel):
     _name = "l10n_br_fiscal.document.line.mixin.methods"
@@ -194,6 +216,10 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
 
     def _compute_taxes(self, taxes, cst=None):
         self.ensure_one()
+
+        # get the dict with the values of the taxes entered manually.
+        manual_tax_values = self._prepare_br_manual_tax_dict()
+
         return taxes.compute_taxes(
             company=self.company_id,
             partner=self.partner_id,
@@ -219,6 +245,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             icmssn_range=self.icmssn_range_id,
             icms_origin=self.icms_origin,
             icms_cst_id=self.icms_cst_id,
+            **manual_tax_values,
             ind_final=self.ind_final,
             icms_relief_id=self.icms_relief_id,
         )
@@ -248,6 +275,17 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         if default:  # in case you want to use new rather than write later
             return {"default_%s" % (k,): vals[k] for k in vals.keys()}
         return vals
+
+    def _prepare_br_manual_tax_dict(self):
+        manual_tax_dict = {}
+        suffixes = ["_base_manual", "_value_manual"]
+
+        for tax_prefix in FISCAL_TAX_PREFIXES:
+            for suffix in suffixes:
+                attr_name = tax_prefix + suffix
+                manual_tax_dict[attr_name] = getattr(self, attr_name)
+
+        return manual_tax_dict
 
     def _get_all_tax_id_fields(self):
         self.ensure_one()
@@ -811,6 +849,44 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         "insurance_value",
         "other_value",
         "freight_value",
+        "icms_base_manual",
+        "icms_value_manual",
+        "icmsst_base_manual",
+        "icmsst_value_manual",
+        "issqn_base_manual",
+        "issqn_value_manual",
+        "issqn_wh_base_manual",
+        "issqn_wh_value_manual",
+        "icmsst_wh_base_manual",
+        "icmsst_wh_value_manual",
+        "ipi_base_manual",
+        "ipi_value_manual",
+        "ii_base_manual",
+        "ii_value_manual",
+        "cofins_base_manual",
+        "cofins_value_manual",
+        "cofinsst_base_manual",
+        "cofinsst_value_manual",
+        "cofins_wh_base_manual",
+        "cofins_wh_value_manual",
+        "pis_base_manual",
+        "pis_value_manual",
+        "pisst_base_manual",
+        "pisst_value_manual",
+        "pis_wh_base_manual",
+        "pis_wh_value_manual",
+        "csll_base_manual",
+        "csll_value_manual",
+        "csll_wh_base_manual",
+        "csll_wh_value_manual",
+        "irpj_base_manual",
+        "irpj_value_manual",
+        "irpj_wh_base_manual",
+        "irpj_wh_value_manual",
+        "inss_base_manual",
+        "inss_value_manual",
+        "inss_wh_base_manual",
+        "inss_wh_value_manual",
     )
     def _onchange_fiscal_taxes(self):
         self._update_fiscal_tax_ids(self._get_all_tax_id_fields())

--- a/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
@@ -1,351 +1,463 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
 
-  <record id="document_fiscal_line_mixin_form" model="ir.ui.view">
-    <field name="name">l10n_br_fiscal.document.line.mixin.form</field>
-    <field name="model">l10n_br_fiscal.document.line</field>
-    <field name="arch" type="xml">
-      <form>
-        <group name="fiscal_fields" invisible="1">
-          <field name="currency_id" force_save="1" invisible="1" />
-          <field name="fiscal_operation_type" force_save="1" invisible="1" />
-          <field name="company_id" force_save="1" invisible="1" />
-          <field name="partner_id" force_save="1" invisible="1" />
-          <field name="fiscal_type" force_save="1" invisible="1" />
-          <field name="partner_company_type" force_save="1" invisible="1" />
-          <field name="tax_framework" force_save="1" invisible="1" />
-          <field name="amount_tax_not_included" force_save="1" invisible="1" />
-          <field name="amount_tax_withholding" force_save="1" invisible="1" />
-          <field name="cfop_destination" force_save="1" invisible="1" />
-          <field name="fiscal_genre_id" force_save="1" invisible="1" />
-          <field name="fiscal_genre_code" force_save="1" invisible="1" />
-          <field name="ncm_id" force_save="1" invisible="1" />
-          <field name="nbm_id" force_save="1" invisible="1" />
-          <field name="cest_id" force_save="1" invisible="1" />
-          <field name="nbs_id" force_save="1" invisible="1" />
-          <field name="service_type_id" force_save="1" invisible="1" />
-          <field name="city_taxation_code_id" force_save="1" invisible="1" />
-          <field name="uot_id" force_save="1" invisible="1" />
-          <field name="fiscal_price" force_save="1" invisible="1" />
-          <field name="fiscal_quantity" force_save="1" invisible="1" />
-          <field name="fiscal_tax_ids" force_save="1" invisible="1" readonly="1" />
-          <field name="allow_csll_irpj" force_save="1" invisible="1" />
-        </group>
-        <notebook>
-          <field name="product_id" force_save="1" invisible="1" />
-          <page name="fiscal_taxes" string="Taxes">
-            <group>
-              <field name="tax_framework" invisible="1" />
-              <field
+    <record id="document_fiscal_line_mixin_form" model="ir.ui.view">
+        <field name="name">l10n_br_fiscal.document.line.mixin.form</field>
+        <field name="model">l10n_br_fiscal.document.line</field>
+        <field name="arch" type="xml">
+            <form>
+                <group name="fiscal_fields" invisible="1">
+                    <field name="currency_id" force_save="1" invisible="1" />
+                    <field name="fiscal_operation_type" force_save="1" invisible="1" />
+                    <field name="company_id" force_save="1" invisible="1" />
+                    <field name="partner_id" force_save="1" invisible="1" />
+                    <field name="fiscal_type" force_save="1" invisible="1" />
+                    <field name="partner_company_type" force_save="1" invisible="1" />
+                    <field name="tax_framework" force_save="1" invisible="1" />
+                    <field
+                        name="amount_tax_not_included"
+                        force_save="1"
+                        invisible="1"
+                    />
+                    <field name="amount_tax_withholding" force_save="1" invisible="1" />
+                    <field name="cfop_destination" force_save="1" invisible="1" />
+                    <field name="fiscal_genre_id" force_save="1" invisible="1" />
+                    <field name="fiscal_genre_code" force_save="1" invisible="1" />
+                    <field name="ncm_id" force_save="1" invisible="1" />
+                    <field name="nbm_id" force_save="1" invisible="1" />
+                    <field name="cest_id" force_save="1" invisible="1" />
+                    <field name="nbs_id" force_save="1" invisible="1" />
+                    <field name="service_type_id" force_save="1" invisible="1" />
+                    <field name="city_taxation_code_id" force_save="1" invisible="1" />
+                    <field name="uot_id" force_save="1" invisible="1" />
+                    <field name="fiscal_price" force_save="1" invisible="1" />
+                    <field name="fiscal_quantity" force_save="1" invisible="1" />
+                    <field
+                        name="fiscal_tax_ids"
+                        force_save="1"
+                        invisible="1"
+                        readonly="1"
+                    />
+                    <field name="allow_csll_irpj" force_save="1" invisible="1" />
+                </group>
+                <notebook>
+                    <field name="product_id" force_save="1" invisible="1" />
+                    <page name="fiscal_taxes" string="Taxes">
+                        <group>
+                            <field name="tax_framework" invisible="1" />
+                            <field
                                 name="tax_icms_or_issqn"
                                 force_save="1"
                                 attrs="{'readonly': [('product_id', '!=', False), ('tax_icms_or_issqn', '!=', False)], 'required': [('tax_icms_or_issqn', '!=', False), ('fiscal_tax_ids', '!=', False)]}"
                             />
-            </group>
-            <notebook>
-              <page
+                        </group>
+                        <notebook>
+                            <page
                                 name="issqn"
                                 string="ISSQN"
                                 attrs="{'invisible': [('tax_icms_or_issqn', '!=', 'issqn')]}"
                             >
-                <group>
-                  <field
+                                <group>
+                                    <field
                                         name="issqn_tax_id"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
-                  <field
+                                    <field
                                         name="issqn_fg_city_id"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
-                  <field
+                                    <field
                                         name="issqn_eligibility"
                                         attrs="{'required': [('tax_icms_or_issqn', '=', 'issqn')]}"
                                     />
-                  <field
+                                    <field
                                         name="issqn_incentive"
                                         attrs="{'required': [('tax_icms_or_issqn', '=', 'issqn')]}"
                                     />
-                </group>
-                <group>
-                  <group>
-                    <field
+                                </group>
+                                <group>
+                                    <group>
+                                        <field
                                             name="issqn_base"
                                             force_save="1"
                                             attrs="{'readonly': [('issqn_tax_id', '!=', False)]}"
                                         />
-                    <field
+                                        <field
                                             name="issqn_percent"
                                             force_save="1"
                                             attrs="{'readonly': [('issqn_tax_id', '!=', False)]}"
                                         />
-                    <field
+                                        <field
                                             name="issqn_reduction"
                                             force_save="1"
                                             attrs="{'readonly': [('issqn_tax_id', '!=', False)]}"
                                         />
-                    <field
+                                        <field
                                             name="issqn_value"
                                             force_save="1"
                                             attrs="{'readonly': [('issqn_tax_id', '!=', False)]}"
                                         />
-                  </group>
-                  <group>
-                    <field
+                                    </group>
+                                    <group name="issqn_manual" string="Manual">
+                                        <div
+                                            class="text-muted"
+                                            colspan="2"
+                                        >Keep empty for automatic
+                                            calculation</div>
+                                        <field
+                                            name="issqn_base_manual"
+                                            string="Base"
+                                            force_save="1"
+                                        />
+                                        <field
+                                            name="issqn_value_manual"
+                                            string="Value"
+                                            force_save="1"
+                                        />
+                                    </group>
+                                    <group>
+                                        <field
                                             name="issqn_deduction_amount"
                                             force_save="1"
                                             attrs="{'readonly': [('issqn_tax_id', '!=', False)]}"
                                         />
-                    <field
+                                        <field
                                             name="issqn_other_amount"
                                             force_save="1"
                                             attrs="{'readonly': [('issqn_tax_id', '!=', False)]}"
                                         />
-                    <field
+                                        <field
                                             name="issqn_desc_incond_amount"
                                             force_save="1"
                                             attrs="{'readonly': [('issqn_tax_id', '!=', False)]}"
                                         />
-                    <field
+                                        <field
                                             name="issqn_desc_cond_amount"
                                             force_save="1"
                                             attrs="{'readonly': [('issqn_tax_id', '!=', False)]}"
                                         />
-                    <field
+                                        <field
                                             name="issqn_desc_cond_amount"
                                             force_save="1"
                                             attrs="{'readonly': [('issqn_tax_id', '!=', False)]}"
                                         />
-                  </group>
-                </group>
-                <group string="Retenções">
-                   <field
+                                    </group>
+                                </group>
+                                <group string="Retenções">
+                                    <field
                                         name="issqn_wh_tax_id"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
-                  </group>
-                  <group>
-                      <group>
-                        <field
-                                            name="issqn_wh_base"
-                                            force_save="1"
-                                            attrs="{'readonly': [('issqn_wh_tax_id', '!=', False)]}"
-                                        />
-                        <field
+                                </group>
+                                <group>
+                                    <group>
+                                        <field name="issqn_wh_base" force_save="1" />
+                                        <field
                                             name="issqn_wh_percent"
                                             force_save="1"
                                             attrs="{'readonly': [('issqn_wh_tax_id', '!=', False)]}"
                                         />
-                      </group>
-                      <group>
-                        <field
+                                        <field
                                             name="issqn_wh_reduction"
                                             force_save="1"
                                             attrs="{'readonly': [('issqn_wh_tax_id', '!=', False)]}"
                                         />
-                        <field
+                                        <field
                                             name="issqn_wh_value"
                                             force_save="1"
                                             attrs="{'readonly': [('issqn_wh_tax_id', '!=', False)]}"
                                         />
-                      </group>
-                  </group>
-              </page>
-              <page
+                                    </group>
+                                    <group name="issqn_wh_manual" string="Manual">
+                                        <div
+                                            class="text-muted"
+                                            colspan="2"
+                                        >Keep empty for automatic
+                                            calculation</div>
+                                        <field
+                                            name="issqn_wh_base_manual"
+                                            string="Base"
+                                            force_save="1"
+                                        />
+                                        <field
+                                            name="issqn_wh_value_manual"
+                                            string="Value"
+                                            force_save="1"
+                                        />
+                                    </group>
+                                </group>
+                            </page>
+                            <page
                                 name="icms"
                                 string="ICMS"
                                 attrs="{'invisible': [('tax_icms_or_issqn', '!=', 'icms')]}"
                             >
-                  <group name="icms" string="ICMS">
-                    <field
+                                <group name="icms" string="ICMS">
+                                    <field
                                         name="icms_tax_id"
                                         attrs="{'invisible': [('tax_framework', 'in', ('1', '2'))]}"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
-                    <field
+                                    <field
                                         name="icmssn_tax_id"
                                         attrs="{'invisible': [('tax_framework', '=', '3')]}"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
-                    <field
+                                    <field
                                         name="icms_cst_id"
                                         force_save="1"
                                         attrs="{'readonly': [('icms_tax_id', '!=', False)]}"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
-                    <field name="icms_cst_code" readonly="1" invisible="1" />
-                    <field
+                                    <field
+                                        name="icms_cst_code"
+                                        readonly="1"
+                                        invisible="1"
+                                    />
+                                    <field
                                         name="icms_origin"
                                         force_save="1"
                                         attrs="{'readonly': ['|', ('icms_tax_id', '!=', False), ('icmssn_tax_id', '!=', False)]}"
                                     />
-                    <field name="icms_tax_benefit_id" force_save="1" />
-                  </group>
-                  <group>
-                      <group>
-                        <field
+                                    <field name="icms_tax_benefit_id" force_save="1" />
+                                </group>
+                                <group>
+                                    <group>
+                                        <field
                                             name="icmssn_range_id"
                                             force_save="1"
                                             readonly="1"
                                             attrs="{'invisible': [('tax_framework', '=', '3')]}"
                                             options="{'no_create': True, 'no_create_edit': True}"
                                         />
-                        <field
+                                        <field
                                             name="icms_base_type"
                                             force_save="1"
                                             attrs="{'readonly': ['|', ('icms_tax_id', '=', False), ('icmssn_tax_id', '=', False)]}"
                                         />
-                        <field
+                                        <field
                                             name="icmssn_base"
                                             force_save="1"
                                             attrs="{'readonly': [('icmssn_tax_id', '!=', False)], 'invisible': [('tax_framework', '=', '3')]}"
                                         />
-                        <field
+                                        <field
                                             name="icmssn_reduction"
                                             force_save="1"
                                             attrs="{'readonly': [('icmssn_tax_id', '!=', False)], 'invisible': [('tax_framework', '=', '3')]}"
                                         />
-                        <field
+                                        <field
                                             name="icms_base"
                                             force_save="1"
                                             attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': ['|', ('tax_framework', '=', '2'), ('icms_cst_code', 'not in', ('00', '10', '20', '30', '40', '41', '50', '51', '60', '70', '90', '900'))]}"
                                         />
-                        <field
+                                        <field
                                             name="icms_percent"
                                             force_save="1"
                                             attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': ['|', ('tax_framework', '=', '2'), ('icms_cst_code', 'not in', ('00', '10', '20', '30', '40', '41', '50', '51', '60', '70', '90', '900'))]}"
                                         />
-                      </group>
-                      <group>
-                        <field
+                                        <field
                                             name="icmssn_percent"
                                             force_save="1"
                                             attrs="{'readonly': [('icmssn_tax_id', '!=', False)], 'invisible': [('tax_framework', '=', '3')]}"
                                         />
-                        <field
+                                        <field
                                             name="icmssn_credit_value"
                                             force_save="1"
                                             attrs="{'readonly': [('icmssn_tax_id', '!=', False)], 'invisible': [('tax_framework', '=', '3')]}"
                                         />
-                        <field
+                                        <field
                                             name="icms_reduction"
                                             force_save="1"
                                             attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': ['|', ('tax_framework', '=', '3'), ('icms_cst_code', '!=', '900')]}"
                                         />
-                        <field
+                                        <field
                                             name="icms_value"
                                             force_save="1"
                                             attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': ['|', ('tax_framework', '=', '2'), ('icms_cst_code', 'not in', ('00', '10', '20', '30', '40', '41', '50', '51', '60', '70', '90', '900'))]}"
                                         />
-                        <field
+                                        <field
                                             name="icms_relief_id"
                                             force_save="1"
                                             attrs="{'readonly': [('icms_tax_id', '!=', False), ('icms_cst_code', 'not in', ('20', '30', '40', '41', '50', '70', '90'))], 'invisible': ['|', ('tax_framework', 'in', ('1', '2')), ('icms_cst_code', 'not in', ('20', '30', '40', '41', '50', '70', '90'))]}"
                                         />
-                        <field
+                                        <field
                                             name="icms_relief_value"
                                             force_save="1"
                                             attrs="{'readonly': [('icms_tax_id', '!=', False), ('icms_cst_code', 'not in', ('20', '30', '40', '41', '50', '70', '90'))], 'invisible': ['|', ('tax_framework', 'in', ('1', '2')), ('icms_cst_code', 'not in', ('20', '30', '40', '41', '50', '70', '90'))]}"
                                         />
-                          <field
+                                        <field
                                             name="icms_substitute"
                                             force_save="1"
                                             attrs="{'readonly': [('icms_cst_code', '!=', '500')]}"
                                         />
-                      </group>
-                  </group>
-                  <group>
-                      <group
+                                    </group>
+                                    <group name="icms_manual" string="Manual">
+                                        <div
+                                            class="text-muted"
+                                            colspan="2"
+                                        >Keep empty for automatic
+                                            calculation</div>
+                                        <field
+                                            name="icms_base_manual"
+                                            string="Base"
+                                            force_save="1"
+                                        />
+                                        <field
+                                            name="icms_value_manual"
+                                            string="Value"
+                                            force_save="1"
+                                        />
+                                    </group>
+                                </group>
+                                <group>
+                                    <group
                                         name="icmsst"
+                                        colspan="2"
                                         string="ICMS ST"
                                         attrs="{'invisible': [('icms_cst_code', 'not in', ('10', '30', '70', '90', '201', '202', '203', '500', '900'))]}"
                                     >
-                        <field
-                                            name="icmsst_tax_id"
-                                            attrs="{'invisible': [('icms_cst_code', 'in', ('60', '500'))]}"
-                                            options="{'no_create': True, 'no_create_edit': True}"
-                                        />
-                        <field
-                                            name="icmsst_base_type"
-                                            force_save="1"
-                                            attrs="{'readonly': [('icmssn_tax_id', '!=', False)], 'invisible': ['|', ('tax_framework', '=', '3'), ('icms_cst_code', 'in', ('60', '500'))]}"
-                                        />
-                        <field
-                                            name="icmsst_mva_percent"
-                                            force_save="1"
-                                            attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('icms_cst_code', 'in', ('60', '500'))]}"
-                                        />
-                        <field
-                                            name="icmsst_percent"
-                                            force_save="1"
-                                            attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('icms_cst_code', 'in', ('60', '500'))]}"
-                                        />
-                        <field
-                                            name="icmsst_reduction"
-                                            force_save="1"
-                                            attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('icms_cst_code', 'in', ('60', '500'))]}"
-                                        />
-                        <field
-                                            name="icmsst_base"
-                                            force_save="1"
-                                            attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('icms_cst_code', 'in', ('60', '500'))]}"
-                                        />
-                        <field
-                                            name="icmsst_value"
-                                            force_save="1"
-                                            attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('icms_cst_code', 'in', ('60', '500'))]}"
-                                        />
-                        <field
-                                            name="icmsst_wh_base"
-                                            force_save="1"
-                                            attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('icms_cst_code', 'not in', ('60', '500'))]}"
-                                        />
-                          <field
-                                            name="icmsst_wh_percent"
-                                            force_save="1"
-                                            attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('icms_cst_code', 'not in', ('60', '500'))]}"
-                                        />
-                        <field
-                                            name="icmsst_wh_value"
-                                            force_save="1"
-                                            attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('icms_cst_code', 'not in', ('60', '500'))]}"
-                                        />
-                      </group>
-                      <group
+                                        <group colspan="2">
+                                            <field
+                                                name="icmsst_tax_id"
+                                                attrs="{'invisible': [('icms_cst_code', 'in', ('60', '500'))]}"
+                                                options="{'no_create': True, 'no_create_edit': True}"
+                                            />
+                                        </group>
+                                        <group>
+                                            <field
+                                                name="icmsst_base_type"
+                                                force_save="1"
+                                                attrs="{'readonly': [('icmssn_tax_id', '!=', False)], 'invisible': ['|', ('tax_framework', '=', '3'), ('icms_cst_code', 'in', ('60', '500'))]}"
+                                            />
+                                            <field
+                                                name="icmsst_mva_percent"
+                                                force_save="1"
+                                                attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('icms_cst_code', 'in', ('60', '500'))]}"
+                                            />
+                                            <field
+                                                name="icmsst_percent"
+                                                force_save="1"
+                                                attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('icms_cst_code', 'in', ('60', '500'))]}"
+                                            />
+                                            <field
+                                                name="icmsst_reduction"
+                                                force_save="1"
+                                                attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('icms_cst_code', 'in', ('60', '500'))]}"
+                                            />
+                                            <field
+                                                name="icmsst_base"
+                                                force_save="1"
+                                                attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('icms_cst_code', 'in', ('60', '500'))]}"
+                                            />
+                                            <field
+                                                name="icmsst_value"
+                                                force_save="1"
+                                                attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('icms_cst_code', 'in', ('60', '500'))]}"
+                                            />
+                                        </group>
+                                        <group name="icmsst_wh_manual" string="Manual">
+                                            <div
+                                                class="text-muted"
+                                                colspan="2"
+                                            >Keep empty for
+                                                automatic calculation</div>
+                                            <field
+                                                name="icmsst_base_manual"
+                                                string="Base"
+                                                force_save="1"
+                                            />
+                                            <field
+                                                name="icmsst_value_manual"
+                                                string="Value"
+                                                force_save="1"
+                                            />
+                                        </group>
+                                        <group
+                                            name="icmsst_wh"
+                                            colspan="2"
+                                            string="Retenções"
+                                            attrs="{'invisible': [('icms_cst_code', 'not in', ('60', '500'))]}"
+                                        >
+                                            <group name="name" string="string">
+                                                <field
+                                                    name="icmsst_wh_base"
+                                                    force_save="1"
+                                                    attrs="{'readonly': [('icms_tax_id', '!=', False)]}"
+                                                />
+                                                <field
+                                                    name="icmsst_wh_percent"
+                                                    force_save="1"
+                                                    attrs="{'readonly': [('icms_tax_id', '!=', False)]}"
+                                                />
+                                                <field
+                                                    name="icmsst_wh_value"
+                                                    force_save="1"
+                                                    attrs="{'readonly': [('icms_tax_id', '!=', False)]}"
+                                                />
+                                            </group>
+                                            <group
+                                                name="icmsst_wh_manual"
+                                                string="Manual"
+                                            >
+                                                <div
+                                                    class="text-muted"
+                                                    colspan="2"
+                                                >Keep empty for
+                                                    automatic calculation</div>
+                                                <field
+                                                    name="icmsst_wh_base_manual"
+                                                    string="Base"
+                                                    force_save="1"
+                                                />
+                                                <field
+                                                    name="icmsst_wh_value_manual"
+                                                    string="Value"
+                                                    force_save="1"
+                                                />
+                                            </group>
+                                        </group>
+                                    </group>
+                                    <group
                                         name="icms_fcp"
                                         string="ICMS FCP"
                                         attrs="{'invisible': [('partner_company_type', 'in', ('company', False))], 'invisible': [('icms_cst_code', 'in', ('40', '41', '50', '101', '102', '103', '300', '400'))]}"
                                     >
-                          <field
+                                        <field
                                             name="icmsfcp_tax_id"
                                             attrs="{'invisible': [('icms_cst_code', '=', '500')]}"
                                             options="{'no_create': True, 'no_create_edit': True}"
                                         />
-                        <field
+                                        <field
                                             name="icmsfcp_base"
                                             force_save="1"
                                             attrs="{'readonly': [('icmsfcp_tax_id', '!=', False)], 'invisible': [('icms_cst_code', '=', '500')]}"
                                         />
-                        <field
+                                        <field
                                             name="icmsfcp_percent"
                                             force_save="1"
                                             attrs="{'readonly': [('icmsfcp_tax_id', '!=', False)], 'invisible': [('icms_cst_code', '=', '500')]}"
                                         />
-                        <field
+                                        <field
                                             name="icmsfcp_value"
                                             force_save="1"
                                             attrs="{'readonly': [('icmsfcp_tax_id', '!=', False)], 'invisible': [('icms_cst_code', '=', '500')]}"
                                         />
-                          <field
+                                        <field
+                                            name="icmsfcpst_value"
+                                            force_save="1"
+                                            attrs="{'readonly': [('icmsfcp_tax_id', '!=', False)], 'invisible': [('icms_cst_code', 'not in', ('10', '30', '70', '90', '201', '202', '203', '900'))]}"
+                                        />
+                                        <field
                                             name="icmsfcp_base_wh"
                                             force_save="1"
                                             attrs="{'invisible': [('icms_cst_code', 'not in', ('60', '500'))]}"
                                         />
-                          <field
+                                        <field
                                             name="icmsfcp_wh_percent"
                                             force_save="1"
                                             attrs="{'invisible': [('icms_cst_code', 'not in', ('60', '500'))]}"
                                         />
-                          <field
+                                        <field
                                             name="icmsfcp_value_wh"
                                             force_save="1"
                                             attrs="{'invisible': [('icms_cst_code', 'not in', ('60', '500'))]}"
@@ -382,634 +494,866 @@
                                         string="ICMS DIFAL"
                                         attrs="{'invisible': [('partner_company_type', 'in', ('company', False)), ('tax_framework', '=', '1'), ('cfop_destination', 'in', ('1', '3', False))]}"
                                     >
-                        <field
+                                        <field
                                             name="icms_destination_base"
                                             force_save="1"
                                             attrs="{'readonly': [('icms_tax_id', '!=', False)]}"
                                         />
-                        <field
+                                        <field
                                             name="icms_origin_percent"
                                             force_save="1"
                                             attrs="{'readonly': [('icms_tax_id', '!=', False)]}"
                                         />
-                        <field
+                                        <field
                                             name="icms_destination_percent"
                                             force_save="1"
                                             attrs="{'readonly': [('icms_tax_id', '!=', False)]}"
                                         />
-                        <field
+                                        <field
                                             name="icms_sharing_percent"
                                             force_save="1"
                                             attrs="{'readonly': [('icms_tax_id', '!=', False)]}"
                                         />
-                        <field
+                                        <field
                                             name="icms_origin_value"
                                             force_save="1"
                                             attrs="{'readonly': [('icms_tax_id', '!=', False)]}"
                                         />
-                        <field
+                                        <field
                                             name="icms_destination_value"
                                             force_save="1"
                                             attrs="{'readonly': [('icms_tax_id', '!=', False)]}"
                                         />
-                      </group>
-                      <group
+                                    </group>
+                                    <group
                                         name="icms_effective"
                                         string="ICMS Effective Calculation"
                                         attrs="{'invisible': [('icms_cst_code', 'not in', ('60', '500'))]}"
                                     >
-                          <field
+                                        <field
                                             name="icms_effective_reduction"
                                             force_save="1"
                                             attr="{'invisible': [('icms_cst_code', '!=', '500')]}"
                                         />
-                          <field
+                                        <field
                                             name="icms_effective_base"
                                             force_save="1"
                                             attr="{'invisible': [('icms_cst_code', '!=', '500')]}"
                                         />
-                          <field
+                                        <field
                                             name="icms_effective_percent"
                                             force_save="1"
                                             attr="{'invisible': [('icms_cst_code', '!=', '500')]}"
                                         />
-                          <field
+                                        <field
                                             name="icms_effective_value"
                                             force_save="1"
                                             attr="{'invisible': [('icms_cst_code', '!=', '500')]}"
                                         />
-                      </group>
-                  </group>
-              </page>
-              <page
+                                    </group>
+                                </group>
+                            </page>
+                            <page
                                 name="ipi"
                                 string="IPI"
                                 attrs="{'invisible': [('tax_icms_or_issqn', '=', 'issqn')]}"
                             >
-                  <group string="IPI">
-                      <field
+                                <group string="IPI">
+                                    <field
                                         name="ipi_tax_id"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
-                      <field
+                                    <field
                                         name="ipi_cst_id"
                                         force_save="1"
                                         attrs="{'readonly': [('ipi_tax_id', '!=', False)]}"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
-                      <field name="ipi_cst_code" readonly="1" invisible="1" />
-                      <field
+                                    <field
+                                        name="ipi_cst_code"
+                                        readonly="1"
+                                        invisible="1"
+                                    />
+                                    <field
                                         name="ipi_guideline_id"
                                         force_save="1"
                                         attrs="{'readonly': [('ipi_tax_id', '!=', False)]}"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
-                  </group>
-                  <group>
-                      <group>
-                        <field
+                                </group>
+                                <group>
+                                    <group>
+                                        <field
                                             name="ipi_base_type"
                                             force_save="1"
                                             attrs="{'readonly': [('ipi_tax_id', '!=', False)]}"
                                         />
-                        <field
+                                        <field
                                             name="ipi_percent"
                                             force_save="1"
                                             attrs="{'readonly': [('ipi_tax_id', '!=', False)]}"
                                         />
-                        <field
+                                        <field
                                             name="ipi_reduction"
                                             force_save="1"
                                             attrs="{'readonly': [('ipi_tax_id', '!=', False)]}"
                                         />
-                      </group>
-                      <group>
-                        <field
+                                        <field
                                             name="ipi_base"
                                             force_save="1"
                                             attrs="{'readonly': [('ipi_tax_id', '!=', False)]}"
                                         />
-                        <field
+                                        <field
                                             name="ipi_value"
                                             force_save="1"
                                             attrs="{'readonly': [('ipi_tax_id', '!=', False)]}"
                                         />
-                      </group>
-                  </group>
-              </page>
-              <page
+                                    </group>
+                                    <group name="ipi_manual" string="Manual">
+                                        <div
+                                            class="text-muted"
+                                            colspan="2"
+                                        >Keep empty for automatic
+                                            calculation</div>
+                                        <field
+                                            name="ipi_base_manual"
+                                            string="Base"
+                                            force_save="1"
+                                        />
+                                        <field
+                                            name="ipi_value_manual"
+                                            string="Value"
+                                            force_save="1"
+                                        />
+                                    </group>
+                                </group>
+                            </page>
+                            <page
                                 name="ii"
                                 string="II"
                                 attrs="{'invisible': [('cfop_destination', '!=', '3')]}"
                             >
-                <group string="II">
-                    <field
+                                <group string="II">
+                                    <field
                                         name="ii_tax_id"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
-                </group>
-                <group>
-                  <group>
-                    <field name="ii_base" />
-                    <field name="ii_value" />
-                  </group>
-                  <group>
-                    <field name="ii_iof_value" />
-                    <field name="ii_customhouse_charges" />
-                  </group>
-                </group>
-              </page>
-              <page name="pis" string="PIS">
-                  <group name="pis" string="PIS">
-                    <field
+                                </group>
+                                <group>
+                                    <group>
+                                        <field name="ii_base" />
+                                        <field name="ii_value" />
+                                    </group>
+                                    <group name="ii_manual" string="Manual">
+                                        <div
+                                            class="text-muted"
+                                            colspan="2"
+                                        >Keep empty for automatic
+                                            calculation</div>
+                                        <field
+                                            name="ii_base_manual"
+                                            string="Base"
+                                            force_save="1"
+                                        />
+                                        <field
+                                            name="ii_value_manual"
+                                            string="Value"
+                                            force_save="1"
+                                        />
+                                    </group>
+                                    <group>
+                                        <field name="ii_iof_value" />
+                                        <field name="ii_customhouse_charges" />
+                                    </group>
+                                </group>
+                            </page>
+                            <page name="pis" string="PIS">
+                                <group name="pis">
+                                    <field
                                         name="pis_tax_id"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
-                    <field
+                                    <field
                                         name="pis_cst_id"
                                         force_save="1"
                                         attrs="{'readonly': [('pis_tax_id', '!=', False)]}"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
-                    <field name="pis_cst_code" readonly="1" invisible="1" />
-                    <field
+                                    <field
+                                        name="pis_cst_code"
+                                        readonly="1"
+                                        invisible="1"
+                                    />
+                                    <field
                                         name="pis_credit_id"
                                         force_save="1"
                                         attrs="{'readonly': [('pis_tax_id', '!=', False)], 'invisible': [('fiscal_operation_type', '=', 'out')]}"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
-                  </group>
-                  <group>
-                    <group>
-                      <field
+                                </group>
+                                <group>
+                                    <group>
+                                        <field
                                             name="pis_base_id"
                                             force_save="1"
                                             attrs="{'readonly': [('pis_tax_id', '!=', False)], 'invisible': [('fiscal_operation_type', '=', 'out')]}"
                                             options="{'no_create': True, 'no_create_edit': True}"
                                         />
-                      <field
+                                        <field
                                             name="pis_base_type"
                                             force_save="1"
                                             attrs="{'readonly': [('pis_tax_id', '!=', False)]}"
                                         />
-                      <field
+                                        <field
                                             name="pis_percent"
                                             force_save="1"
                                             attrs="{'readonly': [('pis_tax_id', '!=', False)]}"
                                         />
-                      <field
+                                        <field
                                             name="pis_reduction"
                                             force_save="1"
                                             attrs="{'readonly': [('pis_tax_id', '!=', False)]}"
                                         />
-                    </group>
-                    <group>
-                      <field
+                                        <field
                                             name="pis_base"
                                             force_save="1"
                                             attrs="{'readonly': [('pis_tax_id', '!=', False)]}"
                                         />
-                      <field
+                                        <field
                                             name="pis_value"
                                             force_save="1"
                                             attrs="{'readonly': [('pis_tax_id', '!=', False)]}"
                                         />
-                    </group>
-                  </group>
-                  <group name="pis_st" string="PIS ST">
-                    <field
+                                    </group>
+                                    <group name="pis_manual" string="Manual">
+                                        <div
+                                            class="text-muted"
+                                            colspan="2"
+                                        >Keep empty for automatic
+                                            calculation</div>
+                                        <field
+                                            name="pis_base_manual"
+                                            string="Base"
+                                            force_save="1"
+                                        />
+                                        <field
+                                            name="pis_value_manual"
+                                            string="Value"
+                                            force_save="1"
+                                        />
+                                    </group>
+                                </group>
+                                <group name="pis_st" string="Substituição Tributária">
+                                    <field
                                         name="pisst_tax_id"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
-                    <field
+                                    <field
                                         name="pisst_cst_id"
                                         force_save="1"
                                         attrs="{'readonly': [('pisst_tax_id', '!=', False)]}"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
-                    <field name="pisst_cst_code" readonly="1" invisible="1" />
-                  </group>
-                  <group>
-                    <group>
-                      <field
+                                    <field
+                                        name="pisst_cst_code"
+                                        readonly="1"
+                                        invisible="1"
+                                    />
+                                </group>
+                                <group>
+                                    <group>
+                                        <field
                                             name="pisst_base_type"
                                             force_save="1"
                                             attrs="{'readonly': [('pisst_tax_id', '!=', False)]}"
                                         />
-                      <field
+                                        <field
                                             name="pisst_percent"
                                             force_save="1"
                                             attrs="{'readonly': [('pisst_tax_id', '!=', False)]}"
                                         />
-                      <field
+                                        <field
                                             name="pisst_reduction"
                                             force_save="1"
                                             attrs="{'readonly': [('pisst_tax_id', '!=', False)]}"
                                         />
-                    </group>
-                    <group>
-                      <field
+                                        <field
                                             name="pisst_base"
                                             force_save="1"
                                             attrs="{'readonly': [('pisst_tax_id', '!=', False)]}"
                                         />
-                      <field
+                                        <field
                                             name="pisst_value"
                                             force_save="1"
                                             attrs="{'readonly': [('pisst_tax_id', '!=', False)]}"
                                         />
-                    </group>
-                  </group>
-                  <group string="Retenções">
-                      <field
+                                    </group>
+                                    <group name="pisst_manual" string="Manual">
+                                        <div
+                                            class="text-muted"
+                                            colspan="2"
+                                        >Keep empty for automatic
+                                            calculation</div>
+                                        <field
+                                            name="pisst_base_manual"
+                                            string="Base"
+                                            force_save="1"
+                                        />
+                                        <field
+                                            name="pisst_value_manual"
+                                            string="Value"
+                                            force_save="1"
+                                        />
+                                    </group>
+                                </group>
+                                <group string="Retenções">
+                                    <field
                                         name="pis_wh_tax_id"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
-                  </group>
-                  <group>
-                      <group>
-                          <field
+                                </group>
+                                <group>
+                                    <group>
+                                        <field
                                             name="pis_wh_base"
                                             force_save="1"
                                             attrs="{'readonly': [('pis_wh_tax_id', '!=', False)]}"
                                         />
-                          <field
+                                        <field
                                             name="pis_wh_percent"
                                             force_save="1"
                                             attrs="{'readonly': [('pis_wh_tax_id', '!=', False)]}"
                                         />
-                      </group>
-                      <group>
-                          <field
+                                        <field
                                             name="pis_wh_reduction"
                                             force_save="1"
                                             attrs="{'readonly': [('pis_wh_tax_id', '!=', False)]}"
                                         />
-                          <field
+                                        <field
                                             name="pis_wh_value"
                                             force_save="1"
                                             attrs="{'readonly': [('pis_wh_tax_id', '!=', False)]}"
                                         />
-                      </group>
-                  </group>
-              </page>
-              <page name="cofins" string="COFINS">
-                <group name="cofins" string="COFINS">
-                  <field
+                                    </group>
+                                    <group name="pis_wh_manual" string="Manual">
+                                        <div
+                                            class="text-muted"
+                                            colspan="2"
+                                        >Keep empty for automatic
+                                            calculation</div>
+                                        <field
+                                            name="pis_wh_base_manual"
+                                            string="Base"
+                                            force_save="1"
+                                        />
+                                        <field
+                                            name="pis_wh_value_manual"
+                                            string="Value"
+                                            force_save="1"
+                                        />
+                                    </group>
+                                </group>
+                            </page>
+                            <page name="cofins" string="COFINS">
+                                <group name="cofins" string="COFINS">
+                                    <field
                                         name="cofins_tax_id"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
-                  <field
+                                    <field
                                         name="cofins_cst_id"
                                         force_save="1"
                                         attrs="{'readonly': [('cofins_tax_id', '!=', False)]}"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
-                  <field name="cofins_cst_code" readonly="1" invisible="1" />
-                  <field
+                                    <field
+                                        name="cofins_cst_code"
+                                        readonly="1"
+                                        invisible="1"
+                                    />
+                                    <field
                                         name="cofins_credit_id"
                                         force_save="1"
                                         attrs="{'readonly': [('cofins_tax_id', '!=', False)], 'invisible': [('fiscal_operation_type', '=', 'out')]}"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
-                </group>
-                <group>
-                  <group>
-                    <field
+                                </group>
+                                <group>
+                                    <group>
+                                        <field
                                             name="cofins_base_id"
                                             force_save="1"
                                             attrs="{'readonly': [('cofins_tax_id', '!=', False)], 'invisible': [('fiscal_operation_type', '=', 'out')]}"
                                             options="{'no_create': True, 'no_create_edit': True}"
                                         />
-                    <field
+                                        <field
                                             name="cofins_base_type"
                                             force_save="1"
                                             attrs="{'readonly': [('cofins_tax_id', '!=', False)]}"
                                         />
-                    <field
+                                        <field
                                             name="cofins_percent"
                                             force_save="1"
                                             attrs="{'readonly': [('cofins_tax_id', '!=', False)]}"
                                         />
-                    <field
+                                        <field
                                             name="cofins_reduction"
                                             force_save="1"
                                             attrs="{'readonly': [('cofins_tax_id', '!=', False)]}"
                                         />
-                  </group>
-                  <group>
-                    <field
+                                        <field
                                             name="cofins_base"
                                             force_save="1"
                                             attrs="{'readonly': [('cofins_tax_id', '!=', False)]}"
                                         />
-                    <field
+                                        <field
                                             name="cofins_value"
                                             force_save="1"
                                             attrs="{'readonly': [('cofins_tax_id', '!=', False)]}"
                                         />
-                  </group>
-                </group>
-                <group name="cofins_st" string="COFINS ST">
-                  <field
+                                    </group>
+                                    <group name="cofins_manual" string="Manual">
+                                        <div
+                                            class="text-muted"
+                                            colspan="2"
+                                        >Keep empty for automatic
+                                            calculation</div>
+                                        <field
+                                            name="cofins_base_manual"
+                                            string="Base"
+                                            force_save="1"
+                                        />
+                                        <field
+                                            name="cofins_value_manual"
+                                            string="Value"
+                                            force_save="1"
+                                        />
+                                    </group>
+                                </group>
+                                <group name="cofins_st" string="COFINS ST">
+                                    <field
                                         name="cofinsst_tax_id"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
-                  <field
+                                    <field
                                         name="cofinsst_cst_id"
                                         force_save="1"
                                         attrs="{'readonly': [('cofinsst_tax_id', '!=', False)]}"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
-                  <field name="cofinsst_cst_code" readonly="1" invisible="1" />
-                </group>
-                <group>
-                  <group>
-                    <field
+                                    <field
+                                        name="cofinsst_cst_code"
+                                        readonly="1"
+                                        invisible="1"
+                                    />
+                                </group>
+                                <group>
+                                    <group>
+                                        <field
                                             name="cofinsst_base_type"
                                             force_save="1"
                                             attrs="{'readonly': [('cofinsst_tax_id', '!=', False)]}"
                                         />
-                    <field
+                                        <field
                                             name="cofinsst_percent"
                                             force_save="1"
                                             attrs="{'readonly': [('cofinsst_tax_id', '!=', False)]}"
                                         />
-                    <field
+                                        <field
                                             name="cofinsst_reduction"
                                             force_save="1"
                                             attrs="{'readonly': [('cofinsst_tax_id', '!=', False)]}"
                                         />
-                  </group>
-                  <group>
-                    <field
+                                        <field
                                             name="cofinsst_base"
                                             force_save="1"
                                             attrs="{'readonly': [('cofinsst_tax_id', '!=', False)]}"
                                         />
-                    <field
+                                        <field
                                             name="cofinsst_value"
                                             force_save="1"
                                             attrs="{'readonly': [('cofinsst_tax_id', '!=', False)]}"
                                         />
-                  </group>
-                </group>
-                  <group string="Retenções">
-                      <field
+                                    </group>
+                                    <group name="cofinsst_manual" string="Manual">
+                                        <div
+                                            class="text-muted"
+                                            colspan="2"
+                                        >Keep empty for automatic
+                                            calculation</div>
+                                        <field
+                                            name="cofinsst_base_manual"
+                                            string="Base"
+                                            force_save="1"
+                                        />
+                                        <field
+                                            name="cofinsst_value_manual"
+                                            string="Value"
+                                            force_save="1"
+                                        />
+                                    </group>
+                                </group>
+                                <group string="Retenções">
+                                    <field
                                         name="cofins_wh_tax_id"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
-                  </group>
-                  <group>
-                      <group>
-                          <field
+                                </group>
+                                <group>
+                                    <group>
+                                        <field
                                             name="cofins_wh_base"
                                             force_save="1"
                                             attrs="{'readonly': [('cofins_wh_tax_id', '!=', False)]}"
                                         />
-                          <field
+                                        <field
                                             name="cofins_wh_percent"
                                             force_save="1"
                                             attrs="{'readonly': [('cofins_wh_tax_id', '!=', False)]}"
                                         />
-                      </group>
-                      <group>
-                          <field
+                                        <field
                                             name="cofins_wh_reduction"
                                             force_save="1"
                                             attrs="{'readonly': [('cofins_wh_tax_id', '!=', False)]}"
                                         />
-                          <field
+                                        <field
                                             name="cofins_wh_value"
                                             force_save="1"
                                             attrs="{'readonly': [('cofins_wh_tax_id', '!=', False)]}"
                                         />
-                      </group>
-                  </group>
-              </page>
-                <page
+                                    </group>
+                                    <group name="cofins_wh_manual" string="Manual">
+                                        <div
+                                            class="text-muted"
+                                            colspan="2"
+                                        >Keep empty for automatic
+                                            calculation</div>
+                                        <field
+                                            name="cofins_wh_base_manual"
+                                            string="Base"
+                                            force_save="1"
+                                        />
+                                        <field
+                                            name="cofins_wh_value_manual"
+                                            string="Value"
+                                            force_save="1"
+                                        />
+                                    </group>
+                                </group>
+                            </page>
+                            <page
                                 name="csll"
                                 string="CSLL"
                                 attrs="{'invisible': [('allow_csll_irpj', '=', False)]}"
                             >
-                    <group>
-                        <field name="csll_tax_id" />
-                    </group>
-                    <group>
-                        <group>
-                            <field
+                                <group>
+                                    <field name="csll_tax_id" />
+                                </group>
+                                <group>
+                                    <group>
+                                        <field
                                             name="csll_base"
                                             force_save="1"
                                             attrs="{'readonly': [('csll_tax_id', '!=', False)]}"
                                         />
-                            <field
+                                        <field
                                             name="csll_percent"
                                             force_save="1"
                                             attrs="{'readonly': [('csll_tax_id', '!=', False)]}"
                                         />
-                        </group>
-                        <group>
-                            <field
+                                        <field
                                             name="csll_reduction"
                                             force_save="1"
                                             attrs="{'readonly': [('csll_tax_id', '!=', False)]}"
                                         />
-                            <field
+                                        <field
                                             name="csll_value"
                                             force_save="1"
                                             attrs="{'readonly': [('csll_tax_id', '!=', False)]}"
                                         />
-                        </group>
-                    </group>
-                    <group string="Retenções">
-                        <field
+                                    </group>
+                                    <group name="csll_manual" string="Manual">
+                                        <div
+                                            class="text-muted"
+                                            colspan="2"
+                                        >Keep empty for automatic
+                                            calculation</div>
+                                        <field
+                                            name="csll_base_manual"
+                                            string="Base"
+                                            force_save="1"
+                                        />
+                                        <field
+                                            name="csll_value_manual"
+                                            string="Value"
+                                            force_save="1"
+                                        />
+                                    </group>
+                                </group>
+                                <group string="Retenções">
+                                    <field
                                         name="csll_wh_tax_id"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
-                    </group>
-                    <group>
-                        <group>
-                            <field
+                                </group>
+                                <group>
+                                    <group>
+                                        <field
                                             name="csll_wh_base"
                                             force_save="1"
                                             attrs="{'readonly': [('csll_wh_tax_id', '!=', False)]}"
                                         />
-                            <field
+                                        <field
                                             name="csll_wh_percent"
                                             force_save="1"
                                             attrs="{'readonly': [('csll_wh_tax_id', '!=', False)]}"
                                         />
-                        </group>
-                        <group>
-                            <field
+                                        <field
                                             name="csll_wh_reduction"
                                             force_save="1"
                                             attrs="{'readonly': [('csll_wh_tax_id', '!=', False)]}"
                                         />
-                            <field
+                                        <field
                                             name="csll_wh_value"
                                             force_save="1"
                                             attrs="{'readonly': [('csll_wh_tax_id', '!=', False)]}"
                                         />
-                        </group>
-                    </group>
-                </page>
-                <page
+                                    </group>
+                                    <group name="csll_wh_manual" string="Manual">
+                                        <div
+                                            class="text-muted"
+                                            colspan="2"
+                                        >Keep empty for automatic
+                                            calculation</div>
+                                        <field
+                                            name="csll_wh_base_manual"
+                                            string="Base"
+                                            force_save="1"
+                                        />
+                                        <field
+                                            name="csll_wh_value_manual"
+                                            string="Value"
+                                            force_save="1"
+                                        />
+                                    </group>
+                                </group>
+                            </page>
+                            <page
                                 name="irpj"
                                 string="IRPJ"
                                 attrs="{'invisible': [('allow_csll_irpj', '=', False)]}"
                             >
-                    <group>
-                        <field
+                                <group>
+                                    <field
                                         name="irpj_tax_id"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
-                    </group>
-                    <group>
-                        <group>
-                            <field
+                                </group>
+                                <group>
+                                    <group>
+                                        <field
                                             name="irpj_base"
                                             force_save="1"
                                             attrs="{'readonly': [('irpj_tax_id', '!=', False)]}"
                                         />
-                            <field
+                                        <field
                                             name="irpj_percent"
                                             force_save="1"
                                             attrs="{'readonly': [('irpj_tax_id', '!=', False)]}"
                                         />
-                        </group>
-                        <group>
-                            <field
+                                        <field
                                             name="irpj_reduction"
                                             force_save="1"
                                             attrs="{'readonly': [('irpj_tax_id', '!=', False)]}"
                                         />
-                            <field
+                                        <field
                                             name="irpj_value"
                                             force_save="1"
                                             attrs="{'readonly': [('irpj_tax_id', '!=', False)]}"
                                         />
-                        </group>
-                    </group>
-                    <group string="Retenções">
-                        <field
+                                    </group>
+                                    <group name="irpj_manual" string="Manual">
+                                        <div
+                                            class="text-muted"
+                                            colspan="2"
+                                        >Keep empty for automatic
+                                            calculation</div>
+                                        <field
+                                            name="irpj_base_manual"
+                                            string="Base"
+                                            force_save="1"
+                                        />
+                                        <field
+                                            name="irpj_value_manual"
+                                            string="Value"
+                                            force_save="1"
+                                        />
+                                    </group>
+                                </group>
+                                <group string="Retenções">
+                                    <field
                                         name="irpj_wh_tax_id"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
-                    </group>
-                    <group>
-                        <group>
-                            <field
+                                </group>
+                                <group>
+                                    <group>
+                                        <field
                                             name="irpj_wh_base"
                                             force_save="1"
                                             attrs="{'readonly': [('irpj_wh_tax_id', '!=', False)]}"
                                         />
-                            <field
+                                        <field
                                             name="irpj_wh_percent"
                                             force_save="1"
                                             attrs="{'readonly': [('irpj_wh_tax_id', '!=', False)]}"
                                         />
-                        </group>
-                        <group>
-                            <field
+                                        <field
                                             name="irpj_wh_reduction"
                                             force_save="1"
                                             attrs="{'readonly': [('irpj_wh_tax_id', '!=', False)]}"
                                         />
-                            <field
+                                        <field
                                             name="irpj_wh_value"
                                             force_save="1"
                                             attrs="{'readonly': [('irpj_wh_tax_id', '!=', False)]}"
                                         />
-                        </group>
-                    </group>
-                </page>
-                <page
+                                    </group>
+                                    <group name="irpj_wh_manual" string="Manual">
+                                        <div
+                                            class="text-muted"
+                                            colspan="2"
+                                        >Keep empty for automatic
+                                            calculation</div>
+                                        <field
+                                            name="irpj_wh_base_manual"
+                                            string="Base"
+                                            force_save="1"
+                                        />
+                                        <field
+                                            name="irpj_wh_value_manual"
+                                            string="Value"
+                                            force_save="1"
+                                        />
+                                    </group>
+                                </group>
+                            </page>
+                            <page
                                 name="inss"
                                 string="INSS"
                                 attrs="{'invisible': [('fiscal_genre_code', '!=', '00')]}"
                             >
-                    <group>
-                        <field
+                                <group>
+                                    <field
                                         name="inss_tax_id"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
-                    </group>
-                    <group>
-                        <group>
-                            <field
+                                </group>
+                                <group>
+                                    <group>
+                                        <field
                                             name="inss_base"
                                             force_save="1"
                                             attrs="{'readonly': [('inss_tax_id', '!=', False)]}"
                                         />
-                            <field
+                                        <field
                                             name="inss_percent"
                                             force_save="1"
                                             attrs="{'readonly': [('inss_tax_id', '!=', False)]}"
                                         />
-                        </group>
-                        <group>
-                            <field
+                                        <field
                                             name="inss_reduction"
                                             force_save="1"
                                             attrs="{'readonly': [('inss_tax_id', '!=', False)]}"
                                         />
-                            <field
+                                        <field
                                             name="inss_value"
                                             force_save="1"
                                             attrs="{'readonly': [('inss_tax_id', '!=', False)]}"
                                         />
-                        </group>
-                    </group>
-                    <group string="Retenções">
-                        <field
+                                    </group>
+                                    <group name="inss_manual" string="Manual">
+                                        <div
+                                            class="text-muted"
+                                            colspan="2"
+                                        >Keep empty for automatic
+                                            calculation</div>
+                                        <field
+                                            name="inss_base_manual"
+                                            string="Base"
+                                            force_save="1"
+                                        />
+                                        <field
+                                            name="inss_value_manual"
+                                            string="Value"
+                                            force_save="1"
+                                        />
+                                    </group>
+                                </group>
+                                <group string="Retenções">
+                                    <field
                                         name="inss_wh_tax_id"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
-                    </group>
-                    <group>
-                        <group>
-                            <field
+                                </group>
+                                <group>
+                                    <group>
+                                        <field
                                             name="inss_wh_base"
                                             force_save="1"
                                             attrs="{'readonly': [('inss_wh_tax_id', '!=', False)]}"
                                         />
-                            <field
+                                        <field
                                             name="inss_wh_percent"
                                             force_save="1"
                                             attrs="{'readonly': [('inss_wh_tax_id', '!=', False)]}"
                                         />
-                        </group>
-                        <group>
-                            <field
+                                        <field
                                             name="inss_wh_reduction"
                                             force_save="1"
                                             attrs="{'readonly': [('inss_wh_tax_id', '!=', False)]}"
                                         />
-                            <field
+                                        <field
                                             name="inss_wh_value"
                                             force_save="1"
                                             attrs="{'readonly': [('inss_wh_tax_id', '!=', False)]}"
                                         />
+                                    </group>
+                                    <group name="inss_wh_manual" string="Manual">
+                                        <div
+                                            class="text-muted"
+                                            colspan="2"
+                                        >Keep empty for automatic
+                                            calculation</div>
+                                        <field
+                                            name="inss_wh_base_manual"
+                                            string="Base"
+                                            force_save="1"
+                                        />
+                                        <field
+                                            name="inss_wh_value_manual"
+                                            string="Value"
+                                            force_save="1"
+                                        />
+                                    </group>
+                                </group>
+                            </page>
+                        </notebook>
+                    </page>
+                    <page name="fiscal_line_extra_info" string="Extra Info">
+                        <group>
+                            <field name="partner_order" />
+                            <field name="partner_order_line" />
                         </group>
-                    </group>
-                </page>
-            </notebook>
-          </page>
-          <page name="fiscal_line_extra_info" string="Extra Info">
-            <group>
-                <field name="partner_order" />
-                <field name="partner_order_line" />
-            </group>
-            <group>
-                <field name="comment_ids" widget="many2many_tags" />
-                <field name="manual_additional_data" />
-                <field name="additional_data" readonly="1" />
-            </group>
-          </page>
-        </notebook>
-      </form>
-    </field>
-  </record>
+                        <group>
+                            <field name="comment_ids" widget="many2many_tags" />
+                            <field name="manual_additional_data" />
+                            <field name="additional_data" readonly="1" />
+                        </group>
+                    </page>
+                </notebook>
+            </form>
+        </field>
+    </record>
 
 </odoo>


### PR DESCRIPTION
A proposta desta PR é adicionar a possibilidade do usuário informar a base ou valor  manualmente para qualquer imposto.

é uma continuação da PR #2550

O diff tá um pouco grande mas é porque mexeu bastante no XML da visão que tava com a formatação zuada.

- [ ]  Incluir testes
- [ ] Adicionar grupo de permissão para a edição manual.
