### PR TITLE
[14][FIX] l10n_br_account: valores em branco nos campos shadowed

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -141,7 +141,7 @@ class AccountMove(models.Model):
     def _inject_shadowed_fields(self, vals_list):
         for vals in vals_list:
             for field in self._shadowed_fields():
-                if vals.get(field):
+                if field in vals:
                     vals["fiscal_%s" % (field,)] = vals[field]
 
     @api.model

--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -144,7 +144,7 @@ class AccountMoveLine(models.Model):
     def _inject_shadowed_fields(self, vals_list):
         for vals in vals_list:
             for field in self._shadowed_fields():
-                if vals.get(field):
+                if field in vals:
                     vals["fiscal_%s" % (field,)] = vals[field]
 
     @api.model_create_multi


### PR DESCRIPTION
Esta PR tem como objetivo corrigir o comportamento inesperado dos campos "shadowed" (campos com nomes correspondentes no 'account' e no 'fiscal'). No comportamento atual, quando um desses campos é alterado para vazio ou em branco, essa mudança não é refletida no documento fiscal correspondente.

Por exemplo, caso o endereço de entrega em uma fatura seja alterado para vazio, quando se procede à emissão da nota fiscal, os dados de entrega ainda são erroneamente incluídos. Isso ocorre porque o campo correspondente no 'fiscal' ainda mantém o valor anterior e a alteração para vazio não é sincronizada.

Para resolver este problema, modificamos a lógica de sincronização. Agora, em vez de verificar se o campo tem um valor definido, verificamos se o campo existe no dicionário correspondente. Desta forma, garantimos que as alterações, inclusive para campos vazios, sejam corretamente refletidas nos documentos fiscais.

cc @rvalyi 