### PR TITLE
[14.0][l10n_br_fiscal][l10n_br_account] mail thread e message_post

### DIFF
--- a/l10n_br_account/models/fiscal_document.py
+++ b/l10n_br_account/models/fiscal_document.py
@@ -140,3 +140,13 @@ class FiscalDocument(models.Model):
             return super().create(filtered_vals_list)
         else:
             return super().create(vals_list)
+
+    @api.returns("mail.message", lambda value: value.id)
+    def message_post(self, **kwargs):
+        """
+        broadcast message_post to all related account.move so
+        messages in a fiscal document chatter are visible in the
+        related account moves.
+        """
+        for doc in self:
+            doc.move_ids.message_post(**kwargs)

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -51,6 +51,7 @@ class Document(models.Model):
         "l10n_br_fiscal.document.mixin.fields",
         "l10n_br_fiscal.document.electronic",
         "l10n_br_fiscal.document.move.mixin",
+        "mail.thread",
     ]
     _description = "Fiscal Document"
     _check_company_auto = True


### PR DESCRIPTION
Lá no inicio da v12 o l10n_br_fiscal.document herdava do mail.thread e eu acabei tirando alegando que pela herança do account.move não era preciso... 

Até que na verdade é desejável sim: [agora que implementamos a possibilidade de encaixar vários documentos fiscais num mesmo account.move](https://github.com/OCA/l10n-brazil/pull/2761), é desejável que cada documento fiscal tenha o mail.thread dele. Mas eu implementei um sistema onde cada vez que é postado algo no chatter de um documento fiscal, o message_post acontece tambem para todos account.move relacionados, de forma que continua possível seguir o historico de cada documento fiscal a partir do chatter dos account.move relacionados.
Essa ideia tinha sido me passado pelo 
Akim Juillerat da C2C no ano passado: https://twitter.com/akim_c2c/status/1671934029946404964

A vantagem desse design vai ficar mais clara em outros PRs a seguir...