### PR TITLE
[ADD] stock invoicing bug - tax included value

### DIFF
--- a/l10n_br_stock_account/views/stock_picking.xml
+++ b/l10n_br_stock_account/views/stock_picking.xml
@@ -179,6 +179,7 @@
                                     <field name="amount_total" />
                                     <field name="amount_tax_withholding" />
                                     <field name="amount_taxed" />
+                                    <field name="amount_tax_included" invisible="1" />
                                 </group>
                             </group>
                         </page>


### PR DESCRIPTION
## Objetivo

Este PR corrige um bug no valor dos lançamentos contábeis para o caso de um faturamento de recebimento que não tenha compra.

Atualmente, ao criar e faturar um recebimento no inventário com impostos incluídos no preço (e.g. ICMS, PIS, ...), o valor dos impostos incluídos não é subtraído do valor do lançamento.

## Como simular

- Ambiente: Runboat, company Lucro presumido
- crie uma transferência de estoque de recebimento e marque para faturar (operação compras)
- confirme, valide e crie a fatura
- observe o valor dos lançamentos de diário na fatura (requer permissão de full accounting features)

Se o fluxo for feito a partir de uma compra esse problema não acontece.

## Prints do runbot


Faturamento pela compra:
![image](https://github.com/OCA/l10n-brazil/assets/12245538/c026436b-45b4-43fd-b5d3-eab20947986e)

Faturamento pela transferência (sem compra):
![image](https://github.com/OCA/l10n-brazil/assets/12245538/0601da49-8a74-4f26-8623-d02ad42e4c59)

Itens do diário:
![image](https://github.com/OCA/l10n-brazil/assets/12245538/ec1209e3-2f57-447c-a61a-67e6bbffb4ea)

* veja que o valor do produto está R$100, ou seja, **com** o valor dos impostos



