### PR TITLE
Definindo campo name como padrão na pesquisa CNAE

### DIFF
--- a/l10n_br_fiscal/views/cnae_view.xml
+++ b/l10n_br_fiscal/views/cnae_view.xml
@@ -6,8 +6,8 @@
         <field name="model">l10n_br_fiscal.cnae</field>
         <field name="arch" type="xml">
             <search string="CNAE">
-                <field name="code" />
                 <field name="name" />
+                <field name="code" />
                 <group expand='0' string='Group By...'>
                     <filter
                         string='Parent'


### PR DESCRIPTION
A alteração torna o campo "name" como o padrão ao começar a digitar na pesquisa para filtrar a lista de códigos CNAE. Dessa forma a pesquisa fica mais intuitiva para o usuário.

