### PR TITLE
[14.0][FIX] l10n_br_nfe: garantir um valor nos campos computados.

### DIFF
--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -211,6 +211,14 @@ class ResPartner(spec_models.SpecModel):
                     rec.nfe40_choice19 = "nfe40_CPF"
                     rec.nfe40_CPF = cnpj_cpf
                     rec.nfe40_CNPJ = None
+            else:
+                rec.nfe40_choice2 = False
+                rec.nfe40_choice6 = False
+                rec.nfe40_choice7 = False
+                rec.nfe40_choice8 = False
+                rec.nfe40_choice19 = False
+                rec.nfe40_CNPJ = ""
+                rec.nfe40_CPF = ""
 
             if rec.inscr_est:
                 rec.nfe40_IE = punctuation_rm(rec.inscr_est)


### PR DESCRIPTION
Após a correção no #2644 ficou faltando garantir que os campos computados sempre tenham um valor atribuido.

Importante para evitar erros como esse:
`ValueError: Compute method failed to assign res.partner(60154,).nfe40_choice2`

