### PR TITLE
[14.0][FIX] l10n_br_sale_stock: Na criação da Fatura a partir do Picking buscar o Modo de Pagto e Inconterm do Pedido de Vendas relacionado

### DIFF
--- a/l10n_br_sale_stock/wizards/stock_invoice_onshipping.py
+++ b/l10n_br_sale_stock/wizards/stock_invoice_onshipping.py
@@ -28,6 +28,18 @@ class StockInvoiceOnshipping(models.TransientModel):
                 values.update(
                     {"invoice_payment_term_id": pick.sale_id.payment_term_id.id}
                 )
+
+            # O campo payment_mode_id é implementado com a instalação do
+            # l10n_br_account_nfe mas o l10n_br_sale_stock não tem
+            # dependencia direta desse modulo, para evitar a necessidade
+            # de um 'glue' modulo para resolver isso é feita a verificação
+            # se o campo existe antes de preenche-lo
+            if hasattr(pick.sale_id, "payment_mode_id"):
+                if pick.sale_id.payment_mode_id.id != values.get("payment_mode_id"):
+                    values.update({"payment_mode_id": pick.sale_id.payment_mode_id.id})
+            if pick.sale_id.incoterm.id != values.get("invoice_incoterm_id"):
+                values.update({"invoice_incoterm_id": pick.sale_id.incoterm.id})
+
             if pick.sale_id.copy_note and pick.sale_id.note:
                 # Evita enviar False quando não tem nada
                 additional_data = ""


### PR DESCRIPTION
Get fields Incoterm and Payment Mode from Sale Order when create from Picking.

 Na criação da Fatura a partir do Picking buscar o Modo de Pagto e Inconterm do Pedido de Vendas relacionado.

O campo payment_mode_id é implementado com a instalação do l10n_br_account_nfe https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_account_nfe/__manifest__.py#L21 mas o l10n_br_sale_stock não tem dependência direta desse modulo, para evitar a necessidade de um 'glue' modulo para resolver isso é feita a verificação se o campo existe no objeto antes de preenche-lo, talvez o melhor nesse modulo será tentar usar o métodos prepare do sale.order e sale.order.line para trazer os campos a mais existentes e resolver o problema de forma dinâmica ao invés de mapear um a um, mas isso é um roadmap, e por enquanto o código resolve o problema.