### PR TITLE
[14.0][FIX] l10n_br_sale: Fatura criada a partir do Pedido de Vendas deve usar o Partner do campo partner_invoice_id

### DIFF
--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -182,7 +182,17 @@ class SaleOrder(models.Model):
         result = super()._prepare_invoice()
         # O caso Brasil se caracteriza por ter a Operação Fiscal
         if self.fiscal_operation_id:
-            result.update(self._prepare_br_fiscal_dict())
+            # TODO: O metodo prepare_br_fiscal_dict retorna o partner_id
+            #  principal e não está considerando os casos do partner_invoice_id
+            #  diferente do partner, deveria?
+            fiscal_values = self._prepare_br_fiscal_dict()
+            if fiscal_values.get("partner_id") != result.get("partner_id"):
+                # Usa o partner mapeado pelos metodos do modulo sale, sem isso
+                # o caso do partner_id ser diferente do partner_invoice_id a
+                # Fatura acabava sendo criada com o partner_id
+                fiscal_values["partner_id"] = result.get("partner_id")
+
+            result.update(fiscal_values)
 
             document_type_id = self._context.get("document_type_id")
 


### PR DESCRIPTION
Invoice should be create with partner_invoice_id not with partner_id.

Fatura criada a partir do Pedido de Vendas deve usar o Partner do campo partner_invoice_id, PR simples que mantem o comportamento padrão do modulo Sale, originalmente esse commit estava no PR https://github.com/OCA/l10n-brazil/pull/2849 mas para facilitar a revisão estou extraindo de lá, o problema pode ser visto na tela com os Dados de Demonstração:

Apesar do campo partner_invoice_id ter um Partner diferente do campo partner_id

![image](https://github.com/OCA/l10n-brazil/assets/6341149/1e30b8f1-2a25-4882-bbe4-35e8955e6ae2)

a Fatura é criada com o valor do partner_id

![image](https://github.com/OCA/l10n-brazil/assets/6341149/849ff526-be09-404e-8b79-12fc768fa338)

Esse comportamento não é o padrão do modulo Sale e isso pode ser visto criando um Pedido que não tem Operação Fiscal, que pode ser o Caso Internacional

![image](https://github.com/OCA/l10n-brazil/assets/6341149/563d4208-59f6-4741-ad5b-d39c8a559bd3)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/d2dbdfae-2237-4c9e-a201-067452d4e4d9)

Isso acontece porque o dicionario de dados chamado pelo método Fiscal esta trazendo o valor do partner_id https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_sale/models/sale_order.py#L185 e quando é feito o update do dicionario de dados do metodo original o valor é substituido( O método ._prepare_br_fiscal_dict deveria resolver essa questão? Deixei um TODO sobre isso )

Com esse PR a Localização passa a ter o mesmo comportamento do modulo original, permitindo os Casos de Uso onde o partner_invoice_id pode ser diferente do partner_id

![image](https://github.com/OCA/l10n-brazil/assets/6341149/d4ded97d-0fee-434e-82d7-9f1b8b63d22a)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/dc7481d0-eb40-480c-bd52-21c3cc06948a)

cc @renatonlima @rvalyi @marcelsavegnago @mileo  