### PR TITLE
[14.0][IMP] l10n_br_fiscal: add support for using icms_imported_tax on incoming documents of return type

### DIFF
--- a/l10n_br_fiscal/models/icms_regulation.py
+++ b/l10n_br_fiscal/models/icms_regulation.py
@@ -7,6 +7,7 @@ from odoo import api, fields, models
 
 from ..constants.fiscal import (
     FINAL_CUSTOMER_YES,
+    FISCAL_IN,
     FISCAL_OUT,
     NFE_IND_IE_DEST_9,
     TAX_DOMAIN_ICMS,
@@ -1783,6 +1784,8 @@ class ICMSRegulation(models.Model):
             product.icms_origin in ICMS_ORIGIN_TAX_IMPORTED
             and company.state_id != partner.state_id
             and operation_line.fiscal_operation_type == FISCAL_OUT
+            or operation_line.fiscal_operation_id.fiscal_type == "return_in"
+            and operation_line.fiscal_operation_type == FISCAL_IN
         ):
             icms_taxes |= self.icms_imported_tax_id
         else:
@@ -1836,6 +1839,8 @@ class ICMSRegulation(models.Model):
             company.state_id != partner.state_id
             and partner.ind_ie_dest == NFE_IND_IE_DEST_9
             and operation_line.fiscal_operation_type == FISCAL_OUT
+            or operation_line.fiscal_operation_id.fiscal_type == "return_in"
+            and operation_line.fiscal_operation_type == FISCAL_IN
         ):
             domain = self._build_map_tax_def_domain(
                 partner, partner, tax_group_icms, ncm, nbm, cest
@@ -1863,8 +1868,10 @@ class ICMSRegulation(models.Model):
         # ICMS FCP for DIFAL
         if (
             company.state_id != partner.state_id
-            and operation_line.fiscal_operation_type == FISCAL_OUT
             and partner.ind_ie_dest == NFE_IND_IE_DEST_9
+            and operation_line.fiscal_operation_type == FISCAL_OUT
+            or operation_line.fiscal_operation_id.fiscal_type == "return_in"
+            and operation_line.fiscal_operation_type == FISCAL_IN
         ):
             domain = self._build_map_tax_def_domain(
                 partner, partner, tax_group_icmsfcp, ncm, nbm, cest

--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -387,9 +387,11 @@ class Tax(models.Model):
         if (
             cfop
             and cfop.destination == CFOP_DESTINATION_EXTERNAL
-            and operation_line.fiscal_operation_type == FISCAL_OUT
             and partner.ind_ie_dest == NFE_IND_IE_DEST_9
             and tax_dict.get("tax_value")
+            and operation_line.fiscal_operation_type == FISCAL_OUT
+            or operation_line.fiscal_operation_id.fiscal_type == "return_in"
+            and operation_line.fiscal_operation_type == FISCAL_IN
         ):
             icms_tax_difal, _ = company.icms_regulation_id.map_tax_def_icms_difal(
                 company, partner, product, ncm, nbm, cest, operation_line, ind_final


### PR DESCRIPTION
Este ajuste visa atender ao casse de uso onde tempos produto de origem importada e que se faz necessário emitir uma nota de devolução de venda de entrada.