### PR TITLE
[14.0][FIX] l10n_br_base: Add missing district to demo companies

### DIFF
--- a/l10n_br_base/demo/res_company_demo.xml
+++ b/l10n_br_base/demo/res_company_demo.xml
@@ -6,6 +6,7 @@
         <field name="legal_name">Sua Empresa Ltda</field>
         <field name="street_name">Avenida Paulista</field>
         <field name="street_number">1</field>
+        <field name="district">Bela Vista</field>
         <field name="city_id" ref="l10n_br_base.city_3550308" />
         <field name="zip">01311-000</field>
         <field name="country_id" ref="base.br" />
@@ -56,6 +57,7 @@
         <field name="company_name">TESTE - Simples Nacional</field>
         <field name="street_name">Rua Paulo Dias</field>
         <field name="street_number">586</field>
+        <field name="district">Vila Santa Luzia</field>
         <field name="city_id" ref="l10n_br_base.city_3501152" />
         <field name="zip">18125-000</field>
         <field name='country_id' ref='base.br' />

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000012062777161.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000012062777161.xml
@@ -30,6 +30,7 @@
             <enderEmit>
                 <xLgr>Rua Paulo Dias</xLgr>
                 <nro>586</nro>
+                <xBairro>Vila Santa Luzia</xBairro>
                 <cMun>3501152</cMun>
                 <xMun>Alumínio</xMun>
                 <UF>SP</UF>


### PR DESCRIPTION
Este PR adiciona a informação do bairro que estava ausente às empresas de demonstração.