### PR TITLE
[14.0][IMP] l10n_br_purchase: Inclusão de Dados de Demonstração e Testes para o caso de Pedido de Compras com Serviço

### DIFF
--- a/l10n_br_purchase/demo/l10n_br_purchase.xml
+++ b/l10n_br_purchase/demo/l10n_br_purchase.xml
@@ -209,4 +209,113 @@
         <value eval="[ref('sn_pl_only_products_2_2')]" />
     </function>
 
+    <!-- Purchase Order with only Service -->
+    <record id="main_po_only_service" model="purchase.order">
+        <field name="name">Main l10n_br_purchase - Serviços</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_akretion" />
+        <field name="payment_term_id" ref="account.account_payment_term_advance" />
+        <field name="state">draft</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field name="user_id" ref="base.user_admin" />
+        <field name="company_id" ref="base.main_company" />
+    </record>
+
+    <function model="purchase.order" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('main_po_only_service')]" />
+    </function>
+
+    <record id="main_pl_only_service_1_1" model="purchase.order.line">
+        <field name="order_id" ref="main_po_only_service" />
+        <field name="name">Desenvolvimento Odoo</field>
+        <field name="product_id" ref="l10n_br_fiscal.customized_development_sale" />
+        <field name="product_qty">1</field>
+        <field name="product_uom" ref="uom.product_uom_hour" />
+        <field name="price_unit">250</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_compras_compras_uso_consumo"
+        />
+        <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
+        <field name="partner_order">0000001</field>
+        <field name="partner_order_line">001</field>
+    </record>
+
+    <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('main_pl_only_service_1_1')]" />
+    </function>
+
+    <function model="purchase.order.line" name="_onchange_fiscal_operation_line_id">
+        <value eval="[ref('main_pl_only_service_1_1')]" />
+    </function>
+
+    <!-- Purchase Order with Service and Product -->
+    <record id="main_po_service_product" model="purchase.order">
+        <field name="name">Main l10n_br_purchase - Serviço e Produto</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_akretion" />
+        <field name="payment_term_id" ref="account.account_payment_term_advance" />
+        <field name="state">draft</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field name="user_id" ref="base.user_admin" />
+        <field name="company_id" ref="base.main_company" />
+    </record>
+
+    <function model="purchase.order" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('main_po_service_product')]" />
+    </function>
+
+    <record id="main_pl_service_product_1_1" model="purchase.order.line">
+        <field name="order_id" ref="main_po_service_product" />
+        <field name="name">Desenvolvimento Odoo</field>
+        <field name="product_id" ref="l10n_br_fiscal.customized_development_sale" />
+        <field name="product_qty">1</field>
+        <field name="product_uom" ref="uom.product_uom_hour" />
+        <field name="price_unit">250</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_compras_compras_uso_consumo"
+        />
+        <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
+        <field name="partner_order">0000001</field>
+        <field name="partner_order_line">001</field>
+    </record>
+
+    <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('main_pl_only_service_1_1')]" />
+    </function>
+
+    <function model="purchase.order.line" name="_onchange_fiscal_operation_line_id">
+        <value eval="[ref('main_pl_service_product_1_1')]" />
+    </function>
+
+    <record id="main_pl_service_product_2_2" model="purchase.order.line">
+        <field name="order_id" ref="main_po_service_product" />
+        <field name="name">Gaveta Preta</field>
+        <field name="product_id" ref="product.product_product_16" />
+        <field name="product_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="price_unit">500</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_compras_compras"
+        />
+        <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
+        <field name="partner_order">0000001</field>
+        <field name="partner_order_line">002</field>
+        <field name="manual_additional_data">Teste - Additional Data</field>
+        <field name="insurance_value">10</field>
+        <field name="other_value">10</field>
+        <field name="freight_value">10</field>
+    </record>
+
+    <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('main_pl_service_product_2_2')]" />
+    </function>
+
+    <function model="purchase.order.line" name="_onchange_fiscal_operation_line_id">
+        <value eval="[ref('main_pl_service_product_2_2')]" />
+    </function>
+
 </odoo>

--- a/l10n_br_purchase/demo/product.xml
+++ b/l10n_br_purchase/demo/product.xml
@@ -10,4 +10,9 @@
         <field name="purchase_method">purchase</field>
     </record>
 
+    <!-- Serviço -->
+    <record id="l10n_br_fiscal.customized_development_sale" model="product.product">
+        <field name="purchase_method">purchase</field>
+    </record>
+
 </odoo>

--- a/l10n_br_purchase/tests/test_l10n_br_purchase.py
+++ b/l10n_br_purchase/tests/test_l10n_br_purchase.py
@@ -533,3 +533,40 @@ class L10nBrPurchaseBaseTest(SavepointCase):
                     13.34,
                     "Unexpected value for the field Other Values in Purchase Order.",
                 )
+
+    def test_purchase_service_and_products(self):
+        """
+        Test Purchase Order with Services and Products.
+        """
+        # Caso Somente Serviços
+        po_only_service = self.env.ref("l10n_br_purchase.main_po_only_service")
+        self._run_purchase_order_onchanges(po_only_service)
+        for line in po_only_service.order_line:
+            self._run_purchase_line_onchanges(line)
+        po_only_service.with_context(tracking_disable=True).button_confirm()
+        self.assertEqual(
+            po_only_service.state, "purchase", "Error to confirm Purchase Order."
+        )
+        po_only_service.action_create_invoice()
+        for invoice in po_only_service.invoice_ids:
+            # Caso Internacional não deve ter Documento Fiscal associado
+            self.assertTrue(
+                invoice.fiscal_document_id,
+                "Fiscal Document missing for Purchase with only Service.",
+            )
+
+        # Caso Serviços e Produtos
+        po_service_product = self.env.ref("l10n_br_purchase.main_po_service_product")
+        self._run_purchase_order_onchanges(po_service_product)
+        for line in po_service_product.order_line:
+            self._run_purchase_line_onchanges(line)
+        po_service_product.with_context(tracking_disable=True).button_confirm()
+        self.assertEqual(
+            po_service_product.state, "purchase", "Error to confirm Purchase Order."
+        )
+        po_service_product.action_create_invoice()
+        for invoice in po_service_product.invoice_ids:
+            self.assertTrue(
+                invoice.fiscal_document_id,
+                "Fiscal Document missing for Purchase with Service and Product.",
+            )


### PR DESCRIPTION
 Included Demo Data and Tests for Purchase Order with Services.

Inclusão de Dados de Demonstração e Testes para o caso de Pedido de Compras com Serviço, eu fiz isso no PR https://github.com/OCA/l10n-brazil/pull/2711 no modulo l10n_br_purchase_stock porém acredito que é melhor já incluir no l10n_br_purchase a alteração da "Politica de Compra" para "Solicitadas" do produto "Desenvolvimento Odoo" por ser um Serviço e criando dois Pedido de Compras um apenas serviço e outro com serviço e produto, inclui testes simples apenas para confirmar que nesse caso não tem um erro.

cc @renatonlima @rvalyi @marcelsavegnago @mileo 