### PR TITLE
[14.0][REM] l10n_br_account_payment_order:  Removendo campo journal_entry_ref por não estar sendo usado

### DIFF
--- a/l10n_br_account_payment_order/models/account_move_line.py
+++ b/l10n_br_account_payment_order/models/account_move_line.py
@@ -88,11 +88,6 @@ class AccountMoveLine(models.Model):
         copy=False,
     )
 
-    journal_entry_ref = fields.Char(
-        compute="_compute_journal_entry_ref",
-        store=True,
-    )
-
     # TODO: Confirmar o caso de uso de diferentes modos de pagto na mesma
     #  account.invoice
     payment_mode_id = fields.Many2one(string="Modo de Pagamento")
@@ -131,18 +126,6 @@ class AccountMoveLine(models.Model):
         readonly=True,
         inverse_name="move_line_id",
     )
-
-    @api.depends("move_id")
-    def _compute_journal_entry_ref(self):
-        for record in self:
-            if record.name:
-                record.journal_entry_ref = record.name
-            elif record.move_id.name:
-                record.journal_entry_ref = record.move_id.name
-            elif record.invoice_id and record.invoice_id.number:
-                record.journal_entry_ref = record.invoice_id.number
-            else:
-                record.journal_entry_ref = "*" + str(record.move_id.id)
 
     def _get_default_service_type(self):
         if self.move_id.move_type == "in_invoice":

--- a/l10n_br_account_payment_order/tests/test_payment_order_inbound.py
+++ b/l10n_br_account_payment_order/tests/test_payment_order_inbound.py
@@ -68,17 +68,6 @@ class TestPaymentOrderInbound(SavepointCase):
         # Change status of Move to draft just to test
         self.invoice_cef.button_cancel()
 
-        # TODO v13, o account.move não tem um campo para informar um account_id
-        #  isso pode ser um problema na localização?
-        # for line in self.invoice_cef.line_ids.filtered(
-        #     lambda l: l.account_id.id == self.invoice_cef.account_id.id
-        # ):
-        #     self.assertEqual(
-        #        line.journal_entry_ref,
-        #        line.invoice_id.name,
-        #        "Error with compute field journal_entry_ref",
-        #    )
-
         # Return the status of Move to Posted
         self.invoice_cef.action_post()
 
@@ -89,11 +78,6 @@ class TestPaymentOrderInbound(SavepointCase):
             ), "own_number field is not filled in created Move Line."
             assert line.mov_instruction_code_id, (
                 "mov_instruction_code_id field is not filled" " in created Move Line."
-            )
-            self.assertEqual(
-                line.journal_entry_ref,
-                line.move_id.name,
-                "Error with compute field journal_entry_ref",
             )
             # testar com a parcela 700
             if line.debit == 700.0:


### PR DESCRIPTION
Remove journal_entry_ref field, field come from extraction and keeped to avoid incompatibiles, but it's not be used for while.

Removendo campo journal_entry_ref por não estar sendo usado, campo veio da extração e foi mantido para evitar incompatibilidades com possíveis implementações, como o modulo já foi integrado a um certo tempo e o campo não parece estar sendo usado e está causando erro https://github.com/OCA/l10n-brazil/issues/3009 está sendo removido, abaixo o resultado do 'grep'

$ grep -rn 'journal_entry_ref' . --color=always
./l10n_br_account_payment_order/models/account_move_line.py:91:    journal_entry_ref = fields.Char(
./l10n_br_account_payment_order/models/account_move_line.py:92:        compute="_compute_journal_entry_ref",
./l10n_br_account_payment_order/models/account_move_line.py:136:    def _compute_journal_entry_ref(self):
./l10n_br_account_payment_order/models/account_move_line.py:139:                record.journal_entry_ref = record.name
./l10n_br_account_payment_order/models/account_move_line.py:141:                record.journal_entry_ref = record.move_id.name
./l10n_br_account_payment_order/models/account_move_line.py:143:                record.journal_entry_ref = record.invoice_id.number
./l10n_br_account_payment_order/models/account_move_line.py:145:                record.journal_entry_ref = "*" + str(record.move_id.id)
./l10n_br_account_payment_order/tests/test_payment_order_inbound.py:77:        #        line.journal_entry_ref,
./l10n_br_account_payment_order/tests/test_payment_order_inbound.py:79:        #        "Error with compute field journal_entry_ref",
./l10n_br_account_payment_order/tests/test_payment_order_inbound.py:94:                line.journal_entry_ref,
./l10n_br_account_payment_order/tests/test_payment_order_inbound.py:96:                "Error with compute field journal_entry_ref",
./l10n_br_account_payment_order/i18n/pt_BR.po:2109:#: model:ir.model.fields,field_description:l10n_br_account_payment_order.field_account_move_line__journal_entry_ref
./l10n_br_account_payment_order/i18n/l10n_br_account_payment_order.pot:2086:#: model:ir.model.fields,field_description:l10n_br_account_payment_order.field_account_move_line__journal_entry_ref

Nos repo bank-payment e ocb não retorna nada

cc @rvalyi @renatonlima @marcelsavegnago @mileo 