### PR TITLE
[14.0][l10n_br_nfe][l10n_br_stock_account_report][l10n_br_nfse_paulistana][l10n_br_nfse_ginfes] no import tests

### DIFF
--- a/l10n_br_nfe/__init__.py
+++ b/l10n_br_nfe/__init__.py
@@ -2,4 +2,3 @@
 
 from .hooks import post_init_hook
 from . import models
-from . import tests

--- a/l10n_br_nfse_ginfes/__init__.py
+++ b/l10n_br_nfse_ginfes/__init__.py
@@ -1,2 +1,1 @@
 from . import models
-from . import tests

--- a/l10n_br_nfse_paulistana/__init__.py
+++ b/l10n_br_nfse_paulistana/__init__.py
@@ -1,2 +1,1 @@
 from . import models
-from . import tests

--- a/l10n_br_stock_account_report/__init__.py
+++ b/l10n_br_stock_account_report/__init__.py
@@ -1,3 +1,2 @@
 from . import report
 from . import wizards
-from . import tests


### PR DESCRIPTION
Quando o odoo roda com --test-enable ele importa os tests automaticamente. Por outro lado, se forçar esse import (como era antes deste PR), tem efeitos colaterais ruins: por exemplo apenas para iniciar o modulo l10n_br_nfe vc precisa então de ter as lib xmldiff ou odoo-test-helper instaladas enquanto são usadas apenas para testes. Alem disso deixa o startup mais lento.
(Separei os commits por modulos para facilitar os cherry-picks)