### PR TITLE
[14.0][l10n_br_fiscal][l10n_br_nfe][REF] made edoc/NFe import wizard more generic

### DIFF
--- a/l10n_br_fiscal/wizards/document_import_wizard_mixin.py
+++ b/l10n_br_fiscal/wizards/document_import_wizard_mixin.py
@@ -1,9 +1,20 @@
 # Copyright (C) 2023  Felipe Zago Rodrigues - Kmee
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import fields, models
+import base64
+import logging
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 from odoo.addons.l10n_br_fiscal.constants.fiscal import FISCAL_IN_OUT_ALL
+
+_logger = logging.getLogger(__name__)
+
+try:
+    from xsdata.formats.dataclass.parsers import XmlParser
+except ImportError:
+    _logger.error(_("xsdata Python lib not installed!"))
 
 
 class DocumentImportWizardMixin(models.TransientModel):
@@ -17,15 +28,109 @@ class DocumentImportWizardMixin(models.TransientModel):
         default=lambda self: self.env.company.id,
     )
 
-    importing_type = fields.Selection(
-        selection=[("xml_file", "XML File")],
-        string="Importing Type",
-        required=True,
-        default="xml_file",
+    file = fields.Binary(string="File to Import")
+
+    fiscal_operation_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.operation",
+        string="Fiscal Operation",
+        domain="[('fiscal_operation_type', '=', fiscal_operation_type)]",
     )
 
-    xml = fields.Binary(string="XML to Import")
+    document_type = fields.Char()
 
     fiscal_operation_type = fields.Selection(
         string="Fiscal Operation Type", selection=FISCAL_IN_OUT_ALL
     )
+
+    def _import_edoc(self):
+        self._find_existing_document()
+        if not self.document_id:
+            binding, self.document_id = self._create_edoc_from_file()
+        else:
+            binding = self._parse_file()
+        return binding, self.document_id
+
+    def action_import_and_open_document(self):
+        self._import_edoc()
+        return self.action_open_document()
+
+    def _create_edoc_from_file(self):
+        pass  # meant to be overriden
+
+    @api.onchange("file")
+    def _onchange_file(self):
+        if self.file:
+            self._fill_wizard_from_binding()
+
+    def _fill_wizard_from_binding(self):
+        pass  # meant to be overriden
+
+    def action_open_document(self):
+        return {
+            "name": _("Document Imported"),
+            "type": "ir.actions.act_window",
+            "target": "current",
+            "views": [[False, "form"]],
+            "res_id": self.document_id.id,
+            "res_model": "l10n_br_fiscal.document",
+        }
+
+    def _document_key_from_binding(self, binding):
+        pass  # meant to be overriden
+
+    def _find_existing_document(self):
+        document_key = self._document_key_from_binding(self._parse_file())
+        self.document_id = self.env["l10n_br_fiscal.document"].search(
+            [("document_key", "=", document_key.chave)],
+            limit=1,
+        )
+
+    def _find_document_type(self, code):
+        return self.env["l10n_br_fiscal.document.type"].search(
+            [("code", "=", code)],
+            limit=1,
+        )
+
+    def _find_fiscal_operation(self, cfop, nat_op, fiscal_operation_type):
+        """try to find a matching fiscal operation via an operation line"""
+        operation_lines = self.env["l10n_br_fiscal.operation.line"].search(
+            [
+                ("state", "=", "approved"),
+                ("fiscal_type", "=", fiscal_operation_type),
+                ("cfop_external_id", "=", cfop),
+            ],
+        )
+        for line in operation_lines:
+            if line.fiscal_operation_id.name == nat_op:
+                return line.fiscal_operation_id
+        if operation_lines:
+            return operation_lines[0].fiscal_operation_id
+
+    def _parse_file(self):
+        return self._parse_file_data(self.file)
+
+    @api.model
+    def _parse_file_data(self, file_data):
+        try:
+            binding = XmlParser().from_bytes(base64.b64decode(file_data))
+        except Exception as e:
+            raise UserError(_("Invalid file: %s" % e))
+        return binding
+
+    @api.model
+    def _detect_binding(self, binding):
+        """
+        A pluggable method were each specialized fiscal document
+        importation wizard can register itself and return a tuple
+        with (the_fiscal_document_type_code, the_name_of_the_importation_wizard)
+        """
+        raise UserError(
+            _(
+                "Importation not implemented for %s!"
+                % (
+                    type(
+                        binding,
+                    )
+                )
+            )
+        )

--- a/l10n_br_fiscal/wizards/document_import_wizard_mixin.xml
+++ b/l10n_br_fiscal/wizards/document_import_wizard_mixin.xml
@@ -9,21 +9,16 @@
         <field name="arch" type="xml">
             <form string="Import Document">
                 <group>
-                    <field name="importing_type" />
-                    <field
-                        name="xml"
-                        attrs="{
-                            'invisible': [('importing_type', '!=', 'xml_file')],
-                            'required': [('importing_type', '=', 'xml_file')]
-                        }"
-                    />
+                    <field name="file" required="1" />
                 </group>
                 <separator
                     string="Preview Data"
-                    attrs="{'invisible': [('xml', '=', False)]}"
+                    attrs="{'invisible': [('file', '=', False)]}"
                 />
-                <group id="document_info" attrs="{'invisible': [('xml', '=', False)]}">
+                <group id="document_info" attrs="{'invisible': [('file', '=', False)]}">
                     <group>
+                        <field name="fiscal_operation_id" required="1" />
+                        <field name="fiscal_operation_type" invisible="1" />
                         <field name="document_key" readonly="1" />
                         <field name="document_number" readonly="1" />
                         <field name="document_serie" readonly="1" />
@@ -33,7 +28,15 @@
                         <field name="partner_id" readonly="1" />
                     </group>
                 </group>
-                <footer />
+                <footer>
+                    <button
+                        name="action_import_and_open_document"
+                        string="Import Fiscal Document"
+                        class="btn-primary"
+                        type="object"
+                    />
+                    <button string="Cancel" class="btn-default" special="cancel" />
+                </footer>
             </form>
         </field>
     </record>

--- a/l10n_br_nfe/i18n/l10n_br_nfe.pot
+++ b/l10n_br_nfe/i18n/l10n_br_nfe.pot
@@ -1579,11 +1579,6 @@ msgid "Imported Products"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_nfe_import_xml__importing_type
-msgid "Importing Type"
-msgstr ""
-
-#. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_company__nfe_authorize_accountant_download_xml
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_config_settings__nfe_authorize_accountant_download_xml
 msgid ""

--- a/l10n_br_nfe/models/dfe.py
+++ b/l10n_br_nfe/models/dfe.py
@@ -128,4 +128,4 @@ class DFe(models.Model):
     @api.model
     def parse_procNFe(self, xml):
         binding = TnfeProc.from_xml(xml.read().decode())
-        return self.env["l10n_br_fiscal.document"].import_nfe_xml(binding)
+        return self.env["l10n_br_fiscal.document"].import_binding_nfe(binding)

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -1115,15 +1115,15 @@ class NFe(spec_models.StackedModel):
             }
         )
 
-    def import_nfe_xml(self, xml, edoc_type="out"):
+    def import_binding_nfe(self, binding, edoc_type="out"):
         document = (
             self.env["nfe.40.infnfe"]
             .with_context(tracking_disable=True, edoc_type=edoc_type, dry_run=False)
-            .build_from_binding(xml.NFe.infNFe)
+            .build_from_binding(binding.NFe.infNFe)
         )
 
         if edoc_type == "in" and document.company_id.cnpj_cpf != cnpj_cpf.formata(
-            xml.NFe.infNFe.emit.CNPJ
+            binding.NFe.infNFe.emit.CNPJ
         ):
             document.fiscal_operation_type = "in"
             document.issuer = "partner"

--- a/l10n_br_nfe/wizards/import_document.xml
+++ b/l10n_br_nfe/wizards/import_document.xml
@@ -35,7 +35,7 @@
                     attrs="{
                     'invisible': [
                         '|',
-                        ('xml', '=', False),
+                        ('file', '=', False),
                         ('document_id', '!=', False),
                     ]
                 }"
@@ -44,22 +44,11 @@
                     <group
                         colspan="4"
                         id="imported_products"
-                        attrs="{'invisible': [('xml', '=', False)]}"
+                        attrs="{'invisible': [('file', '=', False)]}"
                     >
                         <field name="imported_products_ids" nolabel="1" />
                     </group>
                 </group>
-            </xpath>
-
-            <xpath expr="//footer" position="inside">
-                <button
-                    name="import_xml"
-                    string="Import"
-                    class="btn-primary"
-                    type="object"
-                    attrs="{'invisible': [('importing_type', '!=', 'xml_file')]}"
-                />
-                <button string="Cancel" class="btn-default" special="cancel" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
This PR is used in the NFe importation PR https://github.com/OCA/l10n-brazil/pull/2781

Rename some variables and methods from the previous importation wizard: xml can actually be a file of any format (XML and json are natively supported by xsdata and hence nfelib). Typically we "sniff" the uploaded file and only then determine the format so calling the file xml in 1st place was bad. Other bad names: xml while you were actually dealing with a "binding", calling a document what was actually a document_key...