### PR TITLE
[14.0][FIX] l10n_br_base: Ocultação do campo Suframa.

### DIFF
--- a/l10n_br_base/views/res_company_view.xml
+++ b/l10n_br_base/views/res_company_view.xml
@@ -37,7 +37,7 @@
                 <field
                     name="suframa"
                     placeholder="Suframa"
-                    attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
+                    attrs="{'invisible': [('state_id', '!=', %(base.state_br_am)d)]}"
                 />
                 <field
                     name="state_tax_number_ids"


### PR DESCRIPTION
Ocultacao do campo de Suframa, caso o endereço da Empresa ou do Parceiro cadastrado não seja do Amazonas.
attrs alterado para:  `attrs="{'invisible': [('state_id', '!=', %(base.state_br_am)d)]}"`