### PR TITLE
[14.0][FIX] l10n_br_fiscal: Grupo Usuário NFe e Fiscal deve ter acesso para ver e criar Documentos Fiscais

### DIFF
--- a/l10n_br_fiscal/security/ir.model.access.csv
+++ b/l10n_br_fiscal/security/ir.model.access.csv
@@ -62,17 +62,18 @@
 "l10n_br_fiscal_operation_manager","Fiscal Operation for Manager","model_l10n_br_fiscal_operation","l10n_br_fiscal.group_manager",1,1,1,1
 "l10n_br_fiscal_subsequent_operation","Fiscal Subsequent Operation for Manager","model_l10n_br_fiscal_subsequent_operation","l10n_br_fiscal.group_manager",1,1,1,1
 "l10n_br_fiscal_subsequent_document","Fiscal Subsequent Document for Manager","model_l10n_br_fiscal_subsequent_document","l10n_br_fiscal.group_manager",1,1,1,1
+"l10n_br_fiscal_subsequent_document_user","Fiscal Subsequent Document for User","model_l10n_br_fiscal_subsequent_document","l10n_br_fiscal.group_user",1,0,0,0
 "l10n_br_fiscal_operation_line_user","Fiscal Operation Line for User","model_l10n_br_fiscal_operation_line","l10n_br_fiscal.group_user",1,0,0,0
 "l10n_br_fiscal_operation_line_manager","Fiscal Operation Line for Manager","model_l10n_br_fiscal_operation_line","l10n_br_fiscal.group_manager",1,1,1,1
 "l10n_br_fiscal_operation_document_type_user","Fiscal Operation Document Type for User","model_l10n_br_fiscal_operation_document_type","l10n_br_fiscal.group_user",1,0,0,0
 "l10n_br_fiscal_operation_document_type_manager","Fiscal Operation Document Type for Manager","model_l10n_br_fiscal_operation_document_type","l10n_br_fiscal.group_manager",1,1,1,1
 "l10n_br_fiscal_partner_profile_user","Fiscal Partner Profile for User","model_l10n_br_fiscal_partner_profile","l10n_br_fiscal.group_user",1,0,0,0
 "l10n_br_fiscal_partner_profile_manager","Fiscal Partner Profile for Manager","model_l10n_br_fiscal_partner_profile","l10n_br_fiscal.group_manager",1,1,1,1
-"l10n_br_fiscal_document_user","Fiscal Document for User","model_l10n_br_fiscal_document","l10n_br_fiscal.group_user",1,0,0,0
+"l10n_br_fiscal_document_user","Fiscal Document for User","model_l10n_br_fiscal_document","l10n_br_fiscal.group_user",1,1,1,0
 "l10n_br_fiscal_document_manager","Fiscal Document for Manager","model_l10n_br_fiscal_document","l10n_br_fiscal.group_manager",1,1,1,1
 "l10n_br_fiscal_document_related_user","Fiscal Document Related for User","model_l10n_br_fiscal_document_related","l10n_br_fiscal.group_user",1,0,0,0
 "l10n_br_fiscal_document_related_manager","Fiscal Document Related for Manager","model_l10n_br_fiscal_document_related","l10n_br_fiscal.group_manager",1,1,1,1
-"l10n_br_fiscal_document_line_user","Fiscal Document Line for User","model_l10n_br_fiscal_document_line","l10n_br_fiscal.group_user",1,0,0,0
+"l10n_br_fiscal_document_line_user","Fiscal Document Line for User","model_l10n_br_fiscal_document_line","l10n_br_fiscal.group_user",1,1,1,0
 "l10n_br_fiscal_document_line_manager","Fiscal Document Line for Manager","model_l10n_br_fiscal_document_line","l10n_br_fiscal.group_manager",1,1,1,1
 "l10n_br_fiscal_comment_user","Comment for User","model_l10n_br_fiscal_comment","l10n_br_fiscal.group_user",1,0,0,0
 "l10n_br_fiscal_comment_manager","Comment for Manager","model_l10n_br_fiscal_comment","l10n_br_fiscal.group_manager",1,1,1,1


### PR DESCRIPTION
Group User NFe and Fiscal should has access to create Fiscal Documents.

PR simples, hoje se o usuário está no Grupo de Usuário NFe ou Fiscal ele não consegue criar ou mesmo acessar uma NFe, isso está ocorrendo porque o objeto l10n_br_fiscal.subsequent_document estava sem o acesso para esses grupo e no caso do l10n_br_fiscal.document e l10n_br_fiscal.document_line o acesso era 1,0,0,0 mas é preciso ser 1,1,1,0 para que esse Grupo possa gerar os Documentos Fiscais, já que não faz muito sentido que o usuário que vai criar um Documento Fiscal deva ter permissão de Gerente/Manager

![image](https://github.com/OCA/l10n-brazil/assets/6341149/663ee0ef-1091-4585-aef2-8a134fd53720)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/75c27fa5-c4ad-41f5-98b7-e3bd3d526d51)

Acessa o account.move mas não o Documento Fiscal

![image](https://github.com/OCA/l10n-brazil/assets/6341149/6d691f1a-588a-4878-baf7-abe3b8b338c6)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/7820b7df-f751-40db-b8aa-98e75de2e27f)
 
Tem um erro pendente de solução, ao clicar em algum dos Painéis

![image](https://github.com/OCA/l10n-brazil/assets/6341149/8eba850e-f7d5-4110-9d0d-ed89e90dba14)

Esse último pode ser contornado com esse PR porque é possível ir pelo Menu.

Também alterei a permissão do Grupo Gerente/Manager no objeto l10n_br_fiscal.document_type de 1,0,0,0 para 1,1,1,1 esse grupo até onde entendo deve ter o acesso total a todos os objetos, acredito que foi apenas um erro mas talvez existe um motivo para isso, alguém saberia dizer?

cc @renatonlima @rvalyi @marcelsavegnago @mileo 
