### PR TITLE
[14.0][FIX] l10n_br_fiscal: flag to exclude pis cofins from document amount

### DIFF
--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -831,11 +831,12 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             self.cfop_id.destination == CFOP_DESTINATION_EXPORT
             and self.fiscal_operation_id.fiscal_operation_type == FISCAL_IN
         ):
-            fields_to_amount.append("pis_value")
-            fields_to_amount.append("cofins_value")
             fields_to_amount.append("icms_value")
             fields_to_amount.append("ii_value")
             fields_to_amount.append("ii_customhouse_charges")
+            if not self.fiscal_operation_line_id.exclude_pis_cofins_amount:
+                fields_to_amount.append("pis_value")
+                fields_to_amount.append("cofins_value")
         return fields_to_amount
 
     @api.model

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -832,8 +832,13 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             and self.fiscal_operation_id.fiscal_operation_type == FISCAL_IN
         ):
             fields_to_amount.append("icms_value")
-            fields_to_amount.append("ii_value")
-            fields_to_amount.append("ii_customhouse_charges")
+
+            # TODO
+            # para o caso de uso da Engenere não deve ser somado o II no valor total.
+            # entender melhor e por uma logica para verificar quando deve ser aplicado.
+
+            # fields_to_amount.append("ii_value")
+            # fields_to_amount.append("ii_customhouse_charges")
             if not self.fiscal_operation_line_id.exclude_pis_cofins_amount:
                 fields_to_amount.append("pis_value")
                 fields_to_amount.append("cofins_value")

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -109,6 +109,15 @@ class OperationLine(models.Model):
 
     add_to_amount = fields.Boolean(string="Add to Document Amount?", default=True)
 
+    # Algumas empresas de contabilidade ou consultorias de comércio exterior
+    # preferem adicionar o valor do PIS e COFINS no campo 'Outros Valores'.
+    # Para evitar duplicidade, não somamos os valores nesses casos.
+    exclude_pis_cofins_amount = fields.Boolean(
+        string="Exclude PIS/COFINS from Document Amount?",
+        help="Indicates if the taxes PIS and COFINS do not need to be incorporated "
+        "into the total value of the fiscal document during an import transaction.",
+    )
+
     icms_origin = fields.Selection(selection=ICMS_ORIGIN, string="Origin")
 
     tax_definition_ids = fields.One2many(

--- a/l10n_br_fiscal/views/operation_line_view.xml
+++ b/l10n_br_fiscal/views/operation_line_view.xml
@@ -56,6 +56,7 @@
                             <group name="gereral_settings">
                                 <field name="document_type_id" />
                                 <field name="add_to_amount" />
+                                <field name="exclude_pis_cofins_amount" />
                             </group>
                             <group
                                 name="general_cfop"


### PR DESCRIPTION
O objetivo desta PR é adicionar a opção de decidir se os impostos PIS e COFINS devem ser incorporados ou não ao valor total do documento fiscal (valor total da NF-e).

Algumas empresas de contabilidade ou consultorias de comércio exterior têm o costume de incluir o PIS e COFINS no campo "Outros Valores". Como este campo já é somado ao valor total da NF, a inclusão direta do PIS e COFINS no valor total da NF pode resultar em duplicidade. Portanto, em tais casos, o PIS e COFINS não devem ser somados diretamente ao valor total da NF.

A imagem abaixo é um recorte retirado do espelho da nota que a consultoria de comércio exterior enviou ao nosso cliente:
![image](https://github.com/OCA/l10n-brazil/assets/634278/4b0a3b9f-7d9a-4cbd-aef3-b3c86b6c95e3)

Este artigo recomenda a inclusão do PIS e COFINS no campo "Outros Valores":
https://comexblog.com.br/importacao/calculando-uma-nf-de-entrada-na-importacao/

cc @renatonlima 