### PR TITLE
[14.0]REF] l10n_br_fiscal_certificate, l10n_br_fiscal_dfe, l10n_br_nfe, l10n_br_nfse, l10n_br_ie_search: Método para retornar o objeto Certificado da Lib erpbrasil.assinatura

### DIFF
--- a/l10n_br_fiscal_certificate/models/certificate.py
+++ b/l10n_br_fiscal_certificate/models/certificate.py
@@ -95,20 +95,22 @@ class Certificate(models.Model):
 
     @api.depends("file", "password")
     def _compute_name(self):
-        for c in self:
-            if c.file and c.password:
-                c.name = "{} - {} - {} - Valid: {}".format(
-                    c.type and c.type.upper() or "",
-                    c.subtype and c.subtype.upper() or "",
-                    c.owner_name or "",
-                    format_date(self.env, c.date_expiration.date())
-                    if c.date_expiration
+        for cert in self:
+            name = False
+            file_name = False
+            if cert.file and cert.password:
+                name = "{} - {} - {} - Valid: {}".format(
+                    cert.type and cert.type.upper() or "",
+                    cert.subtype and cert.subtype.upper() or "",
+                    cert.owner_name or "",
+                    format_date(self.env, cert.date_expiration.date())
+                    if cert.date_expiration
                     else "",
                 )
-                c.file_name = c.name + ".p12"
-            else:
-                c.name = False
-                c.file_name = False
+                file_name = name + ".p12"
+
+            cert.name = name
+            cert.file_name = file_name
 
     def update_certificate_data(self, values):
         cert_file = values.get("file")

--- a/l10n_br_fiscal_certificate/models/res_company.py
+++ b/l10n_br_fiscal_certificate/models/res_company.py
@@ -3,7 +3,9 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 
-from odoo import _, fields, models
+from erpbrasil.assinatura import certificado as cert
+
+from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 
 
@@ -44,3 +46,18 @@ class ResCompany(models.Model):
                 )
 
             record.certificate = certificate
+
+    @api.model
+    def _get_br_ecertificate(self, only_ecnpj=False):
+        certificate = self.certificate
+        if only_ecnpj:
+            if certificate != self.sudo().certificate_ecnpj_id:
+                certificate = self.sudo().certificate_ecnpj_id
+                if not certificate:
+                    raise ValidationError(
+                        _("Only e-CNPJ Certicate can be used for this case.")
+                    )
+        return cert.Certificado(
+            arquivo=certificate.file,
+            senha=certificate.password,
+        )

--- a/l10n_br_fiscal_certificate/tests/test_certificate.py
+++ b/l10n_br_fiscal_certificate/tests/test_certificate.py
@@ -90,6 +90,9 @@ class TestCertificate(SavepointCase):
         self.assertEqual(cert.date_expiration.day, self.cert_date_exp.day)
         self.assertEqual(cert.name, self.cert_name)
         self.assertEqual(cert.is_valid, True)
+        # Testa metodo write
+        cert.type = "e-cnpj"
+        cert._onchange_file_password()
 
     def test_certificate_wrong_password(self):
         """Write a valid certificate with wrong password"""
@@ -135,3 +138,14 @@ class TestCertificate(SavepointCase):
         # Caso onde apenas o e-CNPJ atende
         with self.assertRaises(ValidationError):
             assert company._get_br_ecertificate(only_ecnpj=True)
+        company.certificate_nfe_id = False
+        cert_ecnpj = self.certificate_model.create(
+            {
+                "type": "e-cnpj",
+                "subtype": "a1",
+                "password": self.cert_passwd,
+                "file": self.certificate_valid,
+            }
+        )
+        company.certificate_ecnpj_id = cert_ecnpj
+        assert company._get_br_ecertificate(only_ecnpj=True)

--- a/l10n_br_fiscal_certificate/tests/test_certificate.py
+++ b/l10n_br_fiscal_certificate/tests/test_certificate.py
@@ -115,8 +115,8 @@ class TestCertificate(SavepointCase):
                 }
             )
 
-    def test_compute_field_to_get_certificate(self):
-        """Test compute field to get Certificate or e-CNPJ or e-NFe"""
+    def test_compute_field_and_method_to_get_certificate(self):
+        """Test compute field and Method to get Certificate or e-CNPJ or e-NFe"""
         company = self.env.company
         with self.assertRaises(ValidationError):
             assert company.certificate
@@ -131,3 +131,7 @@ class TestCertificate(SavepointCase):
 
         company.certificate_nfe_id = cert
         assert company.certificate
+
+        # Caso onde apenas o e-CNPJ atende
+        with self.assertRaises(ValidationError):
+            assert company._get_br_ecertificate(only_ecnpj=True)

--- a/l10n_br_fiscal_dfe/__manifest__.py
+++ b/l10n_br_fiscal_dfe/__manifest__.py
@@ -19,7 +19,6 @@
     "external_dependencies": {
         "python": [
             "erpbrasil.edoc>=2.5.2",
-            "erpbrasil.assinatura>=1.7.0",
             "erpbrasil.transmissao>=1.1.0",
             "nfelib>=2.0.0",
         ],

--- a/l10n_br_fiscal_dfe/models/dfe.py
+++ b/l10n_br_fiscal_dfe/models/dfe.py
@@ -4,7 +4,6 @@
 import logging
 import re
 
-from erpbrasil.assinatura import certificado as cert
 from erpbrasil.transmissao import TransmissaoSOAP
 from nfelib.nfe.ws.edoc_legacy import NFeAdapter as edoc_nfe
 from requests import Session
@@ -53,20 +52,12 @@ class DFe(models.Model):
         return self.mapped(lambda d: (d.id, f"{d.company_id.name} - NSU: {d.last_nsu}"))
 
     @api.model
-    def _get_certificate(self):
-        certificate_id = self.company_id.certificate_nfe_id
-        return cert.Certificado(
-            arquivo=certificate_id.file,
-            senha=certificate_id.password,
-        )
-
-    @api.model
     def _get_processor(self):
+        certificado = self.env.company._get_br_ecertificate()
         session = Session()
         session.verify = False
-
         return edoc_nfe(
-            TransmissaoSOAP(self._get_certificate(), session),
+            TransmissaoSOAP(certificado, session),
             self.company_id.state_id.ibge_code,
             versao=self.version,
             ambiente=self.environment,

--- a/l10n_br_ie_search/models/l10n_br_base_party_mixin.py
+++ b/l10n_br_ie_search/models/l10n_br_base_party_mixin.py
@@ -1,13 +1,11 @@
 # Copyright 2023 KMEE - Breno Oliveira Dias
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from erpbrasil.assinatura import certificado as cert
 from erpbrasil.edoc.nfe import NFe as edoc_nfe
 from erpbrasil.transmissao import TransmissaoSOAP
 from requests import Session, get
 
-from odoo import _, api, models
-from odoo.exceptions import UserError
+from odoo import api, models
 
 SINTEGRA_URL = "https://www.sintegraws.com.br/api/v1/execute-api.php"
 
@@ -62,13 +60,7 @@ class PartyMixin(models.AbstractModel):
     @api.model
     def _processador(self):
         company = self.env.company
-        if not company.certificate_ecnpj_id:
-            raise UserError(_("Certificate not found"))
-
-        certificado = cert.Certificado(
-            arquivo=company.certificate_ecnpj_id.file,
-            senha=company.certificate_ecnpj_id.password,
-        )
+        certificado = company._get_br_ecertificate()
         session = Session()
         session.verify = False
         transmissao = TransmissaoSOAP(certificado, session)

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -8,7 +8,6 @@ import re
 import string
 from datetime import datetime
 
-from erpbrasil.assinatura import certificado as cert
 from erpbrasil.base.fiscal import cnpj_cpf
 from erpbrasil.base.fiscal.edoc import ChaveEdoc
 from erpbrasil.edoc.pdf import base
@@ -864,14 +863,8 @@ class NFe(spec_models.StackedModel):
         return edocs
 
     def _processador(self):
-
         self._check_nfe_environment()
-
-        certificate = self.env.company.certificate
-        certificado = cert.Certificado(
-            arquivo=certificate.file,
-            senha=certificate.password,
-        )
+        certificado = self.env.company._get_br_ecertificate()
         session = Session()
         session.verify = False
         params = {

--- a/l10n_br_nfe/models/invalidate_number.py
+++ b/l10n_br_nfe/models/invalidate_number.py
@@ -3,7 +3,6 @@
 
 from datetime import datetime
 
-from erpbrasil.assinatura import certificado as cert
 from erpbrasil.base.misc import punctuation_rm
 from erpbrasil.transmissao import TransmissaoSOAP
 from nfelib.nfe.ws.edoc_legacy import NFCeAdapter as edoc_nfce, NFeAdapter as edoc_nfe
@@ -18,11 +17,7 @@ class InvalidateNumber(models.Model):
     _inherit = "l10n_br_fiscal.invalidate.number"
 
     def _processador(self):
-        certificate = self.env.company.certificate
-        certificado = cert.Certificado(
-            arquivo=certificate.file,
-            senha=certificate.password,
-        )
+        certificado = self.env.company._get_br_ecertificate()
         session = Session()
         session.verify = False
         params = {

--- a/l10n_br_nfe/models/mde.py
+++ b/l10n_br_nfe/models/mde.py
@@ -122,11 +122,12 @@ class MDe(models.Model):
         ]
 
     def _get_processor(self):
+        certificado = self.env.company._get_br_ecertificate()
         session = Session()
         session.verify = False
 
         return edoc_mde(
-            TransmissaoSOAP(self.dfe_id._get_certificate(), session),
+            TransmissaoSOAP(certificado, session),
             self.company_id.state_id.ibge_code,
             ambiente=self.dfe_id.environment,
         )

--- a/l10n_br_nfse/__manifest__.py
+++ b/l10n_br_nfse/__manifest__.py
@@ -13,7 +13,6 @@
     "external_dependencies": {
         "python": [
             "erpbrasil.edoc>=2.5.2",
-            "erpbrasil.assinatura>=1.7.0",
             "erpbrasil.transmissao>=1.1.0",
             "erpbrasil.base>=2.3.0",
         ],

--- a/l10n_br_nfse/models/document.py
+++ b/l10n_br_nfse/models/document.py
@@ -4,7 +4,6 @@
 import base64
 import logging
 
-from erpbrasil.assinatura import certificado as cert
 from erpbrasil.base import misc
 from erpbrasil.edoc.provedores.cidades import NFSeFactory
 from erpbrasil.transmissao import TransmissaoSOAP
@@ -101,10 +100,7 @@ class Document(models.Model):
             self.file_report_id = self.env["ir.attachment"].create(vals_dict)
 
     def _processador_erpbrasil_nfse(self):
-        certificado = cert.Certificado(
-            arquivo=self.company_id.certificate_nfe_id.file,
-            senha=self.company_id.certificate_nfe_id.password,
-        )
+        certificado = self.env.company._get_br_ecertificate()
         session = Session()
         session.verify = False
         transmissao = TransmissaoSOAP(certificado, session)


### PR DESCRIPTION
Included method to get certificado object from lib assinatura in order to reduce and standarized code.

Apesar de ter mais de um modulo no PR a alteração é simples, foi incluído um método para retornar o objeto Certificado da biblioteca erpbrasil.assinatura no res.company do modulo l10n_br_fiscal_certificate.

Ao ver de implementar o campo compute do certificado referente ao PR https://github.com/OCA/l10n-brazil/pull/2892 nos modulos l10n_br_fiscal_dfe e l10n_br_nfse vi que tinha mais código repetido referente ao Certificado, em todos os casos era feito:

from erpbrasil.assinatura import certificado as cert

        certificado = cert.Certificado(
            arquivo=certificate.file,
            senha=certificate.password,
        )

Isso pelo o que vi pode ser isolado em um único modulo e método para reduzir, padronizar e evitar código duplicado. No modulo l10n_br_fiscal_dfe até existe um método simples que retorna isso em https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_fiscal_dfe/models/dfe.py#L56 basicamente eu fiz o mesmo porém em l10n_br_fiscal_certificate/models/res_company.py com isso foi possível remover a dependência da biblioteca erpbrasil.assinatura dos modulos l10n_br_fiscal_dfe e l10n_br_nfse, no caso do l10n_br_nfe não foi possível porque o misc está sendo usado nos testes https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_nfe/tests/test_nfce.py#L8 

Pode ser avaliado se existe a necessidade de manter o campo compute, já que o código pode ser integrado em um único método ( Existe o caso onde pode ser necessário chamar esse campo compute ao invés de já traze-lo dentro do objeto Certificado? ) e também se deve haver algum tipo de restrição para quando o método for chamado só poder trazer um tipo de certificado ou e-CNPJ ou e-NFe devido algum processo especifico, exemplo: "o certificado o e-NFe não pode emitir NFSe"( não sei dizer se sim ou não, deve ser confirmado) se alguém já souber de um caso posso ver de buscar alterar o metodo para tratar isso.

cc @renatonlima @rvalyi @marcelsavegnago @mileo 