### PR TITLE
[15.0][FIX][l10n_br_fiscal] selection_add 'product'

### DIFF
--- a/l10n_br_fiscal/models/product_template.py
+++ b/l10n_br_fiscal/models/product_template.py
@@ -22,6 +22,18 @@ class ProductTemplate(models.Model):
         if fiscal_type == PRODUCT_FISCAL_TYPE_SERVICE:
             return self.env.ref(NCM_FOR_SERVICE_REF)
 
+    # Some modules of the repo depend on stock and have
+    # demo products of type 'product' (this type is added to product.template
+    # in the stock module).
+    # For some reason when running the tests, some inverse method fields then fail when
+    # reading 'product' value for the product type. It seems it is because l10n_br_fiscal
+    # doesn't depend on stock. But we don't want such a dependency.
+    # So a workaround to avoid the bug we add the 'product' value to the selection.
+    type = fields.Selection(
+        selection_add=[("product", "Storable Product")],
+        ondelete={"product": "set consu"},
+    )
+
     fiscal_type = fields.Selection(
         selection=PRODUCT_FISCAL_TYPE,
         company_dependent=True,


### PR DESCRIPTION
Some modules of the repo depend on stock and have
demo products of type 'product' (this type is added to product.template in the stock module).
For some reason when running the tests, some inverse method fields then fail when reading 'product' value for the product type. It seems it is because l10n_br_fiscal doesn't depend on stock. But we don't want such a dependency.
So to avoid the bug we add the 'product' value to the selection which seems like an acceptable workaround.

example of such bugs:

- v15 https://github.com/OCA/l10n-brazil/actions/runs/8404990013/job/23017186446?pr=2970#step:8:234 (was breaking the l10n_br_nfse_focus migreation PR)
- v16 https://github.com/OCA/l10n-brazil/actions/runs/7844927165/job/21408242041?pr=2911#step:8:239 (we had the bug both for the l10n_br_sale and l10n_br_purchase migration)

Has somebody a better idea?