### PR TITLE
[14.0][FIX] l10n_br_fiscal: remove fcp if not icms

### DIFF
--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -602,6 +602,18 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
 
     def _set_fields_icmsfcp(self, tax_dict):
         self.ensure_one()
+        if not self.icms_tax_id or self.icms_cst_id.code in [
+            "40",
+            "41",
+            "50",
+            "101",
+            "102",
+            "103",
+            "300",
+            "400",
+        ]:
+            tax_dict = TAX_DICT_VALUES
+            self.icmsfcp_tax_id = False
         self.icmsfcp_base = tax_dict.get("base", 0.0)
         self.icmsfcp_percent = tax_dict.get("percent_amount", 0.0)
         self.icmsfcp_value = tax_dict.get("tax_value", 0.0)


### PR DESCRIPTION
Hoje, existem alguns casos de cst do icms que o campo fcp é escondido, porém os valores continuam la e gera erros na nota. Com essa PR os valores do FCP são apagados caso o icms for vazio ou terem os determinados csts que escondem os campos.

Em draft para testes. Aceito sugestões de melhoria porque não sei se a forma mais correta de fazer isso.