### PR TITLE
[FIX][l10n_br_coa] conta ICMS SN à recolher

### DIFF
--- a/l10n_br_coa_simple/data/l10n_br_coa.account.tax.group.account.template.csv
+++ b/l10n_br_coa_simple/data/l10n_br_coa.account.tax.group.account.template.csv
@@ -1,5 +1,6 @@
 "id","tax_group_id:id","account_id:id","refund_account_id:id",ded_account_id:id,chart_template_id:id
 "l10n_br_coa_simple.account_tax_group_account_template_icms","l10n_br_coa.tax_group_icms","l10n_br_coa_simple.account_template_21302","l10n_br_coa_simple.account_template_11402",,l10n_br_coa_simple_chart_template
+"l10n_br_coa_simple.account_tax_group_account_template_icmssn","l10n_br_coa.tax_group_icmssn","l10n_br_coa_simple.account_template_21302","l10n_br_coa_simple.account_template_11402",,l10n_br_coa_simple_chart_template
 "l10n_br_coa_simple.account_tax_group_account_template_ipi","l10n_br_coa.tax_group_ipi","l10n_br_coa_simple.account_template_21304","l10n_br_coa_simple.account_template_11402",,l10n_br_coa_simple_chart_template
 "l10n_br_coa_simple.account_tax_group_account_template_pis","l10n_br_coa.tax_group_pis","l10n_br_coa_simple.account_template_21305","l10n_br_coa_simple.account_template_11402",,l10n_br_coa_simple_chart_template
 "l10n_br_coa_simple.account_tax_group_account_template_confins","l10n_br_coa.tax_group_cofins","l10n_br_coa_simple.account_template_21306","l10n_br_coa_simple.account_template_11402",,l10n_br_coa_simple_chart_template

--- a/l10n_br_coa_simple/data/l10n_br_coa_simple_template_post.xml
+++ b/l10n_br_coa_simple/data/l10n_br_coa_simple_template_post.xml
@@ -7,7 +7,6 @@
         <field name="property_account_payable_id" ref="account_template_21101" />
         <field name="property_account_expense_categ_id" ref="account_template_32103" />
         <field name="property_account_income_categ_id" ref="account_template_31101" />
-        <field name="property_tax_receivable_account_id" ref="account_template_21302" />
         <field
             name="income_currency_exchange_account_id"
             ref="account_template_32302"


### PR DESCRIPTION
Pessoal, peço desculpa pois eu me embananei no fix https://github.com/OCA/l10n-brazil/pull/2579 da conta do ICMS 2 dias atras. Eu não sei como eu errei o teste, mas o que eu tinha feito não resolve. Na vdd pode ate atrapalhar porque uma empresa do simples pode vender com ICMS ou com ISS e ai ter uma conta geral de taxa ICMS a recolher  nem fica legal.

Basicamente o problema era esse que se vc escolhe o plano de conta ITG 1000, a conta que ele lança o ICMS a recolher não é a correta:
![2023-07-05_01-13](https://github.com/OCA/l10n-brazil/assets/16926/712bf141-7019-4457-844a-78f5f0877e6e)

O problema é que no caso do ITG 1000 ele lança as vendas com o impostos ICMS SN e esse ICMS SN não tinha as contas contabeis parametrizadas (diferentemente do ICMS):
![2023-07-05_01-12](https://github.com/OCA/l10n-brazil/assets/16926/4bc6096b-ddd5-46dd-a450-ac97d299825e)

Agora com esse PR ta solucionado:
![2023-07-05_08-57](https://github.com/OCA/l10n-brazil/assets/16926/509be458-8463-478d-bc22-30e84a950172)


cc @renatonlima @marcelsavegnago 
