### PR TITLE
[14.0][FIX] l10n_br_nfse_paulistana: emissão de NFS-e com descontos.

### DIFF
--- a/l10n_br_nfse/models/document_line.py
+++ b/l10n_br_nfse/models/document_line.py
@@ -70,7 +70,7 @@ class DocumentLine(models.Model):
 
     def prepare_line_servico(self):
         return {
-            "valor_servicos": round(self.fiscal_price * self.fiscal_quantity, 2),
+            "valor_servicos": round(self.amount_total, 2),
             "valor_deducoes": round(self.fiscal_deductions_value, 2),
             "valor_pis": round(self.pis_value, 2) or round(self.pis_wh_value, 2),
             "valor_pis_retido": round(self.pis_wh_value, 2),

--- a/l10n_br_nfse_paulistana/models/document.py
+++ b/l10n_br_nfse_paulistana/models/document.py
@@ -275,7 +275,7 @@ class Document(models.Model):
         assinatura += "N"  # Corrigir - Verificar status do RPS
         assinatura += "N"
         assinatura += (
-            ("%.2f" % dados_lote_rps["total_recebido"]).replace(".", "").zfill(15)
+            ("%.2f" % dados_servico["valor_servicos"]).replace(".", "").zfill(15)
         )
         assinatura += (
             ("%.2f" % dados_lote_rps["carga_tributaria"]).replace(".", "").zfill(15)


### PR DESCRIPTION
Esta PR tem como objetivo solucionar um problema identificado na emissão da Nota Fiscal de Serviços Eletrônica (NFS-e) Paulistana quando emitidas a partir de faturas com **descontos aplicados**.

Sem a devida correção, a nota fiscal tem sido rejeitada, conforme ilustrado na seguinte imagem:

![image](https://github.com/OCA/l10n-brazil/assets/634278/ca18baf7-db17-46f0-a462-82a40a63b2fa)

Identificamos que a raiz do problema estava na forma como o valor do serviço era reportado na linha da nota fiscal. O valor correto a ser informado deve ser o Preço do Serviço líquido dos descontos incondicionais. Assim, decidi utilizar o `amount_total` para esse fim.

Este trabalho ainda está em rascunho. Planejo realizar testes em ambiente de produção para garantir a eficácia da correção. Além disso, pretendo adicionar um caso de teste unitário para garantir que o problema não se repita no futuro.


