### PR TITLE
[14.0][FIX] l10n_br_account : Não criar linhas do tipo Seção, Notas e Adiantamentos/'down payments' nos Documentos Fiscais Brasileiros

### DIFF
--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -224,11 +224,18 @@ class AccountMoveLine(models.Model):
         # the creation of l10n_br_fiscal.document.line as it would mess the association
         # of the remaining fiscal document lines with their proper aml. That's why we
         # remove the useless fiscal document lines here.
-        for line in results:
-            if not line.move_id.fiscal_document_id or line.exclude_from_invoice_tab:
-                fiscal_line_to_delete = line.fiscal_document_line_id
-                line.fiscal_document_line_id = False
-                fiscal_line_to_delete.sudo().unlink()
+        fiscal_lines_to_delete = results.filtered(
+            lambda ln: not ln.move_id.fiscal_document_id
+            or ln.exclude_from_invoice_tab
+            # Section and Note lines
+            or ln.display_type
+            # Down Payments
+            or ln.fiscal_quantity < 0.0
+        )
+        for line in fiscal_lines_to_delete:
+            fiscal_line_to_delete = line.fiscal_document_line_id
+            line.fiscal_document_line_id = False
+            fiscal_line_to_delete.sudo().unlink()
 
         return results
 


### PR DESCRIPTION
NFe don't validate Section, Note or DownPayments lines.

Nas linhas da NFe não validar linhas do tipo Seção, Notas e Adiantamentos/'down payments', PR simples para evitar a mensagem de erro ao chamar o método action_post quando alguma dessa linhas estão presentes

l10n_br_nfe/models/document.py", line 807, in _check_product_default_code f"The product {line.product_id.display_name} "
 odoo.exceptions.ValidationError: The product False must have a default code or the product codeline field (nfe40_cProd) should be filled.

Pelo código isso está sendo feito em outros casos, mas é preciso ver outros erros como 

File "l10n_br_nfe/models/document_line.py", line 503,  in _export_fields_nfe_40_icms self.nfe40_choice_icms.replace("nfe40_", "") AttributeError: 'bool' object has no attribute 'replace'

e se essas Linhas devem ser apagadas, bloqueadas ou mantidas de alguma forma já que não vão estar na NFe, portanto esse PR resolve apenas uma parte do problema.

O teste pode ser feito com Pedido de Vendas que tem linhas de Seção, Nota e Adiantamentos, no PR https://github.com/OCA/l10n-brazil/pull/2955 foram incluído dados de demonstração e testes com esses casos

cc @rvalyi @renatonlima @marcelsavegnago @mileo 

