### PR TITLE
[14.0][REF] l10n_br_sale: Adaptando o modulo para ter compatibilidade com o Caso Internacional ou sem Operação Fiscal

### DIFF
--- a/l10n_br_sale/tests/test_l10n_br_sale.py
+++ b/l10n_br_sale/tests/test_l10n_br_sale.py
@@ -619,6 +619,16 @@ class L10nBrSaleBaseTest(SavepointCase):
         for line in so_international.order_line:
             line.product_id.invoice_policy = "order"
             self._run_sale_line_onchanges(line)
+        # TODO: Em algum momento nos dados de demonstração está carregando
+        #  a Operação Fiscal, o problema não aparece quando os testes são
+        #  feitos da forma como ocorre no github, porém ao instalar o modulo
+        #  e depois rodar os testes o valor está vindo preenchido, isso não
+        #  está afetando o processo na tela e até simula o caso quando apesar
+        #  da Empresa ser do Brasil o metodo default preenche o campo mas o
+        #  usuário decide que não deve gerar Documento Fiscal e por isso apaga
+        #  a Operação Fiscal
+        so_international.fiscal_operation_id = False
+
         so_international.action_confirm()
         so_international._create_invoices(final=True)
         for invoice in so_international.invoice_ids:


### PR DESCRIPTION
Adapted module to make compatible with International Cases or without Fiscal Operation.

PR simples que complementa o PR https://github.com/OCA/l10n-brazil/pull/2743 ficou um Caso de Uso a ser resolvido:

Caso de uso onde o Pedido foi criado com a Operação Fiscal tanto no Pedido quanto na Linha, os métodos default podem preencher porém o usuário decide que não deve ter Operação Fiscal e não gerar Documento Fiscal, o caso pode ser visto nos Dados de Demonstração, caso a Operação Fiscal seja apagada e o Pedido já tem linhas é preciso apagar o campo na Linha, sem isso acontece um looping porque ao apagar no Pedido o campo fica invisível na Linha e quando está visível ele é requirido, sem isso o usuário não consegue resolver o problema.

Em algum momento nos dados de demonstração está carregando a Operação Fiscal nos Pedidos de Vendas criados pelo modulo sale, o problema não aparece quando os testes são feitos da forma como ocorre no github, porém ao instalar o modulo e depois rodar os testes o valor está vindo preenchido, isso não está afetando o processo na tela e até simula o caso quando apesar da Empresa ser do Brasil o método default preenche o campo mas o usuário decide que não deve gerar Documento Fiscal e por isso apaga a Operação Fiscal

cc @rvalyi @renatonlima @marcelsavegnago @mileo 