### PR TITLE
[14.0][FIX] l10n_br_nfe:  Falha no schema XML.

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -283,7 +283,7 @@ class NFe(spec_models.StackedModel):
     @api.depends("fiscal_operation_type", "nfe_transmission")
     def _compute_ide_data(self):
         """Set schema data which are not just related fields"""
-        for record in self.filtered(lambda x: x._need_compute_nfe_tags()):
+        for record in self:
             # tpNF
             if record.fiscal_operation_type:
                 operation_2_tpNF = {


### PR DESCRIPTION
Essa PR tem como proposta corrigir o erro que estava acontecendo ao tentar enviar novamente uma NF-e que foi rejeitada.

Por exemplo se ao tentar enviar a primeira vez e a nota seja rejeitada por exemplo, por falta da Inscrição Estadual.
Ao clicar no botão enviar novamente, a nota é rejeitada novamente porém com outro motivo de rejeição:  Falha no schema XML.
Se o usuário clicou em enviar novamente, sem fazer as correções (voltar para o estado de digitação) a rejeição tem que manter a mesmo, no caso do exemplo, teria que dar a rejeição por falta da Inscrição Estadual novamente.

Ao enviar pela segunda vez o XML da nota é serializado novamente, porém sem informar os campos da tag **ide**

O motivo era que o compute responsável por esses campos estava com um filtro que ignorava o calculo nos casos que o documento estava com o status do documento com rejeitada.