### PR TITLE
[15.0][FIX][l10n_br_account] reordering vals_list to correctly associate with with fiscal_document_line - port de #3077

### DIFF
--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -243,10 +243,17 @@ class AccountMoveLine(models.Model):
             AccountMoveLine, self.with_context(create_from_move_line=True)
         ).create(vals_list)
 
+        # Initialize the inverted index list with the same length as the original list
+        inverted_index = [0] * len(original_indexes)
+
+        # Iterate over the original_indexes list and fill the inverted_index list accordingly
+        for i, val in enumerate(original_indexes):
+            inverted_index[val] = i
+
         # Re-order the result according to the initial vals_list order
         sorted_result = self.env["account.move.line"]
-        for i in original_indexes:
-            sorted_result |= result[i]
+        for idx in inverted_index:
+            sorted_result |= result[idx]
 
         return sorted_result
 

--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -229,11 +229,11 @@ class AccountMoveLine(models.Model):
         # Add index to each dictionary in vals_list
         indexed_vals_list = [(idx, val) for idx, val in enumerate(vals_list)]
 
-        # Reorder vals_list for processing based on the presence of
-        # 'fiscal_operation_line_id'
+        # Reorder vals_list so lines with fiscal_operation_line_id will
+        # be created first
         sorted_indexed_vals_list = sorted(
             indexed_vals_list,
-            key=lambda x: x[1].get("fiscal_operation_line_id") is False,
+            key=lambda x: not x[1].get("fiscal_operation_line_id"),
         )
         original_indexes = [idx for idx, _ in sorted_indexed_vals_list]
         vals_list = [val for _, val in sorted_indexed_vals_list]


### PR DESCRIPTION
port de #3077; bem urgente pois temos a mesma regressão de #3064  na 15.0 depois que houve o port em #3069

pessoal eu não entendi porque os commits com fixup não tiveram squash na hora de merge de #3077 (alguem entendeu?), mas enfim nisso re-fiz os mesmos 4 commits do que na 14.0 exactamente (com cherry-pick).

cc @dreispt @mileo se vcs mexem na v15, esse PR é importante!