### PR TITLE
[14.0][FIX] l10n_br_nfse_*: call super in override methods

### DIFF
--- a/l10n_br_nfse_ginfes/models/document.py
+++ b/l10n_br_nfse_ginfes/models/document.py
@@ -262,7 +262,8 @@ class Document(models.Model):
             return status
 
     def _document_status(self):
-        for record in self.filtered(filter_oca_nfse):
+        status = super()._document_status()
+        for record in self.filtered(filter_oca_nfse).filtered(filter_ginfes):
             processador = record._processador_erpbrasil_nfse()
             processo = processador.consulta_nfse_rps(
                 rps_number=int(record.rps_number),
@@ -270,7 +271,7 @@ class Document(models.Model):
                 rps_type=int(record.rps_type),
             )
 
-            return _(
+            status = _(
                 processador.analisa_retorno_consulta(
                     processo,
                     record.document_number,
@@ -278,6 +279,7 @@ class Document(models.Model):
                     record.company_legal_name,
                 )
             )
+        return status
 
     @staticmethod
     def _get_protocolo(record, processador, vals):

--- a/l10n_br_nfse_paulistana/models/document.py
+++ b/l10n_br_nfse_paulistana/models/document.py
@@ -382,6 +382,7 @@ class Document(models.Model):
         return
 
     def _document_status(self):
+        status = super()._document_status()
         for record in self.filtered(filter_oca_nfse).filtered(filter_paulistana):
             processador = record._processador_erpbrasil_nfse()
             processo = processador.consulta_nfse_rps(
@@ -409,7 +410,8 @@ class Document(models.Model):
                     protocol_number=record.authorization_protocol,
                     file_response_xml=processo.retorno,
                 )
-            return _(consulta)
+            status = _(consulta)
+        return status
 
     def cancel_document_paulistana(self):
         def doc_dict(record):


### PR DESCRIPTION
A implementação do método `_document_status` nos módulos `l10n_br_nfse_ginfes` e `l10n_br_nfse_paulistana` não estava invocando o método `super()`, o que estava resultando na interrupção da execução desse método em outros módulos 

No caso do ginfes foi feito a correçao do filtro também, para que a lógica não seja executada para notas de outros provedores.

cc @marcelsavegnago 