### PR TITLE
[12.0][l10n_br_base][BUG] Removido o método _set_street do res.partner

### DIFF
--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -175,12 +175,6 @@ class Partner(models.Model):
         Overwrite this function if you want to add your own fields."""
         return super().get_street_fields() + ["street"]
 
-    def _set_street(self):
-        company_country = self.env.user.company_id.country_id
-        if company_country.code:
-            if company_country.code.upper() != "BR":
-                return super()._set_street()
-
     @api.onchange("city_id")
     def _onchange_city_id(self):
         self.city = self.city_id.name


### PR DESCRIPTION
Antes na localização brasileira era utilizado somente o campo street para armazenar o logradouro do endereço do parceiro e esse método foi implementado para no caso dos clientes brasileiros esse campo não fosse recalculado pelo módulo [base_address_extended](https://github.com/odoo/odoo/tree/12.0/addons/base_address_extended), há algum tempo passou a ser utilizado o campo street_name para o logradouro do endereço do cliente e o campo street passou a ser um campo calculado de acordo com o formato definido no campo street_format do país do parceiro e deixando essa funcionalidade mais nativa, mas na versão 12.0 é necessário remover esse método para permitir que o street seja calculado corretamente, caso contrário o campo não será atualizado, por exemplo:

![Screenshot from 2023-07-05 12-58-24](https://github.com/OCA/l10n-brazil/assets/211005/f62747c0-5244-4ce7-9096-de51d498d23d)

Esse problema não existe mais na 14.0 esse código foi removido durante a migração.
