### PR TITLE
[14.0][FIX] l10n_br_purchase: fix product_id and product_uom attributes on form view

### DIFF
--- a/l10n_br_purchase/views/purchase_view.xml
+++ b/l10n_br_purchase/views/purchase_view.xml
@@ -55,6 +55,27 @@
                   </group>
               </xpath>
               <xpath
+                expr="//field[@name='order_line']/form//field[@name='product_id']"
+                position="attributes"
+            >
+                <attribute name="attrs">{
+                    'readonly': [('id', '!=', False),('state', 'in', ('purchase', 'to approve','done', 'cancel'))],
+                    'required': [('display_type', '=', False)],
+                }</attribute>
+                <attribute name="context">{
+                    'partner_id':parent.partner_id, 'quantity':product_qty,'uom':product_uom, 'company_id': parent.company_id
+                }</attribute>
+              </xpath>
+              <xpath
+                expr="//field[@name='order_line']/form//field[@name='product_uom']"
+                position="attributes"
+            >
+                <attribute name="attrs">{
+                    'readonly': [('id', '!=', False),('state', 'in', ('purchase', 'done', 'cancel'))],
+                    'required': [('display_type', '=', False)]
+                }</attribute>
+              </xpath>
+              <xpath
                 expr="//field[@name='order_line']/form//field[@name='taxes_id']"
                 position="replace"
             >


### PR DESCRIPTION
ref: #2811 

Esta alteração se faz necessária já que na visão form nativa do purchase não é a mesma que a visão tree.

tree: https://github.com/odoo/odoo/blob/68d54118c518887e4c132d8a1bff10d12145d1a6/addons/purchase/views/purchase_views.xml#L227

form: https://github.com/odoo/odoo/blob/68d54118c518887e4c132d8a1bff10d12145d1a6/addons/purchase/views/purchase_views.xml#L262
