### PR TITLE
[14.0][FIX] l10n_br_fiscal: Alterar o valor do tempo limite do serviço ibpt

### DIFF
--- a/l10n_br_fiscal/data/ir_cron.xml
+++ b/l10n_br_fiscal/data/ir_cron.xml
@@ -14,6 +14,10 @@
             <field name="numbercall">-1</field>
             <field name="model_id" ref="model_l10n_br_fiscal_ncm" />
             <field name="code">model._scheduled_update()</field>
+            <field
+            name="nextcall"
+            eval="(DateTime.now()).strftime('%Y-%m-%d 04:00:00')"
+        />
         </record>
 
         <record

--- a/l10n_br_fiscal/models/ibpt.py
+++ b/l10n_br_fiscal/models/ibpt.py
@@ -23,7 +23,7 @@ DeOlhoNoImposto = namedtuple("Config", "token cnpj uf")
 
 def _request(ws_url, params):
     try:
-        response = requests.get(ws_url, params=params, timeout=15)
+        response = requests.get(ws_url, params=params, timeout=30)
         if response.ok:
             data = response.json()
             return namedtuple("Result", [k.lower() for k in data.keys()])(


### PR DESCRIPTION
Hoje essa API tem um tempo de resposta 17s mas podendo variar para 23s e 24s, aumentando para o timeout=30 para corrigir esse warning aqui e também configurando a ação agendada para rodar à noite:

![foto_0_certa2](https://github.com/OCA/l10n-brazil/assets/142639425/4256d428-a476-40c6-b9eb-73ece4cd261e)



![WhatsApp Image 2024-06-06 at 09 30 20 (1)](https://github.com/Engenere/l10n-brazil/assets/142639425/c7760049-cc2b-4cb0-bc78-0236c1a91ca7)
