### PR TITLE
[14.0][FIX][l10n_br_cnpj_search]: adicionar descrição no wizard

### DIFF
--- a/l10n_br_cnpj_search/wizard/partner_cnpj_search_wizard.py
+++ b/l10n_br_cnpj_search/wizard/partner_cnpj_search_wizard.py
@@ -10,6 +10,7 @@ from odoo import api, fields, models
 
 class PartnerCnpjSearchWizard(models.TransientModel):
     _name = "partner.search.wizard"
+    _description = "CNPJ based search wizard allowing to update partner data."
 
     partner_id = fields.Many2one(comodel_name="res.partner")
     provider_name = fields.Char()


### PR DESCRIPTION
O motivo dessa PR para corrigir o warning da descrição do wizard.

![e131906f-7b4a-47db-9f11-2e7c10b874b4](https://github.com/OCA/l10n-brazil/assets/142639425/129ef560-dc35-4813-9747-05ced06d87fa)
