### PR TITLE
[14.0][FIX] l10n_br_purchase: fix purchase order line form button 'save and new'

### DIFF
--- a/l10n_br_purchase/views/purchase_view.xml
+++ b/l10n_br_purchase/views/purchase_view.xml
@@ -131,56 +131,41 @@
                 >{'invisible': ['|', ('parent.fiscal_operation_id', '!=', False), ('display_type', '!=', False)]}</attribute>
               </xpath>
               <xpath
-                expr="//field[@name='order_line']/form/field[@name='name']"
-                position="after"
+                expr="//field[@name='order_line']/form/group/group[3]"
+                position="before"
             >
+                <group colspan="12">
                 <notebook
-                    attrs="{'invisible': ['|', ('parent.fiscal_operation_id', '=', False), ('display_type', '!=', False)]}"
-                >
-                      <page
-                        name="fiscal_taxes"
-                        string="Taxes"
-                        attrs="{'invisible': [('parent.fiscal_operation_id', '=', False)]}"
-                    />
-                      <page
-                        name="fiscal_line_extra_info"
-                        string="Extra Info"
-                        attrs="{'invisible': [('parent.fiscal_operation_id', '=', False)]}"
-                    />
-                      <page
-                        name="others"
-                        string="Outros Custos"
-                        attrs="{'invisible': [('parent.fiscal_operation_id', '=', False)]}"
+                        attrs="{'invisible': ['|', ('parent.fiscal_operation_id', '=', False), ('display_type', '!=', False)]}"
                     >
+                      <page name="fiscal_taxes" string="Taxes" />
+                      <page name="fiscal_line_extra_info" string="Extra Info" />
+                      <page name="others" string="Outros Custos">
                           <group>
                               <field name="delivery_costs" invisible="1" />
                               <field
-                                name="freight_value"
-                                attrs="{'readonly': [('delivery_costs', '=', 'total')]}"
-                            />
+                                    name="freight_value"
+                                    attrs="{'readonly': [('delivery_costs', '=', 'total')]}"
+                                />
                               <field
-                                name="insurance_value"
-                                attrs="{'readonly': [('delivery_costs', '=', 'total')]}"
-                            />
+                                    name="insurance_value"
+                                    attrs="{'readonly': [('delivery_costs', '=', 'total')]}"
+                                />
                               <field
-                                name="other_value"
-                                attrs="{'readonly': [('delivery_costs', '=', 'total')]}"
-                            />
+                                    name="other_value"
+                                    attrs="{'readonly': [('delivery_costs', '=', 'total')]}"
+                                />
                           </group>
                       </page>
-                      <page
-                        name="accounting"
-                        string="Accounting"
-                        attrs="{'invisible': [('parent.fiscal_operation_id', '=', False)]}"
-                    >
+                      <page name="accounting" string="Accounting">
                           <group>
                               <field
-                                name="taxes_id"
-                                widget="many2many_tags"
-                                options="{'no_create': True}"
-                                context="{'search_view_ref': 'account.account_tax_view_search'}"
-                                domain="[('type_tax_use','=','purchase'),('company_id','=',parent.company_id)]"
-                            />
+                                    name="taxes_id"
+                                    widget="many2many_tags"
+                                    options="{'no_create': True}"
+                                    context="{'search_view_ref': 'account.account_tax_view_search'}"
+                                    domain="[('type_tax_use','=','purchase'),('company_id','=',parent.company_id)]"
+                                />
                           </group>
                       </page>
                           <!-- necessario incluir porque o attrs não funciona na tag Page apenas  na Notebook-->
@@ -188,12 +173,13 @@
                               <field name="name" />
                           </page>
                           <page
-                        string="Invoices and Incoming Shipments"
-                        name="invoices_incoming_shiptments"
-                    >
+                            string="Invoices and Incoming Shipments"
+                            name="invoices_incoming_shiptments"
+                        >
                               <field name="invoice_lines" />
                           </page>
-                  </notebook>
+                </notebook>
+                </group>
               </xpath>
               <xpath expr="//field[@name='amount_untaxed']" position="after">
                   <field name="delivery_costs" invisible="1" />


### PR DESCRIPTION
Essa PR visa resolver a Issue #3057 

No formulário da purchase order line, foram adicionados 4 pages (`fiscal_taxes`, `fiscal_line_extra_info`, `others` e `accounting`) ao notebook do formulário através do módulo `l10n_br_purchase`, e é necessário controlar a visibilidade dessas pages para serem exibidas somente quando temos uma Operação Fiscal definida, porém os campos `fiscal_taxes` e `fiscal_line_extra_info` sempre são sobrescritos pelo módulo `l10n_br_fiscal` ([document_fiscal_line_mixin_methods.py#L53](https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py#L53)) não permitindo adicionar o atributo `invisible`. Para isso, através da PR #2759, foi criado um novo notebook ao final do formulário e a visibilidade é controlada nos atributos dos notebooks. Porém no módulo web, ao clicar no botão "Save & New" nos formulários, é feita uma validação do index ativo do notebook ([web/static/src/js/views/form/form_renderer.js#L267](https://github.com/odoo/odoo/blob/14.0/addons/web/static/src/js/views/form/form_renderer.js#L267)), e é nessa validação que o erro reportado na issue é disparado.

Foi identificado que isso está acontecendo pois a validação puxa o primeiro notebook no formulário, por conta disso, movemos o notebook com as pages adicionadas para antes do notebook original, e assim como o original ([purchase/views/purchase_views.xml#L283](https://github.com/odoo/odoo/blob/14.0/addons/purchase/views/purchase_views.xml#L283)), dentro da tag `<group colspan="12"></group>`.

cc: @marcelsavegnago @kaynnan @Matthwhy 
