### PR TITLE
[14.0][l10n_br_nfe][l10n_br_nfse][l10n_br_nfse_paulistana] require erpbrasil.edoc>=2.4.0

### DIFF
--- a/l10n_br_nfe/__manifest__.py
+++ b/l10n_br_nfe/__manifest__.py
@@ -38,7 +38,7 @@
         "python": [
             "nfelib>=2.0.0",
             "erpbrasil.transmissao",
-            "erpbrasil.edoc",
+            "erpbrasil.edoc>=2.4.0",
             "erpbrasil.edoc.pdf",
         ],
     },

--- a/l10n_br_nfse/__manifest__.py
+++ b/l10n_br_nfse/__manifest__.py
@@ -12,7 +12,7 @@
     "website": "https://github.com/OCA/l10n-brazil",
     "external_dependencies": {
         "python": [
-            "erpbrasil.edoc",
+            "erpbrasil.edoc>=2.4.0",
             "erpbrasil.assinatura",
             "erpbrasil.transmissao",
             "erpbrasil.base>=2.3.0",

--- a/l10n_br_nfse_paulistana/__manifest__.py
+++ b/l10n_br_nfse_paulistana/__manifest__.py
@@ -13,7 +13,7 @@
     "website": "https://github.com/OCA/l10n-brazil",
     "external_dependencies": {
         "python": [
-            "erpbrasil.edoc",
+            "erpbrasil.edoc>=2.4.0",
             "erpbrasil.assinatura",
             "erpbrasil.transmissao",
             "erpbrasil.base>=2.3.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@
 email-validator
 erpbrasil.assinatura
 erpbrasil.base>=2.3.0
-erpbrasil.edoc
 erpbrasil.edoc.pdf
+erpbrasil.edoc>=2.4.0
 erpbrasil.transmissao
 nfelib>=2.0.0
 nfselib.paulistana


### PR DESCRIPTION
resolve https://github.com/OCA/l10n-brazil/issues/2599

nota: infelizmente hoje se a gente não declarar uma external_dependencies transitiva, da warning na CI da OCA, então tem que repetir para todos os módulos mesmo. A gente tb tem que dividir os commits por modulo para não complicar os cherry-picks entre as branches...