### PR TITLE
[14.0][l10n_br_coa][l10n_br_simple][l10n_br_generic] refactor load fiscal taxes

### DIFF
--- a/l10n_br_account/hooks.py
+++ b/l10n_br_account/hooks.py
@@ -1,8 +1,7 @@
 # Copyright (C) 2019 - Raphaël Valyi Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import SUPERUSER_ID, _, api
-from odoo.exceptions import UserError
+from odoo import SUPERUSER_ID, api
 from odoo.tools.sql import column_exists, create_column
 
 
@@ -18,35 +17,6 @@ def pre_init_hook(cr):
     that we use to fill these new foreign keys.
     """
     env = api.Environment(cr, SUPERUSER_ID, {})
-
-    cr.execute("select demo from ir_module_module where name='l10n_br_account';")
-    is_demo = cr.fetchone()[0]
-    if is_demo:
-        # load convenient COAs that are used in demos and tests
-        # without a hard dependency (you don't need all COAs for production)
-        coa_modules = env["ir.module.module"].search(
-            [
-                ("name", "in", ("l10n_br_coa_generic", "l10n_br_coa_simple")),
-                ("state", "=", "uninstalled"),
-            ]
-        )
-
-        if coa_modules:
-            raise UserError(
-                _(
-                    """It looks like your database %s is running with demo
-                   data. But the l10n_br_account module will need you to install the
-                   l10n_br_coa_simple and l10n_br_coa_generic
-                   chart of accounts modules first to load l10n_br_account demo data
-                   or run its tests properly (for production, these dependencies are not
-                   required, that is why these are not usual explicit
-                   module dependencies).
-                   Please install the l10n_br_coa_simple and l10n_br_coa_generic modules
-                   first and try installing the l10n_br_account module again.
-                """,
-                    cr.dbname,
-                )
-            )
 
     # Create fiscal_document_id fields
     if not column_exists(cr, "account_move", "fiscal_document_id"):
@@ -83,28 +53,6 @@ def pre_init_hook(cr):
         )
 
 
-def load_fiscal_taxes(env, l10n_br_coa_chart):
-    companies = env["res.company"].search(
-        [("chart_template_id", "=", l10n_br_coa_chart.id)]
-    )
-
-    for company in companies:
-        taxes = env["account.tax"].search([("company_id", "=", company.id)])
-
-        for tax in taxes:
-            if tax.get_external_id():
-                tax_ref = tax.get_external_id().get(tax.id)
-                ref_module, ref_name = tax_ref.split(".")
-                ref_name = ref_name.replace(str(company.id) + "_", "")
-                template_source_ref = ".".join(["l10n_br_coa", ref_name])
-                template_source = env.ref(template_source_ref)
-                tax_source_ref = ".".join([ref_module, ref_name])
-                tax_template = env.ref(tax_source_ref)
-                tax.fiscal_tax_ids = (
-                    tax_template.fiscal_tax_ids
-                ) = template_source.fiscal_tax_ids
-
-
 def post_init_hook(cr, registry):
     """Relate fiscal taxes to account taxes."""
     env = api.Environment(cr, SUPERUSER_ID, {})
@@ -113,4 +61,4 @@ def post_init_hook(cr, registry):
     )
 
     for l10n_br_coa_chart in l10n_br_coa_charts:
-        load_fiscal_taxes(env, l10n_br_coa_chart)
+        l10n_br_coa_chart.load_fiscal_taxes()

--- a/l10n_br_account/models/__init__.py
+++ b/l10n_br_account/models/__init__.py
@@ -1,5 +1,6 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+from . import account_chart_template
 from . import account_document_line_mixin
 from . import account_tax_group
 from . import fiscal_tax_group

--- a/l10n_br_account/models/account_chart_template.py
+++ b/l10n_br_account/models/account_chart_template.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2019  Renato Lima - Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class AccountChartTemplate(models.Model):
+    _inherit = "account.chart.template"
+
+    def _load_template(
+        self, company, code_digits=None, account_ref=None, taxes_ref=None
+    ):
+        """
+        If the CoA is installed before l10n_br_account, at least we trigger
+        load_fiscal_taxes from the l10n_br_account/hooks.py for the demo CoA's.
+        With this override, we also ensure these demo CoA or any custom CoA
+        will get its account taxes properly linked to fiscal taxes when it is
+        installed after l10n_br_account.
+        """
+        self.ensure_one()
+        account_ref, taxes_ref = super()._load_template(
+            company, code_digits, account_ref, taxes_ref
+        )
+
+        if self.parent_id and self.parent_id == self.env.ref(
+            "l10n_br_coa.l10n_br_coa_template"
+        ):
+            self.load_fiscal_taxes()
+        return account_ref, taxes_ref
+
+    def load_fiscal_taxes(self):
+        """
+        Relate account taxes with fiscal taxes to enable the Brazilian
+        tax engine to kick in with the installed chart of account.
+        """
+        for coa_tpl in self:
+            companies = self.env["res.company"].search(
+                [("chart_template_id", "=", coa_tpl.id)]
+            )
+
+            for company in companies:
+                taxes = self.env["account.tax"].search(
+                    [("company_id", "=", company.id)]
+                )
+
+                for tax in taxes:
+                    if tax.get_external_id():
+                        tax_ref = tax.get_external_id().get(tax.id)
+                        ref_module, ref_name = tax_ref.split(".")
+                        ref_name = ref_name.replace(str(company.id) + "_", "")
+                        template_source_ref = ".".join(["l10n_br_coa", ref_name])
+                        template_source = self.env.ref(template_source_ref)
+                        tax_source_ref = ".".join([ref_module, ref_name])
+                        tax_template = self.env.ref(tax_source_ref)
+                        tax.fiscal_tax_ids = (
+                            tax_template.fiscal_tax_ids
+                        ) = template_source.fiscal_tax_ids

--- a/l10n_br_coa/models/account_chart_template.py
+++ b/l10n_br_coa/models/account_chart_template.py
@@ -28,7 +28,9 @@ class AccountChartTemplate(models.Model):
             company, code_digits, account_ref, taxes_ref
         )
 
-        if self.parent_id:
+        if self.parent_id and self.parent_id == self.env.ref(
+            "l10n_br_coa.l10n_br_coa_template"
+        ):
 
             acc_names = {
                 "sale": {

--- a/l10n_br_coa_generic/hooks.py
+++ b/l10n_br_coa_generic/hooks.py
@@ -7,16 +7,6 @@ from odoo import SUPERUSER_ID, api, tools
 def post_init_hook(cr, registry):
     env = api.Environment(cr, SUPERUSER_ID, {})
     coa_generic_tmpl = env.ref("l10n_br_coa_generic.l10n_br_coa_generic_template")
-    if env["ir.module.module"].search_count(
-        [
-            ("name", "=", "l10n_br_account"),
-            ("state", "=", "installed"),
-        ]
-    ):
-        from odoo.addons.l10n_br_account.hooks import load_fiscal_taxes
-
-        # Relate fiscal taxes to account taxes.
-        load_fiscal_taxes(env, coa_generic_tmpl)
 
     # Load COA to Demo Company
     if not tools.config.get("without_demo"):

--- a/l10n_br_coa_simple/hooks.py
+++ b/l10n_br_coa_simple/hooks.py
@@ -7,16 +7,6 @@ from odoo import SUPERUSER_ID, api, tools
 def post_init_hook(cr, registry):
     env = api.Environment(cr, SUPERUSER_ID, {})
     coa_simple_tmpl = env.ref("l10n_br_coa_simple.l10n_br_coa_simple_chart_template")
-    if env["ir.module.module"].search_count(
-        [
-            ("name", "=", "l10n_br_account"),
-            ("state", "=", "installed"),
-        ]
-    ):
-        from odoo.addons.l10n_br_account.hooks import load_fiscal_taxes
-
-        # Relate fiscal taxes to account taxes.
-        load_fiscal_taxes(env, coa_simple_tmpl)
 
     # Load COA to Demo Company
     if not tools.config.get("without_demo"):


### PR DESCRIPTION
Quando eu implementei os testes dos lançamentos em https://github.com/OCA/l10n-brazil/pull/2590 eu me dei conta que o teste precisava chamar aquele metodo `load_fiscal_taxes()`. Ele estava sendo definido no `l10n_br_account/hooks.py` mas eu não acho isso muito bom. Pois hoje, se vc criar um modulo com um plano customizado, vc vai ter que chamar esse metodo tambem e não fica facil. Se vc não carregar seu modulo antes do l10n_br_account, vc tem que chamar o load_fiscal_taxes() pelo odoo shell por examplo.

Não ficaria melhor assim de simplesmente chamar esse `load_fiscal_taxes()` na hora de carregar um novo template de plano se for filho do plano l10n_br_coa? E assim vc consegue instalar seu plano meio que quando vc quiser sem se preocupar e da até para tirar aquele bloqueio que a gente tinha colocado no l10n_br_account/hooks.py.

Minha ideia seria fazer um rebase de https://github.com/OCA/l10n-brazil/pull/2590 depois deste merge.