### PR TITLE
[14.0][REF] l10n_br_repair: Resolvido Warnings no LOG

### DIFF
--- a/l10n_br_repair/models/fiscal_line_mixin.py
+++ b/l10n_br_repair/models/fiscal_line_mixin.py
@@ -3,8 +3,6 @@
 
 from odoo import api, fields, models
 
-import odoo.addons.decimal_precision as dp
-
 
 class FiscalLineMixin(models.AbstractModel):
     _name = "l10n_br_repair.fiscal.line.mixin"
@@ -35,8 +33,10 @@ class FiscalLineMixin(models.AbstractModel):
     price_subtotal = fields.Float(
         "Subtotal",
         compute="_compute_price_subtotal",
-        digits=dp.get_precision("Account"),
+        digits="Product Price",
     )
+
+    fiscal_operation_type = fields.Selection(string="Fiscal Operation Type")
 
     @api.model
     def _fiscal_operation_domain(self):

--- a/l10n_br_repair/models/repair_fee.py
+++ b/l10n_br_repair/models/repair_fee.py
@@ -3,8 +3,6 @@
 
 from odoo import api, fields, models
 
-from ...l10n_br_fiscal.constants.fiscal import TAX_FRAMEWORK
-
 
 class RepairFee(models.Model):
     _name = "repair.fee"
@@ -20,7 +18,6 @@ class RepairFee(models.Model):
     )
 
     tax_framework = fields.Selection(
-        selection=TAX_FRAMEWORK,
         related="repair_id.company_id.tax_framework",
         string="Tax Framework",
     )
@@ -56,6 +53,10 @@ class RepairFee(models.Model):
         related="repair_id.company_id",
         store=True,
     )
+
+    # Fields compute need parameter compute_sudo
+    price_subtotal = fields.Monetary(compute_sudo=True)
+    price_gross = fields.Monetary(compute_sudo=True)
 
     @api.depends(
         "price_unit",

--- a/l10n_br_repair/models/repair_line.py
+++ b/l10n_br_repair/models/repair_line.py
@@ -3,8 +3,6 @@
 
 from odoo import api, fields, models
 
-from ...l10n_br_fiscal.constants.fiscal import TAX_FRAMEWORK
-
 
 class RepairLine(models.Model):
     _name = "repair.line"
@@ -20,7 +18,6 @@ class RepairLine(models.Model):
     )
 
     tax_framework = fields.Selection(
-        selection=TAX_FRAMEWORK,
         related="repair_id.company_id.tax_framework",
         string="Tax Framework",
     )
@@ -56,6 +53,10 @@ class RepairLine(models.Model):
         related="repair_id.company_id",
         store=True,
     )
+
+    # Fields compute need parameter compute_sudo
+    price_subtotal = fields.Monetary(compute_sudo=True)
+    price_gross = fields.Monetary(compute_sudo=True)
 
     @api.depends(
         "price_unit",


### PR DESCRIPTION
Avoid Log Warnings, 'selection attribute will be ignored as the field is related', 'inconsistent 'compute_sudo' for computed fields', 'Deprecated call to decimal_precision.get_precision(<application>)', 'Two fields (fiscal_operation_type, type) of repair.line() have the same label: Type.'

PR simples apenas para "limpar" o Log dos Warnings 

2023-08-09 20:50:38,090 63 WARNING test odoo.fields: repair.line.tax_framework: selection attribute will be ignored as the field is related 
2023-08-09 20:50:38,090 63 WARNING test odoo.fields: repair.fee.tax_framework: selection attribute will be ignored as the field is related 
2023-08-09 20:50:38,533 63 WARNING test odoo.modules.registry: repair.line: inconsistent 'compute_sudo' for computed fields: price_subtotal, price_gross 
2023-08-09 20:50:38,533 63 WARNING test odoo.modules.registry: repair.fee: inconsistent 'compute_sudo' for computed fields: price_subtotal, price_gross 
2023-08-09 21:12:51,108 76 WARNING test odoo.addons.base.models.decimal_precision: Deprecated call to decimal_precision.get_precision(<application>), use digits=<application> instead 
2023-08-09 21:12:51,449 76 WARNING test odoo.addons.base.models.ir_model: Two fields (fiscal_operation_type, type) of repair.line() have the same label: Type.

cc @marcelsavegnago @renatonlima @rvalyi @mileo 