### PR TITLE
[14.0][FIX] spec_driven_model: multiple models with _stacked property

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -853,6 +853,7 @@ class NFe(spec_models.StackedModel):
         for record in self.with_context(lang="pt_BR").filtered(
             filter_processador_edoc_nfe
         ):
+            record = record.with_context(module="l10n_br_nfe")
             inf_nfe = record.export_ds()[0]
 
             inf_nfe_supl = None

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -81,6 +81,7 @@ class NFe(spec_models.StackedModel):
     _schema_version = "4.0.0"
     _odoo_module = "l10n_br_nfe"
     _spec_module = "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00"
+    _binding_module = "nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00"
     _spec_tab_name = "NFe"
     _nfe_search_keys = ["nfe40_Id"]
 

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -72,6 +72,7 @@ class NFeLine(spec_models.StackedModel):
     _schema_version = "4.0.0"
     _odoo_module = "l10n_br_nfe"
     _spec_module = "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00"
+    _binding_module = "nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00"
     _spec_tab_name = "NFe"
     _stacking_points = {}
     # all m2o below this level will be stacked even if not required:

--- a/l10n_br_nfe/models/document_related.py
+++ b/l10n_br_nfe/models/document_related.py
@@ -26,6 +26,7 @@ class NFeRelated(spec_models.StackedModel):
     _schema_version = "4.0.0"
     _odoo_module = "l10n_br_nfe"
     _spec_module = "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00"
+    _binding_module = "nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00"
     _spec_tab_name = "NFe"
     _stack_skip = ("nfe40_NFref_ide_id",)
     # all m2o below this level will be stacked even if not required:

--- a/l10n_br_nfe/models/document_supplement.py
+++ b/l10n_br_nfe/models/document_supplement.py
@@ -15,4 +15,5 @@ class NFeSupplement(spec_models.StackedModel):
     _schema_version = "4.0.0"
     _odoo_module = "l10n_br_nfe"
     _spec_module = "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00"
+    _binding_module = "nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00"
     _spec_tab_name = "NFe"

--- a/l10n_br_nfe/models/res_company.py
+++ b/l10n_br_nfe/models/res_company.py
@@ -26,6 +26,8 @@ PROCESSADOR = [(PROCESSADOR_ERPBRASIL_EDOC, "erpbrasil.edoc")]
 class ResCompany(spec_models.SpecModel):
     _name = "res.company"
     _inherit = ["res.company", "nfe.40.emit"]
+    _field_prefix = "nfe40_"
+    _binding_module = "nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00"
     _nfe_search_keys = ["nfe40_CNPJ", "nfe40_xNome", "nfe40_xFant"]
 
     nfe40_CNPJ = fields.Char(related="partner_id.nfe40_CNPJ")

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -26,6 +26,8 @@ class ResPartner(spec_models.SpecModel):
         "nfe.40.transporta",
         "nfe.40.autxml",
     ]
+    _binding_module = "nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00"
+    _field_prefix = "nfe40_"
     _nfe_search_keys = ["nfe40_CNPJ", "nfe40_CPF", "nfe40_xNome"]
 
     @api.model

--- a/l10n_br_nfe/tests/test_nfce.py
+++ b/l10n_br_nfe/tests/test_nfce.py
@@ -44,7 +44,7 @@ class TestNFCe(TestNFeExport):
             }
         )
         self.document_id.company_id.certificate_nfe_id = certificate_id
-        self.document_id.company_id.nfce_csc_token = "DUMMY"
+        self.document_id.company_id.nfce_csc_token = "2"
         self.document_id.company_id.nfce_csc_code = "DUMMY"
 
         self.prepare_test_nfe(self.document_id)

--- a/spec_driven_model/hooks.py
+++ b/spec_driven_model/hooks.py
@@ -110,6 +110,8 @@ def get_remaining_spec_models(cr, registry, module_name, spec_module):
         # 2nd StackedModel classes, that we will visit
         if hasattr(base_class, "_stacked"):
             node = SpecModel._odoo_name_to_class(base_class._stacked, spec_module)
+            if not node:
+                continue
 
             env = api.Environment(cr, SUPERUSER_ID, {})
             for (

--- a/spec_driven_model/hooks.py
+++ b/spec_driven_model/hooks.py
@@ -107,11 +107,15 @@ def get_remaining_spec_models(cr, registry, module_name, spec_module):
 
     for model in module_models:
         base_class = registry[model]
+
+        if hasattr(base_class, "_find_origin_class_by_module"):
+            base_class = base_class._find_origin_class_by_module(
+                spec_module, spec_module=True
+            )
+
         # 2nd StackedModel classes, that we will visit
         if hasattr(base_class, "_stacked"):
             node = SpecModel._odoo_name_to_class(base_class._stacked, spec_module)
-            if not node:
-                continue
 
             env = api.Environment(cr, SUPERUSER_ID, {})
             for (

--- a/spec_driven_model/models/spec_export.py
+++ b/spec_driven_model/models/spec_export.py
@@ -1,6 +1,5 @@
 # Copyright 2019 KMEE
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
-import inspect
 import logging
 import sys
 from io import StringIO
@@ -15,7 +14,11 @@ class AbstractSpecMixin(models.AbstractModel):
 
     @api.model
     def _get_binding_class(self, class_obj):
-        binding_module = sys.modules[class_obj._binding_module]
+        origin_class = self._get_origin_class()
+        module_name = (
+            origin_class and origin_class._binding_module or class_obj._binding_module
+        )
+        binding_module = sys.modules[module_name]
         for attr in class_obj._binding_type.split("."):
             binding_module = getattr(binding_module, attr)
         return binding_module
@@ -203,7 +206,7 @@ class AbstractSpecMixin(models.AbstractModel):
             ).isoformat("T")
         )
 
-    def _build_generateds(self, class_name=False, origin_class=False):
+    def _build_generateds(self, class_name=False):
         """
         Iterate over an Odoo record and its m2o and o2m sub-records
         using a pre-order tree traversal and maps the Odoo record values
@@ -214,17 +217,16 @@ class AbstractSpecMixin(models.AbstractModel):
         sub binding instances already properly instanciated.
         """
         self.ensure_one()
-        if origin_class:
+
+        if not class_name:
+            origin_class = self._get_origin_class()
+            if not origin_class:
+                origin_class = self
+
             if hasattr(origin_class, "_stacked"):
                 class_name = origin_class._stacked
             else:
                 class_name = origin_class._name
-
-        if not class_name:
-            if hasattr(self, "_stacked"):
-                class_name = self._stacked
-            else:
-                class_name = self._name
 
         class_obj = self.env[class_name]
 
@@ -247,12 +249,12 @@ class AbstractSpecMixin(models.AbstractModel):
             binding_instance = binding_class(**sliced_kwargs)
             return binding_instance
 
-    def export_xml(self, origin_class, print_xml=True):
+    def export_xml(self, print_xml=True):
         self.ensure_one()
         result = []
 
-        if hasattr(origin_class, "_stacked"):
-            binding_instance = self._build_generateds(origin_class=origin_class)
+        if hasattr(self, "_stacked"):
+            binding_instance = self._build_generateds()
             if print_xml:
                 self._print_xml(binding_instance)
             result.append(binding_instance)
@@ -268,15 +270,14 @@ class AbstractSpecMixin(models.AbstractModel):
 
     def export_ds(self):
         self.ensure_one()
-        module_name = inspect.currentframe().f_back.f_locals["__class__"]._module
+        return self.export_xml(print_xml=False)
+
+    def _get_origin_class(self):
+        module_name = self._context.get("module", False)
+        if not module_name:
+            return False
 
         for klass in self.__class__.__bases__:
             module = klass.__module__.split(".")
             if module_name == module[2]:
-                origin_class = klass
-                break
-
-        if not origin_class:
-            origin_class = self
-
-        return self.export_xml(print_xml=False, origin_class=origin_class)
+                return klass

--- a/spec_driven_model/models/spec_export.py
+++ b/spec_driven_model/models/spec_export.py
@@ -279,5 +279,5 @@ class AbstractSpecMixin(models.AbstractModel):
 
         for klass in self.__class__.__bases__:
             module = klass.__module__.split(".")
-            if module_name == module[2]:
+            if len(module) > 2 and module_name == module[2]:
                 return klass

--- a/spec_driven_model/models/spec_export.py
+++ b/spec_driven_model/models/spec_export.py
@@ -14,10 +14,10 @@ class AbstractSpecMixin(models.AbstractModel):
 
     @api.model
     def _get_binding_class(self, class_obj):
+        module_name = class_obj._binding_module
         origin_class = self._get_origin_class()
-        module_name = (
-            origin_class and origin_class._binding_module or class_obj._binding_module
-        )
+        if origin_class:
+            module_name = origin_class._binding_module
         binding_module = sys.modules[module_name]
         for attr in class_obj._binding_type.split("."):
             binding_module = getattr(binding_module, attr)
@@ -277,7 +277,4 @@ class AbstractSpecMixin(models.AbstractModel):
         if not module_name:
             return False
 
-        for klass in self.__class__.__bases__:
-            module = klass.__module__.split(".")
-            if len(module) > 2 and module_name == module[2]:
-                return klass
+        return self._find_origin_class_by_module(module_name)

--- a/spec_driven_model/models/spec_models.py
+++ b/spec_driven_model/models/spec_models.py
@@ -213,6 +213,16 @@ class SpecModel(models.AbstractModel):
                 return base_class
         return None
 
+    @classmethod
+    def _find_origin_class_by_module(cls, module, spec_module=False):
+        for klass in cls.__bases__:
+            if spec_module:
+                if hasattr(klass, "_spec_module") and klass._spec_module == module:
+                    return klass
+
+            elif klass._module == module:
+                return klass
+
     def _register_hook(self):
         res = super()._register_hook()
         from .. import hooks  # importing here avoids loop


### PR DESCRIPTION
Ao implementar a MDF-e (https://github.com/OCA/l10n-brazil/pull/2603) me deparei com um problema ao instalar os módulos `l10n_br_nfe` e `l10n_br_mdfe` simultaneamente, pois ambos os módulos fazem override do modelo `l10n_br_fiscal.document` e definem os campos do spec, como _stacked e _spec_module, e nesse caso o valor desses atributos acaba sendo sobrescrito, ocorrendo problemas nos hooks e na exportação de XML.

Para solucionar esse problema, eu realizo a busca da própria classe do módulo onde foi feito o override, dessa forma conseguindo os atributos originais e não os sobrescritos pelo odoo.

@mileo @lfdivino @rvalyi 