### PR TITLE
[14.0][FIX] l10n_br_nfse: change how the iss_retido field value is set

### DIFF
--- a/l10n_br_nfse/models/document.py
+++ b/l10n_br_nfse/models/document.py
@@ -200,7 +200,7 @@ class Document(models.Model):
             "valor_ir_retido": valor_ir_retido,
             "valor_csll": valor_csll,
             "valor_csll_retido": valor_csll_retido,
-            "iss_retido": "1" if self.fiscal_line_ids[0].issqn_wh_value else "2",
+            "iss_retido": "1" if self.fiscal_line_ids[0].issqn_wh_percent else "2",
             "valor_iss": valor_iss,
             "valor_iss_retido": valor_iss_retido,
             "outras_retencoes": outras_retencoes,

--- a/l10n_br_nfse/models/document_line.py
+++ b/l10n_br_nfse/models/document_line.py
@@ -83,7 +83,7 @@ class DocumentLine(models.Model):
             "valor_ir_retido": round(self.irpj_wh_value, 2),
             "valor_csll": round(self.csll_value, 2) or round(self.csll_wh_value, 2),
             "valor_csll_retido": round(self.csll_wh_value, 2),
-            "iss_retido": "1" if self.issqn_wh_value else "2",
+            "iss_retido": "1" if self.issqn_wh_percent else "2",
             "valor_iss": round(self.issqn_value, 2),
             "valor_iss_retido": round(self.issqn_wh_value, 2),
             "outras_retencoes": round(self.other_retentions_value, 2),


### PR DESCRIPTION
O objetivo é garantir a definição do campo mesmo que o valor do iss da linha da fatura tenha sido calculado com ZERO.

No caso, uma linha de produto da fatura com o valor de 0,16 e que o iss seria 0,0032 