### PR TITLE
[14.0][FIX][l10n_br_account_payment_brcobranca]: sequencial na geração de arquivo REM

### DIFF
--- a/l10n_br_account_payment_brcobranca/models/account_payment_order.py
+++ b/l10n_br_account_payment_brcobranca/models/account_payment_order.py
@@ -102,6 +102,7 @@ class PaymentOrder(models.Model):
     def generate_payment_file(self):
         """Returns (payment file as string, filename)"""
         self.ensure_one()
+        self.file_number = self.payment_mode_id.cnab_sequence_id.next_by_id()
 
         # see remessa fields here:
         # https://github.com/kivanio/brcobranca/blob/master/lib/brcobranca/remessa/base.rb
@@ -154,7 +155,7 @@ class PaymentOrder(models.Model):
                 bank_account_id.partner_id.cnpj_cpf
             ),
             "pagamentos": pagamentos,
-            "sequencial_remessa": self.payment_mode_id.cnab_sequence_id.next_by_id(),
+            "sequencial_remessa": self.file_number,
         }
 
         try:


### PR DESCRIPTION
Objetivo dessa PR é propor uma alteração para um sequencial na criação do arquivo REM.
Esta acontecendo de quando gera arquivo REM no mesmo dia, esta gerando com o mesmo nome então agora com essa alteração vai corrigir esse problema.

Podemos vê conforme o video: 


https://github.com/Engenere/l10n-brazil/assets/142639425/51903fe7-c57b-42d1-9706-e823e8fcc844

