### PR TITLE
[14.0][FIX] l10n_br_account: set doc line to right move line

### DIFF
--- a/l10n_br_account/models/fiscal_document_line.py
+++ b/l10n_br_account/models/fiscal_document_line.py
@@ -33,9 +33,9 @@ class FiscalDocumentLine(models.Model):
         This is a requirement to allow account moves without fiscal documents despite
         the _inherits system.
         """
+
         if self._context.get("create_from_move_line"):
-            return super().create(
-                list(filter(lambda vals: vals.get("document_id"), vals_list))
-            )
-        else:
-            return super().create(vals_list)
+            if not any(vals.get("document_id") for vals in vals_list):
+                return []
+
+        return super().create(vals_list)


### PR DESCRIPTION
Após a retirada do dummy, tivemos uma pequena regressão na criação de faturas com 2 ou mais linhas de fatura, onde as linhas do documento fiscal eram atribuídas a move lines errados(geralmente de impostos).

O erro só acontece com faturas novas sendo criadas diretamente pela visão da fatura, com 2 ou mais linhas. O erro não ocorre se a fatura for criada de um outro modelo(pedido de venda por exemplo) ou tiver uma linha nova.

Exemplificando:
![image](https://github.com/OCA/l10n-brazil/assets/6812128/41f9c599-f282-4233-a1cc-876c08a57b1b)
