### PR TITLE
[14.0][FIX] *_cnpj_search: mock the api response

### DIFF
--- a/l10n_br_cnpj_search/tests/fixtures/test_receitaws_empresa.yaml
+++ b/l10n_br_cnpj_search/tests/fixtures/test_receitaws_empresa.yaml
@@ -1,0 +1,66 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - "*/*"
+        Accept-Encoding:
+          - gzip, deflate
+        Authorization:
+          - Bearer 06aef429-a981-3ec5-a1f8-71d38d86481e
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.25.1
+      method: GET
+      uri: https://www.receitaws.com.br/v1/cnpj/44356113000108
+    response:
+      body:
+        string:
+          "{\"abertura\": \"24/11/2021\", \"situacao\": \"BAIXADA\", \"tipo\":
+          \"MATRIZ\", \"nome\": \"KILIAN MACEDO MELCHER 08777131460\", \"porte\":
+          \"MICRO EMPRESA\", \"natureza_juridica\": \"213-5 - Empres\\u00e1rio
+          (Individual)\", \"logradouro\": \"RUA LUIZA BEZERRA MOTTA\", \"numero\":
+          \"950\", \"complemento\": \"BLOCO E;APT 302\", \"municipio\": \"CAMPINA
+          GRANDE\", \"bairro\": \"CATOLE\", \"uf\": \"PB\", \"cep\": \"58.410-410\",
+          \"email\": \"kilian.melcher@gmail.com\", \"telefone\": \"(83) 8665-0905\",
+          \"data_situacao\": \"18/12/2023\", \"motivo_situacao\": \"EXTIN\\u00c7\\u00c3O
+          POR ENCERRAMENTO LIQUIDA\\u00c7\\u00c3O VOLUNT\\u00c1RIA\", \"cnpj\":
+          \"44356113000108\", \"ultima_atualizacao\": \"2024-01-13T23:59:59.000Z\",
+          \"status\": \"OK\", \"fantasia\": \"\", \"efr\": \"\", \"situacao_especial\":
+          \"\", \"data_situacao_especial\": \"\", \"atividade_principal\": [{\"code\":
+          \"4751-2/01\", \"text\": \"********\"}], \"atividades_secundarias\":
+          [{\"code\": \"00.00-0-00\", \"text\": \"Não informada\"}], \"capital_social\":
+          \"3000.00\", \"qsa\": [], \"extra\": {}, \"billing\": {\"free\": true,
+          \"database\": true}}"
+      headers:
+        Access-Control-Allow-Headers:
+          - authorization,Access-Control-Allow-Origin,Content-Type,SOAPAction,apikey,Internal-Key,x-cpf-usuario,signature,x-signature,x-credencial,X-Request-Trace-Id
+        Access-Control-Allow-Methods:
+          - GET
+        Access-Control-Expose-Headers:
+          - ""
+        Connection:
+          - keep-alive
+        Date:
+          - Wed, 28 Jun 2023 13:45:28 GMT
+        Transfer-Encoding:
+          - chunked
+        access-control-allow-origin:
+          - "*"
+        activityid:
+          - 0c70c470-9419-4869-aa01-b964c345f5ac
+        content-type:
+          - application/json; charset=utf-8
+        etag:
+          - W/"86a-p2CeQnt0OF5zs4vPG4Lpgnsxv8k"
+        strict-transport-security:
+          - max-age=15768000
+        x-content-type-options:
+          - nosniff
+        x-powered-by:
+          - Express
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/l10n_br_cnpj_search/tests/fixtures/test_receitaws_multiplos_telefones.yaml
+++ b/l10n_br_cnpj_search/tests/fixtures/test_receitaws_multiplos_telefones.yaml
@@ -1,0 +1,80 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - "*/*"
+        Accept-Encoding:
+          - gzip, deflate
+        Authorization:
+          - Bearer 06aef429-a981-3ec5-a1f8-71d38d86481e
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.25.1
+      method: GET
+      uri: https://www.receitaws.com.br/v1/cnpj/92666056000106
+    response:
+      body:
+        string:
+          '{"abertura": "26/07/1971", "situacao": "ATIVA", "tipo": "MATRIZ", "nome":
+          "ISLA SEMENTES LTDA.", "porte": "DEMAIS", "natureza_juridica": "206-2 -
+          Sociedade Empresária Limitada", "atividade_principal": [{"code": "46.89-3-99",
+          "text": "Comércio atacadista especializado em outros produtos intermediários
+          não especificados anteriormente"}], "atividades_secundarias": [{"code":
+          "01.11-3-99", "text": "Cultivo de outros cereais não especificados
+          anteriormente"}, {"code": "01.21-1-01", "text": "Horticultura, exceto
+          morango"}, {"code": "01.22-9-00", "text": "Cultivo de flores e plantas
+          ornamentais"}, {"code": "01.41-5-01", "text": "Produção de sementes
+          certificadas, exceto de forrageiras para pasto"}, {"code": "46.32-0-01",
+          "text": "Comércio atacadista de cereais e leguminosas beneficiados"}, {"code":
+          "47.61-0-01", "text": "Comércio varejista de livros"}, {"code": "64.62-0-00",
+          "text": "Holdings de instituições não-financeiras"}, {"code": "71.20-1-00",
+          "text": "Testes e análises técnicas"}, {"code": "74.90-1-03", "text":
+          "Serviços de agronomia e de consultoria às atividades agrícolas e pecuárias"},
+          {"code": "85.99-6-99", "text": "Outras atividades de ensino não especificadas
+          anteriormente"}], "qsa": [{"nome": "EDUARDO LEIVAS PURICELLI", "qual":
+          "05-Administrador"}, {"nome": "ADMINISTRACAO E PARTICIPACOES SPALDING LTDA",
+          "qual": "22-Sócio", "nome_rep_legal": "DIANA TEIXEIRA WERNER",
+          "qual_rep_legal": "05-Administrador"}, {"nome": "JOSE ANDREI SILVA DOS
+          SANTOS", "qual": "49-Sócio-Administrador"}, {"nome": "DIANA TEIXEIRA WERNER",
+          "qual": "49-Sócio-Administrador"}], "logradouro": "AVENIDA SEVERO DULLIUS",
+          "numero": "124", "municipio": "PORTO ALEGRE", "bairro": "ANCHIETA", "uf":
+          "RS", "cep": "90.200-310", "email": "contabilidade@isla.com.br", "telefone":
+          "(51) 9852-9561 / (51) 2136-6600", "data_situacao": "04/10/2003", "cnpj":
+          "92.666.056/0001-06", "ultima_atualizacao": "2024-01-13T23:59:59.000Z",
+          "status": "OK", "fantasia": "", "complemento": "", "efr": "",
+          "motivo_situacao": "", "situacao_especial": "", "data_situacao_especial": "",
+          "capital_social": "10606804.00", "extra": {}, "billing": {"free": true,
+          "database": true}}'
+      headers:
+        Access-Control-Allow-Headers:
+          - authorization,Access-Control-Allow-Origin,Content-Type,SOAPAction,apikey,Internal-Key,x-cpf-usuario,signature,x-signature,x-credencial,X-Request-Trace-Id
+        Access-Control-Allow-Methods:
+          - GET
+        Access-Control-Expose-Headers:
+          - ""
+        Connection:
+          - keep-alive
+        Date:
+          - Wed, 28 Jun 2023 13:45:28 GMT
+        Transfer-Encoding:
+          - chunked
+        access-control-allow-origin:
+          - "*"
+        activityid:
+          - 0c70c470-9419-4869-aa01-b964c345f5ac
+        content-type:
+          - application/json; charset=utf-8
+        etag:
+          - W/"86a-p2CeQnt0OF5zs4vPG4Lpgnsxv8k"
+        strict-transport-security:
+          - max-age=15768000
+        x-content-type-options:
+          - nosniff
+        x-powered-by:
+          - Express
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/l10n_br_cnpj_search/tests/fixtures/test_receitaws_not_found.yaml
+++ b/l10n_br_cnpj_search/tests/fixtures/test_receitaws_not_found.yaml
@@ -1,0 +1,53 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - "*/*"
+        Accept-Encoding:
+          - gzip, deflate
+        Authorization:
+          - Bearer 06aef429-a981-3ec5-a1f8-71d38d86481e
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.25.1
+      method: GET
+      uri: https://www.receitaws.com.br/v1/cnpj/00000000000000
+    response:
+      body:
+        string:
+          '{"cnpj": "00.000.000/0000-00", "ultima_atualizacao":
+          "2024-01-25T23:02:46.856Z", "status": "ERROR", "message": "CNPJ rejeitado pela
+          Receita Federal", "billing": {"free": true, "database": true}}'
+      headers:
+        Access-Control-Allow-Headers:
+          - authorization,Access-Control-Allow-Origin,Content-Type,SOAPAction,apikey,Internal-Key,x-cpf-usuario,signature,x-signature,x-credencial,X-Request-Trace-Id
+        Access-Control-Allow-Methods:
+          - GET
+        Access-Control-Expose-Headers:
+          - ""
+        Connection:
+          - keep-alive
+        Date:
+          - Wed, 28 Jun 2023 13:45:28 GMT
+        Transfer-Encoding:
+          - chunked
+        access-control-allow-origin:
+          - "*"
+        activityid:
+          - 0c70c470-9419-4869-aa01-b964c345f5ac
+        content-type:
+          - application/json; charset=utf-8
+        etag:
+          - W/"86a-p2CeQnt0OF5zs4vPG4Lpgnsxv8k"
+        strict-transport-security:
+          - max-age=15768000
+        x-content-type-options:
+          - nosniff
+        x-powered-by:
+          - Express
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/l10n_br_cnpj_search/tests/test_receitaws.py
+++ b/l10n_br_cnpj_search/tests/test_receitaws.py
@@ -1,7 +1,10 @@
 # Copyright 2022 KMEE
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import os
 import time  # You can't send multiple requests at the same time in trial version
+
+import vcr
 
 from odoo.exceptions import ValidationError
 from odoo.tests import tagged
@@ -16,6 +19,11 @@ class TestReceitaWS(TestCnpjCommon):
 
         self.set_param("cnpj_provider", "receitaws")
 
+    @vcr.use_cassette(
+        os.path.dirname(__file__) + "/fixtures/test_receitaws_empresa.yaml",
+        match_on=["method", "scheme", "host", "port", "path", "query", "body"],
+        ignore_localhost=True,
+    )
     def test_receita_ws_success(self):
         kilian = self.model.create({"name": "Kilian", "cnpj_cpf": "44.356.113/0001-08"})
 
@@ -37,6 +45,11 @@ class TestReceitaWS(TestCnpjCommon):
         self.assertEqual(kilian.equity_capital, 3000)
         self.assertEqual(kilian.cnae_main_id.code, "4751-2/01")
 
+    @vcr.use_cassette(
+        os.path.dirname(__file__) + "/fixtures/test_receitaws_not_found.yaml",
+        match_on=["method", "scheme", "host", "port", "path", "query", "body"],
+        ignore_localhost=True,
+    )
     def test_receita_ws_fail(self):
         invalido = self.model.create({"name": "invalido", "cnpj_cpf": "00000000000000"})
         invalido._onchange_cnpj_cpf()
@@ -45,6 +58,11 @@ class TestReceitaWS(TestCnpjCommon):
         with self.assertRaises(ValidationError):
             invalido.search_cnpj()
 
+    @vcr.use_cassette(
+        os.path.dirname(__file__) + "/fixtures/test_receitaws_multiplos_telefones.yaml",
+        match_on=["method", "scheme", "host", "port", "path", "query", "body"],
+        ignore_localhost=True,
+    )
     def test_receita_ws_multiple_phones(self):
         isla = self.model.create({"name": "Isla", "cnpj_cpf": "92.666.056/0001-06"})
         isla._onchange_cnpj_cpf()


### PR DESCRIPTION
Esse PR corrige o problema identificado nos testes do CNPJ, conforme reportado em https://github.com/OCA/l10n-brazil/pull/2894. Para evitar possíveis erros futuros, seguindo a recomendação do @antoniospneto, foram mockadas as respostas utilizando o VCR para todos os testes, o que deve prevenir a ocorrência do problema novamente.

cc @marcelsavegnago @mbcosta @mileo @rvalyi