### PR TITLE
[12.0][BUG] Atributo ondelete errado do campo carrier_id no fiscal.document.mixin

### DIFF
--- a/l10n_br_delivery/models/fiscal_document_mixin.py
+++ b/l10n_br_delivery/models/fiscal_document_mixin.py
@@ -23,5 +23,5 @@ class FiscalDocumentMixin(models.AbstractModel):
     carrier_id = fields.Many2one(
         comodel_name="delivery.carrier",
         string="Carrier",
-        ondelete="cascade",
+        ondelete="restrict",
     )


### PR DESCRIPTION
Pessoal,

Fazendo alguns testes eu descobri um erro bem grave, no [l10n_br_delivery/models/fiscal_document_mixin.py#L26](https://github.com/OCA/l10n-brazil/blob/12.0/l10n_br_delivery/models/fiscal_document_mixin.py#L26) a definição do campo carrier_id no objeto l10n_br_fiscal.document.mixin esta com o ondelete="cascade" ou seja se for excluido um registro da tabela delivery_carrier, os registros que tem essa chave estrangeira serão excluidos isso afeta os objetos l10n_br_fiscal_document, sale_order, purchase_order, stock_picking.