### PR TITLE
[14.0][l10n_br_account] account move form clean up inherited fields

### DIFF
--- a/l10n_br_account/views/account_invoice_view.xml
+++ b/l10n_br_account/views/account_invoice_view.xml
@@ -214,7 +214,7 @@
                 <field name="uom_id" optional="hide" />
                 <field name="fiscal_genre_id" optional="hide" />
                 <field name="partner_company_type" invisible="1" />
-                    <field name="fiscal_operation_type" invisible="1" />
+                <field name="fiscal_operation_type" invisible="1" />
                 <field
                     name="fiscal_tax_ids"
                     invisible="1"
@@ -319,49 +319,6 @@
             </xpath>
 
             <xpath
-                expr="//field[@name='invoice_line_ids']/form/sheet/group/field[@name='product_id']"
-                position="attributes"
-            >
-                <attribute
-                    name="domain"
-                >context.get('default_move_type') in ('out_invoice', 'out_refund', 'out_receipt') and [('sale_ok', '=', True), '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)] or [('purchase_ok', '=', True), '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]</attribute>
-            </xpath>
-
-            <xpath
-                expr="//field[@name='invoice_line_ids']/form/sheet/group/field[@name='account_id']"
-                position="attributes"
-            >
-                <attribute name="readonly">0</attribute>
-                <attribute name="groups">account.group_account_readonly</attribute>
-                <attribute
-                    name="domain"
-                >[('deprecated', '=', False), ('user_type_id.type', 'not in', ('receivable', 'payable')), ('company_id', '=', parent.company_id), ('is_off_balance', '=', False)]</attribute>
-                <attribute
-                    name="attrs"
-                >{'required': [('display_type', '=', False)]}</attribute>
-            </xpath>
-
-            <xpath
-                expr="//field[@name='invoice_line_ids']/form/sheet/group/field[@name='analytic_account_id']"
-                position="attributes"
-            >
-                <attribute name="groups">analytic.group_analytic_accounting</attribute>
-                <attribute
-                    name="domain"
-                >['|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]</attribute>
-            </xpath>
-
-            <xpath
-                expr="//field[@name='invoice_line_ids']/form/sheet/group/field[@name='analytic_tag_ids']"
-                position="attributes"
-            >
-                <attribute
-                    name="domain"
-                >['|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]</attribute>
-                <attribute name="groups">analytic.group_analytic_tags</attribute>
-            </xpath>
-
-            <xpath
                 expr="//field[@name='invoice_line_ids']/form/sheet/group/field[@name='discount']"
                 position="attributes"
             >
@@ -373,8 +330,9 @@
             >
                 <field name="discount_value" />
             </xpath>
+
             <xpath
-                expr="//field[@name='invoice_line_ids']/form/sheet/group/field[@name='analytic_tag_ids']"
+                expr="//field[@name='invoice_line_ids']/form/sheet/group/field[@name='discount']"
                 position="after"
             >
                 <field


### PR DESCRIPTION
while working on the v16 l10n_br_account migration I spotted this:

domain and groups where added to analytic fields in the account.move.line form view. It came from v12 as it. May be it was required on v12, but on v14 it seems useless as these domain and groups are already present in the parent view: account.view_move_form in
l10n_br_account/views/account_invoice_view.xml
The form view for Brazil is already very complex, it's important to keep only what is strictly necessary.

link: https://github.com/odoo/odoo/blob/14.0/addons/account/views/account_move_views.xml#L763


As I did a POC for the sale view https://github.com/OCA/l10n-brazil/pull/2952 we would like to allow the "native" inline edition mode for account.move too as it would make the localization less invasive. A very first step is to clean up these migration left-overs. The migration of l10n_br_account to v14 was very hard and I guess we ended up not paying attention to these details....