### PR TITLE
[14.0][FIX] saving XML response instead of authorization file

### DIFF
--- a/l10n_br_nfe/__manifest__.py
+++ b/l10n_br_nfe/__manifest__.py
@@ -41,7 +41,7 @@
             "nfelib>=2.0.0",
             "erpbrasil.assinatura>=1.7.0",
             "erpbrasil.transmissao",
-            "erpbrasil.edoc>=2.5.1",
+            "erpbrasil.edoc>=2.5.2",
             "erpbrasil.edoc.pdf",
         ],
     },

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -870,7 +870,7 @@ class NFe(spec_models.StackedModel):
                 response=infProt.xMotivo,
                 protocol_date=protocol_date,
                 protocol_number=infProt.nProt,
-                file_response_xml=processo.retorno.text,
+                file_response_xml=processo.envio_xml.decode("utf-8"),
             )
         self.write(
             {

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -870,7 +870,7 @@ class NFe(spec_models.StackedModel):
                 response=infProt.xMotivo,
                 protocol_date=protocol_date,
                 protocol_number=infProt.nProt,
-                file_response_xml=processo.envio_xml.decode("utf-8"),
+                file_response_xml=processo.processo_xml.decode("utf-8"),
             )
         self.write(
             {

--- a/l10n_br_nfe/tests/test_nfce.py
+++ b/l10n_br_nfe/tests/test_nfce.py
@@ -218,7 +218,7 @@ class TestNFCe(TestNFeExport):
         mock_autorizada.protocolo.infProt.cStat = AUTORIZADO[0]
         mock_autorizada.protocolo.infProt.xMotivo = "TESTE AUTORIZADO"
         mock_autorizada.protocolo.infProt.dhRecbto = datetime.now()
-        mock_autorizada.retorno = FakeRetorno("dummy")
+        mock_autorizada.envio_xml = b"dummy"
         self.document_id.atualiza_status_nfe(mock_autorizada)
 
         self.assertEqual(self.document_id.state_edoc, SITUACAO_EDOC_AUTORIZADA)

--- a/l10n_br_nfe/tests/test_nfce.py
+++ b/l10n_br_nfe/tests/test_nfce.py
@@ -218,7 +218,7 @@ class TestNFCe(TestNFeExport):
         mock_autorizada.protocolo.infProt.cStat = AUTORIZADO[0]
         mock_autorizada.protocolo.infProt.xMotivo = "TESTE AUTORIZADO"
         mock_autorizada.protocolo.infProt.dhRecbto = datetime.now()
-        mock_autorizada.envio_xml = b"dummy"
+        mock_autorizada.processo_xml = b"dummy"
         self.document_id.atualiza_status_nfe(mock_autorizada)
 
         self.assertEqual(self.document_id.state_edoc, SITUACAO_EDOC_AUTORIZADA)

--- a/l10n_br_nfe/tests/test_nfce.py
+++ b/l10n_br_nfe/tests/test_nfce.py
@@ -48,63 +48,75 @@ class FakeRetorno(object):
 
 
 def mocked_nfce_autorizada(*args, **kwargs):
-    return analisar_retorno_raw(
+    result = analisar_retorno_raw(
         "nfeAutorizacaoLote",
         object(),
         b"<fake_post/>",
         FakeRetorno(response_autorizada),
         retEnviNFe,
     )
+    result.processo_xml = b"dummy"
+    return result
 
 
 def mocked_nfce_denegada(*args, **kwargs):
-    return analisar_retorno_raw(
+    result = analisar_retorno_raw(
         "nfeAutorizacaoLote",
         object(),
         b"<fake_post/>",
         FakeRetorno(response_denegada),
         retEnviNFe,
     )
+    result.processo_xml = b"dummy"
+    return result
 
 
 def mocked_nfce_rejeitada(*args, **kwargs):
-    return analisar_retorno_raw(
+    result = analisar_retorno_raw(
         "nfeAutorizacaoLote",
         object(),
         b"<fake_post/>",
         FakeRetorno(response_rejeitada),
         retEnviNFe,
     )
+    result.processo_xml = b"dummy"
+    return result
 
 
 def mocked_nfce_contingencia(*args, **kwargs):
-    return analisar_retorno_raw(
+    result = analisar_retorno_raw(
         "nfeAutorizacaoLote",
         object(),
         b"<fake_post/>",
         FakeRetorno(response_contingency),
         retEnviNFe,
     )
+    result.processo_xml = b"dummy"
+    return result
 
 
 def mocked_inutilizacao(*args, **kwargs):
-    return analisar_retorno_raw(
+    result = analisar_retorno_raw(
         "nfeInutilizacaoNF",
         object(),
         b"<fake_post/>",
         FakeRetorno(response_inutilizacao),
         retInutNFe,
     )
+    result.processo_xml = b"dummy"
+    return result
 
 
 def mock_cancela(*args, **kwargs):
-    return analisar_retorno_raw(
+    result = analisar_retorno_raw(
         "nfeRecepcaoEvento",
         object(),
         b"<fake_post/>",
         FakeRetorno(response_cancelamento),
         retEnvEvento,
     )
+    result.processo_xml = b"dummy"
+    return result
 
 
 class TestNFCe(TestNFeExport):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ erpbrasil.assinatura>=1.7.0
 erpbrasil.base>=2.3.0
 erpbrasil.edoc
 erpbrasil.edoc.pdf
-erpbrasil.edoc>=2.5.1
+erpbrasil.edoc>=2.5.2
 erpbrasil.transmissao
 nfelib>=2.0.0
 nfselib.ginfes


### PR DESCRIPTION
Correção do issue #2641 

Estava salvando o XML de resposta ao invés do XML correto na emissão de NFCe