### PR TITLE
[14.0][l10n_br_base][REF] fix onchange

### DIFF
--- a/l10n_br_base/models/res_company.py
+++ b/l10n_br_base/models/res_company.py
@@ -144,8 +144,8 @@ class Company(models.Model):
 
     @api.onchange("state_id")
     def _onchange_state_id(self):
-        for record in self:
-            super()._onchange_state_id()
-            record.inscr_est = False
-            record.partner_id.inscr_est = False
-            record.partner_id.state_id = record.state_id
+        res = super()._onchange_state_id()
+        self.inscr_est = False
+        self.partner_id.inscr_est = False
+        self.partner_id.state_id = self.state_id
+        return res

--- a/l10n_br_base/tools.py
+++ b/l10n_br_base/tools.py
@@ -35,8 +35,10 @@ def check_ie(env, inscr_est, state, country):
 
                     if not ie.validar(state.code.lower(), inscr_est):
                         raise ValidationError(
-                            _("Estadual Inscription {} Invalid for State {}!").format(
-                                inscr_est, state.name
+                            _(
+                                "Estadual Inscription %(inscr)s Invalid for State %(state)s!",
+                                inscr=inscr_est,
+                                state=state.name,
                             )
                         )
 
@@ -70,5 +72,9 @@ def check_cnpj_cpf(env, cnpj_cpf_value, country):
                         document = "CNPJ"
 
                     raise ValidationError(
-                        _("{} {} Invalid!").format(document, cnpj_cpf_value)
+                        _(
+                            "%(d_type)s %(d_id)s is invalid!",
+                            d_type=document,
+                            d_id=cnpj_cpf_value,
+                        )
                     )


### PR DESCRIPTION
o onchange do state_id tava zoado. @api.onchange é algo que se aplica num registro unico. Por sorte o loop funcionava, mas não era legal. chamar o super sem retornar o valor era algo que blocava o pre-commit na v15. Na verdade isso é um backport desse PR https://github.com/OCA/l10n-brazil/pull/2792

edit: aproveitei e fiz o backport do outro commit de fix de pre-commit da v15.