### PR TITLE
[14.0][FIX] l10n_br_sale: Possibilidade de incluir uma Seção ou Nota na Linha do Pedido de Vendas

### DIFF
--- a/l10n_br_sale/views/sale_view.xml
+++ b/l10n_br_sale/views/sale_view.xml
@@ -194,7 +194,7 @@
                 <field
                     name="fiscal_operation_line_id"
                     options="{'no_create': True}"
-                    attrs="{'readonly': [('state', 'in', ('sale', 'done', 'cancel'))], 'required': [('parent.fiscal_operation_id', '!=', False)], 'invisible': [('parent.fiscal_operation_id', '=', False)]}"
+                    attrs="{'readonly': [('state', 'in', ('sale', 'done', 'cancel'))], 'required': ['&amp;', ('parent.fiscal_operation_id', '!=', False), ('product_id', '!=', False)], 'invisible': [('parent.fiscal_operation_id', '=', False)]}"
                 />
                 <field
                     name="cfop_id"


### PR DESCRIPTION
The possibility of include a Section or Note in Sale lines when Sale Order has Fiscal Operation.

PR simples que resolve o issue https://github.com/OCA/l10n-brazil/issues/2863 que é a possibilidade de incluir uma Seção ou Nota na Linha do Pedido de Vendas no caso que tem Operação Fiscal ou caso internacional

![image](https://github.com/OCA/l10n-brazil/assets/6341149/c9ca923a-a4f0-484c-9da5-35d4a731d36a)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/53c2d6d4-1dc0-4ed1-ba19-e412a89a9e0c)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/9e75150b-3e58-4960-ad8f-34f2b73d3ac8)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/fa00c434-7a9f-4c5f-9de0-3f031c1c5a91)

Para resolver coloquei no atributo de Requerido da Linha de Operação Fiscal o fiscal_operation e o product_id quando não forem Falso

![image](https://github.com/OCA/l10n-brazil/assets/6341149/c0bdc0e8-876c-431e-ba0e-0b07f0ff8f4b)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/a8f41bff-a641-449b-944b-2747418286ee)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/94c13347-8243-49ee-9b22-a8780097ecfe)

cc @renatonlima @rvalyi @marcelsavegnago @mileo @douglascstd @antoniospneto 