### PR TITLE
[16.0][REF] l10n_br_base: Resolvendo Warning da LIB validate_email depreciado

### DIFF
--- a/l10n_br_base/models/res_partner_pix.py
+++ b/l10n_br_base/models/res_partner_pix.py
@@ -57,20 +57,19 @@ class PartnerPix(models.Model):
     def _normalize_email(self, email):
         try:
             result = validate_email(
-                email,
+                email.lower(),
                 check_deliverability=False,
             )
         except EmailSyntaxError as e:
             raise ValidationError(_(f"{email.strip()} is an invalid email")) from e
-        normalized_email = result["local"].lower() + "@" + result["domain_i18n"]
-        if len(normalized_email) > 77:
+        if len(result.normalized) > 77:
             raise ValidationError(
                 _(
                     f"The email is too long, "
                     f"a maximum of 77 characters is allowed: \n{email.strip()}"
                 )
             ) from None
-        return normalized_email
+        return result.normalized
 
     def _normalize_phone(self, phone):
         try:


### PR DESCRIPTION
Solve Warning dict-like access to the return value of validate_email is deprecated.

Resolvendo Warning da LIB validate_email depreciado

2023-08-14 22:18:28,845 1619 WARNING test py.warnings: /odoo/external-src/l10n-brazil-FIX-botao_pesquisa_cep_empresa/l10n_br_base/models/res_partner_pix.py:65: DeprecationWarning: dict-like access to the return value of validate_email is deprecated and may not be supported in the future.
  File "/env/bin/odoo", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/odoo/src/setup/odoo", line 8, in <module>
    odoo.cli.main()
  File "/odoo/src/odoo/cli/command.py", line 66, in main
    o.run(args)
  File "/odoo/src/odoo/cli/server.py", line 180, in run
    main(args)
  File "/odoo/src/odoo/cli/server.py", line 173, in main
    rc = odoo.service.server.start(preload=preload, stop=stop)
  File "/odoo/src/odoo/service/server.py", line 1399, in start
    rc = server.run(preload, stop)
  File "/odoo/src/odoo/service/server.py", line 579, in run
    rc = preload_registries(preload)
  File "/odoo/src/odoo/service/server.py", line 1299, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/env/lib/python3.10/site-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
  File "/odoo/src/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "/odoo/src/odoo/modules/registry.py", line 90, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/odoo/src/odoo/modules/loading.py", line 484, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/odoo/src/odoo/modules/loading.py", line 372, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/odoo/src/odoo/modules/loading.py", line 290, in load_module_graph
    test_results = loader.run_suite(suite, module_name)
  File "/odoo/src/odoo/tests/loader.py", line 80, in run_suite
    suite(results)
  File "/usr/lib/python3.10/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/odoo/src/odoo/tests/suite.py", line 44, in run
    test(result)
  File "/usr/lib/python3.10/unittest/case.py", line 650, in __call__
    return self.run(*args, **kwds)
  File "/odoo/src/odoo/tests/common.py", line 269, in run
    super().run(result)
  File "/odoo/src/odoo/tests/case.py", line 216, in run
    self._callTestMethod(testMethod)
  File "/odoo/src/odoo/tests/case.py", line 184, in _callTestMethod
    method()
  File "/odoo/external-src/l10n-brazil-FIX-botao_pesquisa_cep_empresa/l10n_br_base/tests/test_valid_pix.py", line 75, in test_invalid_pix_email_too_long
    self.check_validation_error_on_create(pix_vals)
  File "/odoo/external-src/l10n-brazil-FIX-botao_pesquisa_cep_empresa/l10n_br_base/tests/test_valid_pix.py", line 103, in check_validation_error_on_create
    self.res_partner_pix_model.with_context(tracking_disable=True).create(
  File "/env/lib/python3.10/site-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
  File "/odoo/src/odoo/api.py", line 409, in _model_create_multi
    return create(self, [arg])
  File "/odoo/external-src/l10n-brazil-FIX-botao_pesquisa_cep_empresa/l10n_br_base/models/res_partner_pix.py", line 135, in create
    self.check_vals(vals)
  File "/odoo/external-src/l10n-brazil-FIX-botao_pesquisa_cep_empresa/l10n_br_base/models/res_partner_pix.py", line 148, in check_vals
    key = self._normalize_email(key)
  File "/odoo/external-src/l10n-brazil-FIX-botao_pesquisa_cep_empresa/l10n_br_base/models/res_partner_pix.py", line 65, in _normalize_email
    normalized_email = result["local"].lower() + "@" + result["domain_i18n"]

Pode ser visto no runboat também https://github.com/OCA/l10n-brazil/actions/runs/5870838927/job/15918698537?pr=2647#step:8:60

cc @rvalyi @renatonlima @marcelsavegnago @mileo @antoniospneto 