### PR TITLE
[16.0][l10n_br_base][l10n_br_fiscal] performance: unaccent=False for code fields

### DIFF
--- a/l10n_br_base/models/party_mixin.py
+++ b/l10n_br_base/models/party_mixin.py
@@ -15,15 +15,18 @@ class PartyMixin(models.AbstractModel):
     cnpj_cpf = fields.Char(
         string="CNPJ/CPF",
         size=18,
+        unaccent=False,
     )
 
     inscr_est = fields.Char(
         string="State Tax Number",
         size=17,
+        unaccent=False,
     )
 
     rg = fields.Char(
         string="RG",
+        unaccent=False,
     )
 
     state_tax_number_ids = fields.One2many(
@@ -35,10 +38,12 @@ class PartyMixin(models.AbstractModel):
     inscr_mun = fields.Char(
         string="Municipal Tax Number",
         size=18,
+        unaccent=False,
     )
 
     suframa = fields.Char(
         size=18,
+        unaccent=False,
     )
 
     legal_name = fields.Char(

--- a/l10n_br_base/models/res_bank.py
+++ b/l10n_br_base/models/res_bank.py
@@ -14,11 +14,13 @@ class ResBank(models.Model):
         string="Brazilian Bank Code",
         size=3,
         help="Brazilian Bank Code ex.: 001 is the code of Banco do Brasil",
+        unaccent=False,
     )
 
     ispb_number = fields.Char(
         string="ISPB Number",
         size=8,
+        unaccent=False,
     )
 
     compe_member = fields.Boolean(

--- a/l10n_br_base/models/res_city.py
+++ b/l10n_br_base/models/res_city.py
@@ -12,6 +12,6 @@ class City(models.Model):
 
     _inherit = "res.city"
 
-    ibge_code = fields.Char(string="IBGE Code", size=7, index=True)
-    siafi_code = fields.Char(string="SIAFI Code", size=4)
-    anp_code = fields.Char(string="ANP Code", size=4)
+    ibge_code = fields.Char(string="IBGE Code", size=7, index=True, unaccent=False)
+    siafi_code = fields.Char(string="SIAFI Code", size=4, unaccent=False)
+    anp_code = fields.Char(string="ANP Code", size=4, unaccent=False)

--- a/l10n_br_base/models/res_country.py
+++ b/l10n_br_base/models/res_country.py
@@ -10,17 +10,21 @@ class Country(models.Model):
     bc_code = fields.Char(
         string="BC Code",
         size=4,
+        unaccent=False,
     )
 
     ibge_code = fields.Char(
         string="IBGE Code",
         size=4,
+        unaccent=False,
     )
 
     siscomex_code = fields.Char(
         size=3,
+        unaccent=False,
     )
 
     nationality_code = fields.Char(
         size=2,
+        unaccent=False,
     )

--- a/l10n_br_base/models/res_country_state.py
+++ b/l10n_br_base/models/res_country_state.py
@@ -7,4 +7,4 @@ from odoo import fields, models
 class CountryState(models.Model):
     _inherit = "res.country.state"
 
-    ibge_code = fields.Char(string="IBGE Code", size=2)
+    ibge_code = fields.Char(string="IBGE Code", size=2, unaccent=False)

--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -34,15 +34,15 @@ class Partner(models.Model):
 
     is_accountant = fields.Boolean(string="Is accountant?")
 
-    crc_code = fields.Char(string="CRC Code", size=18)
+    crc_code = fields.Char(string="CRC Code", size=18, unaccent=False)
 
     crc_state_id = fields.Many2one(comodel_name="res.country.state", string="CRC State")
 
-    rntrc_code = fields.Char(string="RNTRC Code", size=12)
+    rntrc_code = fields.Char(string="RNTRC Code", size=12, unaccent=False)
 
-    cei_code = fields.Char(string="CEI Code", size=12)
+    cei_code = fields.Char(string="CEI Code", size=12, unaccent=False)
 
-    union_entity_code = fields.Char(string="Union Entity code")
+    union_entity_code = fields.Char(string="Union Entity code", unaccent=False)
 
     pix_key_ids = fields.One2many(
         string="Pix Keys",

--- a/l10n_br_base/models/res_partner_bank.py
+++ b/l10n_br_base/models/res_partner_bank.py
@@ -50,6 +50,7 @@ class ResPartnerBank(models.Model):
         string="Account Number",
         size=64,
         required=False,
+        unaccent=False,
     )
 
     acc_number_dig = fields.Char(
@@ -60,6 +61,7 @@ class ResPartnerBank(models.Model):
     bra_number = fields.Char(
         string="Bank Branch",
         size=8,
+        unaccent=False,
     )
 
     bra_number_dig = fields.Char(
@@ -71,6 +73,7 @@ class ResPartnerBank(models.Model):
         string="BIC/Swift Final Code.",
         size=3,
         help="Last part of BIC/Swift Code.",
+        unaccent=False,
     )
 
     company_country_id = fields.Many2one(

--- a/l10n_br_base/models/res_partner_pix.py
+++ b/l10n_br_base/models/res_partner_pix.py
@@ -47,6 +47,7 @@ class PartnerPix(models.Model):
     key = fields.Char(
         help="PIX Addressing key",
         required=True,
+        unaccent=False,
     )
 
     partner_bank_id = fields.Many2one(

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -74,18 +74,21 @@ class Document(models.Model):
     document_number = fields.Char(
         copy=False,
         index=True,
+        unaccent=False,
     )
 
     rps_number = fields.Char(
         string="RPS Number",
         copy=False,
         index=True,
+        unaccent=False,
     )
 
     document_key = fields.Char(
         string="Key",
         copy=False,
         index=True,
+        unaccent=False,
     )
 
     document_date = fields.Datetime(

--- a/l10n_br_fiscal/models/document_serie.py
+++ b/l10n_br_fiscal/models/document_serie.py
@@ -16,9 +16,9 @@ class DocumentSerie(models.Model):
     _description = "Fiscal Document Serie"
     _inherit = "l10n_br_fiscal.data.abstract"
 
-    code = fields.Char(size=3)
+    code = fields.Char(size=3, unaccent=False)
 
-    name = fields.Char(required=True)
+    name = fields.Char(required=True, unaccent=False)
 
     active = fields.Boolean(default=True)
 

--- a/l10n_br_fiscal/models/document_type.py
+++ b/l10n_br_fiscal/models/document_type.py
@@ -14,6 +14,7 @@ class DocumentType(models.Model):
 
     code = fields.Char(
         size=8,
+        unaccent=False,
     )
 
     name = fields.Char(

--- a/l10n_br_fiscal/models/nbm.py
+++ b/l10n_br_fiscal/models/nbm.py
@@ -11,9 +11,9 @@ class Nbm(models.Model):
     _inherit = "l10n_br_fiscal.data.product.abstract"
     _description = "NBM"
 
-    code = fields.Char(size=12)
+    code = fields.Char(size=12, unaccent=False)
 
-    code_unmasked = fields.Char(size=10)
+    code_unmasked = fields.Char(size=10, unaccent=False)
 
     name = fields.Text(required=True, index=True)
 

--- a/l10n_br_fiscal/models/nbs.py
+++ b/l10n_br_fiscal/models/nbs.py
@@ -15,9 +15,9 @@ class Nbs(models.Model):
     ]
     _description = "NBS"
 
-    code = fields.Char(size=12)
+    code = fields.Char(size=12, unaccent=False)
 
-    code_unmasked = fields.Char(size=10)
+    code_unmasked = fields.Char(size=10, unaccent=False)
 
     tax_estimate_ids = fields.One2many(inverse_name="nbs_id")
 

--- a/l10n_br_fiscal/models/ncm.py
+++ b/l10n_br_fiscal/models/ncm.py
@@ -16,9 +16,9 @@ class Ncm(models.Model):
     ]
     _description = "NCM"
 
-    code = fields.Char(size=10)
+    code = fields.Char(size=10, unaccent=False)
 
-    code_unmasked = fields.Char(size=8)
+    code_unmasked = fields.Char(size=8, unaccent=False)
 
     exception = fields.Char(size=2)
 


### PR DESCRIPTION
as per migration guide https://github.com/OCA/maintainer-tools/wiki/Migration-to-version-16.0

> Put unaccent=False on field definitions where no distinction should be made between accented words, for getting better performance on searches. Example: parent_path field. See https://github.com/odoo/odoo/pull/76436 for more details.

it only matters for field we use inside search. Apply to many Brazilian fiscal codes.

Not something urgent, but it's more to avoid forgetting the optimization.