### PR TITLE
[FIX] l10n_br_sale: Impostos errados na geração da fatura pelo pedido.

### DIFF
--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -198,8 +198,7 @@ class SaleOrderLine(models.Model):
         self.ensure_one()
         result = self._prepare_br_fiscal_dict()
         if self.product_id and self.product_id.invoice_policy == "delivery":
-            self._compute_qty_delivered()
-            result["fiscal_quantity"] = self.fiscal_qty_delivered
+            result["fiscal_quantity"] = self.qty_to_invoice
         result.update(super()._prepare_invoice_line(**optional_values))
         return result
 


### PR DESCRIPTION
A proposta desta PR é corrigir a criação da fatura quando gerada a partir do pedido de vendas, os impostos estavam sendo calculados errados quando a política de faturamento é para "**Quantidades Entregues** e o pedido já tenha uma quantidade faturada, ficando pendente para faturar somente a diferença da quantidade entregue com a quantidade faturada.

O erro estava na hora de informar a quantidade fiscal que estava sendo considerado a quantidade entregue, sem desconsiderar o que já estava faturado, consequentemente os impostos também estavam sendo calculados errados. 




