### PR TITLE
[14.0][FIX] l10n_br_nfe: authorization date format with xsdata

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -16,6 +16,7 @@ from lxml import etree
 from nfelib.nfe.bindings.v4_0.nfe_v4_00 import Nfe
 from nfelib.nfe.ws.edoc_legacy import NFCeAdapter as edoc_nfce, NFeAdapter as edoc_nfe
 from requests import Session
+from xsdata.models.datatype import XmlDateTime
 
 from odoo import _, api, fields
 from odoo.exceptions import UserError, ValidationError
@@ -940,6 +941,10 @@ class NFe(spec_models.StackedModel):
         if self.authorization_event_id and infProt.nProt:
             if type(infProt.dhRecbto) is datetime:
                 protocol_date = fields.Datetime.to_string(infProt.dhRecbto)
+            # When the bidding comes from xsdata, the date comes as XmlDateTime
+            elif type(infProt.dhRecbto) is XmlDateTime:
+                dt = infProt.dhRecbto.to_datetime()
+                protocol_date = fields.Datetime.to_string(dt)
             else:
                 protocol_date = fields.Datetime.to_string(
                     datetime.fromisoformat(infProt.dhRecbto)


### PR DESCRIPTION
Por algum motivo que ainda estamos procurando, usando a versão master da nfelib, as vezes os bidings estão vindo do generateds e outras vezes do xsdata. Isso acaba gerando um erro em receber a resposta do autorização da NFe nos casos com xsdata:

![image](https://github.com/OCA/l10n-brazil/assets/6812128/6a09be2a-5908-429d-adff-7e311e358ba6)


Não achamos padrões que possam indicar a origem desse problema, mas segue prints debugando o problema EM UMA MESMA BASE SEM UMA ATUALIZAÇÃO:

Vindo pelo generateDS (não estoura nenhum erro para o usuário):
![image](https://github.com/OCA/l10n-brazil/assets/6812128/fa6ef56f-cde9-4ee6-b73a-04cb4d771dbf)
![image](https://github.com/OCA/l10n-brazil/assets/6812128/4fa50d5d-3411-4ffe-978d-58abd9ef7721)


Vindo pelo xsdata, onde gera o erro citado acima:
![image](https://github.com/OCA/l10n-brazil/assets/6812128/7fff2b76-c529-4bfe-943c-206f1a6d086c)
![image](https://github.com/OCA/l10n-brazil/assets/6812128/94a5c622-feec-45d7-be30-6e10ea87a46e)

@rvalyi @antoniospneto 