### PR TITLE
[14.0][REF] Inform python external dependencies make unnecessary use TRY to import a library.

### DIFF
--- a/l10n_br_account_payment_brcobranca/__manifest__.py
+++ b/l10n_br_account_payment_brcobranca/__manifest__.py
@@ -26,4 +26,9 @@
         "demo/account_move_demo.xml",
         "demo/account_payment_mode.xml",
     ],
+    "external_dependencies": {
+        "python": [
+            "erpbrasil.base>=2.3.0",
+        ]
+    },
 }

--- a/l10n_br_account_payment_brcobranca/models/account_payment_order.py
+++ b/l10n_br_account_payment_brcobranca/models/account_payment_order.py
@@ -9,6 +9,7 @@ import logging
 import tempfile
 
 import requests
+from erpbrasil.base import misc
 
 from odoo import _, fields, models
 from odoo.exceptions import Warning as ValidationError
@@ -20,11 +21,6 @@ from ..constants.br_cobranca import (
 )
 
 _logger = logging.getLogger(__name__)
-
-try:
-    from erpbrasil.base import misc
-except ImportError:
-    _logger.error("Biblioteca erpbrasil.base não instalada")
 
 
 class PaymentOrder(models.Model):

--- a/l10n_br_account_payment_order/__manifest__.py
+++ b/l10n_br_account_payment_order/__manifest__.py
@@ -60,4 +60,9 @@
         "demo/account_payment_order.xml",
     ],
     "installable": True,
+    "external_dependencies": {
+        "python": [
+            "erpbrasil.base>=2.3.0",
+        ]
+    },
 }

--- a/l10n_br_account_payment_order/models/account_payment_line.py
+++ b/l10n_br_account_payment_order/models/account_payment_line.py
@@ -2,7 +2,8 @@
 #  Luis Felipe Miléo - mileo@kmee.com.br
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-import logging
+
+from erpbrasil.base import misc
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
@@ -14,13 +15,6 @@ from ..constants import (
     TIPO_MOVIMENTO,
     TIPO_SERVICO,
 )
-
-_logger = logging.getLogger(__name__)
-
-try:
-    from erpbrasil.base import misc
-except ImportError:
-    _logger.error("Biblioteca erpbrasil.base não instalada")
 
 
 class AccountPaymentLine(models.Model):

--- a/l10n_br_base/models/party_mixin.py
+++ b/l10n_br_base/models/party_mixin.py
@@ -1,17 +1,11 @@
 # Copyright (C) 2021 Renato Lima (Akretion)
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-import logging
+
+from erpbrasil.base import misc
+from erpbrasil.base.fiscal import cnpj_cpf
 
 from odoo import api, fields, models
-
-_logger = logging.getLogger(__name__)
-
-try:
-    from erpbrasil.base import misc
-    from erpbrasil.base.fiscal import cnpj_cpf
-except ImportError:
-    _logger.error("Biblioteca erpbrasil.base não instalada")
 
 
 class PartyMixin(models.AbstractModel):

--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -3,17 +3,11 @@
 # Copyright (C) 2012 Raphaël Valyi (Akretion)
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-import logging
+
+from erpbrasil.base.fiscal import cnpj_cpf, ie
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
-
-_logger = logging.getLogger(__name__)
-
-try:
-    from erpbrasil.base.fiscal import cnpj_cpf, ie
-except ImportError:
-    _logger.error("Biblioteca erpbrasil.base não instalada")
 
 
 class Partner(models.Model):

--- a/l10n_br_cnpj_search/__manifest__.py
+++ b/l10n_br_cnpj_search/__manifest__.py
@@ -20,5 +20,9 @@
         "views/res_company_view.xml",
         "views/res_config_settings_view.xml",
     ],
-    "demo": [],
+    "external_dependencies": {
+        "python": [
+            "erpbrasil.base>=2.3.0",
+        ]
+    },
 }

--- a/l10n_br_crm/__manifest__.py
+++ b/l10n_br_crm/__manifest__.py
@@ -14,4 +14,9 @@
     "data": ["views/crm_lead_view.xml", "views/crm_quick_create_opportunity_form.xml"],
     "installable": True,
     "auto_install": True,
+    "external_dependencies": {
+        "python": [
+            "erpbrasil.base>=2.3.0",
+        ]
+    },
 }

--- a/l10n_br_crm/models/crm_lead.py
+++ b/l10n_br_crm/models/crm_lead.py
@@ -1,18 +1,11 @@
 # Copyright (C) 2012 - TODAY  Renato Lima - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-import logging
+from erpbrasil.base import misc
+from erpbrasil.base.fiscal import cnpj_cpf, ie
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
-
-_logger = logging.getLogger(__name__)
-
-try:
-    from erpbrasil.base import misc
-    from erpbrasil.base.fiscal import cnpj_cpf, ie
-except ImportError:
-    _logger.error("erpbrasil.base library not installed")
 
 
 class Lead(models.Model):

--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -106,4 +106,9 @@
     "installable": True,
     "application": True,
     "auto_install": False,
+    "external_dependencies": {
+        "python": [
+            "erpbrasil.base>=2.3.0",
+        ]
+    },
 }

--- a/l10n_br_fiscal/models/document_workflow.py
+++ b/l10n_br_fiscal/models/document_workflow.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2019  KMEE INFORMATICA LTDA
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-import logging
+from erpbrasil.base.fiscal.edoc import ChaveEdoc
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
@@ -26,13 +26,6 @@ from ..constants.fiscal import (
     WORKFLOW_DOCUMENTO_NAO_ELETRONICO,
     WORKFLOW_EDOC,
 )
-
-_logger = logging.getLogger(__name__)
-
-try:
-    from erpbrasil.base.fiscal.edoc import ChaveEdoc
-except ImportError:
-    _logger.error("Biblioteca erpbrasil.base não instalada")
 
 
 class DocumentWorkflow(models.AbstractModel):

--- a/l10n_br_fiscal_certificate/hooks.py
+++ b/l10n_br_fiscal_certificate/hooks.py
@@ -3,22 +3,13 @@
 
 import logging
 
+from erpbrasil.assinatura import misc
+
 from odoo import SUPERUSER_ID, _, api
 
 from .constants import CERTIFICATE_TYPE_ECNPJ, CERTIFICATE_TYPE_NFE
 
 _logger = logging.getLogger(__name__)
-
-try:
-    from erpbrasil.assinatura import misc
-except ImportError:
-    _logger.error(
-        _(
-            "Python Library erpbrasil.assinatura not installed!"
-            "It doesn't matter much until you want to send NFe or NFSe documents."
-            "You can install it later with: pip install erpbrasil.assinatura."
-        )
-    )
 
 
 def post_init_hook(cr, registry):

--- a/l10n_br_fiscal_certificate/models/certificate.py
+++ b/l10n_br_fiscal_certificate/models/certificate.py
@@ -1,7 +1,8 @@
 # Copyright (C) 2019  Renato Lima - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-import logging
+
+from erpbrasil.assinatura import certificado
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
@@ -14,19 +15,6 @@ from ..constants import (
     CERTIFICATE_TYPE,
     CERTIFICATE_TYPE_DEFAULT,
 )
-
-_logger = logging.getLogger(__name__)
-
-try:
-    from erpbrasil.assinatura import certificado
-except ImportError:
-    _logger.error(
-        _(
-            "Python Library erpbrasil.assinatura not installed!"
-            "It doesn't matter much until you want to send NFe or NFSe documents."
-            "You can install it later with: pip install erpbrasil.assinatura."
-        )
-    )
 
 
 class Certificate(models.Model):

--- a/l10n_br_fiscal_dfe/__manifest__.py
+++ b/l10n_br_fiscal_dfe/__manifest__.py
@@ -16,11 +16,12 @@
         "views/l10n_br_fiscal_menu.xml",
         "views/res_company_view.xml",
     ],
-    "demo": [],
     "external_dependencies": {
         "python": [
             "erpbrasil.edoc>=2.5.2",
+            "erpbrasil.assinatura>=1.7.0",
             "erpbrasil.transmissao>=1.1.0",
+            "nfelib>=2.0.0",
         ],
     },
 }

--- a/l10n_br_hr/__manifest__.py
+++ b/l10n_br_hr/__manifest__.py
@@ -28,4 +28,9 @@
     "installable": True,
     "auto_install": False,
     "license": "AGPL-3",
+    "external_dependencies": {
+        "python": [
+            "erpbrasil.base>=2.3.0",
+        ]
+    },
 }

--- a/l10n_br_nfe/__manifest__.py
+++ b/l10n_br_nfe/__manifest__.py
@@ -58,6 +58,7 @@
             "erpbrasil.transmissao>=1.1.0",
             "erpbrasil.edoc>=2.5.2",
             "erpbrasil.edoc.pdf",
+            "erpbrasil.base>=2.3.0",
         ],
     },
 }

--- a/l10n_br_nfe/models/invalidate_number.py
+++ b/l10n_br_nfe/models/invalidate_number.py
@@ -1,10 +1,10 @@
 # Copyright (C) 2020  KMEE - www.kmee.com.br
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-import logging
 from datetime import datetime
 
 from erpbrasil.assinatura import certificado as cert
+from erpbrasil.base.misc import punctuation_rm
 from erpbrasil.transmissao import TransmissaoSOAP
 from nfelib.nfe.ws.edoc_legacy import NFCeAdapter as edoc_nfce, NFeAdapter as edoc_nfe
 from requests import Session
@@ -13,13 +13,6 @@ from odoo import _, fields, models
 from odoo.exceptions import UserError
 
 from odoo.addons.l10n_br_fiscal.constants.fiscal import EVENT_ENV_HML, EVENT_ENV_PROD
-
-_logger = logging.getLogger(__name__)
-
-try:
-    from erpbrasil.base.misc import punctuation_rm
-except ImportError:
-    _logger.error("Biblioteca erpbrasil.base não instalada")
 
 
 class InvalidateNumber(models.Model):

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -1,19 +1,12 @@
 # Copyright 2019 Akretion (Raphaël Valyi <raphael.valyi@akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-import logging
+from erpbrasil.base.fiscal import cnpj_cpf
+from erpbrasil.base.misc import format_zipcode, punctuation_rm
 
 from odoo import api, fields
 
 from odoo.addons.spec_driven_model.models import spec_models
-
-_logger = logging.getLogger(__name__)
-
-try:
-    from erpbrasil.base.fiscal import cnpj_cpf
-    from erpbrasil.base.misc import format_zipcode, punctuation_rm
-except ImportError:
-    _logger.error("Biblioteca erpbrasil.base não instalada")
 
 
 class ResPartner(spec_models.SpecModel):

--- a/l10n_br_pos/__manifest__.py
+++ b/l10n_br_pos/__manifest__.py
@@ -55,4 +55,9 @@
         "static/src/xml/Screens/OrderManagementScreen/OrderRow.xml",
     ],
     "installable": True,
+    "external_dependencies": {
+        "python": [
+            "erpbrasil.base>=2.3.0",
+        ]
+    },
 }

--- a/l10n_br_pos/models/res_partner.py
+++ b/l10n_br_pos/models/res_partner.py
@@ -1,16 +1,10 @@
 # © 2016 KMEE INFORMATICA LTDA (https://kmee.com.br)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-import logging
+
+from erpbrasil.base.fiscal import cnpj_cpf
 
 from odoo import api, models
-
-_logger = logging.getLogger(__name__)
-
-try:
-    from erpbrasil.base.fiscal import cnpj_cpf
-except ImportError:
-    _logger.error("erpbrasil.base library not installed")
 
 
 class ResPartner(models.Model):

--- a/l10n_br_pos_cfe/__manifest__.py
+++ b/l10n_br_pos_cfe/__manifest__.py
@@ -16,7 +16,10 @@
         "l10n_br_pos",
     ],
     "external_dependencies": {
-        "python": ["satcomum"],
+        "python": [
+            "satcomum",
+            "erpbrasil.base>=2.3.0",
+        ],
     },
     "data": [
         # Views

--- a/l10n_br_pos_cfe/models/pos_order.py
+++ b/l10n_br_pos_cfe/models/pos_order.py
@@ -1,18 +1,12 @@
 # © 2016 KMEE INFORMATICA LTDA (https://kmee.com.br)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-import logging
+
+from satcomum.ersat import ChaveCFeSAT
 
 from odoo import api, models
 
 from odoo.addons.l10n_br_fiscal.constants.fiscal import MODELO_FISCAL_CFE
-
-_logger = logging.getLogger(__name__)
-
-try:
-    from satcomum.ersat import ChaveCFeSAT
-except ImportError:
-    _logger.error("Biblioteca satcomum não instalada")
 
 
 class PosOrder(models.Model):

--- a/l10n_br_website_sale/__manifest__.py
+++ b/l10n_br_website_sale/__manifest__.py
@@ -19,5 +19,9 @@
         "templates/portal_templates.xml",
         "views/assets.xml",
     ],
-    "demo": [],
+    "external_dependencies": {
+        "python": [
+            "erpbrasil.base>=2.3.0",
+        ]
+    },
 }

--- a/l10n_br_website_sale/controllers/main.py
+++ b/l10n_br_website_sale/controllers/main.py
@@ -1,18 +1,13 @@
 # Copyright 2020 KMEE
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-import logging
+
+from erpbrasil.base.fiscal import cnpj_cpf
 
 from odoo import http
 from odoo.http import request
 
 from odoo.addons.website_sale.controllers.main import WebsiteSale
-
-_logger = logging.getLogger(__name__)
-try:
-    from erpbrasil.base.fiscal import cnpj_cpf
-except ImportError:
-    _logger.error("Biblioteca erpbrasil.base não instalada")
 
 
 class L10nBrWebsiteSale(WebsiteSale):

--- a/l10n_br_zip/__manifest__.py
+++ b/l10n_br_zip/__manifest__.py
@@ -20,5 +20,10 @@
     ],
     "installable": True,
     "development_status": "Mature",
-    "external_dependencies": {"python": ["brazilcep"]},
+    "external_dependencies": {
+        "python": [
+            "brazilcep",
+            "erpbrasil.base>=2.3.0",
+        ]
+    },
 }

--- a/l10n_br_zip/models/l10n_br_zip.py
+++ b/l10n_br_zip/models/l10n_br_zip.py
@@ -1,24 +1,12 @@
 # Copyright (C) 2012  Renato Lima (Akretion)
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-import logging
+
+from brazilcep import WebService, get_address_from_cep
+from erpbrasil.base import misc
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
-
-_logger = logging.getLogger(__name__)
-
-try:
-    from erpbrasil.base import misc
-except ImportError:
-    _logger.error("Library erpbrasil.base not installed!")
-
-_logger = logging.getLogger(__name__)
-
-try:
-    from brazilcep import WebService, get_address_from_cep
-except ImportError:
-    _logger.warning("Python Library brazilcep not installed !")
 
 
 class L10nBrZip(models.Model):


### PR DESCRIPTION
Fix Warning PyLint missing manifest dependency.

Corrigido os Warning do PyLint sobre missing-manifest-dependency, apesar do PR estar alterando vários módulos não é algo que afeta nenhum código em si. Uma questão a ser vista é que está sendo removido a definição das versões das bibliotecas ex.: "nfelib>=2.0.0", "erpbrasil.assinatura>=1.7.0" parece que o PyLint não reconhece( ou faltou alguma configuração? ) isso pode ser visto no https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_nfe/__manifest__.py#L47 que gera o Warning do PyLint

************* Module l10n_br_nfe.hooks
l10n_br_nfe/hooks.py:5: [W7936(missing-manifest-dependency), ] Missing external dependency "nfelib" from manifest. More info: https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#external-dependencies

************* Module l10n_br_nfe.models.document
l10n_br_nfe/models/document.py:12: [W7936(missing-manifest-dependency), ] Missing external dependency "erpbrasil.assinatura" from manifest. More info: https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#external-dependencies
l10n_br_nfe/models/document.py:13: [W7936(missing-manifest-dependency), ] Missing external dependency "erpbrasil.base.fiscal.edoc" from manifest. More info: https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#external-dependencies
l10n_br_nfe/models/document.py:15: [W7936(missing-manifest-dependency), ] Missing external dependency "erpbrasil.transmissao" from manifest. More info: https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#external-dependencies
l10n_br_nfe/models/document.py:17: [W7936(missing-manifest-dependency), ] Missing external dependency "nfelib.nfe.bindings.v4_0.nfe_v4_00" from manifest. More info: https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#external-dependencies
l10n_br_nfe/models/document.py:18: [W7936(missing-manifest-dependency), ] Missing external dependency "nfelib.nfe.ws.edoc_legacy" from manifest. More info: https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#external-dependencies

cc @rvalyi @renatonlima @marcelsavegnago @mileo 
