### PR TITLE
[14.0][REF] l10n_br_sale_stock: Adaptando o modulo para ter compatibilidade com o Caso Internacional ou sem Operação Fiscal

### DIFF
--- a/l10n_br_sale_stock/models/sale_order.py
+++ b/l10n_br_sale_stock/models/sale_order.py
@@ -14,28 +14,29 @@ class SaleOrder(models.Model):
 
     @api.depends("state", "order_line.invoice_status")
     def _compute_get_button_create_invoice_invisible(self):
-        button_create_invoice_invisible = False
+        for record in self:
+            button_create_invoice_invisible = False
 
-        lines = self.order_line.filtered(
-            lambda line: line.invoice_status == "to invoice"
-        )
+            lines = record.order_line.filtered(
+                lambda line: line.invoice_status == "to invoice"
+            )
 
-        # Somente depois do Pedido confirmado o botão pode aparecer
-        if self.state != "sale":
-            button_create_invoice_invisible = True
-        else:
-            if self.company_id.sale_create_invoice_policy == "stock_picking":
-                # A criação de Fatura de Serviços deve ser possível via Pedido
-                if not any(line.product_id.type == "service" for line in lines):
-                    button_create_invoice_invisible = True
+            # Somente depois do Pedido confirmado o botão pode aparecer
+            if record.state != "sale":
+                button_create_invoice_invisible = True
             else:
-                # No caso da Politica de criação baseada no Pedido de Venda
-                # qdo acionado o Botão irá criar as Faturas automaticamente
-                # mesmo no caso de ter Produtos e Serviços
-                if not lines:
-                    button_create_invoice_invisible = True
+                if record.company_id.sale_create_invoice_policy == "stock_picking":
+                    # A criação de Fatura de Serviços deve ser possível via Pedido
+                    if not any(line.product_id.type == "service" for line in lines):
+                        button_create_invoice_invisible = True
+                else:
+                    # No caso da Politica de criação baseada no Pedido de Venda
+                    # qdo acionado o Botão irá criar as Faturas automaticamente
+                    # mesmo no caso de ter Produtos e Serviços
+                    if not lines:
+                        button_create_invoice_invisible = True
 
-        self.button_create_invoice_invisible = button_create_invoice_invisible
+            record.button_create_invoice_invisible = button_create_invoice_invisible
 
     @api.onchange("partner_shipping_id")
     def _onchange_partner_shipping_id(self):

--- a/l10n_br_sale_stock/models/sale_order_line.py
+++ b/l10n_br_sale_stock/models/sale_order_line.py
@@ -10,7 +10,9 @@ class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
     def _prepare_procurement_values(self, group_id=False):
-        values = self._prepare_br_fiscal_dict()
+        values = {}
+        if self.fiscal_operation_id:
+            values = self._prepare_br_fiscal_dict()
         values.update(super()._prepare_procurement_values(group_id))
         # Incluir o invoice_state
         if self.order_id.company_id.sale_create_invoice_policy == "stock_picking":

--- a/l10n_br_sale_stock/models/stock_move.py
+++ b/l10n_br_sale_stock/models/stock_move.py
@@ -27,8 +27,9 @@ class StockMove(models.Model):
         values = {}
         fiscal_operation = False
         if self.sale_line_id:
-            values = self.sale_line_id.order_id._prepare_br_fiscal_dict()
             fiscal_operation = self.sale_line_id.order_id.fiscal_operation_id
+            if fiscal_operation:
+                values = self.sale_line_id.order_id._prepare_br_fiscal_dict()
 
         values.update(super()._get_new_picking_values())
         # O self pode conter mais de uma stock.move por isso a Operação Fiscal

--- a/l10n_br_sale_stock/models/stock_picking.py
+++ b/l10n_br_sale_stock/models/stock_picking.py
@@ -13,3 +13,12 @@ class StockPicking(models.Model):
         if self.sale_id:
             partner = self.sale_id.partner_invoice_id
         return partner.address_get(["invoice"]).get("invoice")
+
+    def write(self, values):
+        # Forma encontrada para evitar que Operação Fiscal do metodo default
+        # seja preenchida quando o Pedido não tem o campo preenchido
+        if self.sale_id:
+            if not self.sale_id.fiscal_operation_id:
+                values["fiscal_operation_id"] = False
+
+        return super().write(values)


### PR DESCRIPTION
Adapted l10n_sale_stock to make module compatible with international case or without Fiscal Operation.

Adaptando o modulo l10n_br_sale_stock para ter compatibilidade com o Caso Internacional ou sem Operação Fiscal, esse PR apesar de simples vai ter um erro 

Traceback (most recent call last):
  File "/odoo/external-src/l10n-brazil-REF-adapt_sale_stock_module_to_international_case-3/l10n_br_sale_stock/tests/test_sale_stock.py", line 264, in test_picking_sale_order_product_and_service
    "sale.order.line to account.move.line" % field,
AssertionError: l10n_br_fiscal.operation.line(4,) != l10n_br_fiscal.operation.line(2,) : Field fiscal_operation_line_id failed to transfer from sale.order.line to account.move.line

O erro ocorre na validação que é feita nos Testes se os campos na Linha do Pedido de Vendas estão com os mesmos valores na Linha da Fatura criada a partir do Picking, o problema é que a Linha de Operação Fiscal está diferente, isso acontece porque ao refatorar os testes do l10n_br_sale_stock para usar os métodos Commom do l10n_br_stock_account https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_stock_account/tests/common.py para reduzir código o método onchange_product_id_fiscal é chamado https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_stock_account/tests/common.py#L25  e ao mapear a Linha de Operação Fiscal usando o partner_id do stock.picking que é o partner_shipping_id da sale.order traz outro valor, o teste pode ser feito na tela com os Dados de Demonstração 

![image](https://github.com/OCA/l10n-brazil/assets/6341149/3f13639b-be45-4814-882b-2f7e6ce1a980)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/679a2451-9260-4c16-81bc-8369024260b8)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/9001e576-22f3-4f04-be1d-b39ff850b26b)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/bcb84540-96fa-43ef-b3dd-3cca2833778e)

Se por algum motivo o onchange é chamado, por exemplo alterando a Operação Fiscal para Bonificação e depois voltando para Venda a Linha de Operação Fiscal que era Revenda Não Contribuinte passa para Revenda

![image](https://github.com/OCA/l10n-brazil/assets/6341149/2fc2b829-3942-46df-bdfa-6dfe4298fc37)

Isso também pode ser visto diretamente no Pedido de Venda, onde esse problema do método que mapea/identifica a Linha de Operação Fiscal a ser usada sempre usar o partner_id do objeto pode ser visto, porque ao alterar o partner_invoice_id nada acontece, sendo que o Partner desse campo é o que deve ser usado para criar a Fatura

![image](https://github.com/OCA/l10n-brazil/assets/6341149/cabf0eea-ffb2-44f4-ac7e-76c582b38bd9)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/c0fe046e-7dee-48c6-b17d-1e2201777aad)

mas ao alterar o partner_id aí tem um onchange sendo chamado que atualiza as linhas com a Linha de Operação Fiscal e altera para Revenda 

![image](https://github.com/OCA/l10n-brazil/assets/6341149/c95f379e-3a19-4655-afe3-00d38f216915)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/a965b81e-e230-461d-98fd-830077b319f6)

Por isso esse PR depende da solução proposta no PR https://github.com/OCA/l10n-brazil/pull/2849 ou de alguma outra solução já que esse caso de uso onde o partner_id do objeto é diferente do Partner a ser usado no Faturamento ou devido o método address_get retornar outro Partner ou no caso de Vendas onde existe um campo partner_invoice_id que pode ser diferente do partner_id a identificação da Linha de Operação Fiscal pode ser diferente.

cc @renatonlima @rvalyi @marcelsavegnago @mileo 