### PR TITLE
[FIX][14.0] NFC-e: Cliente sem Identificação

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -414,7 +414,7 @@ class NFe(spec_models.StackedModel):
             if (
                 doc.partner_id.is_anonymous_consumer
                 and not doc.partner_id.cnpj_cpf
-                and doc.document_type != MODELO_FISCAL_NFCE
+                and doc.document_type == MODELO_FISCAL_NFCE
             ):
                 doc.nfe40_dest = None
             else:

--- a/l10n_br_nfe/tests/test_nfce.py
+++ b/l10n_br_nfe/tests/test_nfce.py
@@ -328,6 +328,5 @@ class TestNFCe(TestNFeExport):
         self.document_id._compute_entrega_data()
         self.assertFalse(self.document_id.nfe40_entrega)
 
-        self.document_id.document_type_id = self.env.ref("l10n_br_fiscal.document_55")
         self.document_id._compute_dest_data()
         self.assertFalse(self.document_id.nfe40_dest)


### PR DESCRIPTION
Estava ocorrendo erro ao emitir uma NFCe quando cliente não possui identificação (CPF/CNPJ), nesse caso estava sempre sendo enviado o campo "dest", ocorrendo falha no schema.

Isso estava acontecendo devido a uma validação errada no momento de computar o campo "nfe40_dest".