### PR TITLE
[FIX][15.0][l10n_br_fiscal_dfe] SavepointCase ->TransactionCase

### DIFF
--- a/l10n_br_fiscal_dfe/tests/test_dfe.py
+++ b/l10n_br_fiscal_dfe/tests/test_dfe.py
@@ -8,7 +8,7 @@ from erpbrasil.edoc.resposta import analisar_retorno_raw
 from nfelib.nfe.ws.edoc_legacy import DocumentoElectronicoAdapter
 from nfelib.v4_00 import retDistDFeInt
 
-from odoo.tests.common import SavepointCase
+from odoo.tests.common import TransactionCase
 
 from ..tools import utils
 
@@ -70,7 +70,7 @@ def mocked_post_error_status_code(*args, **kwargs):
     )
 
 
-class TestDFe(SavepointCase):
+class TestDFe(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()


### PR DESCRIPTION
avoids this deprecation warning:

```
2024-03-23 22:36:40,405 567 WARNING odoo py.warnings: /__w/l10n-brazil/l10n-brazil/l10n_br_fiscal_dfe/tests/test_dfe.py:73: DeprecationWarning: Deprecated class SavepointCase has been merged into TransactionCase
```

(já tinha sido resolvido na migração para a 16.0)