### PR TITLE
[14.0] [IMP] l10n_br_fiscal: fill issqn_fg_city_id when city_taxation_code_id changes value

### DIFF
--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -835,6 +835,8 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         if self.city_taxation_code_id:
             self.cnae_id = self.city_taxation_code_id.cnae_id
             self._onchange_fiscal_operation_id()
+            if self.city_taxation_code_id.city_id:
+                self.update({"issqn_fg_city_id": self.city_taxation_code_id.city_id})
 
     @api.model
     def _add_fields_to_amount(self):


### PR DESCRIPTION
Corrige o preenchimento automático do campo issqn_fg_city_id na linha quando city_taxation_code_id tem cidade definida