### PR TITLE
[14.0][FIX] l10n_br_sale: create invoice with section and note

### DIFF
--- a/l10n_br_sale/demo/l10n_br_sale.xml
+++ b/l10n_br_sale/demo/l10n_br_sale.xml
@@ -259,7 +259,7 @@
         <field name="company_id" ref="l10n_br_base.empresa_simples_nacional" />
     </record>
 
-    <record id="sn_sl_product_service_1_2" model="sale.order.line">
+    <record id="sn_sl_product_service_1_4" model="sale.order.line">
         <field name="order_id" ref="sn_so_product_service" />
         <field name="name">Laptop Customized</field>
         <field name="product_id" ref="product.product_product_27" />
@@ -272,10 +272,17 @@
     </record>
 
     <function model="sale.order.line" name="_onchange_product_id_fiscal">
-        <value eval="[ref('sn_sl_product_service_1_2')]" />
+        <value eval="[ref('sn_sl_product_service_1_4')]" />
     </function>
 
-    <record id="sn_sl_product_service_2_2" model="sale.order.line">
+    <!-- Section -->
+    <record id="sn_sl_product_service_2_4" model="sale.order.line">
+        <field name="order_id" ref="sn_so_product_service" />
+        <field name="name">Services</field>
+        <field name="display_type">line_section</field>
+    </record>
+
+    <record id="sn_sl_product_service_3_4" model="sale.order.line">
         <field name="order_id" ref="sn_so_product_service" />
         <field name="name">Customized Odoo Development</field>
         <field name="product_id" ref="l10n_br_fiscal.customized_development_sale" />
@@ -291,8 +298,19 @@
     </record>
 
     <function model="sale.order.line" name="_onchange_product_id_fiscal">
-        <value eval="[ref('sn_sl_product_service_2_2')]" />
+        <value eval="[ref('sn_sl_product_service_3_4')]" />
     </function>
+
+    <!-- Note -->
+    <record id="sn_sl_product_service_4_4" model="sale.order.line">
+        <field name="order_id" ref="sn_so_product_service" />
+        <field
+            name="name"
+        >The hours described are only an estimate and are subject to change.</field>
+        <field name="display_type">line_section</field>
+    </record>
+
+
 
     <!-- Empresa Lucro Presumido -->
     <!-- Sale Order with only products test -->

--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -161,7 +161,8 @@ class SaleOrder(models.Model):
         return [
             line
             for line in lines
-            if line.fiscal_operation_line_id.get_document_type(line.company_id).id
+            if not line.display_type
+            and line.fiscal_operation_line_id.get_document_type(line.company_id).id
             == document_type_id
         ]
 
@@ -172,6 +173,7 @@ class SaleOrder(models.Model):
             line.fiscal_operation_line_id.get_document_type(line.company_id)
             for sale in self
             for line in sale.order_line
+            if not line.display_type
         }
 
         moves = self.env["account.move"]

--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -195,7 +195,7 @@ class SaleOrderLine(models.Model):
     def _prepare_invoice_line(self, **optional_values):
         self.ensure_one()
         result = {}
-        if self.fiscal_operation_id:
+        if not self.display_type and self.fiscal_operation_id:
             # O caso Brasil se caracteriza por ter a Operação Fiscal
             result = self._prepare_br_fiscal_dict()
             if self.product_id and self.product_id.invoice_policy == "delivery":

--- a/l10n_br_sale/tests/test_l10n_br_sale.py
+++ b/l10n_br_sale/tests/test_l10n_br_sale.py
@@ -154,6 +154,9 @@ class L10nBrSaleBaseTest(SavepointCase):
         sale_order._onchange_fiscal_operation_id()
 
     def _run_sale_line_onchanges(self, sale_line):
+        # Skip when it is a display line.
+        if sale_line.display_type:
+            return
         sale_line._onchange_product_id_fiscal()
         sale_line._onchange_fiscal_operation_id()
         sale_line._onchange_fiscal_operation_line_id()


### PR DESCRIPTION
Correção para a issue #2863

Agora é possivel adicionar linhas de exibição para seções e notas, confirmar e criar a fatura do pedido de venda sem problemas.

![image](https://github.com/OCA/l10n-brazil/assets/634278/f7b99f87-bb27-43fa-b872-582115aa9b8f)

Adicionei, em um dos pedidos de venda dos dados de demonstração, que são também utilizados nos testes unitários, uma linha do tipo seção e outra do tipo nota. Isso foi feito para garantir que a criação da fatura a partir do pedido seja realizada corretamente, mesmo na presença dessas linhas.