### PR TITLE
[15.0][FIX][l10n_br_currency_rate_update]: Solve Warning Deprecated class SavepointCase

### DIFF
--- a/l10n_br_currency_rate_update/tests/test_currency_rate_update_bcb.py
+++ b/l10n_br_currency_rate_update/tests/test_currency_rate_update_bcb.py
@@ -4,10 +4,10 @@
 from dateutil.relativedelta import relativedelta
 
 from odoo import fields
-from odoo.tests import SavepointCase
+from odoo.tests.common import TransactionCase
 
 
-class TestCurrencyRateUpdateBCB(SavepointCase):
+class TestCurrencyRateUpdateBCB(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()


### PR DESCRIPTION
backport trivial de https://github.com/OCA/l10n-brazil/commit/1e296588fbd1c6d0568468ccaf7faa892cb86c37 da branch 16.0 para evitar warning nos logs. Isso ajuda a monitorar melhor os logs nessa fase de migração.