### PR TITLE
[14.0][REF] l10n_br_purchase: Adaptando o modulo para manter a compatibilidade com os casos internacionais

### DIFF
--- a/l10n_br_purchase/models/account_move.py
+++ b/l10n_br_purchase/models/account_move.py
@@ -11,7 +11,10 @@ class AccountMove(models.Model):
     @api.onchange("purchase_vendor_bill_id", "purchase_id")
     def _onchange_purchase_auto_complete(self):
         if self.purchase_id:
-            self.fiscal_operation_id = self.purchase_id.fiscal_operation_id
-            if not self.document_type_id:
-                self.document_type_id = self.company_id.document_type_id
+            if self.purchase_id.fiscal_operation_id:
+                self.fiscal_operation_id = self.purchase_id.fiscal_operation_id
+                if not self.document_type_id:
+                    # Testes não passam por aqui, qual seria esse caso de uso?
+                    # Porque se não houver o codigo pode ser removido
+                    self.document_type_id = self.company_id.document_type_id
         return super()._onchange_purchase_auto_complete()

--- a/l10n_br_purchase/views/purchase_view.xml
+++ b/l10n_br_purchase/views/purchase_view.xml
@@ -21,8 +21,15 @@
           <field name="priority">100</field>
           <field name="arch" type="xml">
               <xpath expr="//field[@name='partner_ref']" position="after">
-                  <field name="fiscal_operation_id" required="1" />
-                  <field name="ind_final" />
+                  <field name="active_company_country_id" invisible="True" />
+                  <field
+                    name="fiscal_operation_id"
+                    attrs="{'invisible': [('active_company_country_id', '!=', %(base.br)d)]}"
+                />
+                  <field
+                    name="ind_final"
+                    attrs="{'invisible': [('fiscal_operation_id', '=', False)]}"
+                />
               </xpath>
               <xpath expr="//field[@name='order_line']" position="attributes">
                   <attribute
@@ -37,13 +44,19 @@
                 expr="//field[@name='order_line']/tree/field[@name='taxes_id']"
                 position="attributes"
             >
-                  <attribute name="invisible">1</attribute>
+                  <attribute
+                    name="attrs"
+                >{'column_invisible': [('parent.fiscal_operation_id', '!=', False)]}</attribute>
               </xpath>
               <xpath
                 expr="//field[@name='order_line']/tree/field[@name='taxes_id']"
                 position="before"
             >
-                  <field name="fiscal_tax_ids" widget="many2many_tags" />
+                  <field
+                    name="fiscal_tax_ids"
+                    attrs="{'column_invisible': [('parent.fiscal_operation_id', '=', False)]}"
+                    widget="many2many_tags"
+                />
               </xpath>
               <!-- Edit order_line Form view -->
               <xpath expr="//field[@name='order_line']/form" position="inside">
@@ -77,63 +90,110 @@
               </xpath>
               <xpath
                 expr="//field[@name='order_line']/form//field[@name='taxes_id']"
-                position="replace"
+                position="attributes"
+            >
+                  <attribute
+                    name="attrs"
+                >{'invisible': [('fiscal_operation_id', '!=', False)]}</attribute>
+              </xpath>
+              <xpath
+                expr="//field[@name='order_line']/form//field[@name='taxes_id']"
+                position="after"
             >
                   <field
                     name="fiscal_operation_id"
-                    required="1"
                     options="{'no_create': True}"
+                    attrs="{'invisible': [('parent.fiscal_operation_id', '=', False)], 'required': [('parent.fiscal_operation_id', '!=', False)]}"
                 />
                   <field
                     name="fiscal_operation_line_id"
-                    required="1"
                     options="{'no_create': True}"
+                    attrs="{'invisible': [('parent.fiscal_operation_id', '=', False)], 'required': [('fiscal_operation_id', '!=', False)]}"
                 />
                   <field
                     name="cfop_id"
-                    attrs="{'invisible': [('tax_icms_or_issqn', '=', 'issqn')]}"
+                    attrs="{'invisible': ['|', ('tax_icms_or_issqn', '=', 'issqn'), ('parent.fiscal_operation_id', '=', False)]}"
                     options="{'no_create': True}"
                 />
                   <field
                     name="service_type_id"
                     options="{'no_create': True}"
-                    attrs="{'invisible': [('tax_icms_or_issqn', '=', 'icms')]}"
+                    attrs="{'invisible': ['|', ('tax_icms_or_issqn', '=', 'icms'), ('parent.fiscal_operation_id', '=', False)]}"
                 />
               </xpath>
               <xpath
-                expr="//field[@name='order_line']/form//notebook/page[1]"
-                position="before"
+                expr="//field[@name='order_line']/form//notebook"
+                position="attributes"
             >
-                  <page name="fiscal_taxes" string="Taxes" />
-                  <page name="fiscal_line_extra_info" string="Extra Info" />
-                  <page name="others" string="Outros Custos">
-                      <group>
-                          <field name="delivery_costs" invisible="1" />
-                          <field
-                            name="freight_value"
-                            attrs="{'readonly': [('delivery_costs', '=', 'total')]}"
-                        />
-                          <field
-                            name="insurance_value"
-                            attrs="{'readonly': [('delivery_costs', '=', 'total')]}"
-                        />
-                          <field
-                            name="other_value"
-                            attrs="{'readonly': [('delivery_costs', '=', 'total')]}"
-                        />
-                      </group>
-                  </page>
-                  <page name="accounting" string="Accounting">
-                      <group>
-                          <field
-                            name="taxes_id"
-                            widget="many2many_tags"
-                            options="{'no_create': True}"
-                            context="{'search_view_ref': 'account.account_tax_view_search'}"
-                            domain="[('type_tax_use','=','purchase'),('company_id','=',parent.company_id)]"
-                        />
-                      </group>
-                  </page>
+                  <!-- necessario incluir porque o attrs não funciona na tag Page apenas  na Notebook-->
+                  <attribute
+                    name="attrs"
+                >{'invisible': [('parent.fiscal_operation_id', '!=', False)]}</attribute>
+              </xpath>
+              <xpath
+                expr="//field[@name='order_line']/form/field[@name='name']"
+                position="after"
+            >
+                <notebook
+                    attrs="{'invisible': [('parent.fiscal_operation_id', '=', False)]}"
+                >
+                      <page
+                        name="fiscal_taxes"
+                        string="Taxes"
+                        attrs="{'invisible': [('parent.fiscal_operation_id', '=', False)]}"
+                    />
+                      <page
+                        name="fiscal_line_extra_info"
+                        string="Extra Info"
+                        attrs="{'invisible': [('parent.fiscal_operation_id', '=', False)]}"
+                    />
+                      <page
+                        name="others"
+                        string="Outros Custos"
+                        attrs="{'invisible': [('parent.fiscal_operation_id', '=', False)]}"
+                    >
+                          <group>
+                              <field name="delivery_costs" invisible="1" />
+                              <field
+                                name="freight_value"
+                                attrs="{'readonly': [('delivery_costs', '=', 'total')]}"
+                            />
+                              <field
+                                name="insurance_value"
+                                attrs="{'readonly': [('delivery_costs', '=', 'total')]}"
+                            />
+                              <field
+                                name="other_value"
+                                attrs="{'readonly': [('delivery_costs', '=', 'total')]}"
+                            />
+                          </group>
+                      </page>
+                      <page
+                        name="accounting"
+                        string="Accounting"
+                        attrs="{'invisible': [('parent.fiscal_operation_id', '=', False)]}"
+                    >
+                          <group>
+                              <field
+                                name="taxes_id"
+                                widget="many2many_tags"
+                                options="{'no_create': True}"
+                                context="{'search_view_ref': 'account.account_tax_view_search'}"
+                                domain="[('type_tax_use','=','purchase'),('company_id','=',parent.company_id)]"
+                            />
+                          </group>
+                      </page>
+                          <!-- necessario incluir porque o attrs não funciona na tag Page apenas  na Notebook-->
+                          <page string="Notes" name="notes">
+                              <field name="name" />
+                          </page>
+                          <page
+                        string="Invoices and Incoming Shipments"
+                        name="invoices_incoming_shiptments"
+                    >
+                              <field name="invoice_lines" />
+                          </page>
+                  </notebook>
               </xpath>
               <xpath expr="//field[@name='amount_untaxed']" position="after">
                   <field name="delivery_costs" invisible="1" />
@@ -141,19 +201,19 @@
                     name="amount_freight_value"
                     widget='monetary'
                     options="{'currency_field': 'currency_id'}"
-                    attrs="{'readonly': [('delivery_costs', '=', 'line')]}"
+                    attrs="{'readonly': [('delivery_costs', '=', 'line')], 'invisible': [('fiscal_operation_id', '=', False)]}"
                 />
                   <field
                     name="amount_insurance_value"
                     widget='monetary'
                     options="{'currency_field': 'currency_id'}"
-                    attrs="{'readonly': [('delivery_costs', '=', 'line')]}"
+                    attrs="{'readonly': [('delivery_costs', '=', 'line')], 'invisible': [('fiscal_operation_id', '=', False)]}"
                 />
                   <field
                     name="amount_other_value"
                     widget='monetary'
                     options="{'currency_field': 'currency_id'}"
-                    attrs="{'readonly': [('delivery_costs', '=', 'line')]}"
+                    attrs="{'readonly': [('delivery_costs', '=', 'line')], 'invisible': [('fiscal_operation_id', '=', False)]}"
                 />
               </xpath>
               <xpath
@@ -187,10 +247,9 @@
           <field name="model">purchase.order.line</field>
           <field name="inherit_id" ref="purchase.purchase_order_line_form2" />
           <field name="arch" type="xml">
-            <xpath expr="//form/sheet/group" position="after">
-                <group id="l10n_br_fiscal">
-                </group>
-            </xpath>
+              <xpath expr="//form/sheet/group" position="after">
+                  <group id="l10n_br_fiscal" />
+              </xpath>
           </field>
       </record>
 


### PR DESCRIPTION
Adapted module to make compatible with the international cases.

Adaptando o modulo para manter a compatibilidade com os casos internacionais.

Para tornar compatível é preciso saber o que torna ou não um Pedido de Compra do Brasil ou Internacional( o padrão original sem os campos específicos do Brasil ), estou considerando a Operação Fiscal/fiscal_operation_id( parece ser a melhor opção, teria outra? ), quer dizer quando esse campo está preenchido é um caso Brasil e quando não estiver é um caso internacional, para isso foi preciso manter esse campo em qualquer caso mas tirando o Requerido e também o valor e método Default. 

Assim como no PR que adapta o l10n_br_sale https://github.com/OCA/l10n-brazil/pull/2743 existe uma questão a ser verificada, com essa alteração pode acontecer um "estranhamento" dos usuários porque inicialmente a visão do Pedido de Compras aparece no formato original/caso internacional e somente depois de informar o campo da Operação Fiscal os campos do Brasil aparecem é isso pode ser uma reclamação dos usuários, por enquanto uma forma de diminuir esse problema que imaginei seria adicionar um novo Parâmetro ex.: "Multi Localização" ou outro nome para que quando não estiver marcado a visão do Pedido de Compra seja como está hoje( o parâmetro definiria que a empresa só tem casos do Brasil ) e quando estiver marcado a visão se comporte como está nesse PR ( define que a empresa tem ambos os casos Pedidos de compra tanto no Brasil como os Internacionais ) mas aguardo os testes e a opinião de outros desenvolvedores se existe essa necessidade e se pode ser feito de outra forma. Segue as telas com as alterações, testes feitos com os dados de demonstração:

Pedido de Compra sem definição 

![image](https://github.com/OCA/l10n-brazil/assets/6341149/e3caf502-0d19-4391-bf55-1cea4d50077b)

- Caso Internacional/Original

![image](https://github.com/OCA/l10n-brazil/assets/6341149/baba1c4d-db8f-430e-a249-8d314e3fccd2)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/55b16522-4fb7-4adf-ab58-56e25bfe5612)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/8c9dced7-a43d-42bf-9fc5-6ef4077e5110)

Fatura criada

![image](https://github.com/OCA/l10n-brazil/assets/6341149/2ca9c902-a451-4b49-987f-f37f83e29604)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/251d6bbd-10b7-4d74-aa0e-e9aa9a875df7)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/2d5f4752-ea2f-4e66-9937-d67b4ec8f71c)

- Caso Brasil, a Operação Fiscal é informada

![image](https://github.com/OCA/l10n-brazil/assets/6341149/f286798f-0ed8-4ad0-83b8-74e8c66acb7c)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/fe1436dc-e879-4dd9-a707-f7265618e21f)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/a7dc1085-8b17-434e-94c0-1488d342b3eb)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/040bae5b-7ee6-4314-999c-2ab85079fc16)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/9262c65b-a012-4f92-87b5-517375e2af18)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/8b40464f-b517-4705-b8e1-7dd1ed465e9a)

Outra questão simples que fiz e retirar o "return result" por ser desnecessário em metodos compute e onchanges.

Existe um erro nos testes do l10n_br_purchase_request que preciso verificar, parece que é porque não está sendo informado a Operação Fiscal no teste e por isso com esse PR não cria um documento Fiscal, apesar disso acredito que já possível testar o l10n_br_purchase

cc @rvalyi @renatonlima @marcelsavegnago @mileo 