### PR TITLE
[14.0][IMP] l10n_br_account_payment_brcobranca: message UserError API

### DIFF
--- a/l10n_br_account_payment_brcobranca/constants/br_cobranca.py
+++ b/l10n_br_account_payment_brcobranca/constants/br_cobranca.py
@@ -68,10 +68,14 @@ def get_brcobranca_api_url(env):
     if not brcobranca_api_url:
         raise UserError(
             _(
-                "Inform the URL where BRCobranca API are running"
-                " in Odoo Configuration file or if you are using docky"
-                " in the docker-compose.yml file. Example:\n"
-                "BRCOBRANCA_API_URL=http://boleto_cnab_api:9292"
+                "BRCobranca API URL is not configured.\n\n"
+                " Set the URL using one of the these methods:\n\n"
+                "1. Set the environment variable:"
+                " BRCOBRANCA_API_URL=http://boleto_cnab_api:9292\n"
+                "2. Configure the URL in Odoo configuration file:"
+                " brcobranca_api_url=http://boleto_cnab_api:9292\n"
+                "3. Set the URL in System Parameters:"
+                " brcobranca_api_url=http://boleto_cnab_api:9292\n"
             )
         )
 


### PR DESCRIPTION
cc @marcelsavegnago @douglascstd 

O propósito dessa PR é uma melhoria de como é informado que a URL da API do BRCobranca não está configurada e fornecer orientações claras sobre como realizar a configuração.

Antes:
![image](https://github.com/OCA/l10n-brazil/assets/53870822/12c90b20-5ef9-4daa-b8ca-9ae93d8febc1)

Depois:
![image](https://github.com/OCA/l10n-brazil/assets/53870822/0cacf95c-550a-4797-9c60-8074c26f8d29)
