### PR TITLE
[14.0][l10n_br_cnpj_search][FIX] Test phone value has space.

### DIFF
--- a/l10n_br_cnpj_search/tests/test_receitaws.py
+++ b/l10n_br_cnpj_search/tests/test_receitaws.py
@@ -52,6 +52,6 @@ class TestReceitaWS(TestCnpjCommon):
         time.sleep(2)  # Pause
         isla.search_cnpj()
 
-        self.assertEqual(isla.name, "Isla Sementes Ltda.")
-        self.assertEqual(isla.phone, "(51) 9852-9561")
-        self.assertEqual(isla.mobile, "(51) 2136-6600")
+        self.assertEqual(isla.name.strip(), "Isla Sementes Ltda.")
+        self.assertEqual(isla.phone.strip(), "(51) 9852-9561")
+        self.assertEqual(isla.mobile.strip(), "(51) 2136-6600")


### PR DESCRIPTION
Apareceu um erro nos testes do l10n_br_cnpj_search que esta blocando todos os PRs:
![2023-10-09_09-05](https://github.com/OCA/l10n-brazil/assets/16926/acb8abf2-7664-49f8-b353-1f6766306ddd)

O @mbcosta resolveu isso a semana passada aqui https://github.com/OCA/l10n-brazil/pull/2730

Mas para destravar todos os PRs eu fiz o cherry-pick do fix apenas aqui e sugiro de resolver isso primeiro.
Na vdd eu alterei o fix do Magno, botando uns strip() que eu acho que ficara mais robusto caso eles brincam de mudar os espaços de novo.