### PR TITLE
[14.0][REF] l10n_br_base, l10n_br_fiscal_closing: A TAG external_dependecies no manifest torna desnecessário o TRY ao importar uma biblioteca

### DIFF
--- a/l10n_br_base/tests/test_amount_to_text.py
+++ b/l10n_br_base/tests/test_amount_to_text.py
@@ -2,16 +2,9 @@
 #   Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-import logging
+from num2words.lang_PT_BR import Num2Word_PT_BR
 
 from odoo.tests import SavepointCase
-
-_logger = logging.getLogger(__name__)
-
-try:
-    from num2words.lang_PT_BR import Num2Word_PT_BR
-except ImportError:
-    _logger.info("Biblioteca Num2Words não instalada")
 
 
 class Num2WordsPTBRTest(SavepointCase):

--- a/l10n_br_fiscal_closing/__manifest__.py
+++ b/l10n_br_fiscal_closing/__manifest__.py
@@ -16,5 +16,9 @@
         "security/ir.model.access.csv",
         "views/closing.xml",
     ],
-    "demo": [],
+    "external_dependencies": {
+        "python": [
+            "erpbrasil.base>=2.3.0",
+        ]
+    },
 }

--- a/l10n_br_fiscal_closing/models/closing.py
+++ b/l10n_br_fiscal_closing/models/closing.py
@@ -12,6 +12,8 @@ import tempfile
 import zipfile
 from datetime import datetime
 
+from erpbrasil.base import misc
+
 from odoo import _, api, fields, models
 from odoo.exceptions import RedirectWarning
 
@@ -32,11 +34,6 @@ from odoo.addons.l10n_br_fiscal.constants.fiscal import (
 )
 
 _logger = logging.getLogger(__name__)
-
-try:
-    from erpbrasil.base import misc
-except ImportError:
-    _logger.error("Library erpbrasil.base not installed!")
 
 PATH_MODELO = {
     MODELO_FISCAL_NFE: "nfe",


### PR DESCRIPTION
External dependecies in manifest file replace try import.

A TAG external_dependecies no manifest torna desnecessário o TRY ao importar um biblioteca, PR simples que não deve afetar o código eu já havia feito um outro PR https://github.com/OCA/l10n-brazil/pull/2744 mas faltaram dois arquivos, pelo o que vi devem ser os últimos

$ grep -rn 'except ImportError:' --include=\*.py . --color=always
./l10n_br_base/tests/test_amount_to_text.py:13:except ImportError:
./l10n_br_fiscal_closing/models/closing.py:38:except ImportError:

cc @rvalyi @renatonlima @marcelsavegnago @mileo 