### PR TITLE
[15.0][FIX][PORT-FOWARD] l10n_br_fiscal: Grupo Usuário NFe e Fiscal deve ter acesso para ver e criar Documentos Fiscais

### DIFF
--- a/l10n_br_fiscal/security/ir.model.access.csv
+++ b/l10n_br_fiscal/security/ir.model.access.csv
@@ -62,17 +62,18 @@
 "l10n_br_fiscal_operation_manager","Fiscal Operation for Manager","model_l10n_br_fiscal_operation","l10n_br_fiscal.group_manager",1,1,1,1
 "l10n_br_fiscal_subsequent_operation","Fiscal Subsequent Operation for Manager","model_l10n_br_fiscal_subsequent_operation","l10n_br_fiscal.group_manager",1,1,1,1
 "l10n_br_fiscal_subsequent_document","Fiscal Subsequent Document for Manager","model_l10n_br_fiscal_subsequent_document","l10n_br_fiscal.group_manager",1,1,1,1
+"l10n_br_fiscal_subsequent_document_user","Fiscal Subsequent Document for User","model_l10n_br_fiscal_subsequent_document","l10n_br_fiscal.group_user",1,0,0,0
 "l10n_br_fiscal_operation_line_user","Fiscal Operation Line for User","model_l10n_br_fiscal_operation_line","l10n_br_fiscal.group_user",1,0,0,0
 "l10n_br_fiscal_operation_line_manager","Fiscal Operation Line for Manager","model_l10n_br_fiscal_operation_line","l10n_br_fiscal.group_manager",1,1,1,1
 "l10n_br_fiscal_operation_document_type_user","Fiscal Operation Document Type for User","model_l10n_br_fiscal_operation_document_type","l10n_br_fiscal.group_user",1,0,0,0
 "l10n_br_fiscal_operation_document_type_manager","Fiscal Operation Document Type for Manager","model_l10n_br_fiscal_operation_document_type","l10n_br_fiscal.group_manager",1,1,1,1
 "l10n_br_fiscal_partner_profile_user","Fiscal Partner Profile for User","model_l10n_br_fiscal_partner_profile","l10n_br_fiscal.group_user",1,0,0,0
 "l10n_br_fiscal_partner_profile_manager","Fiscal Partner Profile for Manager","model_l10n_br_fiscal_partner_profile","l10n_br_fiscal.group_manager",1,1,1,1
-"l10n_br_fiscal_document_user","Fiscal Document for User","model_l10n_br_fiscal_document","l10n_br_fiscal.group_user",1,0,0,0
+"l10n_br_fiscal_document_user","Fiscal Document for User","model_l10n_br_fiscal_document","l10n_br_fiscal.group_user",1,1,1,0
 "l10n_br_fiscal_document_manager","Fiscal Document for Manager","model_l10n_br_fiscal_document","l10n_br_fiscal.group_manager",1,1,1,1
 "l10n_br_fiscal_document_related_user","Fiscal Document Related for User","model_l10n_br_fiscal_document_related","l10n_br_fiscal.group_user",1,0,0,0
 "l10n_br_fiscal_document_related_manager","Fiscal Document Related for Manager","model_l10n_br_fiscal_document_related","l10n_br_fiscal.group_manager",1,1,1,1
-"l10n_br_fiscal_document_line_user","Fiscal Document Line for User","model_l10n_br_fiscal_document_line","l10n_br_fiscal.group_user",1,0,0,0
+"l10n_br_fiscal_document_line_user","Fiscal Document Line for User","model_l10n_br_fiscal_document_line","l10n_br_fiscal.group_user",1,1,1,0
 "l10n_br_fiscal_document_line_manager","Fiscal Document Line for Manager","model_l10n_br_fiscal_document_line","l10n_br_fiscal.group_manager",1,1,1,1
 "l10n_br_fiscal_comment_user","Comment for User","model_l10n_br_fiscal_comment","l10n_br_fiscal.group_user",1,0,0,0
 "l10n_br_fiscal_comment_manager","Comment for Manager","model_l10n_br_fiscal_comment","l10n_br_fiscal.group_manager",1,1,1,1


### PR DESCRIPTION
PORT-FOWARD https://github.com/OCA/l10n-brazil/pull/2902 Group User NFe and Fiscal should has access to create Fiscal Documents.

Grupo de Usuário NFe ou Fiscal não consegue criar ou mesmo acessar uma NFe, permissão para o l10n_br_fiscal.subsequent_document e a alteração do l10n_br_fiscal.document e l10n_br_fiscal.document_line o acesso era 1,0,0,0 mas é preciso ser 1,1,1,0

cc @renatonlima @rvalyi @marcelsavegnago @mileo 