### PR TITLE
[14.0][IMP] l10n_br_fiscal: remove required for field fiscal_profile_id

### DIFF
--- a/l10n_br_fiscal/views/res_partner_view.xml
+++ b/l10n_br_fiscal/views/res_partner_view.xml
@@ -11,7 +11,6 @@
                     <field
                         name="fiscal_profile_id"
                         force_save="1"
-                        required="1"
                         groups="l10n_br_fiscal.group_user"
                     />
                     <field


### PR DESCRIPTION
Antes quando esse campo tinha o `widget=radio ` o required não funcionava, depois com o merge da PR https://github.com/OCA/l10n-brazil/pull/2606 o required voltou a funcionar, mas acredito que não tem necessidade para esse campo, até agora estava sem ser requerido e não houve problemas.
