### PR TITLE
[14.0][IMP] l10n_br_nfe: Exporta os campos de desoneração do ICMS caso existam

### DIFF
--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -445,6 +445,14 @@ class NFeLine(spec_models.StackedModel):
                     "vFCPST": str("%.02f" % self.icmsfcpst_value),
                 }
             )
+        if self.icms_relief_id:
+            icms.update(
+                {
+                    # DESONERAÇÃO DO IMCS
+                    "vICMSDeson": str("%.02f" % self.icms_relief_value),
+                    "motDesICMS": self.icms_relief_id.code,
+                }
+            )
         return icms
 
     def _export_fields_nfe_40_icms(self, xsd_fields, class_obj, export_dict):


### PR DESCRIPTION
Apesar de conseguir importar esse campo com a funcionalidade de importação da nota, não estava sendo possível exportar esse mesmo valor caso ele tenha sido preenchido na visão. Esse PR apenas faz esse processo de exportação das tags corretas para a desoneração do ICMS caso o motivo tenha sido preenchido.

cc: @mileo @luismalta @hirokibastos @rvalyi @marcelsavegnago @antoniospneto 