### PR TITLE
[14.0][REF] l10n_br_sale: Adaptando o modulo para manter a compatibilidade com os casos internacionais

### DIFF
--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -26,6 +26,8 @@ class SaleOrder(models.Model):
         domain = [("state", "=", "approved")]
         return domain
 
+    company_country_id = fields.Many2one(related="company_id.country_id")
+
     fiscal_operation_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.operation",
         readonly=True,
@@ -136,7 +138,11 @@ class SaleOrder(models.Model):
         return result
 
     def _get_invoiceable_lines(self, final=False):
+
         lines = super()._get_invoiceable_lines(final=final)
+        if not self.fiscal_operation_id:
+            # O caso Brasil se caracteriza por ter a Operação Fiscal
+            return lines
         document_type_id = self._context.get("document_type_id")
 
         return [
@@ -147,6 +153,8 @@ class SaleOrder(models.Model):
         ]
 
     def _create_invoices(self, grouped=False, final=False, date=None):
+        if not self.fiscal_operation_id:
+            return super()._create_invoices(grouped=grouped, final=final, date=date)
         document_types = {
             line.fiscal_operation_line_id.get_document_type(line.company_id)
             for sale in self
@@ -172,27 +180,28 @@ class SaleOrder(models.Model):
     def _prepare_invoice(self):
         self.ensure_one()
         result = super()._prepare_invoice()
-        result.update(self._prepare_br_fiscal_dict())
+        # O caso Brasil se caracteriza por ter a Operação Fiscal
+        if self.fiscal_operation_id:
+            result.update(self._prepare_br_fiscal_dict())
 
-        document_type_id = self._context.get("document_type_id")
+            document_type_id = self._context.get("document_type_id")
 
-        if document_type_id:
+            if not document_type_id:
+                # Quando ocorre esse caso? Os Testes não estão passando aqui
+                document_type_id = self.company_id.document_type_id.id
+
             document_type = self.env["l10n_br_fiscal.document.type"].browse(
                 document_type_id
             )
-        else:
-            document_type = self.company_id.document_type_id
-            document_type_id = self.company_id.document_type_id.id
 
-        if document_type:
-            result["document_type_id"] = document_type_id
-            document_serie = document_type.get_document_serie(
-                self.company_id, self.fiscal_operation_id
-            )
-            if document_serie:
-                result["document_serie_id"] = document_serie.id
+            if document_type:
+                result["document_type_id"] = document_type_id
+                document_serie = document_type.get_document_serie(
+                    self.company_id, self.fiscal_operation_id
+                )
+                if document_serie:
+                    result["document_serie_id"] = document_serie.id
 
-        if self.fiscal_operation_id:
             if self.fiscal_operation_id.journal_id:
                 result["journal_id"] = self.fiscal_operation_id.journal_id.id
 

--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -9,8 +9,6 @@ class SaleOrderLine(models.Model):
     _name = "sale.order.line"
     _inherit = [_name, "l10n_br_fiscal.document.line.mixin"]
 
-    country_id = fields.Many2one(related="company_id.country_id", store=True)
-
     @api.model
     def _default_fiscal_operation(self):
         return self.env.company.sale_fiscal_operation_id
@@ -117,7 +115,13 @@ class SaleOrderLine(models.Model):
     user_total_discount = fields.Boolean(compute="_compute_user_total_discount")
     user_discount_value = fields.Boolean(compute="_compute_user_discount_value")
 
-    # Depends of price_unit because we need an field to force compute in new records
+    cnae_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.cnae",
+        string="CNAE Code",
+        domain=lambda self: self._cnae_domain(),
+    )
+
+    # Depends on price_unit because we need a field to force compute in new records
     # not created yet. This field is necessary to compute readonly condition for
     # discount/discount value.
     @api.depends("price_unit")
@@ -128,7 +132,7 @@ class SaleOrderLine(models.Model):
             else:
                 rec.user_total_discount = False
 
-    # Depends of price_unit because we need an field to force compute in new records
+    # Depends on price_unit because we need a field to force compute in new records
     # not created yet. This field is necessary to compute readonly condition for
     # discount/discount value.
     @api.depends("price_unit")
@@ -148,12 +152,6 @@ class SaleOrderLine(models.Model):
             cnae_secondary_ids = company.cnae_secondary_ids.ids
             domain = ["|", ("id", "in", cnae_secondary_ids), ("id", "=", cnae_main_id)]
         return domain
-
-    cnae_id = fields.Many2one(
-        comodel_name="l10n_br_fiscal.cnae",
-        string="CNAE Code",
-        domain=lambda self: self._cnae_domain(),
-    )
 
     def _get_protected_fields(self):
         protected_fields = super()._get_protected_fields()
@@ -196,9 +194,12 @@ class SaleOrderLine(models.Model):
 
     def _prepare_invoice_line(self, **optional_values):
         self.ensure_one()
-        result = self._prepare_br_fiscal_dict()
-        if self.product_id and self.product_id.invoice_policy == "delivery":
-            result["fiscal_quantity"] = self.qty_to_invoice
+        result = {}
+        if self.fiscal_operation_id:
+            # O caso Brasil se caracteriza por ter a Operação Fiscal
+            result = self._prepare_br_fiscal_dict()
+            if self.product_id and self.product_id.invoice_policy == "delivery":
+                result["fiscal_quantity"] = self.qty_to_invoice
         result.update(super()._prepare_invoice_line(**optional_values))
         return result
 

--- a/l10n_br_sale/tests/test_l10n_br_sale.py
+++ b/l10n_br_sale/tests/test_l10n_br_sale.py
@@ -611,3 +611,19 @@ class L10nBrSaleBaseTest(SavepointCase):
                     11.43,
                     "Unexpected value for the field Other Values in Sale line.",
                 )
+
+    def test_compatible_with_international_case(self):
+        """Test of compatible with international case, create Invoice but not for Brazil."""
+        so_international = self.env.ref("sale.sale_order_2")
+        self._run_sale_order_onchanges(so_international)
+        for line in so_international.order_line:
+            line.product_id.invoice_policy = "order"
+            self._run_sale_line_onchanges(line)
+        so_international.action_confirm()
+        so_international._create_invoices(final=True)
+        for invoice in so_international.invoice_ids:
+            # Caso Internacional não deve ter Documento Fiscal associado
+            self.assertFalse(
+                invoice.fiscal_document_id,
+                "International case should not has Fiscal Document.",
+            )

--- a/l10n_br_sale/views/sale_view.xml
+++ b/l10n_br_sale/views/sale_view.xml
@@ -25,6 +25,7 @@
                     name="amount_price_gross"
                     widget='monetary'
                     options="{'currency_field': 'currency_id'}"
+                    attrs="{'invisible': [('fiscal_operation_id', '=', False)]}"
                 />
                 <field
                     name="amount_discount_value"
@@ -42,19 +43,19 @@
                     name="amount_freight_value"
                     widget='monetary'
                     options="{'currency_field': 'currency_id'}"
-                    attrs="{'readonly': [('delivery_costs', '=', 'line'),('force_compute_delivery_costs_by_total', '=', False)]}"
+                    attrs="{'readonly': [('delivery_costs', '=', 'line'),('force_compute_delivery_costs_by_total', '=', False)], 'invisible': [('fiscal_operation_id', '=', False)]}"
                 />
                 <field
                     name="amount_insurance_value"
                     widget='monetary'
                     options="{'currency_field': 'currency_id'}"
-                    attrs="{'readonly': [('delivery_costs', '=', 'line'),('force_compute_delivery_costs_by_total', '=', False)]}"
+                    attrs="{'readonly': [('delivery_costs', '=', 'line'),('force_compute_delivery_costs_by_total', '=', False)], 'invisible': [('fiscal_operation_id', '=', False)]}"
                 />
                 <field
                     name="amount_other_value"
                     widget='monetary'
                     options="{'currency_field': 'currency_id'}"
-                    attrs="{'readonly': [('delivery_costs', '=', 'line'),('force_compute_delivery_costs_by_total', '=', False)]}"
+                    attrs="{'readonly': [('delivery_costs', '=', 'line'),('force_compute_delivery_costs_by_total', '=', False)], 'invisible': [('fiscal_operation_id', '=', False)]}"
                 />
             </field>
             <field name="amount_total" position="after">
@@ -62,15 +63,31 @@
                     name="amount_financial_total"
                     widget='monetary'
                     options="{'currency_field': 'currency_id'}"
+                    attrs="{'invisible': [('fiscal_operation_id', '=', False)]}"
                 />
             </field>
             <field name="validity_date" position="after">
-                <field name="fiscal_operation_id" required="True" />
-                <field name="ind_final" required="True" />
-                <field name="ind_pres" required="True" />
+                <field name="company_country_id" invisible="True" />
+                <field
+                    name="fiscal_operation_id"
+                    attrs="{'invisible': [('company_country_id', '!=', %(base.br)d)]}"
+                />
+                <field
+                    name="ind_final"
+                    attrs="{'invisible': [('fiscal_operation_id', '=', False)], 'required': [('fiscal_operation_id', '!=', False)]}"
+                />
+                <field
+                    name="ind_pres"
+                    attrs="{'invisible': [('fiscal_operation_id', '=', False)], 'required': [('fiscal_operation_id', '!=', False)]}"
+                />
             </field>
-            <field name="note" position="replace">
-                <group>
+            <field name="note" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'invisible': [('fiscal_operation_id', '!=', False)]}</attribute>
+            </field>
+            <field name="note" position="after">
+                <group attrs="{'invisible': [('fiscal_operation_id', '=', False)]}">
                     <field name="copy_note" />
                     <field
                         name="note"
@@ -97,8 +114,12 @@
             </xpath>
             <xpath
                 expr="//field[@name='order_line']/tree/field[@name='analytic_tag_ids']"
-                position="replace"
-            />
+                position="attributes"
+            >
+                <attribute
+                    name="attrs"
+                >{'column_invisible': [('parent.fiscal_operation_id', '!=', False)]}</attribute>
+            </xpath>
             <xpath
                 expr="//field[@name='order_line']//form//field[@name='product_id']"
                 position="attributes"
@@ -109,12 +130,20 @@
             </xpath>
             <xpath
                 expr="//field[@name='order_line']/tree/field[@name='discount']"
-                position="replace"
-            />
+                position="attributes"
+            >
+                <attribute
+                    name="attrs"
+                >{'column_invisible': [('parent.fiscal_operation_id', '!=', False)]}</attribute>
+            </xpath>
             <xpath
                 expr="//field[@name='order_line']/tree/field[@name='tax_id']"
-                position="replace"
-            />
+                position="attributes"
+            >
+                <attribute
+                    name="attrs"
+                >{'column_invisible': [('parent.fiscal_operation_id', '!=', False)]}</attribute>
+            </xpath>
             <xpath
                 expr="//field[@name='order_line']/tree/field[@name='price_unit']"
                 position="after"
@@ -122,22 +151,28 @@
                 <field
                     name="discount"
                     groups="!l10n_br_sale.group_discount_per_value"
+                    attrs="{'column_invisible': [('parent.fiscal_operation_id', '=', False)]}"
                 />
                 <field
                     name="discount_value"
                     groups="l10n_br_sale.group_discount_per_value"
+                    attrs="{'column_invisible': [('parent.fiscal_operation_id', '=', False)]}"
                 />
                 <field
                     name="fiscal_tax_ids"
                     widget="many2many_tags"
                     options="{'no_create': True}"
+                    attrs="{'column_invisible': [('parent.fiscal_operation_id', '=', False)]}"
                 />
             </xpath>
             <xpath
                 expr="//field[@name='order_line']/tree/field[@name='price_subtotal']"
                 position="after"
             >
-                <field name="price_total" invisible="1" />
+                <field
+                    name="price_total"
+                    attrs="{'column_invisible': [('parent.fiscal_operation_id', '!=', False)]}"
+                />
             </xpath>
             <xpath expr="//field[@name='order_line']/form" position="inside">
                 <group name="fiscal_fields" invisible="1">
@@ -154,44 +189,52 @@
                 <field
                     name="fiscal_operation_id"
                     options="{'no_create': True}"
-                    attrs="{'readonly': [('state', 'in', ('sale', 'done', 'cancel'))], 'required': [('display_type', '=', False)], 'invisible': [('country_id', '!=', %(base.br)d)]}"
+                    attrs="{'readonly': [('state', 'in', ('sale', 'done', 'cancel'))], 'required': [('parent.fiscal_operation_id', '!=', False)], 'invisible': [('parent.fiscal_operation_id', '=', False)]}"
                 />
                 <field
                     name="fiscal_operation_line_id"
                     options="{'no_create': True}"
-                    attrs="{'readonly': [('state', 'in', ('sale', 'done', 'cancel'))], 'required': [('display_type', '=', False)], 'invisible': [('country_id', '!=', %(base.br)d)]}"
+                    attrs="{'readonly': [('state', 'in', ('sale', 'done', 'cancel'))], 'required': [('parent.fiscal_operation_id', '!=', False)], 'invisible': [('parent.fiscal_operation_id', '=', False)]}"
                 />
                 <field
                     name="cfop_id"
                     options="{'no_create': True}"
-                    attrs="{'invisible': ['|', ('tax_icms_or_issqn', '=', 'issqn'), ('country_id', '!=', %(base.br)d)]}"
+                    attrs="{'invisible': ['|', ('tax_icms_or_issqn', '=', 'issqn'), ('parent.fiscal_operation_id', '=', False)]}"
                 />
                 <field name="price_total" invisible="1" />
                 <field name="price_subtotal" invisible="1" />
                 <field
                     name="service_type_id"
                     options="{'no_create': True}"
-                    attrs="{'invisible': ['|', ('tax_icms_or_issqn', '=', 'icms'), ('country_id', '!=', %(base.br)d)]}"
+                    attrs="{'invisible': ['|', ('tax_icms_or_issqn', '=', 'icms'), ('parent.fiscal_operation_id', '=', False)]}"
                 />
                 <field
                     name="city_taxation_code_id"
-                    attrs="{'invisible': ['|', ('tax_icms_or_issqn', '=', 'icms'), ('country_id', '!=', %(base.br)d)]}"
+                    attrs="{'invisible': ['|', ('tax_icms_or_issqn', '=', 'icms'), ('parent.fiscal_operation_id', '=', False)]}"
                     options="{'no_create': True}"
                 />
                 <field
                     name="cnae_id"
-                    attrs="{'invisible': ['|', ('tax_icms_or_issqn', '=', 'icms'), ('country_id', '!=', %(base.br)d)]}"
+                    attrs="{'invisible': ['|', ('tax_icms_or_issqn', '=', 'icms'), ('parent.fiscal_operation_id', '=', False)]}"
                     options="{'no_create': True}"
                 />
             </xpath>
             <xpath
                 expr="//field[@name='order_line']/form//field[@name='tax_id']"
-                position="replace"
-            />
+                position="attributes"
+            >
+                <attribute
+                    name="attrs"
+                >{'invisible': [('parent.fiscal_operation_id', '!=', False)]}</attribute>
+            </xpath>
             <xpath
                 expr="//field[@name='order_line']/form/div[@groups='base.group_no_one' and field/@name='invoice_lines']"
-                position="replace"
-            />
+                position="attributes"
+            >
+                <attribute
+                    name="attrs"
+                >{'invisible': [('parent.fiscal_operation_id', '!=', False)]}</attribute>
+            </xpath>
             <xpath
                 expr="//field[@name='order_line']/form//field[@name='price_unit']"
                 position="after"
@@ -199,9 +242,11 @@
                 <label
                     for="fiscal_quantity"
                     string="Fiscal Quantity"
-                    attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
+                    attrs="{'invisible': [('parent.fiscal_operation_id', '=', False)]}"
                 />
-                <div attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}">
+                <div
+                    attrs="{'invisible': [('parent.fiscal_operation_id', '=', False)]}"
+                >
                     <field
                         context="{'partner_id':parent.partner_id, 'quantity':fiscal_quantity, 'pricelist':parent.pricelist_id, 'uom':uot_id, 'uom_qty_change':True, 'company_id': parent.company_id}"
                         name="fiscal_quantity"
@@ -217,20 +262,17 @@
                 </div>
                 <field
                     name="fiscal_price"
-                    attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
+                    attrs="{'invisible': [('parent.fiscal_operation_id', '=', False)]}"
                 />
             </xpath>
             <xpath
                 expr="//field[@name='order_line']/form/field[@name='name']"
                 position="after"
             >
-                <field name="country_id" invisible="1" />
-                <notebook attrs="{'invisible': [('display_type', '!=', False)]}">
-                    <page
-                        name="fiscal_taxes"
-                        string="Taxes"
-                        attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
-                    />
+                <notebook
+                    attrs="{'invisible': ['|', ('display_type', '!=', False), ('parent.fiscal_operation_id', '=', False)]}"
+                >
+                    <page name="fiscal_taxes" string="Taxes" />
                     <page
                         string="Invoice Lines"
                         groups="base.group_no_one"


### PR DESCRIPTION
Adapt module to make compatible with the international cases.

Adaptando o modulo para manter a compatibilidade com os casos internacionais, sem esse PR não é possível Confirmar um Pedido de Venda que não seja o caso do Brasil, o teste pode ser feito com os dados de demonstração. Para tornar compatível é preciso saber o que torna ou não um Pedido de Venda do Brasil ou Internacional( o padrão original sem os campos específicos do Brasil ), antes estava sendo usado o País/country_id da empresa mas para melhor compatibilidade alterei para usar o campo Operação Fiscal/fiscal_operation_id( parece ser a melhor opção, teria outra? ), quer dizer quando esse campo está preenchido é um caso Brasil e quando não estiver é um caso internacional, para isso foi preciso manter esse campo em qualquer caso mas tirando o Requerido e também o valor e método Default. Existe uma questão a ser verificada, com essa alteração pode acontecer um "estranhamento" dos usuários porque inicialmente a visão do Pedido de Venda aparece no formato original/caso internacional e somente depois de informar o campo da Operação Fiscal os campos do Brasil aparecem, é isso pode ser uma reclamação dos usuários, por enquanto uma forma de diminuir esse problema que imaginei seria adicionar um novo Parâmetro ex.: "Multi Localização" ou outro nome para que quando não estiver marcado a visão do Pedido de Venda seja como está hoje( define que a empresa só tem casos do Brasil ) e quando estiver marcado a visão se comporte como está nesse PR ( define que a empresa tem ambos os casos Pedidos de Venda tanto no Brasil como os Internacionais ) mas aguardo os testes e a opinião de outros desenvolvedores se existe essa necessidade e se pode ser feito de outra forma. Segue as telas com as alterações, testes feitos com os dados de demonstração:

Pedido de Venda sem definição

![image](https://github.com/OCA/l10n-brazil/assets/6341149/fbba03f4-e00c-41a8-ae1d-b475d64f3e01)


- Caso Internacional/original

![image](https://github.com/OCA/l10n-brazil/assets/6341149/416cc2a1-300a-4693-bed3-fbc35db6b85b)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/16170ac6-cdbe-41b3-bce4-7f7aa7ff32e9)

Fatura criada

![image](https://github.com/OCA/l10n-brazil/assets/6341149/30196fb0-7df1-4ae7-9ed7-cacf2e21f53a)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/e7be91d4-a8b6-4e51-8068-36f91eafdc71)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/4689c845-5eb4-443a-90a4-654ca4fe8f0e)

- Caso Brasil, Operação Fiscal informada

![image](https://github.com/OCA/l10n-brazil/assets/6341149/8d5c5be6-4bef-4eb2-9471-c0b035d4f02e)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/69a86f3e-5a5d-4bda-a9c4-04201f712026)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/3fab6e74-6733-418b-a1d5-fedd5960b934)

Fatura criada

![image](https://github.com/OCA/l10n-brazil/assets/6341149/7c7d697e-1527-4d5b-9c83-e1d2734458f1)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/da4b1978-9433-4480-978d-66d6b504bcc9)

Documento Fiscal
![image](https://github.com/OCA/l10n-brazil/assets/6341149/5f3e7083-d771-434f-b0b0-9cd18e59aef1)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/a955c411-2142-41da-80bd-61513f539220)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/85cd9bb5-cc38-4d1e-8fbc-50f6b731fb0d)

Nesse PR também fiz outras alterações não relacionadas porém que são simples, os métodos compute e onchange não precisam fazer um "return result" isso é desnecessário.

cc @renatonlima @rvalyi @marcelsavegnago @mileo 
