### PR TITLE
[14.0][FIX] l10n_br_nfe: missing tag in icms choice

### DIFF
--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -29,6 +29,7 @@ ICMS_SUB_TAGS = [
     "ICMSST",
     "ICMSSN101",
     "ICMSSN102",
+    "ICMSSN202",
     "ICMSSN500",
     "ICMSSN900",
 ]


### PR DESCRIPTION
Parece que no refactor da PR #2940 ficou faltando incluir uma tag que é utilizada para compor os elementos da lista do `nfe40_choice_icms`  ficou faltando o "ICMSSN202" que já existia na lista antes.

Como pode ver ele é esperado aqui:

https://github.com/OCA/l10n-brazil/blob/3653266ff7f9c63182e756bcf8adaf78b41e6176/l10n_br_nfe/models/document_line.py#L414