### PR TITLE
[14.0][FIX] l10n_br_purchase: Possibilidade de incluir linhas de Seção ou Notas no Pedido de Compra

### DIFF
--- a/l10n_br_purchase/views/purchase_view.xml
+++ b/l10n_br_purchase/views/purchase_view.xml
@@ -108,7 +108,7 @@
                   <field
                     name="fiscal_operation_line_id"
                     options="{'no_create': True}"
-                    attrs="{'invisible': [('parent.fiscal_operation_id', '=', False)], 'required': [('fiscal_operation_id', '!=', False)]}"
+                    attrs="{'invisible': [('parent.fiscal_operation_id', '=', False)], 'required': ['&amp;', ('fiscal_operation_id', '!=', False), ('product_id', '!=', False)]}"
                 />
                   <field
                     name="cfop_id"
@@ -128,14 +128,14 @@
                   <!-- necessario incluir porque o attrs não funciona na tag Page apenas  na Notebook-->
                   <attribute
                     name="attrs"
-                >{'invisible': [('parent.fiscal_operation_id', '!=', False)]}</attribute>
+                >{'invisible': ['|', ('parent.fiscal_operation_id', '!=', False), ('display_type', '!=', False)]}</attribute>
               </xpath>
               <xpath
                 expr="//field[@name='order_line']/form/field[@name='name']"
                 position="after"
             >
                 <notebook
-                    attrs="{'invisible': [('parent.fiscal_operation_id', '=', False)]}"
+                    attrs="{'invisible': ['|', ('parent.fiscal_operation_id', '=', False), ('display_type', '!=', False)]}"
                 >
                       <page
                         name="fiscal_taxes"


### PR DESCRIPTION
Possibility to include Section or Note lines in Purchase Order.

Possibilidade de incluir linhas de Seção ou Notas no Pedido de Compra, PR simples, algo semelhante foi feito no l10n_br_sale recentemente, hoje ao tentar incluir esse tipo de linha acaba retornando erro:

![image](https://github.com/OCA/l10n-brazil/assets/6341149/16d251db-b568-41d2-a518-efc759106ae4)

Com esse PR

![image](https://github.com/OCA/l10n-brazil/assets/6341149/165af686-22ec-4e02-b4b3-ec80675d677c)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/303d71e3-5e3e-4d23-a92f-eb6c871f8391)

![image](https://github.com/OCA/l10n-brazil/assets/6341149/dc3ab2d7-75d0-4d26-b3fd-b86f559a9bb5)

Caso Produto

![image](https://github.com/OCA/l10n-brazil/assets/6341149/3e49f875-b5c1-44ce-82b9-721d210eed31)

cc @rvalyi @renatonlima @marcelsavegnago @mileo 