### PR TITLE
[14.0][FIX] Obtenção incorreta do valor da empresa em alguns casos

### DIFF
--- a/l10n_br_contract/models/contract_contract.py
+++ b/l10n_br_contract/models/contract_contract.py
@@ -32,7 +32,7 @@ class ContractContract(models.Model):
             if company_id:
                 company_id = self.env["res.company"].browse(company_id)
             else:
-                company_id = self.env.user.company_id
+                company_id = self.env.company
             if contract_type == "sale":
                 fiscal_operation_id = company_id.contract_sale_fiscal_operation_id
             else:

--- a/l10n_br_delivery/models/fiscal_document_mixin.py
+++ b/l10n_br_delivery/models/fiscal_document_mixin.py
@@ -9,7 +9,7 @@ class FiscalDocumentMixin(models.AbstractModel):
     _inherit = "l10n_br_fiscal.document.mixin.fields"
 
     def _get_default_incoterm(self):
-        return self.env.user.company_id.incoterm_id
+        return self.env.company.incoterm_id
 
     # Esta sendo implementado aqui para existir nos objetos herdados
     incoterm_id = fields.Many2one(

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -247,7 +247,7 @@ class NFe(spec_models.StackedModel):
         selection=NFE_TRANSMISSIONS,
         string="NFe Transmission",
         copy=False,
-        default=lambda self: self.env.user.company_id.nfe_transmission,
+        default=lambda self: self.env.company.nfe_transmission,
     )
 
     # <cDV>0</cDV> TODO
@@ -258,7 +258,7 @@ class NFe(spec_models.StackedModel):
         selection=NFE_ENVIRONMENTS,
         string="NFe Environment",
         copy=False,
-        default=lambda self: self.env.user.company_id.nfe_environment,
+        default=lambda self: self.env.company.nfe_environment,
     )
 
     nfe40_finNFe = fields.Selection(related="edoc_purpose")
@@ -730,7 +730,7 @@ class NFe(spec_models.StackedModel):
                 value.enderEmit, path=path
             )
             new_value.update(enderEmit_value)
-            company_cnpj = self.env.user.company_id.cnpj_cpf.translate(
+            company_cnpj = self.env.company.cnpj_cpf.translate(
                 str.maketrans("", "", string.punctuation)
             )
             emit_cnpj = new_value.get("nfe40_CNPJ").translate(
@@ -748,7 +748,7 @@ class NFe(spec_models.StackedModel):
                 value.enderDest, path=path
             )
             new_value.update(enderDest_value)
-            company_cnpj = self.env.user.company_id.cnpj_cpf.translate(
+            company_cnpj = self.env.company.cnpj_cpf.translate(
                 str.maketrans("", "", string.punctuation)
             )
             dest_cnpj = new_value.get("nfe40_CNPJ").translate(

--- a/l10n_br_nfe/wizards/l10n_br_account_nfe_export_invoice.py
+++ b/l10n_br_nfe/wizards/l10n_br_account_nfe_export_invoice.py
@@ -17,16 +17,16 @@ class L10nBrAccountNfeExportInvoice(models.TransientModel):
     _description = "Export eletronic invoice"
 
     def _default_file_type(self):
-        return self.env.user.company_id.file_type
+        return self.env.company.file_type
 
     def _default_nfe_environment(self):
-        return self.env.user.company_id.nfe_environment
+        return self.env.company.nfe_environment
 
     def _default_export_folder(self):
-        return self.env.user.company_id.nfe_export_folder
+        return self.env.company.nfe_export_folder
 
     def _default_sign_xml(self):
-        return self.env.user.company_id.sign_xml
+        return self.env.company.sign_xml
 
     name = fields.Char(string="Nome", size=255)
 

--- a/l10n_br_repair/models/fiscal_line_mixin.py
+++ b/l10n_br_repair/models/fiscal_line_mixin.py
@@ -11,7 +11,7 @@ class FiscalLineMixin(models.AbstractModel):
 
     @api.model
     def _default_fiscal_operation(self):
-        return self.env.user.company_id.repair_fiscal_operation_id
+        return self.env.company.repair_fiscal_operation_id
 
     fiscal_operation_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.operation",

--- a/l10n_br_repair/models/repair_order.py
+++ b/l10n_br_repair/models/repair_order.py
@@ -14,11 +14,11 @@ class RepairOrder(models.Model):
 
     @api.model
     def _default_fiscal_operation(self):
-        return self.env.user.company_id.repair_fiscal_operation_id
+        return self.env.company.repair_fiscal_operation_id
 
     @api.model
     def _default_copy_note(self):
-        return self.env.user.company_id.copy_repair_quotation_notes
+        return self.env.company.copy_repair_quotation_notes
 
     @api.model
     def _fiscal_operation_domain(self):


### PR DESCRIPTION
### Problema:
Anteriormente, o valor da empresa estava sendo obtido de forma incorreta usando `self.env.user.company_id`. Este método retorna a empresa principal cadastrada no usuário, o que pode não ser a empresa ativa no momento. Em um ambiente multi-empresas, isso pode levar a inconsistências.

### Correção:
A mudança proposta substitui `self.env.user.company_id` por `self.env.company`.

`self.env.company`: Retorna a empresa ativa no momento, garantindo que os dados sejam consistentes no contexto atual.

Essa correção assegura que os dados da empresa ativa sejam sempre utilizados, evitando inconsistências em ambientes multi-empresas.