### PR TITLE
[14.0][FIX] compute nfe40_infRespTec in order to work with spec_import

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -542,8 +542,18 @@ class NFe(spec_models.StackedModel):
 
     nfe40_infRespTec = fields.Many2one(
         comodel_name="res.partner",
-        related="company_id.technical_support_id",
+        compute="_compute_resptec_data",
     )
+
+    ##########################
+    # NF-e tag: infRespTec
+    # Compute Methods
+    ##########################
+
+    @api.depends("company_id")
+    def _compute_resptec_data(self):
+        for doc in self:
+            doc.nfe40_infRespTec = doc.company_id.technical_support_id
 
     ##########################
     # NF-e tag: autXML


### PR DESCRIPTION
Ao implementar a importação de NF-e, no PR #2552, acabei me deparando com uma situação ao importar um XML que possua uma tag many2one e que esse campo no odoo seja "related", como é o caso da tag **"infRespTec"**:

Nesse caso o valor desse campo estava sendo considerado pelo odoo como literal, ocasionando um erro no momento da importação. Para solucionar, alterei o campo de related para computado.