### PR TITLE
[14.0][FIX] l10n_br_stock_account: Criação da Fatura a partir do Picking está indo com o campo ind_final 'Consumidor Final' com 'Sim' mesmo quando não é o caso

### DIFF
--- a/l10n_br_stock_account/demo/l10n_br_stock_account_demo.xml
+++ b/l10n_br_stock_account/demo/l10n_br_stock_account_demo.xml
@@ -496,11 +496,7 @@
         <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
         <field name="product_id" ref="product.product_product_16" />
         <field name="product_uom_qty">2</field>
-        <!-- Campo preenchido apenas para teste porque ao Validar o Picking
-             o metodo atualiza o campo com o standard_price ou o lst_price do
-             produto dependendo do Tipo do Picking
-        -->
-        <field name="price_unit">3645.00</field>
+        <field name="price_unit">50.00</field>
         <field name="product_uom" ref="uom.product_uom_unit" />
         <field name="picking_id" ref="lucro_presumido-picking_1" />
         <field
@@ -529,7 +525,7 @@
         <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
         <field name="product_id" ref="product.product_product_12" />
         <field name="product_uom_qty">2</field>
-        <field name="price_unit">12.50</field>
+        <field name="price_unit">50.00</field>
         <field name="product_uom" ref="uom.product_uom_unit" />
         <field name="picking_id" ref="lucro_presumido-picking_1" />
         <field
@@ -582,11 +578,7 @@
         <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
         <field name="product_id" ref="product.product_product_16" />
         <field name="product_uom_qty">2</field>
-        <!-- Campo preenchido apenas para teste porque ao Validar o Picking
-             o metodo atualiza o campo com o standard_price ou o lst_price do
-             produto dependendo do Tipo do Picking
-        -->
-        <field name="price_unit">3645.00</field>
+        <field name="price_unit">50.00</field>
         <field name="product_uom" ref="uom.product_uom_unit" />
         <field name="picking_id" ref="lucro_presumido-picking_2" />
         <field
@@ -615,7 +607,7 @@
         <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
         <field name="product_id" ref="product.product_product_12" />
         <field name="product_uom_qty">2</field>
-        <field name="price_unit">12.50</field>
+        <field name="price_unit">50.00</field>
         <field name="product_uom" ref="uom.product_uom_unit" />
         <field name="picking_id" ref="lucro_presumido-picking_2" />
         <field
@@ -668,11 +660,7 @@
         <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
         <field name="product_id" ref="product.product_product_16" />
         <field name="product_uom_qty">2</field>
-        <!-- Campo preenchido apenas para teste porque ao Validar o Picking
-             o metodo atualiza o campo com o standard_price ou o lst_price do
-             produto dependendo do Tipo do Picking
-        -->
-        <field name="price_unit">3645.00</field>
+        <field name="price_unit">50.00</field>
         <field name="product_uom" ref="uom.product_uom_unit" />
         <field name="picking_id" ref="simples_nacional-picking_1" />
         <field
@@ -701,7 +689,7 @@
         <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
         <field name="product_id" ref="product.product_product_12" />
         <field name="product_uom_qty">2</field>
-        <field name="price_unit">12.50</field>
+        <field name="price_unit">50.00</field>
         <field name="product_uom" ref="uom.product_uom_unit" />
         <field name="picking_id" ref="simples_nacional-picking_1" />
         <field
@@ -754,11 +742,7 @@
         <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
         <field name="product_id" ref="product.product_product_16" />
         <field name="product_uom_qty">2</field>
-        <!-- Campo preenchido apenas para teste porque ao Validar o Picking
-             o metodo atualiza o campo com o standard_price ou o lst_price do
-             produto dependendo do Tipo do Picking
-        -->
-        <field name="price_unit">3645.00</field>
+        <field name="price_unit">50.00</field>
         <field name="product_uom" ref="uom.product_uom_unit" />
         <field name="picking_id" ref="simples_nacional-picking_2" />
         <field
@@ -787,7 +771,7 @@
         <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
         <field name="product_id" ref="product.product_product_12" />
         <field name="product_uom_qty">2</field>
-        <field name="price_unit">12.50</field>
+        <field name="price_unit">50.00</field>
         <field name="product_uom" ref="uom.product_uom_unit" />
         <field name="picking_id" ref="simples_nacional-picking_2" />
         <field

--- a/l10n_br_stock_account/demo/l10n_br_stock_account_demo.xml
+++ b/l10n_br_stock_account/demo/l10n_br_stock_account_demo.xml
@@ -72,6 +72,11 @@
         <field name="company_id" ref="base.main_company" />
     </record>
 
+    <!-- Necessário porque sem isso o ind_final fica Sim devido metodo Default -->
+    <function model="stock.picking" name="_onchange_partner_id_fiscal">
+        <value eval="[ref('main_company-picking_1')]" />
+    </function>
+
     <record model="stock.move" id="main_company-move_1_1">
         <field name="name">Test - l10n_br_stock_account - 1</field>
         <!-- sem o campo abaixo falha o mapeamento de CFOP, erro não acontece na tela -->
@@ -162,6 +167,11 @@
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_simples_remessa" />
         <field name="company_id" ref="base.main_company" />
     </record>
+
+    <!-- Necessário porque sem isso o ind_final fica Sim devido metodo Default -->
+    <function model="stock.picking" name="_onchange_partner_id_fiscal">
+        <value eval="[ref('main_company-picking_2')]" />
+    </function>
 
     <record model="stock.move" id="main_company-move_2_1">
         <field name="name">Test - l10n_br_stock_account - 2</field>
@@ -259,6 +269,11 @@
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_simples_remessa" />
         <field name="company_id" ref="base.main_company" />
     </record>
+
+    <!-- Necessário porque sem isso o ind_final fica Sim devido metodo Default -->
+    <function model="stock.picking" name="_onchange_partner_id_fiscal">
+        <value eval="[ref('main_company-picking_3')]" />
+    </function>
 
     <record model="stock.move" id="main_company-move_3_1">
         <field
@@ -358,6 +373,11 @@
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_simples_remessa" />
         <field name="company_id" ref="base.main_company" />
     </record>
+
+    <!-- Necessário porque sem isso o ind_final fica Sim devido metodo Default -->
+    <function model="stock.picking" name="_onchange_partner_id_fiscal">
+        <value eval="[ref('main_company-picking_4')]" />
+    </function>
 
     <record model="stock.move" id="main_company-move_4_1">
         <field
@@ -465,6 +485,11 @@
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
 
+    <!-- Necessário porque sem isso o ind_final fica Sim devido metodo Default -->
+    <function model="stock.picking" name="_onchange_partner_id_fiscal">
+        <value eval="[ref('lucro_presumido-picking_1')]" />
+    </function>
+
     <record model="stock.move" id="lucro_presumido-move_1_1">
         <field name="name">Test - l10n_br_stock_account - 1</field>
         <!-- sem o campo abaixo falha o mapeamento de CFOP, erro não acontece na tela -->
@@ -545,6 +570,11 @@
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_simples_remessa" />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
+
+    <!-- Necessário porque sem isso o ind_final fica Sim devido metodo Default -->
+    <function model="stock.picking" name="_onchange_partner_id_fiscal">
+        <value eval="[ref('lucro_presumido-picking_2')]" />
+    </function>
 
     <record model="stock.move" id="lucro_presumido-move_2_1">
         <field name="name">Test - l10n_br_stock_account - 1</field>
@@ -627,6 +657,11 @@
         <field name="company_id" ref="l10n_br_base.empresa_simples_nacional" />
     </record>
 
+    <!-- Necessário porque sem isso o ind_final fica Sim devido metodo Default -->
+    <function model="stock.picking" name="_onchange_partner_id_fiscal">
+        <value eval="[ref('simples_nacional-picking_1')]" />
+    </function>
+
     <record model="stock.move" id="simples_nacional-move_1_1">
         <field name="name">Test - l10n_br_stock_account - 1</field>
         <!-- sem o campo abaixo falha o mapeamento de CFOP, erro não acontece na tela -->
@@ -690,7 +725,7 @@
         <value eval="[ref('simples_nacional-move_1_2')]" />
     </function>
 
-    <!-- Picking Test - Lucro Presumido -->
+    <!-- Picking Test - Simples Nacional -->
     <record model="stock.picking" id="simples_nacional-picking_2">
         <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
         <field
@@ -707,6 +742,11 @@
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_simples_remessa" />
         <field name="company_id" ref="l10n_br_base.empresa_simples_nacional" />
     </record>
+
+    <!-- Necessário porque sem isso o ind_final fica Sim devido metodo Default -->
+    <function model="stock.picking" name="_onchange_partner_id_fiscal">
+        <value eval="[ref('simples_nacional-picking_2')]" />
+    </function>
 
     <record model="stock.move" id="simples_nacional-move_2_1">
         <field name="name">Test - l10n_br_stock_account - 1</field>

--- a/l10n_br_stock_account/tests/test_invoicing_picking.py
+++ b/l10n_br_stock_account/tests/test_invoicing_picking.py
@@ -292,6 +292,8 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
         self.assertEqual(
             invoice.partner_id, self.env.ref("l10n_br_base.res_partner_cliente1_sp")
         )
+        # Campo 'Consumidor Final' deve estar vazio
+        assert invoice.ind_final, "Error field ind_final not None"
         self.assertIn(invoice, picking.invoice_ids)
         self.assertIn(picking, invoice.picking_ids)
         nb_invoice_after = self.env["account.move"].search_count([])
@@ -315,6 +317,7 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
             self.assertTrue(
                 line.fiscal_operation_line_id, "Missing Fiscal Operation Line."
             )
+            assert line.ind_final, "Error field ind_final in Invoice Line not None"
 
         self.assertTrue(
             invoice.fiscal_operation_id,

--- a/l10n_br_stock_account/tests/test_invoicing_picking.py
+++ b/l10n_br_stock_account/tests/test_invoicing_picking.py
@@ -27,12 +27,13 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
 
         for line in picking.move_lines:
             # No Brasil o caso de Ordens de Entrega que não tem ligação com
-            # Pedido de Venda precisam informar o Preço de Custo e não o de
-            # Venda, ex.: Simples Remessa, Remessa p/ Industrialiazação e etc.
-            # Teria algum caso que não deve usar ?
-
+            # Pedido de Venda por padrão deve trazer o valor o Preço de Custo
+            # e não o de Venda, ex.: Simples Remessa, Remessa p/
+            # Industrialiazação e etc, mas o valor informado pelo usuário deve
+            # ter prioridade.
             # Os metodos do stock/core alteram o valor p/
             # negativo por isso o abs
+
             self.assertEqual(
                 abs(line.price_unit),
                 line.product_id.with_company(line.company_id).standard_price,
@@ -63,7 +64,7 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
             # TODO: No travis falha o browse aqui
             #  l10n_br_stock_account/models/stock_invoice_onshipping.py:105
             #  isso não acontece no caso da empresa de Lucro Presumido
-            #  ou quando é feito o teste apenas instalanado os modulos
+            #  ou quando é feito o teste apenas instalando os modulos
             #  l10n_br_account e em seguida o l10n_br_stock_account
             # self.assertTrue(line.tax_ids, "Taxes in invoice lines are missing.")
 
@@ -139,13 +140,16 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
             # qty = 4 because 2 for each stock.move
             self.assertEqual(inv_line.quantity, 4)
             # Price Unit e Fiscal Price devem ser positivos
+            price_unit_mv_line = picking.move_lines.filtered(
+                lambda mv: mv.product_id == inv_line.product_id
+            ).mapped("price_unit")[0]
             self.assertEqual(
                 inv_line.price_unit,
-                inv_line.product_id.with_company(inv_line.company_id).standard_price,
+                price_unit_mv_line,
             )
             self.assertEqual(
                 inv_line.fiscal_price,
-                inv_line.product_id.with_company(inv_line.company_id).standard_price,
+                price_unit_mv_line,
             )
 
             # TODO: No travis falha o browse aqui
@@ -212,7 +216,7 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
         # TODO: No travis falha o browse aqui
         #  l10n_br_stock_account/models/stock_invoice_onshipping.py:105
         #  isso não acontece no caso da empresa de Lucro Presumido
-        #  ou quando é feito o teste apenas instalanado os modulos
+        #  ou quando é feito o teste apenas instalando os modulos
         #  l10n_br_account e em seguida o l10n_br_stock_account
         # for inv_line in invoice_pick_1.invoice_line_ids:
         #    self.assertTrue(inv_line.tax_ids, "Error to map Sale Tax in invoice.line.")
@@ -269,22 +273,15 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
         # Estoque, o metodo do core é chamado pelo botão Validate
 
         for line in picking.move_lines:
-            # No Brasil o caso de Ordens de Entrega que não tem ligação com
-            # Pedido de Venda precisam informar o Preço de Custo e não o de
-            # Venda, ex.: Simples Remessa, Remessa p/ Industrialiazação e etc.
-            # Teria algum caso que não deve usar ?
-
-            # Os metodos do stock/core alteram o valor p/
-            # negativo por isso o abs
-            self.assertEqual(
-                abs(line.price_unit),
-                line.product_id.with_company(line.company_id).standard_price,
-            )
             # O Campo fiscal_price precisa ser um espelho do price_unit,
             # apesar do onchange p/ preenche-lo sem incluir o compute no campo
             # ele traz o valor do lst_price e falha no teste abaixo
             # TODO - o fiscal_price aqui tbm deve ter um valor negativo ?
             self.assertEqual(line.fiscal_price, line.price_unit)
+            # Testa o _get_price_unit_invoice para o caso onde o Preço Padrão
+            # do Produto e o Preço Unitário informado é Zero
+            line.product_id.standard_price = 0.0
+            line.price_unit = 0.0
 
         invoice = self.create_invoice_wizard(picking)
         self.assertTrue(invoice, "Invoice is not created.")
@@ -317,6 +314,10 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
             self.assertTrue(
                 line.fiscal_operation_line_id, "Missing Fiscal Operation Line."
             )
+            self.assertTrue(
+                line.fiscal_tax_ids, "Error to map fiscal_tax_ids in invoice line."
+            )
+            self.assertTrue(line.tax_ids, "Error to map tax_ids in invoice.line.")
             assert line.ind_final, "Error field ind_final in Invoice Line not None"
 
         self.assertTrue(
@@ -520,12 +521,17 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
             self.env.ref("l10n_br_stock_account.main_company-move_2_1")
         )
         stock_move_form.product_uom_qty = 10
+        # Testa o _onchange_product_quantity
+        stock_move_form.price_unit = 0.0
         stock_move_form.save()
 
     def test_simples_nacional(self):
         """Test case of Simples Nacional"""
         self._change_user_company(self.env.ref("l10n_br_base.empresa_simples_nacional"))
         picking = self.env.ref("l10n_br_stock_account.simples_nacional-picking_1")
+        for line in picking.move_lines:
+            # Testa _get_price_unit
+            line.price_unit = 0.0
         self.picking_move_state(picking)
         self.assertEqual(picking.state, "done", "Change state fail.")
         # Testes falhando apenas no CI, a Operação Fiscal por algum motivo
@@ -539,7 +545,7 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
         # odoo.exceptions.ValidationError: The chosen journal has a type that
         # is not compatible with your invoice type. Sales operations should go
         #  to 'sale' journals, and purchase operations to 'purchase' ones.
-        # TODO: teria alguama forma de corrigir? Por enquanto está sendo
+        # TODO: teria alguma forma de corrigir? Por enquanto está sendo
         # preciso preenche o campo com o Diário correto para evitar o erro
         journal = self.env.ref(
             "l10n_br_stock_account.simples_remessa_journal_simples_nacional"

--- a/l10n_br_stock_account/views/stock_picking.xml
+++ b/l10n_br_stock_account/views/stock_picking.xml
@@ -12,6 +12,10 @@
                     name="fiscal_operation_id"
                     attrs="{'invisible': [('invoice_state', '=', 'none')], 'readonly': [('invoice_state', '=', 'invoiced')]}"
                 />
+                <field
+                    name="ind_final"
+                    attrs="{'invisible': ['|', ('invoice_state', '=', 'none'), ('fiscal_operation_id', '=', False)], 'readonly': [('invoice_state', '=', 'invoiced')]}"
+                />
             </field>
             <field name="invoice_state" position="attributes">
                 <attribute name="readonly">1</attribute>
@@ -141,19 +145,55 @@
                             </group>
                         </page>
                         <page name="fiscal_line_extra_info" string="Extra Info" />
-                        <page name="accounting" string="Accounting" />
+                        <page name="accounting" string="Accounting">
+                            <group string="Taxes">
+                                <field
+                                    name="tax_ids"
+                                    widget="many2many_tags"
+                                    options="{'no_create': True}"
+                                />
+                            </group>
+                            <group
+                                name="invoice_lines"
+                                string="Invoicing"
+                                colspan="4"
+                                groups="base.group_no_one"
+                                attrs="{'invisible': [('invoice_state', 'in', [False, 'none'])]}"
+                            >
+                                <field
+                                    name="invoice_line_ids"
+                                    readonly="1"
+                                    nolabel="1"
+                                />
+                            </group>
+                        </page>
+                        <page name="amounts" string="Amounts">
+                            <group>
+                                <group>
+                                    <field name="amount_untaxed" />
+                                    <field name="amount_fiscal" />
+                                    <field name="amount_tax" />
+                                    <field name="estimate_tax" />
+                                </group>
+                                <group>
+                                    <field name="amount_total" />
+                                    <field name="amount_tax_withholding" />
+                                    <field name="amount_taxed" />
+                                </group>
+                            </group>
+                        </page>
                     </notebook>
                 </group>
-
                 <group
                     name="invoice_lines"
                     string="Invoicing"
                     colspan="4"
                     groups="base.group_no_one"
-                    attrs="{'invisible': [('invoice_state', 'in', [False, 'none'])]}"
+                    attrs="{'invisible': ['|', ('fiscal_operation_line_id', '!=', False), ('invoice_state', 'in', [False, 'none'])]}"
                 >
                     <field name="invoice_line_ids" readonly="1" nolabel="1" />
                 </group>
+
 
             </xpath>
             <xpath expr="//page[@name='extra']/group" position="inside">

--- a/l10n_br_stock_account/wizards/stock_invoice_onshipping.py
+++ b/l10n_br_stock_account/wizards/stock_invoice_onshipping.py
@@ -145,22 +145,6 @@ class StockInvoiceOnshipping(models.TransientModel):
 
         values.update(fiscal_values)
 
-        # Chamar este método garante que os tax_ids sejam calculados corretamente
-        values = self._simulate_onchange_fiscal_tax_ids(values)
-
-        return values
-
-    def _simulate_onchange_fiscal_tax_ids(self, values):
-        """
-        Simulate onchange fiscal tax ids
-        :param values: dict
-        :return: dict
-        """
-        line = self.env["account.move.line"].new(values.copy())
-        line._onchange_fiscal_tax_ids()
-        new_values = line._convert_to_write(line._cache)
-        # Ensure basic values are not updated
-        values.update(new_values)
         return values
 
     def _get_move_key(self, move):


### PR DESCRIPTION
The simulation of onchanges get default values of the fields, by this reason field ind_final come Yes, to avoid this problem was created a compute field tax_ids, the reason for make the simulation, and included ind_final in the view to allow user see it and, if necessary, change. Allow users inform the Price Unit in stock.move, but in the Quants keep the Standard Price.

Ao criar uma Fatura a partir da Separação de Estoque/ Stock Picking o campo 'Consumidor Final' está indo como 'Sim' mesmo quando não é o caso, isso está acontecendo porque na simulação do método onchange para obter o valor do tax_ids https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_stock_account/wizards/stock_invoice_onshipping.py#L153 acaba trazendo os valores Default dos campos, e o ind_final está como Sim, para resolver eu criei um campo compute do tax_ids no stock.move assim a visão fica mais próxima dos outros casos, Pedidos de Compras, Vendas e Fatura, e coloquei o campo "Consumidor Final" no stock.picking com o mesmo objetivo e até para permitir a alteração como ocorre nos outros objetos, com isso removi a simulação do onchange até para evitar outros problemas com essa questão do Default ( devido a quantidade de campos Fiscais poderia estar afetando outros campos ) já que o ideal é que o método do _prepare_br_fiscal_dict traga os campos de forma correta. Esse PR é referente ao issue https://github.com/OCA/l10n-brazil/issues/2924 e acredito que deve resolve-lo, segue images onde o problema apontando está sendo resolvido:

Pedido de Venda

![image](https://github.com/OCA/l10n-brazil/assets/6341149/3c0da008-5a54-42e7-8c95-06b5fdeb86ea)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/2da0530b-da53-4567-ab7e-6ce839b5689a)

Separação de Estoque

![image](https://github.com/OCA/l10n-brazil/assets/6341149/53c0de1a-fcd0-4551-a7aa-b0cba3ae4664)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/5bac60e8-6273-42ab-9a8e-b6d6ba3654e4)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/f4f2cce0-8418-46b6-9e31-82efd79ccfe2)

Na visão do stock.move para deixar mais próxima das outras inclui a aba Totais e as Linhas de Fatura agora nos casos que tem Operação Fiscal aparecem apenas na aba Contabilidade ( imagem acima ) e continuam fora aba quando são dos casos Sem Operação Fiscal ( a imagem abaixo não está relacionada ao exemplo e apenas referente a diferença das Linhas de Fatura no caso Com ou Sem Operação Fiscal )

![image](https://github.com/OCA/l10n-brazil/assets/6341149/3c7b0fd6-9316-4aae-91b5-650fea202cb1)

Fatura

![image](https://github.com/OCA/l10n-brazil/assets/6341149/8798da91-2acb-479a-b3c4-476edbc3e397)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/8d52cd92-5ac1-4903-bd04-d6e417a8e8d9)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/34e077cf-84c3-4f0e-9e7d-6173527d40c8)

Também fiz nesse PR uma alteração para permitir o usuário informar e alterar o valor do 'Preço Unitário'/price_unit antes desse PR o campo estava sempre sendo preenchido com o 'Preço Padrão' agora o programa traz esse valor mas se o usuário alterar ele tem a prioridade, porém mantive o 'Preço Padrão' no método que é usado no Quant assim nesse caso nada mudou( deixei um TODO para avaliar se também deve ser mudado, por enquanto acredito que não, e que o padrão no Brasil é esse de sempre usar o Preço Padrão para Valorização de Estoque, qualquer informação sobre isso é bem vinda ).

Tem algumas questões que não estão sendo resolvidas aqui mas talvez seja importante o debate, esse campo 'Consumidor Final' deveria estar como Default 'Sim'? Não seria melhor deixa none ou 'Não', isso está causando problemas em outros Dados de Demonstração mas também podem afetar os casos onde é feita ou é necessário a simulação de onchanges ou métodos que pegam os valores defaults,

Dados de Demonstração do modulo l10n_br_sale
![image](https://github.com/OCA/l10n-brazil/assets/6341149/1f6488f2-755e-4a22-835a-8f175b939e1b)

Isso hoje é corrigido quando o usuário informa o res.partner devido esse onchange https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_fiscal/models/document_fiscal_mixin_methods.py#L96 por isso aqui nesse PR eu estou incluindo esse onchange nos Dados de demonstração, e aqui tem outra questão essa parametrização se é ou não Consumidor Final não deveria seguir o mesmo padrão dos outros campos Fiscais, exemplo Regime Tributário, onde se existe a necessidade de alteração isso deve ser feito no Cadastro desse Parceiro/res.partner e não no Pedido de Venda, Compras, Separação de Estoque ou Fatura? Quer dizer existe algum caso onde um mesmo res.partner pode ser 'Consumidor Final' em um caso mas não em outro? Porque se não existe esse campo nos objetos poderiam a passar a ser ou related ou compute.

Se necessário posso ver de separar os PRs mas para testes até para verificar os valores de impostos( exemplo o valor 100,00 e mais fácil de verificar do que 3412,25 ) acredito que é melhor os dois commits juntos.


cc @rvalyi @renatonlima @marcelsavegnago @mileo @antoniospneto  @DiegoParadeda