### PR TITLE
[14.0][l10n_br_account] pre-commit fixes - backport

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -131,9 +131,10 @@ class AccountMove(models.Model):
         field as required.
         """
         with InheritsCheckMuteLogger("odoo.models"):  # mute spurious warnings
-            super()._inherits_check()
+            res = super()._inherits_check()
         field = self._fields.get("fiscal_document_id")
         field.required = False  # unset the required = True assignement
+        return res
 
     @api.model
     def _shadowed_fields(self):
@@ -597,9 +598,8 @@ class AccountMove(models.Model):
                     raise UserError(
                         _(
                             """Line without Return Fiscal Operation! \n
-                            Please force one! \n{}""".format(
-                                line.name
-                            )
+                            Please force one! \n%(name)s""",
+                            name=line.name,
                         )
                     )
 

--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -140,9 +140,10 @@ class AccountMoveLine(models.Model):
         field as required.
         """
         with InheritsCheckMuteLogger("odoo.models"):  # mute spurious warnings
-            super()._inherits_check()
+            res = super()._inherits_check()
         field = self._fields.get("fiscal_document_line_id")
         field.required = False  # unset the required = True assignement
+        return res
 
     @api.model
     def _shadowed_fields(self):

--- a/l10n_br_account/report/account_invoice_report_view.xml
+++ b/l10n_br_account/report/account_invoice_report_view.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
+<!-- pylint:disable=file-not-used -->
 <odoo>
 
     <record

--- a/l10n_br_account/tests/test_document_date.py
+++ b/l10n_br_account/tests/test_document_date.py
@@ -71,7 +71,7 @@ class TestInvoiceDiscount(SavepointCase):
 
         cls.move_id = (
             cls.env["account.move"]
-            .with_context({"check_move_validity": False})
+            .with_context(check_move_validity=False)
             .create(
                 {
                     "company_id": cls.company.id,

--- a/l10n_br_account/tests/test_move_discount.py
+++ b/l10n_br_account/tests/test_move_discount.py
@@ -64,7 +64,7 @@ class TestInvoiceDiscount(TransactionCase):
 
         self.move_id = (
             self.env["account.move"]
-            .with_context({"check_move_validity": False})
+            .with_context(check_move_validity=False)
             .create(
                 {
                     "company_id": self.company.id,

--- a/l10n_br_account/tests/test_multi_localizations_invoice.py
+++ b/l10n_br_account/tests/test_multi_localizations_invoice.py
@@ -51,11 +51,12 @@ class MultiLocalizationsInvoice(TestAccountMoveOutInvoiceOnchanges):
 
     @classmethod
     def setUpClass(cls, chart_template_ref=None):
-        super().setUpClass(chart_template_ref)
+        res = super().setUpClass(chart_template_ref)
         # FIXME the following line should not be required but as for
         # now if we don't add this group, creating a refund will result
         # in an attempt to create a l10n_br_fiscal.subsequent.document record.
         cls.env.user.groups_id |= cls.env.ref("l10n_br_fiscal.group_manager")
+        return res
 
     # The following tests list is taken with
     # cat addons/account/tests/test_account_move_out_invoice.py | grep "def test_"
@@ -67,133 +68,133 @@ class MultiLocalizationsInvoice(TestAccountMoveOutInvoiceOnchanges):
     # ideally they should made to pass for a True multi-localizations compatibility
 
     def test_force_out_invoice_onchange_invoice_date(self):
-        super().test_out_invoice_onchange_invoice_date()
+        return super().test_out_invoice_onchange_invoice_date()
 
     def test_force_out_invoice_line_onchange_product_1(self):
-        super().test_out_invoice_line_onchange_product_1()
+        return super().test_out_invoice_line_onchange_product_1()
 
     def test_force_out_invoice_line_onchange_product_2_with_fiscal_pos_1(self):
-        super().test_out_invoice_line_onchange_product_2_with_fiscal_pos_1()
+        return super().test_out_invoice_line_onchange_product_2_with_fiscal_pos_1()
 
     def test_force_out_invoice_line_onchange_product_2_with_fiscal_pos_2(self):
-        super().test_out_invoice_line_onchange_product_2_with_fiscal_pos_2()
+        return super().test_out_invoice_line_onchange_product_2_with_fiscal_pos_2()
 
     #    def test_force_out_invoice_line_onchange_business_fields_1(self):
     #        FIXME
-    #        super().test_out_invoice_line_onchange_business_fields_1()
+    #        return super().test_out_invoice_line_onchange_business_fields_1()
 
     #    def test_force_out_invoice_line_onchange_accounting_fields_1(self):
     #        FIXME this test works with most of the l10n-brazil modules
     #        but fails because of _order = "date desc, date_maturity ASC, id desc"
     #        inside l10n_br_account_payment_order/models/account_move_line.py
-    #        super().test_out_invoice_line_onchange_accounting_fields_1()
+    #        return super().test_out_invoice_line_onchange_accounting_fields_1()
 
     def test_force_out_invoice_line_onchange_partner_1(self):
-        super().test_out_invoice_line_onchange_partner_1()
+        return super().test_out_invoice_line_onchange_partner_1()
 
     def test_force_out_invoice_line_onchange_taxes_1(self):
-        super().test_out_invoice_line_onchange_taxes_1()
+        return super().test_out_invoice_line_onchange_taxes_1()
 
     def test_force_out_invoice_line_onchange_rounding_price_subtotal_1(self):
-        super().test_out_invoice_line_onchange_rounding_price_subtotal_1()
+        return super().test_out_invoice_line_onchange_rounding_price_subtotal_1()
 
     def test_force_out_invoice_line_onchange_rounding_price_subtotal_2(self):
-        super().test_out_invoice_line_onchange_rounding_price_subtotal_2()
+        return super().test_out_invoice_line_onchange_rounding_price_subtotal_2()
 
     def test_force_out_invoice_line_onchange_taxes_2_price_unit_tax_included(self):
-        super().test_out_invoice_line_onchange_taxes_2_price_unit_tax_included()
+        return super().test_out_invoice_line_onchange_taxes_2_price_unit_tax_included()
 
     def test_force_out_invoice_line_onchange_analytic(self):
-        super().test_out_invoice_line_onchange_analytic()
+        return super().test_out_invoice_line_onchange_analytic()
 
     def test_force_out_invoice_line_onchange_analytic_2(self):
-        super().test_out_invoice_line_onchange_analytic_2()
+        return super().test_out_invoice_line_onchange_analytic_2()
 
     def test_force_out_invoice_line_onchange_cash_rounding_1(self):
-        super().test_out_invoice_line_onchange_cash_rounding_1()
+        return super().test_out_invoice_line_onchange_cash_rounding_1()
 
     def test_force_out_invoice_line_onchange_currency_1(self):
-        super().test_out_invoice_line_onchange_currency_1()
+        return super().test_out_invoice_line_onchange_currency_1()
 
     #    def test_force_out_invoice_line_tax_fixed_price_include_free_product(self):
     #        FIXME
-    #        super().test_out_invoice_line_tax_fixed_price_include_free_product()
+    #        return super().test_out_invoice_line_tax_fixed_price_include_free_product()
 
     #    def test_force_out_invoice_line_taxes_fixed_price_include_free_product(self):
     #        FIXME
-    #        super().test_out_invoice_line_taxes_fixed_price_include_free_product()
+    #        return super().test_out_invoice_line_taxes_fixed_price_include_free_product()
 
     def test_force_out_invoice_create_refund(self):
-        super().test_out_invoice_create_refund()
+        return super().test_out_invoice_create_refund()
 
     def test_force_out_invoice_create_refund_multi_currency(self):
-        super().test_out_invoice_create_refund_multi_currency()
+        return super().test_out_invoice_create_refund_multi_currency()
 
     def test_force_out_invoice_create_refund_auto_post(self):
-        super().test_out_invoice_create_refund_auto_post()
+        return super().test_out_invoice_create_refund_auto_post()
 
     def test_force_out_invoice_create_1(self):
-        super().test_out_invoice_create_1()
+        return super().test_out_invoice_create_1()
 
     def test_force_out_invoice_create_child_partner(self):
-        super().test_out_invoice_create_child_partner()
+        return super().test_out_invoice_create_child_partner()
 
     def test_force_out_invoice_write_1(self):
-        super().test_out_invoice_write_1()
+        return super().test_out_invoice_write_1()
 
     def test_force_out_invoice_write_2(self):
-        super().test_out_invoice_write_2()
+        return super().test_out_invoice_write_2()
 
     def test_force_out_invoice_post_1(self):
-        super().test_out_invoice_post_1()
+        return super().test_out_invoice_post_1()
 
     def test_force_out_invoice_post_2(self):
-        super().test_out_invoice_post_2()
+        return super().test_out_invoice_post_2()
 
     def test_force_out_invoice_switch_out_refund_1(self):
-        super().test_out_invoice_switch_out_refund_1()
+        return super().test_out_invoice_switch_out_refund_1()
 
     def test_force_out_invoice_switch_out_refund_2(self):
-        super().test_out_invoice_switch_out_refund_2()
+        return super().test_out_invoice_switch_out_refund_2()
 
     def test_force_out_invoice_reverse_move_tags(self):
-        super().test_out_invoice_reverse_move_tags()
+        return super().test_out_invoice_reverse_move_tags()
 
     def test_force_out_invoice_change_period_accrual_1(self):
-        super().test_out_invoice_change_period_accrual_1()
+        return super().test_out_invoice_change_period_accrual_1()
 
     def test_force_out_invoice_multi_date_change_period_accrual(self):
-        super().test_out_invoice_multi_date_change_period_accrual()
+        return super().test_out_invoice_multi_date_change_period_accrual()
 
     def test_force_out_invoice_filter_zero_balance_lines(self):
-        super().test_out_invoice_filter_zero_balance_lines()
+        return super().test_out_invoice_filter_zero_balance_lines()
 
     def test_force_out_invoice_recomputation_receivable_lines(self):
-        super().test_out_invoice_recomputation_receivable_lines()
+        return super().test_out_invoice_recomputation_receivable_lines()
 
     def test_force_out_invoice_rounding_recomputation_receivable_lines(self):
-        super().test_out_invoice_rounding_recomputation_receivable_lines()
+        return super().test_out_invoice_rounding_recomputation_receivable_lines()
 
     def test_force_out_invoice_multi_company(self):
-        super().test_out_invoice_multi_company()
+        return super().test_out_invoice_multi_company()
 
     def test_force_out_invoice_multiple_switch_payment_terms(self):
-        super().test_out_invoice_multiple_switch_payment_terms()
+        return super().test_out_invoice_multiple_switch_payment_terms()
 
     def test_force_out_invoice_copy_custom_date(self):
-        super().test_out_invoice_copy_custom_date()
+        return super().test_out_invoice_copy_custom_date()
 
     def test_force_select_specific_product_account(self):
-        super().test_select_specific_product_account()
+        return super().test_select_specific_product_account()
 
     def test_force_out_invoice_note_and_tax_partner_is_set(self):
-        super().test_out_invoice_note_and_tax_partner_is_set()
+        return super().test_out_invoice_note_and_tax_partner_is_set()
 
     def test_force_out_invoice_reverse_caba(self):
-        super().test_out_invoice_reverse_caba()
+        return super().test_out_invoice_reverse_caba()
 
     def test_force_out_invoice_duplicate_currency_rate(self):
-        super().test_out_invoice_duplicate_currency_rate()
+        return super().test_out_invoice_duplicate_currency_rate()
 
     def test_force_out_invoice_depreciated_account(self):
-        super().test_out_invoice_depreciated_account()
+        return super().test_out_invoice_depreciated_account()


### PR DESCRIPTION
backport de alguns ajustes para passar o pre-commit na migração para a v15.0 aqui https://github.com/OCA/l10n-brazil/pull/2806

lembrando que fazer esses backports permite de diminuir o diff entre as duas branches e facilitar os forward e backports entre elas...