### PR TITLE
[14.0][FIX] l10n_br_purchase_request: onchange_partner_id_fiscal

### DIFF
--- a/l10n_br_purchase_request/tests/test_l10n_br_purchase_request.py
+++ b/l10n_br_purchase_request/tests/test_l10n_br_purchase_request.py
@@ -42,7 +42,24 @@ class L10nBrPurchaseRequestBaseTest(SavepointCase):
         ).create(vals)
         wiz_id.with_context(default_company_id=self.company.id).make_purchase_order()
         purchase_order = request.line_ids[0].purchase_lines[0].order_id
+        self.assertEqual(purchase_order.ind_final, "0")
         self.assertTrue(purchase_order)
         self.assertTrue(purchase_order.order_line.fiscal_operation_line_id)
         self.assertTrue(purchase_order.order_line.fiscal_tax_ids)
         self.assertTrue(purchase_order.order_line.taxes_id)
+
+    def test_purchase_request_to_rfq_ind_final(self):
+        request = self.purchase_request
+        self.assertTrue(request.to_approve_allowed)
+
+        request.button_approved()
+        self.supplier.ind_final = "1"
+        vals = {
+            "supplier_id": self.supplier.id,
+        }
+        wiz_id = self.wiz.with_context(
+            active_model="purchase.request.line", active_ids=[request.line_ids[0].id]
+        ).create(vals)
+        wiz_id.with_context(default_company_id=self.company.id).make_purchase_order()
+        purchase_order = request.line_ids[0].purchase_lines[0].order_id
+        self.assertEqual(purchase_order.ind_final, "1")

--- a/l10n_br_purchase_request/wizards/purchase_request_line_make_purchase_order.py
+++ b/l10n_br_purchase_request/wizards/purchase_request_line_make_purchase_order.py
@@ -12,6 +12,7 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
         purchases = self.env["purchase.order"].search(res.get("domain"))
         for purchase in purchases:
             if purchase.fiscal_operation_id:
+                purchase._onchange_partner_id_fiscal()
                 for line in purchase.order_line:
                     description = line.name
                     line._onchange_product_id_fiscal()


### PR DESCRIPTION
Objetivo dessa PR é trazer a informação do campo **ind_final** junto para requisição de compras, através desse onchange. 
**OBS: Antes sempre trazia informação igual a Sim.**

Conforme é configurado na aba fiscal do parceiro:

![UNSDUJFDDFSIDFS](https://github.com/Engenere/l10n-brazil/assets/142639425/0ae4184e-f4a8-4e46-a72b-4ea77cf583c2)

Resultado:
![ujfdfdsdfd](https://github.com/Engenere/l10n-brazil/assets/142639425/ec6db1c2-427a-4a9c-af1c-93613c47037e)

