### PR TITLE
[14.0][REF] l10n_br_purchase_stock: Removendo onchanges desnecessários nos Dados de Demonstração

### DIFF
--- a/l10n_br_purchase_stock/demo/purchase_order.xml
+++ b/l10n_br_purchase_stock/demo/purchase_order.xml
@@ -71,14 +71,6 @@
         <value eval="[ref('main_pl_only_products_1_1')]" />
     </function>
 
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_pl_only_products_1_1')]" />
-    </function>
-
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_line_id">
-        <value eval="[ref('main_pl_only_products_1_1')]" />
-    </function>
-
     <record id="main_pl_only_products_1_2" model="purchase.order.line">
         <field name="order_id" ref="main_po_only_products_1" />
         <field name="name">Gaveta Preta</field>
@@ -101,14 +93,6 @@
     </record>
 
     <function model="purchase.order.line" name="_onchange_product_id_fiscal">
-        <value eval="[ref('main_pl_only_products_1_2')]" />
-    </function>
-
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_pl_only_products_1_2')]" />
-    </function>
-
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_line_id">
         <value eval="[ref('main_pl_only_products_1_2')]" />
     </function>
 
@@ -159,14 +143,6 @@
         <value eval="[ref('main_pl_only_products_2_1')]" />
     </function>
 
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_pl_only_products_2_1')]" />
-    </function>
-
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_line_id">
-        <value eval="[ref('main_pl_only_products_2_1')]" />
-    </function>
-
     <record id="main_pl_only_products_2_2" model="purchase.order.line">
         <field name="order_id" ref="main_po_only_products_2" />
         <field name="name">Gaveta Preta</field>
@@ -188,11 +164,7 @@
         <field name="freight_value">10</field>
     </record>
 
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_pl_only_products_2_2')]" />
-    </function>
-
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_line_id">
+    <function model="purchase.order.line" name="_onchange_product_id_fiscal">
         <value eval="[ref('main_pl_only_products_2_2')]" />
     </function>
 
@@ -244,14 +216,6 @@
         <value eval="[ref('lucro_presumido_pol_only_products_1_1')]" />
     </function>
 
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('lucro_presumido_pol_only_products_1_1')]" />
-    </function>
-
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_line_id">
-        <value eval="[ref('lucro_presumido_pol_only_products_1_1')]" />
-    </function>
-
     <record id="lucro_presumido_pol_only_products_1_2" model="purchase.order.line">
         <field name="order_id" ref="lucro_presumido_po_only_products_1" />
         <field name="name">Gaveta Preta</field>
@@ -274,14 +238,6 @@
     </record>
 
     <function model="purchase.order.line" name="_onchange_product_id_fiscal">
-        <value eval="[ref('lucro_presumido_pol_only_products_1_2')]" />
-    </function>
-
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('lucro_presumido_pol_only_products_1_2')]" />
-    </function>
-
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_line_id">
         <value eval="[ref('lucro_presumido_pol_only_products_1_2')]" />
     </function>
 
@@ -323,11 +279,7 @@
         <field name="partner_order_line">001</field>
     </record>
 
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_pl_only_service_stock_1_1')]" />
-    </function>
-
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_line_id">
+    <function model="purchase.order.line" name="_onchange_product_id_fiscal">
         <value eval="[ref('main_pl_only_service_stock_1_1')]" />
     </function>
 
@@ -363,11 +315,7 @@
         <field name="partner_order_line">001</field>
     </record>
 
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_pl_service_product_stock_1_1')]" />
-    </function>
-
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_line_id">
+    <function model="purchase.order.line" name="_onchange_product_id_fiscal">
         <value eval="[ref('main_pl_service_product_stock_1_1')]" />
     </function>
 
@@ -392,11 +340,7 @@
         <field name="freight_value">10</field>
     </record>
 
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_pl_service_product_stock_2_2')]" />
-    </function>
-
-    <function model="purchase.order.line" name="_onchange_fiscal_operation_line_id">
+    <function model="purchase.order.line" name="_onchange_product_id_fiscal">
         <value eval="[ref('main_pl_service_product_stock_2_2')]" />
     </function>
 


### PR DESCRIPTION
Remove unnecessary onchanges in Demo Data.

PR simples que apenas esta removendo onchanges desnecessários nos Dados de Demonstração porque o método _onchange_product_id_fiscal https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py#L378 já chama o _onchange_fiscal_operation_id https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py#L416 e esse método https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py#L335 chama o _onchange_fiscal_operation_line_id https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py#L345 o que torna desnecessário chama-los novamente.

cc @renatonlima @rvalyi @marcelsavegnago @mileo

Tem um erro que está acontecendo durante a instalação do ambiente aqui no github, parece ser algo da infraestrutura que passou ocorrer hoje, pela mensagem parece que está falhando o mapeamento dos modulos da OCA que estão em outros repositorios, o erro não parece ter relação com as alterações do PR 