### PR TITLE
[14.0][l10n_br_coa_simple][FIX] missing tax receivable account

### DIFF
--- a/l10n_br_coa_simple/data/l10n_br_coa_simple_template_post.xml
+++ b/l10n_br_coa_simple/data/l10n_br_coa_simple_template_post.xml
@@ -7,6 +7,7 @@
         <field name="property_account_payable_id" ref="account_template_21101" />
         <field name="property_account_expense_categ_id" ref="account_template_32103" />
         <field name="property_account_income_categ_id" ref="account_template_31101" />
+        <field name="property_tax_receivable_account_id" ref="account_template_21302" />
         <field
             name="income_currency_exchange_account_id"
             ref="account_template_32302"


### PR DESCRIPTION
Empresas do simples não lançam o ICMS das compras, mas elas lançam o ICMS das vendas. No caso tava faltando setar a conta contábil do ICMS a recolher no plano ITG 1000. Agora ta automático, não precisa mais parametrizar manualmente no tax.group.

cc @renatonlima 