### PR TITLE
[14.0][FIX] l10n_br_account_payment_brcobranca: espécie da moeda e documento impresso no boleto

### DIFF
--- a/l10n_br_account_payment_brcobranca/models/account_move_line.py
+++ b/l10n_br_account_payment_brcobranca/models/account_move_line.py
@@ -6,6 +6,10 @@ import logging
 
 from odoo import fields, models
 
+from odoo.addons.l10n_br_account_payment_order.constants import (
+    get_boleto_especie_short_name,
+)
+
 from ..constants.br_cobranca import DICT_BRCOBRANCA_CURRENCY, get_brcobranca_bank
 
 _logger = logging.getLogger(__name__)
@@ -68,7 +72,10 @@ class AccountMoveLine(models.Model):
                 "documento_numero": move_line.document_number,
                 "data_vencimento": move_line.date_maturity.strftime("%Y/%m/%d"),
                 "data_documento": move_line.move_id.invoice_date.strftime("%Y/%m/%d"),
-                "especie": move_line.payment_mode_id.boleto_species,
+                "especie": move_line.currency_id.symbol,
+                "especie_documento": get_boleto_especie_short_name(
+                    move_line.payment_mode_id.boleto_species
+                ),
                 "moeda": DICT_BRCOBRANCA_CURRENCY["R$"],
                 "aceite": move_line.payment_mode_id.boleto_accept,
                 "sacado_endereco": (move_line.partner_id.street_name or "")

--- a/l10n_br_account_payment_order/constants.py
+++ b/l10n_br_account_payment_order/constants.py
@@ -480,21 +480,36 @@ SITUACAO_PAGAMENTO = [
 ]
 
 BOLETO_ESPECIE = [
-    ("01", "DUPLICATA MERCANTIL"),
-    ("02", "NOTA PROMISSÓRIA"),
-    ("03", "NOTA DE SEGURO"),
-    ("04", "MENSALIDADE ESCOLAR"),
-    ("05", "RECIBO"),
-    ("06", "CONTRATO"),
-    ("07", "COSSEGUROS"),
-    ("08", "DUPLICATA DE SERVIÇO"),
-    ("09", "LETRA DE CÂMBIO"),
-    ("13", "NOTA DE DÉBITOS"),
-    ("15", "DOCUMENTO DE DÍVIDA"),
-    ("16", "ENCARGOS CONDOMINIAIS"),
-    ("17", "CONTA DE PRESTAÇÃO DE SERVIÇOS"),
-    ("99", "DIVERSOS"),
+    # CODE, DESCRIPTION, SHORT NAME
+    ("01", "DUPLICATA MERCANTIL", "DM"),
+    ("02", "NOTA PROMISSÓRIA", "NP"),
+    ("03", "NOTA DE SEGURO", "NS"),
+    ("04", "MENSALIDADE ESCOLAR", "ME"),
+    ("05", "RECIBO", "REC"),
+    ("06", "CONTRATO", "CONT"),
+    ("07", "COSSEGUROS", "COSSEG"),
+    ("08", "DUPLICATA DE SERVIÇO", "DS"),
+    ("09", "LETRA DE CÂMBIO", "LC"),
+    ("13", "NOTA DE DÉBITOS", "ND"),
+    ("15", "DOCUMENTO DE DÍVIDA", "DD"),
+    ("16", "ENCARGOS CONDOMINIAIS", "EC"),
+    ("17", "CONTA DE PRESTAÇÃO DE SERVIÇOS", "CPS"),
+    ("99", "DIVERSOS", "DIV"),
 ]
+
+
+def get_boleto_especies():
+    # return the list of "boleto especie" only code and description
+    return [(code, desc) for code, desc, _ in BOLETO_ESPECIE]
+
+
+def get_boleto_especie_short_name(selected_code):
+    # return the short name of "boleto especie"
+    for code, _, short_name in BOLETO_ESPECIE:
+        if code == selected_code:
+            return short_name
+    return None
+
 
 STATE_CNAB = [
     ("draft", "Novo"),

--- a/l10n_br_account_payment_order/models/l10n_br_cnab_boleto_fields.py
+++ b/l10n_br_account_payment_order/models/l10n_br_cnab_boleto_fields.py
@@ -4,7 +4,7 @@
 
 from odoo import fields, models
 
-from ..constants import BOLETO_ESPECIE
+from ..constants import get_boleto_especies
 
 
 class L10nBrCNABBoletoFields(models.AbstractModel):
@@ -99,7 +99,7 @@ class L10nBrCNABBoletoFields(models.AbstractModel):
     )
 
     boleto_species = fields.Selection(
-        selection=BOLETO_ESPECIE,
+        selection=get_boleto_especies(),
         string="Espécie do Título",
         default="01",
         tracking=True,


### PR DESCRIPTION
Proposta para solução do problema da espécie do documento e moeda impressos no boleto, relatado em #2965

### Observação

Dessa forma já fica mais correto que antes, mas ainda pode haver problemas quanto a especie do documento, pois cada banco tem seus próprios termos para a espécie do documento/título. no futuro caso alguém tenha algum problema com isso, será necessário implementar um cadastro para as espécies de cada banco. o @mbcosta já comentou sobre isso aqui também: https://github.com/OCA/l10n-brazil/pull/2870#issuecomment-1955111047




