### PR TITLE
[14.0][l10n_br_nfe][REF] refator dos campos nfe40_choice*

### DIFF
--- a/l10n_br_nfe/__manifest__.py
+++ b/l10n_br_nfe/__manifest__.py
@@ -11,7 +11,7 @@
     "maintainers": ["rvalyi", "renatonlima"],
     "website": "https://github.com/OCA/l10n-brazil",
     "development_status": "Beta",
-    "version": "14.0.13.12.0",
+    "version": "14.0.14.0.0",
     "depends": [
         "l10n_br_fiscal",
         "l10n_br_fiscal_certificate",

--- a/l10n_br_nfe/migrations/14.0.14.0.0/pre-migration.py
+++ b/l10n_br_nfe/migrations/14.0.14.0.0/pre-migration.py
@@ -39,7 +39,7 @@ _field_renames = [
 
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
-    if not openupgrade.column_exists(
+    if openupgrade.column_exists(
         env.cr, "l10n_br_fiscal_document_line", "nfe40_choice3"
     ):
         openupgrade.rename_fields(env, _field_renames)

--- a/l10n_br_nfe/migrations/14.0.14.0.0/pre-migration.py
+++ b/l10n_br_nfe/migrations/14.0.14.0.0/pre-migration.py
@@ -1,0 +1,45 @@
+# Copyright 2024 - TODAY Akretion - Raphael Valyi <raphael.valyi@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+_field_renames = [
+    (
+        "l10n_br_fiscal.document.line",
+        "l10n_br_fiscal_document_line",
+        "nfe40_choice3",
+        "nfe40_choice_tipi",
+    ),
+    (
+        "l10n_br_fiscal.document.line",
+        "l10n_br_fiscal_document_line",
+        "nfe40_choice10",
+        "nfe40_choice_imposto",
+    ),
+    (
+        "l10n_br_fiscal.document.line",
+        "l10n_br_fiscal_document_line",
+        "nfe40_choice13",
+        "nfe40_choice_pisoutr",
+    ),
+    (
+        "l10n_br_fiscal.document.line",
+        "l10n_br_fiscal_document_line",
+        "nfe40_choice16",
+        "nfe40_choice_cofinsoutr",
+    ),
+    (
+        "l10n_br_fiscal.document.line",
+        "l10n_br_fiscal_document_line",
+        "nfe40_choice20",
+        "nfe40_choice_ipitrib",
+    ),
+]
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    if not openupgrade.column_exists(
+        env.cr, "l10n_br_fiscal_document_line", "nfe40_choice3"
+    ):
+        openupgrade.rename_fields(env, _field_renames)

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -223,7 +223,7 @@ class NFeLine(spec_models.StackedModel):
     #######################################
 
     # Overriden to define default value for normal product
-    nfe40_choice9 = fields.Selection(
+    nfe40_choice_prod = fields.Selection(
         selection=[
             ("normal", "Produto Normal"),
             ("nfe40_veicProd", "Veículo"),
@@ -280,7 +280,7 @@ class NFeLine(spec_models.StackedModel):
     nfe40_vTotTrib = fields.Monetary(related="estimate_tax")
 
     def _export_fields_nfe_40_imposto(self, xsd_fields, class_obj, export_dict):
-        if self.nfe40_choice10 == "nfe40_ICMS":
+        if self.nfe40_choice_imposto == "nfe40_ICMS":
             xsd_fields.remove("nfe40_ISSQN")
         else:
             xsd_fields.remove("nfe40_ICMS")
@@ -320,7 +320,7 @@ class NFeLine(spec_models.StackedModel):
     # Grupo N10. Grupo Tributação do ICMS= 90
     #################################################
 
-    nfe40_choice11 = fields.Selection(
+    nfe40_choice_icms = fields.Selection(
         selection=[
             ("nfe40_ICMS00", "ICMS00"),
             ("nfe40_ICMS10", "ICMS10"),
@@ -341,7 +341,7 @@ class NFeLine(spec_models.StackedModel):
             ("nfe40_ICMSSN900", "ICMSSN900"),
         ],
         string="Tipo de ICMS",
-        compute="_compute_choice11",
+        compute="_compute_choice_icms",
         store=True,
     )
 
@@ -379,7 +379,7 @@ class NFeLine(spec_models.StackedModel):
     ##########################
 
     @api.depends("icms_cst_id")
-    def _compute_choice11(self):
+    def _compute_choice_icms(self):
         for record in self:
             icms_choice = ""
             if record.icms_cst_id.code in ICMS_CST:
@@ -394,7 +394,7 @@ class NFeLine(spec_models.StackedModel):
             elif record.icms_cst_id.code in ICMS_SN_CST:
                 icms_choice = "{}{}".format("nfe40_ICMSSN", record.icms_cst_id.code)
 
-            record.nfe40_choice11 = icms_choice
+            record.nfe40_choice_icms = icms_choice
 
     ##########################
     # NF-e tag: ICMS
@@ -464,9 +464,9 @@ class NFeLine(spec_models.StackedModel):
         if "nfe40_ICMSST" in xsd_fields:
             xsd_fields.remove("nfe40_ICMSST")
 
-        xsd_fields = [self.nfe40_choice11]
+        xsd_fields = [self.nfe40_choice_icms]
         icms_tag = (
-            self.nfe40_choice11.replace("nfe40_", "")
+            self.nfe40_choice_icms.replace("nfe40_", "")
             .replace("ICMS", "Icms")
             .replace("IcmsSN", "Icmssn")
         )
@@ -533,14 +533,14 @@ class NFeLine(spec_models.StackedModel):
     # Grupo O. Imposto sobre Produtos Industrializados
     ##################################################
 
-    nfe40_choice3 = fields.Selection(
+    nfe40_choice_tipi = fields.Selection(
         selection=[("nfe40_IPITrib", "IPITrib"), ("nfe40_IPINT", "IPINT")],
         string="IPITrib ou IPINT",
-        compute="_compute_choice3",
+        compute="_compute_choice_tipi",
         store=True,
     )
 
-    nfe40_choice20 = fields.Selection(
+    nfe40_choice_ipitrib = fields.Selection(
         selection=[
             ("nfe40_vBC", "vBC"),
             ("nfe40_pIPI", "pIPI"),
@@ -548,7 +548,7 @@ class NFeLine(spec_models.StackedModel):
             ("nfe40_vUnid", "vUnid"),
         ],
         string="Base vBC/pIPI/qUnid/vUnid",
-        compute="_compute_nfe40_choice20",
+        compute="_compute_nfe40_choice_ipitrib",
         store=True,
     )
 
@@ -570,20 +570,20 @@ class NFeLine(spec_models.StackedModel):
     ##########################
 
     @api.depends("ipi_cst_id")
-    def _compute_choice3(self):
+    def _compute_choice_tipi(self):
         for record in self:
             if record.ipi_cst_id.code in ["00", "49", "50", "99"]:
-                record.nfe40_choice3 = "nfe40_IPITrib"
+                record.nfe40_choice_tipi = "nfe40_IPITrib"
             else:
-                record.nfe40_choice3 = "nfe40_IPINT"
+                record.nfe40_choice_tipi = "nfe40_IPINT"
 
     @api.depends("ipi_base_type")
-    def _compute_nfe40_choice20(self):
+    def _compute_nfe40_choice_ipitrib(self):
         for record in self:
             if record.ipi_base_type == "percent":
-                record.nfe40_choice20 = "nfe40_pIPI"
+                record.nfe40_choice_ipitrib = "nfe40_pIPI"
             else:
-                record.nfe40_choice20 = "nfe40_vUnid"
+                record.nfe40_choice_ipitrib = "nfe40_vUnid"
 
     ##########################
     # NF-e tag: IPI
@@ -603,7 +603,7 @@ class NFeLine(spec_models.StackedModel):
     def _export_fields_nfe_40_ipitrib(self, xsd_fields, class_obj, export_dict):
         self._export_fields_ipi(xsd_fields, class_obj, export_dict)
 
-        if self.nfe40_choice20 == "nfe40_pIPI":
+        if self.nfe40_choice_ipitrib == "nfe40_pIPI":
             xsd_fields.remove("nfe40_qUnid")
             xsd_fields.remove("nfe40_vUnid")
         else:
@@ -631,7 +631,7 @@ class NFeLine(spec_models.StackedModel):
     # Grupo Q. PIS
     ###############
 
-    nfe40_choice12 = fields.Selection(
+    nfe40_choice_pis = fields.Selection(
         selection=[
             ("nfe40_PISAliq", "PISAliq"),
             ("nfe40_PISQtde", "PISQtde"),
@@ -639,18 +639,18 @@ class NFeLine(spec_models.StackedModel):
             ("nfe40_PISOutr", "PISOutr"),
         ],
         stringo="PISAliq/PISQtde/PISNT/PISOutr",
-        compute="_compute_choice12",
+        compute="_compute_choice_pis",
         store=True,
     )
 
-    nfe40_choice13 = fields.Selection(
+    nfe40_choice_pisoutr = fields.Selection(
         [
             ("nfe40_vBC", "vBC"),
             ("nfe40_pPIS", "pPIS"),
             ("nfe40_qBCProd", "qBCProd"),
             ("nfe40_vAliqProd", "vAliqProd"),
         ],
-        compute="_compute_nfe40_choice13",
+        compute="_compute_nfe40_choice_pisoutr",
         store=True,
         string="Tipo de Tributação do PIS",
     )
@@ -676,24 +676,24 @@ class NFeLine(spec_models.StackedModel):
     ##########################
 
     @api.depends("pis_cst_id")
-    def _compute_choice12(self):
+    def _compute_choice_pis(self):
         for record in self:
             if record.pis_cst_id.code in ["01", "02"]:
-                record.nfe40_choice12 = "nfe40_PISAliq"
+                record.nfe40_choice_pis = "nfe40_PISAliq"
             elif record.pis_cst_id.code == "03":
-                record.nfe40_choice12 = "nfe40_PISQtde"
+                record.nfe40_choice_pis = "nfe40_PISQtde"
             elif record.pis_cst_id.code in ["04", "06", "07", "08", "09"]:
-                record.nfe40_choice12 = "nfe40_PISNT"
+                record.nfe40_choice_pis = "nfe40_PISNT"
             else:
-                record.nfe40_choice12 = "nfe40_PISOutr"
+                record.nfe40_choice_pis = "nfe40_PISOutr"
 
     @api.depends("pis_base_type")
-    def _compute_nfe40_choice13(self):
+    def _compute_nfe40_choice_pisoutr(self):
         for record in self:
             if record.pis_base_type == "percent":
-                record.nfe40_choice13 = "nfe40_pPIS"
+                record.nfe40_choice_pisoutr = "nfe40_pPIS"
             else:
-                record.nfe40_choice13 = "nfe40_vAliqProd"
+                record.nfe40_choice_pisoutr = "nfe40_vAliqProd"
 
     ##########################
     # NF-e tag: PIS
@@ -710,7 +710,7 @@ class NFeLine(spec_models.StackedModel):
             "nfe40_PISOutr": ["nfe40_PISAliq", "nfe40_PISQtde", "nfe40_PISNT"],
         }
 
-        for tag_to_remove in remove_tags.get(self.nfe40_choice12, []):
+        for tag_to_remove in remove_tags.get(self.nfe40_choice_pis, []):
             if tag_to_remove in xsd_fields:
                 xsd_fields.remove(tag_to_remove)
 
@@ -727,11 +727,11 @@ class NFeLine(spec_models.StackedModel):
     def _export_fields_nfe_40_pisoutr(self, xsd_fields, class_obj, export_dict):
         self._export_fields_pis(xsd_fields, class_obj, export_dict)
 
-        if self.nfe40_choice13 == "nfe40_pPIS":
+        if self.nfe40_choice_pisoutr == "nfe40_pPIS":
             xsd_fields.remove("nfe40_qBCProd")
             xsd_fields.remove("nfe40_vAliqProd")
 
-        if self.nfe40_choice13 == "nfe40_vAliqProd":
+        if self.nfe40_choice_pisoutr == "nfe40_vAliqProd":
             xsd_fields.remove("nfe40_vBC")
             xsd_fields.remove("nfe40_pPIS")
 
@@ -750,7 +750,7 @@ class NFeLine(spec_models.StackedModel):
     # Grupo S. COFINS
     ##################
 
-    nfe40_choice15 = fields.Selection(
+    nfe40_choice_cofins = fields.Selection(
         selection=[
             ("nfe40_COFINSAliq", "COFINSAliq"),
             ("nfe40_COFINSQtde", "COFINSQtde"),
@@ -758,18 +758,18 @@ class NFeLine(spec_models.StackedModel):
             ("nfe40_COFINSOutr", "COFINSOutr"),
         ],
         string="COFINSAliq/COFINSQtde/COFINSNT/COFINSOutr",
-        compute="_compute_choice15",
+        compute="_compute_choice_cofins",
         store=True,
     )
 
-    nfe40_choice16 = fields.Selection(
+    nfe40_choice_cofinsoutr = fields.Selection(
         selection=[
             ("nfe40_vBC", "vBC"),
             ("nfe40_pCOFINS", "pCOFINS"),
             ("nfe40_qBCProd", "qBCProd"),
             ("nfe40_vAliqProd", "vAliqProd"),
         ],
-        compute="_compute_nfe40_choice16",
+        compute="_compute_nfe40_choice_cofinsoutr",
         store=True,
         string="Tipo de Tributação do COFINS",
     )
@@ -797,24 +797,24 @@ class NFeLine(spec_models.StackedModel):
     ##########################
 
     @api.depends("cofins_cst_id")
-    def _compute_choice15(self):
+    def _compute_choice_cofins(self):
         for record in self:
             if record.cofins_cst_id.code in ["01", "02"]:
-                record.nfe40_choice15 = "nfe40_COFINSAliq"
+                record.nfe40_choice_cofins = "nfe40_COFINSAliq"
             elif record.cofins_cst_id.code == "03":
-                record.nfe40_choice15 = "nfe40_COFINSQtde"
+                record.nfe40_choice_cofins = "nfe40_COFINSQtde"
             elif record.cofins_cst_id.code in ["04", "06", "07", "08", "09"]:
-                record.nfe40_choice15 = "nfe40_COFINSNT"
+                record.nfe40_choice_cofins = "nfe40_COFINSNT"
             else:
-                record.nfe40_choice15 = "nfe40_COFINSOutr"
+                record.nfe40_choice_cofins = "nfe40_COFINSOutr"
 
     @api.depends("cofins_base_type")
-    def _compute_nfe40_choice16(self):
+    def _compute_nfe40_choice_cofinsoutr(self):
         for record in self:
             if record.cofins_base_type == "percent":
-                record.nfe40_choice16 = "nfe40_pCOFINS"
+                record.nfe40_choice_cofinsoutr = "nfe40_pCOFINS"
             else:
-                record.nfe40_choice16 = "nfe40_vAliqProd"
+                record.nfe40_choice_cofinsoutr = "nfe40_vAliqProd"
 
     ##########################
     # NF-e tag: COFINS
@@ -847,7 +847,7 @@ class NFeLine(spec_models.StackedModel):
             ],
         }
 
-        for tag_to_remove in remove_tags.get(self.nfe40_choice15, []):
+        for tag_to_remove in remove_tags.get(self.nfe40_choice_cofins, []):
             if tag_to_remove in xsd_fields:
                 xsd_fields.remove(tag_to_remove)
 
@@ -865,11 +865,11 @@ class NFeLine(spec_models.StackedModel):
     def _export_fields_nfe_40_cofinsoutr(self, xsd_fields, class_obj, export_dict):
         self._export_fields_cofins(xsd_fields, class_obj, export_dict)
 
-        if self.nfe40_choice16 == "nfe40_pCOFINS":
+        if self.nfe40_choice_cofinsoutr == "nfe40_pCOFINS":
             xsd_fields.remove("nfe40_qBCProd")
             xsd_fields.remove("nfe40_vAliqProd")
 
-        if self.nfe40_choice16 == "nfe40_vAliqProd":
+        if self.nfe40_choice_cofinsoutr == "nfe40_vAliqProd":
             xsd_fields.remove("nfe40_vBC")
             xsd_fields.remove("nfe40_pCOFINS")
 
@@ -928,7 +928,7 @@ class NFeLine(spec_models.StackedModel):
     # Grupo W. Total da NF-e
     ########################
 
-    nfe40_choice10 = fields.Selection(
+    nfe40_choice_imposto = fields.Selection(
         selection=[
             ("nfe40_ICMS", "ICMS"),
             #            ("nfe40_II", "II"),
@@ -936,7 +936,7 @@ class NFeLine(spec_models.StackedModel):
             ("nfe40_ISSQN", "ISSQN"),
         ],
         string="ICMS/II/IPI ou ISSQN",
-        compute="_compute_nfe40_choice10",
+        compute="_compute_nfe40_choice_imposto",
         store=True,
     )
 
@@ -946,12 +946,12 @@ class NFeLine(spec_models.StackedModel):
     ##########################
 
     @api.depends("tax_icms_or_issqn")
-    def _compute_nfe40_choice10(self):
+    def _compute_nfe40_choice_imposto(self):
         for record in self:
             if record.tax_icms_or_issqn == "issqn":
-                record.nfe40_choice10 = "nfe40_ISSQN"
+                record.nfe40_choice_imposto = "nfe40_ISSQN"
             else:
-                record.nfe40_choice10 = "nfe40_ICMS"
+                record.nfe40_choice_imposto = "nfe40_ICMS"
 
     #######################################################
     # NF-e tag: infAdProd
@@ -999,7 +999,7 @@ class NFeLine(spec_models.StackedModel):
             "nfe40_ICMSTot",
             "nfe40_ICMSUFDest",
         ]:
-            vals["nfe40_choice11"] = key
+            vals["nfe40_choice_icms"] = key
 
         if key == "nfe40_vUnCom":
             vals["price_unit"] = float(value)

--- a/l10n_br_nfe/models/document_related.py
+++ b/l10n_br_nfe/models/document_related.py
@@ -38,7 +38,7 @@ class NFeRelated(spec_models.StackedModel):
     > <refNFP>
     > <refECF>"""
 
-    nfe40_choice4 = fields.Selection(
+    nfe40_choice_nfref = fields.Selection(
         [
             ("nfe40_refNFe", "refNFe"),
             ("nfe40_refNF", "refNF"),
@@ -48,7 +48,7 @@ class NFeRelated(spec_models.StackedModel):
         ],
         "refNFe/refNF/refNFP/refCTe/refECF",
         compute="_compute_nfe_data",
-        inverse="_inverse_nfe40_choice4",
+        inverse="_inverse_nfe40_choice_nfref",
     )
 
     nfe40_refNFe = fields.Char(
@@ -59,10 +59,6 @@ class NFeRelated(spec_models.StackedModel):
     nfe40_refCTe = fields.Char(
         compute="_compute_nfe_data",
         inverse="_inverse_nfe40_refCTe",
-    )
-
-    nfe40_choice5 = fields.Selection(
-        [("nfe40_CNPJ", "CNPJ"), ("nfe40_CPF", "CPF")], "CNPJ/CPF do Produtor"
     )
 
     # TODO
@@ -95,21 +91,21 @@ class NFeRelated(spec_models.StackedModel):
                     MODELO_FISCAL_NFCE,
                     MODELO_FISCAL_CFE,
                 ):
-                    rec.nfe40_choice4 = "nfe40_refNFe"
+                    rec.nfe40_choice_nfref = "nfe40_refNFe"
                     rec.nfe40_refNFe = rec.document_key
                 elif rec.document_type_id.code == MODELO_FISCAL_CTE:
-                    rec.nfe40_choice4 = "nfe40_refCTe"
+                    rec.nfe40_choice_nfref = "nfe40_refCTe"
                     rec.nfe40_refCTe = rec.document_key
                 else:
                     if rec.document_type_id.code == MODELO_FISCAL_RL:
-                        rec.nfe40_choice4 = "nfe40_refNFP"
+                        rec.nfe40_choice_nfref = "nfe40_refNFP"
                     elif rec.document_type_id.code == MODELO_FISCAL_CUPOM_FISCAL_ECF:
-                        rec.nfe40_choice4 = "nfe40_refECF"
+                        rec.nfe40_choice_nfref = "nfe40_refECF"
                     elif rec.document_type_id.code in (
                         MODELO_FISCAL_01,
                         MODELO_FISCAL_04,
                     ):
-                        rec.nfe40_choice4 = "nfe40_refNF"
+                        rec.nfe40_choice_nfref = "nfe40_refNF"
                     rec.nfe40_cUF = document.partner_id.state_id.ibge_code
                     rec.nfe40_AAMM = (
                         fields.Datetime.from_string(
@@ -127,9 +123,9 @@ class NFeRelated(spec_models.StackedModel):
                     rec.nfe40_serie = document.document_serie
                     rec.nfe40_nNF = document.document_number
 
-    def _inverse_nfe40_choice4(self):
+    def _inverse_nfe40_choice_nfref(self):
         for rec in self:
-            if rec.nfe40_choice4 == "nfe40_refNFe":
+            if rec.nfe40_choice_nfref == "nfe40_refNFe":
                 rec.document_type_id = self.env.ref("l10n_br_fiscal.document_55")
 
     def _inverse_nfe40_refNFe(self):
@@ -147,7 +143,7 @@ class NFeRelated(spec_models.StackedModel):
             xsd_fields = [
                 f
                 for f in xsd_fields
-                if f not in [i[0] for i in self._fields["nfe40_choice4"].selection]
+                if f not in [i[0] for i in self._fields["nfe40_choice_nfref"].selection]
             ]
-            xsd_fields += [self.nfe40_choice4]
+            xsd_fields += [self.nfe40_choice_nfref]
         return super()._export_fields(xsd_fields, class_obj, export_dict)

--- a/l10n_br_nfe/models/res_company.py
+++ b/l10n_br_nfe/models/res_company.py
@@ -42,7 +42,7 @@ class ResCompany(spec_models.SpecModel):
         readonly=False,
     )
 
-    nfe40_choice6 = fields.Selection(
+    nfe40_choice_emit = fields.Selection(
         [("nfe40_CNPJ", "CNPJ"), ("nfe40_CPF", "CPF")],
         string="CNPJ ou CPF?",
         compute="_compute_nfe_data",
@@ -135,9 +135,9 @@ class ResCompany(spec_models.SpecModel):
         # compute because a simple related field makes the match_record fail
         for rec in self:
             if rec.partner_id.is_company:
-                rec.nfe40_choice6 = "nfe40_CNPJ"
+                rec.nfe40_choice_emit = "nfe40_CNPJ"
             else:
-                rec.nfe40_choice6 = "nfe40_CPF"
+                rec.nfe40_choice_emit = "nfe40_CPF"
 
     def _build_attr(self, node, fields, vals, path, attr):
         if attr[0] == "enderEmit" and self.env.context.get("edoc_type") == "in":

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -91,7 +91,7 @@ class ResPartner(spec_models.SpecModel):
     )
 
     # Emit
-    nfe40_choice6 = fields.Selection(
+    nfe40_choice_emit = fields.Selection(
         selection=[("nfe40_CNPJ", "CNPJ"), ("nfe40_CPF", "CPF")],
         string="CNPJ/CPF do Emitente",
         compute="_compute_nfe_data",
@@ -134,13 +134,13 @@ class ResPartner(spec_models.SpecModel):
     # nfe.40.infresptec
     nfe40_xContato = fields.Char(related="legal_name")
 
-    nfe40_choice2 = fields.Selection(
+    nfe40_choice_tlocal = fields.Selection(
         selection=[("nfe40_CNPJ", "CNPJ"), ("nfe40_CPF", "CPF")],
         string="CNPJ/CPF do Parceiro",
         compute="_compute_nfe_data",
     )
 
-    nfe40_choice7 = fields.Selection(
+    nfe40_choice_dest = fields.Selection(
         selection=[
             ("nfe40_CNPJ", "CNPJ"),
             ("nfe40_CPF", "CPF"),
@@ -152,14 +152,14 @@ class ResPartner(spec_models.SpecModel):
     )
 
     # nfe.40.autXML
-    nfe40_choice8 = fields.Selection(
+    nfe40_choice_autxml = fields.Selection(
         selection=[("nfe40_CNPJ", "CNPJ"), ("nfe40_CPF", "CPF")],
         string="CNPJ/CPF do Parceiro Autorizado",
         compute="_compute_nfe_data",
     )
 
     # nfe.40.transporta
-    nfe40_choice19 = fields.Selection(
+    nfe40_choice_transporta = fields.Selection(
         selection=[
             ("nfe40_CNPJ", "CNPJ"),
             ("nfe40_CPF", "CPF"),
@@ -200,30 +200,30 @@ class ResPartner(spec_models.SpecModel):
             cnpj_cpf = punctuation_rm(rec.cnpj_cpf)
             if cnpj_cpf:
                 if rec.country_id.code != "BR":
-                    rec.nfe40_choice7 = "nfe40_idEstrangeiro"
-                    rec.nfe40_choice2 = False
+                    rec.nfe40_choice_dest = "nfe40_idEstrangeiro"
+                    rec.nfe40_choice_tlocal = False
                 elif rec.is_company:
-                    rec.nfe40_choice2 = "nfe40_CNPJ"
-                    rec.nfe40_choice6 = "nfe40_CNPJ"
-                    rec.nfe40_choice7 = "nfe40_CNPJ"
-                    rec.nfe40_choice8 = "nfe40_CNPJ"
-                    rec.nfe40_choice19 = "nfe40_CNPJ"
+                    rec.nfe40_choice_tlocal = "nfe40_CNPJ"
+                    rec.nfe40_choice_emit = "nfe40_CNPJ"
+                    rec.nfe40_choice_dest = "nfe40_CNPJ"
+                    rec.nfe40_choice_autxml = "nfe40_CNPJ"
+                    rec.nfe40_choice_transporta = "nfe40_CNPJ"
                     rec.nfe40_CNPJ = cnpj_cpf
                     rec.nfe40_CPF = None
                 else:
-                    rec.nfe40_choice2 = "nfe40_CPF"
-                    rec.nfe40_choice6 = "nfe40_CPF"
-                    rec.nfe40_choice7 = "nfe40_CPF"
-                    rec.nfe40_choice8 = "nfe40_CPF"
-                    rec.nfe40_choice19 = "nfe40_CPF"
+                    rec.nfe40_choice_tlocal = "nfe40_CPF"
+                    rec.nfe40_choice_emit = "nfe40_CPF"
+                    rec.nfe40_choice_dest = "nfe40_CPF"
+                    rec.nfe40_choice_autxml = "nfe40_CPF"
+                    rec.nfe40_choice_transporta = "nfe40_CPF"
                     rec.nfe40_CPF = cnpj_cpf
                     rec.nfe40_CNPJ = None
             else:
-                rec.nfe40_choice2 = False
-                rec.nfe40_choice6 = False
-                rec.nfe40_choice7 = False
-                rec.nfe40_choice8 = False
-                rec.nfe40_choice19 = False
+                rec.nfe40_choice_tlocal = False
+                rec.nfe40_choice_emit = False
+                rec.nfe40_choice_dest = False
+                rec.nfe40_choice_autxml = False
+                rec.nfe40_choice_transporta = False
                 rec.nfe40_CNPJ = ""
                 rec.nfe40_CPF = ""
 
@@ -239,29 +239,29 @@ class ResPartner(spec_models.SpecModel):
         for rec in self:
             if rec.nfe40_CNPJ:
                 rec.is_company = True
-                rec.nfe40_choice2 = "nfe40_CPF"
-                rec.nfe40_choice6 = "nfe40_CPF"
+                rec.nfe40_choice_tlocal = "nfe40_CPF"
+                rec.nfe40_choice_emit = "nfe40_CPF"
                 if rec.country_id.code != "BR":
-                    rec.nfe40_choice7 = "nfe40_idEstrangeiro"
+                    rec.nfe40_choice_dest = "nfe40_idEstrangeiro"
                 else:
-                    rec.nfe40_choice7 = "nfe40_CNPJ"
-                rec.nfe40_choice7 = "nfe40_CPF"
-                rec.nfe40_choice8 = "nfe40_CPF"
-                rec.nfe40_choice19 = "nfe40_CPF"
+                    rec.nfe40_choice_dest = "nfe40_CNPJ"
+                rec.nfe40_choice_dest = "nfe40_CPF"
+                rec.nfe40_choice_autxml = "nfe40_CPF"
+                rec.nfe40_choice_transporta = "nfe40_CPF"
                 rec.cnpj_cpf = cnpj_cpf.formata(str(rec.nfe40_CNPJ))
 
     def _inverse_nfe40_CPF(self):
         for rec in self:
             if rec.nfe40_CPF:
                 rec.is_company = False
-                rec.nfe40_choice2 = "nfe40_CNPJ"
-                rec.nfe40_choice6 = "nfe40_CNPJ"
+                rec.nfe40_choice_tlocal = "nfe40_CNPJ"
+                rec.nfe40_choice_emit = "nfe40_CNPJ"
                 if rec.country_id.code != "BR":
-                    rec.nfe40_choice7 = "nfe40_idEstrangeiro"
+                    rec.nfe40_choice_dest = "nfe40_idEstrangeiro"
                 else:
-                    rec.nfe40_choice7 = "nfe40_CPF"
-                rec.nfe40_choice8 = "nfe40_CNPJ"
-                rec.nfe40_choice19 = "nfe40_CNPJ"
+                    rec.nfe40_choice_dest = "nfe40_CPF"
+                rec.nfe40_choice_autxml = "nfe40_CNPJ"
+                rec.nfe40_choice_transporta = "nfe40_CNPJ"
                 rec.cnpj_cpf = cnpj_cpf.formata(str(rec.nfe40_CPF))
 
     def _inverse_nfe40_IE(self):
@@ -328,7 +328,7 @@ class ResPartner(spec_models.SpecModel):
             else:
                 cnpj_cpf = punctuation_rm(self.cnpj_cpf)
 
-            if xsd_field == self.nfe40_choice2:
+            if xsd_field == self.nfe40_choice_tlocal:
                 return cnpj_cpf
 
         if self.country_id.code != "BR":


### PR DESCRIPTION
Incialmente nas versões 10 e 12, xsadata ainda não existia e usamos o generateDS. o generateDS tinha suporte para as tags choice dos arquivos xsd, gerava campos choice com um numero para essas tags nos bindings Python (no nfelib). Nos mixins Odoo a gente manteve esses campos porque facilitava para as telas ou para a logica, por exemplo para saber se um parceiro era PJ ou PF.

So que tinha 2 problemas:

1. no generateDS isso era um ponto fraco, pois poderia surgir uma atualização grande dos xsd da Fazenda que fizesse o generateDS re-numerotar todos campos choice numa ordem diferente e zoar tudo, ate os dados no banco de dados...
2. o xsdata não gera atributos para as tags choice (nem procurei faze-lo no xsdata-odoo; apenas copiamos o campos nfe40_choice* geridos pelo generateds/generateds-odoo antes)

Mesmo quando eu fiz o refator do generateDS pro xsdata na 14.0, eu mantive os campos choice. Mas era uma coisa feia: a numeração era arbitraria e nada legível.

Neste PR tou renomeando esses campos choice de forma explicita e sistematica.

Importante: vale a pena fazer esse refator antes de portar o modulo l10n_br_nfe para as v15 e v16!