### PR TITLE
[14.0][l10n_br_sale][WORK IN PROGRESS] sale inline line edition

### DIFF
--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -81,7 +81,8 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 # these will only collect (invisible) fields for onchanges:
                 (
                     ".//control[@name='fiscal_fields']...",
-                    "//group[@name='fiscal_fields']//field"),
+                    "//group[@name='fiscal_fields']//field",
+                ),
                 (
                     ".//control[@name='fiscal_taxes_fields']...",
                     "//page[@name='fiscal_taxes']//field",

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -80,6 +80,9 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 ),
                 # these will only collect (invisible) fields for onchanges:
                 (
+                    ".//control[@name='fiscal_fields']...",
+                    "//group[@name='fiscal_fields']//field"),
+                (
                     ".//control[@name='fiscal_taxes_fields']...",
                     "//page[@name='fiscal_taxes']//field",
                 ),
@@ -89,8 +92,11 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 ),
             )
         for placeholder_xpath, fiscal_xpath in xpath_mappings:
+            placeholder_nodes = doc.findall(placeholder_xpath)
+            if not placeholder_nodes:
+                continue
             fiscal_nodes = fsc_doc.xpath(fiscal_xpath)
-            for target_node in doc.findall(placeholder_xpath):
+            for target_node in placeholder_nodes:
                 if len(fiscal_nodes) == 1:
                     # replace unique placeholder
                     # (deepcopy is required to inject fiscal nodes in possible
@@ -99,10 +105,16 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                     target_node.getparent().replace(target_node, replace_node)
                 else:
                     # append multiple fields to placeholder container
+                    existing_fields = [
+                        e.attrib["name"] for e in target_node if e.tag == "field"
+                    ]
                     for fiscal_node in fiscal_nodes:
+                        if fiscal_node.attrib["name"] in existing_fields:
+                            continue
                         field = deepcopy(fiscal_node)
                         if not field.attrib.get("optional"):
-                            field.attrib["invisible"] = "1"
+                            field.attrib["invisible"] = "0"
+                            field.attrib["optional"] = "hide"
                         target_node.append(field)
         return doc
 

--- a/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
@@ -30,12 +30,14 @@
           <field name="fiscal_quantity" force_save="1" invisible="1" />
           <field name="fiscal_tax_ids" force_save="1" invisible="1" readonly="1" />
           <field name="allow_csll_irpj" force_save="1" invisible="1" />
+          <field name="freight_value" force_save="1" invisible="1" />
+          <field name="insurance_value" force_save="1" invisible="1" />
+          <field name="other_value" force_save="1" invisible="1" />
         </group>
         <notebook>
           <field name="product_id" force_save="1" invisible="1" />
           <page name="fiscal_taxes" string="Taxes">
             <group>
-              <field name="tax_framework" invisible="1" />
               <field
                                 name="tax_icms_or_issqn"
                                 force_save="1"

--- a/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
@@ -9,6 +9,8 @@
         <group name="fiscal_fields" invisible="1">
           <field name="currency_id" force_save="1" invisible="1" />
           <field name="fiscal_operation_type" force_save="1" invisible="1" />
+          <field name="fiscal_operation_id" force_save="1" invisible="1" />
+          <field name="fiscal_operation_line_id" force_save="1" invisible="1" />
           <field name="company_id" force_save="1" invisible="1" />
           <field name="partner_id" force_save="1" invisible="1" />
           <field name="fiscal_type" force_save="1" invisible="1" />

--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -114,19 +114,29 @@ class SaleOrder(models.Model):
         if view_type == "form":
             view = self.env["ir.ui.view"]
 
-            sub_form_view = order_view["fields"]["order_line"]["views"]["form"]["arch"]
+            sub_tree_view = order_view["fields"]["order_line"]["views"]["tree"]["arch"]
+            sub_tree_node = self.env["sale.order.line"].inject_fiscal_fields(
+                sub_tree_view
+            )
+            sub_tree_arch, sub_tree_fields = view.postprocess_and_fields(
+                sub_tree_node, "sale.order.line", False
+            )
 
+            order_view["fields"]["order_line"]["views"]["tree"] = {
+                "fields": sub_tree_fields,
+                "arch": sub_tree_arch,
+            }
+
+            sub_form_view = order_view["fields"]["order_line"]["views"]["form"]["arch"]
             sub_form_node = self.env["sale.order.line"].inject_fiscal_fields(
                 sub_form_view
             )
-
-            sub_arch, sub_fields = view.postprocess_and_fields(
+            sub_form_arch, sub_form_fields = view.postprocess_and_fields(
                 sub_form_node, "sale.order.line", False
             )
-
             order_view["fields"]["order_line"]["views"]["form"] = {
-                "fields": sub_fields,
-                "arch": sub_arch,
+                "fields": sub_form_fields,
+                "arch": sub_form_arch,
             }
 
         return order_view

--- a/l10n_br_sale/security/l10n_br_sale_security.xml
+++ b/l10n_br_sale/security/l10n_br_sale_security.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<odoo noupdate="0">
+<odoo>
 
   <record id="group_discount_per_value" model="res.groups">
     <field name="name">Discount in Sales Orders per Value</field>
@@ -15,6 +15,14 @@
     <field
             name="groups_id"
             eval="[(4, ref('l10n_br_sale.group_discount_per_value')), (4, ref('product.group_discount_per_so_line'))]"
+        />
+  </record>
+
+  <record id="group_so_line_fiscal_detail" model="res.groups">
+    <field name="name">Brazilian Fiscal details (popup) in Sale Order Lines</field>
+    <field
+            name="category_id"
+            ref="l10n_br_fiscal.module_category_l10n_br_fiscal_management"
         />
   </record>
 

--- a/l10n_br_sale/tests/test_l10n_br_sale_discount.py
+++ b/l10n_br_sale/tests/test_l10n_br_sale_discount.py
@@ -19,7 +19,8 @@ class L10nBrSaleDiscount(SavepointCase):
 
         sale_manager_user = cls.env.ref("sales_team.group_sale_manager")
         fiscal_user = cls.env.ref("l10n_br_fiscal.group_user")
-        user_groups = [sale_manager_user.id, fiscal_user.id]
+        line_detailed_edition = cls.env.ref("l10n_br_sale.group_so_line_fiscal_detail")
+        user_groups = [sale_manager_user.id, fiscal_user.id, line_detailed_edition.id]
         cls.user = (
             cls.env["res.users"]
             .with_user(cls.env.user)

--- a/l10n_br_sale/views/res_company_view.xml
+++ b/l10n_br_sale/views/res_company_view.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  Copyright 2019-TODAY Akretion (http://www.akretion.com/)
+  @author: Magno Costa <magno.costa@akretion.com.br>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
 <odoo>
 
     <record id="l10n_br_sale_res_company_form" model="ir.ui.view">

--- a/l10n_br_sale/views/res_config_settings_view.xml
+++ b/l10n_br_sale/views/res_config_settings_view.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright 2014-TODAY Akretion (http://www.akretion.com/)
+  @author: Renato Lima <renato.lima@akretion.com.br>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
 <odoo>
 
     <record id="l10n_br_sale_res_config_settings_form" model="ir.ui.view">

--- a/l10n_br_sale/views/sale_view.xml
+++ b/l10n_br_sale/views/sale_view.xml
@@ -1,6 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  Copyright 2010-TODAY Akretion (http://www.akretion.com/)
+  @author: Renato Lima <renato.lima@akretion.com.br>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
 <odoo>
 
-    <!--Search by cnpj / cpf in the SOs -->
     <record id="view_l10n_br_sale_partner_filter" model="ir.ui.view">
         <field name="name">l10n_br_sale.partner.filter</field>
         <field name="model">sale.order</field>
@@ -20,6 +25,8 @@
         <field name="inherit_id" ref="sale.view_order_form" />
         <field name="priority">99</field>
         <field name="arch" type="xml">
+
+            <!-- order top form view extensions: -->
             <field name="amount_untaxed" position="before">
                 <field
                     name="amount_price_gross"
@@ -109,8 +116,20 @@
                     name="context"
                 >{'default_fiscal_operation_id': fiscal_operation_id, 'default_partner_id': partner_id, 'default_company_id': company_id}</attribute>
             </xpath>
-            <xpath expr="//field[@name='order_line']/tree" position="attributes">
-                <attribute name="editable" />
+
+            <xpath expr="//field[@name='order_line']/tree" position="inside">
+                <control name="fiscal_fields" invisible="1" />
+                <control name="fiscal_taxes_fields" string="Taxes" invisible="1" />
+
+                <!-- these fields would be injected by the placeholders
+                    above, but we need to repeat them here to please the
+                    Form test framework.
+                -->
+                <field name="tax_framework" />
+                <field name="fiscal_operation_line_id" invisible="1" />
+                <field name="freight_value" invisible="1" />
+                <field name="insurance_value" invisible="1" />
+                <field name="other_value" invisible="1" />
             </xpath>
             <xpath
                 expr="//field[@name='order_line']/tree/field[@name='analytic_tag_ids']"
@@ -119,14 +138,6 @@
                 <attribute
                     name="attrs"
                 >{'column_invisible': [('parent.fiscal_operation_id', '!=', False)]}</attribute>
-            </xpath>
-            <xpath
-                expr="//field[@name='order_line']//form//field[@name='product_id']"
-                position="attributes"
-            >
-                <attribute name="widget">product_configurator</attribute>
-                <attribute name="force_save">1</attribute>
-                <attribute name="style">width:80%;</attribute>
             </xpath>
             <xpath
                 expr="//field[@name='order_line']/tree/field[@name='discount']"
@@ -149,16 +160,6 @@
                 position="after"
             >
                 <field
-                    name="discount"
-                    groups="!l10n_br_sale.group_discount_per_value"
-                    attrs="{'column_invisible': [('parent.fiscal_operation_id', '=', False)]}"
-                />
-                <field
-                    name="discount_value"
-                    groups="l10n_br_sale.group_discount_per_value"
-                    attrs="{'column_invisible': [('parent.fiscal_operation_id', '=', False)]}"
-                />
-                <field
                     name="fiscal_tax_ids"
                     widget="many2many_tags"
                     options="{'no_create': True}"
@@ -174,14 +175,98 @@
                     attrs="{'column_invisible': [('parent.fiscal_operation_id', '!=', False)]}"
                 />
             </xpath>
+
+            <!-- order bottom form view extensions: -->
+            <xpath
+                expr="//field[@name='order_line']/form//label[@for='discount']"
+                position="before"
+            >
+                <field
+                    name="discount_fixed"
+                    groups="l10n_br_sale.group_total_discount"
+                />
+                <field name="user_discount_value" invisible="1" />
+                <field name="user_total_discount" invisible="1" />
+            </xpath>
+        </field>
+    </record>
+
+    <record id="l10n_br_sale_order_form_detail" model="ir.ui.view">
+        <field name="name">l10n_br_sale.order.form.detail</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="priority">99</field>
+        <field
+            name="groups_id"
+            eval="[(4, ref('l10n_br_sale.group_so_line_fiscal_detail'))]"
+        />
+        <field name="arch" type="xml">
+            <!-- order lines tree view extensions: -->
+            <xpath expr="//field[@name='order_line']/tree" position="attributes">
+                <attribute name="editable" />
+            </xpath>
+
+            <!-- order lines form view extensions: -->
+            <xpath
+                expr="//field[@name='order_line']//form//field[@name='product_id']"
+                position="attributes"
+            >
+                <attribute name="widget">product_configurator</attribute>
+                <attribute name="force_save">1</attribute>
+                <attribute name="style">width:80%;</attribute>
+            </xpath>
             <xpath expr="//field[@name='order_line']/form" position="inside">
                 <group name="fiscal_fields" invisible="1">
+                    <!-- required because of cfop_id default domain: -->
                     <field name="fiscal_operation_type" invisible="1" readonly="1" />
-                    <field name="fiscal_genre_code" invisible="1" />
-                    <field name="tax_framework" invisible="1" />
+                    <!-- required because used in domain of some next SO view fields: -->
                     <field name="tax_icms_or_issqn" invisible="1" />
                 </group>
             </xpath>
+
+            <!-- discount management: -->
+            <xpath
+                expr="//field[@name='order_line']/form//label[@for='discount']"
+                position="before"
+            >
+                <field
+                    name="discount_fixed"
+                    groups="l10n_br_sale.group_total_discount"
+                />
+                <field name="user_discount_value" invisible="1" />
+                <field name="user_total_discount" invisible="1" />
+            </xpath>
+            <xpath
+                expr="//field[@name='order_line']/form//field[@name='discount']"
+                position="attributes"
+            >
+                <attribute
+                    name="attrs"
+                >{'readonly':['|',['user_discount_value','=',True],'&amp;',['user_total_discount','=',True],['discount_fixed','=',False]]}</attribute>
+            </xpath>
+            <xpath
+                expr="//field[@name='order_line']/form//div[@name='discount']"
+                position="after"
+            >
+                <label for="discount_value" />
+                <div name="discount_value">
+                    <field
+                        name="discount_value"
+                        class="oe_inline"
+                        attrs="{'readonly':['|',['user_discount_value','=',False],'&amp;',['user_total_discount','=',True],['discount_fixed','=',False]]}"
+                    />
+                </div>
+            </xpath>
+            <xpath expr="//group[@name='sale_total']" position="after">
+                <group style="width: 65%%" groups="l10n_br_sale.group_total_discount">
+                    <label for="discount_rate" />
+                    <div>
+                        <field name="discount_rate" class="oe_inline" />
+                        %%
+                    </div>
+                </group>
+            </xpath>
+
             <xpath
                 expr="//field[@name='order_line']/form//label[@for='customer_lead']"
                 position="before"
@@ -333,47 +418,6 @@
                         </group>
                     </page>
                 </notebook>
-            </xpath>
-            <xpath
-                expr="//field[@name='order_line']/form//label[@for='discount']"
-                position="before"
-            >
-                <field
-                    name="discount_fixed"
-                    groups="l10n_br_sale.group_total_discount"
-                />
-                <field name="user_discount_value" invisible="1" />
-                <field name="user_total_discount" invisible="1" />
-            </xpath>
-            <xpath
-                expr="//field[@name='order_line']/form//field[@name='discount']"
-                position="attributes"
-            >
-                <attribute
-                    name="attrs"
-                >{'readonly':['|',['user_discount_value','=',True],'&amp;',['user_total_discount','=',True],['discount_fixed','=',False]]}</attribute>
-            </xpath>
-            <xpath
-                expr="//field[@name='order_line']/form//div[@name='discount']"
-                position="after"
-            >
-                <label for="discount_value" />
-                <div name="discount_value">
-                    <field
-                        name="discount_value"
-                        class="oe_inline"
-                        attrs="{'readonly':['|',['user_discount_value','=',False],'&amp;',['user_total_discount','=',True],['discount_fixed','=',False]]}"
-                    />
-                </div>
-            </xpath>
-            <xpath expr="//group[@name='sale_total']" position="after">
-                <group style="width: 65%%" groups="l10n_br_sale.group_total_discount">
-                    <label for="discount_rate" />
-                    <div>
-                        <field name="discount_rate" class="oe_inline" />
-                        %%
-                    </div>
-                </group>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
[EDIT] 

To have a future proof design, it's important to read:

From https://github.com/OCA/maintainer-tools/wiki/Migration-to-version-16.0:

> Any view with groups_id on it now has to move such groups to the elements of the view. But now you can put groups attribute in a view field instead of isolating it on a view without fear of an access error. Check it in https://github.com/odoo/odoo/pull/98551.
> On the same mood, you should check if the fields protected by a group interact in some way with business logic or UI. For example, a field being part of a domain of another field, or being used in copy/defaults. An special case is the field company_id, which is always used internally for domains on many2one fields referencing multi-company aware records. On these cases, you have to add the same field twice, one with the group, and another invisible without it. Check core examples in https://github.com/odoo/odoo/pull/95729.

And so the explanation here are important too: https://github.com/odoo/odoo/pull/98551
