### PR TITLE
[FIX] ICMS FCP state_to_ids domain

### DIFF
--- a/l10n_br_fiscal/models/icms_regulation.py
+++ b/l10n_br_fiscal/models/icms_regulation.py
@@ -95,7 +95,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP AC",
         domain=[
             ("state_from_id.code", "=", "AC"),
-            ("state_to_ids.code", "=", "AC"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
             ("is_benefit", "=", False),
         ],
@@ -153,7 +152,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP AL",
         domain=[
             ("state_from_id.code", "=", "AL"),
-            ("state_to_ids.code", "=", "AL"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
             ("is_benefit", "=", False),
         ],
@@ -211,7 +209,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP AM",
         domain=[
             ("state_from_id.code", "=", "AM"),
-            ("state_to_ids.code", "=", "AM"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
             ("is_benefit", "=", False),
         ],
@@ -269,7 +266,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP AP",
         domain=[
             ("state_from_id.code", "=", "AP"),
-            ("state_to_ids.code", "=", "AP"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
             ("is_benefit", "=", False),
         ],
@@ -327,7 +323,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP BA",
         domain=[
             ("state_from_id.code", "=", "BA"),
-            ("state_to_ids.code", "=", "BA"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
             ("is_benefit", "=", False),
         ],
@@ -385,7 +380,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP CE",
         domain=[
             ("state_from_id.code", "=", "CE"),
-            ("state_to_ids.code", "=", "CE"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
             ("is_benefit", "=", False),
         ],
@@ -443,7 +437,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP DF",
         domain=[
             ("state_from_id.code", "=", "DF"),
-            ("state_to_ids.code", "=", "DF"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
             ("is_benefit", "=", False),
         ],
@@ -501,7 +494,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP ES",
         domain=[
             ("state_from_id.code", "=", "ES"),
-            ("state_to_ids.code", "=", "ES"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
             ("is_benefit", "=", False),
         ],
@@ -559,7 +551,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP GO",
         domain=[
             ("state_from_id.code", "=", "GO"),
-            ("state_to_ids.code", "=", "GO"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
             ("is_benefit", "=", False),
         ],
@@ -617,7 +608,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP MA",
         domain=[
             ("state_from_id.code", "=", "MA"),
-            ("state_to_ids.code", "=", "MA"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
             ("is_benefit", "=", False),
         ],
@@ -675,7 +665,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP MT",
         domain=[
             ("state_from_id.code", "=", "MT"),
-            ("state_to_ids.code", "=", "MT"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
             ("is_benefit", "=", False),
         ],
@@ -733,7 +722,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP MS",
         domain=[
             ("state_from_id.code", "=", "MS"),
-            ("state_to_ids.code", "=", "MS"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
             ("is_benefit", "=", False),
         ],
@@ -791,7 +779,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP MG",
         domain=[
             ("state_from_id.code", "=", "MG"),
-            ("state_to_ids.code", "=", "MG"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
             ("is_benefit", "=", False),
         ],
@@ -849,7 +836,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP PA",
         domain=[
             ("state_from_id.code", "=", "PA"),
-            ("state_to_ids.code", "=", "PA"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
             ("is_benefit", "=", False),
         ],
@@ -907,7 +893,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP PB",
         domain=[
             ("state_from_id.code", "=", "PB"),
-            ("state_to_ids.code", "=", "PB"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
             ("is_benefit", "=", False),
         ],
@@ -965,7 +950,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP PR",
         domain=[
             ("state_from_id.code", "=", "PR"),
-            ("state_to_ids.code", "=", "PR"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
             ("is_benefit", "=", False),
         ],
@@ -1023,7 +1007,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP PE",
         domain=[
             ("state_from_id.code", "=", "PE"),
-            ("state_to_ids.code", "=", "PE"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
             ("is_benefit", "=", False),
         ],
@@ -1081,7 +1064,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP PI",
         domain=[
             ("state_from_id.code", "=", "PI"),
-            ("state_to_ids.code", "=", "PI"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
             ("is_benefit", "=", False),
         ],
@@ -1139,7 +1121,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP RN",
         domain=[
             ("state_from_id.code", "=", "RN"),
-            ("state_to_ids.code", "=", "RN"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
             ("is_benefit", "=", False),
         ],
@@ -1197,7 +1178,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP RS",
         domain=[
             ("state_from_id.code", "=", "RS"),
-            ("state_to_ids.code", "=", "RS"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
             ("is_benefit", "=", False),
         ],
@@ -1255,7 +1235,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP RJ",
         domain=[
             ("state_from_id.code", "=", "RJ"),
-            ("state_to_ids.code", "=", "RJ"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
             ("is_benefit", "=", False),
         ],
@@ -1313,7 +1292,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP RO",
         domain=[
             ("state_from_id.code", "=", "RO"),
-            ("state_to_ids.code", "=", "RO"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
             ("is_benefit", "=", False),
         ],
@@ -1371,7 +1349,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP RR",
         domain=[
             ("state_from_id.code", "=", "RR"),
-            ("state_to_ids.code", "=", "RR"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
             ("is_benefit", "=", False),
         ],
@@ -1429,7 +1406,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP SC",
         domain=[
             ("state_from_id.code", "=", "SC"),
-            ("state_to_ids.code", "=", "SC"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
             ("is_benefit", "=", False),
         ],
@@ -1487,7 +1463,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP SP",
         domain=[
             ("state_from_id.code", "=", "SP"),
-            ("state_to_ids.code", "=", "SP"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
             ("is_benefit", "=", False),
         ],
@@ -1545,7 +1520,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP SE",
         domain=[
             ("state_from_id.code", "=", "SE"),
-            ("state_to_ids.code", "=", "SE"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
             ("is_benefit", "=", False),
         ],
@@ -1603,7 +1577,6 @@ class ICMSRegulation(models.Model):
         string="ICMS FCP TO",
         domain=[
             ("state_from_id.code", "=", "TO"),
-            ("state_to_ids.code", "=", "TO"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS_FCP),
             ("is_benefit", "=", False),
         ],


### PR DESCRIPTION
Semelhante ao #2984, remove state_to_ids do domain dos campos de ICMS FCP e permite visualizar linhas interestaduais para FCP também