### PR TITLE
[16.0][FIX] l10n_br_zip: Botão de Pesquisa do CEP na visão da Empresa.

### DIFF
--- a/l10n_br_zip/__manifest__.py
+++ b/l10n_br_zip/__manifest__.py
@@ -15,6 +15,7 @@
         "views/l10n_br_zip_view.xml",
         "views/res_partner_address_view.xml",
         "views/res_config_settings_view.xml",
+        "views/res_company_views.xml",
         "wizard/l10n_br_zip_search_view.xml",
         "security/ir.model.access.csv",
     ],

--- a/l10n_br_zip/views/res_company_views.xml
+++ b/l10n_br_zip/views/res_company_views.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="l10n_br_zip_res_company_form" model="ir.ui.view">
+       <field name="name">l10n_br_base.res.company.form</field>
+        <field name="model">res.company</field>
+        <field name="inherit_id" ref="base.view_company_form" />
+        <field name="arch" type="xml">
+
+            <field name="zip" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+
+            <field name="street" position="before">
+                <field name="zip" placeholder="ZIP" class="o_address_zip oe_inline" />
+                <button
+                    name="zip_search"
+                    type="object"
+                    attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
+                    class="btn-sm btn-link mb4 fa fa-search oe_edit_only oe_inline"
+                    aria-label="Pesquisar CEP"
+                    title="Pesquisar CEP"
+                />
+           </field>
+
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
ZIP search button in company view.

Botão de Pesquisa do CEP na visão da Empresa, antes desse PR 

![image](https://github.com/OCA/l10n-brazil/assets/6341149/79edf4f7-f8b5-4262-92b6-4897d57df368)

com esse PR 

![image](https://github.com/OCA/l10n-brazil/assets/6341149/108dbb92-44ef-4109-90df-0d69dc574304)

o campo do CEP foi movido para o topo para facilitar sendo o primeiro campo do Endereço a ser preenchido a partir da pesquisa os outros campos acabam sendo preenchidos automaticamente o que é semelhante a visão no res.partner.

cc @renatonlima @rvalyi @marcelsavegnago @mileo 