### PR TITLE
[16.0][FIX] l10n_br_currency_rate_update: Resolvido Warning Deprecated class SavepointCase

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit =
+    l10n_br_currency_rate_update/tests/test_currency_rate_update_bcb.py

--- a/l10n_br_currency_rate_update/tests/test_currency_rate_update_bcb.py
+++ b/l10n_br_currency_rate_update/tests/test_currency_rate_update_bcb.py
@@ -10,7 +10,7 @@ from dateutil.relativedelta import relativedelta
 from decorator import decorate
 
 from odoo import fields
-from odoo.tests import SavepointCase
+from odoo.tests.common import TransactionCase
 
 _logger = logging.getLogger(__name__)
 
@@ -90,7 +90,7 @@ def mocked_requests_get(*args, **kwargs):
     )
 
 
-class TestCurrencyRateUpdateBCB(SavepointCase):
+class TestCurrencyRateUpdateBCB(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()


### PR DESCRIPTION
Solve Warning Deprecated class SavepointCase.

PR simples mas que resolve o Warning Deprecated class SavepointCase

2023-08-16 15:47:04,838 38 WARNING test py.warnings: /odoo/external-src/l10n-brazil-oca/l10n_br_currency_rate_update/tests/test_currency_rate_update_bcb.py:10: DeprecationWarning: Deprecated class SavepointCase has been merged into TransactionCase
  File "/env/bin/odoo", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/odoo/src/setup/odoo", line 8, in <module>
    odoo.cli.main()
  File "/odoo/src/odoo/cli/command.py", line 66, in main
    o.run(args)
  File "/odoo/src/odoo/cli/server.py", line 180, in run
    main(args)
  File "/odoo/src/odoo/cli/server.py", line 173, in main
    rc = odoo.service.server.start(preload=preload, stop=stop)
  File "/odoo/src/odoo/service/server.py", line 1399, in start
    rc = server.run(preload, stop)
  File "/odoo/src/odoo/service/server.py", line 579, in run
    rc = preload_registries(preload)
  File "/odoo/src/odoo/service/server.py", line 1299, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/env/lib/python3.10/site-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
  File "/odoo/src/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "/odoo/src/odoo/modules/registry.py", line 90, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/odoo/src/odoo/modules/loading.py", line 484, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/odoo/src/odoo/modules/loading.py", line 372, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/odoo/src/odoo/modules/loading.py", line 282, in load_module_graph
    suite = loader.make_suite([module_name], 'at_install')
  File "/odoo/src/odoo/tests/loader.py", line 70, in make_suite
    return OdooSuite(sorted(tests, key=lambda t: t.test_sequence))
  File "/odoo/src/odoo/tests/loader.py", line 66, in <genexpr>
    for m in get_test_modules(module_name)
  File "/odoo/src/odoo/tests/loader.py", line 19, in get_test_modules
    results = _get_tests_modules(importlib.util.find_spec(f'odoo.addons.{module}'))
  File "/odoo/src/odoo/tests/loader.py", line 33, in _get_tests_modules
    tests_mod = importlib.import_module(spec.name)
  File "/odoo/external-src/l10n-brazil-oca/l10n_br_currency_rate_update/tests/__init__.py", line 3, in <module>
    from . import test_currency_rate_update_bcb
  File "/odoo/external-src/l10n-brazil-oca/l10n_br_currency_rate_update/tests/test_currency_rate_update_bcb.py", line 10, in <module>
    class TestCurrencyRateUpdateBCB(SavepointCase):

O erro pode ser visto no runboat https://github.com/OCA/l10n-brazil/actions/runs/5881306170/job/15949509457?pr=2649#step:8:390

cc @renatonlima @rvalyi @marcelsavegnago @mileo 