### PR TITLE
[FIX] ICMS ST state_to_ids domain

### DIFF
--- a/l10n_br_fiscal/models/icms_regulation.py
+++ b/l10n_br_fiscal/models/icms_regulation.py
@@ -316,7 +316,6 @@ class ICMSRegulation(models.Model):
         string="ICMS ST BA",
         domain=[
             ("state_from_id.code", "=", "BA"),
-            ("state_to_ids.code", "=", "BA"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_ST),
             ("is_benefit", "=", False),
         ],
@@ -375,7 +374,6 @@ class ICMSRegulation(models.Model):
         string="ICMS ST CE",
         domain=[
             ("state_from_id.code", "=", "CE"),
-            ("state_to_ids.code", "=", "CE"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_ST),
             ("is_benefit", "=", False),
         ],
@@ -434,7 +432,6 @@ class ICMSRegulation(models.Model):
         string="ICMS ST DF",
         domain=[
             ("state_from_id.code", "=", "DF"),
-            ("state_to_ids.code", "=", "DF"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_ST),
             ("is_benefit", "=", False),
         ],
@@ -493,7 +490,6 @@ class ICMSRegulation(models.Model):
         string="ICMS ST ES",
         domain=[
             ("state_from_id.code", "=", "ES"),
-            ("state_to_ids.code", "=", "ES"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_ST),
             ("is_benefit", "=", False),
         ],
@@ -552,7 +548,6 @@ class ICMSRegulation(models.Model):
         string="ICMS ST GO",
         domain=[
             ("state_from_id.code", "=", "GO"),
-            ("state_to_ids.code", "=", "GO"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_ST),
             ("is_benefit", "=", False),
         ],
@@ -611,7 +606,6 @@ class ICMSRegulation(models.Model):
         string="ICMS ST MA",
         domain=[
             ("state_from_id.code", "=", "MA"),
-            ("state_to_ids.code", "=", "MA"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_ST),
             ("is_benefit", "=", False),
         ],
@@ -670,7 +664,6 @@ class ICMSRegulation(models.Model):
         string="ICMS ST MT",
         domain=[
             ("state_from_id.code", "=", "MT"),
-            ("state_to_ids.code", "=", "MT"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_ST),
             ("is_benefit", "=", False),
         ],
@@ -729,7 +722,6 @@ class ICMSRegulation(models.Model):
         string="ICMS ST MS",
         domain=[
             ("state_from_id.code", "=", "MS"),
-            ("state_to_ids.code", "=", "MS"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_ST),
             ("is_benefit", "=", False),
         ],
@@ -788,7 +780,6 @@ class ICMSRegulation(models.Model):
         string="ICMS ST MG",
         domain=[
             ("state_from_id.code", "=", "MG"),
-            ("state_to_ids.code", "=", "MG"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_ST),
             ("is_benefit", "=", False),
         ],
@@ -847,7 +838,6 @@ class ICMSRegulation(models.Model):
         string="ICMS ST PA",
         domain=[
             ("state_from_id.code", "=", "PA"),
-            ("state_to_ids.code", "=", "PA"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_ST),
             ("is_benefit", "=", False),
         ],
@@ -906,7 +896,6 @@ class ICMSRegulation(models.Model):
         string="ICMS ST PB",
         domain=[
             ("state_from_id.code", "=", "PB"),
-            ("state_to_ids.code", "=", "PB"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_ST),
             ("is_benefit", "=", False),
         ],
@@ -965,7 +954,6 @@ class ICMSRegulation(models.Model):
         string="ICMS ST PR",
         domain=[
             ("state_from_id.code", "=", "PR"),
-            ("state_to_ids.code", "=", "PR"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_ST),
             ("is_benefit", "=", False),
         ],
@@ -1024,7 +1012,6 @@ class ICMSRegulation(models.Model):
         string="ICMS ST PE",
         domain=[
             ("state_from_id.code", "=", "PE"),
-            ("state_to_ids.code", "=", "PE"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_ST),
             ("is_benefit", "=", False),
         ],
@@ -1083,7 +1070,6 @@ class ICMSRegulation(models.Model):
         string="ICMS ST PI",
         domain=[
             ("state_from_id.code", "=", "PI"),
-            ("state_to_ids.code", "=", "PI"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_ST),
             ("is_benefit", "=", False),
         ],
@@ -1142,7 +1128,6 @@ class ICMSRegulation(models.Model):
         string="ICMS ST RN",
         domain=[
             ("state_from_id.code", "=", "RN"),
-            ("state_to_ids.code", "=", "RN"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_ST),
             ("is_benefit", "=", False),
         ],
@@ -1201,7 +1186,6 @@ class ICMSRegulation(models.Model):
         string="ICMS ST RS",
         domain=[
             ("state_from_id.code", "=", "RS"),
-            ("state_to_ids.code", "=", "RS"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_ST),
             ("is_benefit", "=", False),
         ],
@@ -1260,7 +1244,6 @@ class ICMSRegulation(models.Model):
         string="ICMS ST RJ",
         domain=[
             ("state_from_id.code", "=", "RJ"),
-            ("state_to_ids.code", "=", "RJ"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_ST),
             ("is_benefit", "=", False),
         ],
@@ -1319,7 +1302,6 @@ class ICMSRegulation(models.Model):
         string="ICMS ST RO",
         domain=[
             ("state_from_id.code", "=", "RO"),
-            ("state_to_ids.code", "=", "RO"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_ST),
             ("is_benefit", "=", False),
         ],
@@ -1378,7 +1360,6 @@ class ICMSRegulation(models.Model):
         string="ICMS ST RR",
         domain=[
             ("state_from_id.code", "=", "RR"),
-            ("state_to_ids.code", "=", "RR"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_ST),
             ("is_benefit", "=", False),
         ],
@@ -1436,8 +1417,7 @@ class ICMSRegulation(models.Model):
         inverse_name="icms_regulation_id",
         string="ICMS ST SC",
         domain=[
-            ("state_from_id.code", "in", ("SC", False)),
-            ("state_to_ids.code", "in", ("SC", False)),
+            ("state_from_id.code", "=", "SC"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_ST),
             ("is_benefit", "=", False),
         ],
@@ -1554,7 +1534,6 @@ class ICMSRegulation(models.Model):
         string="ICMS ST SE",
         domain=[
             ("state_from_id.code", "=", "SE"),
-            ("state_to_ids.code", "=", "SE"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_ST),
             ("is_benefit", "=", False),
         ],
@@ -1613,7 +1592,6 @@ class ICMSRegulation(models.Model):
         string="ICMS ST TO",
         domain=[
             ("state_from_id.code", "=", "TO"),
-            ("state_to_ids.code", "=", "TO"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_ST),
             ("is_benefit", "=", False),
         ],


### PR DESCRIPTION
Remove state_to_ids do domain dos campos de ICMS ST, permitindo visualizar as linhas interestaduais

Issue: #2980 