### PR TITLE
[14.0][FIX] l10n_br_fiscal: verificação no script de migração

### DIFF
--- a/l10n_br_fiscal/migrations/14.0.14.0.0/pre-migration.py
+++ b/l10n_br_fiscal/migrations/14.0.14.0.0/pre-migration.py
@@ -27,4 +27,5 @@ _field_renames = [
 
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
-    openupgrade.rename_fields(env, _field_renames)
+    if not openupgrade.column_exists(env.cr, "res_company", "simplified_tax_id"):
+        openupgrade.rename_fields(env, _field_renames)


### PR DESCRIPTION
Adiciona uma simples verificação antes de alterar os nomes no script de migração.

O mesmo script foi portado para a versão 12.0 então quando ele executava pela segunda vez  na 14.0 gerava um erro.
