### PR TITLE
[16.0][l10n_br_coa_simple] forward port de #2595

### DIFF
--- a/l10n_br_coa_simple/hooks.py
+++ b/l10n_br_coa_simple/hooks.py
@@ -7,16 +7,6 @@ from odoo import SUPERUSER_ID, api, tools
 def post_init_hook(cr, registry):
     env = api.Environment(cr, SUPERUSER_ID, {})
     coa_simple_tmpl = env.ref("l10n_br_coa_simple.l10n_br_coa_simple_chart_template")
-    if env["ir.module.module"].search_count(
-        [
-            ("name", "=", "l10n_br_account"),
-            ("state", "=", "installed"),
-        ]
-    ):
-        from odoo.addons.l10n_br_account.hooks import load_fiscal_taxes
-
-        # Relate fiscal taxes to account taxes.
-        load_fiscal_taxes(env, coa_simple_tmpl)
 
     # Load COA to Demo Company
     if not tools.config.get("without_demo"):


### PR DESCRIPTION
o port de https://github.com/OCA/l10n-brazil/pull/2595 tava faltando pro modulo l10n_br_simple na 16.0 e isso dava problemas desse tipo ao tentar carregar o plano ( https://github.com/OCA/l10n-brazil/actions/runs/7793922457/job/21254402926?pr=2912 )

```
ImportError: cannot import name 'load_fiscal_taxes' from 'odoo.addons.l10n_br_account.hooks' (/opt/odoo-venv/lib/python3.10/site-packages/odoo/addons/l10n_br_account/hooks.py)
2024-02-06 02:42:25,334 499 CRITICAL odoo odoo.service.server: Failed to initialize database `odoo`. 
Traceback (most recent call last):
  File "/opt/odoo/odoo/service/server.py", line 1299, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "<decorator-gen-16>", line 2, in new
  File "/opt/odoo/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "/opt/odoo/odoo/modules/registry.py", line 90, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/opt/odoo/odoo/modules/loading.py", line 488, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/opt/odoo/odoo/modules/loading.py", line 372, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/opt/odoo/odoo/modules/loading.py", line 249, in load_module_graph
    getattr(py_module, post_init)(cr, registry)
  File "/__w/l10n-brazil/l10n-brazil/l10n_br_coa_simple/hooks.py", line 16, in post_init_hook
    from odoo.addons.l10n_br_account.hooks import load_fiscal_taxes
ImportError: cannot import name 'load_fiscal_taxes' from 'odoo.addons.l10n_br_account.hooks' (/opt/odoo-venv/lib/python3.10/site-packages/odoo/addons/l10n_br_account/hooks.py)
```

Nos modulos l10n_br_coa e l10n_br_coa _generic o port ja tinha sido feito. Na v15 o port ja tinha sido feito pro l10n_br_simple tambem.