### PR TITLE
[14.0][IMP] l10n_br_account:  Funcionalidade para Desabilitar Lançamentos Contábeis de Impostos Fiscais

### DIFF
--- a/l10n_br_account/__manifest__.py
+++ b/l10n_br_account/__manifest__.py
@@ -31,6 +31,7 @@
         "views/document_view.xml",
         "views/fiscal_invoice_view.xml",
         "views/fiscal_invoice_line_view.xml",
+        "views/res_company.xml",
         # Wizards
         "wizards/account_move_reversal_view.xml",
         "wizards/wizard_document_status.xml",

--- a/l10n_br_account/models/__init__.py
+++ b/l10n_br_account/models/__init__.py
@@ -14,3 +14,4 @@ from . import fiscal_document
 from . import fiscal_document_line
 from . import account_incoterms
 from . import ir_model_data
+from . import res_company

--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -477,7 +477,10 @@ class AccountMoveLine(models.Model):
         }
         user_type = user_type_map.get(self.move_id.move_type, "sale")
 
-        if self.fiscal_operation_line_id.disable_tax_entries:
+        if (
+            self.fiscal_operation_line_id.disable_tax_entries
+            or self.company_id.disable_tax_entries
+        ):
             # If the operation line is configured to not generate tax entries,
             self.tax_ids = False
         else:

--- a/l10n_br_account/models/fiscal_operation_line.py
+++ b/l10n_br_account/models/fiscal_operation_line.py
@@ -13,3 +13,9 @@ class OperationLine(models.Model):
         string="Fiscal Position",
         company_dependent=True,
     )
+
+    disable_tax_entries = fields.Boolean(
+        string="Disable Tax Entries",
+        help="If checked, no accounting entries for taxes will be generated for "
+        "this operation line.",
+    )

--- a/l10n_br_account/models/res_company.py
+++ b/l10n_br_account/models/res_company.py
@@ -1,0 +1,14 @@
+# Copyright (C) 2024 - TODAY Felipe Motter Pereira - Engenere.one
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    disable_tax_entries = fields.Boolean(
+        string="Disable Tax Entries",
+        help="If checked, no accounting entries for taxes will be generated for "
+        "this company.",
+    )

--- a/l10n_br_account/views/fiscal_operation_line_view.xml
+++ b/l10n_br_account/views/fiscal_operation_line_view.xml
@@ -12,6 +12,12 @@
                     attrs="{'readonly': [('state', '!=', 'draft')]}"
                 />
             </field>
+            <field name="document_type_id" position="after">
+                <field
+                    name="disable_tax_entries"
+                    attrs="{'readonly': [('state', '!=', 'draft')]}"
+                />
+            </field>
         </field>
     </record>
 

--- a/l10n_br_account/views/res_company.xml
+++ b/l10n_br_account/views/res_company.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="company_form" model="ir.ui.view">
+        <field name="name">res.company.form</field>
+        <field name="model">res.company</field>
+        <field name="inherit_id" ref="l10n_br_fiscal.fiscal_res_company_form" />
+        <field name="arch" type="xml">
+            <group name="inss_taxes" position="after">
+                <group name="tax_entries" string="Taxes Entries">
+                    <field name="disable_tax_entries" />
+                </group>
+            </group>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Esta PR introduz uma nova funcionalidade para desabilitar a criação de lançamentos contábeis para impostos fiscais especificados em faturas. Essa funcionalidade é alcançada através da introdução de um novo campo booleano, `disable_tax_entries`. Quando este campo está marcado, nenhum lançamento contábil para impostos será gerado para a linha de operação.

O objetivo desta funcionalidade é fornecer aos usuários maior flexibilidade no gerenciamento de sua contabilidade fiscal. Isso pode ser particularmente útil em cenários onde, por exemplo, a empresa deseja gerenciar certos aspectos dos impostos manualmente ou em circunstâncias especiais que exigem que os lançamentos de impostos sejam desativados. Além disso, fornece uma maneira de evitar erros de lançamento acidental que podem complicar os registros contábeis.

Qualquer feedback é bem vindo!

