### PR TITLE
[14.0][FIX] Delete modules on DFe migration

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -10,7 +10,7 @@
     "maintainers": ["renatonlima"],
     "website": "https://github.com/OCA/l10n-brazil",
     "development_status": "Production/Stable",
-    "version": "14.0.18.0.0",
+    "version": "14.0.19.0.0",
     "depends": [
         "product",
         "l10n_br_base",

--- a/l10n_br_fiscal/migrations/14.0.19.0.0/pre-migration.py
+++ b/l10n_br_fiscal/migrations/14.0.19.0.0/pre-migration.py
@@ -1,0 +1,25 @@
+# Copyright 2023 KMEE
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+def delete_model(cr, model_name):
+    openupgrade.logged_query(
+        cr,
+        """
+        DELETE FROM ir_model_access
+        WHERE model_id = (SELECT id FROM ir_model where model = '%s')
+        """
+        % model_name,
+    )
+    openupgrade.logged_query(
+        cr, "DELETE FROM ir_model_fields WHERE model = '%s'" % model_name
+    )
+    openupgrade.logged_query(cr, "DELETE FROM ir_model WHERE model = '%s'" % model_name)
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    delete_model(env.cr, "l10n_br_fiscal.mdfe")
+    delete_model(env.cr, "l10n_br_fiscal.dfe_xml")


### PR DESCRIPTION
Script de migração para excluir os modelos `l10n_br_fiscal.mdfe` e `l10n_br_fiscal.dfe_xml`. 

Na implementação do DFe esses módulos foram excluidos, o que acabou ocasionando alguns erros no banco de dados.