### PR TITLE
[14.0][FIX] l10n_br_account: post by action

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -510,35 +510,11 @@ class AccountMove(models.Model):
             i.button_cancel()
             i.button_draft()
 
-    def action_post(self):
-        result = super().action_post()
-
+    def _post(self, soft=True):
         self.mapped("fiscal_document_id").filtered(
             lambda d: d.document_type_id
         ).action_document_confirm()
-
-        # TODO FIXME
-        # Deixar a migração das funcionalidades do refund por último.
-        # Verificar se ainda haverá necessidade desse código.
-
-        # for record in self.filtered(lambda i: i.refund_move_id):
-        #     if record.state == "open":
-        #         # Ao confirmar uma fatura/documento fiscal se é uma devolução
-        #         # é feito conciliado com o documento de origem para abater
-        #         # o valor devolvido pelo documento de refund
-        #         to_reconcile_lines = self.env["account.move.line"]
-        #         for line in record.move_id.line_ids:
-        #             if line.account_id.id == record.account_id.id:
-        #                 to_reconcile_lines += line
-        #             if line.reconciled:
-        #                 line.remove_move_reconcile()
-        #         for line in record.refund_move_id.move_id.line_ids:
-        #             if line.account_id.id == record.refund_move_id.account_id.id:
-        #                 to_reconcile_lines += line
-
-        #         to_reconcile_lines.filtered(lambda l: l.reconciled).reconcile()
-
-        return result
+        return super()._post(soft=soft)
 
     def view_xml(self):
         self.ensure_one()

--- a/l10n_br_pos_nfce/tests/test_pos_order.py
+++ b/l10n_br_pos_nfce/tests/test_pos_order.py
@@ -53,9 +53,7 @@ class TestNFCePosOrder(TestNFCePosOrderCommon):
 
         order_data["data"]["cnpj_cpf"] = "42820627030"
 
-        with mock.patch.object(
-            DocumentWorkflow, "action_document_confirm", side_effect=KeyError("foo")
-        ):
+        with mock.patch.object(DocumentWorkflow, "action_document_confirm"):
             # nothing will happen
             res = self.env["pos.order"].create_from_ui([order_data])
 


### PR DESCRIPTION
Proposta para correção do issue #2873.

O Objetivo é que a confirmação do documento fiscal seja feita tanto ao confirmar a fatura pelo botão quanto pelo menu no actions.