### PR TITLE
[14.0][FIX] l10n_br_cnpj_search: Perda do vínculo com os contatos do parceiro

### DIFF
--- a/l10n_br_cnpj_search/wizard/partner_cnpj_search_wizard.py
+++ b/l10n_br_cnpj_search/wizard/partner_cnpj_search_wizard.py
@@ -102,9 +102,11 @@ class PartnerCnpjSearchWizard(models.TransientModel):
             "equity_capital": self.equity_capital,
             "cnae_main_id": self.cnae_main_id,
             "cnae_secondary_ids": self.cnae_secondary_ids,
-            "child_ids": [(6, 0, self.child_ids.ids)],
             "company_type": "company",
         }
+        if self.child_ids:
+            values_to_update["child_ids"] = [(6, 0, self.child_ids.ids)]
+
         non_empty_values = {
             key: value for key, value in values_to_update.items() if value
         }


### PR DESCRIPTION
Durante a atualização dos dados de um parceiro já existente com as informações adquiridas via busca pelo CNPJ, ocorria um problema onde todos os contatos associados (contatos filhos) eram inadvertidamente desvinculados.

Nota: Implementamos uma correção para evitar regressões neste processo. Nos cenários em que a consulta não se dá por meio do serviço pago SintegraWS, este problema foi resolvido. Entretanto, para os usuários que dependem do SintegraWS, a questão ainda pode surgir. A análise revelou que a lógica atual não contempla a presença prévia de contatos dos sócios no cadastro, desconsiderando qualquer outro contato filho previamente associado ao parceiro. Sugere-se uma revisão dessa mecânica ou a desativação da inclusão automática de contatos dos sócios para evitar futuras complicações

@mileo @rvalyi @marcelsavegnago @AndreMarcos

Esse bug em produção pode levar a perca de dados, se puderem dar uma atenção especial, obrigado!




