### PR TITLE
[14.0][FIX] Quando parceiro estrangeiro com algum valor no CNPJ/Vat dá erro: Compute method... nfe40_choice2

### DIFF
--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -208,6 +208,7 @@ class ResPartner(spec_models.SpecModel):
             if cnpj_cpf:
                 if rec.country_id.code != "BR":
                     rec.nfe40_choice7 = "nfe40_idEstrangeiro"
+                    rec.nfe40_choice2 = False
                 elif rec.is_company:
                     rec.nfe40_choice2 = "nfe40_CNPJ"
                     rec.nfe40_choice6 = "nfe40_CNPJ"


### PR DESCRIPTION
Traceback (most recent call last):
File "/opt/odoo/odoo/http.py", line 652, in _handle_exception
return super(JsonRequest, self)._handle_exception(exception)
File "/opt/odoo/odoo/http.py", line 317, in _handle_exception
raise exception.with_traceback(None) from new_cause
ValueError: Compute method failed to assign res.partner(11,).nfe40_choice2