### PR TITLE
[14.0][FIX] l10n_br_stock_account: Método para obter Operação Fiscal padrão deve usar a empresa do ENV não do usuário

### DIFF
--- a/l10n_br_stock_account/models/stock_picking.py
+++ b/l10n_br_stock_account/models/stock_picking.py
@@ -10,8 +10,8 @@ class StockPicking(models.Model):
 
     @api.model
     def _default_fiscal_operation(self):
-        company = self.env.user.company_id
-        fiscal_operation = self.env.user.company_id.stock_fiscal_operation_id
+        company = self.env.company
+        fiscal_operation = company.stock_fiscal_operation_id
         picking_type_id = self.env.context.get("default_picking_type_id")
         if picking_type_id:
             picking_type = self.env["stock.picking.type"].browse(picking_type_id)


### PR DESCRIPTION
To get the current Company the mehtod should made self.env.company instead of self.env.user.company_id .

PR simples para corrigir no método para obter Operação Fiscal padrão deve usar a empresa do ENV e não do usuário, como está sendo feito em outros módulos, o commit estava no PR https://github.com/OCA/l10n-brazil/pull/2849 mas para facilitar a revisão extrai e criei esse PR

cc @renatonlima @rvalyi @marcelsavegnago @mileo 