### PR TITLE
[14.0][FIX] fiscal,account:  Atualizar os valores do DIFAL ao atualizar o indicador de "Contribuinte do ICMS"

### DIFF
--- a/l10n_br_fiscal/models/document_fiscal_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_mixin_methods.py
@@ -91,6 +91,9 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
     def _onchange_partner_id_fiscal(self):
         if self.partner_id:
             self.ind_final = self.partner_id.ind_final
+            for line in self._get_amount_lines():
+                # reload fiscal data, operation line, cfop, taxes, etc.
+                line._onchange_fiscal_operation_id()
 
     @api.onchange("fiscal_operation_id")
     def _onchange_fiscal_operation_id(self):

--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -51,6 +51,9 @@ TAX_DICT_VALUES = {
     "remove_from_base": 0.00,
     "compute_reduction": True,
     "compute_with_tax_value": False,
+    "icms_dest_base": 0.00,
+    "icms_origin_value": 0.00,
+    "icms_dest_value": 0.00,
 }
 
 


### PR DESCRIPTION
O Objetivo desta PR é corrigir os valores do DIFAL ao alterar o indicador de "contribuinte do ICMS" do Parceiro.

Como esta é uma informação chave para o calculo do DIFAL, sempre que essa informação mudar é preciso atualizar os valores do DIFAL.
