### PR TITLE
[14.0][REF] l10n_br_account_payment_brcobranca: Substituição da precisão decimal "Account" pelo método da Moeda/res.currency

### DIFF
--- a/l10n_br_account_payment_brcobranca/models/account_move_line.py
+++ b/l10n_br_account_payment_brcobranca/models/account_move_line.py
@@ -39,8 +39,6 @@ class AccountMoveLine(models.Model):
             bank_name_brcobranca = get_brcobranca_bank(
                 bank_account_id, move_line.payment_mode_id.payment_method_code
             )
-            precision = self.env["decimal.precision"]
-            precision_account = precision.precision_get("Account")
 
             boleto_cnab_api_data = {
                 "bank": bank_name_brcobranca[0],
@@ -92,10 +90,9 @@ class AccountMoveLine(models.Model):
 
             # Instrução de Juros
             if move_line.payment_mode_id.boleto_interest_perc > 0.0:
-                valor_juros = round(
+                valor_juros = move_line.currency_id.round(
                     move_line.debit
                     * ((move_line.payment_mode_id.boleto_interest_perc / 100) / 30),
-                    precision_account,
                 )
                 instrucao_juros = (
                     "APÓS VENCIMENTO COBRAR PERCENTUAL"
@@ -115,9 +112,8 @@ class AccountMoveLine(models.Model):
 
             # Instrução Multa
             if move_line.payment_mode_id.boleto_fee_perc > 0.0:
-                valor_multa = round(
+                valor_multa = move_line.currency_id.round(
                     move_line.debit * (move_line.payment_mode_id.boleto_fee_perc / 100),
-                    precision_account,
                 )
                 instrucao_multa = (
                     "APÓS VENCIMENTO COBRAR MULTA"
@@ -137,9 +133,8 @@ class AccountMoveLine(models.Model):
 
             # Instrução Desconto
             if move_line.boleto_discount_perc > 0.0:
-                valor_desconto = round(
+                valor_desconto = move_line.currency_id.round(
                     move_line.debit * (move_line.boleto_discount_perc / 100),
-                    precision_account,
                 )
                 instrucao_desconto_vencimento = (
                     "CONCEDER DESCONTO DE" + " %s %% "

--- a/l10n_br_account_payment_brcobranca/models/account_payment_line.py
+++ b/l10n_br_account_payment_brcobranca/models/account_payment_line.py
@@ -95,8 +95,6 @@ class AccountPaymentLine(models.Model):
                 linhas_pagamentos["codigo_multa"] = payment_mode_id.boleto_fee_code
                 linhas_pagamentos["percentual_multa"] = payment_mode_id.boleto_fee_perc
 
-            precision = self.env["decimal.precision"]
-            precision_account = precision.precision_get("Account")
             if payment_mode_id.boleto_interest_perc:
                 linhas_pagamentos["tipo_mora"] = payment_mode_id.boleto_interest_code
                 # TODO - É padrão em todos os bancos ?
@@ -114,10 +112,9 @@ class AccountPaymentLine(models.Model):
                 # para Correspondentes que ainda utilizam.
                 # Isento de Mora caso não exista percentual
                 if payment_mode_id.boleto_interest_code == "1":
-                    linhas_pagamentos["valor_mora"] = round(
+                    linhas_pagamentos["valor_mora"] = self.company_currency_id.round(
                         self.amount_currency
                         * ((payment_mode_id.boleto_interest_perc / 100) / 30),
-                        precision_account,
                     )
                 if payment_mode_id.boleto_interest_code == "2":
                     linhas_pagamentos[


### PR DESCRIPTION
Account Precision should use Monetary rounding method.

Substituição da precisão decimal "Account" pelo método da Moeda/res.currency, o mesmo que o PR https://github.com/OCA/l10n-brazil/pull/2677  ( onde tem um explicação sobre ), porém no modulo l10n_br_account_payment_brcobranca