### PR TITLE
[IMP+REF] l10n_br_stock_account: Modulo compatível com o caso internacional 

### DIFF
--- a/l10n_br_stock_account/models/stock_move.py
+++ b/l10n_br_stock_account/models/stock_move.py
@@ -125,6 +125,10 @@ class StockMove(models.Model):
     def _get_price_unit_invoice(self, inv_type, partner, qty=1):
 
         result = super()._get_price_unit_invoice(inv_type, partner, qty)
+        if not self.fiscal_operation_id:
+            # Caso não tenha a Operação Fiscal não é uma Fatura do Brasil
+            return result
+
         product = self.mapped("product_id")
         product.ensure_one()
 
@@ -139,6 +143,9 @@ class StockMove(models.Model):
     def _get_price_unit(self):
         """Returns the unit price to store on the quant"""
         result = super()._get_price_unit()
+        if not self.fiscal_operation_id:
+            # Caso não tenha a Operação Fiscal não é uma caso do Brasil
+            return result
 
         # No Brasil o caso de Ordens de Entrega com Operação Fiscal
         # de Saída precisam informar o Preço de Custo e não o de Venda

--- a/l10n_br_stock_account/views/stock_account_view.xml
+++ b/l10n_br_stock_account/views/stock_account_view.xml
@@ -9,11 +9,11 @@
             <field name="invoice_state" position="after">
                 <field
                     name="fiscal_operation_id"
-                    attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"
+                    attrs="{'invisible': ['|', ('invoice_state', 'in', [False, 'none']), ('fiscal_operation_id', '=', False)], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"
                 />
                 <field
                     name="fiscal_operation_line_id"
-                    attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"
+                    attrs="{'invisible': ['|', ('invoice_state', 'in', [False, 'none']), ('fiscal_operation_id', '=', False)], 'required': [('fiscal_operation_id', '=', True)], 'readonly': [('invoice_state', '=', 'invoiced')]}"
                 />
             </field>
         </field>
@@ -50,22 +50,22 @@
                 <field name="fiscal_price" />
                 <field
                     name="fiscal_operation_id"
-                    attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"
+                    attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': [('invoice_state', 'in', [False, 'none'])], 'readonly': [('invoice_state', '=', 'invoiced')]}"
                 />
                 <field
                     name="fiscal_operation_line_id"
-                    attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"
+                    attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': ['|', ('invoice_state', 'in', [False, 'none']), ('fiscal_operation_id', '=', False)], 'readonly': [('invoice_state', '=', 'invoiced')]}"
                 />
                 <field
                     name="cfop_id"
-                    attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"
+                    attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': [('fiscal_operation_id', '=', True)], 'readonly': [('invoice_state', '=', 'invoiced')]}"
                 />
                 <field name="partner_id" invisible="1" />
                 <field name="company_id" invisible="1" />
             </field>
             <group name="invoice_lines" position="after">
                 <notebook
-                    attrs="{'invisible': [('invoice_state', '=', 'none')],'required': [('invoice_state', '=', '2binvoiced')],'readonly': [('invoice_state', '=', 'invoiced')]}"
+                    attrs="{'invisible': ['|', ('invoice_state', 'in', [False, 'none']), ('fiscal_operation_id', '=', False)], 'readonly': [('invoice_state', '=', 'invoiced')]}"
                 >
                     <group name="fiscal_fields" invisible="1">
                         <field

--- a/l10n_br_stock_account/views/stock_picking.xml
+++ b/l10n_br_stock_account/views/stock_picking.xml
@@ -10,7 +10,7 @@
             <field name="picking_type_id" position="after">
                 <field
                     name="fiscal_operation_id"
-                    attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"
+                    attrs="{'invisible': [('invoice_state', '=', 'none')], 'readonly': [('invoice_state', '=', 'invoiced')]}"
                 />
             </field>
             <field name="invoice_state" position="attributes">
@@ -42,11 +42,11 @@
             >
                 <field
                     name="fiscal_operation_id"
-                    attrs="{'column_invisible': [('parent.invoice_state', '=', 'none')], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"
+                    attrs="{'column_invisible': ['|', ('parent.invoice_state', '=', 'none'), ('parent.fiscal_operation_id', '=', False)], 'readonly': [('invoice_state', '=', 'invoiced')]}"
                 />
                 <field
                     name="fiscal_operation_line_id"
-                    attrs="{'column_invisible': [('parent.invoice_state', '=', 'none')], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"
+                    attrs="{'column_invisible': ['|', ('parent.invoice_state', '=', 'none'), ('parent.fiscal_operation_id', '=', False)], 'readonly': [('invoice_state', '=', 'invoiced')]}"
                 />
             </xpath>
             <xpath
@@ -56,7 +56,7 @@
                 <group
                     name="fiscal"
                     string="Fiscal"
-                    attrs="{'invisible': [('invoice_state', 'in', [False, 'none'])]}"
+                    attrs="{'invisible': ['|', ('invoice_state', 'in', [False, 'none']), ('parent.fiscal_operation_id', '=', False)]}"
                     colspan="4"
                 >
                     <field name="invoice_state" readonly="1" force_save="1" />
@@ -80,22 +80,22 @@
                     <field name="fiscal_price" />
                     <field
                         name="fiscal_operation_id"
-                        attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"
+                        attrs="{'invisible': ['|', ('invoice_state', 'in', [False, 'none']), ('parent.fiscal_operation_id', '=', False)], 'readonly': [('invoice_state', '=', 'invoiced')]}"
                     />
                     <field
                         name="fiscal_operation_line_id"
-                        attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"
+                        attrs="{'invisible': ['|', ('invoice_state', 'in', [False, 'none']), ('parent.fiscal_operation_id', '=', False)], 'readonly': [('invoice_state', '=', 'invoiced')]}"
                     />
                     <field
                         name="cfop_id"
-                        attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"
+                        attrs="{'invisible': ['|', ('invoice_state', 'in', [False, 'none']), ('parent.fiscal_operation_id', '=', False)], 'required': [('fiscal_operation_id', '=', True)], 'readonly': [('invoice_state', '=', 'invoiced')]}"
                     />
                     <field name="partner_id" invisible="1" />
                     <field name="company_id" invisible="1" />
                 </group>
                 <group colspan="4">
                     <notebook
-                        attrs="{'invisible': [('invoice_state', '=', 'none')],'required': [('invoice_state', '=', '2binvoiced')],'readonly': [('invoice_state', '=', 'invoiced')]}"
+                        attrs="{'invisible': ['|', ('invoice_state', 'in', [False, 'none']), ('parent.fiscal_operation_id', '=', False)], 'readonly': [('invoice_state', '=', 'invoiced')]}"
                     >
                         <group name="fiscal_fields" invisible="1">
                             <field

--- a/l10n_br_stock_account/wizards/stock_invoice_onshipping.py
+++ b/l10n_br_stock_account/wizards/stock_invoice_onshipping.py
@@ -8,9 +8,25 @@ from odoo.exceptions import UserError
 class StockInvoiceOnshipping(models.TransientModel):
     _inherit = "stock.invoice.onshipping"
 
+    def _get_fiscal_operation_journal(self):
+        active_ids = self.env.context.get("active_ids", [])
+        if active_ids:
+            active_ids = active_ids[0]
+        pick_obj = self.env["stock.picking"]
+        picking = pick_obj.browse(active_ids)
+        if not picking or not picking.move_lines:
+            # Caso sem dados, apenas para evitar erro
+            return False
+        if not picking.fiscal_operation_id:
+            # Caso de Fatura Internacional, sem os dados Fiscais do Brasil
+            return False
+        else:
+            # Caso Brasileiro
+            return True
+
     fiscal_operation_journal = fields.Boolean(
         string="Account Jornal from Fiscal Operation",
-        default=True,
+        default=_get_fiscal_operation_journal,
     )
 
     group = fields.Selection(
@@ -43,6 +59,10 @@ class StockInvoiceOnshipping(models.TransientModel):
     def _build_invoice_values_from_pickings(self, pickings):
         invoice, values = super()._build_invoice_values_from_pickings(pickings)
         pick = fields.first(pickings)
+        if not pick.fiscal_operation_id:
+            # Caso de Fatura Internacional, sem os dados Fiscais do Brasil
+            return invoice, values
+
         fiscal_vals = pick._prepare_br_fiscal_dict()
 
         document_type = pick.company_id.document_type_id


### PR DESCRIPTION
Make module compatible with the International cases.

Alteração para deixar o modulo compatível com o caso internacional, extraído do PR https://github.com/OCA/l10n-brazil/pull/2424 , para isso foi necessário retirar o 'requirido' do campo Operação Fiscal, quando o campo é preenchido o código e a visão consideram ser o caso do Brasil quando não é o caso Internacional. Incluído teste para o caso Internacional, também é possível testar com os dados de demonstração do modulo stock_picking_invocing

![image](https://github.com/OCA/l10n-brazil/assets/6341149/4646030f-fa16-469c-917e-4a9f0ba3bdc9)


- Caso Internacional, sem Operação Fiscal

![image](https://github.com/OCA/l10n-brazil/assets/6341149/484a0b82-eff5-4fdc-a671-e2df5b88d5e0)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/1fe319d6-1d17-4f9f-b18c-8c767dce2247)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/c217bef6-2498-4074-a339-27d4a9187728)

- Caso Brasil, com Operação Fiscal

![image](https://github.com/OCA/l10n-brazil/assets/6341149/b113de47-f5d5-4b31-be5c-d9b987b02075)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/b447eee0-56fa-4113-88a7-b8a51be36f7f)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/77249c3c-0f3b-4d9f-9ed9-eca0efb24b1d)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/f7367bf6-1a23-4013-adaa-c2b9d3898326)


cc @renatonlima @rvalyi @marcelsavegnago @mileo 