### PR TITLE
[FIX][14.0] l10n_br_nfe, l10n_br_fiscal: multiple document types

### DIFF
--- a/l10n_br_fiscal/models/__init__.py
+++ b/l10n_br_fiscal/models/__init__.py
@@ -70,3 +70,4 @@ from . import subsequent_operation
 from . import subsequent_document
 from . import document_email
 from . import city_taxation_code
+from . import document_supplement

--- a/l10n_br_fiscal/models/document_supplement.py
+++ b/l10n_br_fiscal/models/document_supplement.py
@@ -1,0 +1,13 @@
+# Copyright 2023 KMEE (Felipe Zago Rodrigues <felipe.zago@kmee.com.br>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class DocumentSupplement(models.Model):
+    _name = "l10n_br_fiscal.document.supplement"
+    _description = "Document Supplement Data"
+
+    qrcode = fields.Char(string="QR Code")
+
+    url_key = fields.Char(string="QR Code URL Key")

--- a/l10n_br_fiscal/models/document_workflow.py
+++ b/l10n_br_fiscal/models/document_workflow.py
@@ -398,3 +398,12 @@ class DocumentWorkflow(models.AbstractModel):
                     "this fical document you are not the document issuer"
                 )
             )
+
+    def _document_qrcode(self):
+        pass
+
+    def _processador(self):
+        pass
+
+    def _valida_xml(self, xml_file):
+        pass

--- a/l10n_br_fiscal/models/document_workflow.py
+++ b/l10n_br_fiscal/models/document_workflow.py
@@ -85,6 +85,7 @@ class DocumentWorkflow(models.AbstractModel):
         self._document_number()
         self._document_comment()
         self._document_check()
+        self._document_qrcode()
         self._document_export()
         return True
 

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -76,6 +76,7 @@ class NFe(spec_models.StackedModel):
     _name = "l10n_br_fiscal.document"
     _inherit = ["l10n_br_fiscal.document", "nfe.40.infnfe", "nfe.40.fat"]
     _stacked = "nfe.40.infnfe"
+    _binding_module = "nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00"
     _field_prefix = "nfe40_"
     _schema_name = "nfe"
     _schema_version = "4.0.0"
@@ -864,6 +865,14 @@ class NFe(spec_models.StackedModel):
         return edocs
 
     def _processador(self):
+        if self.document_type not in (MODELO_FISCAL_NFE, MODELO_FISCAL_NFCE):
+            return super()._processador()
+
+        certificate = False
+        if self.company_id.sudo().certificate_nfe_id:
+            certificate = self.company_id.sudo().certificate_nfe_id
+        elif self.company_id.sudo().certificate_ecnpj_id:
+            certificate = self.company_id.sudo().certificate_ecnpj_id
         self._check_nfe_environment()
         certificado = self.env.company._get_br_ecertificate()
         session = Session()
@@ -967,6 +976,10 @@ class NFe(spec_models.StackedModel):
 
     def _valida_xml(self, xml_file):
         self.ensure_one()
+
+        if self.document_type not in (MODELO_FISCAL_NFE, MODELO_FISCAL_NFCE):
+            return super()._valida_xml(xml_file)
+
         erros = Nfe.schema_validation(xml_file)
         erros = "\n".join(erros)
         self.write({"xml_error_message": erros or False})
@@ -989,7 +1002,11 @@ class NFe(spec_models.StackedModel):
         super()._exec_after_SITUACAO_EDOC_AUTORIZADA(old_state, new_state)
 
     def _generate_key(self):
-        for record in self.filtered(filter_processador_edoc_nfe):
+        records = self.filtered(filter_processador_edoc_nfe)
+        if not records:
+            return super()._generate_key()
+
+        for record in records:
             date = fields.Datetime.context_timestamp(record, record.document_date)
 
             required_fields_gen_edoc = []
@@ -1036,8 +1053,8 @@ class NFe(spec_models.StackedModel):
                     "l10n_br_fiscal.document.supplement"
                 ].create(
                     {
-                        "nfe40_qrCode": self.get_nfce_qrcode(),
-                        "nfe40_urlChave": self.get_nfce_qrcode_url(),
+                        "qrcode": self.get_nfce_qrcode(),
+                        "url_key": self.get_nfce_qrcode_url(),
                     }
                 )
 

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -868,11 +868,10 @@ class NFe(spec_models.StackedModel):
         if self.document_type not in (MODELO_FISCAL_NFE, MODELO_FISCAL_NFCE):
             return super()._processador()
 
-        certificate = False
         if self.company_id.sudo().certificate_nfe_id:
-            certificate = self.company_id.sudo().certificate_nfe_id
+            self.company_id.sudo().certificate_nfe_id
         elif self.company_id.sudo().certificate_ecnpj_id:
-            certificate = self.company_id.sudo().certificate_ecnpj_id
+            self.company_id.sudo().certificate_ecnpj_id
         self._check_nfe_environment()
         certificado = self.env.company._get_br_ecertificate()
         session = Session()

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -67,6 +67,7 @@ class NFeLine(spec_models.StackedModel):
     _name = "l10n_br_fiscal.document.line"
     _inherit = ["l10n_br_fiscal.document.line", "nfe.40.det"]
     _stacked = "nfe.40.det"
+    _binding_module = "nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00"
     _field_prefix = "nfe40_"
     _schema_name = "nfe"
     _schema_version = "4.0.0"

--- a/l10n_br_nfe/models/document_related.py
+++ b/l10n_br_nfe/models/document_related.py
@@ -21,6 +21,7 @@ class NFeRelated(spec_models.StackedModel):
     _name = "l10n_br_fiscal.document.related"
     _inherit = ["l10n_br_fiscal.document.related", "nfe.40.nfref"]
     _stacked = "nfe.40.nfref"
+    _binding_module = "nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00"
     _field_prefix = "nfe40_"
     _schema_name = "nfe"
     _schema_version = "4.0.0"

--- a/l10n_br_nfe/models/document_supplement.py
+++ b/l10n_br_nfe/models/document_supplement.py
@@ -1,18 +1,24 @@
 # Copyright 2023 KMEE (Felipe Zago Rodrigues <felipe.zago@kmee.com.br>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
+from odoo import fields
 
 from odoo.addons.spec_driven_model.models import spec_models
 
 
 class NFeSupplement(spec_models.StackedModel):
     _name = "l10n_br_fiscal.document.supplement"
+    _inherit = ["l10n_br_fiscal.document.supplement", "nfe.40.infnfesupl"]
     _description = "NFe Supplement Document"
-    _inherit = "nfe.40.infnfesupl"
     _stacked = "nfe.40.infnfesupl"
+    _binding_module = "nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00"
     _field_prefix = "nfe40_"
     _schema_name = "nfe"
     _schema_version = "4.0.0"
     _odoo_module = "l10n_br_nfe"
     _spec_module = "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00"
     _spec_tab_name = "NFe"
+
+    nfe40_qrCode = fields.Char(related="qrcode")
+
+    nfe40_urlChave = fields.Char(related="url_key")

--- a/l10n_br_nfe/models/res_company.py
+++ b/l10n_br_nfe/models/res_company.py
@@ -26,6 +26,8 @@ PROCESSADOR = [(PROCESSADOR_ERPBRASIL_EDOC, "erpbrasil.edoc")]
 class ResCompany(spec_models.SpecModel):
     _name = "res.company"
     _inherit = ["res.company", "nfe.40.emit"]
+    _binding_module = "nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00"
+    _field_prefix = "nfe40_"
     _nfe_search_keys = ["nfe40_CNPJ", "nfe40_xNome", "nfe40_xFant"]
 
     nfe40_CNPJ = fields.Char(related="partner_id.nfe40_CNPJ")

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -26,6 +26,8 @@ class ResPartner(spec_models.SpecModel):
         "nfe.40.transporta",
         "nfe.40.autxml",
     ]
+    _binding_module = "nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00"
+    _field_prefix = "nfe40_"
     _nfe_search_keys = ["nfe40_CNPJ", "nfe40_CPF", "nfe40_xNome"]
 
     @api.model

--- a/l10n_br_nfe/tests/test_nfce.py
+++ b/l10n_br_nfe/tests/test_nfce.py
@@ -44,7 +44,7 @@ class TestNFCe(TestNFeExport):
             }
         )
         self.document_id.company_id.certificate_nfe_id = certificate_id
-        self.document_id.company_id.nfce_csc_token = "DUMMY"
+        self.document_id.company_id.nfce_csc_token = "2"
         self.document_id.company_id.nfce_csc_code = "DUMMY"
 
         self.prepare_test_nfe(self.document_id)

--- a/l10n_br_nfe/tests/test_nfe_structure.py
+++ b/l10n_br_nfe/tests/test_nfe_structure.py
@@ -124,7 +124,7 @@ class NFeStructure(SavepointCase):
             "nfe40_cobr",
             "nfe40_fat",
         ]
-        keys = [k for k in self.env["l10n_br_fiscal.document"]._stacking_points.keys()]
+        keys = [k for k in NFe._stacking_points.keys() if k.startswith("nfe40_")]
         self.assertEqual(sorted(keys), sorted(doc_keys))
 
     def test_doc_tree(self):
@@ -159,9 +159,7 @@ class NFeStructure(SavepointCase):
             "nfe40_imposto",
             "nfe40_prod",
         ]
-        keys = [
-            k for k in self.env["l10n_br_fiscal.document.line"]._stacking_points.keys()
-        ]
+        keys = [k for k in NFeLine._stacking_points.keys() if k.startswith("nfe40_")]
         self.assertEqual(sorted(keys), line_keys)
 
     def test_doc_line_tree(self):


### PR DESCRIPTION
Ao implementar o MDF-e, identifiquei a necessidade de fazer algumas alterações no workflow dos documentos fiscais, para que determinadas funções não sejam sobrescrescritas no modelo, e sejam chamadas somente quando o tipo de documento for coerente.

Também fiz a correção dos testes de NFe/NFCe, que estavam quebrados.

cc. @mileo 