### PR TITLE
[14.0][FIX] l10n_br_nfse_focus: SSL verify disabled

### DIFF
--- a/l10n_br_nfse/models/res_company.py
+++ b/l10n_br_nfse/models/res_company.py
@@ -28,6 +28,10 @@ class ResCompany(models.Model):
     nfse_website = fields.Char(
         string="NFSe Website",
     )
+    nfse_ssl_verify = fields.Boolean(
+        string="NFSe SSL Verify",
+        default=False,
+    )
     city_taxation_code_id = fields.Many2many(
         comodel_name="l10n_br_fiscal.city.taxation.code", string="City Taxation Code"
     )

--- a/l10n_br_nfse/views/res_company_view.xml
+++ b/l10n_br_nfse/views/res_company_view.xml
@@ -23,6 +23,7 @@
                             <field name="provedor_nfse" />
                             <field name="nfse_city_logo" widget="image" />
                             <field name="nfse_website" />
+                            <field name="nfse_ssl_verify" invisible="1" />
                         </group>
                     </group>
                 </page>

--- a/l10n_br_nfse_focus/models/document.py
+++ b/l10n_br_nfse_focus/models/document.py
@@ -387,8 +387,16 @@ class Document(models.Model):
                             timeout=TIMEOUT,
                         ).content.decode("utf-8")
                         pdf_content = (
-                            requests.get(json["url"], timeout=TIMEOUT).content
-                            or requests.get(json["url_danfse"], timeout=TIMEOUT).content
+                            requests.get(
+                                json["url"],
+                                timeout=TIMEOUT,
+                                verify=record.company_id.nfse_ssl_verify,
+                            ).content
+                            or requests.get(
+                                json["url_danfse"],
+                                timeout=TIMEOUT,
+                                verify=record.company_id.nfse_ssl_verify,
+                            ).content
                         )
 
                         record.make_focus_nfse_pdf(pdf_content)

--- a/l10n_br_nfse_focus/views/res_company.xml
+++ b/l10n_br_nfse_focus/views/res_company.xml
@@ -28,6 +28,12 @@
                     attrs="{'invisible': [('provedor_nfse','!=', 'focusnfe')]}"
                 />
             </field>
+            <xpath expr="//field[@name='nfse_ssl_verify']" position="attributes">
+                <attribute name="invisible">0</attribute>
+                <attribute
+                    name="attrs"
+                >{'invisible': [('provedor_nfse', '!=', 'focusnfe')]}</attribute>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
cc @marcelsavegnago @douglascstd 

Após a mudança do certificado da Prefeitura de São José dos Campos

![image](https://github.com/OCA/l10n-brazil/assets/53870822/35828889-d481-461f-a82e-6817f9a3f979)

Erro com o Verify=True:

```
requests.exceptions.SSLError: HTTPSConnectionPool(host='notajoseense.sjc.sp.gov.br', port=443): (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1131)')))
```

A solução para evitar esse erro por momento, foi tornar a verificação como `false`

Etapas para reproduzir erro:

Criar uma Fatura -> Detalhes Fiscais -> Enviar -> Ação -> Obter o Status