### PR TITLE
[14.0][FIX] l10n_br_stock_account: Campo parent.state causa erro no Relatório de Movimentações de Estoque

### DIFF
--- a/l10n_br_stock_account/views/stock_account_view.xml
+++ b/l10n_br_stock_account/views/stock_account_view.xml
@@ -25,12 +25,6 @@
         <field name="inherit_id" ref="stock_picking_invoicing.view_move_picking_form" />
         <field name="priority">99</field>
         <field name="arch" type="xml">
-            <field name="name" position="after">
-                <field
-                    name="quantity_done"
-                    attrs="{'readonly': [('parent.state', '!=', 'assigned')]}"
-                />
-            </field>
             <field name="invoice_state" position="attributes">
                 <attribute name="readonly">1</attribute>
                 <attribute name="force_save">1</attribute>


### PR DESCRIPTION
Parent field cause error in Report Stock Move, if necessary change when the field quantity_done is editable or not it can be done in a method _compute_is_quantity_done_editable .

PR simples que está apenas removendo um atributo de readonly no campo quantity_done isso causava erro no Relatório de Movimentações de Estoque, se for necessário algo nesse sentido é melhor usar o método _compute_is_quantity_done_editable https://github.com/OCA/OCB/blob/14.0/addons/stock/models/stock_move.py#L253 , pelo testes esse método já parece atender a necessidade mas revisões são bem vindas, isso deve resolver os issues https://github.com/OCA/l10n-brazil/issues/2900 https://github.com/OCA/l10n-brazil/issues/2946

cc @rvalyi @renatonlima @marcelsavegnago @mileo @antoniospneto 