### PR TITLE
[14.0][FIX] l10n_br_contract: fix contract line report view

### DIFF
--- a/l10n_br_contract/models/contract_line.py
+++ b/l10n_br_contract/models/contract_line.py
@@ -42,6 +42,8 @@ class ContractLine(models.Model):
         string="Comments",
     )
 
+    line_recurrence = fields.Boolean(related="contract_id.line_recurrence")
+
     def _prepare_invoice_line(self, move_form):
         self.ensure_one()
 

--- a/l10n_br_contract/views/contract_line.xml
+++ b/l10n_br_contract/views/contract_line.xml
@@ -91,9 +91,12 @@
                     />
                 </notebook>
             </xpath>
+            <xpath expr="//group[@name='recurrence_info']" position="inside">
+                <field name="line_recurrence" invisible="1" />
+            </xpath>
             <xpath expr="//group[@name='recurrence_info']" position="attributes">
                 <attribute name="attrs">
-                    {'invisible': ['|','|', ('display_type', '=', 'line_section'), ('parent.line_recurrence', '!=', True), '&amp;', ('display_type', '=', 'line_note'), ('note_invoicing_mode', '!=', 'custom')]}
+                    {'invisible': ['|','|', ('display_type', '=', 'line_section'), ('line_recurrence', '!=', True), '&amp;', ('display_type', '=', 'line_note'), ('note_invoicing_mode', '!=', 'custom')]}
                 </attribute>
             </xpath>
         </field>


### PR DESCRIPTION
![image](https://github.com/OCA/l10n-brazil/assets/3595132/13401b0a-3233-4778-8b3e-20c44480c0e4)


Este mesmo form é chamado pelo formulário do contrato.. neste caso o parent.line_recurrence não dava problema.. Porém, quando acessa as linhas de contrato pelo relatório o parent nao existe e da erro. Seria melhor conseguir testar sem o parent está presente ou nao mas nao encontrei uma forma de fazer isso agora.
