### PR TITLE
[14.0][FIX] Ao mapear a Linha de Operação Fiscal o método precisa considerar os casos onde o Partner do objeto não é o Partner para Faturar/Partner to Invoice

### DIFF
--- a/l10n_br_fiscal/models/document_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_line_mixin_methods.py
@@ -47,7 +47,7 @@ FISCAL_CST_ID_FIELDS = [
 
 class FiscalDocumentLineMixinMethods(models.AbstractModel):
     _name = "l10n_br_fiscal.document.line.mixin.methods"
-    _description = "Document Fiscal Mixin Methods"
+    _description = "Fiscal Document Mixin Methods"
 
     @api.model
     def inject_fiscal_fields(
@@ -190,7 +190,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         self.ensure_one()
         return taxes.compute_taxes(
             company=self.company_id,
-            partner=self.partner_id,
+            partner=self._get_fiscal_partner(),
             product=self.product_id,
             price_unit=self.price_unit,
             quantity=self.quantity,
@@ -355,6 +355,17 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 d.__document_comment_vals(), d.manual_additional_data
             )
 
+    def _get_fiscal_partner(self):
+        """
+        Meant to be overriden when the l10n_br_fiscal.document partner_id should not
+        be the same as the sale.order, purchase.order, account.move (...) partner_id.
+
+        (In the case of invoicing, the invoicing partner set by the user should
+        get priority over any invoicing contact returned by address_get.)
+        """
+        self.ensure_one()
+        return self.partner_id
+
     @api.onchange("fiscal_operation_id")
     def _onchange_fiscal_operation_id(self):
         if self.fiscal_operation_id:
@@ -363,7 +374,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             self._onchange_commercial_quantity()
             self.fiscal_operation_line_id = self.fiscal_operation_id.line_definition(
                 company=self.company_id,
-                partner=self.partner_id,
+                partner=self._get_fiscal_partner(),
                 product=self.product_id,
             )
             self._onchange_fiscal_operation_line_id()
@@ -375,7 +386,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         if self.fiscal_operation_line_id:
             mapping_result = self.fiscal_operation_line_id.map_fiscal_taxes(
                 company=self.company_id,
-                partner=self.partner_id,
+                partner=self._get_fiscal_partner(),
                 product=self.product_id,
                 ncm=self.ncm_id,
                 nbm=self.nbm_id,

--- a/l10n_br_purchase/demo/l10n_br_purchase.xml
+++ b/l10n_br_purchase/demo/l10n_br_purchase.xml
@@ -55,6 +55,238 @@
         <value eval="[ref('main_pl_only_products_2_2')]" />
     </function>
 
+    <!-- Endereço de Cobrança Diferente do Partner,a Fatura criada deverá ter
+         outro partner, o Contato definido como Endereço de Faturamento/Cobrança,
+         TODO: deveria criar a fatura usando Partner do Pedido como o Parceiro
+         para Entrega/partner_shipping_id?
+         No caso l10n_br_purchase_stock isso acontece
+    -->
+    <record id="main_company-purchase_2" model="purchase.order">
+        <field name="name">l10n_br_purchase - Endereço de Cobrança Diferente</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente7_rs" />
+        <field name="state">draft</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field name="user_id" ref="base.user_admin" />
+        <field name="company_id" ref="base.main_company" />
+    </record>
+
+    <function model="purchase.order" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('main_company-purchase_2')]" />
+    </function>
+
+    <record id="main_company-purchase_line_2_1" model="purchase.order.line">
+        <field name="order_id" ref="main_company-purchase_2" />
+        <field name="name">Office Chair Black</field>
+        <field name="product_id" ref="product.product_product_12" />
+        <field name="product_qty">4</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <!-- Apesar do Preço ser defindo aqui o _onchange_product_id_fiscal altera o valor -->
+        <field name="price_unit">25.0</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_compras_compras"
+        />
+        <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
+    </record>
+
+    <function model="purchase.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_company-purchase_line_2_1')]" />
+    </function>
+
+    <record id="main_company-purchase_line_2_2" model="purchase.order.line">
+        <field name="order_id" ref="main_company-purchase_2" />
+        <field name="name">Drawer Black</field>
+        <field name="product_id" ref="product.product_product_16" />
+        <field name="product_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="price_unit">50.00</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_compras_compras"
+        />
+        <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
+    </record>
+
+    <function model="purchase.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_company-purchase_line_2_2')]" />
+    </function>
+
+    <!-- Endereço de Cobrança Diferente do Partner, nesse caso o Endereço já
+         está informado, não deve ter o Parceiro para Entrega
+    -->
+    <record id="main_company-purchase_3" model="purchase.order">
+        <field name="name">l10n_br_purchase - Endereço de Cobrança Informado</field>
+        <field
+            name="partner_id"
+            ref="l10n_br_base.res_partner_cliente7_rs_end_cobranca"
+        />
+        <field name="state">draft</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field name="user_id" ref="base.user_admin" />
+        <field name="company_id" ref="base.main_company" />
+    </record>
+
+    <function model="purchase.order" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('main_company-purchase_3')]" />
+    </function>
+
+    <record id="main_company-purchase_line_3_1" model="purchase.order.line">
+        <field name="order_id" ref="main_company-purchase_3" />
+        <field name="name">Office Chair Black</field>
+        <field name="product_id" ref="product.product_product_12" />
+        <field name="product_qty">4</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <!-- Apesar do Preço ser defindo aqui o _onchange_product_id_fiscal altera o valor -->
+        <field name="price_unit">25.0</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_compras_compras"
+        />
+        <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
+    </record>
+
+    <function model="purchase.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_company-purchase_line_3_1')]" />
+    </function>
+
+    <record id="main_company-purchase_line_3_2" model="purchase.order.line">
+        <field name="order_id" ref="main_company-purchase_3" />
+        <field name="name">Drawer Black</field>
+        <field name="product_id" ref="product.product_product_16" />
+        <field name="product_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="price_unit">50.00</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_compras_compras"
+        />
+        <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
+    </record>
+
+    <function model="purchase.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_company-purchase_line_3_2')]" />
+    </function>
+
+    <!-- Partner usado é o Contato de Entrega, a Fatura é criada com
+         o Partner do Pedido
+    -->
+    <record id="main_company-purchase_4" model="purchase.order">
+        <field
+            name="name"
+        >l10n_br_purchase - Contato do Endereço de Entrega Informado</field>
+        <field
+            name="partner_id"
+            ref="l10n_br_base.res_partner_cliente2_sp_end_entrega"
+        />
+        <field name="state">draft</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field name="user_id" ref="base.user_admin" />
+        <field name="company_id" ref="base.main_company" />
+    </record>
+
+    <function model="purchase.order" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('main_company-purchase_4')]" />
+    </function>
+
+    <record id="main_company-purchase_line_4_1" model="purchase.order.line">
+        <field name="order_id" ref="main_company-purchase_4" />
+        <field name="name">Office Chair Black</field>
+        <field name="product_id" ref="product.product_product_12" />
+        <field name="product_qty">4</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <!-- Apesar do Preço ser defindo aqui o _onchange_product_id_fiscal altera o valor -->
+        <field name="price_unit">25.0</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_compras_compras"
+        />
+        <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
+    </record>
+
+    <function model="purchase.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_company-purchase_line_4_1')]" />
+    </function>
+
+    <record id="main_company-purchase_line_4_2" model="purchase.order.line">
+        <field name="order_id" ref="main_company-purchase_4" />
+        <field name="name">Drawer Black</field>
+        <field name="product_id" ref="product.product_product_16" />
+        <field name="product_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="price_unit">50.00</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_compras_compras"
+        />
+        <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
+    </record>
+
+    <function model="purchase.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_company-purchase_line_4_2')]" />
+    </function>
+
+    <!-- Caso do Pedido com o Partner que tem um Contato com um Endereço de Entrega
+    a Fatura é criada com o Partner do Pedido -->
+    <record id="main_company-purchase_5" model="purchase.order">
+        <field
+            name="name"
+        >l10n_br_purchase - Partner que tem um Endereço de Entrega</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente2_sp" />
+        <field name="state">draft</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field name="user_id" ref="base.user_admin" />
+        <field name="company_id" ref="base.main_company" />
+    </record>
+
+    <function model="purchase.order" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('main_company-purchase_5')]" />
+    </function>
+
+    <record id="main_company-purchase_line_5_1" model="purchase.order.line">
+        <field name="order_id" ref="main_company-purchase_5" />
+        <field name="name">Office Chair Black</field>
+        <field name="product_id" ref="product.product_product_12" />
+        <field name="product_qty">4</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <!-- Apesar do Preço ser defindo aqui o _onchange_product_id_fiscal altera o valor -->
+        <field name="price_unit">25.0</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_compras_compras"
+        />
+        <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
+    </record>
+
+    <function model="purchase.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_company-purchase_line_3_1')]" />
+    </function>
+
+    <record id="main_company-purchase_line_5_2" model="purchase.order.line">
+        <field name="order_id" ref="main_company-purchase_5" />
+        <field name="name">Drawer Black</field>
+        <field name="product_id" ref="product.product_product_16" />
+        <field name="product_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="price_unit">50.00</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_compras_compras"
+        />
+        <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
+    </record>
+
+    <function model="purchase.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_company-purchase_line_5_2')]" />
+    </function>
+
     <!-- Empresa Lucro Presumido -->
     <!-- Purchase Order with only products test -->
     <record id="lp_po_only_products" model="purchase.order">

--- a/l10n_br_purchase/models/purchase_order.py
+++ b/l10n_br_purchase/models/purchase_order.py
@@ -116,3 +116,12 @@ class PurchaseOrder(models.Model):
                 }
             )
         return invoice_vals
+
+    def _get_fiscal_partner(self):
+        self.ensure_one()
+        partner = super()._get_fiscal_partner()
+        if partner.id != partner.address_get(["invoice"]).get("invoice"):
+            partner = self.env["res.partner"].browse(
+                partner.address_get(["invoice"]).get("invoice")
+            )
+        return partner

--- a/l10n_br_purchase/models/purchase_order_line.py
+++ b/l10n_br_purchase/models/purchase_order_line.py
@@ -145,3 +145,12 @@ class PurchaseOrderLine(models.Model):
                 values.update(fiscal_values)
 
         return values
+
+    def _get_fiscal_partner(self):
+        self.ensure_one()
+        partner = super()._get_fiscal_partner()
+        if partner.id != partner.address_get(["invoice"]).get("invoice"):
+            partner = self.env["res.partner"].browse(
+                partner.address_get(["invoice"]).get("invoice")
+            )
+        return partner

--- a/l10n_br_purchase/tests/test_l10n_br_purchase.py
+++ b/l10n_br_purchase/tests/test_l10n_br_purchase.py
@@ -609,3 +609,140 @@ class L10nBrPurchaseBaseTest(SavepointCase):
                 invoice.fiscal_document_id,
                 "International case should not has Fiscal Document.",
             )
+
+    def test_purchase_with_partner_to_invoice(self):
+        """
+        Test Purchase Order with different Partner to Invoice.
+        """
+        # Caso do Pedido criado com um Partner que possui um Partner to Invoice
+        purchase = self.env.ref("l10n_br_purchase.main_company-purchase_2")
+        self._run_purchase_order_onchanges(purchase)
+        for line in purchase.order_line:
+            self._run_purchase_line_onchanges(line)
+        purchase.with_context(tracking_disable=True).button_confirm()
+        self.assertEqual(purchase.state, "purchase", "Error to confirm Purchase Order.")
+        purchase.action_create_invoice()
+        for invoice in purchase.invoice_ids:
+            self.assertTrue(
+                invoice.fiscal_document_id,
+                "Fiscal Document missing for Purchase.",
+            )
+            partner_invoice = self.env["res.partner"].browse(
+                purchase.partner_id.address_get(["invoice"]).get("invoice")
+            )
+            self.assertEqual(
+                invoice.partner_id,
+                partner_invoice,
+                "The Invoice should be created with the Partner to Invoice",
+            )
+            self.assertNotEqual(
+                invoice.partner_id,
+                purchase.partner_id,
+                "The Invoice should not be created with the Partner of Purchase.",
+            )
+
+            # TODO: Deveria criar a Fatura com o Endereço de Entrega
+            #  partner_shipping_id preenchido com o Partner do Pedido
+            #  de Compra? Quando criado pelo Picking o campo é preenchido.
+
+            # self.assertEqual(
+            #    invoice.partner_shipping_id,
+            #    purchase.partner_id,
+            #    "The Invoice should be created with Partner to Shipping.",
+            # )
+
+        purchase_2 = self.env.ref("l10n_br_purchase.main_company-purchase_3")
+        self._run_purchase_order_onchanges(purchase_2)
+        for line in purchase_2.order_line:
+            self._run_purchase_line_onchanges(line)
+        purchase_2.with_context(tracking_disable=True).button_confirm()
+        self.assertEqual(
+            purchase_2.state, "purchase", "Error to confirm Purchase Order."
+        )
+        purchase_2.action_create_invoice()
+        for invoice in purchase_2.invoice_ids:
+            self.assertTrue(
+                invoice.fiscal_document_id,
+                "Fiscal Document missing for Purchase.",
+            )
+            self.assertEqual(
+                invoice.partner_id,
+                purchase_2.partner_id,
+                "The Partner in Purchase and Invoice should be the same.",
+            )
+            # O partner_shipping_id aqui também é vazio, deveria ser preenchido?
+            # self.assertEqual(
+            #    invoice.partner_shipping_id,
+            #    purchase_2.partner_id,
+            #    "The Invoice should be created with Partner to Shipping.",
+            # )
+
+    def test_purchase_with_partner_to_shipping(self):
+        """Test brazilian Purchase Order with Partner to Shipping."""
+
+        # Caso do Pedido criado com o Contato de Entrega/Partner to Delivery
+        purchase = self.env.ref("l10n_br_purchase.main_company-purchase_4")
+        self._run_purchase_order_onchanges(purchase)
+        for line in purchase.order_line:
+            self._run_purchase_line_onchanges(line)
+        purchase.with_context(tracking_disable=True).button_confirm()
+        self.assertEqual(purchase.state, "purchase", "Error to confirm Purchase Order.")
+        purchase.action_create_invoice()
+        for invoice in purchase.invoice_ids:
+            self.assertTrue(
+                invoice.fiscal_document_id,
+                "Fiscal Document missing for Purchase.",
+            )
+            # TODO: Campo partner_shipping_id está vazio
+            #  deveria estar preenchido?
+            # self.assertEqual(
+            #    invoice.partner_shipping_id,
+            #    purchase.partner_id,
+            #    "The Invoice should be created with the Partner to Shipping",
+            # )
+            self.assertNotEqual(
+                invoice.partner_id,
+                purchase.partner_id,
+                "The Invoice should not be created with the Partner of Purchase.",
+            )
+            # TODO: Deveria criar a Fatura com o Endereço de Entrega
+            #  partner_shipping_id preenchido com o Partner do Pedido
+            #  de Compra? Quando criado pelo Picking o campo é preenchido.
+
+            # self.assertEqual(
+            #    invoice.partner_shipping_id,
+            #    purchase.partner_id,
+            #    "The Invoice should be created with Partner to Shipping.",
+            # )
+
+        # Caso do Pedido criado com o Partner que tem um Contato de Entrega
+        purchase_2 = self.env.ref("l10n_br_purchase.main_company-purchase_5")
+        self._run_purchase_order_onchanges(purchase_2)
+        for line in purchase_2.order_line:
+            self._run_purchase_line_onchanges(line)
+        purchase_2.with_context(tracking_disable=True).button_confirm()
+        self.assertEqual(
+            purchase_2.state, "purchase", "Error to confirm Purchase Order."
+        )
+        purchase_2.action_create_invoice()
+
+        for invoice in purchase_2.invoice_ids:
+            self.assertTrue(
+                invoice.fiscal_document_id,
+                "Fiscal Document missing for Purchase.",
+            )
+            self.assertEqual(
+                invoice.partner_id,
+                purchase_2.partner_id,
+                "The Partner in Purchase and Invoice should be the same.",
+            )
+            # TODO: O partner_shipping_id aqui também é vazio,
+            #  deveria ser preenchido?
+            # partner_delivery = self.env["res.partner"].browse(
+            #   purchase.partner_id.address_get(["delivery"]).get("delivery")
+            # )
+            # self.assertEqual(
+            #    invoice.partner_shipping_id,
+            #    partner_delivery,
+            #    "The Invoice should be created with Partner to Shipping.",
+            # )

--- a/l10n_br_sale/demo/l10n_br_sale.xml
+++ b/l10n_br_sale/demo/l10n_br_sale.xml
@@ -52,6 +52,108 @@
         <value eval="[ref('main_sl_only_products_2_2')]" />
     </function>
 
+    <!-- Teste Endereço de Cobrança, partner diferente do partner to invoice  -->
+    <record id="main_company-sale_2" model="sale.order">
+        <field name="name">l10n_br_sale - Endereço de Cobrança</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente7_rs" />
+        <field
+            name="partner_invoice_id"
+            ref="l10n_br_base.res_partner_cliente7_rs_end_cobranca"
+        />
+        <field name="partner_shipping_id" ref="l10n_br_base.res_partner_cliente7_rs" />
+        <field name="user_id" ref="base.user_admin" />
+        <field name="pricelist_id" ref="product.list0" />
+        <field name="team_id" ref="sales_team.crm_team_1" />
+        <field name="state">draft</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="note">TESTE</field>
+        <field name="company_id" ref="base.main_company" />
+    </record>
+
+    <record id="main_company-sale_line_2_1" model="sale.order.line">
+        <field name="order_id" ref="main_company-sale_2" />
+        <field name="name">Laptop Customized</field>
+        <field name="product_id" ref="product.product_product_27" />
+        <field name="product_uom_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <!-- Apesar do Preço ser defindo aqui o _onchange_product_id_fiscal altera o valor -->
+        <field name="price_unit">500</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda" />
+    </record>
+
+    <function model="sale.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_company-sale_line_2_1')]" />
+    </function>
+
+    <record id="main_company-sale_line_2_2" model="sale.order.line">
+        <field name="order_id" ref="main_company-sale_2" />
+        <field name="name">Mouse, Wireless</field>
+        <field name="product_id" ref="product.product_product_12" />
+        <field name="product_uom_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="price_unit">500</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda" />
+    </record>
+
+    <function model="sale.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_company-sale_line_2_2')]" />
+    </function>
+
+    <!-- Teste Endereço de Entrega  -->
+    <record id="main_company-sale_3" model="sale.order">
+        <field name="name">l10n_br_sale - Endereço de Entrega</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente2_sp" />
+        <field name="partner_invoice_id" ref="l10n_br_base.res_partner_cliente2_sp" />
+        <field
+            name="partner_shipping_id"
+            ref="l10n_br_base.res_partner_cliente2_sp_end_entrega"
+        />
+        <field name="user_id" ref="base.user_admin" />
+        <field name="pricelist_id" ref="product.list0" />
+        <field name="team_id" ref="sales_team.crm_team_1" />
+        <field name="state">draft</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="note">TESTE</field>
+        <field name="company_id" ref="base.main_company" />
+    </record>
+
+    <record id="main_company-sale_line_3_1" model="sale.order.line">
+        <field name="order_id" ref="main_company-sale_3" />
+        <field name="name">Laptop Customized</field>
+        <field name="product_id" ref="product.product_product_27" />
+        <field name="product_uom_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <!-- Apesar do Preço ser defindo aqui o _onchange_product_id_fiscal altera o valor -->
+        <field name="price_unit">500</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda" />
+    </record>
+
+    <function model="sale.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_company-sale_line_3_1')]" />
+    </function>
+
+    <record id="main_company-sale_line_3_2" model="sale.order.line">
+        <field name="order_id" ref="main_company-sale_3" />
+        <field name="name">Mouse, Wireless</field>
+        <field name="product_id" ref="product.product_product_12" />
+        <field name="product_uom_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="price_unit">500</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda" />
+    </record>
+
+    <function model="sale.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_company-sale_line_3_2')]" />
+    </function>
+
     <!-- Sale Order with only services test -->
     <record id="main_so_only_services" model="sale.order">
         <field name="name">Main l10n_br_sale - Serviços</field>

--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -48,17 +48,17 @@ class SaleOrder(models.Model):
 
     cnpj_cpf = fields.Char(
         string="CNPJ/CPF",
-        related="partner_id.cnpj_cpf",
+        related="partner_invoice_id.cnpj_cpf",
     )
 
     legal_name = fields.Char(
         string="Legal Name",
-        related="partner_id.legal_name",
+        related="partner_invoice_id.legal_name",
     )
 
     ie = fields.Char(
         string="State Tax Number/RG",
-        related="partner_id.inscr_est",
+        related="partner_invoice_id.inscr_est",
     )
 
     discount_rate = fields.Float(
@@ -195,12 +195,15 @@ class SaleOrder(models.Model):
     def _prepare_invoice(self):
         self.ensure_one()
         result = super()._prepare_invoice()
-        # O caso Brasil se caracteriza por ter a Operação Fiscal
-        if self.fiscal_operation_id:
-            result.update(self._prepare_br_fiscal_dict())
+        if self.fiscal_operation_id:  # (Brazil)
+            fiscal_values = self._prepare_br_fiscal_dict()
+            # unlike super()._prepare_invoice(), prepare_fiscal_dict doesn't consider
+            # partner_invoice_id, so we adjust the partner_id eventually:
+            if fiscal_values.get("partner_id") != result.get("partner_id"):
+                fiscal_values["partner_id"] = result.get("partner_id")
+            result.update(fiscal_values)
 
             document_type_id = self._context.get("document_type_id")
-
             if not document_type_id:
                 # Quando ocorre esse caso? Os Testes não estão passando aqui
                 document_type_id = self.company_id.document_type_id.id
@@ -255,3 +258,14 @@ class SaleOrder(models.Model):
                 )
                 for line in res
             ]
+
+    def _get_fiscal_partner(self):
+        self.ensure_one()
+        partner = super()._get_fiscal_partner()
+        # Caso Vendas, a prioridade é do campo informado pelo usuário, quando
+        # o Partner tem um contato definido como Tipo Invoice o campo
+        # partner_invoice_id é preenchido com esse valor automaticamente
+        if partner != self.partner_invoice_id:
+            partner = self.partner_invoice_id
+
+        return partner

--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -284,3 +284,16 @@ class SaleOrderLine(models.Model):
             self.price_unit = self.product_id.standard_price
         else:
             self.price_unit = 0.00
+
+    def _get_fiscal_partner(self):
+        """
+        Return partner_invoice_id if different from partner.
+        partner_invoice_id is auto filled when the partner
+        has some invoicing contact defined, but it can be changed.
+        """
+        self.ensure_one()
+        partner = super()._get_fiscal_partner()
+        if partner != self.order_id.partner_invoice_id:
+            partner = self.order_id.partner_invoice_id
+
+        return partner

--- a/l10n_br_sale/tests/test_l10n_br_sale.py
+++ b/l10n_br_sale/tests/test_l10n_br_sale.py
@@ -642,3 +642,44 @@ class L10nBrSaleBaseTest(SavepointCase):
                 invoice.fiscal_document_id,
                 "International case should not has Fiscal Document.",
             )
+
+    def test_sale_with_partner_to_invoice(self):
+        """Test brazilian Sale Order with Partner to Invoice."""
+        sale = self.env.ref("l10n_br_sale.main_company-sale_2")
+        self._run_sale_order_onchanges(sale)
+        for line in sale.order_line:
+            self._run_sale_line_onchanges(line)
+
+        self._invoice_sale_order(sale)
+        for invoice in sale.invoice_ids:
+            self.assertEqual(
+                invoice.partner_id,
+                sale.partner_invoice_id,
+                "The Invoice Partner should be the same as Partner "
+                "to Invoice in Sale Order.",
+            )
+            self.assertNotEqual(
+                invoice.partner_id,
+                sale.partner_id,
+                "The Invoice should not be created with the Partner of Sale.",
+            )
+            self.assertEqual(
+                invoice.partner_shipping_id,
+                sale.partner_shipping_id,
+                "The Invoice Partner to Shipping should be the same of Sale Order.",
+            )
+
+    def test_sale_with_partner_to_shipping(self):
+        """Test brazilian Sale Order with Partner to Shipping."""
+        sale = self.env.ref("l10n_br_sale.main_company-sale_3")
+        self._run_sale_order_onchanges(sale)
+        for line in sale.order_line:
+            self._run_sale_line_onchanges(line)
+
+        self._invoice_sale_order(sale)
+        for invoice in sale.invoice_ids:
+            self.assertEqual(
+                invoice.partner_shipping_id,
+                sale.partner_shipping_id,
+                "The Invoice Partner to Shipping should be the same of Sale Order.",
+            )

--- a/l10n_br_sale_stock/models/stock_picking.py
+++ b/l10n_br_sale_stock/models/stock_picking.py
@@ -8,8 +8,21 @@ class StockPicking(models.Model):
     _inherit = "stock.picking"
 
     def _get_partner_to_invoice(self):
+        """
+        If the partner has some invoicing contact defined
+        partner_invoice_id is auto filled, but it can also be changed.
+        partner_invoice_id is used if different from partner_id
+        """
         self.ensure_one()
-        partner = self.partner_id
+        partner_id = super()._get_partner_to_invoice()
         if self.sale_id:
-            partner = self.sale_id.partner_invoice_id
-        return partner.address_get(["invoice"]).get("invoice")
+            if partner_id != self.sale_id.partner_invoice_id.id:
+                partner_id = self.sale_id.partner_invoice_id.id
+        return partner_id
+
+    def _get_fiscal_partner(self):
+        self.ensure_one()
+        partner = super()._get_fiscal_partner()
+        if partner != self._get_partner_to_invoice():
+            partner = self._get_partner_to_invoice()
+        return partner

--- a/l10n_br_sale_stock/tests/test_sale_stock.py
+++ b/l10n_br_sale_stock/tests/test_sale_stock.py
@@ -379,8 +379,18 @@ class TestSaleStock(TestBrPickingInvoicingCommon):
         self.assertEqual(invoice_pick_1.partner_id, sale_order_1.partner_invoice_id)
         # Fatura criada com o Partner Shipping usado no Picking
         self.assertEqual(invoice_pick_1.partner_shipping_id, picking.partner_id)
+
+        # TODO: O processo de criação a partir de um Pedido de Venda vem
+        #  preenchido o campo partner_shipping_id, isso deve ser mantido por
+        #  ser considerado o padrão ou é melhor remover o partner_shipping_id
+        #  quando o valor é igual ao partner_id?
+
         # Fatura Agrupada, não deve ter o partner_shipping_id preenchido
-        invoice_pick_3_4 = invoices.filtered(lambda t: not t.partner_shipping_id)
+        # invoice_pick_3_4 = invoices.filtered(lambda t: not t.partner_shipping_id)
+
+        invoice_pick_3_4 = invoices.filtered(
+            lambda t: t.partner_shipping_id == t.partner_id
+        )
         self.assertIn(invoice_pick_3_4, picking3.invoice_ids)
         self.assertIn(invoice_pick_3_4, picking4.invoice_ids)
 

--- a/l10n_br_stock_account/__manifest__.py
+++ b/l10n_br_stock_account/__manifest__.py
@@ -3,10 +3,12 @@
 
 {
     "name": "Brazilian Localization WMS Accounting",
+    "summary": "Invoice from Picking (nota fiscal de remessa) and other WMS overrides",
     "category": "Localisation",
     "license": "AGPL-3",
     "author": "Akretion, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-brazil",
+    "maintainers": ["renatonlima", "mbcosta"],
     "version": "14.0.3.9.2",
     "depends": [
         "stock_account",

--- a/l10n_br_stock_account/demo/l10n_br_stock_account_demo.xml
+++ b/l10n_br_stock_account/demo/l10n_br_stock_account_demo.xml
@@ -464,6 +464,442 @@
         <value eval="[ref('main_company-move_4_3')]" />
     </function>
 
+    <!-- Teste Agrupamento - Endereço de Entrega diferente do Faturamento -->
+    <!--  No caso de uso de ter um Picking para ser Faturado sem
+          relação com um Pedido de Venda/Compras a opção de ter um Endereço
+          de Entrega diferente do de Faturamento só funciona se o campo
+          company_type do res.partner com o Endereço estiver Person.
+          TODO: A localizaçao deveria sobreescrever o metodo address_get
+           para ignorar o company_type?
+    -->
+    <record model="stock.picking" id="main_company-picking_5">
+        <field
+            name="partner_id"
+            ref="l10n_br_base.res_partner_cliente2_sp_end_entrega"
+        />
+        <field name="picking_type_id" ref="stock.picking_type_out" />
+        <field name="location_id" ref="stock.stock_location_stock" />
+        <field name="location_dest_id" ref="stock.stock_location_customers" />
+        <field name="invoice_state">2binvoiced</field>
+        <field
+            name="origin"
+        >l10n_br_stock_account - Endereço Entrega diferente Faturamento 5</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_simples_remessa" />
+        <field name="company_id" ref="base.main_company" />
+    </record>
+
+    <record model="stock.move" id="main_company-move_5_1">
+        <field
+            name="name"
+        >l10n_br_stock_account - Endereço entrega diferente Faturamento 5</field>
+        <!-- sem o campo abaixo falha o mapeamento de CFOP, erro não acontece na tela -->
+        <field
+            name="partner_id"
+            ref="l10n_br_base.res_partner_cliente2_sp_end_entrega"
+        />
+        <field name="product_id" ref="product.product_product_16" />
+        <field name="product_uom_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="picking_id" ref="main_company-picking_5" />
+        <field name="location_id" ref="stock.stock_location_stock" />
+        <field name="location_dest_id" ref="stock.stock_location_customers" />
+        <field name="invoice_state">2binvoiced</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_simples_remessa" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_simples_remessa_simples_remessa"
+        />
+        <field name="company_id" ref="base.main_company" />
+        <field name="freight_value">100</field>
+        <field name="insurance_value">100</field>
+        <field name="other_value">100</field>
+    </record>
+
+    <function model="stock.move" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_company-move_5_1')]" />
+    </function>
+
+    <record model="stock.move" id="main_company-move_5_2">
+        <field
+            name="name"
+        >l10n_br_stock_account - Endereço entrega diferente Faturamento 5</field>
+        <!-- sem o campo abaixo falha o mapeamento de CFOP, erro não acontece na tela -->
+        <field
+            name="partner_id"
+            ref="l10n_br_base.res_partner_cliente2_sp_end_entrega"
+        />
+        <field name="product_id" ref="product.product_product_12" />
+        <field name="product_uom_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="picking_id" ref="main_company-picking_5" />
+        <field name="location_id" ref="stock.stock_location_stock" />
+        <field name="location_dest_id" ref="stock.stock_location_customers" />
+        <field name="invoice_state">2binvoiced</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_simples_remessa" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_simples_remessa_simples_remessa"
+        />
+        <field name="company_id" ref="base.main_company" />
+        <field name="freight_value">100</field>
+        <field name="insurance_value">100</field>
+        <field name="other_value">100</field>
+    </record>
+
+    <function model="stock.move" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_company-move_5_2')]" />
+    </function>
+
+    <!-- usado para o teste de não agrupar qdo operação fiscal for diferente -->
+    <record model="stock.move" id="main_company-move_5_3">
+        <field
+            name="name"
+        >l10n_br_stock_account - Endereço entrega diferente Faturamento 5</field>
+        <!-- sem o campo abaixo falha o mapeamento de CFOP, erro não acontece na tela -->
+        <field
+            name="partner_id"
+            ref="l10n_br_base.res_partner_cliente2_sp_end_entrega"
+        />
+        <field name="product_id" ref="product.product_product_16" />
+        <field name="product_uom_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="picking_id" ref="main_company-picking_5" />
+        <field name="location_id" ref="stock.stock_location_stock" />
+        <field name="location_dest_id" ref="stock.stock_location_customers" />
+        <field name="invoice_state">2binvoiced</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_bonificacao" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_bonificacao_bonificacao"
+        />
+        <field name="company_id" ref="base.main_company" />
+        <field name="freight_value">100</field>
+        <field name="insurance_value">100</field>
+        <field name="other_value">100</field>
+    </record>
+
+    <function model="stock.move" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_company-move_5_3')]" />
+    </function>
+
+    <!-- Teste Agrupamento - Endereço de Entrega diferente do Faturamento 6-->
+    <record model="stock.picking" id="main_company-picking_6">
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente2_sp" />
+        <field name="picking_type_id" ref="stock.picking_type_out" />
+        <field name="location_id" ref="stock.stock_location_stock" />
+        <field name="location_dest_id" ref="stock.stock_location_customers" />
+        <field name="invoice_state">2binvoiced</field>
+        <field
+            name="origin"
+        >l10n_br_stock_account - Endereço entrega diferente Faturamento 6</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_simples_remessa" />
+        <field name="company_id" ref="base.main_company" />
+    </record>
+
+    <record model="stock.move" id="main_company-move_6_1">
+        <field
+            name="name"
+        >l10n_br_stock_account - Endereço entrega diferente Faturamento 6</field>
+        <!-- sem o campo abaixo falha o mapeamento de CFOP, erro não acontece na tela -->
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente2_sp" />
+        <field name="product_id" ref="product.product_product_16" />
+        <field name="product_uom_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="picking_id" ref="main_company-picking_6" />
+        <field name="location_id" ref="stock.stock_location_stock" />
+        <field name="location_dest_id" ref="stock.stock_location_customers" />
+        <field name="invoice_state">2binvoiced</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_simples_remessa" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_simples_remessa_simples_remessa"
+        />
+        <field name="company_id" ref="base.main_company" />
+        <field name="freight_value">100</field>
+        <field name="insurance_value">100</field>
+        <field name="other_value">100</field>
+    </record>
+
+    <function model="stock.move" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_company-move_6_1')]" />
+    </function>
+
+    <record model="stock.move" id="main_company-move_6_2">
+        <field
+            name="name"
+        >l10n_br_stock_account - Endereço entrega diferente Faturamento 6</field>
+        <!-- sem o campo abaixo falha o mapeamento de CFOP, erro não acontece na tela -->
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente2_sp" />
+        <field name="product_id" ref="product.product_product_12" />
+        <field name="product_uom_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="picking_id" ref="main_company-picking_6" />
+        <field name="location_id" ref="stock.stock_location_stock" />
+        <field name="location_dest_id" ref="stock.stock_location_customers" />
+        <field name="invoice_state">2binvoiced</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_simples_remessa" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_simples_remessa_simples_remessa"
+        />
+        <field name="company_id" ref="base.main_company" />
+        <field name="freight_value">100</field>
+        <field name="insurance_value">100</field>
+        <field name="other_value">100</field>
+    </record>
+
+    <function model="stock.move" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_company-move_6_2')]" />
+    </function>
+
+    <!-- usado para o teste de não agrupar qdo operação fiscal for diferente -->
+    <record model="stock.move" id="main_company-move_6_3">
+        <field
+            name="name"
+        >l10n_br_stock_account - Endereço entrega diferente Faturamento 6</field>
+        <!-- sem o campo abaixo falha o mapeamento de CFOP, erro não acontece na tela -->
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente2_sp" />
+        <field name="product_id" ref="product.product_product_16" />
+        <field name="product_uom_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="picking_id" ref="main_company-picking_6" />
+        <field name="location_id" ref="stock.stock_location_stock" />
+        <field name="location_dest_id" ref="stock.stock_location_customers" />
+        <field name="invoice_state">2binvoiced</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_bonificacao" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_bonificacao_bonificacao"
+        />
+        <field name="company_id" ref="base.main_company" />
+        <field name="freight_value">100</field>
+        <field name="insurance_value">100</field>
+        <field name="other_value">100</field>
+    </record>
+
+    <function model="stock.move" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_company-move_6_3')]" />
+    </function>
+
+    <!-- Teste Agrupamento - Endereço de Entrega diferente do Faturamento -->
+    <!--  No caso de uso de ter um Picking para ser Faturado sem
+          relação com um Pedido de Venda/Compras a opção de ter um Endereço
+          de Entrega diferente do de Faturamento só funciona se o campo
+          company_type do res.partner com o Endereço estiver Person.
+          O Partner possui um contato definido como Type Invoice, existem
+          dois Pickings um com o Endereço de Cobrança e outro o Principal
+          TODO: A localizaçao deveria sobreescrever o metodo address_get
+           para ignorar o company_type?
+    -->
+    <record model="stock.picking" id="main_company-picking_7">
+        <field
+            name="partner_id"
+            ref="l10n_br_base.res_partner_cliente7_rs_end_cobranca"
+        />
+        <field name="picking_type_id" ref="stock.picking_type_out" />
+        <field name="location_id" ref="stock.stock_location_stock" />
+        <field name="location_dest_id" ref="stock.stock_location_customers" />
+        <field name="invoice_state">2binvoiced</field>
+        <field
+            name="origin"
+        >l10n_br_stock_account - Partner com Endereço de Faturamento 7</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_simples_remessa" />
+        <field name="company_id" ref="base.main_company" />
+    </record>
+
+    <record model="stock.move" id="main_company-move_7_1">
+        <field
+            name="name"
+        >l10n_br_stock_account - Partner com Endereço de Faturamento 7</field>
+        <!-- sem o campo abaixo falha o mapeamento de CFOP, erro não acontece na tela -->
+        <field
+            name="partner_id"
+            ref="l10n_br_base.res_partner_cliente7_rs_end_cobranca"
+        />
+        <field name="product_id" ref="product.product_product_16" />
+        <field name="product_uom_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="picking_id" ref="main_company-picking_5" />
+        <field name="location_id" ref="stock.stock_location_stock" />
+        <field name="location_dest_id" ref="stock.stock_location_customers" />
+        <field name="invoice_state">2binvoiced</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_simples_remessa" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_simples_remessa_simples_remessa"
+        />
+        <field name="company_id" ref="base.main_company" />
+        <field name="freight_value">100</field>
+        <field name="insurance_value">100</field>
+        <field name="other_value">100</field>
+    </record>
+
+    <function model="stock.move" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_company-move_7_1')]" />
+    </function>
+
+    <record model="stock.move" id="main_company-move_7_2">
+        <field
+            name="name"
+        >l10n_br_stock_account - Endereço entrega diferente Faturamento 7</field>
+        <!-- sem o campo abaixo falha o mapeamento de CFOP, erro não acontece na tela -->
+        <field
+            name="partner_id"
+            ref="l10n_br_base.res_partner_cliente2_sp_end_entrega"
+        />
+        <field name="product_id" ref="product.product_product_12" />
+        <field name="product_uom_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="picking_id" ref="main_company-picking_5" />
+        <field name="location_id" ref="stock.stock_location_stock" />
+        <field name="location_dest_id" ref="stock.stock_location_customers" />
+        <field name="invoice_state">2binvoiced</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_simples_remessa" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_simples_remessa_simples_remessa"
+        />
+        <field name="company_id" ref="base.main_company" />
+        <field name="freight_value">100</field>
+        <field name="insurance_value">100</field>
+        <field name="other_value">100</field>
+    </record>
+
+    <function model="stock.move" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_company-move_7_2')]" />
+    </function>
+
+    <!-- usado para o teste de não agrupar qdo operação fiscal for diferente -->
+    <record model="stock.move" id="main_company-move_7_3">
+        <field
+            name="name"
+        >l10n_br_stock_account - Endereço entrega diferente Faturamento 7</field>
+        <!-- sem o campo abaixo falha o mapeamento de CFOP, erro não acontece na tela -->
+        <field
+            name="partner_id"
+            ref="l10n_br_base.res_partner_cliente2_sp_end_entrega"
+        />
+        <field name="product_id" ref="product.product_product_16" />
+        <field name="product_uom_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="picking_id" ref="main_company-picking_5" />
+        <field name="location_id" ref="stock.stock_location_stock" />
+        <field name="location_dest_id" ref="stock.stock_location_customers" />
+        <field name="invoice_state">2binvoiced</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_bonificacao" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_bonificacao_bonificacao"
+        />
+        <field name="company_id" ref="base.main_company" />
+        <field name="freight_value">100</field>
+        <field name="insurance_value">100</field>
+        <field name="other_value">100</field>
+    </record>
+
+    <function model="stock.move" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_company-move_7_3')]" />
+    </function>
+
+    <!-- Teste Agrupamento - Endereço de Entrega diferente do Faturamento 2-->
+    <record model="stock.picking" id="main_company-picking_8">
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente2_sp" />
+        <field name="picking_type_id" ref="stock.picking_type_out" />
+        <field name="location_id" ref="stock.stock_location_stock" />
+        <field name="location_dest_id" ref="stock.stock_location_customers" />
+        <field name="invoice_state">2binvoiced</field>
+        <field
+            name="origin"
+        >l10n_br_stock_account - Endereço entrega diferente Faturamento 8</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_simples_remessa" />
+        <field name="company_id" ref="base.main_company" />
+    </record>
+
+    <record model="stock.move" id="main_company-move_8_1">
+        <field
+            name="name"
+        >l10n_br_stock_account - Endereço entrega diferente Faturamento 8</field>
+        <!-- sem o campo abaixo falha o mapeamento de CFOP, erro não acontece na tela -->
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente2_sp" />
+        <field name="product_id" ref="product.product_product_16" />
+        <field name="product_uom_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="picking_id" ref="main_company-picking_6" />
+        <field name="location_id" ref="stock.stock_location_stock" />
+        <field name="location_dest_id" ref="stock.stock_location_customers" />
+        <field name="invoice_state">2binvoiced</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_simples_remessa" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_simples_remessa_simples_remessa"
+        />
+        <field name="company_id" ref="base.main_company" />
+        <field name="freight_value">100</field>
+        <field name="insurance_value">100</field>
+        <field name="other_value">100</field>
+    </record>
+
+    <function model="stock.move" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_company-move_8_1')]" />
+    </function>
+
+    <record model="stock.move" id="main_company-move_8_2">
+        <field
+            name="name"
+        >l10n_br_stock_account - Endereço entrega diferente Faturamento 8</field>
+        <!-- sem o campo abaixo falha o mapeamento de CFOP, erro não acontece na tela -->
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente2_sp" />
+        <field name="product_id" ref="product.product_product_12" />
+        <field name="product_uom_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="picking_id" ref="main_company-picking_6" />
+        <field name="location_id" ref="stock.stock_location_stock" />
+        <field name="location_dest_id" ref="stock.stock_location_customers" />
+        <field name="invoice_state">2binvoiced</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_simples_remessa" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_simples_remessa_simples_remessa"
+        />
+        <field name="company_id" ref="base.main_company" />
+        <field name="freight_value">100</field>
+        <field name="insurance_value">100</field>
+        <field name="other_value">100</field>
+    </record>
+
+    <function model="stock.move" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_company-move_8_2')]" />
+    </function>
+
+    <!-- usado para o teste de não agrupar qdo operação fiscal for diferente -->
+    <record model="stock.move" id="main_company-move_8_3">
+        <field
+            name="name"
+        >l10n_br_stock_account - Endereço entrega diferente Faturamento 8</field>
+        <!-- sem o campo abaixo falha o mapeamento de CFOP, erro não acontece na tela -->
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente2_sp" />
+        <field name="product_id" ref="product.product_product_16" />
+        <field name="product_uom_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="picking_id" ref="main_company-picking_6" />
+        <field name="location_id" ref="stock.stock_location_stock" />
+        <field name="location_dest_id" ref="stock.stock_location_customers" />
+        <field name="invoice_state">2binvoiced</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_bonificacao" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_bonificacao_bonificacao"
+        />
+        <field name="company_id" ref="base.main_company" />
+        <field name="freight_value">100</field>
+        <field name="insurance_value">100</field>
+        <field name="other_value">100</field>
+    </record>
+
+    <function model="stock.move" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_company-move_8_3')]" />
+    </function>
+
     <!-- Dados demo com a empresa Lucro Presumido para validar os impostos
          OBS.: necessário alterar a empresa do usuario para visualizar o Picking -->
 

--- a/l10n_br_stock_account/models/stock_move.py
+++ b/l10n_br_stock_account/models/stock_move.py
@@ -279,3 +279,22 @@ class StockMove(models.Model):
             taxes = self.tax_ids
 
         return taxes
+
+    def _get_fiscal_partner(self):
+        """
+        Adjust the partner, both for an invoice from picking with
+        no related SO or PO,
+        https://github.com/OCA/account-invoicing/blob/14.0/
+        stock_picking_invoicing/models/stock_picking.py#L38
+        and also in the case of a picking originating from a PO:
+        https://github.com/OCA/OCB/blob/14.0/addons/purchase/
+        models/purchase.py#L556
+        """
+        self.ensure_one()
+        partner = super()._get_fiscal_partner()
+        if partner.id != partner.address_get(["invoice"]).get("invoice"):
+            partner = self.env["res.partner"].browse(
+                partner.address_get(["invoice"]).get("invoice")
+            )
+
+        return partner

--- a/l10n_br_stock_account/wizards/stock_invoice_onshipping.py
+++ b/l10n_br_stock_account/wizards/stock_invoice_onshipping.py
@@ -99,17 +99,34 @@ class StockInvoiceOnshipping(models.TransientModel):
         if picking.fiscal_operation_id and picking.fiscal_operation_id.journal_id:
             fiscal_vals["journal_id"] = picking.fiscal_operation_id.journal_id.id
 
+        # Necessário para o caso do Pedido de Compra criado com o Contato
+        # de Faturamento onde o Picking é criado com esse partner e está
+        # sendo necessário preencher o partner_shipping_id com esse partner
+        # do Picking, sem isso o uso o Partner principal do Contato
+        if values.get("partner_shipping_id") != values.get("partner_id"):
+            if not fiscal_vals.get("partner_shipping_id"):
+                fiscal_vals["partner_shipping_id"] = picking.partner_id.id
+
         # Endereço de Entrega diferente do Endereço de Faturamento
         # so informado quando é diferente
         if fiscal_vals["partner_id"] != values["partner_id"]:
             values["partner_shipping_id"] = fiscal_vals["partner_id"]
-        else:
-            # Já no modulo stock_picking_invoicing o campo partner_shipping_id
-            # é informado mas para evitar ter a NFe com o Endereço de Entrega
-            # quando esse é o mesmo Endereço, esta sendo removido.
-            # TODO: Deveria ser informado mesmo quando é o mesmo? Isso não
-            #  acontecia na v12.
-            del values["partner_shipping_id"]
+            # Necessário para manter o Partner mapeado pelo metodo
+            # https://github.com/OCA/account-invoicing/blob/14.0/
+            # stock_picking_invoicing/models/stock_picking.py#L38
+            fiscal_vals["partner_id"] = values["partner_id"]
+
+        # TODO: Na criação da Fatura pelo Pedido de Venda o campo
+        #  partner_shipping_id sempre vai preenchido, isso deve ser
+        #  considerado o padrão? Ou deveria ser feito como antes aqui
+        #  onde nos casos em que o partner_id é o mesmo que o partner_shipping_id
+        #  o campo era apagado e assim a Fatura era criada sem o Endereço de
+        #  Entrega
+        # else:
+        #    # Já no modulo stock_picking_invoicing o campo partner_shipping_id
+        #    # é informado mas para evitar ter a NFe com o Endereço de Entrega
+        #    # quando esse é o mesmo Endereço, esta sendo removido.
+        #    del values["partner_shipping_id"]
 
         # Ser for feito o update como abaixo o campo
         # fiscal_operation_id vai vazio


### PR DESCRIPTION
When mapping Line Fiscal Operation the Partner used can be or not the Partner to Invoice, so to has the correct mapping the method should use the Partner to Invoice.

Ao selecionar uma Operação Fiscal nas linhas o método line_definition chamado pelo _onchange_fiscal_operation_id sempre usa o campo partner_id/res.partner do objeto https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py#L342 porém existem Casos de Uso onde o Partner selecionado no objeto pode não ser o Partner to Invoice/Parceiro para Faturar, um res.partner pode ter um Contato/res.partner definido com o campo Type como Invoice e se estiver com o campo company_type como Person o método address_get retorna esse Contato/res.partner na criação da Fatura/Invoice ou quando o objeto tem um campo especifico para isso o partner_invoice_id. Ao testar e validar esse problema também foi preciso fazer algumas correções referentes, foi preciso alterar mais de um modulo nesse PR para permitir testes mas dependendo posso ver de dividir o PR, segue abaixo os detalhes das alterações em cada modulo e os Casos de Uso mapeados, por enquanto, por isso testes e a verificação se faltou atender algum Caso de Uso são bem vindos:

l10n_br_base e l10n_br_fiscal 

* apenas inclusão de Dados de Demonstração usando dois Parceiros que não estavam sendo usados antes em outros testes um definido com um Contato de Fatura e outro Contato de Entrega

l10n_br_purchase

* esse caso pode ser remoto( qual a situação/caso de uso um pedido seria criado com o Fornecedor sendo diferente do res.partner de Faturamento? Ou usando o Endereço de Entrega? Seria o caso do dropshipping a Empresa faz o Pedido de Compra porém o Endereço de Entrega e o Cliente?) porém como ao criar uma Fatura o método do modulo purchase chama o address_get para preencher o Partner https://github.com/OCA/OCB/blob/14.0/addons/purchase/models/purchase.py#L556 isso permite que o Partner do objeto possa ser diferente do Partner to Invoice, por isso é preciso considerar o Partner retornado pelo address_get na Operação Fiscal

* inclui nos Dados de Demonstração quatro Pedidos de Compras:
   (1) Partner principal que tem um contato com Endereço de Faturamento
         Cria a Fatura com o Contato definido com o type invoice, que é diferente do Partner Principal( TODO: Nesse caso deveria considerar esse partner do Pedido o partner_shippping_id da Fatura? Isso ocorre no caso de criar a Fatura a partir de um Picking relacionado a um Pedido de Compra quando o modulo l10n_br_purchase_stock está instalado)   
   (2) Contato de um Partner definido como o Partner to Invoice
         A Fatura é criada com o mesmo Partner do Pedido
   (3) Partner que tem um Contato como Endereço de Entrega
        TODO: Deveria criar Fatura com partner_shipping_id com o Partner do Pedido de Compra?
   (4) Contato de um Partner definido como o Partner to Delivery/Parceiro de Entrega 
       TODO: Não cria a Fatura com o partner_shipping_id definido, deveria estar com o contato?

l10n_br_purchase_stock

* adicionado apenas testes, as correções necessárias para esse caso foram feitas no modulo l10n_br_stock_account por usar o address_get para definir o Partner to Invoice

l10n_br_sale

* esse caso o objeto tem um campo partner_invoice_id e quando o Partner selecionado tem um Contato Invoice o onchange preenche o campo com esse Contato mas o usuário também pode alterar o campo manualmente, por isso a Operação Fiscal precisa considerar o partner_invoice_id e não o partner_id, 

* Correção no método _prepare_invoice https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_sale/models/sale_order.py#L172 porque ao chamar o _prepare_br_fiscal_dict e fazer o update com esse dicionario acabava substituindo o Partner que é mapeado pelos métodos do modulo Sale e a Fatura acabava sendo criada com o partner_id e não o partner_invoice_id,

Apenas o modulo sale instalado

![image](https://github.com/OCA/l10n-brazil/assets/6341149/ca538b6d-12ca-4706-8aa8-113d78dce925)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/3a652a5e-edd1-4730-a752-395e7512baaa)

l10n_br_sale instalado

![image](https://github.com/OCA/l10n-brazil/assets/6341149/d6190fe0-c0d1-4e42-bdfe-f7cee12e21da)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/dfc5ce3f-36c9-4580-9fe5-44cb2872704c)


* adicionado nos Dados de Demontração dois Pedido de Vendas e testes para validar se os campos estão sendo preenchidos nas Faturas criadas:
   (1) Partner que possui o Endereço de Cobrança/partner_invoice_id 
   (2) Partner que possui o Endereço de Entrega/partner_shipping_id

l10n_br_sale_stock

* esse caso o Picking quando tem um Pedido de Venda/sale.order relacionado precisa usar o partner_invoice_id definido no Pedido e não o Partner do stock.picking que pode ser o partner_shipping_id do Pedido

* Correção no metodo _get_partner_to_invoice nesse mesmo sentido de usar o partner_invoice_id do Pedido

* Sobre os Casos de Uso antes desse PR ao criar uma Fatura onde o partner_id era igual ao partner_shipping_id esse era apagado e assim a Fatura era criada sem o Endereço de Entrega porém vendo que o comportamento padrão do modulo sale é de sempre criar a Fatura com o partner_shipping_id preenchido mesmo quando igual ao partner_id eu estou alterando nesse PR para fazer o mesmo ( TODO: Isso é o certo? Ou o melhor é manter como antes e alterar o l10n_br_sale para que quando o partner_id for igual ao partner_shipping_id deveria apagar o valor do campo e assim criar a Fatura sem o partner_shipping_id )

l10n_br_stock_account 

* esse Caso de Uso precisa considerar o Partner retornado pelo address_get( isso também atende o caso do l10n_br_purchase_stock ), a criação da Fatura já considera esse caso https://github.com/OCA/account-invoicing/blob/14.0/stock_picking_invoicing/models/stock_picking.py#L38 isso também resolve um TODO que existia que é a criação de uma Ordem de Entrega ou Recebimento/stock.picking sem relação com Pedido de Venda ou Compra que precisa ter um Endereço de Entrega/Recebimento diferente do Faturamento, 

* correção feita no método que retorna a Operação Fiscal padrão da empresa é preciso fazer self.env.company e não self.env.user.company_id

* Incluí nos Dados de Demonstração mais quatro pickings 
   (1) Partner principal que tem um Partner com Endereço de Entrega definido
         Caso Remoto? Um erro do usuário? Ou pode ocorrer um caso onde o usuário precisa fazer uma Entrega para um endereço diferente do que está definido com o type delivery
   (2) Partner de Endereço de Entrega
         A Fatura precisa ser criada com Partner principal
   (3) Partner principal que tem um Endereço de Faturamento definido
         A Fatura deve ser criada com o partner do addres_get e não do Picking
   (4) Partner de Endereço de Faturamento
         A Fatura criada deve ter o mesmo Partner do Picking

isso também está sendo feito para testar a criação de Faturas com Agrupamento Partner/Products nesses casos apesar das Faturas criadas acabarem sendo iguais não são agrupadas porque o método _get_picking_key considera o partner do picking https://github.com/OCA/account-invoicing/blob/14.0/stock_picking_invoicing/wizards/stock_invoice_onshipping.py#L316 TODO: é preciso avaliar se isso deve ser alterado para nesses casos Agrupar ou na localização ou mesmo no modulo stock_picking_invoicing

cc @renatonlima @rvalyi @marcelsavegnago @mileo 