### PR TITLE
[14.0][FIX] l10n_br_purchase_request: calculation when keep_estimated_cost is present

### DIFF
--- a/l10n_br_purchase_request/wizards/purchase_request_line_make_purchase_order.py
+++ b/l10n_br_purchase_request/wizards/purchase_request_line_make_purchase_order.py
@@ -15,7 +15,13 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
                 purchase._onchange_partner_id_fiscal()
                 for line in purchase.order_line:
                     description = line.name
+                    price_unit = line.price_unit
                     line._onchange_product_id_fiscal()
                     line._onchange_fiscal_tax_ids()
                     line.name = description
+                    for item in self.item_ids:
+                        if item.keep_estimated_cost:
+                            line.price_unit = price_unit
+                            line.fiscal_price = price_unit
+                            line._compute_amount()
         return res


### PR DESCRIPTION
cc @marcelsavegnago @douglascstd @WesleyOliveira98 

Correção para quando o `keep_estimated_cost` está ativado no módulo `purchase_request`. Quando essa opção está habilitada, o sistema deve copiar o valor do `estimated_cost` para as ordens de compra (PO), o que não está ocorrendo na versão 14.0 do `l10n_br_purchase_request`.