### PR TITLE
[14.0][REF][several modules...] use setUpClass

### DIFF
--- a/l10n_br_account/tests/test_move_discount.py
+++ b/l10n_br_account/tests/test_move_discount.py
@@ -5,55 +5,56 @@ from odoo.tests import TransactionCase
 
 
 class TestInvoiceDiscount(TransactionCase):
-    def setUp(self):
-        super().setUp()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
-        self.company = self.env.ref("l10n_br_base.empresa_lucro_presumido")
+        cls.company = cls.env.ref("l10n_br_base.empresa_lucro_presumido")
 
         # set default user company
-        companies = self.env["res.company"].search([])
-        self.env.user.company_ids = [(6, 0, companies.ids)]
-        self.env.user.company_id = self.company
+        companies = cls.env["res.company"].search([])
+        cls.env.user.company_ids = [(6, 0, companies.ids)]
+        cls.env.user.company_id = cls.company
 
-        self.invoice_account_id = self.env["account.account"].create(
+        cls.invoice_account_id = cls.env["account.account"].create(
             {
-                "company_id": self.company.id,
-                "user_type_id": self.env.ref("account.data_account_type_receivable").id,
+                "company_id": cls.company.id,
+                "user_type_id": cls.env.ref("account.data_account_type_receivable").id,
                 "code": "RECTEST",
                 "name": "Test receivable account",
                 "reconcile": True,
             }
         )
 
-        self.invoice_journal = self.env["account.journal"].create(
+        cls.invoice_journal = cls.env["account.journal"].create(
             {
-                "company_id": self.company.id,
+                "company_id": cls.company.id,
                 "name": "Invoice Journal - (test)",
                 "code": "INVTEST",
                 "type": "sale",
             }
         )
 
-        self.invoice_line_account_id = self.env["account.account"].create(
+        cls.invoice_line_account_id = cls.env["account.account"].create(
             {
-                "company_id": self.company.id,
-                "user_type_id": self.env.ref("account.data_account_type_revenue").id,
+                "company_id": cls.company.id,
+                "user_type_id": cls.env.ref("account.data_account_type_revenue").id,
                 "code": "705070",
                 "name": "Product revenue account (test)",
             }
         )
 
-        self.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
-        self.fiscal_operation_id.deductible_taxes = True
+        cls.fiscal_operation_id = cls.env.ref("l10n_br_fiscal.fo_venda")
+        cls.fiscal_operation_id.deductible_taxes = True
 
-        product_id = self.env.ref("product.product_product_7")
+        product_id = cls.env.ref("product.product_product_7")
 
         invoice_line_vals = [
             (
                 0,
                 0,
                 {
-                    "account_id": self.invoice_line_account_id.id,
+                    "account_id": cls.invoice_line_account_id.id,
                     "product_id": product_id.id,
                     "quantity": 1,
                     "price_unit": 1000.0,
@@ -62,20 +63,20 @@ class TestInvoiceDiscount(TransactionCase):
             )
         ]
 
-        self.move_id = (
-            self.env["account.move"]
+        cls.move_id = (
+            cls.env["account.move"]
             .with_context(check_move_validity=False)
             .create(
                 {
-                    "company_id": self.company.id,
-                    "document_serie_id": self.env.ref(
+                    "company_id": cls.company.id,
+                    "document_serie_id": cls.env.ref(
                         "l10n_br_fiscal.empresa_lc_document_55_serie_1"
                     ).id,
-                    "journal_id": self.invoice_journal.id,
-                    "invoice_user_id": self.env.user.id,
-                    "fiscal_operation_id": self.fiscal_operation_id,
+                    "journal_id": cls.invoice_journal.id,
+                    "invoice_user_id": cls.env.user.id,
+                    "fiscal_operation_id": cls.fiscal_operation_id,
                     "move_type": "out_invoice",
-                    "currency_id": self.company.currency_id.id,
+                    "currency_id": cls.company.currency_id.id,
                     "invoice_line_ids": invoice_line_vals,
                 }
             )

--- a/l10n_br_coa_simple/tests/test_l10n_br_coa_simple.py
+++ b/l10n_br_coa_simple/tests/test_l10n_br_coa_simple.py
@@ -5,13 +5,13 @@ from odoo.tests.common import TransactionCase
 
 
 class L10nBrSimpleCOA(TransactionCase):
-    def setUp(self):
-        super().setUp()
-
-        self.l10n_br_coa_simple = self.env.ref(
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.l10n_br_coa_simple = cls.env.ref(
             "l10n_br_coa_simple.l10n_br_coa_simple_chart_template"
         )
-        self.l10n_br_company = self.env["res.company"].create(
+        cls.l10n_br_company = cls.env["res.company"].create(
             {"name": "Empresa Teste do Plano de Contas Simplificado"}
         )
 

--- a/l10n_br_crm/tests/test_crm_onchange.py
+++ b/l10n_br_crm/tests/test_crm_onchange.py
@@ -6,10 +6,11 @@ from odoo.tests.common import TransactionCase
 
 
 class L10nBrCrmOnchangeTest(TransactionCase):
-    def setUp(self):
-        super().setUp()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
-        self.crm_lead_01 = self.env["crm.lead"].create(
+        cls.crm_lead_01 = cls.env["crm.lead"].create(
             {
                 "name": "Test Company Lead",
                 "partner_name": "Test Company",
@@ -17,8 +18,8 @@ class L10nBrCrmOnchangeTest(TransactionCase):
                 "contact_name": "Test Name Contact",
                 "name_surname": "Test NameSurname Contact",
                 "cnpj": "56.647.352/0001-98",
-                "city_id": self.env.ref("l10n_br_base.city_3205002").id,
-                "country_id": self.env.ref("base.br").id,
+                "city_id": cls.env.ref("l10n_br_base.city_3205002").id,
+                "country_id": cls.env.ref("base.br").id,
                 "zip": "29161-695",
                 "cpf": "70531160505",
                 "email_from": "testcontact@email.com",

--- a/l10n_br_fiscal/tests/test_fiscal_document_nfse.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_nfse.py
@@ -5,10 +5,10 @@ from odoo.tests.common import TransactionCase
 
 
 class TestFiscalDocumentNFSe(TransactionCase):
-    def setUp(self):
-        super().setUp()
-
-        self.nfse_same_state = self.env.ref("l10n_br_fiscal.demo_nfse_same_state")
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.nfse_same_state = cls.env.ref("l10n_br_fiscal.demo_nfse_same_state")
 
     def test_nfse_same_state(self):
         """Test NFSe same state."""

--- a/l10n_br_fiscal/tests/test_subsequent_operation.py
+++ b/l10n_br_fiscal/tests/test_subsequent_operation.py
@@ -5,22 +5,18 @@ from odoo.tests.common import TransactionCase
 
 
 class TestSubsequentOperation(TransactionCase):
-    def setUp(self):
-        super().setUp()
-
-        self.nfe_simples_faturamento = self.env.ref(
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.nfe_simples_faturamento = cls.env.ref(
             "l10n_br_fiscal.demo_nfe_so_simples_faturamento"
         ).copy()
-
-        self.so_simples_faturamento = self.env.ref(
+        cls.so_simples_faturamento = cls.env.ref(
             "l10n_br_fiscal.so_simples_faturamento"
         )
-
-        self.tax_icms_12 = self.env.ref("l10n_br_fiscal.tax_icms_12")
-
-        self.pis_tax_0 = self.env.ref("l10n_br_fiscal.tax_pis_0")
-
-        self.cofins_tax_0 = self.env.ref("l10n_br_fiscal.tax_cofins_0")
+        cls.tax_icms_12 = cls.env.ref("l10n_br_fiscal.tax_icms_12")
+        cls.pis_tax_0 = cls.env.ref("l10n_br_fiscal.tax_pis_0")
+        cls.cofins_tax_0 = cls.env.ref("l10n_br_fiscal.tax_cofins_0")
 
     def test_subsequent_operation_simple_faturamento(self):
         """Test Fiscal Subsequent Operation Simples Faturamento"""

--- a/l10n_br_fiscal/tests/test_tax_benefit.py
+++ b/l10n_br_fiscal/tests/test_tax_benefit.py
@@ -7,15 +7,16 @@ from ..constants.fiscal import SITUACAO_EDOC_A_ENVIAR, SITUACAO_EDOC_AUTORIZADA
 
 
 class TestTaxBenefit(SavepointCase):
-    def setUp(self):
-        super().setUp()
-        self.nfe_tax_benefit = self.env.ref("l10n_br_fiscal.demo_nfe_tax_benefit")
-        self.tax_benefit = self.env["l10n_br_fiscal.tax.definition"].create(
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.nfe_tax_benefit = cls.env.ref("l10n_br_fiscal.demo_nfe_tax_benefit")
+        cls.tax_benefit = cls.env["l10n_br_fiscal.tax.definition"].create(
             {
-                "icms_regulation_id": self.env.ref(
+                "icms_regulation_id": cls.env.ref(
                     "l10n_br_fiscal.tax_icms_regulation"
                 ).id,
-                "tax_group_id": self.env.ref("l10n_br_fiscal.tax_group_icms").id,
+                "tax_group_id": cls.env.ref("l10n_br_fiscal.tax_group_icms").id,
                 "code": "SP810001",
                 "name": "TAX BENEFIT DEMO",
                 "description": "TAX BENEFIT DEMO",
@@ -24,12 +25,12 @@ class TestTaxBenefit(SavepointCase):
                 "is_taxed": True,
                 "is_debit_credit": True,
                 "custom_tax": True,
-                "tax_id": self.env.ref("l10n_br_fiscal.tax_icms_12_red_26_57").id,
-                "cst_id": self.env.ref("l10n_br_fiscal.cst_icms_20").id,
-                "state_from_id": self.env.ref("base.state_br_sp").id,
-                "state_to_ids": [(6, 0, self.env.ref("base.state_br_mg").ids)],
+                "tax_id": cls.env.ref("l10n_br_fiscal.tax_icms_12_red_26_57").id,
+                "cst_id": cls.env.ref("l10n_br_fiscal.cst_icms_20").id,
+                "state_from_id": cls.env.ref("base.state_br_sp").id,
+                "state_to_ids": [(6, 0, cls.env.ref("base.state_br_mg").ids)],
                 "ncms": "73269090",
-                "ncm_ids": [(6, 0, self.env.ref("l10n_br_fiscal.ncm_73269090").ids)],
+                "ncm_ids": [(6, 0, cls.env.ref("l10n_br_fiscal.ncm_73269090").ids)],
                 "state": "approved",
             }
         )

--- a/l10n_br_fiscal/tests/test_uom_uom.py
+++ b/l10n_br_fiscal/tests/test_uom_uom.py
@@ -5,9 +5,10 @@ from odoo.tests.common import TransactionCase
 
 
 class TestUomUom(TransactionCase):
-    def setUp(self):
-        super().setUp()
-        self.uom_uom_kg = self.env.ref("uom.product_uom_kgm")
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.uom_uom_kg = cls.env.ref("uom.product_uom_kgm")
 
     def test_uom_uom_alternative(self):
         uom_uom_alternative = self.env["uom.uom.alternative"].create(

--- a/l10n_br_purchase_stock/tests/test_l10n_br_purchase_stock.py
+++ b/l10n_br_purchase_stock/tests/test_l10n_br_purchase_stock.py
@@ -9,13 +9,14 @@ from odoo.addons.l10n_br_purchase.tests import test_l10n_br_purchase
 
 
 class L10nBrPurchaseStockBase(test_l10n_br_purchase.L10nBrPurchaseBaseTest):
-    def setUp(self):
-        super().setUp()
-        self.invoice_model = self.env["account.move"]
-        self.invoice_wizard = self.env["stock.invoice.onshipping"]
-        self.stock_return_picking = self.env["stock.return.picking"]
-        self.stock_picking = self.env["stock.picking"]
-        self.company_lucro_presumido = self.env.ref(
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.invoice_model = cls.env["account.move"]
+        cls.invoice_wizard = cls.env["stock.invoice.onshipping"]
+        cls.stock_return_picking = cls.env["stock.return.picking"]
+        cls.stock_picking = cls.env["stock.picking"]
+        cls.company_lucro_presumido = cls.env.ref(
             "l10n_br_base.empresa_lucro_presumido"
         )
 

--- a/l10n_br_purchase_stock/tests/test_l10n_br_purchase_stock_lp.py
+++ b/l10n_br_purchase_stock/tests/test_l10n_br_purchase_stock_lp.py
@@ -7,5 +7,6 @@ from .test_l10n_br_purchase_stock import L10nBrPurchaseStockBase
 
 
 class L10nBrPurchaseStockBase(L10nBrPurchaseStockBase):
-    def setUp(self):
-        super().setUp()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()

--- a/l10n_br_purchase_stock/tests/test_l10n_br_purchase_stock_sn.py
+++ b/l10n_br_purchase_stock/tests/test_l10n_br_purchase_stock_sn.py
@@ -7,5 +7,6 @@ from .test_l10n_br_purchase_stock import L10nBrPurchaseStockBase
 
 
 class L10nBrPurchaseStockBase(L10nBrPurchaseStockBase):
-    def setUp(self):
-        super().setUp()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()

--- a/l10n_br_stock_account/tests/test_stock_rule.py
+++ b/l10n_br_stock_account/tests/test_stock_rule.py
@@ -9,12 +9,13 @@ from odoo.tools import mute_logger
 class StockRuleTest(TransactionCase):
     """Test Stock Rule"""
 
-    def setUp(self):
-        super().setUp()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
         # Create a product route containing a stock rule that will
         # generate a move from Stock for every procurement created in Output
-        self.product_route = self.env["stock.location.route"].create(
+        cls.product_route = cls.env["stock.location.route"].create(
             {
                 "name": "Stock -> output route",
                 "product_selectable": True,
@@ -25,11 +26,11 @@ class StockRuleTest(TransactionCase):
                         {
                             "name": "Stock -> output rule",
                             "action": "pull",
-                            "picking_type_id": self.ref("stock.picking_type_internal"),
-                            "location_src_id": self.ref("stock.stock_location_stock"),
-                            "location_id": self.ref("stock.stock_location_output"),
+                            "picking_type_id": cls.ref("stock.picking_type_internal"),
+                            "location_src_id": cls.ref("stock.stock_location_stock"),
+                            "location_id": cls.ref("stock.stock_location_output"),
                             "invoice_state": "2binvoiced",
-                            "fiscal_operation_id": self.ref("l10n_br_fiscal.fo_venda"),
+                            "fiscal_operation_id": cls.ref("l10n_br_fiscal.fo_venda"),
                         },
                     )
                 ],
@@ -37,8 +38,8 @@ class StockRuleTest(TransactionCase):
         )
 
         # Set this route on `product.product_product_3`
-        self.env.ref("product.product_product_3").write(
-            {"route_ids": [(4, self.product_route.id)]}
+        cls.env.ref("product.product_product_3").write(
+            {"route_ids": [(4, cls.product_route.id)]}
         )
 
     def test_procument_order(self):


### PR DESCRIPTION
a ideia é aplicar a mudança de setUp para SetUpClass conforme o guideline de migração para a 15.0 (em baixo) https://github.com/OCA/maintainer-tools/wiki/Migration-to-version-15.0
Nos arquivos que tem apenas um teste, isso não torna mais rapido, mas é uma forma de se garantir se tiver novos tests adicionados.

Para ser completo: a maioria dos arquivos onde tem vários testes eu tinha mudado para SavepointCase que era mais rápido e eu tinha feito a mudança para setUpClass. Acontece que a partir da v15, TransactionCase ja funciona como SavepointCase. Então fazer essa mudança aqui vai principalmente ajudar a ter um código mais igual entre a 14 e a 16 ao mesmo que la na v16 vai garantir de não deixar mais lento se acrescentar novos testes.