### PR TITLE
[14.0][IMP] Enforces fiscal operation and operation line definition in billable stock movements

### DIFF
--- a/l10n_br_stock_account/models/stock_move.py
+++ b/l10n_br_stock_account/models/stock_move.py
@@ -263,6 +263,8 @@ class StockMove(models.Model):
     @api.depends("price_unit")
     def _compute_fiscal_price(self):
         for record in self:
+            if record.fiscal_operation_id and not record.fiscal_operation_line_id:
+                record._onchange_product_id_fiscal()
             record.fiscal_price = record.price_unit
 
     def _get_taxes(self, fiscal_position, inv_type):
@@ -278,3 +280,15 @@ class StockMove(models.Model):
             taxes = self.tax_ids
 
         return taxes
+
+    def _set_as_2binvoiced(self):
+        res = super()._set_as_2binvoiced()
+        for record in self:
+            if (
+                res
+                and record.picking_id.fiscal_operation_id
+                and not record.fiscal_operation_id
+            ):
+                record.fiscal_operation_id = record.picking_id.fiscal_operation_id
+                record._onchange_product_id_fiscal()
+        return res


### PR DESCRIPTION
Estas mudanças tem como objetivo garantir que mesmo o picking sendo criado por outros modulos como por exemplo o stock_request, tanto a oepração como a linha da operação serão definidas nos movimentos do estoque.