### PR TITLE
[16.0][FIX] l10n_br_fiscal: Criado parâmetro para configurar o valor do tempo limite do serviço ibpt

### DIFF
--- a/l10n_br_fiscal/models/data_ncm_nbs_abstract.py
+++ b/l10n_br_fiscal/models/data_ncm_nbs_abstract.py
@@ -9,6 +9,7 @@ from erpbrasil.base import misc
 from lxml import etree
 
 from odoo import _, api, fields, models
+from odoo.tools import config as odooconfig
 
 from .ibpt import DeOlhoNoImposto
 
@@ -90,6 +91,10 @@ class DataNcmNbsAbstract(models.AbstractModel):
                     company.ibpt_token,
                     misc.punctuation_rm(company.cnpj_cpf),
                     company.state_id.code,
+                    odooconfig.get("ibpt_request_timeout")
+                    or self.env["ir.config_parameter"]
+                    .sudo()
+                    .get_param("ibpt_request_timeout"),
                 )
 
                 result = self._get_ibpt(config, record.code_unmasked)

--- a/l10n_br_fiscal/models/ibpt.py
+++ b/l10n_br_fiscal/models/ibpt.py
@@ -18,12 +18,14 @@ WS_IBPT = {
 }
 
 
-DeOlhoNoImposto = namedtuple("Config", "token cnpj uf")
+DeOlhoNoImposto = namedtuple("Config", "token cnpj uf ibpt_request_timeout")
 
 
-def _request(ws_url, params):
+def _request(ws_url, params, ibpt_request_timeout=30):
     try:
-        response = requests.get(ws_url, params=params, timeout=15)
+        response = requests.get(
+            ws_url, params=params, timeout=int(ibpt_request_timeout)
+        )
         if response.ok:
             data = response.json()
             return namedtuple("Result", [k.lower() for k in data.keys()])(
@@ -62,7 +64,7 @@ def get_ibpt_product(
         "gtin": gtin,
     }
 
-    return _request(WS_IBPT[WS_PRODUTOS], data)
+    return _request(WS_IBPT[WS_PRODUTOS], data, config.ibpt_request_timeout)
 
 
 def get_ibpt_service(config, nbs, description="", uom="", amount="0"):
@@ -76,4 +78,4 @@ def get_ibpt_service(config, nbs, description="", uom="", amount="0"):
         "valor": amount,
     }
 
-    return _request(WS_IBPT[WS_SERVICOS], data)
+    return _request(WS_IBPT[WS_SERVICOS], data, config.ibpt_request_timeout)

--- a/l10n_br_fiscal/tests/test_ibpt.py
+++ b/l10n_br_fiscal/tests/test_ibpt.py
@@ -9,6 +9,7 @@ from decorator import decorate
 from erpbrasil.base import misc
 
 from odoo.tests import TransactionCase
+from odoo.tools import config as odooconfig
 
 from odoo.addons.l10n_br_fiscal.models.ibpt import (
     DeOlhoNoImposto,
@@ -109,6 +110,10 @@ class TestIbpt(TransactionCase):
                 company.ibpt_token,
                 misc.punctuation_rm(company.cnpj_cpf),
                 company.state_id.code,
+                odooconfig.get("ibpt_request_timeout")
+                or cls.env["ir.config_parameter"]
+                .sudo()
+                .get_param("ibpt_request_timeout"),
             )
             if ncm_nbs._name == "l10n_br_fiscal.ncm":
                 result = bool(get_ibpt_product(config, ncm_nbs.code_unmasked))


### PR DESCRIPTION
Criado o parâmetro ibpt_request_timeout para configurar o limite do serviço de ibpt. O Parâmetro **ibpt_request_timeout** poderá ser adicionado nas configurações de parâmetros do Odoo(ir.config_parameter) ou no arquivo odoo.conf.

Esta PR é um "git cherry-pick b2a2c2dbd796e14cb72e815410067b58130d94ec" criado apartir da PR #3115 