### PR TITLE
[14.0][CI] avoid suprious coverage changes

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,7 @@
 [run]
 omit =
-    l10n_br_currency_rate_update/tests/test_currency_rate_update_bcb.py
+    l10n_br_currency_rate_update/tests/test_currency_rate_update_bcb.ry
+    l10n_br_currency_rate_update/models/res_currency_rate_provider_bcb.py
     l10n_br_fiscal/tests/test_ibpt_service.py
     l10n_br_fiscal/tests/test_ibpt_product.py
+    l10n_br_fiscal/models/ibpt.py


### PR DESCRIPTION
com esse PR o codecoverage ira deixar de monitorar o coverage 2 arquivos do cliente do IBPT e do cliente do Banco do Brasil. Como esses serviços tem problemas de vez enquando a gente optou por testar com o verdadeiro servidor apenas um certo dia da semana e testar apenas com mock o restante do tempo. Mas isso faz variar levamente o % de coverage desses arquivos e consequentemente deixa PRs validos em vermelhos porque o coverage baixou algo como 0.01%.

Eu acho melhor não monitorar mais o coverage destes 2 arquivos (que tem um coverage OK) e poder confiar se os PR são verdes ou vermelhos.

(exemplo https://app.codecov.io/gh/OCA/l10n-brazil/pull/3110/indirect-changes )