### PR TITLE
[14.0][l10n_br_fiscal][REF] unnest tools dir

### DIFF
--- a/l10n_br_fiscal/models/cest.py
+++ b/l10n_br_fiscal/models/cest.py
@@ -3,8 +3,8 @@
 
 from odoo import api, fields, models
 
+from .. import tools
 from ..constants.fiscal import CEST_SEGMENT
-from ..tools import misc
 
 
 class Cest(models.Model):
@@ -61,5 +61,5 @@ class Cest(models.Model):
         ncm = self.env["l10n_br_fiscal.ncm"]
         for r in self:
             if r.ncms:
-                domain = misc.domain_field_codes(field_codes=r.ncms)
+                domain = tools.domain_field_codes(field_codes=r.ncms)
                 r.ncm_ids = ncm.search(domain)

--- a/l10n_br_fiscal/models/document_event.py
+++ b/l10n_br_fiscal/models/document_event.py
@@ -10,7 +10,7 @@ from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 from ..constants.fiscal import EVENT_ENVIRONMENT
-from ..tools.misc import build_edoc_path
+from ..tools import build_edoc_path
 
 _logger = logging.getLogger(__name__)
 

--- a/l10n_br_fiscal/models/nbm.py
+++ b/l10n_br_fiscal/models/nbm.py
@@ -3,7 +3,7 @@
 
 from odoo import api, fields, models
 
-from ..tools import misc
+from .. import tools
 
 
 class Nbm(models.Model):
@@ -56,5 +56,5 @@ class Nbm(models.Model):
         ncm = self.env["l10n_br_fiscal.ncm"]
         for r in self:
             if r.ncms:
-                domain = misc.domain_field_codes(field_codes=r.ncms)
+                domain = tools.domain_field_codes(field_codes=r.ncms)
                 r.ncm_ids = ncm.search(domain)

--- a/l10n_br_fiscal/models/tax_definition.py
+++ b/l10n_br_fiscal/models/tax_definition.py
@@ -4,6 +4,7 @@
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
+from .. import tools
 from ..constants.fiscal import (
     FINAL_CUSTOMER,
     FISCAL_IN_OUT,
@@ -11,7 +12,6 @@ from ..constants.fiscal import (
     OPERATION_STATE,
     OPERATION_STATE_DEFAULT,
 )
-from ..tools import misc
 
 
 class TaxDefinition(models.Model):
@@ -272,15 +272,15 @@ class TaxDefinition(models.Model):
             domain = []
 
             if r.ncms:
-                domain += misc.domain_field_codes(r.ncms)
+                domain += tools.domain_field_codes(r.ncms)
 
             if r.not_in_ncms:
-                domain += misc.domain_field_codes(
+                domain += tools.domain_field_codes(
                     field_codes=r.not_in_ncms, operator1="!=", operator2="not ilike"
                 )
 
             if r.ncm_exception:
-                domain += misc.domain_field_codes(
+                domain += tools.domain_field_codes(
                     field_codes=r.ncm_exception, field_name="exception", code_size=2
                 )
 
@@ -295,7 +295,7 @@ class TaxDefinition(models.Model):
             domain = []
 
             if r.cests:
-                domain += misc.domain_field_codes(r.cests, code_size=7)
+                domain += tools.domain_field_codes(r.cests, code_size=7)
 
             if domain:
                 r.cest_ids = cest.search(domain)
@@ -308,10 +308,10 @@ class TaxDefinition(models.Model):
             domain = []
 
             if r.nbms:
-                domain += misc.domain_field_codes(r.nbms, code_size=10)
+                domain += tools.domain_field_codes(r.nbms, code_size=10)
 
             if r.not_in_nbms:
-                domain += misc.domain_field_codes(
+                domain += tools.domain_field_codes(
                     field_codes=r.not_in_nbms,
                     operator1="!=",
                     operator2="not ilike",

--- a/l10n_br_fiscal/models/tax_pis_cofins.py
+++ b/l10n_br_fiscal/models/tax_pis_cofins.py
@@ -3,13 +3,13 @@
 
 from odoo import _, api, fields, models
 
+from .. import tools
 from ..constants.fiscal import (
     TAX_DOMAIN_COFINS,
     TAX_DOMAIN_COFINS_ST,
     TAX_DOMAIN_PIS,
     TAX_DOMAIN_PIS_ST,
 )
-from ..tools import misc
 
 
 class TaxPisCofins(models.Model):
@@ -82,15 +82,15 @@ class TaxPisCofins(models.Model):
             # Clear Field to recompute
             r.ncm_ids = False
             if r.ncms:
-                domain = misc.domain_field_codes(r.ncms)
+                domain = tools.domain_field_codes(r.ncms)
 
             if r.not_in_ncms:
-                domain += misc.domain_field_codes(
+                domain += tools.domain_field_codes(
                     field_codes=r.not_in_ncms, operator1="!=", operator2="not ilike"
                 )
 
             if r.ncm_exception:
-                domain += misc.domain_field_codes(
+                domain += tools.domain_field_codes(
                     field_codes=r.ncm_exception, field_name="exception", code_size=2
                 )
 

--- a/l10n_br_fiscal/tools.py
+++ b/l10n_br_fiscal/tools.py
@@ -9,7 +9,7 @@ from erpbrasil.base.misc import punctuation_rm
 
 from odoo.tools import config
 
-from ..constants.fiscal import EVENT_ENV_HML, EVENT_ENV_PROD
+from .constants.fiscal import EVENT_ENV_HML, EVENT_ENV_PROD
 
 _logger = logging.getLogger(__name__)
 

--- a/l10n_br_fiscal/tools/__init__.py
+++ b/l10n_br_fiscal/tools/__init__.py
@@ -1,3 +1,0 @@
-# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
-
-from . import misc


### PR DESCRIPTION
desde a extração do modulo l10n_br_fiscal_certificate, a pasta l10n_br_fiscal/tools ficou com apenas um arquivo dentro. Da para simplificar usando um arquivo tools.py em vez da pasta tools. Como se espera que o modulo l10n_br_fiscal não cresça mais, não tem chance de ter outros arquivos do mesmo tipo para agupar numa pasta tools. Lembrando que a limpeza das pastas dfe e mdfe esta sendo feito em outros PR.