### PR TITLE
[14.0][FIX] l10n_br_purchase: operação fiscal da linha editavel depois de pedido confirmado

### DIFF
--- a/l10n_br_purchase/models/purchase_order_line.py
+++ b/l10n_br_purchase/models/purchase_order_line.py
@@ -24,8 +24,6 @@ class PurchaseOrderLine(models.Model):
     # Adapt Mixin's fields
     fiscal_operation_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.operation",
-        readonly=True,
-        states={"draft": [("readonly", False)]},
         default=_default_fiscal_operation,
         domain=lambda self: self._fiscal_operation_domain(),
     )


### PR DESCRIPTION
Existem alguns pontos aqui:

1) Existe a possibilidade de adicionar linhas novas, mesmo com o pedido confirmado. Então acho que o correto é o usuário poder escolher a operação, mesmo nesse caso. Isso já ocorre no pedido de venda por exemplo.
2) O maior problema que estava ocorrendo no nosso cliente é que depois de confirmado o pedido sem operação fiscal(é um processo de importação que possui varios passos bem chatos), se fosse colocar uma linha nova, ao salvar ele colocava o padrão da empresa. O problema maior que como há uma operação, ele não deixa mexer em mais nada porque o line fica vazio e passa a ser obrigatório. (Lembrando que nesse caso vai ser required e invisível)

![image](https://github.com/OCA/l10n-brazil/assets/6812128/852fb333-b3d2-4506-a7e1-92806a4eb827)

O problema 2 acontecia porque o vals_list iria sem o fiscal_operation_id devido ao readonly=True, e por isso o create buscaria esse valor padrão para completar a o dict. O exemplo acima deixei o campo visível para ficar mais claro.


PS:
Está em testes.
Elimina algumas linhas.