### PR TITLE
[14.0][FIX+IMP] l10n_br_purchase_stock: Método para criar Linhas de Compras mudou de objeto e incluído testes para Stock Orderpoint, Stock Rule 

### DIFF
--- a/l10n_br_purchase_stock/models/purchase_order_line.py
+++ b/l10n_br_purchase_stock/models/purchase_order_line.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2012  Raphaël Valyi - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import models
+from odoo import api, models
 
 
 class PurchaseOrderLine(models.Model):
@@ -19,3 +19,18 @@ class PurchaseOrderLine(models.Model):
             if self.env.company.purchase_create_invoice_policy == "stock_picking":
                 v["invoice_state"] = "2binvoiced"
         return values
+
+    @api.model
+    def _prepare_purchase_order_line_from_procurement(
+        self, product_id, product_qty, product_uom, company_id, values, po
+    ):
+        res = super()._prepare_purchase_order_line_from_procurement(
+            product_id, product_qty, product_uom, company_id, values, po
+        )
+        if values.get("move_dest_ids"):
+            for move in values.get("move_dest_ids"):
+                move.fiscal_operation_id = (
+                    move.fiscal_operation_id.inverse_fiscal_operation_id.id
+                )
+
+        return res

--- a/l10n_br_purchase_stock/models/stock_rule.py
+++ b/l10n_br_purchase_stock/models/stock_rule.py
@@ -15,25 +15,11 @@ class StockRule(models.Model):
                 [("origin", "=", procurement.origin), ("state", "=", "draft")]
             )
             for purchase in purchases:
-                for line in purchase.order_line:
-                    price_unit = line.price_unit
-                    line._onchange_product_id_fiscal()
-                    line.price_unit = price_unit
-                    line._onchange_fiscal_operation_id()
-                    line._onchange_fiscal_operation_line_id()
+                if purchase.fiscal_operation_id:
+                    for line in purchase.order_line:
+                        price_unit = line.price_unit
+                        line._onchange_product_id_fiscal()
+                        line.price_unit = price_unit
+                        line._onchange_fiscal_operation_id()
+                        line._onchange_fiscal_operation_line_id()
         return result
-
-    def _prepare_purchase_order_line(
-        self, product_id, product_qty, product_uom, values, po, partner
-    ):
-        values = super()._prepare_purchase_order_line(
-            product_id, product_qty, product_uom, values, po, partner
-        )
-        if values.get("move_dest_ids"):
-            move_ids = [mv[1] for mv in values.get("move_dest_ids")]
-            moves = self.env["stock.move"].browse(move_ids)
-            for m in moves:
-                values[
-                    "fiscal_operation_id"
-                ] = m.fiscal_operation_id.inverse_fiscal_operation_id.id
-        return values

--- a/l10n_br_purchase_stock/tests/__init__.py
+++ b/l10n_br_purchase_stock/tests/__init__.py
@@ -1,5 +1,4 @@
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-
 from . import test_l10n_br_purchase_stock
 from . import test_l10n_br_purchase_stock_sn
 from . import test_l10n_br_purchase_stock_lp
+from . import test_stock_rule

--- a/l10n_br_purchase_stock/tests/test_stock_rule.py
+++ b/l10n_br_purchase_stock/tests/test_stock_rule.py
@@ -1,0 +1,85 @@
+# Copyright (C) 2023-Today - Akretion (<http://www.akretion.com>).
+# @author Magno Costa <magno.costa@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import TransactionCase
+
+
+class StockRuleTest(TransactionCase):
+    """Test Stock Rule"""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+    def test_stock_rule_purchase(self):
+        """
+        Test Stock Rule related to Purchase
+        """
+        warehouse_1 = self.env["stock.warehouse"].search(
+            [("company_id", "=", self.env.user.id)], limit=1
+        )
+        warehouse_1 = warehouse_1.write({"reception_steps": "two_steps"})
+        self.env.ref("purchase_stock.route_warehouse0_buy")
+        orderpoint = self.env["stock.warehouse.orderpoint"].create(
+            {
+                "product_id": self.env.ref("product.product_product_12").id,
+                "product_min_qty": 100.0,
+            }
+        )
+
+        # Run scheduler
+        self.env["procurement.group"].run_scheduler()
+
+        orderpoint.action_replenish()
+        orderpoint.action_replenish_auto()
+        po_line = self.env["purchase.order.line"].search(
+            [("orderpoint_id", "=", orderpoint.id)]
+        )
+        self.assertTrue(po_line.fiscal_operation_id, "Missing Fiscal Operation.")
+        po_line._onchange_fiscal_operation_id()
+        po_line._onchange_fiscal_operation_line_id()
+        self.assertTrue(
+            po_line.fiscal_operation_line_id,
+            "Missing Fiscal Operation Line in Purchase Order.",
+        )
+        po_order = po_line.order_id
+        self.assertTrue(
+            po_order.fiscal_operation_id, "Missing Fiscal Operation in Purchase Order."
+        )
+        po_order.button_confirm()
+        picking = po_order.picking_ids
+        self.assertTrue(
+            picking.fiscal_operation_id, "Missing Fiscal Operation in Picking."
+        )
+        for line in picking.move_lines:
+            self.assertEqual(line.invoice_state, "2binvoiced")
+            # Valida presença dos campos principais para o mapeamento Fiscal
+            line._onchange_fiscal_operation_id()
+            line._onchange_fiscal_operation_line_id()
+            self.assertTrue(
+                line.fiscal_operation_id, "Missing Fiscal Operation in Stock Move."
+            )
+
+            self.assertTrue(
+                line.fiscal_operation_line_id,
+                "Missing Fiscal Operation Line in Stock Move.",
+            )
+
+        picking.action_confirm()
+        # Necessario para testar
+        # l10n_br_purchase_stock/models/stock_rule.py  Linhas 18-23
+        product_mto = self.env.ref("product.product_product_16")
+        product_mto.route_ids |= self.env.ref("stock.route_warehouse0_mto")
+        orderpoint_2 = self.env["stock.warehouse.orderpoint"].create(
+            {
+                "product_id": product_mto.id,
+                "product_min_qty": 150.0,
+                "route_id": self.env.ref("stock.route_warehouse0_mto").id,
+            }
+        )
+
+        # Run scheduler
+        self.env["procurement.group"].run_scheduler()
+        orderpoint_2.action_replenish()
+        orderpoint_2.action_replenish_auto()


### PR DESCRIPTION
Fix method to get Purchase Line values has being moved from stock.rule objetct to purchase.order.line and included tests for stock rule procurements creation.

Método para criar Linhas de Compras mudou de objeto antes estava no stock.rule porém passou para o purchase.order.line https://github.com/OCA/OCB/blob/14.0/addons/purchase_stock/models/stock_rule.py#L141 acredito que isso acabou passando por não haver testes por isso estou incluindo testes que criam um Stock Orderpoint que deve gerar um Pedido de Compra e no caso do Armazém com Dois Passos gera um Picking.

cc @renatonlima @rvalyi @marcelsavegnago @mileo 