### PR TITLE
[14.0][REF] l10n_br_purchase: Removendo onchanges desnecessários nos Dados de Demonstração

### DIFF
--- a/l10n_br_purchase/demo/l10n_br_purchase.xml
+++ b/l10n_br_purchase/demo/l10n_br_purchase.xml
@@ -36,14 +36,6 @@
         <value eval="[ref('main_pl_only_products_1_2')]" />
     </function>
 
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_pl_only_products_1_2')]" />
-    </function>
-
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_line_id">
-        <value eval="[ref('main_pl_only_products_1_2')]" />
-    </function>
-
     <record id="main_pl_only_products_2_2" model="purchase.order.line">
         <field name="order_id" ref="main_po_only_products" />
         <field name="name">Drawer Black</field>
@@ -60,14 +52,6 @@
     </record>
 
     <function model="purchase.order.line" name="_onchange_product_id_fiscal">
-        <value eval="[ref('main_pl_only_products_2_2')]" />
-    </function>
-
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_pl_only_products_2_2')]" />
-    </function>
-
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_line_id">
         <value eval="[ref('main_pl_only_products_2_2')]" />
     </function>
 
@@ -105,14 +89,6 @@
         <value eval="[ref('lp_pl_only_products_1_2')]" />
     </function>
 
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('lp_pl_only_products_1_2')]" />
-    </function>
-
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_line_id">
-        <value eval="[ref('lp_pl_only_products_1_2')]" />
-    </function>
-
     <record id="lp_pl_only_products_2_2" model="purchase.order.line">
         <field name="order_id" ref="lp_po_only_products" />
         <field name="name">Drawer Black</field>
@@ -129,14 +105,6 @@
     </record>
 
     <function model="purchase.order.line" name="_onchange_product_id_fiscal">
-        <value eval="[ref('lp_pl_only_products_2_2')]" />
-    </function>
-
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('lp_pl_only_products_2_2')]" />
-    </function>
-
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_line_id">
         <value eval="[ref('lp_pl_only_products_2_2')]" />
     </function>
 
@@ -174,14 +142,6 @@
         <value eval="[ref('sn_pl_only_products_1_2')]" />
     </function>
 
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('sn_pl_only_products_1_2')]" />
-    </function>
-
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_line_id">
-        <value eval="[ref('sn_pl_only_products_1_2')]" />
-    </function>
-
     <record id="sn_pl_only_products_2_2" model="purchase.order.line">
         <field name="order_id" ref="sn_po_only_products" />
         <field name="name">Drawer Black</field>
@@ -198,14 +158,6 @@
     </record>
 
     <function model="purchase.order.line" name="_onchange_product_id_fiscal">
-        <value eval="[ref('sn_pl_only_products_2_2')]" />
-    </function>
-
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('sn_pl_only_products_2_2')]" />
-    </function>
-
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_line_id">
         <value eval="[ref('sn_pl_only_products_2_2')]" />
     </function>
 
@@ -241,11 +193,7 @@
         <field name="partner_order_line">001</field>
     </record>
 
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_pl_only_service_1_1')]" />
-    </function>
-
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_line_id">
+    <function model="purchase.order.line" name="_onchange_product_id_fiscal">
         <value eval="[ref('main_pl_only_service_1_1')]" />
     </function>
 
@@ -281,12 +229,8 @@
         <field name="partner_order_line">001</field>
     </record>
 
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
+    <function model="purchase.order.line" name="_onchange_product_id_fiscal">
         <value eval="[ref('main_pl_only_service_1_1')]" />
-    </function>
-
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_line_id">
-        <value eval="[ref('main_pl_service_product_1_1')]" />
     </function>
 
     <record id="main_pl_service_product_2_2" model="purchase.order.line">
@@ -310,11 +254,7 @@
         <field name="freight_value">10</field>
     </record>
 
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_pl_service_product_2_2')]" />
-    </function>
-
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_line_id">
+    <function model="purchase.order.line" name="_onchange_product_id_fiscal">
         <value eval="[ref('main_pl_service_product_2_2')]" />
     </function>
 


### PR DESCRIPTION
Remove unnecessary onchanges in Demo Data.

PR simples que apenas esta removendo onchanges desnecessários nos Dados de Demonstração porque o método _onchange_product_id_fiscal https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py#L378 já chama o _onchange_fiscal_operation_id https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py#L416 e esse método https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py#L335 chama o _onchange_fiscal_operation_line_id https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py#L345 o que torna desnecessário chama-los novamente.

cc @renatonlima @rvalyi @marcelsavegnago @mileo