### PR TITLE
[14.0][FIX] l10n_br_purchase_stock:  Botão para acessar as Faturas a partir do Pedido de Compra

### DIFF
--- a/l10n_br_purchase_stock/demo/purchase_order.xml
+++ b/l10n_br_purchase_stock/demo/purchase_order.xml
@@ -285,5 +285,119 @@
         <value eval="[ref('lucro_presumido_pol_only_products_1_2')]" />
     </function>
 
+    <!-- Purchase Order with only Service -->
+    <!-- Necessario alterar o Metodo de Compra do Servico
+         para evitar necessidade de Receber/Stock Picking-->
+    <record id="l10n_br_fiscal.customized_development_sale" model="product.product">
+        <field name="purchase_method">purchase</field>
+    </record>
+
+    <record id="main_po_only_service_stock" model="purchase.order">
+        <field name="name">Main l10n_br_purchase_stock - Serviços</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_akretion" />
+        <field name="payment_term_id" ref="account.account_payment_term_advance" />
+        <field name="state">draft</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field name="user_id" ref="base.user_admin" />
+        <field name="company_id" ref="base.main_company" />
+    </record>
+
+    <function model="purchase.order" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('main_po_only_service_stock')]" />
+    </function>
+
+    <record id="main_pl_only_service_stock_1_1" model="purchase.order.line">
+        <field name="order_id" ref="main_po_only_service_stock" />
+        <field name="name">Desenvolvimento Odoo</field>
+        <field name="product_id" ref="l10n_br_fiscal.customized_development_sale" />
+        <field name="product_qty">1</field>
+        <field name="product_uom" ref="uom.product_uom_hour" />
+        <field name="price_unit">250</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_compras_compras_uso_consumo"
+        />
+        <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
+        <field name="partner_order">0000001</field>
+        <field name="partner_order_line">001</field>
+    </record>
+
+    <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('main_pl_only_service_stock_1_1')]" />
+    </function>
+
+    <function model="purchase.order.line" name="_onchange_fiscal_operation_line_id">
+        <value eval="[ref('main_pl_only_service_stock_1_1')]" />
+    </function>
+
+    <!-- Purchase Order with Service and Product -->
+    <record id="main_po_service_product_stock" model="purchase.order">
+        <field name="name">Main l10n_br_purchase_stock - Serviço e Produto</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_akretion" />
+        <field name="payment_term_id" ref="account.account_payment_term_advance" />
+        <field name="state">draft</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field name="user_id" ref="base.user_admin" />
+        <field name="company_id" ref="base.main_company" />
+    </record>
+
+    <function model="purchase.order" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('main_po_service_product_stock')]" />
+    </function>
+
+    <record id="main_pl_service_product_stock_1_1" model="purchase.order.line">
+        <field name="order_id" ref="main_po_service_product_stock" />
+        <field name="name">Desenvolvimento Odoo</field>
+        <field name="product_id" ref="l10n_br_fiscal.customized_development_sale" />
+        <field name="product_qty">1</field>
+        <field name="product_uom" ref="uom.product_uom_hour" />
+        <field name="price_unit">250</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_compras_compras_uso_consumo"
+        />
+        <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
+        <field name="partner_order">0000001</field>
+        <field name="partner_order_line">001</field>
+    </record>
+
+    <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('main_pl_service_product_stock_1_1')]" />
+    </function>
+
+    <function model="purchase.order.line" name="_onchange_fiscal_operation_line_id">
+        <value eval="[ref('main_pl_service_product_stock_1_1')]" />
+    </function>
+
+    <record id="main_pl_service_product_stock_2_2" model="purchase.order.line">
+        <field name="order_id" ref="main_po_service_product_stock" />
+        <field name="name">Gaveta Preta</field>
+        <field name="product_id" ref="product.product_product_16" />
+        <field name="product_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="price_unit">500</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_compras_compras"
+        />
+        <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
+        <field name="partner_order">0000001</field>
+        <field name="partner_order_line">002</field>
+        <field name="manual_additional_data">Teste - Additional Data</field>
+        <field name="insurance_value">10</field>
+        <field name="other_value">10</field>
+        <field name="freight_value">10</field>
+    </record>
+
+    <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('main_pl_service_product_stock_2_2')]" />
+    </function>
+
+    <function model="purchase.order.line" name="_onchange_fiscal_operation_line_id">
+        <value eval="[ref('main_pl_service_product_stock_2_2')]" />
+    </function>
 
 </odoo>

--- a/l10n_br_purchase_stock/models/purchase_order.py
+++ b/l10n_br_purchase_stock/models/purchase_order.py
@@ -12,6 +12,33 @@ class PurchaseOrder(models.Model):
         related="company_id.purchase_create_invoice_policy",
     )
 
+    # Make Invisible Invoice Button
+    button_create_invoice_invisible = fields.Boolean(
+        compute="_compute_get_button_create_invoice_invisible"
+    )
+
+    @api.depends("state", "invoice_status")
+    def _compute_get_button_create_invoice_invisible(self):
+        for record in self:
+            button_create_invoice_invisible = False
+
+            # Somente depois do Pedido confirmado o botão pode aparecer
+            if (
+                record.state not in ("purchase", "done")
+                or record.invoice_status != "to invoice"
+                or not record.order_line
+            ):
+                button_create_invoice_invisible = True
+            else:
+                if record.purchase_create_invoice_policy == "stock_picking":
+                    # A criação de Fatura de Serviços deve ser possível via Pedido
+                    if not any(
+                        line.product_id.type == "service" for line in record.order_line
+                    ):
+                        button_create_invoice_invisible = True
+
+            record.button_create_invoice_invisible = button_create_invoice_invisible
+
     @api.model
     def _prepare_picking(self):
         values = super()._prepare_picking()

--- a/l10n_br_purchase_stock/tests/test_l10n_br_purchase_stock.py
+++ b/l10n_br_purchase_stock/tests/test_l10n_br_purchase_stock.py
@@ -246,3 +246,45 @@ class L10nBrPurchaseStockBase(test_l10n_br_purchase.L10nBrPurchaseBaseTest):
         # Confirmando a Fatura
         invoice.action_post()
         self.assertEqual(invoice.state, "posted", "Invoice should be in state Posted")
+
+    def test_button_create_bill_in_view(self):
+        """
+        Test Field to make Button Create Bill invisible.
+        """
+        purchase_products = self.env.ref(
+            "l10n_br_purchase_stock.main_po_only_products_2"
+        )
+        # Caso do Pedido de Compra em Rascunho
+        self.assertTrue(
+            purchase_products.button_create_invoice_invisible,
+            "Field to make invisible the Button Create Bill should be"
+            " invisible when Purchase Order is not in state Purchase or Done.",
+        )
+        # Caso somente com Produtos
+        purchase_products.button_confirm()
+        self.assertTrue(
+            purchase_products.button_create_invoice_invisible,
+            "Field to make invisible the button Create Bill should be"
+            " invisible when Purchase Order has only products.",
+        )
+
+        # Caso Somente Serviços
+        purchase_only_service = self.env.ref(
+            "l10n_br_purchase_stock.main_po_only_service_stock"
+        )
+        purchase_only_service.button_confirm()
+        self.assertFalse(
+            purchase_only_service.button_create_invoice_invisible,
+            "Field to make invisible the Button Create Bill should be"
+            " False when the Purchase Order has only Services.",
+        )
+        # Caso Serviço e Produto
+        purchase_service_product = self.env.ref(
+            "l10n_br_purchase_stock.main_po_service_product_stock"
+        )
+        purchase_service_product.button_confirm()
+        self.assertFalse(
+            purchase_only_service.button_create_invoice_invisible,
+            "Field to make invisible the Button Create Bill should be"
+            " False when the Purchase Order has Service and Product.",
+        )

--- a/l10n_br_purchase_stock/tests/test_l10n_br_purchase_stock.py
+++ b/l10n_br_purchase_stock/tests/test_l10n_br_purchase_stock.py
@@ -39,6 +39,28 @@ class L10nBrPurchaseStockBase(test_l10n_br_purchase.L10nBrPurchaseBaseTest):
         self._picking_purchase_order(self.po_products)
         return result
 
+    def picking_move_state(self, picking):
+        picking.action_confirm()
+        # Check product availability
+        picking.action_assign()
+        # Force product availability
+        for move in picking.move_ids_without_package:
+            move.quantity_done = move.product_uom_qty
+        picking.button_validate()
+
+    def wizard_create_invoice(self, pickings):
+        wizard_obj = self.invoice_wizard.with_context(
+            active_ids=pickings.ids,
+            active_model=pickings._name,
+        )
+        fields_list = wizard_obj.fields_get().keys()
+        wizard_values = wizard_obj.default_get(fields_list)
+        # One invoice per partner but group products
+        wizard_values.update({"group": "partner_product"})
+        wizard = wizard_obj.create(wizard_values)
+        wizard.onchange_group()
+        wizard.action_generate()
+
     def test_grouping_pickings(self):
         """
         Test the invoice generation grouped by partner/product with 2
@@ -51,12 +73,8 @@ class L10nBrPurchaseStockBase(test_l10n_br_purchase.L10nBrPurchaseBaseTest):
             picking_1.invoice_state, "2binvoiced", "Error to inform Invoice State."
         )
 
-        picking_1.action_confirm()
-        picking_1.action_assign()
-        # Force product availability
-        for move in picking_1.move_ids_without_package:
-            move.quantity_done = move.product_uom_qty
-        picking_1.button_validate()
+        self.picking_move_state(picking_1)
+
         self.assertEqual(picking_1.state, "done")
 
         self.assertEqual(
@@ -68,30 +86,12 @@ class L10nBrPurchaseStockBase(test_l10n_br_purchase.L10nBrPurchaseBaseTest):
 
         purchase_2 = self.env.ref("l10n_br_purchase_stock.main_po_only_products_2")
         purchase_2.button_confirm()
+
         picking_2 = purchase_2.picking_ids
-        picking_2.action_confirm()
-        picking_2.action_assign()
-        # Force product availability
-        for move in picking_2.move_ids_without_package:
-            move.quantity_done = move.product_uom_qty
-        picking_2.button_validate()
+        self.picking_move_state(picking_2)
 
         pickings = picking_1 | picking_2
-        wizard_obj = self.invoice_wizard.with_context(
-            active_ids=pickings.ids,
-            active_model=pickings._name,
-        )
-        fields_list = wizard_obj.fields_get().keys()
-        wizard_values = wizard_obj.default_get(fields_list)
-        # One invoice per partner but group products
-        wizard_values.update(
-            {
-                "group": "partner_product",
-            }
-        )
-        wizard = wizard_obj.create(wizard_values)
-        wizard.onchange_group()
-        wizard.action_generate()
+        self.wizard_create_invoice(pickings)
         domain = [("picking_ids", "in", (picking_1.id, picking_2.id))]
         invoice = self.invoice_model.search(domain)
         # Fatura Agrupada
@@ -160,23 +160,10 @@ class L10nBrPurchaseStockBase(test_l10n_br_purchase.L10nBrPurchaseBaseTest):
             self.assertTrue(
                 line.fiscal_operation_line_id, "Missing Fiscal Operation Line."
             )
-        picking_devolution.action_confirm()
-        picking_devolution.action_assign()
-        # Force product availability
-        for move in picking_devolution.move_ids_without_package:
-            move.quantity_done = move.product_uom_qty
-        picking_devolution.button_validate()
+        self.picking_move_state(picking_devolution)
         self.assertEqual(picking_devolution.state, "done", "Change state fail.")
-        wizard_obj = self.invoice_wizard.with_context(
-            active_ids=picking_devolution.ids,
-            active_model=picking_devolution._name,
-            active_id=picking_devolution.id,
-        )
-        fields_list = wizard_obj.fields_get().keys()
-        wizard_values = wizard_obj.default_get(fields_list)
-        wizard = wizard_obj.create(wizard_values)
-        wizard.onchange_group()
-        wizard.action_generate()
+
+        self.wizard_create_invoice(picking_devolution)
         domain = [("picking_ids", "=", picking_devolution.id)]
         invoice_devolution = self.invoice_model.search(domain)
         # Confirmando a Fatura
@@ -206,19 +193,13 @@ class L10nBrPurchaseStockBase(test_l10n_br_purchase.L10nBrPurchaseBaseTest):
         purchase.button_confirm()
         picking = purchase.picking_ids
 
-        #
         picking.set_to_be_invoiced()
 
         self.assertEqual(
             picking.invoice_state, "2binvoiced", "Error to inform Invoice State."
         )
 
-        picking.action_confirm()
-        picking.action_assign()
-        # Force product availability
-        for move in picking.move_ids_without_package:
-            move.quantity_done = move.product_uom_qty
-        picking.button_validate()
+        self.picking_move_state(picking)
         self.assertEqual(picking.state, "done")
 
         self.assertEqual(
@@ -228,21 +209,7 @@ class L10nBrPurchaseStockBase(test_l10n_br_purchase.L10nBrPurchaseBaseTest):
             " before create invoice by Picking.",
         )
 
-        wizard_obj = self.invoice_wizard.with_context(
-            active_ids=picking.ids,
-            active_model=picking._name,
-        )
-        fields_list = wizard_obj.fields_get().keys()
-        wizard_values = wizard_obj.default_get(fields_list)
-        # One invoice per partner but group products
-        wizard_values.update(
-            {
-                "group": "partner_product",
-            }
-        )
-        wizard = wizard_obj.create(wizard_values)
-        wizard.onchange_group()
-        wizard.action_generate()
+        self.wizard_create_invoice(picking)
         domain = [("picking_ids", "=", picking.id)]
         invoice = self.invoice_model.search(domain)
 

--- a/l10n_br_purchase_stock/views/purchase_order.xml
+++ b/l10n_br_purchase_stock/views/purchase_order.xml
@@ -8,13 +8,30 @@
         <field name="priority">120</field>
         <field name="arch" type="xml">
             <field name="fiscal_operation_id" position="after">
-                <field name="purchase_create_invoice_policy" invisible="1" />
+                <field name="button_create_invoice_invisible" invisible="1" />
             </field>
-            <xpath expr="//button[@name='action_view_invoice']" position="attributes">
+
+            <xpath
+                expr="//button[@name='action_create_invoice'][1]"
+                position="attributes"
+            >
                 <attribute
                     name="attrs"
-                >{'invisible': ['|','|', ('invoice_count', '=', 0), ('purchase_create_invoice_policy', '=', 'stock_picking'), ('state', 'in', ('draft','sent','to approve'))]}</attribute>
+                >{'invisible': [('button_create_invoice_invisible', '=', True)]}</attribute>
+
             </xpath>
+
+            <xpath
+                expr="//button[@name='action_create_invoice'][2]"
+                position="attributes"
+            >
+                <attribute
+                    name="attrs"
+                >{'invisible': [('button_create_invoice_invisible', '=', True)]}</attribute>
+
+            </xpath>
+
+
         </field>
     </record>
 


### PR DESCRIPTION
There is no reason to make invisible the Button to acess Invoices from Purchase Order when the Invoice Policy are From Picking, file removed because whithout it the attrs is the same of main module. Refectoring Tests to avoid reapeting code.

Não parece existir motivo para manter o botão de acesso as Faturas a partir do Pedido de Compra invisível quando a Politica de Fatura é pelo Picking, isso não interfere no processo

![image](https://github.com/OCA/l10n-brazil/assets/6341149/95cd4426-de0b-4394-bb3b-6df1a0c28bc3)

Como com essa alteração o attrs ficou igual ao do modulo principal https://github.com/odoo/odoo/blob/14.0/addons/purchase/views/purchase_views.xml#L158 eu apaguei o arquivo, procurei ver se teria algum PR em aberto que estaria usando esse arquivo para mante-lo mas não encontrei, se houver e só avisar que vejo de voltar o arquivo, isso deve resolver o issue https://github.com/OCA/l10n-brazil/issues/2708

Também refatorei os testes para incluir dois metodos que evitam a necessidade de repetir código.
