### PR TITLE
[14.0][FIX] l10n_br_nfe: remove duplicate vFCPUFDest

### DIFF
--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -982,11 +982,6 @@ class NFeLine(spec_models.StackedModel):
             else:
                 record.nfe40_infAdProd = False
 
-    # Todo: Calcular
-    nfe40_vFCPUFDest = fields.Monetary(
-        string="Valor total do ICMS relativo ao Fundo de Combate à Pobreza",
-    )
-
     @api.model
     def _prepare_import_dict(
         self, values, model=None, parent_dict=None, defaults_model=None


### PR DESCRIPTION
Antes o campo **nfe40_vFCPUFDest** estava duplicado dentro do mesmo arquivo, o mesmo já está sendo definido na linha 517.

Sem essa correção o related definido na linha 517 não está sendo assumido, fazendo com que o valor deste campo não chegue no XML da NF-e.