### PR TITLE
[14.0][IMP] l10n_br_fiscal: Make the 'Back to Draft' button invisible if the electronic document is sent and awaiting processing.

### DIFF
--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -118,7 +118,7 @@
                         string="Voltar p/ Em Digitação"
                         groups="l10n_br_fiscal.group_user"
                         class="btn-secondary"
-                        attrs="{'invisible': ['|', ('state_edoc', 'not in', ('a_enviar', 'rejeitada')), ('document_electronic', '=', False)]}"
+                        attrs="{'invisible': ['|', ('state_edoc', 'not in', ('a_enviar', 'rejeitada', 'enviada')), ('document_electronic', '=', False)]}"
                     />
             <button
                         name="view_pdf"


### PR DESCRIPTION
Quando o documento eletronico foi enviado e está aguardando o processamento, entendo que permitir voltar o documento para rascunho sem ainda ter recebido um retorno de rejeição não seria correto.