### PR TITLE
[14.0][FIX] l10n_br_nfe: remoção do warning inconsistent 'compute_sudo' 

### DIFF
--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -42,10 +42,16 @@ class ResPartner(spec_models.SpecModel):
     # nfe.40.tlocal / nfe.40.enderEmit / 'nfe.40.enderDest
     # TODO: may be not store=True -> then override match
     nfe40_CNPJ = fields.Char(
-        compute="_compute_nfe_data", inverse="_inverse_nfe40_CNPJ", store=True
+        compute="_compute_nfe_data",
+        inverse="_inverse_nfe40_CNPJ",
+        store=True,
+        compute_sudo=True,
     )
     nfe40_CPF = fields.Char(
-        compute="_compute_nfe_data", inverse="_inverse_nfe40_CPF", store=True
+        compute="_compute_nfe_data",
+        inverse="_inverse_nfe40_CPF",
+        store=True,
+        compute_sudo=True,
     )
     nfe40_xLgr = fields.Char(
         readonly=True,
@@ -95,6 +101,7 @@ class ResPartner(spec_models.SpecModel):
         selection=[("nfe40_CNPJ", "CNPJ"), ("nfe40_CPF", "CPF")],
         string="CNPJ/CPF do Emitente",
         compute="_compute_nfe_data",
+        compute_sudo=True,
     )
 
     # nfe.40.tendereco
@@ -138,6 +145,7 @@ class ResPartner(spec_models.SpecModel):
         selection=[("nfe40_CNPJ", "CNPJ"), ("nfe40_CPF", "CPF")],
         string="CNPJ/CPF do Parceiro",
         compute="_compute_nfe_data",
+        compute_sudo=True,
     )
 
     nfe40_choice_dest = fields.Selection(
@@ -156,6 +164,7 @@ class ResPartner(spec_models.SpecModel):
         selection=[("nfe40_CNPJ", "CNPJ"), ("nfe40_CPF", "CPF")],
         string="CNPJ/CPF do Parceiro Autorizado",
         compute="_compute_nfe_data",
+        compute_sudo=True,
     )
 
     # nfe.40.transporta
@@ -166,6 +175,7 @@ class ResPartner(spec_models.SpecModel):
         ],
         string="CNPJ or CPF",
         compute="_compute_nfe_data",
+        compute_sudo=True,
     )
 
     is_anonymous_consumer = fields.Boolean(


### PR DESCRIPTION
Pequena correção para remover o seguinte WARNING:

```python
2024-05-29 18:08:06,760 572 WARNING odoo odoo.modules.registry: 
res.partner: inconsistent 'compute_sudo' for computed fields: 
nfe40_CNPJ, nfe40_CPF, nfe40_choice_emit, nfe40_CEP, nfe40_fone, nfe40_IE, 
nfe40_choice_tlocal, nfe40_choice_dest, nfe40_choice_autxml, nfe40_choice_transporta 
```

O problema ocorre porque alguns campos computados pela função `_compute_nfe_data` possuem a propriedade `compute_sudo=True`, enquanto outros não. Para garantir consistência, todos os campos foram ajustados para `compute_sudo=True`.