### PR TITLE
[14.0][FIX] l10n_br_base: Informar os campo de Outras Inscrições Estaduais na visão da Empresa

### DIFF
--- a/l10n_br_base/models/__init__.py
+++ b/l10n_br_base/models/__init__.py
@@ -1,6 +1,3 @@
-# Copyright (C) 2015  Renato Lima - Akretion
-# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
-
 from . import format_address_mixin
 from . import res_bank
 from . import res_city

--- a/l10n_br_base/models/res_company.py
+++ b/l10n_br_base/models/res_company.py
@@ -103,7 +103,7 @@ class Company(models.Model):
     state_tax_number_ids = fields.One2many(
         string="State Tax Numbers",
         comodel_name="state.tax.numbers",
-        inverse_name="partner_id",  # FIXME
+        inverse_name="company_id",
         compute="_compute_address",
         inverse="_inverse_state_tax_number_ids",
     )

--- a/l10n_br_base/models/state_tax_numbers.py
+++ b/l10n_br_base/models/state_tax_numbers.py
@@ -16,6 +16,12 @@ class StateTaxNumbers(models.Model):
         ondelete="cascade",
     )
 
+    company_id = fields.Many2one(
+        comodel_name="res.company",
+        string="Company",
+        ondelete="cascade",
+    )
+
     inscr_est = fields.Char(string="State Tax Number", size=16, required=True)
 
     state_id = fields.Many2one(

--- a/l10n_br_base/models/state_tax_numbers.py
+++ b/l10n_br_base/models/state_tax_numbers.py
@@ -1,7 +1,8 @@
-# Copyright (C) 2009 Gabriel C. Stabel
-# Copyright (C) 2009 Renato Lima (Akretion)
-# Copyright (C) 2012 Raphaël Valyi (Akretion)
-# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+# Copyright (C) 2018-Today - Akretion (<http://www.akretion.com>).
+# @author Renato Lima - Akretion <renato.lima@akretion.com.br>
+# @author Raphael Valyi - Akretion <raphael.valyi@akretion.com>
+# @author Magno Costa - Akretion <magno.costa@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields, models
 

--- a/l10n_br_base/tests/__init__.py
+++ b/l10n_br_base/tests/__init__.py
@@ -1,9 +1,3 @@
-# @ 2016 Akretion - www.akretion.com.br -
-#   Magno Costa <magno.costa@akretion.com.br>
-#  @ 2016 KMEE - www.kmee.com.br -
-#   Luis Felipe Miléo <mileo@kmee.com.br>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-
 from . import test_amount_to_text
 from . import test_valid_createid
 from . import test_base_onchange

--- a/l10n_br_base/views/res_company_view.xml
+++ b/l10n_br_base/views/res_company_view.xml
@@ -44,7 +44,7 @@
                     attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
                 >
                     <tree editable="bottom">
-                        <field name="partner_id" invisible="1" />
+                        <field name="company_id" invisible="1" />
                         <field name="inscr_est" />
                         <field
                             name="state_id"


### PR DESCRIPTION
Inform other IEs in view company.

Corrigindo a possibilidade de informar o campo de Outras Inscrições Estaduais na visão da Empresa,  issue https://github.com/OCA/l10n-brazil/issues/2714 , parece ser desnecessário um script de migração, testei com os dados de demonstração adicionando um IE através do res.partner relacionado, para evitar o erro, e depois usando a mesma base de dados atualizei o modulo com as alterações desse PR e não tive erros, mas testes são bem vindos e recomendo o teste em um banco de dados de homologação para confirmar, segue imagens:

![image](https://github.com/OCA/l10n-brazil/assets/6341149/c4011dcc-cb0a-4fcb-8ff8-94b93f7b4526)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/0feb5cb9-26e9-492f-a3a1-56331704dc01)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/fd552f41-f07c-4b63-b72c-4833dac3abaa)

Fiz mais duas alterações nesse PR simples que não afetam código:
- Inclui eu como um dos autores da implementação dessa possibilidade de informar Outras Inscrições Estaduais e atualizei a Data da implementação baseado nesse commit https://github.com/OCA/l10n-brazil/commit/f1eda14d1d40fc307e5eeecff2cd4dcf18629cc1
- Removi o cabeçalho de Licença nos arquivos __init__ que só tem imports, algo que já é padrão e já foram integrados outros commits nesse sentido

cc @renatonlima @rvalyi @marcelsavegnago @mileo 
