### PR TITLE
[14.0][FIX] l10n_br_fiscal: DIFAL nos estados destinos que dependem do Indicador de Consumidor Final

### DIFF
--- a/l10n_br_fiscal/models/icms_regulation.py
+++ b/l10n_br_fiscal/models/icms_regulation.py
@@ -1828,6 +1828,7 @@ class ICMSRegulation(models.Model):
         nbm=None,
         cest=None,
         operation_line=None,
+        ind_final=None,
     ):
         self.ensure_one()
         tax_definitions = self.env["l10n_br_fiscal.tax.definition"]
@@ -1843,7 +1844,7 @@ class ICMSRegulation(models.Model):
             )
 
             tax_definitions = self._tax_definition_search(
-                domain, ncm, nbm, cest, product
+                domain, ncm, nbm, cest, product, ind_final
             )
         return tax_definitions.mapped("tax_id"), tax_definitions
 

--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -389,9 +389,9 @@ class Tax(models.Model):
             and tax_dict.get("tax_value")
         ):
             icms_tax_difal, _ = company.icms_regulation_id.map_tax_def_icms_difal(
-                company, partner, product, ncm, nbm, cest, operation_line
+                company, partner, product, ncm, nbm, cest, operation_line, ind_final
             )
-            icmsfcp_tax_difal = tax_dict_ipi = taxes_dict.get("icmsfcp", {})
+            icmsfcp_tax_difal = taxes_dict.get("icmsfcp", {})
 
             # Difal - Origin Percent
             icms_origin_perc = tax_dict.get("percent_amount")


### PR DESCRIPTION
Esta PR tem o propósito de corrigir o DIFAL na NF-e, nos casos em que o estado de destino tem o ICMS diferenciado caso seja Consumidor Final como é o caso de Santa Catarina.

Sem essa correção o sistema não estava conseguindo encontrar o ICMS do destino corretamente, trazendo  sempre zerado. Após a correção o ICMS do Destino está sendo buscado corretamente, que é os 17% no caso de Santa Catarina.