### PR TITLE
[14.0][FIX] l10n_br_pos_nfce: desabilita a emissão da fatura por padrão

### DIFF
--- a/l10n_br_pos_nfce/static/src/js/Screens/OrderManagementScreen/ControlButtons/CancelOrderButton.js
+++ b/l10n_br_pos_nfce/static/src/js/Screens/OrderManagementScreen/ControlButtons/CancelOrderButton.js
@@ -5,6 +5,7 @@ odoo.define("l10n_br_pos_cfe.CancelOrderButton", function (require) {
     const CancelOrderButton = require("l10n_br_pos.CancelOrderButton");
     const Registries = require("point_of_sale.Registries");
 
+    // eslint-disable-next-line no-shadow
     const L10nBrPosNFCeCancelOrderButton = (CancelOrderButton) =>
         class extends CancelOrderButton {
             async _onClick() {

--- a/l10n_br_pos_nfce/static/src/js/Screens/ReceiptScreen/ReceiptScreen.js
+++ b/l10n_br_pos_nfce/static/src/js/Screens/ReceiptScreen/ReceiptScreen.js
@@ -17,11 +17,21 @@ odoo.define("l10n_br_pos_nfce.ReceiptScreen", function (require) {
         class extends _ReceiptScreen {
             constructor() {
                 super(...arguments);
-                if (this.currentOrder.document_type === "65") {
+                if (
+                    this.currentOrder.document_type === "65" &&
+                    this.currentOrder.to_invoice
+                ) {
                     this.orderReceipt = useRef("nfce-order-receipt");
                 } else {
                     this.orderReceipt = useRef("order-receipt");
                 }
+            }
+
+            checkNFCeType() {
+                return (
+                    this.currentOrder.document_type === "65" &&
+                    this.currentOrder.to_invoice
+                );
             }
         };
 

--- a/l10n_br_pos_nfce/static/src/js/models.js
+++ b/l10n_br_pos_nfce/static/src/js/models.js
@@ -44,13 +44,6 @@ odoo.define("l10n_br_pos_nfce.models", function (require) {
 
     var _super_order = models.Order.prototype;
     models.Order = models.Order.extend({
-        initialize: function (attributes, options) {
-            _super_order.initialize.apply(this, arguments, options);
-            if (this.document_type === "65") {
-                this.to_invoice = true;
-            }
-        },
-
         async document_send(component) {
             if (this.document_type !== "65") {
                 return _super_order.document_send.apply(this, arguments);

--- a/l10n_br_pos_nfce/static/src/js/nfe-xml.js
+++ b/l10n_br_pos_nfce/static/src/js/nfe-xml.js
@@ -391,11 +391,11 @@ odoo.define("l10n_br_pos_nfce.nfe-xml", function (require) {
         }
 
         getUOMCode(product) {
-            return this.pos.uoms.find((uom) => {
-                if (uom.id === product.uom_id[0]) {
-                    return uom.code;
-                }
+            const foundUOM = this.pos.uoms.find((uom) => {
+                return uom.id === product.uom_id[0];
             });
+
+            return foundUOM ? foundUOM.code : undefined;
         }
 
         mountICMSTag(line) {
@@ -452,6 +452,10 @@ odoo.define("l10n_br_pos_nfce.nfe-xml", function (require) {
                         },
                     };
                 case "51":
+                    /**
+                     * FIXME: Verificar e corrigir os campos em que estão sendo
+                     *  definidos valores fixos.
+                     */
                     return {
                         ICMS51: {
                             orig: icms_origin,
@@ -460,9 +464,9 @@ odoo.define("l10n_br_pos_nfce.nfe-xml", function (require) {
                             pRedBC: taxes.icms_reduction.toFixed(4),
                             vBC: taxes.icms_base.toFixed(2),
                             pICMS: taxes.icms_percent.toFixed(4),
-                            vICMSOp: "0.00", // FIXME
-                            pDif: "0.0000", // FIXME
-                            vICMSDif: "0.00", // FIXME
+                            vICMSOp: "0.00",
+                            pDif: "0.0000",
+                            vICMSDif: "0.00",
                             vICMS: taxes.icms_value.toFixed(2),
                         },
                     };

--- a/l10n_br_pos_nfce/static/src/js/utils.js
+++ b/l10n_br_pos_nfce/static/src/js/utils.js
@@ -62,6 +62,8 @@ odoo.define("l10n_br_pos_nfce.utils", function (require) {
             codigoAleatorio = false,
             validar = false
         ) {
+            // FIXME: Alterar a verificação condicional
+            // eslint-disable-next-line no-negated-condition
             if (!chave) {
                 if (
                     !(
@@ -89,11 +91,12 @@ odoo.define("l10n_br_pos_nfce.utils", function (require) {
                 campos += numeroDocumento.toString().padStart(9, "0");
                 campos += formaEmissao.toString().padStart(1, "0");
 
+                let aleatorio = "";
                 if (!codigoAleatorio) {
-                    codigoAleatorio = this.calculoCodigoAleatorio(campos);
+                    aleatorio = this.calculoCodigoAleatorio(campos);
                 }
 
-                campos += codigoAleatorio.toString().padStart(8, "0");
+                campos += aleatorio.toString().padStart(8, "0");
                 campos += modulo11(campos).toString();
 
                 this.modeloDocumento = parseInt(
@@ -144,6 +147,9 @@ odoo.define("l10n_br_pos_nfce.utils", function (require) {
             return this._generatedChave;
         }
 
+        // FIXME: Alterar a classe para que o nome do campo não seja o mesmo
+        //  da função.
+        // eslint-disable-next-line accessor-pairs
         set chaveGerada(textChave) {
             this._generatedChave = textChave;
         }

--- a/l10n_br_pos_nfce/static/src/xml/Screens/ReceiptScreen/ReceiptScreen.xml
+++ b/l10n_br_pos_nfce/static/src/xml/Screens/ReceiptScreen/ReceiptScreen.xml
@@ -2,14 +2,14 @@
 <templates id="template" xml:space="preserve">
     <t t-inherit="point_of_sale.ReceiptScreen" t-inherit-mode="extension" owl="1">
         <xpath expr="//div[hasclass('pos-receipt-container')]" position="replace">
-            <t t-if="currentOrder.document_type === '59'">
-                <div class="pos-receipt-container">
-                    <OrderReceipt order="currentOrder" t-ref="order-receipt" />
-                </div>
-            </t>
-            <t t-if="currentOrder.document_type === '65'">
+            <t t-if="checkNFCeType()">
                 <div class="pos-receipt-container-nfce">
                     <NFCeOrderReceipt order="currentOrder" t-ref="nfce-order-receipt" />
+                </div>
+            </t>
+            <t t-else="">
+                <div class="pos-receipt-container">
+                    <OrderReceipt order="currentOrder" t-ref="order-receipt" />
                 </div>
             </t>
         </xpath>


### PR DESCRIPTION
Na versão anterior do código, a fatura era sempre emitida por padrão. No entanto, agora, isso não é verdadeiro. No Odoo, que por padrão já deixa a opção de escolha, a opção padrão é definida como falso, portanto só voltei ao fluxo normal. A responsabilidade de escolher essa opção fica a cargo do usuário.

Além disso, se a fatura não for emitida, o cupom fiscal padrão do Odoo será impresso.

Também resolvi os warnings do pre-commit relacionados a este módulo.

cc: @luismalta @mileo @rvalyi @DiegoParadeda 