### PR TITLE
[14.0][IMP] l10n_br_account: if the fiscal operation is not deductible, add the amount_tax_withholding to the total

### DIFF
--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -199,6 +199,7 @@ class AccountMoveLine(models.Model):
                         amount_tax_not_included=values.get(
                             "amount_tax_not_included", 0
                         ),
+                        amount_tax_withholding=values.get("amount_tax_withholding", 0),
                         amount_total=fiscal_line.amount_total,
                         currency_id=move_id.currency_id,
                         company_id=move_id.company_id,
@@ -268,6 +269,7 @@ class AccountMoveLine(models.Model):
                     exclude_from_invoice_tab=line.exclude_from_invoice_tab,
                     amount_tax_included=line.amount_tax_included,
                     amount_tax_not_included=line.amount_tax_not_included,
+                    amount_tax_withholding=line.amount_tax_withholding,
                     amount_total=line.amount_total,
                     currency_id=line.currency_id,
                     company_id=line.company_id,
@@ -536,6 +538,7 @@ class AccountMoveLine(models.Model):
         exclude_from_invoice_tab=None,
         amount_tax_included=None,
         amount_tax_not_included=None,
+        amount_tax_withholding=None,
         amount_total=None,
         currency_id=None,
         company_id=None,
@@ -557,6 +560,9 @@ class AccountMoveLine(models.Model):
             amount_tax_not_included=self.amount_tax_not_included
             if amount_tax_not_included is None
             else amount_tax_not_included,
+            amount_tax_withholding=self.amount_tax_withholding
+            if amount_tax_withholding is None
+            else amount_tax_withholding,
             amount_total=self.amount_total if amount_total is None else amount_total,
             currency_id=self.currency_id if currency_id is None else currency_id,
             company_id=self.company_id if company_id is None else company_id,
@@ -572,6 +578,7 @@ class AccountMoveLine(models.Model):
         exclude_from_invoice_tab,
         amount_tax_included,
         amount_tax_not_included,
+        amount_tax_withholding,
         amount_total,
         currency_id,
         company_id,
@@ -593,7 +600,10 @@ class AccountMoveLine(models.Model):
                 amount_currency = amount_total
             else:
                 amount_currency = (
-                    amount_total - amount_tax_included - amount_tax_not_included
+                    amount_total
+                    - amount_tax_included
+                    - amount_tax_not_included
+                    + amount_tax_withholding
                 )
 
         amount_currency = amount_currency * sign


### PR DESCRIPTION
Quando você utiliza uma operação fiscal com impostos dedutíveis, o cálculo do total a pagar é correto, mesmo com a presença de impostos retidos. No entanto, se a operação fiscal não for configurada como dedutível, o valor total a pagar é debitado duas vezes. Para resolver isso, este PR adiciona o valor do imposto retido ao total, corrigindo assim o valor total a pagar.

Observe principalmente a linha FORNECEDORES e o valor da coluna CREDITO.

**Exemplo de lançamento contábil com operação fiscal configurada como dedutível (True):**

![image](https://github.com/OCA/l10n-brazil/assets/3595132/ee7079b0-09fc-4b14-9434-ee6eb6679674)

**Exemplo de lançamento contábil com operação fiscal configurada como não dedutível (False)(COM ESTA PR):**

![image](https://github.com/OCA/l10n-brazil/assets/3595132/380ffc79-d8e6-4e74-bbf9-7a2a4e5bb7cd)

**Exemplo de lançamento contábil com operação fiscal configurada como não dedutível (False:)(CENARIO ATUAL, SEM ESTA PR)(TESTADO NO RUNBOAT)**
![image](https://github.com/OCA/l10n-brazil/assets/3595132/36d60855-4063-4939-87da-45899ce314b0)
