### PR TITLE
[14.0][IMP] l10n_br_account_payment_brcobranca: add Santander cod_desconto

### DIFF
--- a/l10n_br_account_payment_brcobranca/models/account_payment_line.py
+++ b/l10n_br_account_payment_brcobranca/models/account_payment_line.py
@@ -14,14 +14,6 @@ _logger = logging.getLogger(__name__)
 class AccountPaymentLine(models.Model):
     _inherit = "account.payment.line"
 
-    def _prepare_bank_line_ailos(self, payment_mode_id, linhas_pagamentos):
-        if self.discount_value:
-            # Código adotado pela FEBRABAN para identificação do desconto.
-            # Domínio:
-            # 0 = Isento
-            # 1 = Valor Fixo
-            linhas_pagamentos["cod_desconto"] = "1"
-
     def _prepare_bank_line_unicred(self, payment_mode_id, linhas_pagamentos):
         # TODO - Valores padrões ?
         #  Estou preenchendo valores que se forem vazios geram erro
@@ -61,9 +53,6 @@ class AccountPaymentLine(models.Model):
             doc_number = doc_number[start_point : len(self.document_number)]
 
         linhas_pagamentos["numero"] = doc_number
-
-        if self.discount_value:
-            linhas_pagamentos["cod_desconto"] = "1"
 
     def _prepare_bank_line_banco_brasil(self, payment_mode_id, linhas_pagamentos):
         if (
@@ -179,5 +168,12 @@ class AccountPaymentLine(models.Model):
                     linhas_pagamentos[
                         "dias_protesto"
                     ] = payment_mode_id.boleto_days_protest
+
+            # Desconto
+            # Código adotado pela FEBRABAN para identificação do desconto.
+            # Domínio: 0 = Isento | 1 = Valor Fixo
+            if payment_mode_id.payment_method_code == "240":
+                if self.discount_value:
+                    linhas_pagamentos["cod_desconto"] = "1"
 
         return linhas_pagamentos


### PR DESCRIPTION
cc @marcelsavegnago @rvalyi @mbcosta 

Essa PR propõe a inclusão do código de desconto na preparação das linhas do Santander.

Ao definir um percentual de desconto, observei que o arquivo de remessa no Segmento P posição 142 não está retornando o código de desconto conforme esperado, especificamente o código "1". 

Após analisar o modelo em questão, percebi que existe uma condição que deveria atribuir o valor "1" ao código de desconto no arquivo de remessa quando um valor de desconto é especificado:

```
if self.discount_value:
    # Código adotado pela FEBRABAN para identificação do desconto.
    # Domínio:
    # 0 = Isento
    # 1 = Valor Fixo
    linhas_pagamentos["cod_desconto"] = "1"
```

Retorno do Santander referente a ausência do código de desconto:

![image](https://github.com/OCA/l10n-brazil/assets/53870822/c49cfce8-6419-40d0-8e7c-98531d142965)
