### PR TITLE
[16.0][l10n_br_hr][REF] l10n_br_hr: SavepointCase->TransactionCase

### DIFF
--- a/l10n_br_hr/tests/test_l10n_br_hr.py
+++ b/l10n_br_hr/tests/test_l10n_br_hr.py
@@ -1,8 +1,8 @@
 from odoo.exceptions import ValidationError
-from odoo.tests import SavepointCase
+from odoo.tests import TransactionCase
 
 
-class TestL10nBr(SavepointCase):
+class TestL10nBr(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()


### PR DESCRIPTION
olhando os logs na 16.0 acabei de me deparar com o fato que o módulo l10n_br_hr que acabou de ser migrado para a v16 ainda usa SavepointCase que ta deprecated agora na v16.
Melhor seguir e evitar o warning nos logs.

cc @mileo @DiegoParadeda 