### PR TITLE
[16.0][FIX] l10n_br_fiscal: update icms_base_type when icms_tax_id is set

### DIFF
--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -380,6 +380,7 @@ class Tax(models.Model):
             tax_dict["compute_with_tax_value"] = True
 
         tax_dict.update(self._compute_tax(tax, taxes_dict, **kwargs))
+        tax_dict.update({"icms_base_type": tax.icms_base_type})
 
         # DIFAL
         # TODO


### PR DESCRIPTION
port from https://github.com/OCA/l10n-brazil/pull/2933