### PR TITLE
[14.0][muitos modulos] fix demo mode detection

### DIFF
--- a/l10n_br_account_nfe/hooks.py
+++ b/l10n_br_account_nfe/hooks.py
@@ -17,12 +17,15 @@ def load_simples_nacional_demo(env, registry):
     """
 
     # Load XML file with demo data.
-    if not tools.config["without_demo"]:
+    company_sn = env.ref(
+        "l10n_br_base.empresa_simples_nacional", raise_if_not_found=False
+    )
+    if company_sn:
 
         # Allow all companies for OdooBot user and set default user company
         companies = env["res.company"].search([])
         env.user.company_ids = [(6, 0, companies.ids)]
-        env.user.company_id = env.ref("l10n_br_base.empresa_simples_nacional")
+        env.user.company_id = company_sn
 
         tools.convert_file(
             env.cr,

--- a/l10n_br_base/__init__.py
+++ b/l10n_br_base/__init__.py
@@ -23,8 +23,9 @@ def _auto_install_l10n_br_generic_module(env):
         else:
             module_name_domain = [("name", "=", "l10n_br_coa_simple")]
 
-        # Load all l10n_br COA in Demo
-        if not tools.config["without_demo"]:
+        # Load all l10n_br COA's in demo mode:
+        env.cr.execute("select demo from ir_module_module where name='l10n_br_base';")
+        if env.cr.fetchone()[0]:
             module_name_domain = [
                 (
                     "name",

--- a/l10n_br_cnab_structure/hooks.py
+++ b/l10n_br_cnab_structure/hooks.py
@@ -34,7 +34,8 @@ def post_init_hook(cr, registry):
             kind="init",
         )
 
-    if not tools.config["without_demo"]:
+    cr.execute("select demo from ir_module_module where name='l10n_br_cnab_structure';")
+    if cr.fetchone()[0]:
         demofiles = [
             "demo/account_account.xml",
             "demo/account_journal.xml",

--- a/l10n_br_coa_generic/hooks.py
+++ b/l10n_br_coa_generic/hooks.py
@@ -18,19 +18,18 @@ def post_init_hook(cr, registry):
         # Relate fiscal taxes to account taxes.
         load_fiscal_taxes(env, coa_generic_tmpl)
 
-    # Load COA to Demo Company
-    if not tools.config.get("without_demo"):
-        company = env.ref(
-            "l10n_br_base.empresa_lucro_presumido", raise_if_not_found=False
+    # Load COA for demo Company
+    company_lc = env.ref(
+        "l10n_br_base.empresa_lucro_presumido", raise_if_not_found=False
+    )
+    if company_lc:
+        coa_generic_tmpl.try_loading(company=company_lc)
+        tools.convert_file(
+            cr,
+            "l10n_br_coa_generic",
+            "demo/account_journal.xml",
+            None,
+            mode="init",
+            noupdate=True,
+            kind="init",
         )
-        if company:
-            coa_generic_tmpl.try_loading(company=company)
-            tools.convert_file(
-                cr,
-                "l10n_br_coa_generic",
-                "demo/account_journal.xml",
-                None,
-                mode="init",
-                noupdate=True,
-                kind="init",
-            )

--- a/l10n_br_coa_simple/hooks.py
+++ b/l10n_br_coa_simple/hooks.py
@@ -18,19 +18,18 @@ def post_init_hook(cr, registry):
         # Relate fiscal taxes to account taxes.
         load_fiscal_taxes(env, coa_simple_tmpl)
 
-    # Load COA to Demo Company
-    if not tools.config.get("without_demo"):
-        company = env.ref(
-            "l10n_br_base.empresa_simples_nacional", raise_if_not_found=False
+    # Load COA for demo Company
+    company_sn = env.ref(
+        "l10n_br_base.empresa_simples_nacional", raise_if_not_found=False
+    )
+    if company_sn:
+        coa_simple_tmpl.try_loading(company=company_sn)
+        tools.convert_file(
+            cr,
+            "l10n_br_coa_simple",
+            "demo/account_journal.xml",
+            None,
+            mode="init",
+            noupdate=True,
+            kind="init",
         )
-        if company:
-            coa_simple_tmpl.try_loading(company=company)
-            tools.convert_file(
-                cr,
-                "l10n_br_coa_simple",
-                "demo/account_journal.xml",
-                None,
-                mode="init",
-                noupdate=True,
-                kind="init",
-            )

--- a/l10n_br_fiscal/hooks.py
+++ b/l10n_br_fiscal/hooks.py
@@ -44,7 +44,9 @@ def post_init_hook(cr, registry):
             kind="init",
         )
 
-    if not tools.config["without_demo"]:
+    env.cr.execute("select demo from ir_module_module where name='l10n_br_fiscal';")
+    is_demo = env.cr.fetchone()[0]
+    if is_demo:
         demofiles = [
             "demo/l10n_br_fiscal.ncm-demo.csv",
             "demo/l10n_br_fiscal.nbm-demo.csv",
@@ -105,7 +107,7 @@ def post_init_hook(cr, registry):
                 misc.prepare_fake_certificate_vals(cert_type=CERTIFICATE_TYPE_ECNPJ)
             )
 
-    if tools.config["without_demo"]:
+    if not is_demo:
         prodfiles = []
         # Load full CSV files with few lines unless a flag
         # mention the contrary
@@ -157,7 +159,7 @@ def post_init_hook(cr, registry):
         )
 
     # Load post demo files
-    if not tools.config["without_demo"]:
+    if is_demo:
         posdemofiles = [
             "demo/fiscal_document_demo.xml",
         ]

--- a/l10n_br_purchase/hooks.py
+++ b/l10n_br_purchase/hooks.py
@@ -6,7 +6,8 @@ from odoo import SUPERUSER_ID, api, tools
 
 def post_init_hook(cr, registry):
 
-    if not tools.config["without_demo"]:
+    cr.execute("select demo from ir_module_module where name='l10n_br_purchase';")
+    if cr.fetchone()[0]:
         env = api.Environment(cr, SUPERUSER_ID, {})
         purchase_orders = env["purchase.order"].search(
             [("company_id", "!=", env.ref("base.main_company").id)]

--- a/l10n_br_sale/hooks.py
+++ b/l10n_br_sale/hooks.py
@@ -6,7 +6,8 @@ from odoo import SUPERUSER_ID, api, tools
 
 def post_init_hook(cr, registry):
 
-    if not tools.config["without_demo"]:
+    cr.execute("select demo from ir_module_module where name='l10n_br_sale';")
+    if cr.fetchone()[0]:
         env = api.Environment(cr, SUPERUSER_ID, {})
         sale_orders = env["sale.order"].search(
             [("company_id", "!=", env.ref("base.main_company").id)]

--- a/l10n_br_stock/hooks.py
+++ b/l10n_br_stock/hooks.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from odoo import SUPERUSER_ID, _, api, tools
+from odoo import SUPERUSER_ID, _, api
 
 _logger = logging.getLogger(__name__)
 
@@ -84,10 +84,13 @@ def set_stock_warehouse_external_ids(env, company_external_id):
 def pre_init_hook(cr):
     """Import XML data to change core data"""
 
-    if not tools.config["without_demo"]:
-        _logger.info(_("Loading l10n_br_stock warehouse external ids..."))
-        with api.Environment.manage():
-            env = api.Environment(cr, SUPERUSER_ID, {})
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        company_sn = env.ref(
+            "l10n_br_base.empresa_simples_nacional", raise_if_not_found=False
+        )
+        if company_sn:
+            _logger.info(_("Loading l10n_br_stock warehouse external ids..."))
             set_stock_warehouse_external_ids(
                 env, "l10n_br_base.empresa_simples_nacional"
             )

--- a/l10n_br_stock_account/hooks.py
+++ b/l10n_br_stock_account/hooks.py
@@ -6,7 +6,8 @@ from odoo import SUPERUSER_ID, api, tools
 
 def post_init_hook(cr, registry):
 
-    if not tools.config["without_demo"]:
+    cr.execute("select demo from ir_module_module where name='l10n_br_stock_account';")
+    if cr.fetchone()[0]:
         env = api.Environment(cr, SUPERUSER_ID, {})
 
         # Load COA Fiscal Operation properties


### PR DESCRIPTION
Pessoal, eu acabei de instalar um novo ambiente de dev Docky e por padrão na minha configuração odoo.cfg tinha `without_demo = False`
enquanto que no meu ambiente antigo eu tinha `without_demo = ` (vazio) que parece ser tb a configuração na CI e Runboat.

So que `without_demo = False` é perfeitamente valido pro Odoo tambem e com isso ele começa a carregar os dados de demo. So que ele não carrega nada do que a gente espera dos dados de demo do OCA/l10n-brazil dentro dos hooks e depois  quebra com outros dados de demo da localização (que não estão nos hooks) e nem roda os testes. Isso deve estar ferrando uma galera de pessoas iniciantes tentando estudar o projeto. Nos reportaram muitos erros do tipo que algum registro de demo não tinha sido encontrado. Talvez era isso as vezes....

Bem nisso eu corrigi para ficar mais robusto: quando o hook precisava em especial de alguma empresa de demo eu procurei a empresa de demo, senão eu usei a query do campo demo na tabela ir_module_module.