### PR TITLE
[14.0][IMP][l10n_br_cnpj_search]: adicionar wizard para atualizar dados do parceiro

### DIFF
--- a/l10n_br_cnpj_search/__init__.py
+++ b/l10n_br_cnpj_search/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import models
+from . import wizard

--- a/l10n_br_cnpj_search/__manifest__.py
+++ b/l10n_br_cnpj_search/__manifest__.py
@@ -16,6 +16,7 @@
     ],
     "data": [
         "security/ir.model.access.csv",
+        "wizard/partner_cnpj_search_wizard.xml",
         "views/res_partner_view.xml",
         "views/res_company_view.xml",
         "views/res_config_settings_view.xml",

--- a/l10n_br_cnpj_search/models/res_partner.py
+++ b/l10n_br_cnpj_search/models/res_partner.py
@@ -1,7 +1,6 @@
 # Copyright 2022 KMEE - Luis Felipe Mileo
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-
 from odoo import fields, models
 
 

--- a/l10n_br_cnpj_search/security/ir.model.access.csv
+++ b/l10n_br_cnpj_search/security/ir.model.access.csv
@@ -2,3 +2,4 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_l10n_br_cnpj_search_webservice,access_l10n_br_cnpj_search_webservice,model_l10n_br_cnpj_search_webservice_abstract,base.group_user,1,1,1,1
 "l10n_br_fiscal_partner_profile_user","l10n_br_fiscal.partner_profile","l10n_br_fiscal.model_l10n_br_fiscal_partner_profile","base.group_user",1,0,0,0
 "l10n_br_fiscal_cnae","l10n_br_fiscal.cnae","l10n_br_fiscal.model_l10n_br_fiscal_cnae","base.group_user",1,0,0,0
+access_partner_search_wizard,res_partner_wizard,model_partner_search_wizard,base.group_user,1,1,1,1

--- a/l10n_br_cnpj_search/static/description/index.html
+++ b/l10n_br_cnpj_search/static/description/index.html
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>

--- a/l10n_br_cnpj_search/tests/test_serpro.py
+++ b/l10n_br_cnpj_search/tests/test_serpro.py
@@ -1,9 +1,10 @@
 # Copyright 2022 KMEE
+# Copyright (C) 2024-Today - Engenere (<https://engenere.one>).
+# @author Cristiano Mafra Junior
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import logging
 import os
-import time  # You can't send multiple requests at the same time in trial version
 
 import vcr
 
@@ -34,15 +35,19 @@ class TestTestSerPro(TestCnpjCommon):
         dummy_basica = self.model.create(
             {"name": "Dummy Basica", "cnpj_cpf": "34.238.864/0001-68"}
         )
-        time.sleep(3)
         dummy_basica._onchange_cnpj_cpf()
-        dummy_basica.search_cnpj()
 
-        self.assertEqual(dummy_basica.company_type, "company")
+        action_wizard = dummy_basica.action_open_cnpj_search_wizard()
+        wizard_context = action_wizard.get("context")
+        wizard = (
+            self.env["partner.search.wizard"].with_context(wizard_context).create({})
+        )
+        wizard.action_update_partner()
         self.assertEqual(
             dummy_basica.legal_name,
             "Uhieqkx Whnhiwd Nh Fixkhuuwphmvx Nh Nwnxu (Uhifix)",
         )
+        self.assertEqual(dummy_basica.company_type, "company")
         self.assertEqual(dummy_basica.name, "Uhifix Uhnh")
         self.assertEqual(dummy_basica.email, "EMPRESA@XXXXXX.BR")
         self.assertEqual(dummy_basica.street_name, "Nh Biwmnh Wihw Mxivh")
@@ -62,15 +67,16 @@ class TestTestSerPro(TestCnpjCommon):
         ignore_localhost=True,
     )
     def test_serpro_not_found(self):
-        # Na versão Trial só há alguns registros de CNPJ cadastrados
+        # In the Trial version there are only a few registered CNPJ records
         invalid = self.model.create(
             {"name": "invalid", "cnpj_cpf": "44.356.113/0001-08"}
         )
         invalid._onchange_cnpj_cpf()
 
-        time.sleep(3)  # Pause
         with self.assertRaises(ValidationError):
-            invalid.search_cnpj()
+            action_wizard = invalid.action_open_cnpj_search_wizard()
+            wizard_context = action_wizard.get("context")
+            self.env["partner.search.wizard"].with_context(wizard_context).create({})
 
     def assert_socios(self, partner, expected_cnpjs):
         socios = self.model.search_read(
@@ -126,9 +132,13 @@ class TestTestSerPro(TestCnpjCommon):
             {"name": "Dummy Empresa", "cnpj_cpf": "34.238.864/0001-68"}
         )
 
-        time.sleep(3)  # Pause
         dummy_empresa._onchange_cnpj_cpf()
-        dummy_empresa.search_cnpj()
+        action_wizard = dummy_empresa.action_open_cnpj_search_wizard()
+        wizard_context = action_wizard.get("context")
+        wizard = (
+            self.env["partner.search.wizard"].with_context(wizard_context).create({})
+        )
+        wizard.action_update_partner()
 
         expected_cnpjs = {
             "Joana": "23982012600",
@@ -155,9 +165,13 @@ class TestTestSerPro(TestCnpjCommon):
             {"name": "Dummy QSA", "cnpj_cpf": "34.238.864/0001-68"}
         )
 
-        time.sleep(3)  # Pause
         dummy_qsa._onchange_cnpj_cpf()
-        dummy_qsa.search_cnpj()
+        action_wizard = dummy_qsa.action_open_cnpj_search_wizard()
+        wizard_context = action_wizard.get("context")
+        wizard = (
+            self.env["partner.search.wizard"].with_context(wizard_context).create({})
+        )
+        wizard.action_update_partner()
 
         expected_cnpjs = {
             "Joana": False,

--- a/l10n_br_cnpj_search/views/res_company_view.xml
+++ b/l10n_br_cnpj_search/views/res_company_view.xml
@@ -17,7 +17,7 @@
                      <div class="o_row" colspan="1">
                         <field name="cnpj_cpf" />
                         <button
-                        name="search_cnpj"
+                        name="action_open_cnpj_search_wizard"
                         type="object"
                         class="btn-sm btn-link mb4 fa fa-search oe_edit_only oe_inline"
                         aria-label="Pesquisar CNPJ"

--- a/l10n_br_cnpj_search/views/res_partner_view.xml
+++ b/l10n_br_cnpj_search/views/res_partner_view.xml
@@ -19,7 +19,7 @@
                      <div class="o_row" colspan="4">
                         <field name="cnpj_cpf" nolabel="1" />
                         <button
-                        name="search_cnpj"
+                        name="action_open_cnpj_search_wizard"
                         type="object"
                         attrs="{'invisible':
                                 [

--- a/l10n_br_cnpj_search/wizard/__init__.py
+++ b/l10n_br_cnpj_search/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import partner_cnpj_search_wizard

--- a/l10n_br_cnpj_search/wizard/partner_cnpj_search_wizard.py
+++ b/l10n_br_cnpj_search/wizard/partner_cnpj_search_wizard.py
@@ -1,0 +1,114 @@
+# Copyright (C) 2024-Today - Engenere (<https://engenere.one>).
+# @author Cristiano Mafra Junior
+from erpbrasil.base import misc
+from erpbrasil.base.fiscal import cnpj_cpf
+from erpbrasil.base.misc import punctuation_rm
+from requests import get
+
+from odoo import api, fields, models
+
+
+class PartnerCnpjSearchWizard(models.TransientModel):
+    _name = "partner.search.wizard"
+
+    partner_id = fields.Many2one(comodel_name="res.partner")
+    provider_name = fields.Char()
+    cnpj_cpf = fields.Char()
+    legal_name = fields.Char()
+    name = fields.Char()
+    inscr_est = fields.Char()
+    zip = fields.Char()
+    street_name = fields.Char()
+    street_number = fields.Char()
+    street2 = fields.Char()
+    district = fields.Char()
+    state_id = fields.Many2one(comodel_name="res.country.state")
+    city_id = fields.Many2one(
+        comodel_name="res.city",
+        domain="[('state_id', '=', state_id)]",
+    )
+    country_id = fields.Many2one(comodel_name="res.country")
+    phone = fields.Char()
+    mobile = fields.Char()
+    email = fields.Char()
+    legal_nature = fields.Char()
+    currency_id = fields.Many2one(
+        comodel_name="res.currency",
+        default=lambda self: self.env.ref("base.BRL"),
+    )
+    equity_capital = fields.Monetary(currency_field="currency_id")
+    cnae_main_id = fields.Many2one(comodel_name="l10n_br_fiscal.cnae")
+    cnae_secondary_ids = fields.Many2many(
+        comodel_name="l10n_br_fiscal.cnae",
+        relation="wizard_fiscal_cnae_rel",
+        column1="company_id",
+        column2="cnae_id",
+    )
+    child_ids = fields.Many2many(
+        comodel_name="res.partner",
+        relation="parent_id_wizard_id",
+        column1="parent_id",
+        column2="wizard_id",
+    )
+
+    @api.onchange("zip")
+    def _onchange_zip(self):
+        self.zip = misc.format_zipcode(self.zip)
+
+    @api.onchange("cnpj_cpf")
+    def _onchange_cnpj_cpf(self):
+        self.cnpj_cpf = cnpj_cpf.formata(str(self.cnpj_cpf))
+
+    def _get_partner_values(self, cnpj_cpf):
+        webservice = self.env["l10n_br_cnpj_search.webservice.abstract"]
+        provider_name = webservice.get_provider()
+        response = get(
+            webservice.get_api_url(cnpj_cpf), headers=webservice.get_headers()
+        )
+        data = webservice.validate(response)
+        values = webservice.import_data(data)
+        values["provider_name"] = provider_name
+        values["cnpj_cpf"] = cnpj_cpf
+        return values
+
+    def default_get(self, fields):
+        res = super().default_get(fields)
+        partner_id = self._context.get("default_partner_id")
+        partner_model = self.env["res.partner"]
+        partner = partner_model.browse(partner_id)
+        cnpj_cpf = punctuation_rm(partner.cnpj_cpf)
+        misc.punctuation_rm(self.zip)
+        values = self._get_partner_values(cnpj_cpf)
+        res.update(values)
+        return res
+
+    def action_update_partner(self):
+        values_to_update = {
+            "legal_name": self.legal_name,
+            "name": self.name,
+            "inscr_est": self.inscr_est,
+            "zip": self.zip,
+            "street_name": self.street_name,
+            "street_number": self.street_number,
+            "street2": self.street2,
+            "district": self.district,
+            "state_id": self.state_id.id,
+            "city_id": self.city_id.id,
+            "country_id": self.country_id.id,
+            "phone": self.phone,
+            "mobile": self.mobile,
+            "email": self.email,
+            "legal_nature": self.legal_nature,
+            "equity_capital": self.equity_capital,
+            "cnae_main_id": self.cnae_main_id,
+            "cnae_secondary_ids": self.cnae_secondary_ids,
+            "child_ids": [(6, 0, self.child_ids.ids)],
+            "company_type": "company",
+        }
+        non_empty_values = {
+            key: value for key, value in values_to_update.items() if value
+        }
+        if non_empty_values:
+            # Update partner only if there are non-empty values
+            self.partner_id.write(non_empty_values)
+        return {"type": "ir.actions.act_window_close"}

--- a/l10n_br_cnpj_search/wizard/partner_cnpj_search_wizard.xml
+++ b/l10n_br_cnpj_search/wizard/partner_cnpj_search_wizard.xml
@@ -1,0 +1,67 @@
+<!-- Copyright (C) 2024-Today - Engenere (<https://engenere.one>).
+@author Cristiano Mafra Junior-->
+<odoo>
+    <record id="res_partner_wizard_view" model="ir.ui.view">
+        <field name="name">res_partner_wizard</field>
+        <field name="model">partner.search.wizard</field>
+        <field name="arch" type="xml">
+            <form class="o_form_sheet">
+                <div class="alert alert-info" role="alert" style="margin-bottom: 0px;">
+                    CNPJ data was obtained through the webservice: <field
+                        name="provider_name"
+                        readonly="1"
+                    />
+                </div>
+
+                <group>
+                    <group name="Identification" string="Identification">
+                        <field name="name" />
+                        <field name="legal_name" />
+                        <field name="cnpj_cpf" readonly="1" string="CNPJ" />
+                        <field name="inscr_est" string="IE" />
+                    </group>
+
+                    <group name="Contacts" string="Contacts">
+                        <field name="phone" />
+                        <field name="mobile" />
+                        <field name="email" />
+                    </group>
+                </group>
+
+                <group>
+                    <group name="Address" string="Address">
+                        <field name="zip" />
+                        <field name="street_name" />
+                        <field name="street_number" />
+                        <field name="street2" />
+                        <field name="district" />
+                        <field name="state_id" />
+                        <field name="city_id" />
+                    </group>
+
+                    <group name="Other Information" string="Other Information">
+                        <field name="legal_nature" />
+                        <field name="equity_capital" widget="monetary" />
+                        <field name="cnae_main_id" string="Main CNAE" />
+                        <field
+                            name="cnae_secondary_ids"
+                            widget="many2many_tags"
+                            string="Secundary CNAE"
+                        />
+                        <field name="currency_id" invisible="1" />
+                    </group>
+                </group>
+
+                <footer>
+                    <button
+                        string="Update Partner"
+                        type="object"
+                        class="oe_highlight"
+                        name="action_update_partner"
+                    />
+                    <button string="Close" class="oe_link" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/l10n_br_ie_search/__init__.py
+++ b/l10n_br_ie_search/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import models
+from . import wizard

--- a/l10n_br_ie_search/models/__init__.py
+++ b/l10n_br_ie_search/models/__init__.py
@@ -3,4 +3,3 @@
 from . import sefaz_webservice
 from . import sintegra_webservice
 from . import res_config_settings
-from . import l10n_br_base_party_mixin

--- a/l10n_br_ie_search/tests/fixtures/test_sefaz.yaml
+++ b/l10n_br_ie_search/tests/fixtures/test_sefaz.yaml
@@ -1,0 +1,66 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - "*/*"
+        Accept-Encoding:
+          - gzip, deflate
+        Authorization:
+          - Bearer 06aef429-a981-3ec5-a1f8-71d38d86481e
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.25.1
+      method: GET
+      uri: https://www.receitaws.com.br/v1/cnpj/88570377000127
+    response:
+      body:
+        string:
+          "{\"abertura\": \"24/11/2021\", \"situacao\": \"BAIXADA\", \"tipo\":
+          \"MATRIZ\", \"nome\": \"Dummy Empresa\", \"porte\": \"MICRO EMPRESA\",
+          \"natureza_juridica\": \"213-5 - Empres\\u00e1rio (Individual)\",
+          \"logradouro\": \"RUA DUMMY\", \"numero\": \"250\", \"complemento\": \"BLOCO
+          E;APT 302\", \"municipio\": \"SAO PAULO\", \"bairro\": \"VILA FELIZ\", \"uf\":
+          \"SP\", \"cep\": \"01222001\", \"email\": \"kilian.melcher@gmail.com\",
+          \"telefone\": \"(83) 8665-0905\", \"data_situacao\": \"18/12/2023\",
+          \"motivo_situacao\": \"EXTIN\\u00c7\\u00c3O POR ENCERRAMENTO
+          LIQUIDA\\u00c7\\u00c3O VOLUNT\\u00c1RIA\", \"cnpj\": \"88570377000127\",
+          \"ultima_atualizacao\": \"2024-01-13T23:59:59.000Z\", \"status\": \"OK\",
+          \"fantasia\": \"\", \"efr\": \"\", \"situacao_especial\": \"\",
+          \"data_situacao_especial\": \"\", \"atividade_principal\": [{\"code\":
+          \"4751-2/01\", \"text\": \"********\"}], \"atividades_secundarias\":
+          [{\"code\": \"00.00-0-00\", \"text\": \"Não informada\"}], \"capital_social\":
+          \"3000.00\", \"qsa\": [], \"extra\": {}, \"billing\": {\"free\": true,
+          \"database\": true}}"
+      headers:
+        Access-Control-Allow-Headers:
+          - authorization,Access-Control-Allow-Origin,Content-Type,SOAPAction,apikey,Internal-Key,x-cpf-usuario,signature,x-signature,x-credencial,X-Request-Trace-Id
+        Access-Control-Allow-Methods:
+          - GET
+        Access-Control-Expose-Headers:
+          - ""
+        Connection:
+          - keep-alive
+        Date:
+          - Wed, 28 Jun 2023 13:45:28 GMT
+        Transfer-Encoding:
+          - chunked
+        access-control-allow-origin:
+          - "*"
+        activityid:
+          - 0c70c470-9419-4869-aa01-b964c345f5ac
+        content-type:
+          - application/json; charset=utf-8
+        etag:
+          - W/"86a-p2CeQnt0OF5zs4vPG4Lpgnsxv8k"
+        strict-transport-security:
+          - max-age=15768000
+        x-content-type-options:
+          - nosniff
+        x-powered-by:
+          - Express
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/l10n_br_ie_search/wizard/__init__.py
+++ b/l10n_br_ie_search/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import extend_partner_cnpj_search_wizard

--- a/l10n_br_ie_search/wizard/extend_partner_cnpj_search_wizard.py
+++ b/l10n_br_ie_search/wizard/extend_partner_cnpj_search_wizard.py
@@ -1,53 +1,38 @@
 # Copyright 2023 KMEE - Breno Oliveira Dias
+# Copyright (C) 2024-Today - Engenere (<https://engenere.one>).
+# @author Cristiano Mafra Junior
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import requests
 from erpbrasil.edoc.nfe import NFe as edoc_nfe
 from erpbrasil.transmissao import TransmissaoSOAP
-from requests import Session, get
+from requests import Session
 
 from odoo import api, models
 
 SINTEGRA_URL = "https://www.sintegraws.com.br/api/v1/execute-api.php"
 
 
-class PartyMixin(models.AbstractModel):
-    _inherit = "l10n_br_base.party.mixin"
+class ExtendPartnerCnpjSearchWizard(models.TransientModel):
+    _inherit = "partner.search.wizard"
 
-    def search_cnpj(self):
-        """Search state subscription"""
-
-        super().search_cnpj()
-        self.ie_search()
-
-    @api.model
-    def ie_search(self, mockresponse=False):
+    def _get_partner_ie(self, state_code, cnpj):
         webservice = self.env["l10n_br_cnpj_search.webservice.abstract"]
         if self._provider() == "sefaz":
             processo = self._processador()
-            response = (
-                webservice.sefaz_search(self.state_id.code, self.cnpj_cpf, processo)
-                if not mockresponse
-                else mockresponse
-            )
+            response = webservice.sefaz_search(state_code, cnpj, processo)
             data = webservice.sefaz_validate(response)
             values = webservice._sefaz_import_data(data)
-            self.write(values)
+            return values
         elif self._provider() == "sintegraws":
-            response = (
-                get(
-                    SINTEGRA_URL,
-                    data="",
-                    params=webservice._get_query(
-                        self.cnpj_cpf, webservice._get_token()
-                    ),
-                )
-                if not mockresponse
-                else mockresponse
+            response = requests.get(
+                SINTEGRA_URL,
+                data="",
+                params=webservice._get_query(cnpj, webservice._get_token()),
             )
-
             data = webservice.sintegra_validate(response)
             values = webservice._sintegra_import_data(data)
-            self.write(values)
+            return values
 
     @api.model
     def _provider(self):
@@ -56,6 +41,15 @@ class PartyMixin(models.AbstractModel):
             .sudo()
             .get_param("l10n_br_ie_search.ie_search")
         )
+
+    @api.model
+    def _get_partner_values(self, cnpj_cpf):
+        values = super()._get_partner_values(cnpj_cpf)
+        state_id = self.env["res.country.state"].browse(values["state_id"])
+        ie_values = self._get_partner_ie(state_code=state_id.code, cnpj=cnpj_cpf)
+        if ie_values:
+            values.update(ie_values)
+        return values
 
     @api.model
     def _processador(self):


### PR DESCRIPTION
Criação de um wizard para alteração dos campos de contatos, a criação desse wizard visa simplificar e agilizar o processo de alteração dos campos feita pela pesquisa do CNPJ.
Também foi mudado os **test_sefaz** e **test_sintegra** agora usando a biblioteca do **unittest.mock**



![image](https://github.com/OCA/l10n-brazil/assets/142639425/03966fa1-5364-4b2a-a293-2fcb310ec44f)

