### PR TITLE
[14.0][FIX] l10n_br_account: validate move on document

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -562,7 +562,7 @@ class AccountMove(models.Model):
                     )
             move.fiscal_document_ids.filtered(
                 lambda d: d.state_edoc != SITUACAO_EDOC_EM_DIGITACAO
-            ).action_document_back2draft()
+            ).document_back2draft()
         return super().button_draft()
 
     def action_document_send(self):

--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -599,7 +599,7 @@ class AccountMove(models.Model):
     def _post(self, soft=True):
         self.mapped("fiscal_document_id").filtered(
             lambda d: d.document_type_id
-        ).action_document_confirm()
+        )._document_confirm_to_send()
         return super()._post(soft=soft)
 
     def view_xml(self):

--- a/l10n_br_account/models/fiscal_document.py
+++ b/l10n_br_account/models/fiscal_document.py
@@ -168,3 +168,9 @@ class FiscalDocument(models.Model):
         msg = "Carta de correção: {}".format(justificative)
         self.message_post(body=msg)
         return result
+
+    def action_document_confirm(self):
+        result = super().action_document_confirm()
+        move_ids = self.move_ids.filtered(lambda move: move.state == "draft")
+        move_ids._post()
+        return result

--- a/l10n_br_account/models/fiscal_document.py
+++ b/l10n_br_account/models/fiscal_document.py
@@ -174,3 +174,9 @@ class FiscalDocument(models.Model):
         move_ids = self.move_ids.filtered(lambda move: move.state == "draft")
         move_ids._post()
         return result
+
+    def action_document_back2draft(self):
+        result = super().action_document_back2draft()
+        if self.move_ids:
+            self.move_ids.button_draft()
+        return result

--- a/l10n_br_account/tests/common.py
+++ b/l10n_br_account/tests/common.py
@@ -25,6 +25,7 @@ class AccountMoveBRCommon(AccountTestInvoicingCommon):
         cls.env.user.groups_id |= cls.env.ref("l10n_br_fiscal.group_manager")
         cls.product_a.write(
             {
+                "default_code": "prod_a",
                 "standard_price": 1000.0,
                 "ncm_id": cls.env.ref("l10n_br_fiscal.ncm_94033000").id,
                 "fiscal_genre_id": cls.env.ref("l10n_br_fiscal.product_genre_94").id,
@@ -64,6 +65,7 @@ class AccountMoveBRCommon(AccountTestInvoicingCommon):
 
         cls.product_b.write(
             {
+                "default_code": "prod_b",
                 "lst_price": 1000.0,
                 "ncm_id": cls.env.ref("l10n_br_fiscal.ncm_94013090").id,
                 "fiscal_genre_id": cls.env.ref("l10n_br_fiscal.product_genre_94").id,

--- a/l10n_br_account/tests/test_account_move_lc.py
+++ b/l10n_br_account/tests/test_account_move_lc.py
@@ -206,8 +206,10 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
     def setup_company_data(cls, company_name, chart_template=None, **kwargs):
         if company_name == "company_1_data":
             company_name = "empresa 1 Lucro Presumido"
+            cnpj = "62.128.834/0001-34"
         else:
             company_name = "empresa 2 Lucro Presumido"
+            cnpj = "87.396.251/0001-15"
         chart_template = cls.env.ref("l10n_br_coa_generic.l10n_br_coa_generic_template")
         res = super().setup_company_data(
             company_name,
@@ -224,6 +226,7 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             **kwargs
         )
         res["company"].partner_id.state_id = cls.env.ref("base.state_br_sp").id
+        res["company"].partner_id.cnpj_cpf = cnpj
         chart_template.load_fiscal_taxes()
         return res
 
@@ -235,7 +238,7 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
 
     def test_venda(self):
         product_line_vals_1 = {
-            "name": self.product_a.name,
+            "name": self.product_a.display_name,
             "product_id": self.product_a.id,
             "account_id": self.product_a.property_account_income_id.id,
             "partner_id": self.partner_a.id,
@@ -410,7 +413,7 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
 
     def test_venda_with_icms_reduction(self):
         product_line_vals_1 = {
-            "name": self.product_a.name,
+            "name": self.product_a.display_name,
             "product_id": self.product_a.id,
             "account_id": self.product_a.property_account_income_id.id,
             "partner_id": self.partner_a.id,
@@ -598,7 +601,7 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
         self.move_out_venda_with_icms_reduction._check_balanced()
 
         product_line_vals_1 = {
-            "name": self.product_a.name,
+            "name": self.product_a.display_name,
             "product_id": self.product_a.id,
             "account_id": self.product_a.property_account_income_id.id,
             "partner_id": self.partner_a.id,
@@ -773,7 +776,7 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
 
     def test_simples_remessa(self):
         product_line_vals_1 = {
-            "name": self.product_a.name,
+            "name": self.product_a.display_name,
             "product_id": self.product_a.id,
             "account_id": self.product_a.property_account_income_id.id,
             "partner_id": self.partner_a.id,
@@ -951,7 +954,7 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
         Test move with deductible taxes
         """
         product_line_vals_1 = {
-            "name": self.product_a.name,
+            "name": self.product_a.display_name,
             "product_id": self.product_a.id,
             "account_id": self.product_a.property_account_expense_id.id,
             "partner_id": self.partner_a.id,
@@ -1229,7 +1232,7 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
     # Tax Withholding Tests
     def test_venda_tax_withholding(self):
         product_line_vals_1 = {
-            "name": self.product_a.name,
+            "name": self.product_a.display_name,
             "product_id": self.product_a.id,
             "account_id": self.product_a.property_account_income_id.id,
             "partner_id": self.partner_a.id,
@@ -1400,7 +1403,7 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
 
     def test_simples_remessa_tax_withholding(self):
         product_line_vals_1 = {
-            "name": self.product_a.name,
+            "name": self.product_a.display_name,
             "product_id": self.product_a.id,
             "account_id": self.product_a.property_account_income_id.id,
             "partner_id": self.partner_a.id,
@@ -1574,7 +1577,7 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
         Test move with deductible taxes and tax withholding
         """
         product_line_vals_1 = {
-            "name": self.product_a.name,
+            "name": self.product_a.display_name,
             "product_id": self.product_a.id,
             "account_id": self.product_a.property_account_expense_id.id,
             "partner_id": self.partner_a.id,
@@ -1863,3 +1866,21 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
         )
         self.assertEqual(len(self.move_in_compra_para_revenda.line_ids), 11)
         self.assertEqual(self.move_in_compra_para_revenda.amount_total, 2100)
+
+    def test_change_states(self):
+        # first we make a few assertions about an existing vendor bill:
+        document_id = self.move_out_venda.fiscal_document_id
+        self.assertEqual(self.move_out_venda.state, "draft")
+        self.assertEqual(document_id.state, "em_digitacao")
+        self.move_out_venda.action_post()
+        self.assertEqual(self.move_out_venda.state, "posted")
+        self.assertEqual(document_id.state, "a_enviar")
+        self.move_out_venda.button_draft()
+        self.assertEqual(self.move_out_venda.state, "draft")
+        self.assertEqual(document_id.state, "em_digitacao")
+        document_id.action_document_confirm()
+        self.assertEqual(self.move_out_venda.state, "posted")
+        self.assertEqual(document_id.state, "a_enviar")
+        document_id.action_document_back2draft()
+        self.assertEqual(self.move_out_venda.state, "draft")
+        self.assertEqual(document_id.state, "em_digitacao")

--- a/l10n_br_account/tests/test_account_move_sn.py
+++ b/l10n_br_account/tests/test_account_move_sn.py
@@ -102,7 +102,7 @@ class AccountMoveSimpleNacional(AccountMoveBRCommon):
 
     def test_revenda(self):
         product_line_vals_1 = {
-            "name": self.product_a.name,
+            "name": self.product_a.display_name,
             "product_id": self.product_a.id,
             "account_id": self.product_a.property_account_income_id.id,
             "partner_id": self.partner_a.id,

--- a/l10n_br_account_withholding/tests/test_account_wh_invoice.py
+++ b/l10n_br_account_withholding/tests/test_account_wh_invoice.py
@@ -85,7 +85,7 @@ class AccountMoveWithWhInvoice(AccountMoveBRCommon):
         Test move with deductible taxes and withholding taxes
         """
         product_line_vals_1 = {
-            "name": self.product_a.name,
+            "name": self.product_a.display_name,
             "product_id": self.product_a.id,
             "account_id": self.product_a.property_account_expense_id.id,
             "partner_id": self.partner_a.id,

--- a/l10n_br_fiscal/models/document_workflow.py
+++ b/l10n_br_fiscal/models/document_workflow.py
@@ -331,13 +331,16 @@ class DocumentWorkflow(models.AbstractModel):
         if to_send:
             to_send._document_send()
 
-    def action_document_back2draft(self):
+    def document_back2draft(self):
         self.xml_error_message = False
         self.file_report_id = False
         if self.issuer == DOCUMENT_ISSUER_COMPANY:
             self._change_state(SITUACAO_EDOC_EM_DIGITACAO)
         else:
             self.state_edoc = SITUACAO_EDOC_EM_DIGITACAO
+
+    def action_document_back2draft(self):
+        self.document_back2draft()
 
     def _document_cancel(self, justificative):
         self.ensure_one()

--- a/l10n_br_fiscal/models/document_workflow.py
+++ b/l10n_br_fiscal/models/document_workflow.py
@@ -305,10 +305,13 @@ class DocumentWorkflow(models.AbstractModel):
         else:
             self._change_state(SITUACAO_EDOC_AUTORIZADA)
 
-    def action_document_confirm(self):
+    def _document_confirm_to_send(self):
         to_confirm = self.filtered(lambda inv: inv.state_edoc != SITUACAO_EDOC_A_ENVIAR)
         if to_confirm:
             to_confirm._document_confirm()
+
+    def action_document_confirm(self):
+        self._document_confirm_to_send()
 
     def _no_eletronic_document_send(self):
         self._change_state(SITUACAO_EDOC_AUTORIZADA)


### PR DESCRIPTION
Um problema semelhante ao corrigido na PR #3090, estou corrigindo a validação do account.move quando se valida pela visualização do l10n_br_fiscal.document. Com a possibilidade de visualizar diretamente o documento depois da PR #2761 , isso acabou ficando quebrado. Logo dou exemplos. 