### PR TITLE
[14.0][REF] Atualização da bibliotecas do Pre-commit: Outras alterações diversas

### DIFF
--- a/l10n_br_account_due_list/models/account_move.py
+++ b/l10n_br_account_due_list/models/account_move.py
@@ -26,7 +26,7 @@ class AccountInvoice(models.Model):
     def _compute_financial(self):
         for move in self:
             lines = move.line_ids.filtered(
-                lambda l: l.account_id.internal_type in ("receivable", "payable")
+                lambda line: line.account_id.internal_type in ("receivable", "payable")
             )
             move.financial_move_line_ids = lines.sorted()
 

--- a/l10n_br_base/tools.py
+++ b/l10n_br_base/tools.py
@@ -32,7 +32,6 @@ def check_ie(env, inscr_est, state, country):
                 #  Se no caso da empresa ser 'isenta' do IE o campo
                 #  deve estar vazio ou pode ter algum valor como abaixo
                 if inscr_est not in ("isento", "isenta", "ISENTO", "ISENTA"):
-
                     if not ie.validar(state.code.lower(), inscr_est):
                         raise ValidationError(
                             _("Estadual Inscription {} Invalid for State {}!").format(

--- a/l10n_br_fiscal/models/document_event.py
+++ b/l10n_br_fiscal/models/document_event.py
@@ -235,7 +235,7 @@ class Event(models.Model):
             if not os.path.exists(save_dir):
                 os.makedirs(save_dir)
             f = open(file_path, "w")
-        except IOError as e:
+        except OSError as e:
             raise UserError(
                 _("Erro!"),
                 _(

--- a/l10n_br_fiscal/models/subsequent_document.py
+++ b/l10n_br_fiscal/models/subsequent_document.py
@@ -3,7 +3,6 @@
 # License AGPL-3 or later (http://www.gnu.org/licenses/agpl)
 #
 
-from __future__ import division, print_function, unicode_literals
 
 from odoo import api, fields, models
 

--- a/l10n_br_fiscal/models/subsequent_operation.py
+++ b/l10n_br_fiscal/models/subsequent_operation.py
@@ -2,8 +2,6 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 
-from __future__ import division, print_function, unicode_literals
-
 from odoo import fields, models
 
 from ..constants.fiscal import SITUACAO_EDOC

--- a/l10n_br_fiscal/wizards/document_import_wizard_mixin.py
+++ b/l10n_br_fiscal/wizards/document_import_wizard_mixin.py
@@ -3,7 +3,7 @@
 
 from odoo import fields, models
 
-from odoo.addons.l10n_br_fiscal.constants.fiscal import FISCAL_IN_OUT_ALL
+from ..constants.fiscal import FISCAL_IN_OUT_ALL
 
 
 class DocumentImportWizardMixin(models.TransientModel):

--- a/l10n_br_fiscal_dfe/tests/test_dfe.py
+++ b/l10n_br_fiscal_dfe/tests/test_dfe.py
@@ -20,7 +20,7 @@ response_sucesso_individual = """<?xml version="1.0" encoding="UTF-8"?><soap:Env
 response_rejeicao = """<?xml version="1.0" encoding="UTF-8"?><soap:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><nfeDistDFeInteresseResponse xmlns="http://www.portalfiscal.inf.br/nfe/wsdl/NFeDistribuicaoDFe"><nfeDistDFeInteresseResult><retDistDFeInt xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.portalfiscal.inf.br/nfe" versao="1.01"><tpAmb>2</tpAmb><verAplic>1.4.0</verAplic><cStat>589</cStat><xMotivo>Rejeicao: Numero do NSU informado superior ao maior NSU da base de dados doAmbiente Nacional</xMotivo><dhResp>2022-04-04T11:54:49-03:00</dhResp><ultNSU>000000000000000</ultNSU><maxNSU>000000000000000</maxNSU></retDistDFeInt></nfeDistDFeInteresseResult></nfeDistDFeInteresseResponse></soap:Body></soap:Envelope>"""
 
 
-class FakeRetorno(object):
+class FakeRetorno:
     def __init__(self, text, status_code=200):
         self.text = text
         self.content = text.encode("utf-8")

--- a/l10n_br_ie_search/tests/test_sefaz.py
+++ b/l10n_br_ie_search/tests/test_sefaz.py
@@ -12,7 +12,7 @@ from odoo.tests.common import SavepointCase
 from odoo.tools.misc import format_date
 
 
-class FakeRetorno(object):
+class FakeRetorno:
     __slots__ = "text", "ok"
 
 

--- a/l10n_br_ie_search/tests/test_sintegra.py
+++ b/l10n_br_ie_search/tests/test_sintegra.py
@@ -10,7 +10,7 @@ from odoo.tests.common import SavepointCase
 _logger = logging.getLogger(__name__)
 
 
-class FakeRetorno(object):
+class FakeRetorno:
     __slots__ = "text", "status_code"
 
     def json(self):

--- a/l10n_br_nfe/tests/test_nfce.py
+++ b/l10n_br_nfe/tests/test_nfce.py
@@ -38,7 +38,7 @@ response_cancelamento = """<?xml version="1.0" encoding="UTF-8"?><soap:Envelope 
 response_contingency = """<?xml version="1.0" encoding="UTF-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><nfeResultMsg xmlns="http://www.portalfiscal.inf.br/nfe/wsdl/NFeAutorizacao4"><retEnviNFe xmlns="http://www.portalfiscal.inf.br/nfe" versao="4.00"><tpAmb>2</tpAmb><verAplic>4.0.0</verAplic><cStat>108</cStat><xMotivo>Rejeição: Duplicidade de NF-e</xMotivo><cUF>33</cUF><dhRecbto>2023-08-08T10:30:00-03:00</dhRecbto><infRec><nRec>123456789012345</nRec><tMed>1</tMed></infRec></retEnviNFe></nfeResultMsg></soap:Body></soap:Envelope>"""
 
 
-class FakeRetorno(object):
+class FakeRetorno:
     def __init__(self, text):
         self.text = text
         self.content = text.encode("utf-8")

--- a/l10n_br_nfe/tests/test_nfe_import_wizard.py
+++ b/l10n_br_nfe/tests/test_nfe_import_wizard.py
@@ -13,7 +13,7 @@ from ..wizards.import_document import NfeImport
 
 class NFeImportWizardTest(SavepointCase):
     def setUp(self):
-        super(NFeImportWizardTest, self).setUp()
+        super().setUp()
 
         def test_xml_path(filename):
             return os.path.join(

--- a/l10n_br_nfe/tests/test_nfe_mde.py
+++ b/l10n_br_nfe/tests/test_nfe_mde.py
@@ -27,7 +27,7 @@ response_desconhecimento_operacao = """<?xml version="1.0" encoding="UTF-8"?><so
 response_operacao_nao_realizada = """<?xml version="1.0" encoding="UTF-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soap:Body><nfeResultMsg xmlns="http://www.portalfiscal.inf.br/nfe/wsdl/NFeRecepcaoEvento4"><retEnvEvento xmlns="http://www.portalfiscal.inf.br/nfe" versao="1.00"><idLote /><tpAmb>2</tpAmb><verAplic>SVRS202305251555</verAplic><cStat>135</cStat><retEvento versao="1.00"><infEvento><tpAmb>2</tpAmb><verAplic>SVRS202305251555</verAplic><cStat>135</cStat><xMotivo>Teste Operação não Realizada.</xMotivo><chNFe>31201010588201000105550010038421171838422178</chNFe><tpEvento>210240</tpEvento><xEvento>Operacao nao Realizada registrada</xEvento><nSeqEvento>1</nSeqEvento><CNPJDest>81583054000129</CNPJDest><dhRegEvento>2023-07-10T10:00:00-03:00</dhRegEvento></infEvento></retEvento></retEnvEvento></nfeResultMsg></soap:Body></soap:Envelope>"""
 
 
-class FakeRetorno(object):
+class FakeRetorno:
     def __init__(self, text, status_code=200):
         self.text = text
         self.content = text.encode("utf-8")

--- a/l10n_br_nfe/tests/test_nfe_webservices.py
+++ b/l10n_br_nfe/tests/test_nfe_webservices.py
@@ -53,7 +53,7 @@ def is_libreoffice_command_available():
         return False
 
 
-class FakeRetorno(object):
+class FakeRetorno:
     def __init__(self, text):
         self.text = text
         self.content = text.encode("utf-8")

--- a/l10n_br_pos_cfe/models/pos_order.py
+++ b/l10n_br_pos_cfe/models/pos_order.py
@@ -14,7 +14,7 @@ class PosOrder(models.Model):
 
     @api.model
     def _order_fields(self, ui_order):
-        order_fields = super(PosOrder, self)._order_fields(ui_order)
+        order_fields = super()._order_fields(ui_order)
 
         document_key = ui_order.get("document_key")
         document_type = ui_order.get("document_type")


### PR DESCRIPTION
Fix problems related to recent versions of pre-commit librarys.

PR simples que não deve afetar o código, alterações diversas que restaram para atender as versões mais recentes das bibliotecas do pre-commit, as alterações:

- O IOError é um apelido/alias do OSError https://stackoverflow.com/questions/29347790/difference-between-ioerror-and-oserror
- Essa importação não estava sendo usada "from __future__ import division, print_function, unicode_literals", acredito que por ser __future__ a versão atual do pre-commit não fazia essa validação
- A importação de algo que está no mesmo modulo deve usar o ponto "."  W8150(odoo-addons-relative-import), ] Same Odoo module absolute import. You should use relative import with "." instead of "odoo.addons.l10n_br_fiscal"   https://github.com/OCA/l10n-brazil/actions/runs/6643339050/job/18050180768?pr=2747#step:7:307
- A classe "class FakeRetorno(object):" foi alterada para "class FakeRetorno:" pelo o que entendi isso foi feito pelo pre-commit porque o parâmetro não estava sendo usado

Estou vendo a possibilidade de atualizar as bibliotecas do Pre-Commit no PR https://github.com/OCA/l10n-brazil/pull/2747 ( isso ainda está em debate por existir uma forma automatizada de fazer essa atualização, mas essa alteração já antecipa o que vai precisar ser feito quando houver a atualização ), essa validação está sendo feita nas recentes versões das bibliotecas do pre-commit.

cc @rvalyi @renatonlima @marcelsavegnago @mileo