### PR TITLE
[14.0][l10n_br_fiscal] infors typo fix

### DIFF
--- a/l10n_br_account/views/fiscal_invoice_line_view.xml
+++ b/l10n_br_account/views/fiscal_invoice_line_view.xml
@@ -7,7 +7,7 @@
     <field name="inherit_id" ref="l10n_br_fiscal.document_line_form" />
     <field name="mode">primary</field>
     <field name="arch" type="xml">
-      <xpath expr="//group[@name='fiscal_infors']" position="after">
+      <xpath expr="//group[@name='fiscal_info']" position="after">
           <group
                     name="accounting_fields"
                     string="Accounting"

--- a/l10n_br_fiscal/views/document_line_view.xml
+++ b/l10n_br_fiscal/views/document_line_view.xml
@@ -25,7 +25,7 @@
         <notebook>
           <page name="general" string="General">
             <group>
-              <group name="commercial_infors" string="Commercial">
+              <group name="commercial_info" string="Commercial">
                 <label for="quantity" />
                 <div class="o_row">
                   <field name="quantity" class="oe_inline" />
@@ -48,7 +48,7 @@
                                     attrs="{'readonly': ['|', ('delivery_costs', '=', 'total'), ('force_compute_delivery_costs_by_total', '=', True)]}"
                                 />
               </group>
-              <group name="fiscal_infors" string="Fiscal">
+              <group name="fiscal_info" string="Fiscal">
                 <label for="fiscal_quantity" />
                 <div class="o_row">
                   <field name="fiscal_quantity" class="oe_inline" />


### PR DESCRIPTION
s/_infors/_info/g

infors não é uma abreviação em inglês, agride o olho. Mas pode ser _info.