### PR TITLE
[14.0][spec_driven_model][l10n_br_nfe] fix readonly related import

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -369,7 +369,6 @@ class NFe(spec_models.StackedModel):
     nfe40_emit = fields.Many2one(
         comodel_name="res.company",
         compute="_compute_emit_data",
-        readonly=True,
         string="Emit",
     )
 
@@ -427,7 +426,6 @@ class NFe(spec_models.StackedModel):
     nfe40_entrega = fields.Many2one(
         comodel_name="res.partner",
         compute="_compute_entrega_data",
-        readonly=True,
         string="Entrega",
     )
 
@@ -457,7 +455,6 @@ class NFe(spec_models.StackedModel):
     # NF-e tag: det
     ##########################
 
-    # TODO should be done by framework?
     nfe40_det = fields.One2many(
         comodel_name="l10n_br_fiscal.document.line",
         inverse_name="document_id",

--- a/l10n_br_nfe/models/res_company.py
+++ b/l10n_br_nfe/models/res_company.py
@@ -39,6 +39,7 @@ class ResCompany(spec_models.SpecModel):
     nfe40_enderEmit = fields.Many2one(
         comodel_name="res.partner",
         related="partner_id",
+        readonly=False,
     )
 
     nfe40_choice6 = fields.Selection(

--- a/spec_driven_model/models/spec_import.py
+++ b/spec_driven_model/models/spec_import.py
@@ -1,11 +1,13 @@
 # Copyright 2019-2020 Akretion - Raphael Valyi <raphael.valyi@akretion.com>
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
 
+import dataclasses
 import inspect
 import logging
 import re
 from datetime import datetime
 from enum import Enum
+from typing import ForwardRef
 
 from odoo import api, models
 
@@ -76,13 +78,15 @@ class AbstractSpecMixin(models.AbstractModel):
             attr[1].metadata.get("name", attr[0]),
         )
         child_path = "%s.%s" % (path, key)
-        if (
-            (
-                attr[1].type == str
-                or not any(["odoo.addons." in str(i) for i in attr[1].type.__args__])
-            )
-            and not str(attr[1].type).startswith("typing.List")
-            and "ForwardRef" not in str(attr[1].type)
+
+        # Is attr a xsd SimpleType or a ComplexType?
+        # with xsdata a ComplexType can have a type like:
+        # typing.Union[nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00.TinfRespTec, NoneType]
+        # or typing.Union[ForwardRef('Tnfe.InfNfe.Det.Imposto'), NoneType]
+        # that's why we test if the 1st Union type is a dataclass or a ForwardRef
+        if attr[1].type == str or (
+            not isinstance(attr[1].type.__args__[0], ForwardRef)
+            and not dataclasses.is_dataclass(attr[1].type.__args__[0])
         ):
             # SimpleType
             if isinstance(value, Enum):

--- a/spec_driven_model/models/spec_import.py
+++ b/spec_driven_model/models/spec_import.py
@@ -107,13 +107,14 @@ class AbstractSpecMixin(models.AbstractModel):
 
             # ComplexType
             if fields.get(key) and fields[key].related:
+                if fields[key].readonly and fields[key].type == "many2one":
+                    return False  # ex: don't import NFe infRespTec
                 # example: company.nfe40_enderEmit related on partner_id
                 # then we need to set partner_id, not nfe40_enderEmit
                 key = fields[key].related[-1]  # -1 works with _inherits
                 comodel_name = fields[key].comodel_name
             else:
-                # clean_type = attr.get_child_attrs()["type"].replace("Type", "").lower()
-                clean_type = binding_type.lower()  # TODO double check
+                clean_type = binding_type.lower()
                 comodel_name = "%s.%s.%s" % (
                     self._schema_name,
                     self._schema_version.replace(".", "")[0:2],

--- a/spec_driven_model/tests/spec_purchase.py
+++ b/spec_driven_model/tests/spec_purchase.py
@@ -48,8 +48,8 @@ class PurchaseOrder(spec_models.StackedModel):
 
     poxsd10_orderDate = fields.Date(compute="_compute_date")
     poxsd10_confirmDate = fields.Date(related="date_approve")
-    poxsd10_shipTo = fields.Many2one(related="dest_address_id")
-    poxsd10_billTo = fields.Many2one(related="partner_id")
+    poxsd10_shipTo = fields.Many2one(related="dest_address_id", readonly=False)
+    poxsd10_billTo = fields.Many2one(related="partner_id", readonly=False)
     poxsd10_item = fields.One2many(related="order_line", relation_field="order_id")
 
     def _compute_date(self):


### PR DESCRIPTION
O objetivo deste PR é de lidar corretamente com a importação dos campos mapeados Many2one com related. Importante dizer que por padrão desde Odoo v13 ou Odoo v14+, esses related vem tb com o attributo readonly=True (era o contrario na v12). Eh algo que eu tinha comentado em algumas ocasioẽs quando a KMEE propois de mudar alguns campos related para compute mas que eu acho menos DRY e menos declarativo como aqui recentemente https://github.com/OCA/l10n-brazil/pull/2552/files#diff-c00a5f12ea34fc891d5146e4412cded665e4c204e69343d6e5425e0eb0b4bb98R608
Em especial quando se considera os outros esquemas que vamos mapear ainda como MDF-e ou CT-e...

Nisso a ideia é que o framework de importação do spec_driven_model não tente importar tais campos Many2one com related e readonly=True  (o padrão) e que ele importe apenas os campos com readonly=False, **exactamente como se fosse uma edição pela interface web**.

Finalmente eu ajustei alguns attributos readonly dentros dos poucos campos Many2one com related to modulo l10n_br_nfe para que funcione bem. Em especial, o campo nfe40_det nao deve ser readonly para que as linhas de NFe sejam importadas mas o campo nfe40_infRespTec precisa sim ser readonly=True (o padrão) para que o responsavel tecnico de uma NFe de fornecedor não seja importado (se vc adicionar o infRespTec no XML da nota com o teste de importação pode verificar que o infRespTec não vai ser importado; vamos ter isso na proxima versão da nfelib).

cc @mileo @hirokibastos @ygcarvalh @felipezago @marcelsavegnago @renatonlima @antoniospneto 