### PR TITLE
[14.0][l10n_br_portal][l10n_br_website_sale][REF] promote to Beta status

### DIFF
--- a/l10n_br_portal/__manifest__.py
+++ b/l10n_br_portal/__manifest__.py
@@ -9,6 +9,7 @@
     "license": "AGPL-3",
     "author": "KMEE,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-brazil",
+    "development_status": "Beta",
     "depends": [
         "portal",
         "l10n_br_zip",

--- a/l10n_br_website_sale/__manifest__.py
+++ b/l10n_br_website_sale/__manifest__.py
@@ -6,7 +6,7 @@
     "summary": """
         Website sale localização brasileira.""",
     "version": "14.0.2.0.0",
-    "development_status": "Alpha",
+    "development_status": "Beta",
     "license": "AGPL-3",
     "author": "KMEE, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-brazil",


### PR DESCRIPTION
depois das ultimas arrumadas feitas pelo @marcelsavegnago, me parece razoável a gente mudar a maturidade dos módulos l10n_br_portal e l10n_br_website_sale de Alpha para Beta. OK para vcs @mileo ?