### PR TITLE
[14.0][FIX] l10n_br_cnpj_search: Fix the tests

### DIFF
--- a/l10n_br_cnpj_search/tests/test_receitaws.py
+++ b/l10n_br_cnpj_search/tests/test_receitaws.py
@@ -24,7 +24,7 @@ class TestReceitaWS(TestCnpjCommon):
 
         self.assertEqual(kilian.company_type, "company")
         self.assertEqual(kilian.legal_name, "Kilian Macedo Melcher 08777131460")
-        self.assertEqual(kilian.name, "Kilian Macedo Melcher")
+        self.assertEqual(kilian.name, "Kilian Macedo Melcher 08777131460")
         self.assertEqual(kilian.email, "kilian.melcher@gmail.com")
         self.assertEqual(kilian.street_name, "Rua Luiza Bezerra Motta")
         self.assertEqual(kilian.street2, "Bloco E;Apt 302")


### PR DESCRIPTION
Esse PR está corrigindo o problema que estava gerando ao rodar os testes do CNPJ Search. 

@marcelsavegnago pode verificar se essa correção satisfaz o problema que estava tendo?