### PR TITLE
[14.0][FIX] l10n_br_fiscal: remove duplicate code

### DIFF
--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -494,18 +494,6 @@ class Document(models.Model):
         self.document_subsequent_ids = subsequent_documents
         return result
 
-    @api.onchange("document_type_id")
-    def _onchange_document_type_id(self):
-        if self.document_type_id and self.issuer == DOCUMENT_ISSUER_COMPANY:
-            self.document_serie_id = self.document_type_id.get_document_serie(
-                self.company_id, self.fiscal_operation_id
-            )
-
-    @api.onchange("document_serie_id")
-    def _onchange_document_serie_id(self):
-        if self.document_serie_id and self.issuer == DOCUMENT_ISSUER_COMPANY:
-            self.document_serie = self.document_serie_id.code
-
     def _prepare_referenced_subsequent(self, doc_referenced):
         self.ensure_one()
         return {


### PR DESCRIPTION
Mais uma pequena limpeza, remove o código duplicado no fiscal.
Esses dois "onchanges" que estão sendo removidos já estão implementados no [document.move.mixin](https://github.com/OCA/l10n-brazil/blob/15dca6c4e83d9847015ee608bc9d3bb004672116/l10n_br_fiscal/models/document_move_mixin.py#L214-L224)

Testei na prática e não teve alteração no comportamento, testei primeiro somente com o módulo fiscal instalado e em seguida com o account junto.