### PR TITLE
[14.0][l10n_br_account][FIX] uom_id -> product_uom_id in AML, uom_id in fiscal line

### DIFF
--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -19,7 +19,6 @@ from .account_move import InheritsCheckMuteLogger
 SHADOWED_FIELDS = [
     "name",
     "product_id",
-    "uom_id",
     "quantity",
     "price_unit",
 ]
@@ -172,10 +171,12 @@ class AccountMoveLine(models.Model):
                     values.get("product_id"),
                     values.get("price_unit"),
                     values.get("quantity"),
-                    values.get("uom_id"),
+                    values.get("product_uom_id"),
                     values.get("uot_id"),
                 )
             )
+            if values.get("product_uom_id"):
+                values["uom_id"] = values["product_uom_id"]
             values["document_id"] = fiscal_doc_id  # pass through the _inherits system
 
             if (
@@ -232,6 +233,8 @@ class AccountMoveLine(models.Model):
         return results
 
     def write(self, values):
+        if values.get("product_uom_id"):
+            values["uom_id"] = values["product_uom_id"]
         non_dummy = self.filtered(lambda line: line.fiscal_document_line_id)
         self._inject_shadowed_fields([values])
         if values.get("move_id") and len(non_dummy) == len(self):

--- a/l10n_br_account/models/fiscal_document_line.py
+++ b/l10n_br_account/models/fiscal_document_line.py
@@ -27,11 +27,6 @@ class FiscalDocumentLine(models.Model):
         related="product_id",
         readonly=False,
     )
-    fiscal_uom_id = fields.Many2one(
-        string="Fiscal UOM",
-        related="uom_id",
-        readonly=False,
-    )
     fiscal_quantity = fields.Float(
         string="Fiscal Quantity",
         related="quantity",

--- a/l10n_br_account/views/account_invoice_view.xml
+++ b/l10n_br_account/views/account_invoice_view.xml
@@ -161,7 +161,7 @@
                 <field name="nbs_id" optional="hide" />
                 <field name="nbm_id" optional="hide" />
                 <field name="cest_id" optional="hide" />
-                <field name="uom_id" optional="hide" />
+                <field name="product_uom_id" optional="hide" />
                 <field name="fiscal_genre_id" optional="hide" />
                 <field
                     name="fiscal_tax_ids"

--- a/l10n_br_account/views/fiscal_invoice_view.xml
+++ b/l10n_br_account/views/fiscal_invoice_view.xml
@@ -87,7 +87,7 @@
                 >
                 <tree>
                   <field name="product_id" />
-                  <field name="uom_id" />
+                  <field name="product_uom_id" />
                   <field name="price_unit" />
                   <field name="quantity" />
                   <field name="amount_total" />

--- a/l10n_br_account_nfe/tests/test_nfe_generate_tags_cobr_dup_pag.py
+++ b/l10n_br_account_nfe/tests/test_nfe_generate_tags_cobr_dup_pag.py
@@ -114,7 +114,7 @@ class TestGeneratePaymentInfo(SavepointCase):
             {
                 "account_id": cls.invoice_line_account_id.id,
                 "quantity": 1,
-                "uom_id": cls.env.ref("uom.product_uom_unit").id,
+                "product_uom_id": cls.env.ref("uom.product_uom_unit").id,
                 "price_unit": 450.0,
                 "name": "Product - Invoice Line Test",
                 "fiscal_operation_line_id": cls.env.ref(

--- a/l10n_br_sale_stock/tests/test_sale_stock.py
+++ b/l10n_br_sale_stock/tests/test_sale_stock.py
@@ -198,6 +198,7 @@ class TestSaleStock(SavepointCase):
             # Usado para validar a transferencia dos campos da linha
             # do Pedido de Venda para a linha da Fatura/Invoice
             sale_order_line = move.sale_line_id
+            self.assertEqual(sale_order_line.product_uom, move.product_uom)
 
         picking.button_validate()
         self.assertEqual(picking.state, "done")
@@ -256,6 +257,11 @@ class TestSaleStock(SavepointCase):
             "display_name",
             "state",
             "create_date",
+            # O campo da Unidade de Medida possui um nome diferente na
+            # account.move.line product_uom_id, por isso é removido porém
+            # a copia entre os objetos é testada tanto no stock.move acima
+            # quanto na account.move.line abaixo
+            "uom_id",
         ]
 
         common_fields = list(set(acl_fields) & set(sol_fields) - set(skipped_fields))
@@ -268,6 +274,10 @@ class TestSaleStock(SavepointCase):
                 "Field %s failed to transfer from "
                 "sale.order.line to account.move.line" % field,
             )
+
+        for inv_line in invoice_lines:
+            if inv_line.product_id == sale_order_line.product_id:
+                self.assertEqual(sale_order_line.product_uom, inv_line.product_uom_id)
 
         # Teste de Retorno
         return_wizard_form = Form(


### PR DESCRIPTION
Na versão 12.0, no objeto `account.invoice.line`, a unidade de medida era `uom_id` enquanto no `account.move.line` era `product_uom_id`.

So que na migração para a versão 14.0, a gente não se ligou que agora o campo que lidamos é o `product_uom_id` do `account.move.line`  que é diferente do campo `uom_id` que temos nas linhas de documentos fiscais. O PR é para resolver isso.