### PR TITLE
[14.0][REF] l10n_br_account_payment_order, l10n_br_account_payment_brcobranca, l10n_br_cnab_structure: Movido o método get_file_name para evitar ter código duplicado

### DIFF
--- a/l10n_br_account_payment_brcobranca/models/account_payment_order.py
+++ b/l10n_br_account_payment_brcobranca/models/account_payment_order.py
@@ -11,7 +11,7 @@ import tempfile
 import requests
 from erpbrasil.base import misc
 
-from odoo import _, fields, models
+from odoo import _, models
 from odoo.exceptions import Warning as ValidationError
 
 from ..constants.br_cobranca import (
@@ -84,24 +84,6 @@ class PaymentOrder(models.Model):
         remessa_values["codigo_empresa"] = int(
             self.payment_mode_id.cnab_company_bank_code
         )
-
-    def get_file_name(self, cnab_type):
-        context_today = fields.Date.context_today(self)
-        if cnab_type == "240":
-            return "CB%s%s.REM" % (
-                context_today.strftime("%d%m"),
-                str(self.file_number),
-            )
-        elif cnab_type == "400":
-            return "CB%s%02d.REM" % (
-                context_today.strftime("%d%m"),
-                self.file_number or 1,
-            )
-        elif cnab_type == "500":
-            return "PG%s%s.REM" % (
-                context_today.strftime("%d%m"),
-                str(self.file_number),
-            )
 
     def generate_payment_file(self):
         """Returns (payment file as string, filename)"""

--- a/l10n_br_account_payment_order/models/account_payment_order.py
+++ b/l10n_br_account_payment_order/models/account_payment_order.py
@@ -221,3 +221,21 @@ class AccountPaymentOrder(models.Model):
             return (False, False)
         else:
             return super().generate_payment_file()
+
+    def get_file_name(self, cnab_type):
+        context_today = fields.Date.context_today(self)
+        if cnab_type == "240":
+            return "CB%s%s.REM" % (
+                context_today.strftime("%d%m"),
+                str(self.file_number),
+            )
+        elif cnab_type == "400":
+            return "CB%s%02d.REM" % (
+                context_today.strftime("%d%m"),
+                self.file_number or 1,
+            )
+        elif cnab_type == "500":
+            return "PG%s%s.REM" % (
+                context_today.strftime("%d%m"),
+                str(self.file_number),
+            )

--- a/l10n_br_cnab_structure/models/account_payment_oder.py
+++ b/l10n_br_cnab_structure/models/account_payment_oder.py
@@ -39,24 +39,6 @@ class AccountPaymentOrder(models.Model):
                     order.journal_id.default_outbound_cnab_structure_id
                 )
 
-    def get_file_name(self, cnab_type):
-        context_today = fields.Date.context_today(self)
-        if cnab_type == "240":
-            return "CB%s%s.REM" % (
-                context_today.strftime("%d%m"),
-                str(self.file_number),
-            )
-        elif cnab_type == "400":
-            return "CB%s%02d.REM" % (
-                context_today.strftime("%d%m"),
-                self.file_number or 1,
-            )
-        elif cnab_type == "500":
-            return "PG%s%s.REM" % (
-                context_today.strftime("%d%m"),
-                str(self.file_number),
-            )
-
     def generate_payment_file(self):
         """Returns (payment file as string, filename)"""
         self.ensure_one()


### PR DESCRIPTION
Moved method get_file_name to avoid duplicate code.

PR simples, onde está sendo movido o método get_file_name para o modulo l10n_br_account_payment_order, onde fica o que é comum entre as implementações do CNAB, para não ter métodos duplicados.

cc @rvalyi @renatonlima @marcelsavegnago @mileo 