### PR TITLE
[14.0][REF] l10n_br_account_payment_order: Substituição da precisão decimal "Account" pelo método da Moeda/res.currency

### DIFF
--- a/l10n_br_account_payment_order/models/account_move_line.py
+++ b/l10n_br_account_payment_order/models/account_move_line.py
@@ -155,7 +155,6 @@ class AccountMoveLine(models.Model):
             vals["partner_pix_id"] = self.partner_id.pix_key_ids[0].id
         # Preenchendo apenas nos casos CNAB
         if self.payment_mode_id.payment_method_code in BR_CODES_PAYMENT_ORDER:
-            digits = self.env["decimal.precision"].precision_get("Account")
             vals.update(
                 {
                     "own_number": self.own_number,
@@ -172,8 +171,8 @@ class AccountMoveLine(models.Model):
                     "ml_maturity_date": self.date_maturity,
                     "move_id": self.move_id.id,
                     "service_type": self._get_default_service_type(),
-                    "discount_value": round(
-                        self.amount_currency * (self.boleto_discount_perc / 100), digits
+                    "discount_value": self.currency_id.round(
+                        self.amount_currency * (self.boleto_discount_perc / 100)
                     ),
                 }
             )


### PR DESCRIPTION
Account Precision should use Monetary rounding method.

Apesar do método precision_get("Account") retornar um valor pelo o que entendi isso vem sendo mantido por compatibilidade, mas ao acessar a Precisão Decimal( o Decimal Accurancy foi traduzido por Exatidão Decimal, um termo que eu não vejo sendo usado) em Definições > Técnico > Estrutura de Dados > Exatidão decimal não aparece o "Account"

![image](https://github.com/OCA/l10n-brazil/assets/6341149/44f46906-009f-4c5d-b620-d242ed6d505e)

Essa informação passou para a Moeda/res.currency onde existem métodos de arredondamento e o número de Casas Decimais

![image](https://github.com/OCA/l10n-brazil/assets/6341149/54e93485-cd96-490a-8232-bf99e88954ae)

Um PR simples porém evita confusões.
