### PR TITLE
[16.0[l10n_br_fiscal][MIG] dup restricted view fields as invisible

### DIFF
--- a/l10n_br_fiscal/views/document_serie_view.xml
+++ b/l10n_br_fiscal/views/document_serie_view.xml
@@ -36,7 +36,8 @@
                         <field name="code" />
                         <field name="name" />
                         <field name="document_type_id" />
-                        <field name="company_id" />
+                        <field name="company_id" invisible="1" />
+                        <field name="company_id" groups="base.group_multi_company" />
                         <field name="internal_sequence_id" />
                         <field name="sequence_number_next" />
                     </group>

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -297,7 +297,12 @@
                 </group>
               </group>
               <group name="company_info" string="Company">
-                <field name="company_id" required="1" />
+                <field name="company_id" invisible="1" />
+                <field
+                                    name="company_id"
+                                    required="1"
+                                    groups="base.group_multi_company"
+                                />
               </group>
               <group>
                 <group name="company_left">

--- a/l10n_br_fiscal/views/res_partner_view.xml
+++ b/l10n_br_fiscal/views/res_partner_view.xml
@@ -8,7 +8,12 @@
         <field name="arch" type="xml">
             <group name="fiscal_numbers" position="after">
                 <group string="Fiscal Profile" name="fiscal_profile">
-                    <field name="fiscal_profile_id" />
+                    <field name="fiscal_profile_id" invisible="1" force_save="1" />
+                    <field
+                        name="fiscal_profile_id"
+                        force_save="1"
+                        groups="l10n_br_fiscal.group_user"
+                    />
                     <field
                         name="ind_ie_dest"
                         force_save="1"


### PR DESCRIPTION
I got it wrong with this detail when migrating l10n_br_fiscal to v16 here https://github.com/OCA/l10n-brazil/pull/2805
As I was suspecting it was more of a hack I did a separated commit for this, so it was easy to revert it and complete it properly here.

Here is the detail of the commit message:

Revert "[FIX] restricted fields were required in domains" This reverts commit bf0a729014b798d6e18042e3134e2a3434f3af62.

As per OCA v16 migration guide:
you should check if the fields protected by a group interact in some way with business logic or UI. For example, a field being part of a domain of another field, or being used in copy/defaults. An special case is the field company_id, which is always used internally for domains on many2one fields referencing multi-company aware records. On these cases, you have to add the same field twice, one with the group, and another invisible without it. Check core examples in https://github.com/odoo/odoo/pull/95729.