### PR TITLE
[14.0][FIX] l10_br_fiscal: não forçar o re-carregamento dos comentários ao confirmar o documento

### DIFF
--- a/l10n_br_fiscal/models/document_workflow.py
+++ b/l10n_br_fiscal/models/document_workflow.py
@@ -300,12 +300,6 @@ class DocumentWorkflow(models.AbstractModel):
 
     def _document_confirm(self):
         if self.issuer == DOCUMENT_ISSUER_COMPANY:
-            if not self.comment_ids and self.fiscal_operation_id.comment_ids:
-                self.comment_ids |= self.fiscal_operation_id.comment_ids
-
-            for line in self.fiscal_line_ids:
-                if not line.comment_ids and line.fiscal_operation_line_id.comment_ids:
-                    line.comment_ids |= line.fiscal_operation_line_id.comment_ids
             self._change_state(SITUACAO_EDOC_A_ENVIAR)
         else:
             self._change_state(SITUACAO_EDOC_AUTORIZADA)

--- a/l10n_br_nfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_nfe/demo/fiscal_document_demo.xml
@@ -83,6 +83,9 @@
         <field name="user_id" ref="base.user_demo" />
         <field name="fiscal_operation_type">out</field>
     </record>
+    <function model="l10n_br_fiscal.document" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state')]" />
+    </function>
 
     <record
         id="demo_nfe_national_sale_for_same_state-1"
@@ -127,6 +130,9 @@
         <field name="user_id" ref="base.user_demo" />
         <field name="fiscal_operation_type">out</field>
     </record>
+    <function model="l10n_br_fiscal.document" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11')]" />
+    </function>
 
     <record
         id="demo_nfe_natural_icms_18_red_51_11-1"
@@ -171,6 +177,9 @@
         <field name="user_id" ref="base.user_demo" />
         <field name="fiscal_operation_type">out</field>
     </record>
+    <function model="l10n_br_fiscal.document" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale')]" />
+    </function>
 
     <record id="demo_nfe_natural_icms_7_resale-1" model="l10n_br_fiscal.document.line">
         <field name="document_id" ref="demo_nfe_natural_icms_7_resale" />

--- a/l10n_br_sale/views/sale_view.xml
+++ b/l10n_br_sale/views/sale_view.xml
@@ -77,6 +77,7 @@
                         placeholder="Terms and conditions... (note: you can setup default ones in the Configuration menu)"
                         style="min-width: 590px;"
                     />
+                    <field name="comment_ids" widget="many2many_tags" />
                     <field
                         name="manual_customer_additional_data"
                         style="min-width: 590px;"
@@ -85,6 +86,7 @@
                         name="manual_fiscal_additional_data"
                         style="min-width: 590px;"
                     />
+
                 </group>
             </field>
             <xpath expr="//field[@name='order_line']" position="attributes">


### PR DESCRIPTION
O propósito desta PR é tornar possível um usuário apagar manualmente um comentário que foi carregado no documento a partir da operação fiscal.

![image](https://github.com/OCA/l10n-brazil/assets/634278/b7cd2d04-4395-451e-8be3-c1df1772de3e)


Hoje atualmente isso não é possível, mesmo que você vá e apague algum item no campo `comment_ids` ao validar/confirmar o documento, os comentários são carregado da operação fiscal novamente, o que você apagou volta..

A solução foi apagar a parte do código que força o carregamento dos comentários ao confirmar o documento.
Agora os comentários são carregados apenas ao preencher a operação fiscal.

Caso o forçar o carregamento dos comentários na confirmação do documento seja muito importante para alguém
posso alterar a PR para implementar um novo campo `force_load_comments` para controlar quando ou não os comentários devem ser recarregados.



