### PR TITLE
[14.0][REF] l10n_br_fiscal, l10n_br_account: Cálculo e Visualização das Alíquotas Efetivas do Simples Nacional

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -448,7 +448,6 @@ class AccountMove(models.Model):
             fiscal_price=base_line.fiscal_price,
             fiscal_quantity=base_line.fiscal_quantity,
             uot_id=base_line.uot_id,
-            icmssn_range=base_line.icmssn_range_id,
             icms_origin=base_line.icms_origin,
             ind_final=base_line.ind_final,
         )

--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -387,7 +387,7 @@ class AccountMoveLine(models.Model):
                 fiscal_price=self.fiscal_price,
                 fiscal_quantity=self.fiscal_quantity,
                 uot_id=self.uot_id,
-                icmssn_range=self.icmssn_range_id,
+                cfop=self.cfop_id,
                 icms_origin=self.icms_origin,
                 ind_final=self.ind_final,
                 icms_relief_value=self.icms_relief_value,
@@ -467,7 +467,6 @@ class AccountMoveLine(models.Model):
                 fiscal_price=self.env.context.get("fiscal_price"),
                 fiscal_quantity=self.env.context.get("fiscal_quantity"),
                 uot_id=self.env.context.get("uot_id"),
-                icmssn_range=self.env.context.get("icmssn_range"),
                 icms_origin=self.env.context.get("icms_origin"),
                 ind_final=self.env.context.get("ind_final"),
             )

--- a/l10n_br_account/models/account_tax.py
+++ b/l10n_br_account/models/account_tax.py
@@ -41,7 +41,6 @@ class AccountTax(models.Model):
         fiscal_price=None,
         fiscal_quantity=None,
         uot_id=None,
-        icmssn_range=None,
         icms_origin=None,
         ind_final=FINAL_CUSTOMER_NO,
     ):
@@ -114,7 +113,6 @@ class AccountTax(models.Model):
             ii_customhouse_charges=ii_customhouse_charges,
             freight_value=freight_value,
             operation_line=operation_line,
-            icmssn_range=icmssn_range,
             icms_origin=icms_origin or product.icms_origin,
             ind_final=ind_final,
         )

--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -84,6 +84,7 @@
         "views/invalidate_number_view.xml",
         "views/city_taxation_code.xml",
         "views/operation_dashboard_view.xml",
+        "views/simplified_tax_effecitve_view.xml",
         # Actions
         "views/l10n_br_fiscal_action.xml",
         # Menus

--- a/l10n_br_fiscal/data/l10n_br_fiscal_comment_data.xml
+++ b/l10n_br_fiscal/data/l10n_br_fiscal_comment_data.xml
@@ -18,9 +18,25 @@
 
     <record id="fiscal_comment_sn_permissao_credito" model="l10n_br_fiscal.comment">
         <field name="name">Simples Nacional permissão de crédito</field>
-        <field
-            name="comment"
-        >SIMPLES NACIONAL - Documento emitido por ME ou EPP optante pelo simples nacional, não gera direito a credito fiscal de IPI. Permite o aproveitamento de crédito de ICMS no valor de ${format_amount(doc.amount_icmssn_credit_value)},  nos termos do artigo 23 da LC 123/2006.</field>
+        <field name="comment">
+SIMPLES NACIONAL - Documento emitido por ME ou EPP optante pelo simples nacional, não gera direito a credito fiscal de IPI. Permite o aproveitamento do crédito de ICMS, no valor de ${format_amount(doc.amount_icmssn_credit_value)}, correspondente à alíquota de
+%- if doc.is_sale_industry():
+%- if not doc.is_sale_commerce():
+${format_number(doc.company_id.icmssn_credit_industry)}%
+%- endif
+%- endif
+%- if doc.is_sale_commerce():
+%- if not doc.is_sale_industry():
+ ${format_number(doc.company_id.icmssn_credit_commerce)}%
+%- endif
+%- endif
+%- if doc.is_sale_industry():
+%- if doc.is_sale_commerce():
+ ${format_number(doc.company_id.icmssn_credit_industry)}% para industrialização e de ${format_number(doc.company_id.icmssn_credit_commerce)}% para revenda
+%- endif
+%- endif
+, nos termos do artigo 23 da LC 123/2006.
+        </field>
         <field name="comment_type">fiscal</field>
         <field name="object">l10n_br_fiscal.document.mixin</field>
     </record>

--- a/l10n_br_fiscal/models/__init__.py
+++ b/l10n_br_fiscal/models/__init__.py
@@ -40,6 +40,7 @@ from . import product_template
 from . import product_product
 from . import simplified_tax
 from . import simplified_tax_range
+from . import simplified_tax_effective
 from . import operation
 from . import operation_line
 from . import operation_document_type

--- a/l10n_br_fiscal/models/comment.py
+++ b/l10n_br_fiscal/models/comment.py
@@ -121,6 +121,8 @@ class Comment(models.Model):
 
         from jinja2.sandbox import SandboxedEnvironment
 
+        lang_br = self.env.ref("base.lang_pt_BR")
+
         mako_template_env = SandboxedEnvironment(
             block_start_string="<%",
             block_end_string="%>",
@@ -154,6 +156,11 @@ class Comment(models.Model):
                 "format_amount": (
                     lambda amount, context=self._context: self.format_amount(
                         self.env, amount, self.env.ref("base.BRL")
+                    )
+                ),
+                "format_number": (
+                    lambda value, format_pattern="%.2f": lang_br.format(
+                        format_pattern, value, grouping=True
                     )
                 ),
             }

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -29,7 +29,6 @@ from ..constants.fiscal import (
     TAX_DOMAIN_PIS,
     TAX_DOMAIN_PIS_ST,
     TAX_DOMAIN_PIS_WH,
-    TAX_FRAMEWORK_SIMPLES_ALL,
     TAX_ICMS_OR_ISSQN,
 )
 from ..constants.icms import (
@@ -56,21 +55,6 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     @api.model
     def _default_operation(self):
         return False
-
-    @api.model
-    def _default_icmssn_range_id(self):
-        company = self.env.company
-        stax_range_id = self.env["l10n_br_fiscal.simplified.tax.range"]
-
-        if self.env.context.get("default_company_id"):
-            company = self.env["res.company"].browse(
-                self.env.context.get("default_company_id")
-            )
-
-        if company.tax_framework in TAX_FRAMEWORK_SIMPLES_ALL:
-            stax_range_id = company.simplified_tax_range_id
-
-        return stax_range_id
 
     @api.model
     def _operation_domain(self):
@@ -490,7 +474,6 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     icmssn_range_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.simplified.tax.range",
         string="Simplified Range Tax",
-        default=_default_icmssn_range_id,
     )
 
     icmssn_tax_id = fields.Many2one(
@@ -856,12 +839,6 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     inss_wh_reduction = fields.Float(string="INSS RET % Reduction")
 
     inss_wh_value = fields.Monetary(string="INSS RET Value")
-
-    simple_value = fields.Monetary(string="National Simple Taxes")
-
-    simple_without_icms_value = fields.Monetary(
-        string="National Simple Taxes without ICMS"
-    )
 
     comment_ids = fields.Many2many(
         comodel_name="l10n_br_fiscal.comment",

--- a/l10n_br_fiscal/models/document_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_line_mixin_methods.py
@@ -210,7 +210,6 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             cest=self.cest_id,
             operation_line=self.fiscal_operation_line_id,
             cfop=self.cfop_id,
-            icmssn_range=self.icmssn_range_id,
             icms_origin=self.icms_origin,
             icms_cst_id=self.icms_cst_id,
             ind_final=self.ind_final,
@@ -593,16 +592,12 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         cst_id = tax_dict.get("cst_id").id if tax_dict.get("cst_id") else False
         icmssn_base = tax_dict.get("base", 0.0)
         icmssn_credit_value = tax_dict.get("tax_value", 0.0)
-        simple_value = icmssn_base * self.icmssn_range_id.total_tax_percent
-        simple_without_icms_value = simple_value - icmssn_credit_value
         return {
             "icms_cst_id": cst_id,
             "icmssn_base": icmssn_base,
             "icmssn_percent": tax_dict.get("percent_amount"),
             "icmssn_reduction": tax_dict.get("percent_reduction"),
             "icmssn_credit_value": icmssn_credit_value,
-            "simple_value": simple_value,
-            "simple_without_icms_value": simple_without_icms_value,
         }
 
     @api.onchange(

--- a/l10n_br_fiscal/models/document_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_mixin_methods.py
@@ -33,6 +33,14 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
         fiscal_line_ids = self._get_amount_lines()
         return fiscal_line_ids.filtered(lambda line: line.product_id.type != "service")
 
+    def is_sale_industry(self):
+        types = self.fiscal_line_ids.mapped("cfop_id").mapped("type_move")
+        return "sale_industry" in types
+
+    def is_sale_commerce(self):
+        types = self.fiscal_line_ids.mapped("cfop_id").mapped("type_move")
+        return "sale_commerce" in types
+
     @api.model
     def _get_amount_fields(self):
         """Get all fields with 'amount_' prefix"""

--- a/l10n_br_fiscal/models/res_company.py
+++ b/l10n_br_fiscal/models/res_company.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2013  Renato Lima - Akretion
 # Copyright (C) 2020  Luis Felipe Mileo - KMEE
+# Copyright (C) 2023  Antônio S. Pereira Neto - Engenere
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 import logging
@@ -41,10 +42,34 @@ _logger = logging.getLogger(__name__)
 class ResCompany(models.Model):
     _inherit = "res.company"
 
+    sn_effective_tax_ids = fields.One2many(
+        comodel_name="l10n_br_fiscal.simplified.tax.effective",
+        inverse_name="company_id",
+        string="Effective Taxs",
+        help="Simples Nacional effective tax rate for each annex,"
+        "based on the range the company currently falls into.",
+    )
+
+    icmssn_credit_industry = fields.Float(
+        string="ICMS Credit rate for Industry",
+        help="Rate referring to the icms credit allowed when it is a sale of"
+        "industrialized product in the establishment."
+        "Applicable to Simple Nacional.",
+        readonly=True,
+        compute="_compute_icmssn",
+    )
+
+    icmssn_credit_commerce = fields.Float(
+        string="ICMS Credit rate for Commerce",
+        help="Rate referring to the icms credit allowed when it is a resale"
+        "of merchandise. Applicable to Simple Nacional.",
+        readonly=True,
+        compute="_compute_icmssn",
+    )
+
     def _get_company_address_field_names(self):
         partner_fields = super()._get_company_address_field_names()
         return partner_fields + [
-            "tax_framework",
             "cnae_main_id",
         ]
 
@@ -53,57 +78,15 @@ class ResCompany(models.Model):
         for c in self:
             c.partner_id.cnae_main_id = c.cnae_main_id
 
+    @api.depends("partner_id", "partner_id.tax_framework")
+    def _compute_tax_framework(self):
+        for c in self:
+            c.tax_framework = c.partner_id.tax_framework
+
     def _inverse_tax_framework(self):
         """Write the l10n_br specific functional fields."""
         for c in self:
             c.partner_id.tax_framework = c.tax_framework
-
-    @api.depends("cnae_main_id", "annual_revenue", "payroll_amount")
-    def _compute_simplified_tax(self):
-        for record in self:
-            record.coefficient_r = False
-            if record.payroll_amount and record.annual_revenue:
-                coefficient_r_percent = record.payroll_amount / record.annual_revenue
-                if coefficient_r_percent > COEFFICIENT_R:
-                    record.coefficient_r = True
-                record.coefficient_r_percent = coefficient_r_percent
-
-            simplified_tax_id = self.env["l10n_br_fiscal.simplified.tax"].search(
-                [
-                    ("cnae_ids", "=", record.cnae_main_id.id),
-                    ("coefficient_r", "=", record.coefficient_r),
-                ]
-            )
-            record.simplified_tax_id = simplified_tax_id
-
-            if simplified_tax_id:
-                tax_range = record.env["l10n_br_fiscal.simplified.tax.range"].search(
-                    [
-                        ("simplified_tax_id", "=", simplified_tax_id.id),
-                        ("inital_revenue", "<=", record.annual_revenue),
-                        ("final_revenue", ">=", record.annual_revenue),
-                        ("simplified_tax_id.coefficient_r", "=", record.coefficient_r),
-                    ],
-                    limit=1,
-                )
-                record.simplified_tax_range_id = tax_range
-
-                if record.simplified_tax_range_id and record.annual_revenue:
-                    record.simplified_tax_percent = round(
-                        (
-                            (
-                                (
-                                    record.annual_revenue
-                                    * record.simplified_tax_range_id.total_tax_percent
-                                    / 100
-                                )
-                                - record.simplified_tax_range_id.amount_deduced
-                            )
-                            / record.annual_revenue
-                        )
-                        * 100,
-                        record.currency_id.decimal_places,
-                    )
 
     cnae_main_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.cnae",
@@ -126,8 +109,10 @@ class ResCompany(models.Model):
     tax_framework = fields.Selection(
         selection=TAX_FRAMEWORK,
         default=TAX_FRAMEWORK_NORMAL,
-        compute="_compute_address",
+        compute="_compute_tax_framework",
         inverse="_inverse_tax_framework",
+        store=True,
+        string="Tax Framework",
     )
 
     profit_calculation = fields.Selection(
@@ -147,28 +132,6 @@ class ResCompany(models.Model):
 
     annual_revenue = fields.Monetary(
         currency_field="currency_id",
-    )
-
-    simplified_tax_id = fields.Many2one(
-        comodel_name="l10n_br_fiscal.simplified.tax",
-        compute="_compute_simplified_tax",
-        string="Simplified Tax",
-        store=True,
-        readonly=True,
-    )
-
-    simplified_tax_range_id = fields.Many2one(
-        comodel_name="l10n_br_fiscal.simplified.tax.range",
-        compute="_compute_simplified_tax",
-        store=True,
-        readonly=True,
-        string="Simplified Tax Range",
-    )
-
-    simplified_tax_percent = fields.Float(
-        compute="_compute_simplified_tax",
-        store=True,
-        digits="Fiscal Tax Percent",
     )
 
     payroll_amount = fields.Monetary(
@@ -504,3 +467,57 @@ class ResCompany(models.Model):
             self._set_tax_definition(self.tax_inss_wh_id)
         else:
             self._del_tax_definition(TAX_DOMAIN_INSS_WH)
+
+    @api.depends("annual_revenue", "payroll_amount")
+    def _compute_simplified_tax(self):
+        for record in self:
+            record._calculate_coefficient_r()
+
+    def _compute_icmssn(self):
+        for rec in self:
+            rec.icmssn_credit_commerce = rec.sn_effective_tax_ids.filtered(
+                lambda t: t.simplified_tax_id.name == "Anexo 1 - Comércio"
+            ).tax_icms_percent
+            rec.icmssn_credit_industry = rec.sn_effective_tax_ids.filtered(
+                lambda t: t.simplified_tax_id.name == "Anexo 2 - Indústria"
+            ).tax_icms_percent
+
+    def _calculate_coefficient_r(self):
+        for record in self:
+            record.coefficient_r = False
+            if record.payroll_amount and record.annual_revenue:
+                coefficient_r_percent = record.payroll_amount / record.annual_revenue
+                if coefficient_r_percent > COEFFICIENT_R:
+                    record.coefficient_r = True
+                record.coefficient_r_percent = coefficient_r_percent
+
+    def update_effective_tax_lines(self):
+        for record in self:
+            simplified_tax_model = self.env["l10n_br_fiscal.simplified.tax"]
+            for simplified_id in simplified_tax_model.search([]):
+                effective_tax = record.sn_effective_tax_ids.filtered(
+                    lambda t: t.simplified_tax_id.id == simplified_id.id
+                )
+                if not effective_tax:
+                    record.sn_effective_tax_ids.create(
+                        {
+                            "simplified_tax_id": simplified_id.id,
+                            "company_id": record.id,
+                        }
+                    )
+
+    @api.model
+    def create(self, vals):
+        record = super().create(vals)
+        if vals.get("tax_framework") == TAX_FRAMEWORK_SIMPLES:
+            record.sudo().update_effective_tax_lines()
+        return record
+
+    def write(self, vals):
+        result = super().write(vals)
+        if "tax_framework" in vals:
+            if vals["tax_framework"] == TAX_FRAMEWORK_SIMPLES:
+                self.sudo().update_effective_tax_lines()
+            else:
+                self.sn_effective_tax_ids = [(5, 0, 0)]
+        return result

--- a/l10n_br_fiscal/models/simplified_tax.py
+++ b/l10n_br_fiscal/models/simplified_tax.py
@@ -1,8 +1,11 @@
 # Copyright (C) 2019  Renato Lima - Akretion
 # Copyright (C) 2020  Luis Felipe Mileo - KMEE
+# Copyright (C) 2023  Antônio S. Pereira Neto - Engenere
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import fields, models
+from odoo import api, fields, models
+
+from ..constants.fiscal import TAX_FRAMEWORK_SIMPLES
 
 
 class SimplifiedTax(models.Model):
@@ -30,3 +33,14 @@ class SimplifiedTax(models.Model):
     coefficient_r = fields.Boolean(
         readonly=True,
     )
+
+    @api.model
+    def create(self, vals):
+        """Override create for update effective tax lines in all companys"""
+        record = super().create(vals)
+        companies = self.env["res.company"].search(
+            [("tax_framework", "=", TAX_FRAMEWORK_SIMPLES)]
+        )
+        for company in companies:
+            company.update_effective_tax_lines()
+        return record

--- a/l10n_br_fiscal/models/simplified_tax.py
+++ b/l10n_br_fiscal/models/simplified_tax.py
@@ -34,13 +34,15 @@ class SimplifiedTax(models.Model):
         readonly=True,
     )
 
-    @api.model
-    def create(self, vals):
-        """Override create for update effective tax lines in all companys"""
-        record = super().create(vals)
+    @api.model_create_multi
+    def create(self, vals_list):
+        """
+        Override the create method to update the effective tax lines in all companies
+        """
+        simplified_taxes = super().create(vals_list)
         companies = self.env["res.company"].search(
             [("tax_framework", "=", TAX_FRAMEWORK_SIMPLES)]
         )
         for company in companies:
             company.update_effective_tax_lines()
-        return record
+        return simplified_taxes

--- a/l10n_br_fiscal/models/simplified_tax_effective.py
+++ b/l10n_br_fiscal/models/simplified_tax_effective.py
@@ -1,0 +1,169 @@
+# Copyright 2023 Engenere - Antônio S. Pereira Neto <neto@engenere.one>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class SimplifiedTaxEffective(models.Model):
+    _name = "l10n_br_fiscal.simplified.tax.effective"
+    _description = "Effective Tax Rate for Simples Nacional"
+
+    _sql_constraints = [
+        (
+            "sn_effective_tax_unique",
+            "unique (simplified_tax_id,company_id)",
+            "There is already an effective tax line for this "
+            "company and this Simples Nacional table",
+        )
+    ]
+
+    simplified_tax_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.simplified.tax",
+        string="Annex",
+        help="Annex Tax Table of Simples Nacional",
+        required=True,
+    )
+
+    company_id = fields.Many2one(
+        comodel_name="res.company",
+        string="Company",
+        ondelete="cascade",
+    )
+
+    current_range_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.simplified.tax.range",
+        string="Range",
+        help="Range into which the company falls based on current revenue.",
+        compute="_compute_current_range_id",
+        store=True,
+    )
+
+    current_effective_tax = fields.Float(
+        string="Tax Rate %",
+        help="Effective tax of Simples Nacional, when the activity falls"
+        "under this annex, based on the current range.",
+        digits="Fiscal Tax Percent",
+        compute="_compute_current_effective_tax",
+        store=True,
+    )
+
+    tax_icms_percent = fields.Float(
+        string="ICMS %",
+        digits="Fiscal Tax Percent",
+        compute="_compute_tax_percent",
+        store=True,
+    )
+
+    tax_cpp_percent = fields.Float(
+        string="CPP %",
+        digits="Fiscal Tax Percent",
+        compute="_compute_tax_percent",
+        store=True,
+    )
+
+    tax_csll_percent = fields.Float(
+        string="CSLL %",
+        digits="Fiscal Tax Percent",
+        compute="_compute_tax_percent",
+        store=True,
+    )
+
+    tax_ipi_percent = fields.Float(
+        string="IPI %",
+        digits="Fiscal Tax Percent",
+        compute="_compute_tax_percent",
+        store=True,
+    )
+
+    tax_iss_percent = fields.Float(
+        string="ISS %",
+        digits="Fiscal Tax Percent",
+        compute="_compute_tax_percent",
+        store=True,
+    )
+
+    tax_irpj_percent = fields.Float(
+        string="IRPJ %",
+        digits="Fiscal Tax Percent",
+        compute="_compute_tax_percent",
+        store=True,
+    )
+
+    tax_cofins_percent = fields.Float(
+        string="COFINS %",
+        digits="Fiscal Tax Percent",
+        compute="_compute_tax_percent",
+        store=True,
+    )
+
+    tax_pis_percent = fields.Float(
+        string="PIS %",
+        digits="Fiscal Tax Percent",
+        compute="_compute_tax_percent",
+        store=True,
+    )
+
+    @api.depends(
+        "current_effective_tax",
+        "current_range_id",
+        "current_range_id.tax_icms_percent",
+        "current_range_id.tax_cpp_percent",
+        "current_range_id.tax_csll_percent",
+        "current_range_id.tax_ipi_percent",
+        "current_range_id.tax_irpj_percent",
+        "current_range_id.tax_cofins_percent",
+        "current_range_id.tax_pis_percent",
+        "current_range_id.tax_iss_percent",
+    )
+    def _compute_tax_percent(self):
+        for rec in self:
+            range_id = rec.current_range_id
+            rec.tax_icms_percent = rec.calculate_tax(range_id.tax_icms_percent)
+            rec.tax_cpp_percent = rec.calculate_tax(range_id.tax_cpp_percent)
+            rec.tax_csll_percent = rec.calculate_tax(range_id.tax_csll_percent)
+            rec.tax_ipi_percent = rec.calculate_tax(range_id.tax_ipi_percent)
+            rec.tax_irpj_percent = rec.calculate_tax(range_id.tax_irpj_percent)
+            rec.tax_cofins_percent = rec.calculate_tax(range_id.tax_cofins_percent)
+            rec.tax_pis_percent = rec.calculate_tax(range_id.tax_pis_percent)
+            rec.tax_iss_percent = rec.calculate_tax(range_id.tax_iss_percent)
+
+    def calculate_tax(self, x_tax_rate):
+        self.ensure_one()
+        effective_total_tax = self.current_effective_tax
+        effective_x_tax = effective_total_tax * (x_tax_rate / 100)
+        return round(effective_x_tax, 2)
+
+    @api.depends("company_id", "company_id.annual_revenue", "current_range_id")
+    def _compute_current_effective_tax(self):
+        for record in self:
+            annual_revenue = record.company_id.annual_revenue
+            tax_range_id = record.current_range_id
+            record.current_effective_tax = 0.0
+            if not tax_range_id:
+                return
+            if annual_revenue:
+                tax = annual_revenue * tax_range_id.total_tax_percent / 100
+                tax = tax - tax_range_id.amount_deduced
+                tax = tax / annual_revenue
+                tax = tax * 100
+                record.current_effective_tax = tax
+            else:
+                record.current_effective_tax = tax_range_id.total_tax_percent
+
+    @api.depends(
+        "company_id",
+        "company_id.annual_revenue",
+        "company_id.coefficient_r",
+    )
+    def _compute_current_range_id(self):
+        for record in self:
+            company_id = record.company_id
+            tax_range = record.env["l10n_br_fiscal.simplified.tax.range"].search(
+                [
+                    ("simplified_tax_id", "=", record.simplified_tax_id.id),
+                    ("inital_revenue", "<=", company_id.annual_revenue),
+                    ("final_revenue", ">=", company_id.annual_revenue),
+                ],
+                limit=1,
+            )
+            record.current_range_id = tax_range

--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -567,9 +567,8 @@ class Tax(models.Model):
         tax_dict = taxes_dict.get(tax.tax_domain)
         partner = kwargs.get("partner")
         company = kwargs.get("company")
-        currency = kwargs.get("currency", company.currency_id)
         cst = kwargs.get("cst", self.env["l10n_br_fiscal.cst"])
-        icmssn_range = kwargs.get("icmssn_range")
+        cfop_id = kwargs.get("cfop")
 
         # Get Computed IPI Tax
         tax_dict_ipi = taxes_dict.get("ipi", {})
@@ -582,10 +581,11 @@ class Tax(models.Model):
         # Partner ICMS's Contributor
         if partner.ind_ie_dest in (NFE_IND_IE_DEST_1, NFE_IND_IE_DEST_2):
             if cst.code in ICMS_SN_CST_WITH_CREDIT:
-                icms_sn_percent = currency.round(
-                    company.simplified_tax_percent
-                    * (icmssn_range.tax_icms_percent / 100)
-                )
+                icms_sn_percent = 0.0
+                if cfop_id.type_move == "sale_commerce":
+                    icms_sn_percent = company.icmssn_credit_commerce
+                if cfop_id.type_move == "sale_industry":
+                    icms_sn_percent = company.icmssn_credit_industry
 
                 tax_dict["percent_amount"] = icms_sn_percent
                 tax_dict["value_amount"] = icms_sn_percent

--- a/l10n_br_fiscal/security/ir.model.access.csv
+++ b/l10n_br_fiscal/security/ir.model.access.csv
@@ -99,3 +99,5 @@
 "l10n_br_fiscal_city_taxation_code_manager","Fiscal City Taxation Code for Manager","model_l10n_br_fiscal_city_taxation_code","l10n_br_fiscal.group_user",1,1,1,1
 "l10n_br_fiscal_base_wizard_mixin_user",l10n_br_fiscal_base_wizard_mixin,model_l10n_br_fiscal_base_wizard_mixin,base.group_user,1,1,1,1
 "l10n_br_fiscal_document_status_wizard_user",l10n_br_fiscal_document_status_wizard,model_l10n_br_fiscal_document_status_wizard,base.group_user,1,1,1,1
+"l10n_br_fiscal_simplified_effective_tax_user","SN Effective Tax for User","model_l10n_br_fiscal_simplified_tax_effective","l10n_br_fiscal.group_user",1,1,1,0
+"l10n_br_fiscal_simplified_effective_tax_manager","SN Effective Tax for Manager","model_l10n_br_fiscal_simplified_tax_effective","l10n_br_fiscal.group_manager",1,1,1,1

--- a/l10n_br_fiscal/static/description/index.html
+++ b/l10n_br_fiscal/static/description/index.html
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -14,4 +14,5 @@ from . import (
     test_service_type,
     test_subsequent_operation,
     test_uom_uom,
+    test_icmssn,
 )

--- a/l10n_br_fiscal/tests/test_fiscal_tax.py
+++ b/l10n_br_fiscal/tests/test_fiscal_tax.py
@@ -95,7 +95,6 @@ class TestFiscalTax(SavepointCase):
             "cest": False,
             "operation_line": self.env.ref("l10n_br_fiscal.fo_venda_venda"),
             "cfop": self.env.ref("l10n_br_fiscal.cfop_6101"),
-            "icmssn_range": False,
             "icms_origin": ICMS_ORIGIN_DEFAULT,
             "ind_final": FINAL_CUSTOMER_YES,
         }

--- a/l10n_br_fiscal/tests/test_icmssn.py
+++ b/l10n_br_fiscal/tests/test_icmssn.py
@@ -1,0 +1,65 @@
+# Copyright 2023 Engenere - Antônio S. Pereira Neto <neto@engenere.one>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestNFE(TransactionCase):
+    def test_icmssn_tax_rate(self):
+        """Test to verify if the calculation of the icms credit
+        for Simples Nacional companies is correct."""
+        document_model = self.env["l10n_br_fiscal.document"]
+        document_line_model = self.env["l10n_br_fiscal.document.line"]
+        akretion_partner = self.env.ref("l10n_br_base.res_partner_address_ak3")
+        company_id = self.env.ref("l10n_br_base.empresa_simples_nacional")
+        self.env.user.company_ids += company_id
+        self.env.user.company_id = company_id
+        document = document_model.create(
+            {
+                "partner_id": akretion_partner.id,
+                "document_type_id": self.env.ref("l10n_br_fiscal.document_55").id,
+                "fiscal_operation_id": self.env.ref("l10n_br_fiscal.fo_venda").id,
+            }
+        )
+        document._onchange_fiscal_operation_id()
+        document._onchange_document_type_id()
+        document._onchange_document_serie_id()
+        # venda de industrialização própria.
+        line = document_line_model.create(
+            {
+                "document_id": document.id,
+                "company_id": document.company_id.id,
+                "partner_id": document.partner_id.id,
+                "fiscal_operation_type": document.fiscal_operation_type,
+                "fiscal_operation_id": document.fiscal_operation_id.id,
+                "product_id": self.env.ref("product.product_product_4c").id,
+            }
+        )
+        line._onchange_product_id_fiscal()
+        line.fiscal_operation_line_id = self.env.ref("l10n_br_fiscal.fo_venda_venda")
+        line._onchange_fiscal_operation_line_id()
+        # Revenda
+        line2 = document_line_model.create(
+            {
+                "document_id": document.id,
+                "company_id": document.company_id.id,
+                "partner_id": document.partner_id.id,
+                "fiscal_operation_type": document.fiscal_operation_type,
+                "fiscal_operation_id": document.fiscal_operation_id.id,
+                "product_id": self.env.ref("product.product_product_4c").id,
+            }
+        )
+        line2._onchange_product_id_fiscal()
+        line2.fiscal_operation_line_id = self.env.ref("l10n_br_fiscal.fo_venda_revenda")
+        line2._onchange_fiscal_operation_line_id()
+        document.comment_ids = [
+            (4, self.env.ref("l10n_br_fiscal.fiscal_comment_sn_permissao_credito").id)
+        ]
+        document._compute_amount()
+        document.action_document_confirm()
+        icmss_credit_info = (
+            "Permite o aproveitamento do crédito de ICMS, no valor de "
+            "R$\N{NO-BREAK SPACE}40,20, correspondente à alíquota de 2,70% para "
+            "industrialização e de 2,66% para revenda"
+        )
+        self.assertIn(icmss_credit_info, document.fiscal_additional_data)

--- a/l10n_br_fiscal/views/res_company_view.xml
+++ b/l10n_br_fiscal/views/res_company_view.xml
@@ -37,11 +37,19 @@
                                     <field name="payroll_amount" />
                                 </group>
                                 <group>
-                                    <field name="simplified_tax_id" />
-                                    <field name="simplified_tax_range_id" />
                                     <field name="coefficient_r" />
                                     <field name="coefficient_r_percent" />
-                                    <field name="simplified_tax_percent" />
+                                </group>
+                                <group
+                                    colspan="4"
+                                    string="Current Effective Taxes for Simples Nacional"
+                                >
+                                    <field
+                                        colspan="4"
+                                        nolabel="1"
+                                        name="sn_effective_tax_ids"
+                                        readonly="True"
+                                    />
                                 </group>
                             </group>
                             <group

--- a/l10n_br_fiscal/views/simplified_tax_effecitve_view.xml
+++ b/l10n_br_fiscal/views/simplified_tax_effecitve_view.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="simplified_tax_effecitve_tree" model="ir.ui.view">
+        <field name="name">l10n_br_fiscal.simplified.tax.effecitve.tree</field>
+        <field name="model">l10n_br_fiscal.simplified.tax.effective</field>
+        <field name="arch" type="xml">
+            <tree create="0" delete="0">
+                <field name="simplified_tax_id" />
+                <field name="current_range_id" />
+                <field name="current_effective_tax" />
+                <field name="tax_irpj_percent" />
+                <field name="tax_csll_percent" />
+                <field name="tax_cofins_percent" />
+                <field name="tax_pis_percent" />
+                <field name="tax_cpp_percent" />
+                <field name="tax_icms_percent" />
+                <field name="tax_iss_percent" />
+                <field name="tax_ipi_percent" />
+            </tree>
+        </field>
+    </record>
+</odoo>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000012062777161.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000012062777161.xml
@@ -84,8 +84,8 @@
                     <ICMSSN101>
                         <orig>0</orig>
                         <CSOSN>101</CSOSN>
-                        <pCredSN>2.7000</pCredSN>
-                        <vCredICMSSN>0.38</vCredICMSSN>
+                        <pCredSN>2.6600</pCredSN>
+                        <vCredICMSSN>0.37</vCredICMSSN>
                     </ICMSSN101>
                 </ICMS>
                 <IPI>


### PR DESCRIPTION
Migração da PR #1831 (12.0)

Esta PR refatora a forma como as alíquotas do Simples Nacional são calculadas. A atualização visa principalmente resolver o problema que não permitia que uma mesma empresa exercesse atividades de indústria e comércio simultaneamente, e melhorar a eficiência do cálculo. Além disso, foi aprimorado o comentário sobre o aproveitamento de crédito do ICMS incluído nas notas fiscais de venda para empresas no regime tributário Simples Nacional, tornando-o mais dinâmico para cobrir todos os casos. Essa mudança traz benefícios como maior clareza na visualização das alíquotas efetivas calculadas para a empresa do Simples Nacional.

