### PR TITLE
[14.0][REF] l10n_br_sale: Removendo onchanges desnecessários nos Dados de Demonstração

### DIFF
--- a/l10n_br_sale/demo/l10n_br_sale.xml
+++ b/l10n_br_sale/demo/l10n_br_sale.xml
@@ -34,14 +34,6 @@
         <value eval="[ref('main_sl_only_products_1_2')]" />
     </function>
 
-    <function model="sale.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_sl_only_products_1_2')]" />
-    </function>
-
-    <function model="sale.order.line" name="_onchange_fiscal_operation_line_id">
-        <value eval="[ref('main_sl_only_products_1_2')]" />
-    </function>
-
     <record id="main_sl_only_products_2_2" model="sale.order.line">
         <field name="order_id" ref="main_so_only_products" />
         <field name="name">Mouse, Wireless</field>
@@ -57,14 +49,6 @@
     </record>
 
     <function model="sale.order.line" name="_onchange_product_id_fiscal">
-        <value eval="[ref('main_sl_only_products_2_2')]" />
-    </function>
-
-    <function model="sale.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_sl_only_products_2_2')]" />
-    </function>
-
-    <function model="sale.order.line" name="_onchange_fiscal_operation_line_id">
         <value eval="[ref('main_sl_only_products_2_2')]" />
     </function>
 
@@ -99,14 +83,6 @@
         <value eval="[ref('main_sl_only_services_1_2')]" />
     </function>
 
-    <function model="sale.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_sl_only_services_1_2')]" />
-    </function>
-
-    <function model="sale.order.line" name="_onchange_fiscal_operation_line_id">
-        <value eval="[ref('main_sl_only_services_1_2')]" />
-    </function>
-
     <record id="main_sl_only_services_2_2" model="sale.order.line">
         <field name="order_id" ref="main_so_only_services" />
         <field name="name">Virtual Home Staging</field>
@@ -120,14 +96,6 @@
     </record>
 
     <function model="sale.order.line" name="_onchange_product_id_fiscal">
-        <value eval="[ref('main_sl_only_services_2_2')]" />
-    </function>
-
-    <function model="sale.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_sl_only_services_2_2')]" />
-    </function>
-
-    <function model="sale.order.line" name="_onchange_fiscal_operation_line_id">
         <value eval="[ref('main_sl_only_services_2_2')]" />
     </function>
 
@@ -162,14 +130,6 @@
         <value eval="[ref('main_sl_product_service_1_2')]" />
     </function>
 
-    <function model="sale.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_sl_product_service_1_2')]" />
-    </function>
-
-    <function model="sale.order.line" name="_onchange_fiscal_operation_line_id">
-        <value eval="[ref('main_sl_product_service_1_2')]" />
-    </function>
-
     <record id="main_sl_product_service_2_2" model="sale.order.line">
         <field name="order_id" ref="main_so_product_service" />
         <field name="name">Customized Odoo Development</field>
@@ -186,14 +146,6 @@
     </record>
 
     <function model="sale.order.line" name="_onchange_product_id_fiscal">
-        <value eval="[ref('main_sl_product_service_2_2')]" />
-    </function>
-
-    <function model="sale.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_sl_product_service_2_2')]" />
-    </function>
-
-    <function model="sale.order.line" name="_onchange_fiscal_operation_line_id">
         <value eval="[ref('main_sl_product_service_2_2')]" />
     </function>
 
@@ -229,14 +181,6 @@
         <value eval="[ref('sn_sl_only_products_1_2')]" />
     </function>
 
-    <function model="sale.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('sn_sl_only_products_1_2')]" />
-    </function>
-
-    <function model="sale.order.line" name="_onchange_fiscal_operation_line_id">
-        <value eval="[ref('sn_sl_only_products_1_2')]" />
-    </function>
-
     <record id="sn_sl_only_products_2_2" model="sale.order.line">
         <field name="order_id" ref="sn_so_only_products" />
         <field name="name">Mouse, Wireless</field>
@@ -250,14 +194,6 @@
     </record>
 
     <function model="sale.order.line" name="_onchange_product_id_fiscal">
-        <value eval="[ref('sn_sl_only_products_2_2')]" />
-    </function>
-
-    <function model="sale.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('sn_sl_only_products_2_2')]" />
-    </function>
-
-    <function model="sale.order.line" name="_onchange_fiscal_operation_line_id">
         <value eval="[ref('sn_sl_only_products_2_2')]" />
     </function>
 
@@ -292,14 +228,6 @@
         <value eval="[ref('sn_sl_only_services_1_2')]" />
     </function>
 
-    <function model="sale.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('sn_sl_only_services_1_2')]" />
-    </function>
-
-    <function model="sale.order.line" name="_onchange_fiscal_operation_line_id">
-        <value eval="[ref('sn_sl_only_services_1_2')]" />
-    </function>
-
     <record id="sn_sl_only_services_2_2" model="sale.order.line">
         <field name="order_id" ref="sn_so_only_services" />
         <field name="name">Virtual Home Staging</field>
@@ -313,14 +241,6 @@
     </record>
 
     <function model="sale.order.line" name="_onchange_product_id_fiscal">
-        <value eval="[ref('sn_sl_only_services_2_2')]" />
-    </function>
-
-    <function model="sale.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('sn_sl_only_services_2_2')]" />
-    </function>
-
-    <function model="sale.order.line" name="_onchange_fiscal_operation_line_id">
         <value eval="[ref('sn_sl_only_services_2_2')]" />
     </function>
 
@@ -355,14 +275,6 @@
         <value eval="[ref('sn_sl_product_service_1_2')]" />
     </function>
 
-    <function model="sale.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('sn_sl_product_service_1_2')]" />
-    </function>
-
-    <function model="sale.order.line" name="_onchange_fiscal_operation_line_id">
-        <value eval="[ref('sn_sl_product_service_1_2')]" />
-    </function>
-
     <record id="sn_sl_product_service_2_2" model="sale.order.line">
         <field name="order_id" ref="sn_so_product_service" />
         <field name="name">Customized Odoo Development</field>
@@ -379,14 +291,6 @@
     </record>
 
     <function model="sale.order.line" name="_onchange_product_id_fiscal">
-        <value eval="[ref('sn_sl_product_service_2_2')]" />
-    </function>
-
-    <function model="sale.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('sn_sl_product_service_2_2')]" />
-    </function>
-
-    <function model="sale.order.line" name="_onchange_fiscal_operation_line_id">
         <value eval="[ref('sn_sl_product_service_2_2')]" />
     </function>
 
@@ -422,14 +326,6 @@
         <value eval="[ref('lc_sl_only_products_1_2')]" />
     </function>
 
-    <function model="sale.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('lc_sl_only_products_1_2')]" />
-    </function>
-
-    <function model="sale.order.line" name="_onchange_fiscal_operation_line_id">
-        <value eval="[ref('lc_sl_only_products_1_2')]" />
-    </function>
-
     <record id="lc_sl_only_products_2_2" model="sale.order.line">
         <field name="order_id" ref="lc_so_only_products" />
         <field name="name">Mouse, Wireless</field>
@@ -443,14 +339,6 @@
     </record>
 
     <function model="sale.order.line" name="_onchange_product_id_fiscal">
-        <value eval="[ref('lc_sl_only_products_2_2')]" />
-    </function>
-
-    <function model="sale.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('lc_sl_only_products_2_2')]" />
-    </function>
-
-    <function model="sale.order.line" name="_onchange_fiscal_operation_line_id">
         <value eval="[ref('lc_sl_only_products_2_2')]" />
     </function>
 
@@ -485,14 +373,6 @@
         <value eval="[ref('lc_sl_only_services_1_2')]" />
     </function>
 
-    <function model="sale.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('lc_sl_only_services_1_2')]" />
-    </function>
-
-    <function model="sale.order.line" name="_onchange_fiscal_operation_line_id">
-        <value eval="[ref('lc_sl_only_services_1_2')]" />
-    </function>
-
     <record id="lc_sl_only_services_2_2" model="sale.order.line">
         <field name="order_id" ref="lc_so_only_services" />
         <field name="name">Customized Odoo Development</field>
@@ -506,14 +386,6 @@
     </record>
 
     <function model="sale.order.line" name="_onchange_product_id_fiscal">
-        <value eval="[ref('lc_sl_only_services_2_2')]" />
-    </function>
-
-    <function model="sale.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('lc_sl_only_services_2_2')]" />
-    </function>
-
-    <function model="sale.order.line" name="_onchange_fiscal_operation_line_id">
         <value eval="[ref('lc_sl_only_services_2_2')]" />
     </function>
 
@@ -548,14 +420,6 @@
         <value eval="[ref('lc_sl_product_service_1_2')]" />
     </function>
 
-    <function model="sale.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('lc_sl_product_service_1_2')]" />
-    </function>
-
-    <function model="sale.order.line" name="_onchange_fiscal_operation_line_id">
-        <value eval="[ref('lc_sl_product_service_1_2')]" />
-    </function>
-
     <record id="lc_sl_product_service_2_2" model="sale.order.line">
         <field name="order_id" ref="lc_so_product_service" />
         <field name="name">Customized Odoo Development</field>
@@ -572,14 +436,6 @@
     </record>
 
     <function model="sale.order.line" name="_onchange_product_id_fiscal">
-        <value eval="[ref('lc_sl_product_service_2_2')]" />
-    </function>
-
-    <function model="sale.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('lc_sl_product_service_2_2')]" />
-    </function>
-
-    <function model="sale.order.line" name="_onchange_fiscal_operation_line_id">
         <value eval="[ref('lc_sl_product_service_2_2')]" />
     </function>
 


### PR DESCRIPTION
Remove unnecessary onchanges in Demo Data.

PR simples que apenas esta removendo onchanges desnecessários nos Dados de Demonstração porque o método _onchange_product_id_fiscal https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py#L378 já chama o _onchange_fiscal_operation_id  https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py#L416 e esse método https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py#L335 chama o _onchange_fiscal_operation_line_id https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py#L345 o que torna desnecessário chama-los novamente.

cc @renatonlima @rvalyi @marcelsavegnago @mileo 