### PR TITLE
[14.0][IMP] l10n_br_nfe: Verificar campos necessários para Gerar Chave EDOC

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -926,6 +926,24 @@ class NFe(spec_models.StackedModel):
     def _generate_key(self):
         for record in self.filtered(filter_processador_edoc_nfe):
             date = fields.Datetime.context_timestamp(record, record.document_date)
+
+            required_fields_gen_edoc = []
+            if not record.company_cnpj_cpf:
+                required_fields_gen_edoc.append("CNPJ/CPF")
+            elif not record.company_state_id:
+                required_fields_gen_edoc.append("State Company")
+            elif not record.document_type_id:
+                required_fields_gen_edoc.append("Document Type")
+            elif not record.document_number:
+                required_fields_gen_edoc.append("Document Number")
+            elif not record.document_serie:
+                required_fields_gen_edoc.append("Document Serie")
+
+            for field in required_fields_gen_edoc:
+                raise ValidationError(
+                    _("To Generate EDoc Key, you need to fill the %s field.") % field
+                )
+
             chave_edoc = ChaveEdoc(
                 ano_mes=date.strftime("%y%m").zfill(4),
                 cnpj_cpf_emitente=record.company_cnpj_cpf,


### PR DESCRIPTION
Check Fields used to generate Chave EDOC to avoid LIB error.

PR simples para verificar campos necessários para Gerar Chave EDOC e evitar o erro da biblioteca que não é muito claro sobre o problema.

![image](https://github.com/OCA/l10n-brazil/assets/6341149/1e75ac98-06cd-4181-a07e-0657a4bfc0a8)

2023-08-30 23:38:14,005 1985 ERROR mbc_commerce-teste odoo.http: Exception during JSON request handling. 
Traceback (most recent call last):
  File "/odoo/src/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/odoo/src/odoo/http.py", line 696, in dispatch
    result = self._call_function(**self.params)
  File "/odoo/src/odoo/http.py", line 370, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/odoo/src/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/odoo/src/odoo/http.py", line 358, in checked_call
    result = self.endpoint(*a, **kw)
  File "/odoo/src/odoo/http.py", line 919, in __call__
    return self.method(*args, **kw)
  File "/odoo/src/odoo/http.py", line 544, in response_wrap
    response = f(*args, **kw)
  File "/odoo/src/addons/web/controllers/main.py", line 1374, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "/odoo/src/addons/web/controllers/main.py", line 1362, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/odoo/src/odoo/api.py", line 399, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/odoo/src/odoo/api.py", line 386, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/odoo/external-src/l10n-brazil-oca-30_08_2023/l10n_br_account/models/account_move.py", line 520, in action_post
    lambda d: d.document_type_id
  File "/odoo/external-src/l10n-brazil-oca-30_08_2023/l10n_br_fiscal/models/document_workflow.py", line 316, in action_document_confirm
    to_confirm._document_confirm()
  File "/odoo/external-src/l10n-brazil-oca-30_08_2023/l10n_br_fiscal/models/document_workflow.py", line 309, in _document_confirm
    self._change_state(SITUACAO_EDOC_A_ENVIAR)
  File "/odoo/external-src/l10n-brazil-oca-30_08_2023/l10n_br_fiscal/models/document_workflow.py", line 232, in _change_state
    if record._before_change_state(old_state, new_state):
  File "/odoo/external-src/l10n-brazil-oca-30_08_2023/l10n_br_fiscal/models/document_workflow.py", line 130, in _before_change_state
    return self._exec_before_SITUACAO_EDOC_A_ENVIAR(old_state, new_state)
  File "/odoo/external-src/l10n-brazil-oca-30_08_2023/l10n_br_fiscal/models/document_workflow.py", line 92, in _exec_before_SITUACAO_EDOC_A_ENVIAR
    self._document_number()
  File "/odoo/external-src/l10n-brazil-oca-30_08_2023/l10n_br_nfe/models/document.py", line 765, in _document_number
    result = super()._document_number()
  File "/odoo/external-src/l10n-brazil-oca-30_08_2023/l10n_br_fiscal/models/document_workflow.py", line 299, in _document_number
    self._generate_key()
  File "/odoo/external-src/l10n-brazil-oca-30_08_2023/l10n_br_nfe/models/document.py", line 933, in _generate_key
    validar=False,
  File "/usr/local/lib/python3.7/dist-packages/erpbrasil/base/fiscal/edoc.py", line 108, in __init__
    raise ValueError('Impossível gerar a chave!!')
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/odoo/src/odoo/http.py", line 652, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/odoo/src/odoo/http.py", line 317, in _handle_exception
    raise exception.with_traceback(None) from new_cause
ValueError: Impossível gerar a chave!!

cc @rvalyi @renatonlima @marcelsavegnago @mileo 