### PR TITLE
[14.0][REF] l10n_br_stock_account_report: Substituição da precisão decimal "Account" pelo método da Moeda/res.currency

### DIFF
--- a/l10n_br_stock_account_report/wizards/l10n_br_p7_model_inventory_report_wizard.py
+++ b/l10n_br_stock_account_report/wizards/l10n_br_p7_model_inventory_report_wizard.py
@@ -139,8 +139,9 @@ class L10nBRP7ModelInventoryReportWizard(models.TransientModel):
 
         # Precision
         obj_precision = self.env["decimal.precision"]
-        account_precision = obj_precision.precision_get("Account")
         price_precision = obj_precision.precision_get("Product Price")
+        # Relatorio usado apenas no Brasil
+        account_precision = self.env.ref("base.BRL").decimal_places
 
         # TODO: Teria outra forma de fazer isso na v12 ?
         # Format Lang


### PR DESCRIPTION
Account Precision should use Monetary rounding method.

Substituição da precisão decimal "Account" pelo método da Moeda/res.currency, o mesmo que o PR https://github.com/OCA/l10n-brazil/pull/2677 ( onde tem um explicação sobre ), porém no modulo l10n_br_stock_account_report