### PR TITLE
[14.0][REF] l10n_br_base, l10n_br_crm, l10n_br_fiscal, l10n_br_hr: Unificando as validações do IE, CNPJ e CPF

### DIFF
--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -4,10 +4,12 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 
-from erpbrasil.base.fiscal import cnpj_cpf, ie
+from erpbrasil.base.fiscal import cnpj_cpf
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+
+from ..tools import check_cnpj_cpf, check_ie
 
 
 class Partner(models.Model):
@@ -92,29 +94,12 @@ class Partner(models.Model):
 
     @api.constrains("cnpj_cpf", "country_id")
     def _check_cnpj_cpf(self):
-        result = True
         for record in self:
-            disable_cnpj_ie_validation = record.env[
-                "ir.config_parameter"
-            ].sudo().get_param(
-                "l10n_br_base.disable_cpf_cnpj_validation", default=False
-            ) or self.env.context.get(
-                "disable_cpf_cnpj_validation"
+            check_cnpj_cpf(
+                record.env,
+                record.cnpj_cpf,
+                record.country_id,
             )
-            if not disable_cnpj_ie_validation:
-                if record.country_id:
-                    country_code = record.country_id.code
-                    if country_code:
-                        if record.cnpj_cpf and country_code.upper() == "BR":
-                            if record.is_company:
-                                if not cnpj_cpf.validar(record.cnpj_cpf):
-                                    result = False
-                                    document = "CNPJ"
-                            elif not cnpj_cpf.validar(record.cnpj_cpf):
-                                result = False
-                                document = "CPF"
-                if not result:
-                    raise ValidationError(_("{} Invalid!").format(document))
 
     @api.constrains("inscr_est", "state_id")
     def _check_ie(self):
@@ -122,24 +107,9 @@ class Partner(models.Model):
         this method call others methods because this validation is State wise
 
         :Return: True or False.
-
-        :Parameters:
         """
         for record in self:
-            result = True
-
-            disable_ie_validation = record.env["ir.config_parameter"].sudo().get_param(
-                "l10n_br_base.disable_ie_validation", default=False
-            ) or self.env.context.get("disable_ie_validation")
-            if not disable_ie_validation:
-                if record.inscr_est == "ISENTO":
-                    return
-                if record.inscr_est and record.is_company and record.state_id:
-                    state_code = record.state_id.code or ""
-                    uf = state_code.lower()
-                    result = ie.validar(uf, record.inscr_est)
-                if not result:
-                    raise ValidationError(_("Estadual Inscription Invalid !"))
+            check_ie(record.env, record.inscr_est, record.state_id, record.country_id)
 
     @api.constrains("state_tax_number_ids")
     def _check_state_tax_number_ids(self):
@@ -149,11 +119,13 @@ class Partner(models.Model):
         """
         for record in self:
             for inscr_est_line in record.state_tax_number_ids:
-                state_code = inscr_est_line.state_id.code or ""
-                uf = state_code.lower()
-                valid_ie = ie.validar(uf, inscr_est_line.inscr_est)
-                if not valid_ie:
-                    raise ValidationError(_("Invalid State Tax Number!"))
+                check_ie(
+                    record.env,
+                    inscr_est_line.inscr_est,
+                    inscr_est_line.state_id,
+                    record.country_id,
+                )
+
                 if inscr_est_line.state_id.id == record.state_id.id:
                     raise ValidationError(
                         _(

--- a/l10n_br_base/models/res_partner_pix.py
+++ b/l10n_br_base/models/res_partner_pix.py
@@ -4,10 +4,11 @@
 
 import phonenumbers
 from email_validator import EmailSyntaxError, validate_email
-from erpbrasil.base.fiscal import cnpj_cpf
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+
+from ..tools import check_cnpj_cpf
 
 
 class PartnerPix(models.Model):
@@ -54,6 +55,7 @@ class PartnerPix(models.Model):
         domain="[('partner_id', '=', partner_id)]",
     )
 
+    @api.model
     def _normalize_email(self, email):
         try:
             result = validate_email(
@@ -72,6 +74,7 @@ class PartnerPix(models.Model):
             ) from None
         return normalized_email
 
+    @api.model
     def _normalize_phone(self, phone):
         try:
             phonenumber = phonenumbers.parse(phone, "BR")
@@ -90,20 +93,15 @@ class PartnerPix(models.Model):
         )
         return phone
 
-    def _normalize_cnpj_cpf(self, doc_number):
+    @api.model
+    def _normalize_cnpj_cpf(self, doc_number, partner_id):
         doc_number = "".join(char for char in doc_number if char.isdigit())
-        if not 11 <= len(doc_number) <= 14:
-            raise ValidationError(
-                _(
-                    f"Invalid Document Number {doc_number}: "
-                    f"\nThe CPF must have 11 digits and the CNPJ 14 digits."
-                )
-            )
-        is_valid = cnpj_cpf.validar(doc_number)
-        if not is_valid:
-            raise ValidationError(_(f"Invalid Document Number: {doc_number}"))
+        partner = self.env["res.partner"].browse(partner_id)
+        check_cnpj_cpf(self.env, doc_number, partner.country_id)
+
         return doc_number
 
+    @api.model
     def _normalize_evp(self, key):
         # EVP: Endereço Virtual de Pagamento (chave aleatória)
         # ex: 123e4567-e12b-12d1-a456-426655440000
@@ -139,6 +137,7 @@ class PartnerPix(models.Model):
         self.check_vals(vals)
         return super().write(vals)
 
+    @api.model
     def check_vals(self, vals):
         key_type = vals.get("key_type") or self.key_type
         key = vals.get("key") or self.key
@@ -149,7 +148,8 @@ class PartnerPix(models.Model):
         elif key_type == "phone":
             key = self._normalize_phone(key)
         elif key_type == "cnpj_cpf":
-            key = self._normalize_cnpj_cpf(key)
+            partner_id = vals.get("partner_id") or self.partner_id.id
+            key = self._normalize_cnpj_cpf(key, partner_id)
         elif key_type == "evp":
             key = self._normalize_evp(key)
         vals["key"] = key

--- a/l10n_br_base/tools.py
+++ b/l10n_br_base/tools.py
@@ -1,0 +1,74 @@
+# Copyright (C) 2009-Today - Akretion (<http://www.akretion.com>).
+# @author Gabriel C. Stabel - Akretion
+# @author Renato Lima <renato.lima@akretion.com.br>
+# @author Raphael Valyi <raphael.valyi@akretion.com>
+# @author Magno Costa <magno.costa@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from erpbrasil.base.fiscal import cnpj_cpf, ie
+
+from odoo import _
+from odoo.exceptions import ValidationError
+
+
+def check_ie(env, inscr_est, state, country):
+    """
+    Checks if 'Inscrição Estadual' field is valid
+    using erpbrasil library
+    :param env:
+    :param inscr_est:
+    :param state:
+    :param country:
+    :return:
+    """
+    if env and inscr_est and state and country:
+        if country == env.ref("base.br"):
+            disable_ie_validation = env["ir.config_parameter"].sudo().get_param(
+                "l10n_br_base.disable_ie_validation", default=False
+            ) or env.context.get("disable_ie_validation")
+
+            if not disable_ie_validation:
+                # TODO: em aberto debate sobre:
+                #  Se no caso da empresa ser 'isenta' do IE o campo
+                #  deve estar vazio ou pode ter algum valor como abaixo
+                if inscr_est not in ("isento", "isenta", "ISENTO", "ISENTA"):
+
+                    if not ie.validar(state.code.lower(), inscr_est):
+                        raise ValidationError(
+                            _("Estadual Inscription {} Invalid for State {}!").format(
+                                inscr_est, state.name
+                            )
+                        )
+
+
+def check_cnpj_cpf(env, cnpj_cpf_value, country):
+    """
+    Check CNPJ or CPF is valid using erpbrasil library
+    :param env:
+    :param cnpj_cpf_value:
+    :param country:
+    :return:
+    """
+    if env and cnpj_cpf_value and country:
+        if country == env.ref("base.br"):
+            disable_cpf_cnpj_validation = env["ir.config_parameter"].sudo().get_param(
+                "l10n_br_base.disable_cpf_cnpj_validation", default=False
+            ) or env.context.get("disable_cpf_cnpj_validation")
+
+            if not disable_cpf_cnpj_validation:
+                if not cnpj_cpf.validar(cnpj_cpf_value):
+                    # Removendo . / - para diferenciar o CNPJ do CPF
+                    # 62.228.384/0001-51 -CNPJ
+                    # 62228384000151 - CNPJ
+                    # 765.865.078-12 - CPF
+                    # 76586507812 - CPF
+                    document = "CPF"
+                    if (
+                        len("".join(char for char in cnpj_cpf_value if char.isdigit()))
+                        == 14
+                    ):
+                        document = "CNPJ"
+
+                    raise ValidationError(
+                        _("{} {} Invalid!").format(document, cnpj_cpf_value)
+                    )

--- a/l10n_br_hr/models/hr_employee.py
+++ b/l10n_br_hr/models/hr_employee.py
@@ -8,6 +8,8 @@ from erpbrasil.base.fiscal import cnpj_cpf, pis
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 
+from odoo.addons.l10n_br_base.tools import check_cnpj_cpf
+
 
 class HrEmployee(models.Model):
     _inherit = "hr.employee"
@@ -233,8 +235,7 @@ class HrEmployee(models.Model):
     @api.constrains("cpf")
     def _check_cpf(self):
         for record in self:
-            if record.cpf and not cnpj_cpf.validar(record.cpf):
-                raise ValidationError(_("CPF Invalido!"))
+            check_cnpj_cpf(record.env, record.cpf, record.country_id)
 
     @api.onchange("cpf")
     def onchange_cpf(self):


### PR DESCRIPTION
Unified IE, CNPJ and CPF validations.

Unificando a validação da Inscrição Estadual, CNPJ e CPF.  Apesar de ter mais de um modulo no mesmo PR a alteração é simples, criei um novo arquivo tools.py no l10n_br_base com os métodos de validação e passei a chamar esses métodos nos arquivos onde são feitas essas validações, dessa forma a validação fica padronizada, evitando diferenças entre os métodos, e diminuindo código duplicado, outras alterações simples foram feitas:

- l10n_br_base coloquei a importação de bibliotecas externas dentro do TRY e no res_partner_pix removi os parâmetros ao chamar o SUPER
- l10n_br_crm removi um "return result" por ser desnecessário
- l10n_br_fiscal e l10n_br_hr coloquei a importação de bibliotecas externas dentro do TRY

No cabeçalho de licença do novo arquivo tools.py eu copiei e adaptei o do arquivo res_partner.py https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_base/models/res_partner.py#L1 por parecer ser o original e me inclui como autor devido as alterações necessárias para esse PR, mas se acharem que isso não estar certo ou houverem outros autores a serem incluídos por favor vejam de informar que eu atualizo o PR.

cc @renatonlima @rvalyi @marcelsavegnago @mileo 