### PR TITLE
[14.0][FIX] l10n_br_stock_account: Campo tax_ids indo errado na criação da Fatura a partir da Ordem de Separação/stock.picking

### DIFF
--- a/l10n_br_stock_account/tests/test_invoicing_picking.py
+++ b/l10n_br_stock_account/tests/test_invoicing_picking.py
@@ -303,7 +303,6 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
                 "Relation between invoice and picking are missing.",
             )
         for line in invoice.invoice_line_ids:
-            self.assertTrue(line.tax_ids, "Taxes in invoice lines are missing.")
             # No Brasil o caso de Ordens de Entrega que não tem ligação com
             # Pedido de Venda precisam informar o Preço de Custo e não o de
             # Venda, ex.: Simples Remessa, Remessa p/ Industrialiazação e etc.
@@ -317,8 +316,17 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
             self.assertTrue(
                 line.fiscal_tax_ids, "Error to map fiscal_tax_ids in invoice line."
             )
-            self.assertTrue(line.tax_ids, "Error to map tax_ids in invoice.line.")
             assert line.ind_final, "Error field ind_final in Invoice Line not None"
+            # Verifica se o campo tax_ids da Fatura esta igual ao da Separação
+            mv_line = picking.move_lines.filtered(
+                lambda ln: ln.product_id == line.product_id
+                and ln.fiscal_operation_id == line.fiscal_operation_id
+            )
+            self.assertEqual(
+                line.tax_ids,
+                mv_line.tax_ids,
+                "Taxes in invoice lines are different from move lines.",
+            )
 
         self.assertTrue(
             invoice.fiscal_operation_id,

--- a/l10n_br_stock_account/wizards/stock_invoice_onshipping.py
+++ b/l10n_br_stock_account/wizards/stock_invoice_onshipping.py
@@ -145,6 +145,16 @@ class StockInvoiceOnshipping(models.TransientModel):
 
         values.update(fiscal_values)
 
+        # Apesar do metodo _get_taxes retornar os Impostos corretamente
+        # ao rodar o _simulate_line_onchange
+        # https://github.com/OCA/account-invoicing/blob/14.0/
+        # stock_picking_invoicing/wizards/stock_invoice_onshipping.py#L415
+        # o valor acaba sendo alterado
+        # TODO: Analisar se isso é um problema da Localização e se existe
+        #  alguma forma de resolver, por enquanto está sendo informado
+        #  novamente aqui
+        values["tax_ids"] = [(6, 0, move.tax_ids.ids)]
+
         return values
 
     def _get_move_key(self, move):


### PR DESCRIPTION
Even field tax_ids being informed by _get_taxes when run _simulate_line_onchange method in stock_picking_invoicing the value be change( by some reason not idtentify yet), to avoid error for now the value need to be infomed again after those methods.

Campo tax_ids indo errado na criação da Fatura a partir da Ordem de Separação/stock.picking, o problema acabou passando no PR https://github.com/OCA/l10n-brazil/pull/2941 depois do Force-push ao colocar o campo sendo informado pelo método _get_taxes, o campo até acaba sendo informado corretamente no dicionário mas ao rodar o _simulate_line_onchange https://github.com/OCA/account-invoicing/blob/14.0/stock_picking_invoicing/wizards/stock_invoice_onshipping.py#L415, por algum motivo que ainda não identifiquei, acaba deixando apenas um Imposto o que acaba causando erros nas Entradas Contabéis, por isso por enquanto para contornar o problema o método informar novamente esse valor e para evitar regressões o teste passou ao invés de apenas validar a presença do campo agora compara com o valor da Linhas da Separação/stock.move, isso deve resolver o problema do https://github.com/OCA/l10n-brazil/issues/2924 mas testes são bem vindos para confirma se tudo está de acordo com o esperado.

cc @rvalyi @renatonlima @marcelsavegnago @mileo @DiegoParadeda 


