### PR TITLE
[14.0][FIX] l10n_br_fiscal: fix access to contact form

### DIFF
--- a/l10n_br_fiscal/views/res_partner_view.xml
+++ b/l10n_br_fiscal/views/res_partner_view.xml
@@ -11,8 +11,8 @@
                     <field
                         name="fiscal_profile_id"
                         force_save="1"
-                        widget="radio"
                         required="1"
+                        groups="l10n_br_fiscal.group_user"
                     />
                     <field
                         name="ind_ie_dest"


### PR DESCRIPTION
O objetivo desta mudança é permitir o acesso ao formulário do contato sem ter que adicionar o usuário ao grupo l10n_br_fiscal.group_user. Tive que remover o widget porque com ele não está aplicando a verificação do grupo mas não me aprofundei. 