### PR TITLE
[14.0][REF+FIX] l10n_br_fiscal_certificate, l10n_br_nfe: Incluído um campo compute para obter o Certificado( e-CNPJ ou e-NFe)

### DIFF
--- a/l10n_br_fiscal_certificate/models/res_company.py
+++ b/l10n_br_fiscal_certificate/models/res_company.py
@@ -3,7 +3,8 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 
-from odoo import fields, models
+from odoo import _, fields, models
+from odoo.exceptions import ValidationError
 
 
 class ResCompany(models.Model):
@@ -20,3 +21,26 @@ class ResCompany(models.Model):
         string="NFe",
         domain="[('type', '=', 'nf-e')]",
     )
+
+    certificate = fields.Many2one(
+        comodel_name="l10n_br_fiscal.certificate",
+        compute="_compute_certificate",
+    )
+
+    def _compute_certificate(self):
+        for record in self:
+            certificate = False
+            if record.sudo().certificate_nfe_id:
+                certificate = record.sudo().certificate_nfe_id
+            elif record.sudo().certificate_ecnpj_id:
+                certificate = record.sudo().certificate_ecnpj_id
+
+            if not certificate:
+                raise ValidationError(
+                    _(
+                        "Certificate not found, you need to inform your e-CNPJ"
+                        " or e-NFe certificate in the Company."
+                    )
+                )
+
+            record.certificate = certificate

--- a/l10n_br_fiscal_certificate/tests/__init__.py
+++ b/l10n_br_fiscal_certificate/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_certificate

--- a/l10n_br_fiscal_certificate/tests/test_certificate.py
+++ b/l10n_br_fiscal_certificate/tests/test_certificate.py
@@ -114,3 +114,20 @@ class TestCertificate(SavepointCase):
                     "file": self.certificate_invalid,
                 }
             )
+
+    def test_compute_field_to_get_certificate(self):
+        """Test compute field to get Certificate or e-CNPJ or e-NFe"""
+        company = self.env.company
+        with self.assertRaises(ValidationError):
+            assert company.certificate
+        cert = self.certificate_model.create(
+            {
+                "type": "nf-e",
+                "subtype": "a1",
+                "password": self.cert_passwd,
+                "file": self.certificate_valid,
+            }
+        )
+
+        company.certificate_nfe_id = cert
+        assert company.certificate

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -864,16 +864,10 @@ class NFe(spec_models.StackedModel):
         return edocs
 
     def _processador(self):
-        certificate = False
-        if self.company_id.sudo().certificate_nfe_id:
-            certificate = self.company_id.sudo().certificate_nfe_id
-        elif self.company_id.sudo().certificate_ecnpj_id:
-            certificate = self.company_id.sudo().certificate_ecnpj_id
 
-        if not certificate:
-            raise UserError(_("Certificado não encontrado"))
         self._check_nfe_environment()
 
+        certificate = self.env.company.certificate
         certificado = cert.Certificado(
             arquivo=certificate.file,
             senha=certificate.password,

--- a/l10n_br_nfe/models/invalidate_number.py
+++ b/l10n_br_nfe/models/invalidate_number.py
@@ -9,8 +9,7 @@ from erpbrasil.transmissao import TransmissaoSOAP
 from nfelib.nfe.ws.edoc_legacy import NFCeAdapter as edoc_nfce, NFeAdapter as edoc_nfe
 from requests import Session
 
-from odoo import _, fields, models
-from odoo.exceptions import UserError
+from odoo import fields, models
 
 from odoo.addons.l10n_br_fiscal.constants.fiscal import EVENT_ENV_HML, EVENT_ENV_PROD
 
@@ -19,12 +18,10 @@ class InvalidateNumber(models.Model):
     _inherit = "l10n_br_fiscal.invalidate.number"
 
     def _processador(self):
-        if not self.company_id.sudo().certificate_nfe_id:
-            raise UserError(_("Certificado não encontrado"))
-
+        certificate = self.env.company.certificate
         certificado = cert.Certificado(
-            arquivo=self.company_id.sudo().certificate_nfe_id.file,
-            senha=self.company_id.sudo().certificate_nfe_id.password,
+            arquivo=certificate.file,
+            senha=certificate.password,
         )
         session = Session()
         session.verify = False


### PR DESCRIPTION
Included a method to get e-Certificate to reduce duplicate code and keep a standard.

Incluído um método padrão para obter o E-Certificado para unificar, padronizar e reduzir código duplicado

Já tinha visto em algum PR ( se encontrar vejo de marca-lo aqui ) que o código para buscar o certificado estava sendo duplicado em alguns objetos e módulos e em alguns casos não estava considerando o e-cnpj, cheguei a fazer um PR para corrigir esse caso na Emissão de uma NF-e https://github.com/OCA/l10n-brazil/pull/2668 mas ficou faltando no processo de Invalidar Numeração, recentemente vi que foi aberto um PR que também estava refatorando esse processo de obter o e-certificado mas no modulo l10n_br_ie_search https://github.com/OCA/l10n-brazil/pull/2891 ( preciso confirmar no caso desse modulo apenas o e-cnpj pode ser usado, para pensar uma forma de alterar o código se houver necessidade ), existem outros módulos que caso esse PR seja aprovado poderão ser alterados mas achei melhor fazer aqui apenas o l10n_br_nfe para facilitar a revisão.

Uma alteração que fiz do original ao invés de usar o self.company_id passei a usar o self.env.company, teria algum problema? Pode exisitir algum caso onde o esses campos seja diferentes?

cc @renatonlima @rvalyi @marcelsavegnago @mileo @felipemotter 