### PR TITLE
[14.0][l10n_br_sale] enable inline tree view edition - POC

### DIFF
--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -81,7 +81,8 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 # these will only collect (invisible) fields for onchanges:
                 (
                     ".//control[@name='fiscal_fields']...",
-                    "//group[@name='fiscal_fields']//field"),
+                    "//group[@name='fiscal_fields']//field",
+                ),
                 (
                     ".//control[@name='fiscal_taxes_fields']...",
                     "//page[@name='fiscal_taxes']//field",

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -80,6 +80,9 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 ),
                 # these will only collect (invisible) fields for onchanges:
                 (
+                    ".//control[@name='fiscal_fields']...",
+                    "//group[@name='fiscal_fields']//field"),
+                (
                     ".//control[@name='fiscal_taxes_fields']...",
                     "//page[@name='fiscal_taxes']//field",
                 ),
@@ -89,8 +92,11 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 ),
             )
         for placeholder_xpath, fiscal_xpath in xpath_mappings:
+            placeholder_nodes = doc.findall(placeholder_xpath)
+            if not placeholder_nodes:
+                continue
             fiscal_nodes = fsc_doc.xpath(fiscal_xpath)
-            for target_node in doc.findall(placeholder_xpath):
+            for target_node in placeholder_nodes:
                 if len(fiscal_nodes) == 1:
                     # replace unique placeholder
                     # (deepcopy is required to inject fiscal nodes in possible
@@ -99,10 +105,16 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                     target_node.getparent().replace(target_node, replace_node)
                 else:
                     # append multiple fields to placeholder container
+                    existing_fields = [
+                        e.attrib["name"] for e in target_node if e.tag == "field"
+                    ]
                     for fiscal_node in fiscal_nodes:
+                        if fiscal_node.attrib["name"] in existing_fields:
+                            continue
                         field = deepcopy(fiscal_node)
                         if not field.attrib.get("optional"):
-                            field.attrib["invisible"] = "1"
+                            field.attrib["invisible"] = "0"
+                            field.attrib["optional"] = "hide"
                         target_node.append(field)
         return doc
 

--- a/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
@@ -30,11 +30,17 @@
           <field name="fiscal_quantity" force_save="1" invisible="1" />
           <field name="fiscal_tax_ids" force_save="1" invisible="1" readonly="1" />
           <field name="allow_csll_irpj" force_save="1" invisible="1" />
+          <field name="freight_value" force_save="1" invisible="1" />
+          <field name="insurance_value" force_save="1" invisible="1" />
+          <field name="other_value" force_save="1" invisible="1" />
         </group>
         <notebook>
           <field name="product_id" force_save="1" invisible="1" />
           <page name="fiscal_taxes" string="Taxes">
             <group>
+              <!-- for some reason l10n_br_account Form tests fail without
+                  repeating tax_framework here:
+              -->
               <field name="tax_framework" invisible="1" />
               <field
                                 name="tax_icms_or_issqn"

--- a/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
@@ -9,6 +9,8 @@
         <group name="fiscal_fields" invisible="1">
           <field name="currency_id" force_save="1" invisible="1" />
           <field name="fiscal_operation_type" force_save="1" invisible="1" />
+          <field name="fiscal_operation_id" force_save="1" invisible="1" />
+          <field name="fiscal_operation_line_id" force_save="1" invisible="1" />
           <field name="company_id" force_save="1" invisible="1" />
           <field name="partner_id" force_save="1" invisible="1" />
           <field name="fiscal_type" force_save="1" invisible="1" />

--- a/l10n_br_sale/security/l10n_br_sale_security.xml
+++ b/l10n_br_sale/security/l10n_br_sale_security.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<odoo noupdate="0">
+<odoo>
 
   <record id="group_discount_per_value" model="res.groups">
     <field name="name">Discount in Sales Orders per Value</field>
@@ -15,6 +15,14 @@
     <field
             name="groups_id"
             eval="[(4, ref('l10n_br_sale.group_discount_per_value')), (4, ref('product.group_discount_per_so_line'))]"
+        />
+  </record>
+
+  <record id="group_so_line_fiscal_detail" model="res.groups">
+    <field name="name">Brazilian Fiscal details (popup) in Sale Order Lines</field>
+    <field
+            name="category_id"
+            ref="l10n_br_fiscal.module_category_l10n_br_fiscal_management"
         />
   </record>
 

--- a/l10n_br_sale/tests/test_l10n_br_sale_discount.py
+++ b/l10n_br_sale/tests/test_l10n_br_sale_discount.py
@@ -19,7 +19,8 @@ class L10nBrSaleDiscount(SavepointCase):
 
         sale_manager_user = cls.env.ref("sales_team.group_sale_manager")
         fiscal_user = cls.env.ref("l10n_br_fiscal.group_user")
-        user_groups = [sale_manager_user.id, fiscal_user.id]
+        line_detailed_edition = cls.env.ref("l10n_br_sale.group_so_line_fiscal_detail")
+        user_groups = [sale_manager_user.id, fiscal_user.id, line_detailed_edition.id]
         cls.user = (
             cls.env["res.users"]
             .with_user(cls.env.user)

--- a/l10n_br_sale/views/res_company_view.xml
+++ b/l10n_br_sale/views/res_company_view.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  Copyright 2019-TODAY Akretion (http://www.akretion.com/)
+  @author: Magno Costa <magno.costa@akretion.com.br>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
 <odoo>
 
     <record id="l10n_br_sale_res_company_form" model="ir.ui.view">

--- a/l10n_br_sale/views/res_config_settings_view.xml
+++ b/l10n_br_sale/views/res_config_settings_view.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright 2014-TODAY Akretion (http://www.akretion.com/)
+  @author: Renato Lima <renato.lima@akretion.com.br>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
 <odoo>
 
     <record id="l10n_br_sale_res_config_settings_form" model="ir.ui.view">

--- a/l10n_br_sale/views/sale_view.xml
+++ b/l10n_br_sale/views/sale_view.xml
@@ -1,6 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  Copyright 2010-TODAY Akretion (http://www.akretion.com/)
+  @author: Renato Lima <renato.lima@akretion.com.br>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
 <odoo>
 
-    <!--Search by cnpj / cpf in the SOs -->
     <record id="view_l10n_br_sale_partner_filter" model="ir.ui.view">
         <field name="name">l10n_br_sale.partner.filter</field>
         <field name="model">sale.order</field>
@@ -20,6 +25,8 @@
         <field name="inherit_id" ref="sale.view_order_form" />
         <field name="priority">99</field>
         <field name="arch" type="xml">
+
+            <!-- order top form view extensions: -->
             <field name="amount_untaxed" position="before">
                 <field
                     name="amount_price_gross"
@@ -81,22 +88,38 @@
                     attrs="{'invisible': [('fiscal_operation_id', '=', False)], 'required': [('fiscal_operation_id', '!=', False)]}"
                 />
             </field>
+
+            <!-- order lines tree view extensions: -->
             <xpath expr="//field[@name='order_line']" position="attributes">
                 <attribute
                     name="context"
                 >{'default_fiscal_operation_id': fiscal_operation_id, 'default_partner_id': partner_id, 'default_company_id': company_id}</attribute>
             </xpath>
-            <xpath expr="//field[@name='order_line']/tree" position="attributes">
-                <attribute name="editable" />
+
+            <xpath expr="//field[@name='order_line']/tree" position="inside">
+                <control
+                    name="fiscal_fields"
+                    invisible="1"
+                /><!-- this is a dynamic fiscal fields placeholder-->
+                <control
+                    name="fiscal_taxes_fields"
+                    string="Taxes"
+                    invisible="1"
+                /><!-- this is a dynamic fiscal fields placeholder-->
+
+                <!-- the fields below would be injected by the placeholders
+                    above, but we need to repeat them here to please the
+                    Form test framework or because they are used in some
+                    domain here that is checked before the dynamic fiscal
+                    placeholders kick in.
+                -->
+                <field name="tax_framework" invisible="1" />
+                <field name="fiscal_operation_id" invisible="1" />
+                <field name="freight_value" invisible="1" />
+                <field name="insurance_value" invisible="1" />
+                <field name="other_value" invisible="1" />
             </xpath>
-            <xpath
-                expr="//field[@name='order_line']//form//field[@name='product_id']"
-                position="attributes"
-            >
-                <attribute name="widget">product_configurator</attribute>
-                <attribute name="force_save">1</attribute>
-                <attribute name="style">width:80%;</attribute>
-            </xpath>
+
             <xpath
                 expr="//field[@name='order_line']/tree/field[@name='discount']"
                 position="attributes"
@@ -113,6 +136,7 @@
                     name="attrs"
                 >{'column_invisible': [('parent.fiscal_operation_id', '!=', False)]}</attribute>
             </xpath>
+
             <xpath
                 expr="//field[@name='order_line']/tree/field[@name='price_unit']"
                 position="after"
@@ -126,6 +150,10 @@
                     name="discount_value"
                     groups="l10n_br_sale.group_discount_per_value"
                     attrs="{'column_invisible': [('parent.fiscal_operation_id', '=', False)]}"
+                />
+                <field
+                    name="fiscal_operation_line_id"
+                    attrs="{'invisible': [('parent.fiscal_operation_id', '=', False)]}"
                 />
                 <field
                     name="fiscal_tax_ids"
@@ -143,11 +171,27 @@
                     attrs="{'column_invisible': [('parent.fiscal_operation_id', '!=', False)]}"
                 />
             </xpath>
+
+            <!-- order lines form view extensions:
+                (only users belonging to the l10n_br_sale.group_so_line_fiscal_detail
+                group will see this form view)
+            -->
+            <xpath
+                expr="//field[@name='order_line']//form//field[@name='product_id']"
+                position="attributes"
+            >
+                <attribute name="widget">product_configurator</attribute>
+                <attribute name="force_save">1</attribute>
+                <attribute name="style">width:80%;</attribute>
+            </xpath>
             <xpath expr="//field[@name='order_line']/form" position="inside">
-                <group name="fiscal_fields" invisible="1">
+                <group
+                    name="fiscal_fields"
+                    invisible="1"
+                ><!-- this is a dynamic fiscal fields placeholder-->
+                    <!-- required because of cfop_id default domain: -->
                     <field name="fiscal_operation_type" invisible="1" readonly="1" />
-                    <field name="fiscal_genre_code" invisible="1" />
-                    <field name="tax_framework" invisible="1" />
+                    <!-- required because used in domain of some next SO view fields: -->
                     <field name="tax_icms_or_issqn" invisible="1" />
                 </group>
             </xpath>
@@ -285,7 +329,10 @@
                 <notebook
                     attrs="{'invisible': ['|', ('display_type', '!=', False), ('parent.fiscal_operation_id', '=', False)]}"
                 >
-                    <page name="fiscal_taxes" string="Taxes" />
+                    <page
+                        name="fiscal_taxes"
+                        string="Taxes"
+                    /><!-- this is a dynamic fiscal fields placeholder-->
                     <page
                         string="Invoice Lines"
                         groups="base.group_no_one"
@@ -348,6 +395,7 @@
                 </notebook>
             </xpath>
 
+            <!-- order bottom form view extensions: -->
             <field name="note" position="attributes">
                 <attribute
                     name="attrs"

--- a/l10n_br_sale/views/sale_view.xml
+++ b/l10n_br_sale/views/sale_view.xml
@@ -151,6 +151,50 @@
                     <field name="tax_icms_or_issqn" invisible="1" />
                 </group>
             </xpath>
+
+            <!-- discount management in line form: -->
+            <xpath
+                expr="//field[@name='order_line']/form//label[@for='discount']"
+                position="before"
+            >
+                <field
+                    name="discount_fixed"
+                    groups="l10n_br_sale.group_total_discount"
+                />
+                <field name="user_discount_value" invisible="1" />
+                <field name="user_total_discount" invisible="1" />
+            </xpath>
+            <xpath
+                expr="//field[@name='order_line']/form//field[@name='discount']"
+                position="attributes"
+            >
+                <attribute
+                    name="attrs"
+                >{'readonly':['|',['user_discount_value','=',True],'&amp;',['user_total_discount','=',True],['discount_fixed','=',False]]}</attribute>
+            </xpath>
+            <xpath
+                expr="//field[@name='order_line']/form//div[@name='discount']"
+                position="after"
+            >
+                <label for="discount_value" />
+                <div name="discount_value">
+                    <field
+                        name="discount_value"
+                        class="oe_inline"
+                        attrs="{'readonly':['|',['user_discount_value','=',False],'&amp;',['user_total_discount','=',True],['discount_fixed','=',False]]}"
+                    />
+                </div>
+            </xpath>
+            <xpath expr="//group[@name='sale_total']" position="after">
+                <group style="width: 65%%" groups="l10n_br_sale.group_total_discount">
+                    <label for="discount_rate" />
+                    <div>
+                        <field name="discount_rate" class="oe_inline" />
+                        %%
+                    </div>
+                </group>
+            </xpath>
+
             <xpath
                 expr="//field[@name='order_line']/form//label[@for='customer_lead']"
                 position="before"
@@ -303,44 +347,12 @@
                     </page>
                 </notebook>
             </xpath>
-            <xpath
-                expr="//field[@name='order_line']/form//label[@for='discount']"
-                position="before"
-            >
-                <field
-                    name="discount_fixed"
-                    groups="l10n_br_sale.group_total_discount"
-                />
-                <field name="user_discount_value" invisible="1" />
-                <field name="user_total_discount" invisible="1" />
-            </xpath>
-            <xpath
-                expr="//field[@name='order_line']/form//field[@name='discount']"
-                position="attributes"
-            >
-                <attribute
-                    name="attrs"
-                >{'readonly':['|',['user_discount_value','=',True],'&amp;',['user_total_discount','=',True],['discount_fixed','=',False]]}</attribute>
-            </xpath>
 
             <field name="note" position="attributes">
                 <attribute
                     name="attrs"
                 >{'invisible': [('fiscal_operation_id', '!=', False)]}</attribute>
             </field>
-            <xpath
-                expr="//field[@name='order_line']/form//div[@name='discount']"
-                position="after"
-            >
-                <label for="discount_value" />
-                <div name="discount_value">
-                    <field
-                        name="discount_value"
-                        class="oe_inline"
-                        attrs="{'readonly':['|',['user_discount_value','=',False],'&amp;',['user_total_discount','=',True],['discount_fixed','=',False]]}"
-                    />
-                </div>
-            </xpath>
             <field name="note" position="after">
                 <group attrs="{'invisible': [('fiscal_operation_id', '=', False)]}">
                     <field name="copy_note" />

--- a/l10n_br_sale/views/sale_view.xml
+++ b/l10n_br_sale/views/sale_view.xml
@@ -81,29 +81,6 @@
                     attrs="{'invisible': [('fiscal_operation_id', '=', False)], 'required': [('fiscal_operation_id', '!=', False)]}"
                 />
             </field>
-            <field name="note" position="attributes">
-                <attribute
-                    name="attrs"
-                >{'invisible': [('fiscal_operation_id', '!=', False)]}</attribute>
-            </field>
-            <field name="note" position="after">
-                <group attrs="{'invisible': [('fiscal_operation_id', '=', False)]}">
-                    <field name="copy_note" />
-                    <field
-                        name="note"
-                        placeholder="Terms and conditions... (note: you can setup default ones in the Configuration menu)"
-                        style="min-width: 590px;"
-                    />
-                    <field
-                        name="manual_customer_additional_data"
-                        style="min-width: 590px;"
-                    />
-                    <field
-                        name="manual_fiscal_additional_data"
-                        style="min-width: 590px;"
-                    />
-                </group>
-            </field>
             <xpath expr="//field[@name='order_line']" position="attributes">
                 <attribute
                     name="context"
@@ -345,6 +322,12 @@
                     name="attrs"
                 >{'readonly':['|',['user_discount_value','=',True],'&amp;',['user_total_discount','=',True],['discount_fixed','=',False]]}</attribute>
             </xpath>
+
+            <field name="note" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'invisible': [('fiscal_operation_id', '!=', False)]}</attribute>
+            </field>
             <xpath
                 expr="//field[@name='order_line']/form//div[@name='discount']"
                 position="after"
@@ -358,6 +341,24 @@
                     />
                 </div>
             </xpath>
+            <field name="note" position="after">
+                <group attrs="{'invisible': [('fiscal_operation_id', '=', False)]}">
+                    <field name="copy_note" />
+                    <field
+                        name="note"
+                        placeholder="Terms and conditions... (note: you can setup default ones in the Configuration menu)"
+                        style="min-width: 590px;"
+                    />
+                    <field
+                        name="manual_customer_additional_data"
+                        style="min-width: 590px;"
+                    />
+                    <field
+                        name="manual_fiscal_additional_data"
+                        style="min-width: 590px;"
+                    />
+                </group>
+            </field>
             <xpath expr="//group[@name='sale_total']" position="after">
                 <group style="width: 65%%" groups="l10n_br_sale.group_total_discount">
                     <label for="discount_rate" />

--- a/l10n_br_sale/views/sale_view.xml
+++ b/l10n_br_sale/views/sale_view.xml
@@ -113,14 +113,6 @@
                 <attribute name="editable" />
             </xpath>
             <xpath
-                expr="//field[@name='order_line']/tree/field[@name='analytic_tag_ids']"
-                position="attributes"
-            >
-                <attribute
-                    name="attrs"
-                >{'column_invisible': [('parent.fiscal_operation_id', '!=', False)]}</attribute>
-            </xpath>
-            <xpath
                 expr="//field[@name='order_line']//form//field[@name='product_id']"
                 position="attributes"
             >


### PR DESCRIPTION
WORK IN PROGRESS (não fazer merge 1h depois hein pfv)

With this PR by default user edit sale orders using the native "editable" inline tree view. But a new group is created. If the user belong to this new group, then he will use the detailed popup "form" view with all details.

The goal is to:

- increase the compatibility with other modules (as they will expect the default tree view)
- enable faster edition for some users who don't need fiscal details (specially for companies from the Simple fiscal regime)
- increase the multi-localizations compatibility
- it also makes tests run faster

For more explanations you can read: https://odoo-community.org/groups/contributors-15/contributors-1809168?mode=thread&date_begin=&date_end=

The diff is not as crazy as it might look as most of the diff is just moving pieces around to match the top to bottom visual order. I also added a few comments.
[EDIT]: I split the commits so you can follow the commits to see how I first moved chunks of XML around.

Replaces https://github.com/OCA/l10n-brazil/pull/2952
This new PR is future proof, considering this https://odoo-community.org/groups/contributors-15/contributors-1809168?mode=thread&date_begin=&date_end=
