### PR TITLE
[14.0][FIX] l10n_br_base: Retorna campo a view

### DIFF
--- a/l10n_br_base/views/res_partner_address_view.xml
+++ b/l10n_br_base/views/res_partner_address_view.xml
@@ -8,6 +8,9 @@
         <field name="arch" type="xml">
             <form>
                 <div class="o_address_format">
+                    <div>
+                        <field name="street" class="oe_read_only" invisible="1" />
+                    </div>
                     <field
                         name="zip"
                         placeholder="Zip code..."


### PR DESCRIPTION
Esse PR apenas adiciona um campo na view. Para não ficar confuso a forma como ele é visualizado, eu apenas deixei ele invísivel.

O motivo de eu estar fazendo isso, é que no módulo `base_address_extended` esse campo `street` e colocado ainda na view, mas mesmo que sejam adicionados `street_name` e `street_number`. O problema é alguns outros módulos que utilizam ele como base, também usam o campo `street` dentro de um context. Por esse módulo base estar substituindo e removendo, ele acaba conseguindo fazer a referência.

Sugestão são sempre bem-vindas, mas acredito que se ele estava no core e não foi substituido em outro módulo, ele acaba sendo importante de alguma forma.