### PR TITLE
[12.0][FIX][l10n_br_nfe] Removido campo duplicado vFCPUFDest

### DIFF
--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -962,11 +962,6 @@ class NFeLine(spec_models.StackedModel):
             else:
                 record.nfe40_infAdProd = False
 
-    # Todo: Calcular
-    nfe40_vFCPUFDest = fields.Monetary(
-        string="Valor total do ICMS relativo ao Fundo de Combate à Pobreza",
-    )
-
     @api.model
     def _prepare_import_dict(
         self, values, model=None, parent_dict=None, defaults_model=None


### PR DESCRIPTION
Uma pequena regressão, o campo nfe40_vFCPUFDest está sendo definido duas vezes e não esta exportado para o XML