### PR TITLE
[14.0][FIX+IMP] spec_driven_model, l10n_br_nfe: XML dos Documentos Fiscais não devem ter caracteres Não ASCII para evitar a troca por símbolos ou números 

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -7,7 +7,6 @@ import logging
 import re
 import string
 from datetime import datetime
-from unicodedata import normalize
 
 from erpbrasil.assinatura import certificado as cert
 from erpbrasil.base.fiscal.edoc import ChaveEdoc
@@ -563,27 +562,15 @@ class NFe(spec_models.StackedModel):
         comodel_name="l10n_br_fiscal.document.supplement",
     )
 
-    @api.depends("fiscal_additional_data", "fiscal_additional_data")
+    @api.depends("fiscal_additional_data", "customer_additional_data")
     def _compute_nfe40_additional_data(self):
         for record in self:
             record.nfe40_infCpl = False
             record.nfe40_infAdFisco = False
             if record.fiscal_additional_data:
-                record.nfe40_infAdFisco = (
-                    normalize("NFKD", record.fiscal_additional_data)
-                    .encode("ASCII", "ignore")
-                    .decode("ASCII")
-                    .replace("\n", "")
-                    .replace("\r", "")
-                )
+                record.nfe40_infAdFisco = record.fiscal_additional_data
             if record.customer_additional_data:
-                record.nfe40_infCpl = (
-                    normalize("NFKD", record.customer_additional_data)
-                    .encode("ASCII", "ignore")
-                    .decode("ASCII")
-                    .replace("\n", "")
-                    .replace("\r", "")
-                )
+                record.nfe40_infCpl = record.customer_additional_data
 
     ##########################
     # NF-e tag: fat

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -3,12 +3,12 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import sys
-from unicodedata import normalize
 
 from odoo import api, fields
 
 from odoo.addons.l10n_br_fiscal.constants.icms import ICMS_CST, ICMS_SN_CST
 from odoo.addons.spec_driven_model.models import spec_models
+from odoo.addons.spec_driven_model.tools import remove_non_ascii_characters
 
 ICMSSN_CST_CODES_USE_102 = ("102", "103", "300", "400")
 ICMSSN_CST_CODES_USE_202 = ("202", "203")
@@ -176,7 +176,7 @@ class NFeLine(spec_models.StackedModel):
             or self.name
             or ""
         )
-        export_dict["xProd"] = nfe40_xProd[:120].replace("\n", " ").strip()
+        export_dict["xProd"] = remove_non_ascii_characters(nfe40_xProd[:120])
 
         nfe40_cEAN = nfe40_cEANTrib = self.product_id.barcode or "SEM GTIN"
         export_dict["cEAN"] = export_dict["cEANTrib"] = nfe40_cEAN
@@ -976,12 +976,8 @@ class NFeLine(spec_models.StackedModel):
     def _compute_nfe40_infAdProd(self):
         for record in self:
             if record.additional_data:
-                record.nfe40_infAdProd = (
-                    normalize("NFKD", record.additional_data)
-                    .encode("ASCII", "ignore")
-                    .decode("ASCII")
-                    .replace("\n", "")
-                    .replace("\r", "")
+                record.nfe40_infAdProd = remove_non_ascii_characters(
+                    record.additional_data
                 )
             else:
                 record.nfe40_infAdProd = False

--- a/spec_driven_model/models/spec_export.py
+++ b/spec_driven_model/models/spec_export.py
@@ -6,6 +6,8 @@ from io import StringIO
 
 from odoo import api, fields, models
 
+from ..tools import remove_non_ascii_characters
+
 _logger = logging.getLogger(__name__)
 
 
@@ -150,7 +152,8 @@ class AbstractSpecMixin(models.AbstractModel):
                 xsd_field, xsd_type, class_obj, xsd_required, export_value
             )
         elif type(self[xsd_field]) == str:
-            return self[xsd_field].strip()
+            xsd_field_non_ascii = remove_non_ascii_characters(self[xsd_field])
+            return xsd_field_non_ascii
         else:
             return self[xsd_field]
 

--- a/spec_driven_model/tools.py
+++ b/spec_driven_model/tools.py
@@ -1,0 +1,24 @@
+# Copyright 2023-TODAY Akretion
+# @author Magno Costa <magno.costa@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from unicodedata import normalize
+
+
+def remove_non_ascii_characters(value):
+    # TODO: Ver se existe a possibilidade de fazer essa conversão de
+    #  caracteres de forma automatica em todos os campos na criação
+    #  do XML, por enquanto isso esta sendo feito campo a campo em
+    #  usando esse metodo.
+    result = ""
+    if value and type(value) == str:
+        result = (
+            normalize("NFKD", value)
+            .encode("ASCII", "ignore")
+            .decode("ASCII")
+            .replace("\n", "")
+            .replace("\r", "")
+            .strip()
+        )
+
+    return result


### PR DESCRIPTION
XML Fiscal Documents should not has non ascii characters to avoid to be changed by symbols and numbers.

XML dos Documentos Fiscais não devem ter caracteres Não ASCII, para evitar a troca desses caracteres por símbolos e números, exemplo:

![image](https://github.com/OCA/l10n-brazil/assets/6341149/83c6c158-eaf2-4d99-974e-83716e2a7cfe)

O Github trata os caracteres se for texto por isso a imagem acima

Carácter "é" acaba sendo alterado para
<enderEmit><xLgr>Rua X Jos&#233; Y</xLgr>

Carácter "ção" acaba sendo alterado para 
<xProd>ZZZZ VEDA&#199;&#195;O YYYYYYYY</xProd>

Isso foi testado na NFe e ocorre no XML devolvido pela SEFAZ, provavelmente ocorre em outros Documentos Fiscais( por existir uma certa padronização mas testes são bem vindos para confirmar), por isso procurei substituir todos os caracteres que não são ASCII de uma forma genérica no spec_driven_model, porém lá só foi possível resolver uma parte dos campos Nome e Endereços do Emissor, Destinatário e Transportadora e os campos de Observações e Comentários( esse dois últimos já eram tratados), porém os campos dos Produtos eu precisei alterar no modulo l10n_br_nfe, para evitar código duplicado eu criei uma função simples em um arquivo tools.py no spec_driven_model e assim poder usar nos outros módulos, isso afeta a DANFE( talvez seja possível fazer de uma forma que só altere o XML, é preciso analisar) porém parece ser melhor ter o XML gerado sem esses erros até para não ter problema com os casos onde a empresa que recebe a NFe gerada por um cliente do Odoo/OCA/Localização vão importar esse XML gerado.

Para testar é possível incluir um Endereço com um carácter Não ASCII "é á à ç ão" gera a NFe em Homologação e olhar o XML.

cc @rvalyi @renatonlima @marcelsavegnago @mileo 