### PR TITLE
[14.0][FIX] l10n_br_product_contract: is_contract

### DIFF
--- a/l10n_br_product_contract/demo/sale_order.xml
+++ b/l10n_br_product_contract/demo/sale_order.xml
@@ -33,6 +33,7 @@
         <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_servico" />
         <field name="recurring_invoicing_type">pre-paid</field>
         <field name="recurring_rule_type">monthly</field>
+        <field name="is_contract">True</field>
     </record>
 
     <function model="sale.order.line" name="_onchange_fiscal_operation_id">


### PR DESCRIPTION
cc @marcelsavegnago 

Adicionado o field is_contract para o demo referente ao sale.order.line e com esse ajuste o erro relatado nos tests pela PR #2545, fez com que o teste seja executado corretamente.

Seguindo a lógica pelo IMP realizado no product_contract, notei que o product_id.is_contract foi alterado por is_contract, em base disso fiz essa adição do campo ao demo do sale.order.line