### PR TITLE
[14.0][REF] Impressão da DANFE a partir da lib BrazilFiscalReport

### DIFF
--- a/l10n_br_account_nfe/__init__.py
+++ b/l10n_br_account_nfe/__init__.py
@@ -1,3 +1,4 @@
 from .hooks import post_init_hook
 
 from . import models
+from . import report

--- a/l10n_br_account_nfe/__manifest__.py
+++ b/l10n_br_account_nfe/__manifest__.py
@@ -22,6 +22,7 @@
     ],
     "data": [
         "views/account_payment_mode.xml",
+        "report/danfe_report.xml",
     ],
     "post_init_hook": "post_init_hook",
     "installable": True,

--- a/l10n_br_account_nfe/report/__init__.py
+++ b/l10n_br_account_nfe/report/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_actions_report

--- a/l10n_br_account_nfe/report/danfe_report.xml
+++ b/l10n_br_account_nfe/report/danfe_report.xml
@@ -1,0 +1,12 @@
+<odoo>
+    <record id="report_danfe_account" model="ir.actions.report">
+        <field name="name">DANFE</field>
+        <field name="model">account.move</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">main_template_danfe_account</field>
+        <field name="report_file">main_template_danfe_account</field>
+        <field name="print_report_name">'%s' % (object.document_key)</field>
+        <field name="binding_model_id" ref="account.model_account_move" />
+        <field name="binding_type">report</field>
+    </record>
+</odoo>

--- a/l10n_br_account_nfe/report/ir_actions_report.py
+++ b/l10n_br_account_nfe/report/ir_actions_report.py
@@ -1,0 +1,27 @@
+# Copyright 2024 Engenere.one
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class IrActionsReport(models.Model):
+    _inherit = "ir.actions.report"
+
+    def temp_xml_autorizacao(self, xml_string):
+        return super().temp_xml_autorizacao(xml_string=xml_string)
+
+    def _render_qweb_html(self, res_ids, data=None):
+        if self.report_name == "main_template_danfe_account":
+            return
+        return super()._render_qweb_html(res_ids, data=data)
+
+    def _render_qweb_pdf(self, res_ids, data=None):
+        if self.report_name not in ["main_template_danfe_account"]:
+            return super()._render_qweb_pdf(res_ids, data=data)
+
+        nfe = self.env["account.move"].search([("id", "in", res_ids)])
+
+        return self._render_danfe(nfe)
+
+    def _render_danfe(self, nfe):
+        return super()._render_danfe(nfe=nfe)

--- a/l10n_br_account_nfe/tests/__init__.py
+++ b/l10n_br_account_nfe/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import test_nfe_generate_tags_cobr_dup_pag
 from . import test_nfce_contingency
 from . import test_nfe_with_ipi
+from . import test_nfe_danfe_account

--- a/l10n_br_account_nfe/tests/test_nfe_danfe_account.py
+++ b/l10n_br_account_nfe/tests/test_nfe_danfe_account.py
@@ -1,0 +1,37 @@
+# Copyright 2024 Engenere.one
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from unittest.mock import patch
+
+from odoo.tests import SavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestGeneratePaymentInfo(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+    def test_generate_danfe_brazil_fiscal_report(self):
+        nfe = self.env.ref("l10n_br_account_nfe.demo_nfe_dados_de_cobranca")
+        nfe.action_post()
+
+        danfe_report = self.env["ir.actions.report"].search(
+            [("report_name", "=", "main_template_danfe_account")]
+        )
+        danfe_pdf = danfe_report._render_qweb_pdf([nfe.id])
+        self.assertTrue(danfe_pdf)
+
+    def test_generate_danfe_erpbrasil_edoc(self):
+        nfe = self.env.ref("l10n_br_account_nfe.demo_nfe_dados_de_cobranca")
+        nfe.company_id.danfe_library = "erpbrasil.edoc.pdf"
+
+        with patch("erpbrasil.edoc.pdf.base.ImprimirXml.imprimir") as mock_make_pdf:
+            mock_make_pdf.return_value = b"Mock PDF"
+
+            nfe.action_post()
+
+            danfe_report = self.env["ir.actions.report"].search(
+                [("report_name", "=", "main_template_danfe_account")]
+            )
+            danfe_pdf = danfe_report._render_qweb_pdf([nfe.id])
+            self.assertTrue(danfe_pdf)

--- a/l10n_br_nfe/__init__.py
+++ b/l10n_br_nfe/__init__.py
@@ -4,3 +4,4 @@ from .hooks import post_init_hook
 from . import models
 from . import tests
 from . import wizards
+from . import report

--- a/l10n_br_nfe/__manifest__.py
+++ b/l10n_br_nfe/__manifest__.py
@@ -35,6 +35,7 @@
         # Report
         "report/reports.xml",
         "report/danfe_nfce.xml",
+        "report/danfe_report.xml",
         # Wizards
         "wizards/import_document.xml",
         # Actions,
@@ -58,6 +59,7 @@
             "erpbrasil.edoc>=2.5.2",
             "erpbrasil.edoc.pdf",
             "erpbrasil.base>=2.3.0",
+            "brazilfiscalreport",
         ],
     },
 }

--- a/l10n_br_nfe/constants/nfe.py
+++ b/l10n_br_nfe/constants/nfe.py
@@ -6,6 +6,13 @@ NFE_VERSIONS = [("1.10", "1.10"), ("2.00", "2.00"), ("3.10", "3.10"), ("4.00", "
 
 NFE_VERSION_DEFAULT = "4.00"
 
+DANFE_LIBRARY = [
+    ("brazil_fiscal_report", "Brazil Fiscal Report"),
+    ("erpbrasil.edoc.pdf", "ERPBrasil"),
+]
+
+DANFE_LIBRARY_DEFAULT = "brazil_fiscal_report"
+
 
 NFE_ENVIRONMENTS = [("1", "Produção"), ("2", "Homologação")]
 

--- a/l10n_br_nfe/constants/nfe.py
+++ b/l10n_br_nfe/constants/nfe.py
@@ -13,6 +13,12 @@ DANFE_LIBRARY = [
 
 DANFE_LIBRARY_DEFAULT = "brazil_fiscal_report"
 
+DANFE_INVOICE_DISPLAY = [
+    ("full_details", "Full Details"),
+    ("duplicates_only", "Duplicates Only"),
+]
+
+DANFE_INVOICE_DISPLAY_DEFAULT = "full_details"
 
 NFE_ENVIRONMENTS = [("1", "Produção"), ("2", "Homologação")]
 

--- a/l10n_br_nfe/models/res_company.py
+++ b/l10n_br_nfe/models/res_company.py
@@ -7,6 +7,8 @@ from odoo import api, fields
 from odoo.addons.spec_driven_model.models import spec_models
 
 from ..constants.nfe import (
+    DANFE_LIBRARY,
+    DANFE_LIBRARY_DEFAULT,
     NFCE_DANFE_LAYOUT_DEFAULT,
     NFCE_DANFE_LAYOUTS,
     NFE_DANFE_LAYOUT_DEFAULT,
@@ -160,6 +162,16 @@ class ResCompany(spec_models.SpecModel):
         string="CSC Code",
         help="Código CSC (Código de Segurança do Contribuinte) "
         "fornecido pela SEFAZ para a NFC-e",
+    )
+    danfe_library = fields.Selection(
+        selection=DANFE_LIBRARY,
+        default=DANFE_LIBRARY_DEFAULT,
+        help="""
+        Choose the library used for generating the DANFE
+        (Document Auxiliary for Nota Fiscal Eletrônica).
+        Options include 'erpbrasil.edoc.pdf' and 'brazil_fiscal_report'.
+        The default library is set to 'erpbrasil.edoc.pdf'.
+        """,
     )
 
     def _compute_nfe_data(self):

--- a/l10n_br_nfe/models/res_company.py
+++ b/l10n_br_nfe/models/res_company.py
@@ -7,6 +7,8 @@ from odoo import api, fields
 from odoo.addons.spec_driven_model.models import spec_models
 
 from ..constants.nfe import (
+    DANFE_INVOICE_DISPLAY,
+    DANFE_INVOICE_DISPLAY_DEFAULT,
     DANFE_LIBRARY,
     DANFE_LIBRARY_DEFAULT,
     NFCE_DANFE_LAYOUT_DEFAULT,
@@ -172,6 +174,17 @@ class ResCompany(spec_models.SpecModel):
         Options include 'erpbrasil.edoc.pdf' and 'brazil_fiscal_report'.
         The default library is set to 'erpbrasil.edoc.pdf'.
         """,
+    )
+
+    danfe_invoice_display = fields.Selection(
+        selection=DANFE_INVOICE_DISPLAY,
+        default=DANFE_INVOICE_DISPLAY_DEFAULT,
+        help="Choose to generate a full or incomplete invoice frame in the DANFE.",
+    )
+
+    danfe_display_pis_cofins = fields.Boolean(
+        default=False,
+        help="Select whether PIS and COFINS should be displayed in DANFE.",
     )
 
     def _compute_nfe_data(self):

--- a/l10n_br_nfe/report/__init__.py
+++ b/l10n_br_nfe/report/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_actions_report

--- a/l10n_br_nfe/report/danfe_report.xml
+++ b/l10n_br_nfe/report/danfe_report.xml
@@ -1,0 +1,12 @@
+<odoo>
+        <record id="report_danfe" model="ir.actions.report">
+            <field name="name">DANFE</field>
+            <field name="model">l10n_br_fiscal.document</field>
+            <field name="report_type">qweb-pdf</field>
+            <field name="report_name">main_template_danfe</field>
+            <field name="report_file">main_template_danfe</field>
+            <field name="print_report_name">'%s' % (object.document_key)</field>
+            <field name="binding_model_id" ref="model_l10n_br_fiscal_document" />
+            <field name="binding_type">report</field>
+        </record>
+</odoo>

--- a/l10n_br_nfe/report/ir_actions_report.py
+++ b/l10n_br_nfe/report/ir_actions_report.py
@@ -1,0 +1,107 @@
+# Copyright 2024 Engenere.one
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+import base64
+import logging
+from io import BytesIO
+
+from brazilfiscalreport.danfe import Danfe, DanfeConfig, Margins
+from erpbrasil.edoc.pdf import base
+from lxml import etree
+
+from odoo import _, models
+from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
+
+
+class IrActionsReport(models.Model):
+    _inherit = "ir.actions.report"
+
+    def temp_xml_autorizacao(self, xml_string):
+        """TODO: Migrate-me to erpbrasil.edoc.pdf ASAP"""
+        root = etree.fromstring(xml_string)
+        ns = {None: "http://www.portalfiscal.inf.br/nfe"}
+        new_root = etree.Element("nfeProc", nsmap=ns)
+
+        protNFe_node = etree.Element("protNFe")
+        infProt = etree.SubElement(protNFe_node, "infProt")
+        etree.SubElement(infProt, "tpAmb").text = "2"
+        etree.SubElement(infProt, "verAplic").text = ""
+        etree.SubElement(infProt, "dhRecbto").text = None
+        etree.SubElement(infProt, "nProt").text = ""
+        etree.SubElement(infProt, "digVal").text = ""
+        etree.SubElement(infProt, "cStat").text = ""
+        etree.SubElement(infProt, "xMotivo").text = ""
+
+        new_root.append(root)
+        new_root.append(protNFe_node)
+        return etree.tostring(new_root)
+
+    def _render_qweb_html(self, res_ids, data=None):
+        if self.report_name == "main_template_danfe":
+            return
+
+        return super()._render_qweb_html(res_ids, data=data)
+
+    def _render_qweb_pdf(self, res_ids, data=None):
+        if self.report_name not in ["main_template_danfe"]:
+            return super()._render_qweb_pdf(res_ids, data=data)
+
+        nfe = self.env["l10n_br_fiscal.document"].search([("id", "in", res_ids)])
+
+        return self._render_danfe(nfe)
+
+    def _render_danfe(self, nfe):
+        if nfe.document_type != "55":
+            raise UserError(_("You can only print a DANFE of a NFe(55)."))
+
+        nfe_xml = False
+        if nfe.authorization_file_id:
+            nfe_xml = base64.b64decode(nfe.authorization_file_id.datas)
+        elif nfe.send_file_id:
+            nfe_xml = base64.b64decode(nfe.send_file_id.datas)
+
+        if not nfe_xml:
+            raise UserError(_("No xml file was found."))
+
+        if nfe.company_id.danfe_library == "erpbrasil.edoc.pdf":
+            nfe_xml = self.temp_xml_autorizacao(nfe_xml)
+            return self.render_danfe_erpbrasil(nfe_xml)
+        elif nfe.company_id.danfe_library == "brazil_fiscal_report":
+            return self.render_danfe_brazilfiscalreport(nfe, nfe_xml)
+
+    def render_danfe_brazilfiscalreport(self, nfe, nfe_xml):
+        logo = False
+        if nfe.issuer == "company" and nfe.company_id.logo:
+            logo = base64.b64decode(nfe.company_id.logo)
+        elif nfe.issuer != "company" and nfe.company_id.logo_web:
+            logo = base64.b64decode(nfe.company_id.logo_web)
+
+        if logo:
+            tmpLogo = BytesIO()
+            tmpLogo.write(logo)
+            tmpLogo.seek(0)
+        else:
+            tmpLogo = False
+
+        config = self._get_danfe_config(tmpLogo)
+        danfe = Danfe(xml=nfe_xml, config=config)
+
+        tmpDanfe = BytesIO()
+        danfe.output(tmpDanfe)
+        danfe_file = tmpDanfe.getvalue()
+        tmpDanfe.close()
+
+        return danfe_file, "pdf"
+
+    def _get_danfe_config(self, tmpLogo):
+        return DanfeConfig(
+            logo=tmpLogo,
+            margins=Margins(top=5, right=5, bottom=5, left=5),
+        )
+
+    def render_danfe_erpbrasil(self, nfe_xml):
+        pdf = base.ImprimirXml.imprimir(
+            string_xml=nfe_xml,
+        )
+        return pdf, "pdf"

--- a/l10n_br_nfe/tests/__init__.py
+++ b/l10n_br_nfe/tests/__init__.py
@@ -10,3 +10,4 @@ from . import test_nfe_xml_validation
 from . import test_res_partner
 from . import test_nfe_dfe
 from . import test_nfe_mde
+from . import test_nfe_danfe

--- a/l10n_br_nfe/tests/test_nfe_danfe.py
+++ b/l10n_br_nfe/tests/test_nfe_danfe.py
@@ -1,0 +1,52 @@
+# Copyright 2024 Engenere.one
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from unittest.mock import patch
+
+from odoo.exceptions import UserError
+from odoo.tests.common import TransactionCase
+
+
+class TestDanfeGeneration(TransactionCase):
+    def setUp(self):
+        super().setUp()
+
+    def test_generate_danfe_brazil_fiscal_report(self):
+        nfe = self.env.ref("l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11")
+        nfe.action_document_confirm()
+        nfe.view_pdf()
+
+        self.assertTrue(nfe.file_report_id)
+
+    def test_generate_danfe_erpbrasil_edoc(self):
+        nfe = self.env.ref("l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11")
+        nfe.company_id.danfe_library = "erpbrasil.edoc.pdf"
+
+        with patch("erpbrasil.edoc.pdf.base.ImprimirXml.imprimir") as mock_make_pdf:
+            mock_make_pdf.return_value = b"Mock PDF"
+
+            nfe.action_document_confirm()
+            nfe.make_pdf()
+
+            self.assertTrue(nfe.file_report_id)
+
+    def test_generate_danfe_document_type_error(self):
+        danfe_report = self.env["ir.actions.report"].search(
+            [("report_name", "=", "main_template_danfe")]
+        )
+        nfe = self.env.ref("l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11")
+        nfe.document_type_id = self.env.ref("l10n_br_fiscal.document_01")
+        nfe.action_document_confirm()
+        with self.assertRaises(UserError) as captured_exception:
+            danfe_report._render_qweb_pdf([nfe.id])
+        self.assertEqual(
+            captured_exception.exception.args[0],
+            "You can only print a DANFE of a NFe(55).",
+        )
+
+    def test_generate_danfe_brazil_fiscal_report_partner(self):
+        nfe = self.env.ref("l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11")
+        nfe.action_document_confirm()
+        nfe.issuer = "partner"
+        nfe.view_pdf()
+
+        self.assertTrue(nfe.file_report_id)

--- a/l10n_br_nfe/views/res_company_view.xml
+++ b/l10n_br_nfe/views/res_company_view.xml
@@ -33,7 +33,6 @@
                             />
                           <field name="nfe_authorize_accountant_download_xml" />
                           <field name="nfe_authorize_technical_download_xml" />
-                          <field name="danfe_library" />
                       </group>
                   </group>
 
@@ -42,6 +41,22 @@
                         <field name="nfce_qrcode_version" />
                         <field name="nfce_csc_token" />
                         <field name="nfce_csc_code" />
+                    </group>
+                  </group>
+
+                  <group name="danfe_settings" string="DANFE Settings">
+                    <group>
+                        <field name="danfe_library" />
+                        <field
+                                name="danfe_invoice_display"
+                                string="Invoice Display"
+                                attrs="{'invisible': [('danfe_library', '!=', 'brazil_fiscal_report')]}"
+                            />
+                        <field
+                                name="danfe_display_pis_cofins"
+                                string="PIS/COFINS Display"
+                                attrs="{'invisible': [('danfe_library', '!=', 'brazil_fiscal_report')]}"
+                            />
                     </group>
                   </group>
               </page>

--- a/l10n_br_nfe/views/res_company_view.xml
+++ b/l10n_br_nfe/views/res_company_view.xml
@@ -33,6 +33,7 @@
                             />
                           <field name="nfe_authorize_accountant_download_xml" />
                           <field name="nfe_authorize_technical_download_xml" />
+                          <field name="danfe_library" />
                       </group>
                   </group>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # generated from manifests external_dependencies
 brazilcep
+brazilfiscalreport
 email-validator
 erpbrasil.assinatura>=1.7.0
 erpbrasil.base>=2.3.0


### PR DESCRIPTION
Adiciona opção de imprimir a DANFE a partir da biblioteca [brazilfiscalreport](https://github.com/Engenere/BrazilFiscalReport)

A biblioteca a ser usada pode ser definido na configuração da empresa:
![image](https://github.com/OCA/l10n-brazil/assets/634278/e1be03c6-ba1e-44bc-8259-435fef012c92)
ainda é possivel configurar para imprimir a DANFE usando o jeito antigo (erpbrasil usando o libreoffice) é bom ter essa opção até que se confirme que a DANFE no BrazilFiscalReport se confirme estavel.

Agora é possivel também imprimir a DANFE usando os menus nativos de relatórios do Odoo:
![image](https://github.com/OCA/l10n-brazil/assets/634278/b390f770-afae-474b-b3d2-90734cdcf686)
Foi implementando tando no modelo `account.move` quanto `l10n_br_fiscal.document`

Exemplos de DANFE geradas podem ser vistas no repositório da biblioteca: https://github.com/Engenere/BrazilFiscalReport/tree/main/tests/generated/danfe






