### PR TITLE
[14.0][IMP] l10n_br_nfe: Adicionar valores para o Grupo Retenção de Tributos.

### DIFF
--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -105,6 +105,12 @@ class AccountMoveLine(models.Model):
         string="PIS ST CST Code",
     )
 
+    partner_is_public_entity = fields.Boolean(related="partner_id.is_public_entity")
+
+    allow_csll_irpj = fields.Boolean(
+        compute="_compute_allow_csll_irpj",
+    )
+
     wh_move_line_id = fields.Many2one(
         comodel_name="account.move.line",
         string="WH Account Move Line",

--- a/l10n_br_fiscal/data/partner_profile_data.xml
+++ b/l10n_br_fiscal/data/partner_profile_data.xml
@@ -83,4 +83,14 @@
         <field name="tax_framework" eval="False" />
     </record>
 
+    <record id="partner_fiscal_profile_estatal" model="l10n_br_fiscal.partner.profile">
+        <field name="code">ESTCONT</field>
+        <field name="name">Empresa Estatal Contribuinte</field>
+        <field name="is_company" eval="True" />
+        <field name="is_public_entity" eval="True" />
+        <field name="default" eval="False" />
+        <field name="ind_ie_dest">1</field>
+        <field name="tax_framework">3</field>
+    </record>
+
 </odoo>

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin.py
@@ -94,6 +94,13 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         default=TAX_DOMAIN_ICMS,
     )
 
+    partner_is_public_entity = fields.Boolean(related="partner_id.is_public_entity")
+
+    allow_csll_irpj = fields.Boolean(
+        compute="_compute_allow_csll_irpj",
+        help="Indicates potential 'CSLL' and 'IRPJ' tax charges.",
+    )
+
     price_unit = fields.Float(digits="Product Price")
 
     partner_id = fields.Many2one(comodel_name="res.partner", string="Partner")

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -214,6 +214,18 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             ind_final=self.ind_final,
         )
 
+    @api.depends("tax_icms_or_issqn", "partner_is_public_entity")
+    def _compute_allow_csll_irpj(self):
+        """Calculates the possibility of 'CSLL' and 'IRPJ' tax charges."""
+        for line in self:
+            # Determine if 'CSLL' and 'IRPJ' taxes may apply:
+            # 1. When providing services (tax_icms_or_issqn == "issqn")
+            # 2. When supplying products to public entities (partner_is_public_entity is True)
+            if line.tax_icms_or_issqn == "issqn" or line.partner_is_public_entity:
+                line.allow_csll_irpj = True  # Tax charges may apply
+            else:
+                line.allow_csll_irpj = False  # No tax charges expected
+
     def _prepare_br_fiscal_dict(self, default=False):
         self.ensure_one()
         fields = self.env["l10n_br_fiscal.document.line.mixin"]._fields.keys()

--- a/l10n_br_fiscal/models/partner_profile.py
+++ b/l10n_br_fiscal/models/partner_profile.py
@@ -23,6 +23,15 @@ class PartnerProfile(models.Model):
 
     is_company = fields.Boolean(string="Is Company?")
 
+    is_public_entity = fields.Boolean(
+        string="Public Entity",
+        help="Indicates whether the entity in question is a "
+        "public organization or government-related entity. It encompasses a "
+        "range of entities such as municipal governments, state-owned "
+        "enterprises (where the government is the largest shareholder), and "
+        "other government-controlled organizations.",
+    )
+
     default = fields.Boolean(string="Default Profile", default=True)
 
     ind_ie_dest = fields.Selection(

--- a/l10n_br_fiscal/models/res_partner.py
+++ b/l10n_br_fiscal/models/res_partner.py
@@ -56,6 +56,15 @@ class ResPartner(models.Model):
         tracking=True,
     )
 
+    is_public_entity = fields.Boolean(
+        string="Public Entity",
+        help="Indicates whether the entity in question is a "
+        "public organization or government-related entity. It encompasses a "
+        "range of entities such as municipal governments, state-owned "
+        "enterprises (where the government is the largest shareholder), and "
+        "other government-controlled organizations.",
+    )
+
     ind_final = fields.Selection(
         selection=FINAL_CUSTOMER,
         string="Final Consumption Operation",
@@ -102,6 +111,7 @@ class ResPartner(models.Model):
             if p.fiscal_profile_id:
                 p.tax_framework = p.fiscal_profile_id.tax_framework
                 p.ind_ie_dest = p.fiscal_profile_id.ind_ie_dest
+                p.is_public_entity = p.fiscal_profile_id.is_public_entity
 
     @api.onchange("ind_ie_dest")
     def _onchange_ind_ie_dest(self):

--- a/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
@@ -29,6 +29,7 @@
           <field name="fiscal_price" force_save="1" invisible="1" />
           <field name="fiscal_quantity" force_save="1" invisible="1" />
           <field name="fiscal_tax_ids" force_save="1" invisible="1" readonly="1" />
+          <field name="allow_csll_irpj" force_save="1" invisible="1" />
         </group>
         <notebook>
           <field name="product_id" force_save="1" invisible="1" />
@@ -768,7 +769,7 @@
                 <page
                                 name="csll"
                                 string="CSLL"
-                                attrs="{'invisible': [('tax_icms_or_issqn', '=', 'icms')]}"
+                                attrs="{'invisible': [('allow_csll_irpj', '=', False)]}"
                             >
                     <group>
                         <field name="csll_tax_id" />
@@ -835,7 +836,7 @@
                 <page
                                 name="irpj"
                                 string="IRPJ"
-                                attrs="{'invisible': [('fiscal_genre_code', '!=', '00')]}"
+                                attrs="{'invisible': [('allow_csll_irpj', '=', False)]}"
                             >
                     <group>
                         <field

--- a/l10n_br_fiscal/views/partner_profile_view.xml
+++ b/l10n_br_fiscal/views/partner_profile_view.xml
@@ -28,6 +28,7 @@
                 <field name="code" />
                 <field name="name" />
                 <field name="is_company" />
+                <field name="is_public_entity" />
                 <field name="default" />
                 <field name="ind_ie_dest" />
                 <field name="tax_framework" />
@@ -62,6 +63,7 @@
                         <field name="code" />
                         <field name="name" />
                         <field name="is_company" />
+                        <field name="is_public_entity" />
                         <field name="default" />
                         <field name="ind_ie_dest" />
                         <field

--- a/l10n_br_fiscal/views/res_partner_view.xml
+++ b/l10n_br_fiscal/views/res_partner_view.xml
@@ -24,6 +24,11 @@
                         attrs="{'readonly': [('fiscal_profile_id', '!=', False)]}"
                     />
                     <field
+                        name="is_public_entity"
+                        force_save="1"
+                        attrs="{'readonly': [('fiscal_profile_id', '!=', False)]}"
+                    />
+                    <field
                         name="cnae_main_id"
                         options="{'no_create': True, 'no_create_edit': True}"
                     />

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -534,6 +534,20 @@ class NFe(spec_models.StackedModel):
     # TODO
 
     ##########################
+    # NF-e tag: retTrib
+    ##########################
+
+    nfe40_vRetPIS = fields.Monetary(related="amount_pis_wh_value")
+
+    nfe40_vRetCOFINS = fields.Monetary(related="amount_cofins_wh_value")
+
+    nfe40_vRetCSLL = fields.Monetary(related="amount_csll_wh_value")
+
+    nfe40_vBCIRRF = fields.Monetary(related="amount_irpj_wh_base")
+
+    nfe40_vIRRF = fields.Monetary(related="amount_irpj_wh_value")
+
+    ##########################
     # NF-e tag: transp
     ##########################
 


### PR DESCRIPTION
A proposta desta PR é atender o caso de uso de vendas de produtos para Órgãos Públicos.

Foram feitas duas alterações:

1) Remoção das condições que escondem as abas dos impostos **CSLL** e **IRPJ**,
Antes estavam para serem exibidas apenas nos casos de **Prestação de Serviço**.
Porém para uma entidade pública deve haver retenção destes impostos no **fornecimentos de bens** também.

2) Mapeado os valores das retenções para as  tags correspondentes da NF-e (Grupo Retenção de Tributos)
 
 Fonte:
![image](https://github.com/OCA/l10n-brazil/assets/634278/795110ac-5044-41aa-9e53-7baaa8498a9e)
![image](https://github.com/OCA/l10n-brazil/assets/634278/6bad0d60-ffaa-4002-8fdc-85bb04862008)
