### PR TITLE
[15.0][l10n_br_account][MIG] update account test framework to v15

### DIFF
--- a/l10n_br_account/tests/common.py
+++ b/l10n_br_account/tests/common.py
@@ -211,7 +211,7 @@ class AccountMoveBRCommon(AccountTestInvoicingCommon):
         if document_serie is not None:
             move_form.document_serie = document_serie
 
-        for index, product in enumerate(products):
+        for index, product in enumerate(products or []):
             with move_form.invoice_line_ids.new() as line_form:
                 line_form.product_id = product
 
@@ -220,9 +220,10 @@ class AccountMoveBRCommon(AccountTestInvoicingCommon):
 
                 if taxes:
                     line_form.tax_ids.clear()
-                    line_form.tax_ids.add(taxes)
+                    for tax in taxes:
+                        line_form.tax_ids.add(tax)
 
-        for amount in amounts:
+        for amount in amounts or []:
             with move_form.invoice_line_ids.new() as line_form:
                 line_form.name = "test line"
                 # We use account_predictive_bills_disable_prediction context key so that

--- a/l10n_br_account_due_list/models/account_invoice.py
+++ b/l10n_br_account_due_list/models/account_invoice.py
@@ -28,7 +28,11 @@ class AccountInvoice(models.Model):
             lines = move.line_ids.filtered(
                 lambda l: l.account_id.internal_type in ("receivable", "payable")
             )
-            move.financial_move_line_ids = lines.sorted()
+            # we added filtered because since odoo/odoo#156729
+            # sorted doesn't filter new records anymore and this
+            # causes issues in l10n_br_account tests for instance,
+            # see https://github.com/OCA/l10n-brazil/pull/2943#issuecomment-1988556702
+            move.financial_move_line_ids = lines.sorted().filtered("id")
 
     @api.depends("line_ids.amount_residual")
     def _compute_payments(self):


### PR DESCRIPTION
EDIT: o segundo commit com o sorted.filtered("id") resolve esse tipo de erro inconsistente que temos nos testes da v15 como https://github.com/OCA/l10n-brazil/pull/2943#issuecomment-1988556702
Isso foi devido a uma mudança no upstream do Odoo e o fix foi sugerido pelo [ryv](https://github.com/ryv-odoo) da Odoo aqui:
https://github.com/odoo/odoo/pull/156729#issuecomment-1993916081

O primeiro commit segue a mudança que foi feita no Odoo 15 e 16 https://github.com/odoo/odoo/commit/2a953ce7e478766175b8fcc069c58edb52737732
e que resolve esses problemas https://github.com/odoo/odoo/pull/98613 e https://github.com/odoo/odoo/pull/102895

- na v14 era: https://github.com/odoo/odoo/blob/14.0/addons/account/tests/common.py#L380
- já na v15 mudou: https://github.com/odoo/odoo/blob/15.0/addons/account/tests/common.py#L391
- e na v16 é o mesmo do que na v15: https://github.com/odoo/odoo/blob/16.0/addons/account/tests/common.py#L399

