### PR TITLE
[14.0][FIX] l10n_br_account_payment_order: don't copy CNAB fields for invoice

### DIFF
--- a/l10n_br_account_payment_order/models/account_move_line.py
+++ b/l10n_br_account_payment_order/models/account_move_line.py
@@ -26,10 +26,12 @@ class AccountMoveLine(models.Model):
     cnab_state = fields.Selection(
         selection=ESTADOS_CNAB,
         string="Estados CNAB",
+        copy=False,
     )
 
     own_number = fields.Char(
         string="Nosso Numero",
+        copy=False,
     )
 
     # No arquivo de retorno do CNAB o campo pode ter um tamanho diferente,
@@ -58,16 +60,19 @@ class AccountMoveLine(models.Model):
 
     document_number = fields.Char(
         string="Número documento",
+        copy=False,
     )
 
     company_title_identification = fields.Char(
         string="Identificação Titulo Empresa",
+        copy=False,
     )
 
     payment_situation = fields.Selection(
         selection=SITUACAO_PAGAMENTO,
         string="Situação do Pagamento",
         default="inicial",
+        copy=False,
     )
 
     boleto_discount_perc = fields.Float(
@@ -80,6 +85,7 @@ class AccountMoveLine(models.Model):
     instructions = fields.Text(
         string="Instruções de cobrança",
         readonly=True,
+        copy=False,
     )
 
     journal_entry_ref = fields.Char(
@@ -94,12 +100,14 @@ class AccountMoveLine(models.Model):
     last_change_reason = fields.Text(
         readonly=True,
         string="Justificativa",
+        copy=False,
     )
 
     mov_instruction_code_id = fields.Many2one(
         comodel_name="l10n_br_cnab.mov.instruction.code",
         string="Código da Instrução para Movimento",
         help="Campo G061 do CNAB",
+        copy=False,
     )
 
     # Usados para deixar invisiveis/somente leitura


### PR DESCRIPTION
O objetivo desta PR é tornar os campos associados às informações do CNAB (Boleto) não copiáveis. Esses campos são específicos para cada fatura e devem ser gerados no momento em que a fatura é confirmada.


Esta melhoria é essencial para evitar a possibilidade de múltiplas faturas compartilharem o mesmo "nosso número" do boleto. Tal situação pode ocorrer se estes campos forem copiados de uma fatura para outra, levando a erros durante o processamento do retorno. Com essa correção, cada fatura terá seu "nosso número" único, garantindo a integridade dos dados e o funcionamento correto do sistema.


