### PR TITLE
[14.0][FIX] l10n_br_fiscal_dfe: Dependência do modulo l10n_br_fiscal_certificate e Warnings no LOG

### DIFF
--- a/l10n_br_fiscal_dfe/__manifest__.py
+++ b/l10n_br_fiscal_dfe/__manifest__.py
@@ -8,7 +8,7 @@
     "license": "AGPL-3",
     "author": "KMEE,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-brazil",
-    "depends": ["l10n_br_fiscal"],
+    "depends": ["l10n_br_fiscal", "l10n_br_fiscal_certificate"],
     "data": [
         "data/ir_cron.xml",
         "security/ir.model.access.csv",

--- a/l10n_br_fiscal_dfe/models/attachment.py
+++ b/l10n_br_fiscal_dfe/models/attachment.py
@@ -16,6 +16,7 @@ _logger = logging.getLogger(__name__)
 
 class Attachment(models.TransientModel):
     _name = "l10n_br_fiscal.attachment"
+    _description = "Fiscal Document Attachment"
 
     attachment = fields.Binary(string="Attachment", readonly=True)
 

--- a/l10n_br_fiscal_dfe/security/ir.model.access.csv
+++ b/l10n_br_fiscal_dfe/security/ir.model.access.csv
@@ -1,3 +1,5 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
-"l10n_br_fiscal_dfe_user","Consut DFe for User","model_l10n_br_fiscal_dfe","l10n_br_fiscal.group_user",1,1,1,0
-"l10n_br_fiscal_dfe_manager","Consut DFe for Manager","model_l10n_br_fiscal_dfe","l10n_br_fiscal.group_manager",1,1,1,1
+l10n_br_fiscal_dfe_user,Consut DFe for User,model_l10n_br_fiscal_dfe,l10n_br_fiscal.group_user,1,1,1,0
+l10n_br_fiscal_dfe_manager,Consut DFe for Manager,model_l10n_br_fiscal_dfe,l10n_br_fiscal.group_manager,1,1,1,1
+access_l10n_br_fiscal_attachment_user,access_l10n_br_fiscal_attachment_user,model_l10n_br_fiscal_attachment,l10n_br_fiscal.group_user,1,0,0,0
+access_l10n_br_fiscal_attachment_manager,access_l10n_br_fiscal_attachment_manager,model_l10n_br_fiscal_attachment,l10n_br_fiscal.group_manager,1,1,1,1


### PR DESCRIPTION
Module dependecy log warnings.

O modulo tem dependência do l10n_br_fiscal_certificate, sem isso a instalação gera o erro:

2023-09-13 19:08:04,378 77 INFO test odoo.addons.base.models.ir_ui_view: Unknown field "res.company.certificate_nfe_id" in domain of <field name="company_id"> "[('certificate_nfe_id', '!=', False)]"

  File "/odoo/src/odoo/addons/base/models/ir_ui_view.py", line 1546, in _get_server_domain_variables
    self.handle_view_error(msg)
  File "/odoo/src/odoo/addons/base/models/ir_ui_view.py", line 680, in handle_view_error
    raise ValueError(formatted_message).with_traceback(from_traceback) from from_exception
odoo.exceptions.ValidationError: Error while validating view:

Unknown field "res.company.certificate_nfe_id" in domain of <field name="company_id"> "[('certificate_nfe_id', '!=', False)]"

View name: l10n_br_fiscal.dfe.form
Error context:
 view: ir.ui.view(579,)
 xmlid: dfe_form
 view.model: l10n_br_fiscal.dfe
 file: /odoo/external-src/l10n-brazil-FIX-warnigs_l10n_fiscal_dfe/l10n_br_fiscal_dfe/views/dfe/dfe_views.xml


Também resolvido Warnings do LOG referente ao modulo, declaração de uma classe precisa do parâmetro _description e grupo de acesso a essa classe:

2023-09-13 19:02:17,494 70 WARNING test odoo.models: The model l10n_br_fiscal.attachment has no _description

2023-09-12 23:13:16,776 61 WARNING test odoo.modules.loading: The model l10n_br_fiscal.attachment has no access rules, consider adding one. E.g. access_l10n_br_fiscal_attachment,access_l10n_br_fiscal_attachment,model_l10n_br_fiscal_attachment,base.group_user,1,0,0,0

