### PR TITLE
[14.0][FIX] l10n_br_account_payment_order: tracking field warn

### DIFF
--- a/l10n_br_account_payment_order/models/l10n_br_cnab_boleto_fields.py
+++ b/l10n_br_account_payment_order/models/l10n_br_cnab_boleto_fields.py
@@ -56,14 +56,14 @@ class L10nBrCNABBoletoFields(models.AbstractModel):
         help="Código da carteira para ser impresso no boleto, "
         "quando o mesmo for diferente do impresso na remessa.",
         size=3,
-        track_visibility="always",
+        tracking=True,
     )
 
     transmission_code = fields.Char(
         string="Código de Transmissão",
         help="Informação cedida pelo banco que identifica o arquivo remessa do cliente",
         size=20,
-        track_visibility="always",
+        tracking=True,
     )
 
     boleto_modality = fields.Char(


### PR DESCRIPTION
No merge da PR #2848 ficou faltando arrumar o campo `tracking` que mudou a forma de escrever.
Resolve estes warnings:

```
2024-01-14 23:37:06,287 1 WARNING devel odoo.fields: Field account.payment.mode.boleto_wallet2: unknown parameter 'track_visibility', if this is an actual parameter you may want to override the method _valid_field_parameter on the relevant model in order to allow it 
2024-01-14 23:37:06,287 1 WARNING devel odoo.fields: Field account.payment.mode.transmission_code: unknown parameter 'track_visibility', if this is an actual parameter you may want to override the method _valid_field_parameter on the relevant model in order to allow it 
```