### PR TITLE
[14.0][FIX] l10n_br_nfe: Resolvendo Warnings do modulo

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -961,7 +961,7 @@ class NFe(spec_models.StackedModel):
     def _eletronic_document_send(self):
         self._prepare_payments_for_nfce()
 
-        super(NFe, self)._eletronic_document_send()
+        super()._eletronic_document_send()
         for record in self.filtered(filter_processador_edoc_nfe):
             if record.xml_error_message:
                 return
@@ -1076,7 +1076,7 @@ class NFe(spec_models.StackedModel):
         return etree.tostring(new_root)
 
     def _document_cancel(self, justificative):
-        result = super(NFe, self)._document_cancel(justificative)
+        result = super()._document_cancel(justificative)
         online_event = self.filtered(filter_processador_edoc_nfe)
         if online_event:
             online_event._nfe_cancel()
@@ -1145,7 +1145,7 @@ class NFe(spec_models.StackedModel):
             )
 
     def _document_correction(self, justificative):
-        result = super(NFe, self)._document_correction(justificative)
+        result = super()._document_correction(justificative)
         online_event = self.filtered(filter_processador_edoc_nfe)
         if online_event:
             online_event._nfe_correction(justificative)

--- a/l10n_br_nfe/models/document_supplement.py
+++ b/l10n_br_nfe/models/document_supplement.py
@@ -7,6 +7,7 @@ from odoo.addons.spec_driven_model.models import spec_models
 
 class NFeSupplement(spec_models.StackedModel):
     _name = "l10n_br_fiscal.document.supplement"
+    _description = "NFe Supplement Document"
     _inherit = "nfe.40.infnfesupl"
     _stacked = "nfe.40.infnfesupl"
     _field_prefix = "nfe40_"

--- a/l10n_br_nfe/models/invalidate_number.py
+++ b/l10n_br_nfe/models/invalidate_number.py
@@ -97,4 +97,4 @@ class InvalidateNumber(models.Model):
         )
 
         if processo.resposta.infInut.cStat == "102":
-            return super(InvalidateNumber, self)._invalidate(document_id)
+            return super()._invalidate(document_id)

--- a/l10n_br_nfe/models/mde.py
+++ b/l10n_br_nfe/models/mde.py
@@ -48,7 +48,7 @@ class MDe(models.Model):
 
     cnpj_cpf = fields.Char(string="CNPJ/CPF", size=18)
 
-    nsu = fields.Char(string="NSU", size=25, select=True)
+    nsu = fields.Char(string="NSU", size=25, index=True)
 
     operation_type = fields.Selection(
         selection=OPERATION_TYPE,
@@ -95,13 +95,13 @@ class MDe(models.Model):
     document_state = fields.Selection(
         string="Document State",
         selection=SITUACAO_NFE,
-        select=True,
+        index=True,
     )
 
     state = fields.Selection(
         string="Manifestation State",
         selection=SITUACAO_MANIFESTACAO,
-        select=True,
+        index=True,
     )
 
     dfe_id = fields.Many2one(string="DF-e", comodel_name="l10n_br_fiscal.dfe")

--- a/l10n_br_nfe/tests/test_account_customer_invoice.py
+++ b/l10n_br_nfe/tests/test_account_customer_invoice.py
@@ -8,7 +8,7 @@ from odoo.tests.common import TransactionCase
 
 class TestCustomerInvoice(TransactionCase):
     def setUp(self):
-        super(TestCustomerInvoice, self).setUp()
+        super().setUp()
         # Não foi possível usar um arquivo de demo criado pelo YAML
         # todas as vezes que rodava os testes o valor total da invoice
         # era alterado gerando falha no teste de 'status' em 'paid'

--- a/l10n_br_nfe/tests/test_account_nfe_refund.py
+++ b/l10n_br_nfe/tests/test_account_nfe_refund.py
@@ -8,7 +8,7 @@ from odoo.tests.common import TransactionCase
 
 class TestCustomerNFeRefund(TransactionCase):
     def setUp(self):
-        super(TestCustomerNFeRefund, self).setUp()
+        super().setUp()
         self.wizard_export = self.env["l10n_br_account_product.nfe_export_invoice"]
         self.wizard_refund = self.env["account.invoice.refund"]
         self.invoice_same_state = self.env.ref(

--- a/l10n_br_nfe/tests/test_account_supplier_nfe.py
+++ b/l10n_br_nfe/tests/test_account_supplier_nfe.py
@@ -8,7 +8,7 @@ from odoo.tests.common import TransactionCase
 
 class TestSupplierNFe(TransactionCase):
     def setUp(self):
-        super(TestSupplierNFe, self).setUp()
+        super().setUp()
         self.invoice_same_state = self.env.ref(
             "l10n_br_account_product.demo_nfe_supplier_same_state"
         )

--- a/l10n_br_nfe/tests/test_nfe_export.py
+++ b/l10n_br_nfe/tests/test_nfe_export.py
@@ -7,7 +7,7 @@ from odoo.tests.common import TransactionCase
 
 class TestNFeExport(TransactionCase):
     def setUp(self):
-        super(TestNFeExport, self).setUp()
+        super().setUp()
         self.wizard_export = self.env["l10n_br_account_product.nfe_export_invoice"]
         self.invoice_same_state = self.env.ref(
             "l10n_br_account_product.demo_nfe_same_state"

--- a/l10n_br_nfe/tests/test_nfe_serialize.py
+++ b/l10n_br_nfe/tests/test_nfe_serialize.py
@@ -19,7 +19,7 @@ _logger = logging.getLogger(__name__)
 
 class TestNFeExport(TransactionCase):
     def setUp(self, nfe_list):
-        super(TestNFeExport, self).setUp()
+        super().setUp()
         hooks.register_hook(
             self.env,
             "l10n_br_nfe",

--- a/l10n_br_nfe/tests/test_nfe_structure.py
+++ b/l10n_br_nfe/tests/test_nfe_structure.py
@@ -16,7 +16,7 @@ from ..models.document_related import NFeRelated
 class NFeStructure(SavepointCase):
     @classmethod
     def setUpClass(cls):
-        super(NFeStructure, cls).setUpClass()
+        super().setUpClass()
         hooks.register_hook(
             cls.env,
             "l10n_br_nfe",


### PR DESCRIPTION
Solve Warnings in LOGs and refactoring for unnecessary call super with parameters.

Resolvendo os Warnings do modulo l10n_br_nfe:

- Declaração de uma classe precisa do parâmetro _description

2023-09-12 22:35:18,754 63 WARNING test odoo.models: The model l10n_br_fiscal.document.supplement has no _description

- Na definição dos campos o parametro "select" foi substituido pelo "index"

2023-09-12 22:35:19,109 63 WARNING test odoo.fields: Field l10n_br_nfe.mde.nsu: unknown parameter 'select', if this is an actual parameter you may want to override the method _valid_field_parameter on the relevant model in order to allow it 
2023-09-12 22:35:19,110 63 WARNING test odoo.fields: Field l10n_br_nfe.mde.document_state: unknown parameter 'select', if this is an actual parameter you may want to override the method _valid_field_parameter on the relevant model in order to allow it 
2023-09-12 22:35:19,110 63 WARNING test odoo.fields: Field l10n_br_nfe.mde.state: unknown parameter 'select', if this is an actual parameter you may want to override the method _valid_field_parameter on the relevant model in order to allow it


E o último commit é apenas um refatoração por não ser necessário chamar o "super" com parâmetros


