### PR TITLE
[14.0][l10n_br_fiscal][FIX] selection_add 'product'

### DIFF
--- a/l10n_br_fiscal/models/product_template.py
+++ b/l10n_br_fiscal/models/product_template.py
@@ -22,6 +22,18 @@ class ProductTemplate(models.Model):
         if fiscal_type == PRODUCT_FISCAL_TYPE_SERVICE:
             return self.env.ref(NCM_FOR_SERVICE_REF)
 
+    # Some modules of the repo depend on stock and have
+    # demo products of type 'product' (this type is added to product.template
+    # in the stock module).
+    # For some reason when running the tests, some inverse method fields then fail when
+    # reading 'product' value for the product type. It seems it is because l10n_br_fiscal
+    # doesn't depend on stock. But we don't want such a dependency.
+    # So a workaround to avoid the bug we add the 'product' value to the selection.
+    type = fields.Selection(
+        selection_add=[("product", "Storable Product")],
+        ondelete={"product": "set default"},
+    )
+
     fiscal_type = fields.Selection(
         selection=PRODUCT_FISCAL_TYPE,
         company_dependent=True,


### PR DESCRIPTION
backport do fix que eu eu tinha feito nas v15 e v16: https://github.com/OCA/l10n-brazil/pull/2974

Pois eu tinha visto o bug apenas nas v15 e v16, mas agora eu vi na v14 tambem aqui ao subir um PR pro SPED:
https://github.com/OCA/l10n-brazil/actions/runs/9277353735/job/25526357097?pr=3102#step:8:247

![2024-05-29_00-03](https://github.com/OCA/l10n-brazil/assets/16926/02e41e52-b6f6-40a0-9d2a-b9b78b6feced)


Some modules of the repo depend on stock and have
demo products of type 'product' (this type is added to product.template in the stock module).
For some reason when running the tests, some inverse method fields then fail when reading 'product' value for the product type. It seems it is because l10n_br_fiscal doesn't depend on stock. But we don't want such a dependency.
So to avoid the bug we add the 'product' value to the selection which seems like an acceptable workaround.