### PR TITLE
[14.0][RFC] l10n_br_account: refactor method to override create in account.move.line and fiscal.document.line

### DIFF
--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -220,15 +220,9 @@ class AccountMoveLine(models.Model):
             AccountMoveLine, self.with_context(create_from_move_line=True)
         ).create(vals_list)
 
-        # Unfortunately when creating several aml there is no way to selectively avoid
-        # the creation of l10n_br_fiscal.document.line as it would mess the association
-        # of the remaining fiscal document lines with their proper aml. That's why we
-        # remove the useless fiscal document lines here.
         for line in results:
             if not line.move_id.fiscal_document_id or line.exclude_from_invoice_tab:
-                fiscal_line_to_delete = line.fiscal_document_line_id
                 line.fiscal_document_line_id = False
-                fiscal_line_to_delete.sudo().unlink()
 
         return results
 

--- a/l10n_br_account/models/fiscal_document_line.py
+++ b/l10n_br_account/models/fiscal_document_line.py
@@ -41,16 +41,26 @@ class FiscalDocumentLine(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         """
-        It's not allowed to create a fiscal document line without a document_id anyway.
-        But instead of letting Odoo crash in this case we simply avoid creating the
-        record. This makes it possible to create an account.move.line without
-        a fiscal_document_line_id: Odoo will write NULL as the value in this case.
-        This is a requirement to allow account moves without fiscal documents despite
-        the _inherits system.
+        Override the create method to ensure it filters out account.move.line records
+        that lack a valid document_id or fiscal_operation_line_id. Prevent the
+        creation  of fiscal document lines without these mandatory fields to avoid
+        system crashes due to invalid records. If the conditions are not met, return an
+        empty list instead of creating any records. This supports the creation of
+        account.move.line records with NULL values for fiscal_document_line_id where
+        necessary.
         """
 
         if self._context.get("create_from_move_line"):
-            if not any(vals.get("document_id") for vals in vals_list):
+            # Filter out the dictionaries that do not meet the conditions
+            filtered_vals_list = [
+                vals
+                for vals in vals_list
+                if vals.get("document_id") and vals.get("fiscal_operation_line_id")
+            ]
+            # Stop execution and return empty if no dictionary meets the conditions
+            if not filtered_vals_list:
                 return []
+            # Assign the filtered list back to the original list for further processing
+            vals_list = filtered_vals_list
 
         return super().create(vals_list)

--- a/l10n_br_sale_commission/tests/test_l10n_br_sale_commission.py
+++ b/l10n_br_sale_commission/tests/test_l10n_br_sale_commission.py
@@ -89,6 +89,7 @@ class TestL10nBrSalesCommission(SavepointCase):
         payment.with_context(context).create_invoices()
         self.assertNotEqual(len(sale_order.invoice_ids), 0)
         for invoice in sale_order.invoice_ids:
+            invoice.flush()
             invoice.action_post()
             self.assertEqual(invoice.state, "posted")
 


### PR DESCRIPTION
Este unlink está afetando os valores de alguns campos do account.move como por exemplo o ind_final, ind_pres e outros e entendo que se faz melhor não deixar criar a linha do documento fiscal ao invés de criar para depois excluir.

![image](https://github.com/OCA/l10n-brazil/assets/3595132/b480a526-cdef-4431-9beb-364138216348)
