### PR TITLE
[14.0][l10n_br_nfe] Não criar supplierinfo em importação de notas de saída

### DIFF
--- a/l10n_br_nfe/wizards/import_document.py
+++ b/l10n_br_nfe/wizards/import_document.py
@@ -55,7 +55,7 @@ class NfeImport(models.TransientModel):
         self.partner_id = self.env["res.partner"].search(
             [
                 "|",
-                ("cnpj_cpf", "=", document.cnpj_cpf_emitente),
+                ("cnpj_cpf", "=", infNFe.emit.CNPJ),
                 ("nfe40_xNome", "=", infNFe.emit.xNome),
             ],
             limit=1,
@@ -222,7 +222,9 @@ class NfeImport(models.TransientModel):
             self.partner_id = edoc.partner_id
 
         self._attach_original_nfe_xml_to_document(edoc)
-        self.imported_products_ids._find_or_create_product_supplierinfo()
+
+        if self.fiscal_operation_type == "in":
+            self.imported_products_ids._find_or_create_product_supplierinfo()
 
         return edoc
 


### PR DESCRIPTION
Checa se a nota sendo importada é de entrada ou saída antes de criar um registro na tabela product.supplierinfo.

Além disso troca o campo de cpf/cnpj utilizado para busca do res.partner, pois este campo já vem apenas com os caracteres numéricos.