### PR TITLE
[14.0][FIX] l10n_br_fiscal: FCP-ST tax domain and view adjustment

### DIFF
--- a/l10n_br_fiscal/models/icms_regulation.py
+++ b/l10n_br_fiscal/models/icms_regulation.py
@@ -1968,6 +1968,9 @@ class ICMSRegulation(models.Model):
             domain += [
                 ("state_from_id", "=", company.state_id.id),
                 ("state_to_ids", "=", partner.state_id.id),
+                ("ncm_ids", "=", ncm.id),
+                ("nbm_ids", "=", nbm.id),
+                ("cest_ids", "=", cest.id),
             ]
 
         return domain

--- a/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
@@ -336,11 +336,6 @@
                                             attrs="{'readonly': [('icmsfcp_tax_id', '!=', False)], 'invisible': [('icms_cst_code', '=', '500')]}"
                                         />
                           <field
-                                            name="icmsfcpst_value"
-                                            force_save="1"
-                                            attrs="{'readonly': [('icmsfcp_tax_id', '!=', False)], 'invisible': [('icms_cst_code', 'not in', ('10', '30', '70', '90', '201', '202', '203', '900'))]}"
-                                        />
-                          <field
                                             name="icmsfcp_base_wh"
                                             force_save="1"
                                             attrs="{'invisible': [('icms_cst_code', 'not in', ('60', '500'))]}"


### PR DESCRIPTION
Este PR corrige dois pontos do FCP-ST:

1. Remove campo legado de valor de FCP-ST, que antes ficava na seção do FCP próprio (note que o campo novo já existe na nova seção)
2. Utiliza regras de NCM, CEST, NBM no domínio do tax definition (semelhante ao ICMS-ST)