### PR TITLE
[14.0][FIX+IMP] l10n_br_nfe: Endereço da Transportadora na NFe duplicando o Número

### DIFF
--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -182,11 +182,19 @@ class ResPartner(spec_models.SpecModel):
 
     def _compute_nfe40_xEnder(self):
         for rec in self:
-            rec.nfe40_xEnder = ", ".join(
-                [i for i in [rec.street, rec.street_number] if i]
-            )
+            # Campos do endereço são separados no Emitente e Destinatario
+            # porém no caso da Transportadadora o campo do endereço é maior
+            # porém sem os detalhes como complemento e bairro, mas
+            # operacionalmente são importantes, por isso caso existam o
+            # Complemento e o Bairro é melhor agrega-los.
+            # campo street retorna "street_name, street_number"
+            endereco = rec.street
             if rec.street2:
-                rec.nfe40_xEnder = " - ".join((rec.nfe40_xEnder, rec.street2))
+                endereco += " - " + rec.street2
+            if rec.district:
+                endereco += " - " + rec.district
+
+            rec.nfe40_xEnder = endereco
 
     def _compute_nfe40_enderDest(self):
         for rec in self:


### PR DESCRIPTION
NFe Transporter address, solve duplicate street number and included District when exists.

Hoje no campo do Endereço da Transportadora o Número/street_number está duplicado

![image](https://github.com/OCA/l10n-brazil/assets/6341149/08addabe-2386-48c8-831e-3d655f4a2dcc)

Isso acontece porque o campo street já retorna "street_name , street_number" , além de corrigir isso eu adicionei o campo Bairro porque diferente do endereço do Emissor e Destinatário onde o endereço completo é informado por ter campos separados, no caso da Transportadora existe apenas um campo, porém operacionalmente é melhor incluir também o Bairro já que a DANFE é o documento que vai com o motorista onde essa informção acaba ajudando.  