### PR TITLE
[14.0][REF]  Atualização da bibliotecas do Pre-commit: Flake8 E721 do not compare types

### DIFF
--- a/l10n_br_contract/models/contract_contract.py
+++ b/l10n_br_contract/models/contract_contract.py
@@ -124,7 +124,7 @@ class ContractContract(models.Model):
 
             # Identify how many Document Types exist
             for inv_line in invoice_val.get("invoice_line_ids"):
-                if type(inv_line[2]) == list:
+                if type(inv_line[2]) is list:
                     continue
 
                 operation_line_id = self.env["l10n_br_fiscal.operation.line"].browse(

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -899,7 +899,7 @@ class NFe(spec_models.StackedModel):
         else:
             state = SITUACAO_EDOC_REJEITADA
         if self.authorization_event_id and infProt.nProt:
-            if type(infProt.dhRecbto) == datetime:
+            if type(infProt.dhRecbto) is datetime:
                 protocol_date = fields.Datetime.to_string(infProt.dhRecbto)
             else:
                 protocol_date = fields.Datetime.to_string(

--- a/l10n_br_stock_account_report/wizards/l10n_br_p7_model_inventory_report_wizard.py
+++ b/l10n_br_stock_account_report/wizards/l10n_br_p7_model_inventory_report_wizard.py
@@ -234,7 +234,7 @@ class L10nBRP7ModelInventoryReportWizard(models.TransientModel):
                 tmp_total_value_ncm = round(product_inventory_value, account_precision)
                 # A validação abaixo é necessária p/
                 # não preencher a primeira linha
-                if type(tmp_ncm_controler) != bool:
+                if type(tmp_ncm_controler) is not bool:
                     tmp_ncm_controler_line = True
 
             result_lines.append(

--- a/l10n_br_website_sale/controllers/main.py
+++ b/l10n_br_website_sale/controllers/main.py
@@ -100,7 +100,7 @@ class L10nBrWebsiteSale(WebsiteSale):
             and res.qcontext["checkout"]["city_id"]
         ):
             state_id = res.qcontext["checkout"]["state_id"]
-            if type(state_id) != str:
+            if type(state_id) is not str:
                 state_id = state_id.id
             elif state_id:
                 state_id = int(state_id)

--- a/payment_pagseguro/models/payment_transaction.py
+++ b/payment_pagseguro/models/payment_transaction.py
@@ -92,7 +92,7 @@ class PaymentTransactionPagseguro(models.Model):
         )
 
         if (
-            type(res) == dict
+            type(res) is dict
             and res.get("payment_response")
             and res.get("payment_response").get("message") == "SUCESSO"
         ):
@@ -136,7 +136,7 @@ class PaymentTransactionPagseguro(models.Model):
         )
 
         if (
-            type(res) == dict
+            type(res) is dict
             and res.get("payment_response")
             and res.get("payment_response").get("message") == "SUCESSO"
         ):

--- a/spec_driven_model/models/spec_export.py
+++ b/spec_driven_model/models/spec_export.py
@@ -149,7 +149,7 @@ class AbstractSpecMixin(models.AbstractModel):
             return self._export_float_monetary(
                 xsd_field, xsd_type, class_obj, xsd_required, export_value
             )
-        elif type(self[xsd_field]) == str:
+        elif type(self[xsd_field]) is str:
             return self[xsd_field].strip()
         else:
             return self[xsd_field]


### PR DESCRIPTION
Fix Flake8 E721 do not compare types.

PR simples que não deve afetar o código, ao comparar um TYPE ao usar o "is" ou "is not", erro apontado pelo Flake8 https://github.com/OCA/l10n-brazil/actions/runs/6643339050/job/18050180768?pr=2747#step:7:606

E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
l10n_br_website_sale/controllers/main.py:102:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()` 

Estou vendo a possibilidade de atualizar as bibliotecas do Pre-Commit no PR https://github.com/OCA/l10n-brazil/pull/2747 ( isso ainda está em debate por existir uma forma automatizada de fazer essa atualização, mas essa alteração já antecipa o que vai precisar ser feito quando houver a atualização ), essa validação está sendo feita nas recentes versões das bibliotecas do pre-commit.

cc @rvalyi @renatonlima @marcelsavegnago @mileo 