### PR TITLE
[14.0][l10n_br_account][REM] partner_shipping_id is not a shadowed field anymore

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -48,13 +48,7 @@ MOVE_TAX_USER_TYPE = {
     "in_refund": "purchase",
 }
 
-SHADOWED_FIELDS = [
-    "partner_id",
-    "company_id",
-    "currency_id",
-    "partner_shipping_id",
-    "user_id",
-]
+SHADOWED_FIELDS = ["company_id", "currency_id", "user_id", "partner_id"]
 
 
 class InheritsCheckMuteLogger(mute_logger):

--- a/l10n_br_account/models/fiscal_document.py
+++ b/l10n_br_account/models/fiscal_document.py
@@ -41,11 +41,6 @@ class FiscalDocument(models.Model):
         related="currency_id",
         readonly=False,
     )
-    fiscal_partner_shipping_id = fields.Many2one(
-        string="Fiscal Partner Shipping",
-        related="partner_shipping_id",
-        readonly=False,
-    )
     fiscal_user_id = fields.Many2one(
         string="Fiscal User",
         related="user_id",

--- a/l10n_br_sale/models/__init__.py
+++ b/l10n_br_sale/models/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2015  Renato Lima - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+from . import account_move
+from . import fiscal_document
 from . import res_company
 from . import res_config_settings
 from . import sale_order

--- a/l10n_br_sale/models/account_move.py
+++ b/l10n_br_sale/models/account_move.py
@@ -1,0 +1,12 @@
+# Copyright 2023 Akretion (Raphaël Valyi <raphael.valyi@akretion.com>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    @api.model
+    def _shadowed_fields(self):
+        return super()._shadowed_fields() + ["partner_shipping_id"]

--- a/l10n_br_sale/models/fiscal_document.py
+++ b/l10n_br_sale/models/fiscal_document.py
@@ -1,0 +1,17 @@
+# Copyright 2023 Akretion (Raphaël Valyi <raphael.valyi@akretion.com>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class FiscalDocument(models.Model):
+    _inherit = "l10n_br_fiscal.document"
+
+    # proxy field used to handle partner_shipping_id
+    # in l10n_br_fiscal.document while the sale module
+    # also brings a partner_shipping_id field to account.move.
+    fiscal_partner_shipping_id = fields.Many2one(
+        string="Fiscal Partner Shipping",
+        related="partner_shipping_id",
+        readonly=False,
+    )


### PR DESCRIPTION
na versão 14.0, o campo partner_shipping_id não esta mais nativo do modulo account e portanto não tem mais um "conflito" com o campo partner_shipping_id do modulo l10n_br_fiscal, ou seja não é mais um SHADOWED_FIELDS.

Alem de tirar ele do SHADOWED_FIELDS eu ordenei a lista SHADOWED_FIELDS pela ordem no qual vc preencheria se vc for preencher um account.move pela interface. Pois em vez de ter uma ordem aleatoria como antes, é melhor carregar essa informação, pois pode ser util, como por examplo na hora de importar uma NFe, pois é a ordem que tem que chamar os onchanges. Como eu ja falei futuramente a gente podera usar menos os onchanges e mais os computes, porem o modulo account na v14 ainda esta muito movido a onchange e precisamos dessa informação por examplo para importar as NFe's.

Esse refator na verdade foi extraido do meu PR de importação de NFe aqui: https://github.com/OCA/l10n-brazil/pull/2781 
Depois do merge irei dar um rebase nele. Esse PR tb foi inspirado em https://github.com/OCA/l10n-brazil/pull/2731