### PR TITLE
[14.0][IMP] spec_driven_model: Verificação no loop de registro dos hooks

### DIFF
--- a/spec_driven_model/hooks.py
+++ b/spec_driven_model/hooks.py
@@ -151,6 +151,12 @@ def register_hook(env, module_name, spec_module, force=False):
         spec_class = StackedModel._odoo_name_to_class(name, spec_module)
         spec_class._module = "fiscal"  # TODO use python_module ?
         fields = env[spec_class._name].fields_get_keys()
+
+        if not any(
+            field.startswith(env[spec_class._name]._field_prefix) for field in fields
+        ):
+            continue
+
         rec_name = next(
             filter(
                 lambda x: (


### PR DESCRIPTION
Quando estava implementando o módulo para a CT-e e utilizando o código em https://github.com/OCA/l10n-brazil/pull/2596, acabei esbarrando em um problema de uma classe que estava sendo utilizada e não possuía nenhum campo com o prefixo implementada. Isso faz com a que a iteração do loop seja interrompida e gere um erro, além de não deixar o módulo ser instalado.

Eu consegui contornar no módulo que está sendo desenvolvido comentando a definição da classe e de onde está o relacional, mas é apenas uma gambiarra para não interromper nada.

A ideia dessa melhoria é que ele só continue com o restante do código, apenas, se qualquer um dos campos contenha esse prefixo.

cc: @mileo @rvalyi @marcelsavegnago @antoniospneto 