### PR TITLE
[14.0][FIX] l10n_br_account_payment_brcobranca: due_date referenced before

### DIFF
--- a/l10n_br_account_payment_brcobranca/parser/cnab_file_parser.py
+++ b/l10n_br_account_payment_brcobranca/parser/cnab_file_parser.py
@@ -332,6 +332,7 @@ class CNABFileParser(FileParser):
                 account_move_line.payment_mode_id.fixed_journal_id.bank_account_id
             )
 
+            due_date = False
             # as vezes o vencimento pode ser branco
             if (
                 linha_cnab.get("data_vencimento")


### PR DESCRIPTION
Em casos em que a primeira linha do retorno não tem data de vencimento, ta estourando erro porque a variável due_date ta sendo usada antes de ser definida.

![2023-09-21_15-04](https://github.com/OCA/l10n-brazil/assets/6812128/899be7af-26dd-48a4-b16a-8990f5d54d63)
