### PR TITLE
[14.0][spec_driven_model][REF] cleaner db wise mixin mappings

### DIFF
--- a/spec_driven_model/models/spec_import.py
+++ b/spec_driven_model/models/spec_import.py
@@ -11,8 +11,6 @@ from typing import ForwardRef
 
 from odoo import api, models
 
-from .spec_models import SpecModel
-
 _logger = logging.getLogger(__name__)
 
 
@@ -44,8 +42,7 @@ class SpecMixinImport(models.AbstractModel):
 
         Defaults values and control options are meant to be passed in the context.
         """
-        model_name = SpecModel._get_concrete(self._name) or self._name
-        model = self.env[model_name]
+        model = self._get_concrete_model(self._name)
         attrs = model.with_context(dry_run=dry_run).build_attrs(node)
         if dry_run:
             return model.new(attrs)
@@ -124,7 +121,7 @@ class SpecMixinImport(models.AbstractModel):
                     clean_type.split(".")[-1],
                 )
 
-            comodel = self.get_concrete_model(comodel_name)
+            comodel = self._get_concrete_model(comodel_name)
             if comodel is None:  # example skip ICMS100 class
                 return
             if str(attr[1].type).startswith("typing.List"):
@@ -158,17 +155,6 @@ class SpecMixinImport(models.AbstractModel):
             vals.update(comodel_vals)
         else:
             vals[key] = comodel.match_or_create_m2o(comodel_vals, vals)
-
-    @api.model
-    def get_concrete_model(self, comodel_name):
-        "Lookup for concrete models where abstract schema mixins were injected"
-        if (
-            hasattr(models.MetaModel, "mixin_mappings")
-            and models.MetaModel.mixin_mappings.get(comodel_name) is not None
-        ):
-            return self.env[models.MetaModel.mixin_mappings[comodel_name]]
-        else:
-            return self.env.get(comodel_name)
 
     @api.model
     def _extract_related_values(self, vals, key):
@@ -229,7 +215,7 @@ class SpecMixinImport(models.AbstractModel):
         # (example: create Nfe lines product)
         for related_m2o, sub_val in related_many2ones.items():
             comodel_name = fields[related_m2o].comodel_name
-            comodel = model.get_concrete_model(comodel_name)
+            comodel = model._get_concrete_model(comodel_name)
             related_many2ones = model._verify_related_many2ones(related_many2ones)
             if hasattr(comodel, "match_or_create_m2o"):
                 vals[related_m2o] = comodel.match_or_create_m2o(sub_val, vals)

--- a/spec_driven_model/models/spec_mixin.py
+++ b/spec_driven_model/models/spec_mixin.py
@@ -1,7 +1,11 @@
 # Copyright 2019-2020 Akretion - Raphael Valyi <raphael.valyi@akretion.com>
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
 
-from odoo import models
+from collections import defaultdict
+
+from odoo import api, models
+
+SPEC_MIXIN_MAPPINGS = defaultdict(dict)  # by db
 
 
 class SpecMixin(models.AbstractModel):
@@ -30,6 +34,14 @@ class SpecMixin(models.AbstractModel):
             return True
         else:
             return super()._valid_field_parameter(field, name)
+
+    @api.model
+    def _get_concrete_model(self, model_name):
+        "Lookup for concrete models where abstract schema mixins were injected"
+        if SPEC_MIXIN_MAPPINGS[self.env.cr.dbname].get(model_name) is not None:
+            return self.env[SPEC_MIXIN_MAPPINGS[self.env.cr.dbname].get(model_name)]
+        else:
+            return self.env.get(model_name)
 
     @classmethod
     def _auto_fill_access_data(cls, env, module_name: str, access_data: list):


### PR DESCRIPTION
dicionario mais limpo (por banco de dados) de onde são mapeados os mixins geridos a partir de XSD (como os do l10n_br_nfe_spec). Inspirado por: https://github.com/OCA/web-api/blob/14.0/endpoint_route_handler/models/endpoint_route_handler.py#L9. 

@marcelsavegnago @antoniospneto vcs reportaram problemas que as vezes precisava dar um -u l10n_br_nfe na 14.0 se atualizava o modulo l10n_br_nfe_spec ou o l10n_br_account_nfe. O PR é para corrigir esse tipo de coisa. Antes a gente tinha um dicionario do mapping dos mixins xsd pros objetos concretos Odoo não tava isolado corretamente por banco de dados e eu acredito que é o que podia criar esse tipo de problema. Eu tinha me inspirado do base_rest na v12 e acompanhei as mudanças feitas pelo fastapi/web_api a partir da v14.0.  Vale a pena ver tb o porque desse keyword global https://www.programiz.com/python-programming/global-keyword