### PR TITLE
[14.0] l10n_br_fiscal, l10n_br_account: refatoração do processo de estorno.

### DIFF
--- a/l10n_br_account/tests/test_invoice_refund.py
+++ b/l10n_br_account/tests/test_invoice_refund.py
@@ -2,7 +2,6 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from odoo import fields
-from odoo.exceptions import UserError
 from odoo.tests import SavepointCase
 
 
@@ -107,13 +106,7 @@ class TestInvoiceRefund(SavepointCase):
             .create(reverse_vals)
         )
 
-        with self.assertRaises(UserError):
-            move_reversal.reverse_moves()
-
         invoice["fiscal_operation_id"] = (self.env.ref("l10n_br_fiscal.fo_venda").id,)
-
-        with self.assertRaises(UserError):
-            move_reversal.reverse_moves()
 
         for line_id in invoice.invoice_line_ids:
             line_id["fiscal_operation_id"] = (

--- a/l10n_br_fiscal/data/operation_data.xml
+++ b/l10n_br_fiscal/data/operation_data.xml
@@ -10,6 +10,8 @@
         <field name="active">True</field>
     </record>
 
+
+
     <!-- l10n_br_fiscal.operation -->
     <record id="fo_venda" model="l10n_br_fiscal.operation">
         <field name="code">Venda</field>
@@ -17,6 +19,29 @@
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_type">sale</field>
         <field name="default_price_unit">sale_price</field>
+        <field name="state">approved</field>
+    </record>
+
+    <record id="fo_devolucao_venda" model="l10n_br_fiscal.operation">
+        <field name="code">Devolução de Venda</field>
+        <field name="name">Devolução de Venda</field>
+        <field name="fiscal_operation_type">in</field>
+        <field name="fiscal_type">sale_refund</field>
+        <field name="default_price_unit">cost_price</field>
+        <field name="state">approved</field>
+        <field name="edoc_purpose">4</field>
+    </record>
+
+    <record
+        id="fo_devolucao_venda_devolucao_venda"
+        model="l10n_br_fiscal.operation.line"
+    >
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_devolucao_venda" />
+        <field name="name">Devolução de Venda</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1201" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2201" />
+        <field name="cfop_export_id" ref="l10n_br_fiscal.cfop_3201" />
+        <field name="product_type">04</field>
         <field name="state">approved</field>
     </record>
 
@@ -29,6 +54,10 @@
         <field name="cfop_export_id" ref="l10n_br_fiscal.cfop_7101" />
         <field name="state">approved</field>
         <field name="product_type">04</field>
+        <field
+            name="return_fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_devolucao_venda_devolucao_venda"
+        />
     </record>
 
     <record id="fo_venda_revenda" model="l10n_br_fiscal.operation.line">
@@ -123,29 +152,6 @@
         <field name="name">Bonificação</field>
         <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5910" />
         <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6910" />
-        <field name="state">approved</field>
-    </record>
-
-    <record id="fo_devolucao_venda" model="l10n_br_fiscal.operation">
-        <field name="code">Devolução de Venda</field>
-        <field name="name">Devolução de Venda</field>
-        <field name="fiscal_operation_type">in</field>
-        <field name="fiscal_type">sale_refund</field>
-        <field name="default_price_unit">cost_price</field>
-        <field name="state">approved</field>
-        <field name="edoc_purpose">4</field>
-    </record>
-
-    <record
-        id="fo_devolucao_venda_devolucao_venda"
-        model="l10n_br_fiscal.operation.line"
-    >
-        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_devolucao_venda" />
-        <field name="name">Devolução de Venda</field>
-        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1201" />
-        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2201" />
-        <field name="cfop_export_id" ref="l10n_br_fiscal.cfop_3201" />
-        <field name="product_type">04</field>
         <field name="state">approved</field>
     </record>
 

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -68,11 +68,25 @@ class OperationLine(models.Model):
         readonly=True,
     )
 
+    return_fiscal_operation_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.operation",
+        string="Return Operation",
+        related="fiscal_operation_id.return_fiscal_operation_id",
+    )
+
     fiscal_type = fields.Selection(
         related="fiscal_operation_id.fiscal_type",
         string="Fiscal Type",
         store=True,
         readonly=True,
+    )
+
+    return_fiscal_operation_line_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.operation.line",
+        string="Return Operation Line",
+        readonly=True,
+        states={"draft": [("readonly", False)]},
+        domain="[('fiscal_operation_id', '=', return_fiscal_operation_id)]",
     )
 
     tax_icms_or_issqn = fields.Selection(

--- a/l10n_br_fiscal/views/operation_line_view.xml
+++ b/l10n_br_fiscal/views/operation_line_view.xml
@@ -23,6 +23,7 @@
             <form string="Fiscal Operation Line">
                 <field name="fiscal_type" invisible="1" />
                 <field name="fiscal_operation_type" invisible="1" />
+                <field name="return_fiscal_operation_id" invisible="1" />
                 <header>
                     <button
                         name="action_review"
@@ -56,6 +57,7 @@
                             <group name="gereral_settings">
                                 <field name="document_type_id" />
                                 <field name="add_to_amount" />
+                                <field name="return_fiscal_operation_line_id" />
                             </group>
                             <group
                                 name="general_cfop"


### PR DESCRIPTION
Este PR visa melhorar a eficiência e segurança do processo de estorno do faturamento (Nota de crédito) quando for uma NF-e

A principal mudança que implementamos é prevenir que a fatura seja alterada após sua criação pelo método nativo. Assim, todas as informações necessárias para alterações na fatura de estorno são agora passadas antecipadamente para o dicionário de valores. Este será utilizado pelo método nativo no momento da criação da fatura de estorno.

Ao fazer isso, evitamos a re-computação de muitos campos, o que traz dois benefícios principais:

Melhoria de Performance: Reduzimos o tempo de processamento ao evitar computações desnecessárias.
Segurança de Dados: Garantimos que nenhum campo seja alterado indevidamente por uma re-computação desencadeada.

Agradecemos qualquer feedback ou sugestão.