### PR TITLE
[14.0][Anglo-saxon accounting]: Habilita anglo-saxon para COA templates e cria contas intermediárias para COA generic

### DIFF
--- a/l10n_br_coa_generic/data/account.account.template.csv
+++ b/l10n_br_coa_generic/data/account.account.template.csv
@@ -25,6 +25,8 @@ coa_generic_114109,1.1.4.1.09,ISSF a Compensar,,l10n_br_coa.data_account_type_cu
 coa_generic_115101,1.1.5.1.01,Seguros a Apropriar,,l10n_br_coa.data_account_type_current_assets_other_credits,0,l10n_br_coa_generic_template
 coa_generic_115102,1.1.5.1.02,Encargos a Apropriar,,l10n_br_coa.data_account_type_current_assets_other_credits,0,l10n_br_coa_generic_template
 coa_generic_115103,1.1.5.1.03,IPTU a Apropriar,,l10n_br_coa.data_account_type_current_assets_other_credits,0,l10n_br_coa_generic_template
+coa_generic_119001,1.1.9.0.01,Estoque Intermediário (Recebido),,account.data_account_type_non_current_assets,1,l10n_br_coa_generic_template
+coa_generic_119002,1.1.9.0.02,Estoque Intermediário (Enviado),,account.data_account_type_non_current_assets,1,l10n_br_coa_generic_template
 coa_generic_119101,1.1.9.1.01,Estoque Inicial Mercadorias,,l10n_br_coa.data_account_type_current_assets_stock,1,l10n_br_coa_generic_template
 coa_generic_119102,1.1.9.1.02,Compras Mercadorias,,l10n_br_coa.data_account_type_current_assets_stock,0,l10n_br_coa_generic_template
 coa_generic_119103,1.1.9.1.03,Fretes e Carretos Mercadorias,,l10n_br_coa.data_account_type_current_assets_stock,0,l10n_br_coa_generic_template

--- a/l10n_br_coa_generic/data/l10n_br_coa_generic_template.xml
+++ b/l10n_br_coa_generic/data/l10n_br_coa_generic_template.xml
@@ -11,6 +11,7 @@
         <field name="transfer_account_code_prefix">1.1.1.2.0</field>
         <field name="currency_id" ref="base.BRL" />
         <field name="parent_id" ref="l10n_br_coa.l10n_br_coa_template" />
+        <field name="use_anglo_saxon" eval="1" />
     </record>
 
 </odoo>

--- a/l10n_br_coa_simple/data/l10n_br_coa_simple_template.xml
+++ b/l10n_br_coa_simple/data/l10n_br_coa_simple_template.xml
@@ -9,6 +9,7 @@
         <field name="transfer_account_code_prefix">1.1.1.0</field>
         <field name="currency_id" ref="base.BRL" />
         <field name="parent_id" ref="l10n_br_coa.l10n_br_coa_template" />
+        <field name="use_anglo_saxon" eval="1" />
     </record>
 
 </odoo>


### PR DESCRIPTION
## Objetivo

Habilitar anglo-saxon accounting e criar contas auxiliares para o fluxo contábil.

## Background
---

A funcionalidade anglo-saxon foi discutida de modo extensivo no PR https://github.com/OCA/l10n-brazil/pull/1561 para a versão 12.0, que ativa o modo anglo-saxon e adiciona melhorias no fluxo.

O PR ficou travado por um conflito no conceito anglo-saxon e suas funcionalidades que posso resumir brevemente aqui:

- "Anglo-saxon accounting" é um termo sem ligação com a contabilidade e aparenta ser utilizado no Odoo apenas por motivos históricos/legado. Esse termo causou confusão e discordância por (especulando) parecer alterar funcionalidades chave da contabilidade.
- Na realidade esse modo apenas permite a **contabilização automática dos custos de estoque*** no momento da venda. Este é o padrão Brasileiro (como falarei abaixo). Exemplo: sabe-se que uma compra de mercadoria para revenda gera custos. Estes podem ser lançados de duas formas:
  - No momento da própria compra: funcionamento padrão atual.
  - No momento da venda: funcionamento facilitado pelo modo anglo-saxon
    - Padrão Brasileiro e objetivo desse PR

***Contabilização automática dos custos de estoque** -> Pode ser interpretado (no contexto da revenda de mercadorias) como um lançamento contábil com **débito** na conta Custo das Mercadorias Vendidas (CMV) e **crédito** na conta Estoque.

Para entender esse fluxo e embasar as soluções técnicas contratamos uma consultoria de contabilidade e realizamos testes e simulações extensas. Seguem comparações entre os fluxos demonstrando os resultados.

## Simulação SEM ANGLO-SAXON:
---

Sem a utilização do modo anglo-saxon a configuração validada com a contabilidade foi a seguinte:
![image](https://github.com/OCA/l10n-brazil/assets/12245538/cb78a057-8f49-4a38-886d-69625312f0b8)

Repare na utilização de uma conta transitória, sem ela os lançamentos não ficam corretos (considerando contabilização no CMV na venda), e parece até não haver contas para preencher toda a configuração.

**IMPORTANTE: Apesar de ser/parecer um *workaround* os lançamentos contábeis foram validados como corretos, veja:**

### Na Compra:
![image](https://github.com/OCA/l10n-brazil/assets/12245538/505a9e6e-4688-44d0-85a8-ad907c7e53a6)
![image](https://github.com/OCA/l10n-brazil/assets/12245538/4801ec8a-a24c-4cbe-a260-731472c6959e)

* Repare que o valor do estoque foi alterado para não conter imposto, isso é feito automaticamente em https://github.com/OCA/l10n-brazil/pull/2635. De qualquer maneira basta testar o fluxo sem impostos, usar o PR ou ajustar manualmente o valor que chegará nos lançamentos corretos.

### Na Venda:
![image](https://github.com/OCA/l10n-brazil/assets/12245538/f510c343-6099-48ce-9060-241b0fce947a)
![image](https://github.com/OCA/l10n-brazil/assets/12245538/eb1fbb61-2887-45c9-9865-d1fc1840faea)


Outras tentativas com a conta CMV no campo Expense Account também ficaram inconsistentes pelos seguintes motivos:

1. A conta CMV é debitada no momento da compra. Mais especificamente na fatura do fornecedor:
![image](https://github.com/OCA/l10n-brazil/assets/12245538/267660a1-1fad-4edd-b2ab-a8f4f9692dd0)

2. Os lançamentos automáticos de estoque (tanto de entrada como de saída) não ficam certos pois não geram relação nenhuma com a conta CMV (mesmo se utilizar outras contas fora desse exemplo):
![image](https://github.com/OCA/l10n-brazil/assets/12245538/38c35c4b-47cf-4231-afe7-802e90f88954)
![image](https://github.com/OCA/l10n-brazil/assets/12245538/52fd10f4-61f4-4e37-a589-5bd13b93ae5c)
 

## Simulação COM ANGLO-SAXON:
---

Finalmente, com modo anglo-saxon ativado os lançamentos ficam semelhantes aos estratégia da conta transitória. Por se tratar de um módulo padrão do Odoo acredito que a maioria irá concordar que é uma estratégia melhor do que o *workaround* e outras estratégias mencionadas.

### Configuração utilizada:
![image](https://github.com/OCA/l10n-brazil/assets/12245538/51fb6c22-85c6-4619-8702-7e85b823f245)

### Lançamentos na Compra:
![image](https://github.com/OCA/l10n-brazil/assets/12245538/07f5b767-c48a-4119-bed5-66a7315adf31)
![image](https://github.com/OCA/l10n-brazil/assets/12245538/e1b607a9-2943-40ef-8c6e-c49f9ea12775)

### Lançamentos na Venda:
![image](https://github.com/OCA/l10n-brazil/assets/12245538/f072f63a-1fff-42a0-824e-0d5fa4e57720)
![image](https://github.com/OCA/l10n-brazil/assets/12245538/70cc79d4-70aa-4ae9-8516-2320175db8a9)

* com impostos zerados dessa vez

O módulo l10n_br_coa_generic é baseado no [Livro_Escrituracao_contabil.pdf](https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_coa_generic/static/pdf/Livro_Escrituracao_contabil.pdf), de onde retirei os seguintes trechos:

Compra:
![image](https://github.com/OCA/l10n-brazil/assets/12245538/d008a5d5-264a-4f19-99ac-f0aba118e274)

Venda:
![image](https://github.com/OCA/l10n-brazil/assets/12245538/d9d446f3-96dc-453c-af04-a4ecb7ffd0e4)

As contas utilizadas estão ligeiramente diferentes e no Odoo os lançamentos estoque/financeiro são separados, necessitando as contas de estoque intermediário para juntá-los. De qualquer forma, o resultado dos lançamentos após simplificação bate com o do livro e com a teoria passada pela consultoria que comentei.

---
## NOTAS:
- Esse funcionamento também já foi testado com [2635](https://github.com/OCA/l10n-brazil/pull/2635)
- O PR do @rvalyi [1561](https://github.com/OCA/l10n-brazil/pull/1561) possui outras melhorias no fluxo como a remoção de linhas de lançamentos contábeis zeradas que também observei em alguns casos. Ainda não olhei como ficaria na 14.0 mas com certeza é válido.