### PR TITLE
[14.0][IMP][l10n_br_cte_spec] CTe NT2024.002 - Publicado em 08/04/2024 

### DIFF
--- a/l10n_br_cte_spec/models/v4_0/cte_modal_aereo_v4_00.py
+++ b/l10n_br_cte_spec/models/v4_0/cte_modal_aereo_v4_00.py
@@ -30,7 +30,10 @@ NATCARGA_CINFMANU = [
         "06",
         "gelo seco para refrigeração (especificar no campo observações a quantidade)",
     ),
-    ("07", "não restrito (especificar a Disposição Especial no campo observações)"),
+    (
+        "07",
+        "não restrito (especificar a Disposição Especial no campo observações)",
+    ),
     (
         "08",
         "artigo perigoso em carga consolidada (especificar a quantidade no campo observações)",
@@ -39,10 +42,22 @@ NATCARGA_CINFMANU = [
         "09",
         "autorização da autoridade governamental anexa (especificar no campo observações)",
     ),
-    ("10", "baterias de íons de lítio em conformidade com a Seção II da PI965 – CAO"),
-    ("11", "baterias de íons de lítio em conformidade com a Seção II da PI966"),
-    ("12", "baterias de íons de lítio em conformidade com a Seção II da PI967"),
-    ("13", "baterias de metal lítio em conformidade com a Seção II da PI968 — CAO"),
+    (
+        "10",
+        "baterias de íons de lítio em conformidade com a Seção II da PI965 – CAO",
+    ),
+    (
+        "11",
+        "baterias de íons de lítio em conformidade com a Seção II da PI966",
+    ),
+    (
+        "12",
+        "baterias de íons de lítio em conformidade com a Seção II da PI967",
+    ),
+    (
+        "13",
+        "baterias de metal lítio em conformidade com a Seção II da PI968 — CAO",
+    ),
     ("14", "baterias de metal lítio em conformidade com a Seção II da PI969"),
     ("15", "baterias de metal lítio em conformidade com a Seção II da PI970"),
     ("99", "outro (especificar no campo observações)"),
@@ -51,6 +66,7 @@ NATCARGA_CINFMANU = [
 
 class Aereo(models.AbstractModel):
     "Informações do modal Aéreo"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.aereo"
     _inherit = "spec.mixin.cte"
@@ -87,11 +103,15 @@ class Aereo(models.AbstractModel):
     )
 
     cte40_natCarga = fields.Many2one(
-        comodel_name="cte.40.natcarga", string="Natureza da carga", xsd_required=True
+        comodel_name="cte.40.natcarga",
+        string="Natureza da carga",
+        xsd_required=True,
     )
 
     cte40_tarifa = fields.Many2one(
-        comodel_name="cte.40.tarifa", string="Informações de tarifa", xsd_required=True
+        comodel_name="cte.40.tarifa",
+        string="Informações de tarifa",
+        xsd_required=True,
     )
 
     cte40_peri = fields.One2many(
@@ -109,6 +129,7 @@ class Aereo(models.AbstractModel):
 
 class NatCarga(models.AbstractModel):
     "Natureza da carga"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.natcarga"
     _inherit = "spec.mixin.cte"
@@ -126,9 +147,9 @@ class NatCarga(models.AbstractModel):
     )
 
 
-
 class Tarifa(models.AbstractModel):
     "Informações de tarifa"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tarifa"
     _inherit = "spec.mixin.cte"

--- a/l10n_br_cte_spec/models/v4_0/cte_modal_aquaviario_v4_00.py
+++ b/l10n_br_cte_spec/models/v4_0/cte_modal_aquaviario_v4_00.py
@@ -24,6 +24,7 @@ AQUAV_TPNAV = [
 
 class Aquav(models.AbstractModel):
     "Informações do modal Aquaviário"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.aquav"
     _inherit = "spec.mixin.cte"
@@ -45,10 +46,14 @@ class Aquav(models.AbstractModel):
         help=("AFRMM (Adicional de Frete para Renovação da Marinha Mercante)"),
     )
 
-    cte40_xNavio = fields.Char(string="Identificação do Navio", xsd_required=True)
+    cte40_xNavio = fields.Char(
+        string="Identificação do Navio", xsd_required=True
+    )
 
     cte40_balsa = fields.One2many(
-        "cte.40.balsa", "cte40_balsa_aquav_id", string="Grupo de informações das balsas"
+        "cte.40.balsa",
+        "cte40_balsa_aquav_id",
+        string="Grupo de informações das balsas",
     )
 
     cte40_nViag = fields.Char(string="Número da Viagem")
@@ -88,6 +93,7 @@ class Aquav(models.AbstractModel):
 
 class Balsa(models.AbstractModel):
     "Grupo de informações das balsas"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.balsa"
     _inherit = "spec.mixin.cte"
@@ -96,7 +102,9 @@ class Balsa(models.AbstractModel):
     cte40_balsa_aquav_id = fields.Many2one(
         comodel_name="cte.40.aquav", xsd_implicit=True, ondelete="cascade"
     )
-    cte40_xBalsa = fields.Char(string="Identificador da Balsa", xsd_required=True)
+    cte40_xBalsa = fields.Char(
+        string="Identificador da Balsa", xsd_required=True
+    )
 
 
 class DetCont(models.AbstractModel):
@@ -112,14 +120,18 @@ class DetCont(models.AbstractModel):
         comodel_name="cte.40.aquav", xsd_implicit=True, ondelete="cascade"
     )
     cte40_nCont = fields.Char(
-        string="Identificação do Container", xsd_required=True, xsd_type="TContainer"
+        string="Identificação do Container",
+        xsd_required=True,
+        xsd_type="TContainer",
     )
 
     cte40_lacre = fields.One2many(
         "cte.40.lacre",
         "cte40_lacre_detCont_id",
         string="Grupo de informações dos lacres",
-        help=("Grupo de informações dos lacres dos cointainers da qtde da carga"),
+        help=(
+            "Grupo de informações dos lacres dos cointainers da qtde da carga"
+        ),
     )
 
     cte40_infDoc = fields.Many2one(
@@ -131,6 +143,7 @@ class DetCont(models.AbstractModel):
 
 class Lacre(models.AbstractModel):
     "Grupo de informações dos lacres dos cointainers da qtde da carga"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.lacre"
     _inherit = "spec.mixin.cte"
@@ -144,6 +157,7 @@ class Lacre(models.AbstractModel):
 
 class AquavInfDoc(models.AbstractModel):
     "Informações dos documentos dos conteiners"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.aquav_infdoc"
     _inherit = "spec.mixin.cte"
@@ -168,13 +182,16 @@ class AquavInfDoc(models.AbstractModel):
 
 class AquavInfNf(models.AbstractModel):
     "Informações das NF"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.aquav_infnf"
     _inherit = "spec.mixin.cte"
     _binding_type = "Aquav.DetCont.InfDoc.InfNf"
 
     cte40_infNF_infDoc_id = fields.Many2one(
-        comodel_name="cte.40.aquav_infdoc", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.aquav_infdoc",
+        xsd_implicit=True,
+        ondelete="cascade",
     )
     cte40_serie = fields.Char(string="Série", xsd_required=True)
 
@@ -190,13 +207,16 @@ class AquavInfNf(models.AbstractModel):
 
 class AquavInfNfe(models.AbstractModel):
     "Informações das NFe"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.aquav_infnfe"
     _inherit = "spec.mixin.cte"
     _binding_type = "Aquav.DetCont.InfDoc.InfNfe"
 
     cte40_infNFe_infDoc_id = fields.Many2one(
-        comodel_name="cte.40.aquav_infdoc", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.aquav_infdoc",
+        xsd_implicit=True,
+        ondelete="cascade",
     )
     cte40_chave = fields.Char(
         string="Chave de acesso da NF-e", xsd_required=True, xsd_type="TChDFe"

--- a/l10n_br_cte_spec/models/v4_0/cte_modal_dutoviario_v4_00.py
+++ b/l10n_br_cte_spec/models/v4_0/cte_modal_dutoviario_v4_00.py
@@ -10,6 +10,7 @@ __NAMESPACE__ = "http://www.portalfiscal.inf.br/cte"
 
 class Duto(models.AbstractModel):
     "Informações do modal Dutoviário"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.duto"
     _inherit = "spec.mixin.cte"

--- a/l10n_br_cte_spec/models/v4_0/cte_modal_ferroviario_v4_00.py
+++ b/l10n_br_cte_spec/models/v4_0/cte_modal_ferroviario_v4_00.py
@@ -32,6 +32,7 @@ TRAFMUT_RESPFAT = [
 
 class TenderFer(models.AbstractModel):
     "Tipo Dados do Endereço"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tenderfer"
     _inherit = "spec.mixin.cte"
@@ -58,7 +59,10 @@ class TenderFer(models.AbstractModel):
     cte40_xMun = fields.Char(
         string="Nome do município",
         xsd_required=True,
-        help=("Nome do município\nInformar EXTERIOR para operações com o " "exterior."),
+        help=(
+            "Nome do município\nInformar EXTERIOR para operações com o "
+            "exterior."
+        ),
     )
 
     cte40_CEP = fields.Char(string="CEP", xsd_required=True)
@@ -74,6 +78,7 @@ class TenderFer(models.AbstractModel):
 
 class Ferrov(models.AbstractModel):
     "Informações do modal Ferroviário"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.ferrov"
     _inherit = "spec.mixin.cte"
@@ -108,6 +113,7 @@ class Ferrov(models.AbstractModel):
 
 class TrafMut(models.AbstractModel):
     "Detalhamento de informações para o tráfego mútuo"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.trafmut"
     _inherit = "spec.mixin.cte"
@@ -157,6 +163,7 @@ class TrafMut(models.AbstractModel):
 
 class FerroEnv(models.AbstractModel):
     "Informações das Ferrovias Envolvidas"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.ferroenv"
     _inherit = "spec.mixin.cte"

--- a/l10n_br_cte_spec/models/v4_0/cte_modal_rodoviario_os_v4_00.py
+++ b/l10n_br_cte_spec/models/v4_0/cte_modal_rodoviario_os_v4_00.py
@@ -25,6 +25,7 @@ PROP_TPPROP = [
 
 class RodoOs(models.AbstractModel):
     "Informações do modal Rodoviário"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.rodoos"
     _inherit = "spec.mixin.cte"
@@ -53,7 +54,9 @@ class RodoOs(models.AbstractModel):
         ),
     )
 
-    cte40_veic = fields.Many2one(comodel_name="cte.40.veic", string="Dados do Veículo")
+    cte40_veic = fields.Many2one(
+        comodel_name="cte.40.veic", string="Dados do Veículo"
+    )
 
     cte40_infFretamento = fields.Many2one(
         comodel_name="cte.40.inffretamento",
@@ -64,6 +67,7 @@ class RodoOs(models.AbstractModel):
 
 class Veic(models.AbstractModel):
     "Dados do Veículo"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.veic"
     _inherit = "spec.mixin.cte"
@@ -163,6 +167,7 @@ class Prop(models.AbstractModel):
 
 class InfFretamento(models.AbstractModel):
     "Dados do fretamento (apenas para Transporte de Pessoas)"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.inffretamento"
     _inherit = "spec.mixin.cte"

--- a/l10n_br_cte_spec/models/v4_0/cte_modal_rodoviario_v4_00.py
+++ b/l10n_br_cte_spec/models/v4_0/cte_modal_rodoviario_v4_00.py
@@ -12,6 +12,7 @@ __NAMESPACE__ = "http://www.portalfiscal.inf.br/cte"
 
 class Rodo(models.AbstractModel):
     "Informações do modal Rodoviário"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.rodo"
     _inherit = "spec.mixin.cte"
@@ -35,6 +36,7 @@ class Rodo(models.AbstractModel):
 
 class Occ(models.AbstractModel):
     "Ordens de Coleta associados"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.occ"
     _inherit = "spec.mixin.cte"
@@ -45,7 +47,9 @@ class Occ(models.AbstractModel):
     )
     cte40_serie = fields.Char(string="Série da OCC")
 
-    cte40_nOcc = fields.Char(string="Número da Ordem de coleta", xsd_required=True)
+    cte40_nOcc = fields.Char(
+        string="Número da Ordem de coleta", xsd_required=True
+    )
 
     cte40_dEmi = fields.Date(
         string="Data de emissão da ordem de coleta",

--- a/l10n_br_cte_spec/models/v4_0/cte_multi_modal_v4_00.py
+++ b/l10n_br_cte_spec/models/v4_0/cte_multi_modal_v4_00.py
@@ -16,6 +16,7 @@ MULTIMODAL_INDNEGOCIAVEL = [
 
 class Multimodal(models.AbstractModel):
     "Informações do Multimodal"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.multimodal"
     _inherit = "spec.mixin.cte"
@@ -32,7 +33,8 @@ class Multimodal(models.AbstractModel):
         string="Indicador Negociável",
         xsd_required=True,
         help=(
-            "Indicador Negociável\nPreencher com: 0 - Não Negociável; 1 - " "Negociável"
+            "Indicador Negociável\nPreencher com: 0 - Não Negociável; 1 - "
+            "Negociável"
         ),
     )
 
@@ -44,6 +46,7 @@ class Multimodal(models.AbstractModel):
 
 class MultimodalSeg(models.AbstractModel):
     "Informações de Seguro do Multimodal"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.multimodal_seg"
     _inherit = "spec.mixin.cte"
@@ -73,6 +76,7 @@ class MultimodalSeg(models.AbstractModel):
 
 class InfSeg(models.AbstractModel):
     "Informações da seguradora"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.infseg"
     _inherit = "spec.mixin.cte"

--- a/l10n_br_cte_spec/models/v4_0/cte_tipos_basico_v4_00.py
+++ b/l10n_br_cte_spec/models/v4_0/cte_tipos_basico_v4_00.py
@@ -100,6 +100,12 @@ TFINCTE = [
     ("3", "3"),
 ]
 
+"Tipos Finalidade de CT-e Simplificado"
+TFINCTESIMP = [
+    ("4", "4"),
+    ("5", "5"),
+]
+
 "Tipo Finalidade da GTV-e"
 TFINGTVE = [
     ("4", "4"),
@@ -111,6 +117,13 @@ TMODTRANSPOS = [
     ("02", "02"),
     ("03", "03"),
     ("04", "04"),
+]
+
+"Tipo Modal transporte do CTe Simplificado"
+TMODTRANSPSIMP = [
+    ("01", "01"),
+    ("02", "02"),
+    ("03", "03"),
 ]
 
 "Tipo processo de emissão do CT-e"
@@ -183,6 +196,13 @@ INFCTESUB_INDALTERATOMA = [
     ("1", "1"),
 ]
 
+"""indica se a prestação é total ou parcial em relação as notas do
+    documento anterior"""
+INFDOCANT_TPPREST = [
+    ("1", "Total"),
+    ("2", "Parcial"),
+]
+
 "Tipo da Espécie"
 INFESPECIE_TPESPECIE = [
     ("1", "Numerário"),
@@ -214,6 +234,27 @@ INFQ_CUNID = [
     ("03", "UNIDADE"),
     ("04", "LITROS"),
     ("05", "MMBTU"),
+]
+
+"Tipo da Medida"
+INFQ_TPMED = [
+    ("00", "Cubagem da NF-e"),
+    ("01", "Cubagem Aferida pelo Transportador"),
+    ("02", "Peso Bruto da NF-e"),
+    ("03", "Peso Bruto Aferido pelo Transportador"),
+    ("04", "Peso Cubado"),
+    ("05", "Peso Base do Cálculo do Frete"),
+    ("06", "Peso para uso Operacional"),
+    ("07", "Caixas"),
+    ("08", "Paletes"),
+    ("09", "Sacas"),
+    ("10", "Containers"),
+    ("11", "Rolos"),
+    ("12", "Bombonas"),
+    ("13", "Latas"),
+    ("14", "Litragem"),
+    ("15", "Milhão de BTU (British Thermal Units)"),
+    ("99", "Outros"),
 ]
 
 "Tipo de hora"
@@ -260,10 +301,17 @@ TOMATERCEIRO_TOMA = [
     ("4", "Outros"),
 ]
 
+"Indicador do papel do tomador na prestação do serviço"
+TOMA_INDIETOMA = [
+    ("1", "Contribuinte ICMS"),
+    ("2", "Contribuinte isento de inscrição"),
+    ("9", "Não Contribuinte"),
+]
+
 "Tomador do Serviço"
 TOMA_TOMA = [
     ("0", "Remetente"),
-    ("1", "Destinatário"),
+    ("1", "Expedidor"),
 ]
 
 
@@ -935,6 +983,11 @@ class TunidCarga(models.AbstractModel):
     _inherit = "spec.mixin.cte"
     _binding_type = "TunidCarga"
 
+    cte40_infUnidCarga_infNFe_id = fields.Many2one(
+        comodel_name="cte.40.tctesimp_infnfe",
+        xsd_implicit=True,
+        ondelete="cascade",
+    )
     cte40_infUnidCarga_infNF_id = fields.Many2one(
         comodel_name="cte.40.tcte_infnf", xsd_implicit=True, ondelete="cascade"
     )
@@ -1065,6 +1118,7 @@ class TcteOsInfCte(models.AbstractModel):
         comodel_name="cte.40.tcteos_vprest",
         string="Valores da Prestação de Serviço",
         xsd_required=True,
+        xsd_type="TDec_1302",
     )
 
     cte40_imp = fields.Many2one(
@@ -1202,8 +1256,8 @@ class TcteOsIde(models.AbstractModel):
         string="Forma de emissão do CT-e",
         xsd_required=True,
         help=(
-            "Forma de emissão do CT-e\nPreencher com:\n 1 - Normal;\n 5 - "
-            "Contingência FSDA;\n 7 - Autorização pela SVC-RS;\n 8 - "
+            "Forma de emissão do CT-e\nPreencher com:\n1 - Normal;\n 5 - "
+            "Contingência FSDA;\n7 - Autorização pela SVC-RS;\n 8 - "
             "Autorização pela SVC-SP"
         ),
     )
@@ -1617,11 +1671,12 @@ class TcteOsToma(models.AbstractModel):
         xsd_type="TEndereco",
     )
 
-    cte40_email = fields.Char(string="Endereço de email")
+    cte40_email = fields.Char(string="Endereço de email", xsd_type="TEmail")
 
 
 class TcteOsVPrest(models.AbstractModel):
-    "Valores da Prestação de Serviço"
+    """Valorl da Prestação do Serviço
+    Pode conter zeros quando o CT-e for de complemento de ICMS"""
 
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcteos_vprest"
@@ -3127,6 +3182,61 @@ class TretCteOs(models.AbstractModel):
     )
 
 
+class TretCteSimp(models.AbstractModel):
+    """Tipo Retorno do Pedido de Autorização de CT-e Simplificado (Modelo
+    57)"""
+
+    _description = textwrap.dedent("    %s" % (__doc__,))
+    _name = "cte.40.tretctesimp"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TretCteSimp"
+
+    cte40_tpAmb = fields.Selection(
+        TAMB,
+        string="Identificação do Ambiente",
+        xsd_required=True,
+        xsd_type="TAmb",
+        help="Identificação do Ambiente:\n1 - Produção\n2 - Homologação",
+    )
+
+    cte40_cUF = fields.Selection(
+        TCODUFIBGE,
+        string="Identificação da UF",
+        xsd_required=True,
+        xsd_type="TCodUfIBGE",
+    )
+
+    cte40_verAplic = fields.Char(
+        string="Versão do Aplicativo que processou",
+        xsd_required=True,
+        xsd_type="TVerAplic",
+        help="Versão do Aplicativo que processou a CT-e",
+    )
+
+    cte40_cStat = fields.Char(
+        string="código do status do retorno da consulta",
+        xsd_required=True,
+        xsd_type="TStat",
+    )
+
+    cte40_xMotivo = fields.Char(
+        string="Descrição literal do status",
+        xsd_required=True,
+        xsd_type="TMotivo",
+        help="Descrição literal do status do do retorno da consulta.",
+    )
+
+    cte40_protCTe = fields.Many2one(
+        comodel_name="cte.40.tprotcte",
+        string="Reposta ao processamento do CT-e",
+        xsd_type="TProtCTe",
+    )
+
+    cte40_versao = fields.Char(
+        string="versao", xsd_required=True, xsd_type="TVerCTe"
+    )
+
+
 class TretGtve(models.AbstractModel):
     "Tipo Retorno do Pedido de Autorização de GTV-e (Modelo 64)"
 
@@ -3189,6 +3299,11 @@ class TunidadeTransp(models.AbstractModel):
     _inherit = "spec.mixin.cte"
     _binding_type = "TunidadeTransp"
 
+    cte40_infUnidTransp_infNFe_id = fields.Many2one(
+        comodel_name="cte.40.tctesimp_infnfe",
+        xsd_implicit=True,
+        ondelete="cascade",
+    )
     cte40_infUnidTransp_infNF_id = fields.Many2one(
         comodel_name="cte.40.tcte_infnf", xsd_implicit=True, ondelete="cascade"
     )
@@ -3348,6 +3463,7 @@ class TcteInfCte(models.AbstractModel):
         comodel_name="cte.40.tcte_vprest",
         string="Valores da Prestação de Serviço",
         xsd_required=True,
+        xsd_type="TDec_1302",
     )
 
     cte40_imp = fields.Many2one(
@@ -3614,9 +3730,9 @@ class TcteIde(models.AbstractModel):
         string="Tipo do Serviço",
         xsd_required=True,
         help=(
-            "Tipo do Serviço\nPreencher com: \n0 - Normal;1 - "
-            "Subcontratação;\n2 - Redespacho;3 - Redespacho Intermediário; 4 -"
-            " Serviço Vinculado a Multimodal"
+            "Tipo do Serviço\nPreencher com: \n0 - Normal;\n1 - "
+            "Subcontratação;\n2 - Redespacho;\n3 - Redespacho Intermediário; "
+            "\n4 - Serviço Vinculado a Multimodal"
         ),
     )
 
@@ -3851,7 +3967,7 @@ class TcteCompl(models.AbstractModel):
     cte40_xEmi = fields.Char(string="Funcionário emissor do CTe")
 
     cte40_fluxo = fields.Many2one(
-        comodel_name="cte.40.fluxo",
+        comodel_name="cte.40.tcte_fluxo",
         string="Previsão do fluxo da carga",
         help=(
             "Previsão do fluxo da carga\nPreenchimento obrigatório para o "
@@ -3898,12 +4014,12 @@ class TcteCompl(models.AbstractModel):
     )
 
 
-class Fluxo(models.AbstractModel):
+class TcteFluxo(models.AbstractModel):
     """Previsão do fluxo da carga
     Preenchimento obrigatório para o modal aéreo."""
 
     _description = textwrap.dedent("    %s" % (__doc__,))
-    _name = "cte.40.fluxo"
+    _name = "cte.40.tcte_fluxo"
     _inherit = "spec.mixin.cte"
     _binding_type = "Tcte.InfCte.Compl.Fluxo"
 
@@ -3921,7 +4037,7 @@ class Fluxo(models.AbstractModel):
     )
 
     cte40_pass = fields.One2many(
-        "cte.40.pass", "cte40_pass_fluxo_id", string="pass"
+        "cte.40.tcte_pass", "cte40_pass_fluxo_id", string="pass"
     )
 
     cte40_xDest = fields.Char(
@@ -3939,14 +4055,14 @@ class Fluxo(models.AbstractModel):
     cte40_xRota = fields.Char(string="Código da Rota de Entrega")
 
 
-class Pass(models.AbstractModel):
+class TctePass(models.AbstractModel):
     _description = "pass"
-    _name = "cte.40.pass"
+    _name = "cte.40.tcte_pass"
     _inherit = "spec.mixin.cte"
     _binding_type = "Tcte.InfCte.Compl.Fluxo.Pass"
 
     cte40_pass_fluxo_id = fields.Many2one(
-        comodel_name="cte.40.fluxo", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcte_fluxo", xsd_implicit=True, ondelete="cascade"
     )
     cte40_xPass = fields.Char(
         string="Sigla ou código interno",
@@ -4505,7 +4621,8 @@ class TcteDest(models.AbstractModel):
 
 
 class TcteVPrest(models.AbstractModel):
-    "Valores da Prestação de Serviço"
+    """Valorl da Prestação do Serviço
+    Pode conter zeros quando o CT-e for de complemento de ICMS"""
 
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcte_vprest"
@@ -4706,7 +4823,7 @@ class TcteInfCteNorm(models.AbstractModel):
     _binding_type = "Tcte.InfCte.InfCteNorm"
 
     cte40_infCarga = fields.Many2one(
-        comodel_name="cte.40.infcarga",
+        comodel_name="cte.40.tcte_infcarga",
         string="Informações da Carga do CT-e",
         xsd_required=True,
     )
@@ -4761,11 +4878,11 @@ class TcteInfCteNorm(models.AbstractModel):
     )
 
 
-class InfCarga(models.AbstractModel):
+class TcteInfCarga(models.AbstractModel):
     "Informações da Carga do CT-e"
 
     _description = textwrap.dedent("    %s" % (__doc__,))
-    _name = "cte.40.infcarga"
+    _name = "cte.40.tcte_infcarga"
     _inherit = "spec.mixin.cte"
     _binding_type = "Tcte.InfCte.InfCteNorm.InfCarga"
 
@@ -4841,7 +4958,9 @@ class TcteInfQ(models.AbstractModel):
     _binding_type = "Tcte.InfCte.InfCteNorm.InfCarga.InfQ"
 
     cte40_infQ_infCarga_id = fields.Many2one(
-        comodel_name="cte.40.infcarga", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcte_infcarga",
+        xsd_implicit=True,
+        ondelete="cascade",
     )
     cte40_cUnid = fields.Selection(
         INFQ_CUNID,
@@ -5590,6 +5709,1334 @@ class TcteInfCteSupl(models.AbstractModel):
     _name = "cte.40.tcte_infctesupl"
     _inherit = "spec.mixin.cte"
     _binding_type = "Tcte.InfCteSupl"
+
+    cte40_qrCodCTe = fields.Char(
+        string="Texto com o QR-Code impresso no DACTE", xsd_required=True
+    )
+
+
+class TcteSimp(models.AbstractModel):
+    """Tipo Conhecimento de Transporte Eletrônico (Modelo 57) - Modelo
+    Simplificado"""
+
+    _description = textwrap.dedent("    %s" % (__doc__,))
+    _name = "cte.40.tctesimp"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TcteSimp"
+
+    cte40_infCte = fields.Many2one(
+        comodel_name="cte.40.tctesimp_infcte",
+        string="Informações do CT-e",
+        xsd_required=True,
+    )
+
+    cte40_infCTeSupl = fields.Many2one(
+        comodel_name="cte.40.tctesimp_infctesupl",
+        string="Informações suplementares do CT-e",
+    )
+
+
+class TcteSimpInfCte(models.AbstractModel):
+    "Informações do CT-e do tipo GTV-e"
+
+    _description = textwrap.dedent("    %s" % (__doc__,))
+    _name = "cte.40.tctesimp_infcte"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TcteSimp.InfCte"
+
+    cte40_ide = fields.Many2one(
+        comodel_name="cte.40.tctesimp_ide",
+        string="Identificação do CT-e",
+        xsd_required=True,
+    )
+
+    cte40_compl = fields.Many2one(
+        comodel_name="cte.40.tctesimp_compl",
+        string="Dados complementares do CT-e",
+        help=(
+            "Dados complementares do CT-e para fins operacionais ou comerciais"
+        ),
+    )
+
+    cte40_emit = fields.Many2one(
+        comodel_name="cte.40.tctesimp_emit",
+        string="Identificação do Emitente do CT-e",
+        xsd_required=True,
+    )
+
+    cte40_toma = fields.Many2one(
+        comodel_name="cte.40.tctesimp_toma",
+        string="Identificação do tomador do serviço",
+        xsd_required=True,
+        choice="infcte",
+        xsd_choice_required=True,
+        help="Identificação do tomador do serviço no CT-e",
+    )
+
+    cte40_infCarga = fields.Many2one(
+        comodel_name="cte.40.tctesimp_infcarga",
+        string="Informações da Carga do CT-e",
+        xsd_required=True,
+    )
+
+    cte40_det = fields.One2many(
+        "cte.40.det",
+        "cte40_det_infCte_id",
+        string="Detalhamento das entregas / prestações",
+        help="Detalhamento das entregas / prestações do CTe Simplificado",
+    )
+
+    cte40_infModal = fields.Many2one(
+        comodel_name="cte.40.tctesimp_infmodal",
+        string="Informações do modal",
+        xsd_required=True,
+    )
+
+    cte40_cobr = fields.Many2one(
+        comodel_name="cte.40.tctesimp_cobr", string="Dados da cobrança do CT-e"
+    )
+
+    cte40_infCteSub = fields.Many2one(
+        comodel_name="cte.40.tctesimp_infctesub",
+        string="Informações do CT-e de substituição",
+    )
+
+    cte40_imp = fields.Many2one(
+        comodel_name="cte.40.tctesimp_imp",
+        string="Informações relativas aos Impostos",
+        xsd_required=True,
+    )
+
+    cte40_total = fields.Many2one(
+        comodel_name="cte.40.total",
+        string="Valores Totais do CTe",
+        xsd_required=True,
+    )
+
+    cte40_autXML = fields.One2many(
+        "cte.40.tctesimp_autxml",
+        "cte40_autXML_infCte_id",
+        string="Autorizados para download do XML do DF-e",
+        help=(
+            "Autorizados para download do XML do DF-e\nInformar CNPJ ou CPF. "
+            "Preencher os zeros não significativos."
+        ),
+    )
+
+    cte40_infRespTec = fields.Many2one(
+        comodel_name="cte.40.tresptec",
+        string="Informações do Responsável Técnico",
+        xsd_type="TRespTec",
+        help="Informações do Responsável Técnico pela emissão do DF-e",
+    )
+
+    cte40_infSolicNFF = fields.Many2one(
+        comodel_name="cte.40.tctesimp_infsolicnff",
+        string="Grupo de informações do pedido",
+        help=(
+            "Grupo de informações do pedido de emissão da Nota Fiscal Fácil"
+        ),
+    )
+
+    cte40_infPAA = fields.Many2one(
+        comodel_name="cte.40.tctesimp_infpaa",
+        string="Grupo de Informação do Provedor",
+        help="Grupo de Informação do Provedor de Assinatura e Autorização",
+    )
+
+    cte40_versao = fields.Char(
+        string="Versão do leiaute",
+        xsd_required=True,
+        help="Versão do leiaute\nEx: '4.00'",
+    )
+
+    cte40_Id = fields.Char(
+        string="Identificador da tag a ser assinada",
+        xsd_required=True,
+        help=(
+            "Identificador da tag a ser assinada\nInformar a chave de acesso "
+            "do CT-e e precedida do literal 'CTe'"
+        ),
+    )
+
+
+class TcteSimpIde(models.AbstractModel):
+    "Identificação da GTV-e"
+
+    _description = textwrap.dedent("    %s" % (__doc__,))
+    _name = "cte.40.tctesimp_ide"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TcteSimp.InfCte.Ide"
+
+    cte40_cUF = fields.Selection(
+        TCODUFIBGE,
+        string="Código da UF do emitente do CT-e",
+        xsd_required=True,
+        xsd_type="TCodUfIBGE",
+        help=("Código da UF do emitente do CT-e.\nUtilizar a Tabela do IBGE."),
+    )
+
+    cte40_cCT = fields.Char(
+        string="Código numérico que compõe a Chave",
+        xsd_required=True,
+        help=(
+            "Código numérico que compõe a Chave de Acesso.\nNúmero aleatório "
+            "gerado pelo emitente para cada CT-e, com o objetivo de evitar "
+            "acessos indevidos ao documento."
+        ),
+    )
+
+    cte40_CFOP = fields.Char(
+        string="Código Fiscal de Operações e Prestações",
+        xsd_required=True,
+        xsd_type="TCfop",
+    )
+
+    cte40_natOp = fields.Char(string="Natureza da Operação", xsd_required=True)
+
+    cte40_mod = fields.Selection(
+        TMODCT,
+        string="Modelo do documento fiscal",
+        xsd_required=True,
+        xsd_type="TModGTVe",
+        help=(
+            "Modelo do documento fiscal\nUtilizar o código 57 para "
+            "identificação do CT-e, emitido em substituição aos modelos de "
+            "conhecimentos em papel."
+        ),
+    )
+
+    cte40_serie = fields.Char(
+        string="Série do CT-e",
+        xsd_required=True,
+        help="Série do CT-e\nPreencher com '0' no caso de série única",
+    )
+
+    cte40_nCT = fields.Char(
+        string="Número do CT-e", xsd_required=True, xsd_type="TNF"
+    )
+
+    cte40_dhEmi = fields.Char(
+        string="Data e hora de emissão do CT-e",
+        xsd_required=True,
+        help=(
+            "Data e hora de emissão do CT-e\nFormato AAAA-MM-DDTHH:MM:DD TZD"
+        ),
+    )
+
+    cte40_tpImp = fields.Selection(
+        IDE_TPIMP,
+        string="Formato de impressão do DACTE",
+        xsd_required=True,
+        help=(
+            "Formato de impressão do DACTE\nPreencher com: 1 - Retrato; 2 - "
+            "Paisagem."
+        ),
+    )
+
+    cte40_tpEmis = fields.Selection(
+        IDE_TPEMIS,
+        string="Forma de emissão do CT-e",
+        xsd_required=True,
+        help=(
+            "Forma de emissão do CT-e\nPreencher com:\n1 - Normal;\n3 - Regime"
+            " Especial NFF;  \n4 - EPEC pela SVC; \n7 - Autorização pela SVC-"
+            "RS;\n8 - Autorização pela SVC-SP"
+        ),
+    )
+
+    cte40_cDV = fields.Char(
+        string="Digito Verificador da chave de acesso",
+        xsd_required=True,
+        help=(
+            "Digito Verificador da chave de acesso do CT-e\nInformar o dígito"
+            "  de controle da chave de acesso do CT-e, que deve ser calculado "
+            "com a aplicação do algoritmo módulo 11 (base 2,9) da chave de "
+            "acesso."
+        ),
+    )
+
+    cte40_tpAmb = fields.Selection(
+        TAMB,
+        string="Tipo do Ambiente",
+        xsd_required=True,
+        xsd_type="TAmb",
+        help=(
+            "Tipo do Ambiente\nPreencher com:1 - Produção; 2 - Homologação."
+        ),
+    )
+
+    cte40_tpCTe = fields.Selection(
+        TFINCTESIMP,
+        string="Tipo do CT-e Simplificado",
+        xsd_required=True,
+        help=(
+            "Tipo do CT-e Simplificado\nPreencher com:\n4 - CTe "
+            "Simplificado\n5 - Substituição CTe Simplificado"
+        ),
+    )
+
+    cte40_procEmi = fields.Selection(
+        TPROCEMI,
+        string="Identificador do processo de emissão",
+        xsd_required=True,
+        xsd_type="TProcEmi",
+        help=(
+            "Identificador do processo de emissão do CT-e\nPreencher com: "
+            "\n\t\t\t\t\t\t\t\t\t\t\t0 - emissão de CT-e com aplicativo do "
+            "contribuinte;\n\t\t\t\t\t\t\t\t\t\t\t3- emissão CT-e pelo "
+            "contribuinte com aplicativo fornecido pelo SEBRAE."
+        ),
+    )
+
+    cte40_verProc = fields.Char(
+        string="Versão do processo de emissão",
+        xsd_required=True,
+        help=(
+            "Versão do processo de emissão\nInformar a versão do aplicativo "
+            "emissor de CT-e."
+        ),
+    )
+
+    cte40_cMunEnv = fields.Char(
+        string="Código do Município de envio do CT-e",
+        xsd_required=True,
+        xsd_type="TCodMunIBGE",
+        help=(
+            "Código do Município de envio do CT-e (de onde o documento foi "
+            "transmitido)\nUtilizar a tabela do IBGE. Informar 9999999 para as"
+            " operações com o exterior."
+        ),
+    )
+
+    cte40_xMunEnv = fields.Char(
+        string="Nome do Município de envio do CT-e",
+        xsd_required=True,
+        help=(
+            "Nome do Município de envio do CT-e (de onde o documento foi "
+            "transmitido)\nInformar PAIS/Municipio para as operações com o "
+            "exterior."
+        ),
+    )
+
+    cte40_UFEnv = fields.Selection(
+        TUF,
+        string="Sigla da UF de envio do CT-e",
+        xsd_required=True,
+        xsd_type="TUf",
+        help=(
+            "Sigla da UF de envio do CT-e (de onde o documento foi "
+            "transmitido)\nInformar 'EX' para operações com o exterior."
+        ),
+    )
+
+    cte40_modal = fields.Selection(
+        TMODTRANSPSIMP,
+        string="Modal",
+        xsd_required=True,
+        help=("Modal\nPreencher com:\n01-Rodoviário\n02-Aéreo\n03-Aquaviário"),
+    )
+
+    cte40_tpServ = fields.Selection(
+        IDE_TPSERV,
+        string="Tipo do Serviço",
+        xsd_required=True,
+        help=(
+            "Tipo do Serviço\nPreencher com: \n0 - Normal;\n1 - "
+            "Subcontratação;\n2 - Redespacho;"
+        ),
+    )
+
+    cte40_UFIni = fields.Selection(
+        TUF,
+        string="UF do início da prestação",
+        xsd_required=True,
+        xsd_type="TUf",
+        help=(
+            "UF do início da prestação\nInformar 'EX' para operações com o "
+            "exterior."
+        ),
+    )
+
+    cte40_UFFim = fields.Selection(
+        TUF,
+        string="UF do término da prestação",
+        xsd_required=True,
+        xsd_type="TUf",
+        help=(
+            "UF do término da prestação\nInformar 'EX' para operações com o "
+            "exterior."
+        ),
+    )
+
+    cte40_retira = fields.Selection(
+        IDE_RETIRA,
+        string="Indicador se o Recebedor retira",
+        xsd_required=True,
+        help=(
+            "Indicador se o Recebedor retira no Aeroporto, Filial, Porto ou "
+            "Estação de Destino?\nPreencher com: 0 - sim; 1 - não"
+        ),
+    )
+
+    cte40_xDetRetira = fields.Char(string="Detalhes do retira")
+
+    cte40_dhCont = fields.Datetime(
+        string="Data e Hora da entrada em contingência",
+        xsd_type="TDateTimeUTC",
+        help=(
+            "Data e Hora da entrada em contingência\nInformar a data e hora no"
+            " formato AAAA-MM-DDTHH:MM:SS"
+        ),
+    )
+
+    cte40_xJust = fields.Char(
+        string="Justificativa da entrada em contingência"
+    )
+
+
+class TcteSimpCompl(models.AbstractModel):
+    "Dados complementares da GTV-e para fins operacionais ou comerciais"
+
+    _description = textwrap.dedent("    %s" % (__doc__,))
+    _name = "cte.40.tctesimp_compl"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TcteSimp.InfCte.Compl"
+
+    cte40_xCaracAd = fields.Char(
+        string="Característica adicional do transporte",
+        help=(
+            "Característica adicional do transporte\nTexto livre:\nREENTREGA; "
+            "DEVOLUÇÃO; REFATURAMENTO; etc"
+        ),
+    )
+
+    cte40_xCaracSer = fields.Char(
+        string="Característica adicional do serviço",
+        help=(
+            "Característica adicional do serviço\nTexto "
+            "livre:\n\t\t\t\t\t\t\t\t\t\t\tENTREGA EXPRESSA; LOGÍSTICA "
+            "REVERSA; CONVENCIONAL; EMERGENCIAL; etc"
+        ),
+    )
+
+    cte40_fluxo = fields.Many2one(
+        comodel_name="cte.40.tctesimp_fluxo",
+        string="Previsão do fluxo da carga",
+        help=(
+            "Previsão do fluxo da carga\nPreenchimento obrigatório para o "
+            "modal aéreo."
+        ),
+    )
+
+    cte40_xObs = fields.Char(string="Observações Gerais")
+
+    cte40_obsCont = fields.One2many(
+        "cte.40.tctesimp_obscont",
+        "cte40_ObsCont_compl_id",
+        string="Campo de uso livre do contribuinte",
+        help=(
+            "Campo de uso livre do contribuinte\nInformar o nome do campo no "
+            "atributo xCampo e o conteúdo do campo no XTexto"
+        ),
+    )
+
+    cte40_obsFisco = fields.One2many(
+        "cte.40.tctesimp_obsfisco",
+        "cte40_ObsFisco_compl_id",
+        string="ObsFisco",
+        help=(
+            "Campo de uso livre do contribuinte\nInformar o nome do campo no "
+            "atributo xCampo e o conteúdo do campo no XTexto"
+        ),
+    )
+
+
+class TcteSimpFluxo(models.AbstractModel):
+    """Previsão do fluxo da carga
+    Preenchimento obrigatório para o modal aéreo."""
+
+    _description = textwrap.dedent("    %s" % (__doc__,))
+    _name = "cte.40.tctesimp_fluxo"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TcteSimp.InfCte.Compl.Fluxo"
+
+    cte40_xOrig = fields.Char(
+        string="Sigla ou código interno",
+        help=(
+            "Sigla ou código interno da Filial/Porto/Estação/ Aeroporto de "
+            "Origem\nObservações para o modal "
+            "aéreo:\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t- Preenchimento obrigatório "
+            "para o modal aéreo.\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t- O código de "
+            "três letras IATA do aeroporto de partida deverá ser incluído como"
+            " primeira anotação. Quando não for possível, utilizar a sigla "
+            "OACI."
+        ),
+    )
+
+    cte40_pass = fields.One2many(
+        "cte.40.tctesimp_pass", "cte40_pass_fluxo_id", string="pass"
+    )
+
+    cte40_xDest = fields.Char(
+        string="Sigla ou código interno (xDest)",
+        help=(
+            "Sigla ou código interno da Filial/Porto/Estação/Aeroporto de "
+            "Destino\nObservações para o modal "
+            "aéreo:\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t- Preenchimento obrigatório "
+            "para o modal aéreo.\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t- Deverá ser "
+            "incluído o código de três letras IATA do aeroporto de destino. "
+            "Quando não for possível, utilizar a sigla OACI."
+        ),
+    )
+
+    cte40_xRota = fields.Char(string="Código da Rota de Entrega")
+
+
+class TcteSimpPass(models.AbstractModel):
+    _description = "pass"
+    _name = "cte.40.tctesimp_pass"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TcteSimp.InfCte.Compl.Fluxo.Pass"
+
+    cte40_pass_fluxo_id = fields.Many2one(
+        comodel_name="cte.40.tctesimp_fluxo",
+        xsd_implicit=True,
+        ondelete="cascade",
+    )
+    cte40_xPass = fields.Char(
+        string="Sigla ou código interno",
+        help=(
+            "Sigla ou código interno da Filial/Porto/Estação/Aeroporto de "
+            "Passagem\nObservação para o modal "
+            "aéreo:\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t- O código de três "
+            "letras IATA, referente ao aeroporto de transferência, deverá ser "
+            "incluído, quando for o caso. Quando não for possível,  utilizar a"
+            " sigla OACI. Qualquer solicitação de itinerário deverá ser "
+            "incluída."
+        ),
+    )
+
+
+class TcteSimpObsCont(models.AbstractModel):
+    """Campo de uso livre do contribuinte
+    Informar o nome do campo no atributo xCampo e o conteúdo do campo no XTexto"""
+
+    _description = textwrap.dedent("    %s" % (__doc__,))
+    _name = "cte.40.tctesimp_obscont"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TcteSimp.InfCte.Compl.ObsCont"
+
+    cte40_ObsCont_compl_id = fields.Many2one(
+        comodel_name="cte.40.tctesimp_compl",
+        xsd_implicit=True,
+        ondelete="cascade",
+    )
+    cte40_xTexto = fields.Char(string="Conteúdo do campo", xsd_required=True)
+
+    cte40_xCampo = fields.Char(
+        string="Identificação do campo", xsd_required=True
+    )
+
+
+class TcteSimpObsFisco(models.AbstractModel):
+    """Campo de uso livre do contribuinte
+    Informar o nome do campo no atributo xCampo e o conteúdo do campo no XTexto"""
+
+    _description = textwrap.dedent("    %s" % (__doc__,))
+    _name = "cte.40.tctesimp_obsfisco"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TcteSimp.InfCte.Compl.ObsFisco"
+
+    cte40_ObsFisco_compl_id = fields.Many2one(
+        comodel_name="cte.40.tctesimp_compl",
+        xsd_implicit=True,
+        ondelete="cascade",
+    )
+    cte40_xTexto = fields.Char(string="Conteúdo do campo", xsd_required=True)
+
+    cte40_xCampo = fields.Char(
+        string="Identificação do campo", xsd_required=True
+    )
+
+
+class TcteSimpEmit(models.AbstractModel):
+    "Identificação do Emitente da GTV-e"
+
+    _description = textwrap.dedent("    %s" % (__doc__,))
+    _name = "cte.40.tctesimp_emit"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TcteSimp.InfCte.Emit"
+
+    cte40_CNPJ = fields.Char(
+        string="CNPJ do emitente",
+        xsd_type="TCnpj",
+        help="CNPJ do emitente\nInformar zeros não significativos",
+    )
+
+    cte40_CPF = fields.Char(
+        string="CPF do emitente",
+        choice="emit",
+        xsd_choice_required=True,
+        xsd_type="TCpf",
+        help=(
+            "CPF do emitente\nInformar zeros não significativos.\n\nUsar com "
+            "série específica 920-969 para emitente pessoa física com "
+            "inscrição estadual"
+        ),
+    )
+
+    cte40_IE = fields.Char(
+        string="Inscrição Estadual do Emitente",
+        help=(
+            "Inscrição Estadual do Emitente\nA IE do emitente somente ficará "
+            "sem informação para o caso do Regime Especial da NFF (tpEmis=3)"
+        ),
+    )
+
+    cte40_IEST = fields.Char(
+        string="Inscrição Estadual",
+        help="Inscrição Estadual do Substituto Tributário",
+    )
+
+    cte40_xNome = fields.Char(
+        string="Razão social ou Nome do emitente", xsd_required=True
+    )
+
+    cte40_xFant = fields.Char(string="Nome fantasia")
+
+    cte40_enderEmit = fields.Many2one(
+        comodel_name="cte.40.tendeemi",
+        string="Endereço do emitente",
+        xsd_required=True,
+        xsd_type="TEndeEmi",
+    )
+
+    cte40_CRT = fields.Selection(
+        TCRT,
+        string="Código do Regime Tributário",
+        xsd_required=True,
+        xsd_type="TCRT",
+        help=(
+            "Código do Regime Tributário\nInformar: 1=Simples Nacional; "
+            "\n2=Simples Nacional, excesso sublimite de receita "
+            "bruta;\n3=Regime Normal. \n4=Simples Nacional - Microempreendedor"
+            " Individual – MEI."
+        ),
+    )
+
+
+class TcteSimpToma(models.AbstractModel):
+    """Indicador do "papel" do tomador do serviço no GT-e"""
+
+    _description = textwrap.dedent("    %s" % (__doc__,))
+    _name = "cte.40.tctesimp_toma"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TcteSimp.InfCte.Toma"
+
+    cte40_toma = fields.Selection(
+        TOMA_TOMA,
+        string="Tomador do Serviço",
+        xsd_required=True,
+        help=(
+            "Tomador do Serviço\nPreencher com:\n\n0-Remetente;\n1-"
+            "Expedidor;\n2-Recebedor;\n3-Destinatário\n4-Terceiro"
+        ),
+    )
+
+    cte40_indIEToma = fields.Selection(
+        TOMA_INDIETOMA,
+        string="Indicador do papel do tomador",
+        xsd_required=True,
+        help=(
+            "Indicador do papel do tomador na prestação do serviço:\n1 – "
+            "Contribuinte ICMS;\n2 – Contribuinte isento de inscrição;\n9 – "
+            "Não Contribuinte\nAplica-se ao tomador que for indicado no toma3 "
+            "ou toma4"
+        ),
+    )
+
+    cte40_CNPJ = fields.Char(
+        string="Número do CNPJ",
+        choice="toma",
+        xsd_choice_required=True,
+        xsd_type="TCnpjOpc",
+        help=(
+            "Número do CNPJ\nEm caso de empresa não estabelecida no Brasil, "
+            "será informado o CNPJ com "
+            "zeros.\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\nInformar os zeros não "
+            "significativos."
+        ),
+    )
+
+    cte40_CPF = fields.Char(
+        string="Número do CPF",
+        choice="toma",
+        xsd_choice_required=True,
+        xsd_type="TCpf",
+        help="Número do CPF\nInformar os zeros não significativos.",
+    )
+
+    cte40_IE = fields.Char(
+        string="Inscrição Estadual",
+        help=(
+            "Inscrição Estadual\nInformar a IE do tomador ou ISENTO se tomador"
+            " é contribuinte do ICMS isento de inscrição no cadastro de "
+            "contribuintes do ICMS. Caso o tomador não seja contribuinte do "
+            "ICMS não informar o conteúdo."
+        ),
+    )
+
+    cte40_xNome = fields.Char(string="Razão Social ou Nome", xsd_required=True)
+
+    cte40_ISUF = fields.Char(
+        string="Inscrição na SUFRAMA",
+        help=(
+            "Inscrição na SUFRAMA\n(Obrigatório nas operações com as áreas com"
+            " benefícios de incentivos fiscais sob controle da SUFRAMA)"
+        ),
+    )
+
+    cte40_fone = fields.Char(string="Telefone", xsd_type="TFone")
+
+    cte40_enderToma = fields.Many2one(
+        comodel_name="cte.40.tendereco",
+        string="Dados do endereço",
+        xsd_required=True,
+        xsd_type="TEndereco",
+    )
+
+    cte40_email = fields.Char(string="Endereço de email", xsd_type="TEmail")
+
+
+class TcteSimpInfCarga(models.AbstractModel):
+    "Informações da Carga do CT-e"
+
+    _description = textwrap.dedent("    %s" % (__doc__,))
+    _name = "cte.40.tctesimp_infcarga"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TcteSimp.InfCte.InfCarga"
+
+    cte40_vCarga = fields.Monetary(
+        string="Valor total da carga",
+        xsd_required=True,
+        xsd_type="TDec_1302",
+        currency_field="brl_currency_id",
+    )
+
+    cte40_proPred = fields.Char(
+        string="Produto predominante",
+        xsd_required=True,
+        help=(
+            "Produto predominante\nInformar a descrição do produto "
+            "predominante"
+        ),
+    )
+
+    cte40_xOutCat = fields.Char(
+        string="Outras características da carga",
+        help=(
+            "Outras características da carga\n'FRIA', 'GRANEL', 'REFRIGERADA',"
+            " 'Medidas: 12X12X12'"
+        ),
+    )
+
+    cte40_infQ = fields.One2many(
+        "cte.40.tctesimp_infq",
+        "cte40_infQ_infCarga_id",
+        string="Informações de quantidades da Carga",
+        help=(
+            "Informações de quantidades da Carga do CT-e\nPara o Aéreo é "
+            "obrigatório o preenchimento desse campo da seguinte forma.\n1 - "
+            "Peso Bruto, sempre em quilogramas (obrigatório);\n2 - Peso "
+            "Cubado; sempre em quilogramas;\n3 - Quantidade de volumes, sempre"
+            " em unidades (obrigatório);\n4 - Cubagem, sempre em metros "
+            "cúbicos (obrigatório apenas quando for impossível preencher as "
+            "dimensões da(s) embalagem(ens) na tag xDime do leiaute do Aéreo)."
+        ),
+    )
+
+    cte40_vCargaAverb = fields.Monetary(
+        string="Valor da Carga para efeito de averbação",
+        xsd_type="TDec_1302Opc",
+        currency_field="brl_currency_id",
+        help=(
+            "Valor da Carga para efeito de averbação\nNormalmente igual ao "
+            "valor declarado da mercadoria, diferente por exemplo, quando a "
+            "mercadoria transportada é isenta de tributos nacionais para "
+            "exportação, onde é preciso averbar um valor maior, pois no caso "
+            "de indenização, o valor a ser pago será maior"
+        ),
+    )
+
+
+class TcteSimpInfQ(models.AbstractModel):
+    """Informações de quantidades da Carga do CT-e
+    Para o Aéreo é obrigatório o preenchimento desse campo da seguinte forma.
+    1 - Peso Bruto, sempre em quilogramas (obrigatório);
+    2 - Peso Cubado; sempre em quilogramas;
+    3 - Quantidade de volumes, sempre em unidades (obrigatório);
+    4 - Cubagem, sempre em metros cúbicos (obrigatório apenas quando for impossível
+    preencher as dimensões da(s) embalagem(ens) na tag xDime do leiaute do
+    Aéreo)."""
+
+    _description = textwrap.dedent("    %s" % (__doc__,))
+    _name = "cte.40.tctesimp_infq"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TcteSimp.InfCte.InfCarga.InfQ"
+
+    cte40_infQ_infCarga_id = fields.Many2one(
+        comodel_name="cte.40.tctesimp_infcarga",
+        xsd_implicit=True,
+        ondelete="cascade",
+    )
+    cte40_cUnid = fields.Selection(
+        INFQ_CUNID,
+        string="Código da Unidade de Medida",
+        xsd_required=True,
+        help=(
+            "Código da Unidade de Medida\nPreencher "
+            "com:\n00-M3;\n01-KG;\n02-TON;\n03-UNIDADE;\n04-LITROS;\n05-MMBTU"
+        ),
+    )
+
+    cte40_tpMed = fields.Selection(
+        INFQ_TPMED,
+        string="Tipo da Medida",
+        xsd_required=True,
+        help=(
+            "Tipo da Medida\nInformar com:\n00-Cubagem da NF-e\n01-Cubagem "
+            "Aferida pelo Transportador\n02-Peso Bruto da NF-e\n03-Peso Bruto "
+            "Aferido pelo Transportador\n04-Peso Cubado\n05-Peso Base do "
+            "Cálculo do Frete\n06-Peso para uso Operacional\n07-Caixas\n08-"
+            "Paletes\n09-Sacas\n10-Containers\n11-Rolos\n12-Bombonas\n13-"
+            "Latas\n14-Litragem\n15-Milhão de BTU (British Thermal "
+            "Units)\n99-Outros"
+        ),
+    )
+
+    cte40_qCarga = fields.Float(
+        string="Quantidade",
+        xsd_required=True,
+        xsd_type="TDec_1104",
+        digits=(
+            11,
+            4,
+        ),
+    )
+
+
+class Det(models.AbstractModel):
+    "Detalhamento das entregas / prestações do CTe Simplificado"
+
+    _description = textwrap.dedent("    %s" % (__doc__,))
+    _name = "cte.40.det"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TcteSimp.InfCte.Det"
+
+    cte40_det_infCte_id = fields.Many2one(
+        comodel_name="cte.40.tctesimp_infcte",
+        xsd_implicit=True,
+        ondelete="cascade",
+    )
+    cte40_cMunIni = fields.Char(
+        string="Código do Município de início",
+        xsd_required=True,
+        xsd_type="TCodMunIBGE",
+        help=(
+            "Código do Município de início da prestação\nUtilizar a tabela do "
+            "IBGE. Informar 9999999 para operações com o exterior."
+        ),
+    )
+
+    cte40_xMunIni = fields.Char(
+        string="Nome do Município do início da prestação",
+        xsd_required=True,
+        help=(
+            "Nome do Município do início da prestação\nInformar 'EXTERIOR' "
+            "para operações com o exterior."
+        ),
+    )
+
+    cte40_cMunFim = fields.Char(
+        string="Código do Município de término",
+        xsd_required=True,
+        xsd_type="TCodMunIBGE",
+        help=(
+            "Código do Município de término da prestação\nUtilizar a tabela do"
+            " IBGE. Informar 9999999 para operações com o exterior."
+        ),
+    )
+
+    cte40_xMunFim = fields.Char(
+        string="Nome do Município do término",
+        xsd_required=True,
+        help=(
+            "Nome do Município do término da prestação\nInformar 'EXTERIOR' "
+            "para operações com o exterior."
+        ),
+    )
+
+    cte40_vPrest = fields.Monetary(
+        string="Valorl da Prestação do Serviço",
+        xsd_required=True,
+        xsd_type="TDec_1302",
+        currency_field="brl_currency_id",
+        help=(
+            "Valorl da Prestação do Serviço\nPode conter zeros quando o CT-e "
+            "for de complemento de ICMS"
+        ),
+    )
+
+    cte40_vRec = fields.Monetary(
+        string="Valor a Receber",
+        xsd_required=True,
+        xsd_type="TDec_1302",
+        currency_field="brl_currency_id",
+    )
+
+    cte40_comp = fields.One2many(
+        "cte.40.tctesimp_det_comp",
+        "cte40_Comp_det_id",
+        string="Componentes do Valor da Prestação",
+    )
+
+    cte40_infNFe = fields.One2many(
+        "cte.40.tctesimp_infnfe",
+        "cte40_infNFe_det_id",
+        string="Informações das NF-e",
+        choice="det",
+        xsd_choice_required=True,
+    )
+
+    cte40_infDocAnt = fields.One2many(
+        "cte.40.infdocant",
+        "cte40_infDocAnt_det_id",
+        string="Documentos anteriores",
+        choice="det",
+        xsd_choice_required=True,
+    )
+
+    cte40_nItem = fields.Char(
+        string="Número identificador do item agrupador",
+        xsd_required=True,
+        help="Número identificador do item agrupador da prestação",
+    )
+
+
+class TcteSimpDetComp(models.AbstractModel):
+    "Componentes do Valor da Prestação"
+
+    _description = textwrap.dedent("    %s" % (__doc__,))
+    _name = "cte.40.tctesimp_det_comp"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TcteSimp.InfCte.Det.Comp"
+
+    cte40_Comp_det_id = fields.Many2one(
+        comodel_name="cte.40.det", xsd_implicit=True, ondelete="cascade"
+    )
+    cte40_xNome = fields.Char(
+        string="Nome do componente",
+        xsd_required=True,
+        help=(
+            "Nome do componente\nExxemplos: FRETE PESO, FRETE VALOR, SEC/CAT, "
+            "ADEME, AGENDAMENTO, etc"
+        ),
+    )
+
+    cte40_vComp = fields.Monetary(
+        string="Valor do componente",
+        xsd_required=True,
+        xsd_type="TDec_1302",
+        currency_field="brl_currency_id",
+    )
+
+
+class TcteSimpInfNfe(models.AbstractModel):
+    "Informações das NF-e"
+
+    _description = textwrap.dedent("    %s" % (__doc__,))
+    _name = "cte.40.tctesimp_infnfe"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TcteSimp.InfCte.Det.InfNfe"
+
+    cte40_infNFe_det_id = fields.Many2one(
+        comodel_name="cte.40.det", xsd_implicit=True, ondelete="cascade"
+    )
+    cte40_chNFe = fields.Char(
+        string="Chave de acesso da NF-e", xsd_required=True, xsd_type="TChDFe"
+    )
+
+    cte40_PIN = fields.Char(
+        string="PIN SUFRAMA",
+        help="PIN SUFRAMA\nPIN atribuído pela SUFRAMA para a operação.",
+    )
+
+    cte40_dPrev = fields.Date(
+        string="Data prevista de entrega",
+        xsd_type="TData",
+        help="Data prevista de entrega\nFormato AAAA-MM-DD",
+    )
+
+    cte40_infUnidCarga = fields.One2many(
+        "cte.40.tunidcarga",
+        "cte40_infUnidCarga_infNFe_id",
+        string="Informações das Unidades de Carga",
+        choice="infnfe",
+        xsd_choice_required=True,
+        xsd_type="TUnidCarga",
+        help=(
+            "Informações das Unidades de Carga "
+            "(Containeres/ULD/Outros)\nDispositivo de carga utilizada (Unit "
+            "Load Device - ULD) significa todo tipo de contêiner de carga, "
+            "vagão, contêiner de avião, palete de aeronave com rede ou palete "
+            "de aeronave com rede sobre um iglu."
+        ),
+    )
+
+    cte40_infUnidTransp = fields.One2many(
+        "cte.40.tunidadetransp",
+        "cte40_infUnidTransp_infNFe_id",
+        string="Informações das Unidades de Transporte",
+        choice="infnfe",
+        xsd_choice_required=True,
+        xsd_type="TUnidadeTransp",
+        help=(
+            "Informações das Unidades de Transporte "
+            "(Carreta/Reboque/Vagão)\nDeve ser preenchido com as informações "
+            "das unidades de transporte utilizadas."
+        ),
+    )
+
+
+class InfDocAnt(models.AbstractModel):
+    "Documentos anteriores"
+
+    _description = textwrap.dedent("    %s" % (__doc__,))
+    _name = "cte.40.infdocant"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TcteSimp.InfCte.Det.InfDocAnt"
+
+    cte40_infDocAnt_det_id = fields.Many2one(
+        comodel_name="cte.40.det", xsd_implicit=True, ondelete="cascade"
+    )
+    cte40_chCTe = fields.Char(
+        string="Chave de acesso do CT-e", xsd_required=True, xsd_type="TChDFe"
+    )
+
+    cte40_tpPrest = fields.Selection(
+        INFDOCANT_TPPREST,
+        string="indica se a prestação é total ou parcial",
+        xsd_required=True,
+        help=(
+            "indica se a prestação é total ou parcial em relação as notas do "
+            "documento anterior\nPreencher com:\n\n1 - Total\n2 - Parcial"
+        ),
+    )
+
+    cte40_infNFeTranspParcial = fields.One2many(
+        "cte.40.infnfetranspparcial",
+        "cte40_infNFeTranspParcial_infDocAnt_id",
+        string="infNFeTranspParcial",
+    )
+
+
+class InfNfeTranspParcial(models.AbstractModel):
+    _description = "infNFeTranspParcial"
+    _name = "cte.40.infnfetranspparcial"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TcteSimp.InfCte.Det.InfDocAnt.InfNfeTranspParcial"
+
+    cte40_infNFeTranspParcial_infDocAnt_id = fields.Many2one(
+        comodel_name="cte.40.infdocant", xsd_implicit=True, ondelete="cascade"
+    )
+    cte40_chNFe = fields.Char(
+        string="Chave de acesso da NF-e",
+        xsd_required=True,
+        xsd_type="TChDFe",
+        help=(
+            "Chave de acesso da NF-e\nInformando o tpPrest com “2 – Parcial” "
+            "deve-se informar as chaves de acesso das NF-e que acobertam a "
+            "carga transportada."
+        ),
+    )
+
+
+class TcteSimpInfModal(models.AbstractModel):
+    "Informações do modal"
+
+    _description = textwrap.dedent("    %s" % (__doc__,))
+    _name = "cte.40.tctesimp_infmodal"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TcteSimp.InfCte.InfModal"
+
+    cte40_versaoModal = fields.Char(
+        string="Versão do leiaute específico",
+        xsd_required=True,
+        help="Versão do leiaute específico para o Modal",
+    )
+
+
+class TcteSimpCobr(models.AbstractModel):
+    "Dados da cobrança do CT-e"
+
+    _description = textwrap.dedent("    %s" % (__doc__,))
+    _name = "cte.40.tctesimp_cobr"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TcteSimp.InfCte.Cobr"
+
+    cte40_fat = fields.Many2one(
+        comodel_name="cte.40.tctesimp_fat", string="Dados da fatura"
+    )
+
+    cte40_dup = fields.One2many(
+        "cte.40.tctesimp_dup",
+        "cte40_dup_cobr_id",
+        string="Dados das duplicatas",
+    )
+
+
+class TcteSimpFat(models.AbstractModel):
+    "Dados da fatura"
+
+    _description = textwrap.dedent("    %s" % (__doc__,))
+    _name = "cte.40.tctesimp_fat"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TcteSimp.InfCte.Cobr.Fat"
+
+    cte40_nFat = fields.Char(string="Número da fatura")
+
+    cte40_vOrig = fields.Monetary(
+        string="Valor original da fatura",
+        xsd_type="TDec_1302Opc",
+        currency_field="brl_currency_id",
+    )
+
+    cte40_vDesc = fields.Monetary(
+        string="Valor do desconto da fatura",
+        xsd_type="TDec_1302Opc",
+        currency_field="brl_currency_id",
+    )
+
+    cte40_vLiq = fields.Monetary(
+        string="Valor líquido da fatura",
+        xsd_type="TDec_1302Opc",
+        currency_field="brl_currency_id",
+    )
+
+
+class TcteSimpDup(models.AbstractModel):
+    "Dados das duplicatas"
+
+    _description = textwrap.dedent("    %s" % (__doc__,))
+    _name = "cte.40.tctesimp_dup"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TcteSimp.InfCte.Cobr.Dup"
+
+    cte40_dup_cobr_id = fields.Many2one(
+        comodel_name="cte.40.tctesimp_cobr",
+        xsd_implicit=True,
+        ondelete="cascade",
+    )
+    cte40_nDup = fields.Char(string="Número da duplicata")
+
+    cte40_dVenc = fields.Date(
+        string="Data de vencimento da duplicata",
+        xsd_type="TData",
+        help="Data de vencimento da duplicata (AAAA-MM-DD)",
+    )
+
+    cte40_vDup = fields.Monetary(
+        string="Valor da duplicata",
+        xsd_type="TDec_1302Opc",
+        currency_field="brl_currency_id",
+    )
+
+
+class TcteSimpInfCteSub(models.AbstractModel):
+    "Informações do CT-e de substituição"
+
+    _description = textwrap.dedent("    %s" % (__doc__,))
+    _name = "cte.40.tctesimp_infctesub"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TcteSimp.InfCte.InfCteSub"
+
+    cte40_chCte = fields.Char(
+        string="Chave de acesso do CT-e",
+        xsd_required=True,
+        help="Chave de acesso do CT-e a ser substituído (original)",
+    )
+
+    cte40_indAlteraToma = fields.Selection(
+        INFCTESUB_INDALTERATOMA,
+        string="Indicador de CT-e Alteração de Tomador",
+    )
+
+
+class TcteSimpImp(models.AbstractModel):
+    "Informações relativas aos Impostos"
+
+    _description = textwrap.dedent("    %s" % (__doc__,))
+    _name = "cte.40.tctesimp_imp"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TcteSimp.InfCte.Imp"
+
+    cte40_ICMS = fields.Many2one(
+        comodel_name="cte.40.timp",
+        string="Informações relativas ao ICMS",
+        xsd_required=True,
+        xsd_type="TImp",
+    )
+
+    cte40_vTotTrib = fields.Monetary(
+        string="Valor Total dos Tributos",
+        xsd_type="TDec_1302",
+        currency_field="brl_currency_id",
+    )
+
+    cte40_infAdFisco = fields.Char(
+        string="Informações adicionais de interesse",
+        help=(
+            "Informações adicionais de interesse do Fisco\nNorma referenciada,"
+            " informações complementares, etc"
+        ),
+    )
+
+
+class Total(models.AbstractModel):
+    "Valores Totais do CTe"
+
+    _description = textwrap.dedent("    %s" % (__doc__,))
+    _name = "cte.40.total"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TcteSimp.InfCte.Total"
+
+    cte40_vTPrest = fields.Monetary(
+        string="Valor Total da Prestação do Serviço",
+        xsd_required=True,
+        xsd_type="TDec_1302",
+        currency_field="brl_currency_id",
+        help=(
+            "Valor Total da Prestação do Serviço\nPode conter zeros quando o "
+            "CT-e for de complemento de ICMS"
+        ),
+    )
+
+    cte40_vTRec = fields.Monetary(
+        string="Valor total a Receber",
+        xsd_required=True,
+        xsd_type="TDec_1302",
+        currency_field="brl_currency_id",
+    )
+
+
+class TcteSimpAutXml(models.AbstractModel):
+    """Autorizados para download do XML do DF-e
+    Informar CNPJ ou CPF. Preencher os zeros não significativos."""
+
+    _description = textwrap.dedent("    %s" % (__doc__,))
+    _name = "cte.40.tctesimp_autxml"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TcteSimp.InfCte.AutXml"
+
+    cte40_autXML_infCte_id = fields.Many2one(
+        comodel_name="cte.40.tctesimp_infcte",
+        xsd_implicit=True,
+        ondelete="cascade",
+    )
+    cte40_CNPJ = fields.Char(
+        string="CNPJ do autorizado",
+        choice="autxml",
+        xsd_choice_required=True,
+        xsd_type="TCnpj",
+        help="CNPJ do autorizado\nInformar zeros não significativos",
+    )
+
+    cte40_CPF = fields.Char(
+        string="CPF do autorizado",
+        choice="autxml",
+        xsd_choice_required=True,
+        xsd_type="TCpf",
+        help="CPF do autorizado\nInformar zeros não significativos",
+    )
+
+
+class TcteSimpInfSolicNff(models.AbstractModel):
+    "Grupo de informações do pedido de emissão da Nota Fiscal Fácil"
+
+    _description = textwrap.dedent("    %s" % (__doc__,))
+    _name = "cte.40.tctesimp_infsolicnff"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TcteSimp.InfCte.InfSolicNff"
+
+    cte40_xSolic = fields.Char(
+        string="Solicitação do pedido de emissão da NFF",
+        xsd_required=True,
+        help=(
+            "Solicitação do pedido de emissão da NFF.\nSerá preenchido com a "
+            "totalidade de campos informados no aplicativo emissor "
+            "serializado."
+        ),
+    )
+
+
+class TcteSimpInfPaa(models.AbstractModel):
+    "Grupo de Informação do Provedor de Assinatura e Autorização"
+
+    _description = textwrap.dedent("    %s" % (__doc__,))
+    _name = "cte.40.tctesimp_infpaa"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TcteSimp.InfCte.InfPaa"
+
+    cte40_CNPJPAA = fields.Char(
+        string="CNPJ do Provedor de Assinatura",
+        xsd_required=True,
+        xsd_type="TCnpj",
+        help="CNPJ do Provedor de Assinatura e Autorização",
+    )
+
+    cte40_PAASignature = fields.Many2one(
+        comodel_name="cte.40.tctesimp_paasignature",
+        string="Assinatura RSA do Emitente",
+        xsd_required=True,
+        help="Assinatura RSA do Emitente para DFe gerados por PAA",
+    )
+
+
+class TcteSimpPaasignature(models.AbstractModel):
+    "Assinatura RSA do Emitente para DFe gerados por PAA"
+
+    _description = textwrap.dedent("    %s" % (__doc__,))
+    _name = "cte.40.tctesimp_paasignature"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TcteSimp.InfCte.InfPaa.Paasignature"
+
+    cte40_signatureValue = fields.Char(
+        string="Assinatura digital padrão RSA",
+        xsd_required=True,
+        xsd_type="xs:base64Binary",
+        help=(
+            "Assinatura digital padrão RSA\nConverter o atributo Id do DFe "
+            "para array de bytes e assinar com a chave privada do RSA com "
+            "algoritmo SHA1 gerando um valor no formato base64."
+        ),
+    )
+
+    cte40_RSAKeyValue = fields.Many2one(
+        comodel_name="cte.40.trsakeyvaluetype",
+        string="Chave Publica no padrão XML RSA Key",
+        xsd_required=True,
+        xsd_type="TRSAKeyValueType",
+    )
+
+
+class TcteSimpInfCteSupl(models.AbstractModel):
+    "Informações suplementares da GTV-e"
+
+    _description = textwrap.dedent("    %s" % (__doc__,))
+    _name = "cte.40.tctesimp_infctesupl"
+    _inherit = "spec.mixin.cte"
+    _binding_type = "TcteSimp.InfCteSupl"
 
     cte40_qrCodCTe = fields.Char(
         string="Texto com o QR-Code impresso no DACTE", xsd_required=True

--- a/l10n_br_cte_spec/models/v4_0/cte_tipos_basico_v4_00.py
+++ b/l10n_br_cte_spec/models/v4_0/cte_tipos_basico_v4_00.py
@@ -269,6 +269,7 @@ TOMA_TOMA = [
 
 class TrespTec(models.AbstractModel):
     "Tipo Dados da Responsável Técnico"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tresptec"
     _inherit = "spec.mixin.cte"
@@ -334,6 +335,7 @@ class TrespTec(models.AbstractModel):
 
 class TendOrg(models.AbstractModel):
     "Tipo Dados do Endereço"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tendorg"
     _inherit = "spec.mixin.cte"
@@ -360,7 +362,10 @@ class TendOrg(models.AbstractModel):
     cte40_xMun = fields.Char(
         string="Nome do município",
         xsd_required=True,
-        help=("Nome do município\nInformar EXTERIOR para operações com o " "exterior."),
+        help=(
+            "Nome do município\nInformar EXTERIOR para operações com o "
+            "exterior."
+        ),
     )
 
     cte40_CEP = fields.Char(string="CEP")
@@ -382,6 +387,7 @@ class TendOrg(models.AbstractModel):
 
 class TendReEnt(models.AbstractModel):
     "Tipo Dados do Local de Retirada ou Entrega"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tendreent"
     _inherit = "spec.mixin.cte"
@@ -424,7 +430,10 @@ class TendReEnt(models.AbstractModel):
     cte40_xMun = fields.Char(
         string="Nome do município",
         xsd_required=True,
-        help=("Nome do município\nInformar EXTERIOR para operações com o " "exterior."),
+        help=(
+            "Nome do município\nInformar EXTERIOR para operações com o "
+            "exterior."
+        ),
     )
 
     cte40_UF = fields.Selection(
@@ -438,6 +447,7 @@ class TendReEnt(models.AbstractModel):
 
 class TendeEmi(models.AbstractModel):
     "Tipo Dados do Endereço"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tendeemi"
     _inherit = "spec.mixin.cte"
@@ -460,10 +470,15 @@ class TendeEmi(models.AbstractModel):
 
     cte40_xMun = fields.Char(string="Nome do município", xsd_required=True)
 
-    cte40_CEP = fields.Char(string="CEP", help="CEP\nInformar zeros não significativos")
+    cte40_CEP = fields.Char(
+        string="CEP", help="CEP\nInformar zeros não significativos"
+    )
 
     cte40_UF = fields.Selection(
-        TUF_SEM_EX, string="Sigla da UF", xsd_required=True, xsd_type="TUF_sem_EX"
+        TUF_SEM_EX,
+        string="Sigla da UF",
+        xsd_required=True,
+        xsd_type="TUF_sem_EX",
     )
 
     cte40_fone = fields.Char(string="Telefone", xsd_type="TFone")
@@ -471,6 +486,7 @@ class TendeEmi(models.AbstractModel):
 
 class Tendereco(models.AbstractModel):
     "Tipo Dados do Endereço"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tendereco"
     _inherit = "spec.mixin.cte"
@@ -497,7 +513,10 @@ class Tendereco(models.AbstractModel):
     cte40_xMun = fields.Char(
         string="Nome do município",
         xsd_required=True,
-        help=("Nome do município\nInformar EXTERIOR para operações com o " "exterior."),
+        help=(
+            "Nome do município\nInformar EXTERIOR para operações com o "
+            "exterior."
+        ),
     )
 
     cte40_CEP = fields.Char(
@@ -513,7 +532,8 @@ class Tendereco(models.AbstractModel):
     )
 
     cte40_cPais = fields.Char(
-        string="Código do país", help="Código do país\nUtilizar a tabela do BACEN"
+        string="Código do país",
+        help="Código do país\nUtilizar a tabela do BACEN",
     )
 
     cte40_xPais = fields.Char(string="Nome do país")
@@ -521,6 +541,7 @@ class Tendereco(models.AbstractModel):
 
 class Tendernac(models.AbstractModel):
     "Tipo Dados do Endereço"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tendernac"
     _inherit = "spec.mixin.cte"
@@ -548,7 +569,8 @@ class Tendernac(models.AbstractModel):
         string="Nome do município, ",
         xsd_required=True,
         help=(
-            "Nome do município, , informar EXTERIOR para operações com o " "exterior."
+            "Nome do município, , informar EXTERIOR para operações com o "
+            "exterior."
         ),
     )
 
@@ -565,6 +587,7 @@ class Tendernac(models.AbstractModel):
 
 class Timp(models.AbstractModel):
     "Tipo Dados do Imposto CT-e"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.timp"
     _inherit = "spec.mixin.cte"
@@ -573,6 +596,7 @@ class Timp(models.AbstractModel):
 
 class TimpOs(models.AbstractModel):
     "Tipo Dados do Imposto para CT-e OS"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.timpos"
     _inherit = "spec.mixin.cte"
@@ -581,6 +605,7 @@ class TimpOs(models.AbstractModel):
 
 class Tlocal(models.AbstractModel):
     "Tipo Dados do Local de Origem ou Destino"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tlocal"
     _inherit = "spec.mixin.cte"
@@ -602,6 +627,7 @@ class Tlocal(models.AbstractModel):
 
 class TprotCte(models.AbstractModel):
     "Tipo Protocolo de status resultado do processamento da CT-e"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tprotcte"
     _inherit = "spec.mixin.cte"
@@ -622,6 +648,7 @@ class TprotCte(models.AbstractModel):
 
 class TprotCteInfProt(models.AbstractModel):
     "Dados do protocolo de status"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tprotcte_infprot"
     _inherit = "spec.mixin.cte"
@@ -650,7 +677,9 @@ class TprotCteInfProt(models.AbstractModel):
         string="Data e hora de processamento",
         xsd_required=True,
         xsd_type="TDateTimeUTC",
-        help=("Data e hora de processamento, no formato AAAA-MM-DDTHH:MM:SS TZD."),
+        help=(
+            "Data e hora de processamento, no formato AAAA-MM-DDTHH:MM:SS TZD."
+        ),
     )
 
     cte40_nProt = fields.Char(
@@ -666,7 +695,9 @@ class TprotCteInfProt(models.AbstractModel):
         ),
     )
 
-    cte40_cStat = fields.Char(string="Código do status do CT-e", xsd_required=True)
+    cte40_cStat = fields.Char(
+        string="Código do status do CT-e", xsd_required=True
+    )
 
     cte40_xMotivo = fields.Char(
         string="Descrição literal do status do CT-e",
@@ -679,6 +710,7 @@ class TprotCteInfProt(models.AbstractModel):
 
 class TprotCteInfFisco(models.AbstractModel):
     "Mensagem do Fisco"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tprotcte_inffisco"
     _inherit = "spec.mixin.cte"
@@ -717,6 +749,7 @@ class TprotCteOs(models.AbstractModel):
 
 class TprotCteOsInfProt(models.AbstractModel):
     "Dados do protocolo de status"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tprotcteos_infprot"
     _inherit = "spec.mixin.cte"
@@ -745,7 +778,9 @@ class TprotCteOsInfProt(models.AbstractModel):
         string="Data e hora de processamento",
         xsd_required=True,
         xsd_type="TDateTimeUTC",
-        help=("Data e hora de processamento, no formato AAAA-MM-DDTHH:MM:SS TZD."),
+        help=(
+            "Data e hora de processamento, no formato AAAA-MM-DDTHH:MM:SS TZD."
+        ),
     )
 
     cte40_nProt = fields.Char(
@@ -761,7 +796,9 @@ class TprotCteOsInfProt(models.AbstractModel):
         ),
     )
 
-    cte40_cStat = fields.Char(string="Código do status do CT-e", xsd_required=True)
+    cte40_cStat = fields.Char(
+        string="Código do status do CT-e", xsd_required=True
+    )
 
     cte40_xMotivo = fields.Char(
         string="Descrição literal do status do CT-e",
@@ -774,6 +811,7 @@ class TprotCteOsInfProt(models.AbstractModel):
 
 class TprotCteOsInfFisco(models.AbstractModel):
     "Mensagem do Fisco"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tprotcteos_inffisco"
     _inherit = "spec.mixin.cte"
@@ -812,6 +850,7 @@ class TprotGtve(models.AbstractModel):
 
 class TprotGtveInfProt(models.AbstractModel):
     "Dados do protocolo de status"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tprotgtve_infprot"
     _inherit = "spec.mixin.cte"
@@ -840,7 +879,9 @@ class TprotGtveInfProt(models.AbstractModel):
         string="Data e hora de processamento",
         xsd_required=True,
         xsd_type="TDateTimeUTC",
-        help=("Data e hora de processamento, no formato AAAA-MM-DDTHH:MM:SS TZD."),
+        help=(
+            "Data e hora de processamento, no formato AAAA-MM-DDTHH:MM:SS TZD."
+        ),
     )
 
     cte40_nProt = fields.Char(
@@ -856,7 +897,9 @@ class TprotGtveInfProt(models.AbstractModel):
         ),
     )
 
-    cte40_cStat = fields.Char(string="Código do status da GTV-e", xsd_required=True)
+    cte40_cStat = fields.Char(
+        string="Código do status da GTV-e", xsd_required=True
+    )
 
     cte40_xMotivo = fields.Char(
         string="Descrição literal do status da GTV-e",
@@ -869,6 +912,7 @@ class TprotGtveInfProt(models.AbstractModel):
 
 class TprotGtveInfFisco(models.AbstractModel):
     "Mensagem do Fisco"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tprotgtve_inffisco"
     _inherit = "spec.mixin.cte"
@@ -885,6 +929,7 @@ class TprotGtveInfFisco(models.AbstractModel):
 
 class TunidCarga(models.AbstractModel):
     "Tipo Dados Unidade de Carga"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tunidcarga"
     _inherit = "spec.mixin.cte"
@@ -894,13 +939,17 @@ class TunidCarga(models.AbstractModel):
         comodel_name="cte.40.tcte_infnf", xsd_implicit=True, ondelete="cascade"
     )
     cte40_infUnidCarga_infNFe_id = fields.Many2one(
-        comodel_name="cte.40.tcte_infnfe", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcte_infnfe",
+        xsd_implicit=True,
+        ondelete="cascade",
     )
     cte40_infUnidCarga_infOutros_id = fields.Many2one(
         comodel_name="cte.40.infoutros", xsd_implicit=True, ondelete="cascade"
     )
     cte40_infUnidCarga_TUnidadeTransp_id = fields.Many2one(
-        comodel_name="cte.40.tunidadetransp", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tunidadetransp",
+        xsd_implicit=True,
+        ondelete="cascade",
     )
     cte40_tpUnidCarga = fields.Selection(
         TTIPOUNIDCARGA,
@@ -938,6 +987,7 @@ class TunidCarga(models.AbstractModel):
 
 class LacUnidCarga(models.AbstractModel):
     "Lacres das Unidades de Carga"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.lacunidcarga"
     _inherit = "spec.mixin.cte"
@@ -974,6 +1024,7 @@ class TcteOs(models.AbstractModel):
 
 class TcteOsInfCte(models.AbstractModel):
     "Informações do CT-e do tipo GTV-e"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcteos_infcte"
     _inherit = "spec.mixin.cte"
@@ -988,7 +1039,9 @@ class TcteOsInfCte(models.AbstractModel):
     cte40_compl = fields.Many2one(
         comodel_name="cte.40.tcteos_compl",
         string="Dados complementares do CT-e",
-        help=("Dados complementares do CT-e para fins operacionais ou comerciais"),
+        help=(
+            "Dados complementares do CT-e para fins operacionais ou comerciais"
+        ),
     )
 
     cte40_emit = fields.Many2one(
@@ -1070,6 +1123,7 @@ class TcteOsInfCte(models.AbstractModel):
 
 class TcteOsIde(models.AbstractModel):
     "Identificação da GTV-e"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcteos_ide"
     _inherit = "spec.mixin.cte"
@@ -1127,7 +1181,10 @@ class TcteOsIde(models.AbstractModel):
     cte40_dhEmi = fields.Char(
         string="Data e hora de emissão do CT-e OS",
         xsd_required=True,
-        help=("Data e hora de emissão do CT-e OS\nFormato AAAA-MM-DDTHH:MM:DD " "TZD"),
+        help=(
+            "Data e hora de emissão do CT-e OS\nFormato AAAA-MM-DDTHH:MM:DD "
+            "TZD"
+        ),
     )
 
     cte40_tpImp = fields.Selection(
@@ -1145,8 +1202,8 @@ class TcteOsIde(models.AbstractModel):
         string="Forma de emissão do CT-e",
         xsd_required=True,
         help=(
-            "Forma de emissão do CT-e\nPreencher com:\n1 - Normal;\n 5 - "
-            "Contingência FSDA;\n7 - Autorização pela SVC-RS;\n 8 - "
+            "Forma de emissão do CT-e\nPreencher com:\n 1 - Normal;\n 5 - "
+            "Contingência FSDA;\n 7 - Autorização pela SVC-RS;\n 8 - "
             "Autorização pela SVC-SP"
         ),
     )
@@ -1287,7 +1344,8 @@ class TcteOsIde(models.AbstractModel):
         string="UF do início da prestação",
         xsd_type="TUf",
         help=(
-            "UF do início da prestação\nInformar 'EX' para operações com o " "exterior."
+            "UF do início da prestação\nInformar 'EX' para operações com o "
+            "exterior."
         ),
     )
 
@@ -1334,11 +1392,14 @@ class TcteOsIde(models.AbstractModel):
         ),
     )
 
-    cte40_xJust = fields.Char(string="Justificativa da entrada em contingência")
+    cte40_xJust = fields.Char(
+        string="Justificativa da entrada em contingência"
+    )
 
 
 class InfPercurso(models.AbstractModel):
     "Informações do Percurso do CT-e Outros Serviços"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.infpercurso"
     _inherit = "spec.mixin.cte"
@@ -1361,6 +1422,7 @@ class InfPercurso(models.AbstractModel):
 
 class TcteOsCompl(models.AbstractModel):
     "Dados complementares da GTV-e para fins operacionais ou comerciais"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcteos_compl"
     _inherit = "spec.mixin.cte"
@@ -1418,11 +1480,15 @@ class TcteOsObsCont(models.AbstractModel):
     _binding_type = "TcteOs.InfCte.Compl.ObsCont"
 
     cte40_ObsCont_compl_id = fields.Many2one(
-        comodel_name="cte.40.tcteos_compl", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcteos_compl",
+        xsd_implicit=True,
+        ondelete="cascade",
     )
     cte40_xTexto = fields.Char(string="Conteúdo do campo", xsd_required=True)
 
-    cte40_xCampo = fields.Char(string="Identificação do campo", xsd_required=True)
+    cte40_xCampo = fields.Char(
+        string="Identificação do campo", xsd_required=True
+    )
 
 
 class TcteOsObsFisco(models.AbstractModel):
@@ -1435,15 +1501,20 @@ class TcteOsObsFisco(models.AbstractModel):
     _binding_type = "TcteOs.InfCte.Compl.ObsFisco"
 
     cte40_ObsFisco_compl_id = fields.Many2one(
-        comodel_name="cte.40.tcteos_compl", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcteos_compl",
+        xsd_implicit=True,
+        ondelete="cascade",
     )
     cte40_xTexto = fields.Char(string="Conteúdo do campo", xsd_required=True)
 
-    cte40_xCampo = fields.Char(string="Identificação do campo", xsd_required=True)
+    cte40_xCampo = fields.Char(
+        string="Identificação do campo", xsd_required=True
+    )
 
 
 class TcteOsEmit(models.AbstractModel):
     "Identificação do Emitente da GTV-e"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcteos_emit"
     _inherit = "spec.mixin.cte"
@@ -1456,10 +1527,13 @@ class TcteOsEmit(models.AbstractModel):
         help="CNPJ do emitente\nInformar zeros não significativos",
     )
 
-    cte40_IE = fields.Char(string="Inscrição Estadual do Emitente", xsd_required=True)
+    cte40_IE = fields.Char(
+        string="Inscrição Estadual do Emitente", xsd_required=True
+    )
 
     cte40_IEST = fields.Char(
-        string="Inscrição Estadual", help="Inscrição Estadual do Substituto Tributário"
+        string="Inscrição Estadual",
+        help="Inscrição Estadual do Substituto Tributário",
     )
 
     cte40_xNome = fields.Char(
@@ -1548,6 +1622,7 @@ class TcteOsToma(models.AbstractModel):
 
 class TcteOsVPrest(models.AbstractModel):
     "Valores da Prestação de Serviço"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcteos_vprest"
     _inherit = "spec.mixin.cte"
@@ -1580,13 +1655,16 @@ class TcteOsVPrest(models.AbstractModel):
 
 class TcteOsVPrestComp(models.AbstractModel):
     "Componentes do Valor da Prestação"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcteos_vprest_comp"
     _inherit = "spec.mixin.cte"
     _binding_type = "TcteOs.InfCte.VPrest.Comp"
 
     cte40_Comp_vPrest_id = fields.Many2one(
-        comodel_name="cte.40.tcteos_vprest", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcteos_vprest",
+        xsd_implicit=True,
+        ondelete="cascade",
     )
     cte40_xNome = fields.Char(
         string="Nome do componente",
@@ -1607,6 +1685,7 @@ class TcteOsVPrestComp(models.AbstractModel):
 
 class TcteOsImp(models.AbstractModel):
     "Informações relativas aos Impostos"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcteos_imp"
     _inherit = "spec.mixin.cte"
@@ -1655,11 +1734,15 @@ class InfTribFed(models.AbstractModel):
     _binding_type = "TcteOs.InfCte.Imp.InfTribFed"
 
     cte40_vPIS = fields.Monetary(
-        string="Valor do PIS", xsd_type="TDec_1302", currency_field="brl_currency_id"
+        string="Valor do PIS",
+        xsd_type="TDec_1302",
+        currency_field="brl_currency_id",
     )
 
     cte40_vCOFINS = fields.Monetary(
-        string="Valor COFINS", xsd_type="TDec_1302", currency_field="brl_currency_id"
+        string="Valor COFINS",
+        xsd_type="TDec_1302",
+        currency_field="brl_currency_id",
     )
 
     cte40_vIR = fields.Monetary(
@@ -1669,11 +1752,15 @@ class InfTribFed(models.AbstractModel):
     )
 
     cte40_vINSS = fields.Monetary(
-        string="Valor do INSS", xsd_type="TDec_1302", currency_field="brl_currency_id"
+        string="Valor do INSS",
+        xsd_type="TDec_1302",
+        currency_field="brl_currency_id",
     )
 
     cte40_vCSLL = fields.Monetary(
-        string="Valor do CSLL", xsd_type="TDec_1302", currency_field="brl_currency_id"
+        string="Valor do CSLL",
+        xsd_type="TDec_1302",
+        currency_field="brl_currency_id",
     )
 
 
@@ -1687,7 +1774,9 @@ class TcteOsAutXml(models.AbstractModel):
     _binding_type = "TcteOs.InfCte.AutXml"
 
     cte40_autXML_infCte_id = fields.Many2one(
-        comodel_name="cte.40.tcteos_infcte", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcteos_infcte",
+        xsd_implicit=True,
+        ondelete="cascade",
     )
     cte40_CNPJ = fields.Char(
         string="CNPJ do autorizado",
@@ -1708,6 +1797,7 @@ class TcteOsAutXml(models.AbstractModel):
 
 class TcteOsInfCteNorm(models.AbstractModel):
     "Grupo de informações do CT-e Normal e Substituto"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcteos_infctenorm"
     _inherit = "spec.mixin.cte"
@@ -1745,7 +1835,8 @@ class TcteOsInfCteNorm(models.AbstractModel):
     cte40_refCTeCanc = fields.Char(
         string="Chave de acesso do CT-e Cancelado",
         help=(
-            "Chave de acesso do CT-e Cancelado\nSomente para Transporte de " "Valores"
+            "Chave de acesso do CT-e Cancelado\nSomente para Transporte de "
+            "Valores"
         ),
     )
 
@@ -1763,6 +1854,7 @@ class TcteOsInfCteNorm(models.AbstractModel):
 
 class InfServico(models.AbstractModel):
     "Informações da Prestação do Serviço"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.infservico"
     _inherit = "spec.mixin.cte"
@@ -1811,13 +1903,16 @@ class TcteOsInfQ(models.AbstractModel):
 
 class InfDocRef(models.AbstractModel):
     "Informações dos documentos referenciados"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.infdocref"
     _inherit = "spec.mixin.cte"
     _binding_type = "TcteOs.InfCte.InfCteNorm.InfDocRef"
 
     cte40_infDocRef_infCTeNorm_id = fields.Many2one(
-        comodel_name="cte.40.tcteos_infctenorm", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcteos_infctenorm",
+        xsd_implicit=True,
+        ondelete="cascade",
     )
     cte40_nDoc = fields.Char(
         string="Número", choice="infdocref", xsd_choice_required=True
@@ -1857,13 +1952,16 @@ class InfDocRef(models.AbstractModel):
 
 class TcteOsSeg(models.AbstractModel):
     "Informações de Seguro da Carga"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcteos_seg"
     _inherit = "spec.mixin.cte"
     _binding_type = "TcteOs.InfCte.InfCteNorm.Seg"
 
     cte40_seg_infCTeNorm_id = fields.Many2one(
-        comodel_name="cte.40.tcteos_infctenorm", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcteos_infctenorm",
+        xsd_implicit=True,
+        ondelete="cascade",
     )
     cte40_respSeg = fields.Selection(
         SEG_RESPSEG,
@@ -1885,6 +1983,7 @@ class TcteOsSeg(models.AbstractModel):
 
 class TcteOsInfModal(models.AbstractModel):
     "Informações do modal"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcteos_infmodal"
     _inherit = "spec.mixin.cte"
@@ -1899,6 +1998,7 @@ class TcteOsInfModal(models.AbstractModel):
 
 class TcteOsInfCteSub(models.AbstractModel):
     "Informações do CT-e de substituição"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcteos_infctesub"
     _inherit = "spec.mixin.cte"
@@ -1913,6 +2013,7 @@ class TcteOsInfCteSub(models.AbstractModel):
 
 class TcteOsCobr(models.AbstractModel):
     "Dados da cobrança do CT-e"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcteos_cobr"
     _inherit = "spec.mixin.cte"
@@ -1929,6 +2030,7 @@ class TcteOsCobr(models.AbstractModel):
 
 class TcteOsFat(models.AbstractModel):
     "Dados da fatura"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcteos_fat"
     _inherit = "spec.mixin.cte"
@@ -1957,13 +2059,16 @@ class TcteOsFat(models.AbstractModel):
 
 class TcteOsDup(models.AbstractModel):
     "Dados das duplicatas"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcteos_dup"
     _inherit = "spec.mixin.cte"
     _binding_type = "TcteOs.InfCte.InfCteNorm.Cobr.Dup"
 
     cte40_dup_cobr_id = fields.Many2one(
-        comodel_name="cte.40.tcteos_cobr", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcteos_cobr",
+        xsd_implicit=True,
+        ondelete="cascade",
     )
     cte40_nDup = fields.Char(string="Número da duplicata")
 
@@ -1982,15 +2087,20 @@ class TcteOsDup(models.AbstractModel):
 
 class InfGtve(models.AbstractModel):
     "Informações das GTV-e relacionadas ao CT-e OS"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.infgtve"
     _inherit = "spec.mixin.cte"
     _binding_type = "TcteOs.InfCte.InfCteNorm.InfGtve"
 
     cte40_infGTVe_infCTeNorm_id = fields.Many2one(
-        comodel_name="cte.40.tcteos_infctenorm", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcteos_infctenorm",
+        xsd_implicit=True,
+        ondelete="cascade",
     )
-    cte40_chCTe = fields.Char(string="Chave de acesso da GTV-e", xsd_required=True)
+    cte40_chCTe = fields.Char(
+        string="Chave de acesso da GTV-e", xsd_required=True
+    )
 
     cte40_comp = fields.One2many(
         "cte.40.tcteos_infctenorm_comp",
@@ -2001,6 +2111,7 @@ class InfGtve(models.AbstractModel):
 
 class TcteOsInfCteNormComp(models.AbstractModel):
     "Componentes do Valor da Prestação"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcteos_infctenorm_comp"
     _inherit = "spec.mixin.cte"
@@ -2037,21 +2148,27 @@ class TcteOsInfCteNormComp(models.AbstractModel):
 
 class TcteOsInfCteComp(models.AbstractModel):
     "Detalhamento do CT-e complementado"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcteos_infctecomp"
     _inherit = "spec.mixin.cte"
     _binding_type = "TcteOs.InfCte.InfCteComp"
 
     cte40_infCteComp_infCte_id = fields.Many2one(
-        comodel_name="cte.40.tcteos_infcte", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcteos_infcte",
+        xsd_implicit=True,
+        ondelete="cascade",
     )
     cte40_chCTe = fields.Char(
-        string="Chave do CT-e complementado", xsd_required=True, xsd_type="TChDFe"
+        string="Chave do CT-e complementado",
+        xsd_required=True,
+        xsd_type="TChDFe",
     )
 
 
 class TcteOsInfCteSupl(models.AbstractModel):
     "Informações suplementares da GTV-e"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcteos_infctesupl"
     _inherit = "spec.mixin.cte"
@@ -2064,6 +2181,7 @@ class TcteOsInfCteSupl(models.AbstractModel):
 
 class Tgtve(models.AbstractModel):
     "Tipo Guia de Transporte de Valores Eletrônica (Modelo 64)"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tgtve"
     _inherit = "spec.mixin.cte"
@@ -2085,6 +2203,7 @@ class Tgtve(models.AbstractModel):
 
 class TgtveInfCte(models.AbstractModel):
     "Informações do CT-e do tipo GTV-e"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tgtve_infcte"
     _inherit = "spec.mixin.cte"
@@ -2099,7 +2218,10 @@ class TgtveInfCte(models.AbstractModel):
     cte40_compl = fields.Many2one(
         comodel_name="cte.40.tgtve_compl",
         string="Dados complementares da GTV-e",
-        help=("Dados complementares da GTV-e para fins operacionais ou " "comerciais"),
+        help=(
+            "Dados complementares da GTV-e para fins operacionais ou "
+            "comerciais"
+        ),
     )
 
     cte40_emit = fields.Many2one(
@@ -2185,6 +2307,7 @@ class TgtveInfCte(models.AbstractModel):
 
 class TgtveIde(models.AbstractModel):
     "Identificação da GTV-e"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tgtve_ide"
     _inherit = "spec.mixin.cte"
@@ -2195,7 +2318,9 @@ class TgtveIde(models.AbstractModel):
         string="Código da UF do emitente da GTV-e",
         xsd_required=True,
         xsd_type="TCodUfIBGE",
-        help=("Código da UF do emitente da GTV-e.\nUtilizar a Tabela do IBGE."),
+        help=(
+            "Código da UF do emitente da GTV-e.\nUtilizar a Tabela do IBGE."
+        ),
     )
 
     cte40_cCT = fields.Char(
@@ -2233,12 +2358,16 @@ class TgtveIde(models.AbstractModel):
         help="Série da GTV-e\nPreencher com '0' no caso de série única",
     )
 
-    cte40_nCT = fields.Char(string="Número da GTV-e", xsd_required=True, xsd_type="TNF")
+    cte40_nCT = fields.Char(
+        string="Número da GTV-e", xsd_required=True, xsd_type="TNF"
+    )
 
     cte40_dhEmi = fields.Char(
         string="Data e hora de emissão da GTV-e",
         xsd_required=True,
-        help=("Data e hora de emissão da GTV-e\nFormato AAAA-MM-DDTHH:MM:DD TZD"),
+        help=(
+            "Data e hora de emissão da GTV-e\nFormato AAAA-MM-DDTHH:MM:DD TZD"
+        ),
     )
 
     cte40_tpImp = fields.Selection(
@@ -2357,13 +2486,18 @@ class TgtveIde(models.AbstractModel):
     cte40_dhSaidaOrig = fields.Char(
         string="Data e hora de saida da origem",
         xsd_required=True,
-        help=("Data e hora de saida da origem\nFormato AAAA-MM-DDTHH:MM:DD TZD"),
+        help=(
+            "Data e hora de saida da origem\nFormato AAAA-MM-DDTHH:MM:DD TZD"
+        ),
     )
 
     cte40_dhChegadaDest = fields.Char(
         string="Data e hora de chegada no destino",
         xsd_required=True,
-        help=("Data e hora de chegada no destino\nFormato AAAA-MM-DDTHH:MM:DD " "TZD"),
+        help=(
+            "Data e hora de chegada no destino\nFormato AAAA-MM-DDTHH:MM:DD "
+            "TZD"
+        ),
     )
 
     cte40_toma = fields.Many2one(
@@ -2391,7 +2525,9 @@ class TgtveIde(models.AbstractModel):
         ),
     )
 
-    cte40_xJust = fields.Char(string="Justificativa da entrada em contingência")
+    cte40_xJust = fields.Char(
+        string="Justificativa da entrada em contingência"
+    )
 
 
 class TgtveToma(models.AbstractModel):
@@ -2481,6 +2617,7 @@ class TomaTerceiro(models.AbstractModel):
 
 class TgtveCompl(models.AbstractModel):
     "Dados complementares da GTV-e para fins operacionais ou comerciais"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tgtve_compl"
     _inherit = "spec.mixin.cte"
@@ -2538,11 +2675,15 @@ class TgtveObsCont(models.AbstractModel):
     _binding_type = "Tgtve.InfCte.Compl.ObsCont"
 
     cte40_ObsCont_compl_id = fields.Many2one(
-        comodel_name="cte.40.tgtve_compl", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tgtve_compl",
+        xsd_implicit=True,
+        ondelete="cascade",
     )
     cte40_xTexto = fields.Char(string="Conteúdo do campo", xsd_required=True)
 
-    cte40_xCampo = fields.Char(string="Identificação do campo", xsd_required=True)
+    cte40_xCampo = fields.Char(
+        string="Identificação do campo", xsd_required=True
+    )
 
 
 class TgtveObsFisco(models.AbstractModel):
@@ -2555,15 +2696,20 @@ class TgtveObsFisco(models.AbstractModel):
     _binding_type = "Tgtve.InfCte.Compl.ObsFisco"
 
     cte40_ObsFisco_compl_id = fields.Many2one(
-        comodel_name="cte.40.tgtve_compl", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tgtve_compl",
+        xsd_implicit=True,
+        ondelete="cascade",
     )
     cte40_xTexto = fields.Char(string="Conteúdo do campo", xsd_required=True)
 
-    cte40_xCampo = fields.Char(string="Identificação do campo", xsd_required=True)
+    cte40_xCampo = fields.Char(
+        string="Identificação do campo", xsd_required=True
+    )
 
 
 class TgtveEmit(models.AbstractModel):
     "Identificação do Emitente da GTV-e"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tgtve_emit"
     _inherit = "spec.mixin.cte"
@@ -2576,10 +2722,13 @@ class TgtveEmit(models.AbstractModel):
         help="CNPJ do emitente\nInformar zeros não significativos",
     )
 
-    cte40_IE = fields.Char(string="Inscrição Estadual do Emitente", xsd_required=True)
+    cte40_IE = fields.Char(
+        string="Inscrição Estadual do Emitente", xsd_required=True
+    )
 
     cte40_IEST = fields.Char(
-        string="Inscrição Estadual", help="Inscrição Estadual do Substituto Tributário"
+        string="Inscrição Estadual",
+        help="Inscrição Estadual do Substituto Tributário",
     )
 
     cte40_xNome = fields.Char(
@@ -2722,6 +2871,7 @@ class TgtveDest(models.AbstractModel):
 
 class DetGtv(models.AbstractModel):
     "Grupo de informações detalhadas da GTV-e"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.detgtv"
     _inherit = "spec.mixin.cte"
@@ -2748,13 +2898,15 @@ class DetGtv(models.AbstractModel):
         "cte40_infVeiculo_detGTV_id",
         string="Grupo de informações",
         help=(
-            "Grupo de informações dos veículos utilizados no transporte de " "valores"
+            "Grupo de informações dos veículos utilizados no transporte de "
+            "valores"
         ),
     )
 
 
 class TgtveInfEspecie(models.AbstractModel):
     "Informações das Espécies transportadas"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tgtve_infespecie"
     _inherit = "spec.mixin.cte"
@@ -2767,7 +2919,9 @@ class TgtveInfEspecie(models.AbstractModel):
         INFESPECIE_TPESPECIE,
         string="Tipo da Espécie",
         xsd_required=True,
-        help=("Tipo da Espécie\n1 - Cédula\n2 - Cheque\n3 - Moeda\n4 - Outros"),
+        help=(
+            "Tipo da Espécie\n1 - Cédula\n2 - Cheque\n3 - Moeda\n4 - Outros"
+        ),
     )
 
     cte40_vEspecie = fields.Monetary(
@@ -2831,7 +2985,9 @@ class TgtveAutXml(models.AbstractModel):
     _binding_type = "Tgtve.InfCte.AutXml"
 
     cte40_autXML_infCte_id = fields.Many2one(
-        comodel_name="cte.40.tgtve_infcte", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tgtve_infcte",
+        xsd_implicit=True,
+        ondelete="cascade",
     )
     cte40_CNPJ = fields.Char(
         string="CNPJ do autorizado",
@@ -2852,6 +3008,7 @@ class TgtveAutXml(models.AbstractModel):
 
 class TgtveInfCteSupl(models.AbstractModel):
     "Informações suplementares da GTV-e"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tgtve_infctesupl"
     _inherit = "spec.mixin.cte"
@@ -2864,6 +3021,7 @@ class TgtveInfCteSupl(models.AbstractModel):
 
 class TretCte(models.AbstractModel):
     "Tipo Retorno do Pedido de Autorização de CT-e (Modelo 57)"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tretcte"
     _inherit = "spec.mixin.cte"
@@ -2910,11 +3068,14 @@ class TretCte(models.AbstractModel):
         xsd_type="TProtCTe",
     )
 
-    cte40_versao = fields.Char(string="versao", xsd_required=True, xsd_type="TVerCTe")
+    cte40_versao = fields.Char(
+        string="versao", xsd_required=True, xsd_type="TVerCTe"
+    )
 
 
 class TretCteOs(models.AbstractModel):
     "Tipo Retorno do Pedido de Autorização de CT-e OS (Modelo 67)"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tretcteos"
     _inherit = "spec.mixin.cte"
@@ -2961,11 +3122,14 @@ class TretCteOs(models.AbstractModel):
         xsd_type="TProtCTeOS",
     )
 
-    cte40_versao = fields.Char(string="versao", xsd_required=True, xsd_type="TVerCTe")
+    cte40_versao = fields.Char(
+        string="versao", xsd_required=True, xsd_type="TVerCTe"
+    )
 
 
 class TretGtve(models.AbstractModel):
     "Tipo Retorno do Pedido de Autorização de GTV-e (Modelo 64)"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tretgtve"
     _inherit = "spec.mixin.cte"
@@ -3012,11 +3176,14 @@ class TretGtve(models.AbstractModel):
         xsd_type="TProtGTVe",
     )
 
-    cte40_versao = fields.Char(string="versao", xsd_required=True, xsd_type="TVerCTe")
+    cte40_versao = fields.Char(
+        string="versao", xsd_required=True, xsd_type="TVerCTe"
+    )
 
 
 class TunidadeTransp(models.AbstractModel):
     "Tipo Dados Unidade de Transporte"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tunidadetransp"
     _inherit = "spec.mixin.cte"
@@ -3026,7 +3193,9 @@ class TunidadeTransp(models.AbstractModel):
         comodel_name="cte.40.tcte_infnf", xsd_implicit=True, ondelete="cascade"
     )
     cte40_infUnidTransp_infNFe_id = fields.Many2one(
-        comodel_name="cte.40.tcte_infnfe", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcte_infnfe",
+        xsd_implicit=True,
+        ondelete="cascade",
     )
     cte40_infUnidTransp_infOutros_id = fields.Many2one(
         comodel_name="cte.40.infoutros", xsd_implicit=True, ondelete="cascade"
@@ -3084,19 +3253,23 @@ class TunidadeTransp(models.AbstractModel):
 
 class LacUnidTransp(models.AbstractModel):
     "Lacres das Unidades de Transporte"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.lacunidtransp"
     _inherit = "spec.mixin.cte"
     _binding_type = "TunidadeTransp.LacUnidTransp"
 
     cte40_lacUnidTransp_TUnidadeTransp_id = fields.Many2one(
-        comodel_name="cte.40.tunidadetransp", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tunidadetransp",
+        xsd_implicit=True,
+        ondelete="cascade",
     )
     cte40_nLacre = fields.Char(string="Número do lacre", xsd_required=True)
 
 
 class Tcte(models.AbstractModel):
     "Tipo Conhecimento de Transporte Eletrônico (Modelo 57)"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcte"
     _inherit = "spec.mixin.cte"
@@ -3116,6 +3289,7 @@ class Tcte(models.AbstractModel):
 
 class TcteInfCte(models.AbstractModel):
     "Informações do CT-e do tipo GTV-e"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcte_infcte"
     _inherit = "spec.mixin.cte"
@@ -3130,7 +3304,9 @@ class TcteInfCte(models.AbstractModel):
     cte40_compl = fields.Many2one(
         comodel_name="cte.40.tcte_compl",
         string="Dados complementares do CT-e",
-        help=("Dados complementares do CT-e para fins operacionais ou comerciais"),
+        help=(
+            "Dados complementares do CT-e para fins operacionais ou comerciais"
+        ),
     )
 
     cte40_emit = fields.Many2one(
@@ -3216,7 +3392,9 @@ class TcteInfCte(models.AbstractModel):
     cte40_infSolicNFF = fields.Many2one(
         comodel_name="cte.40.tcte_infsolicnff",
         string="Grupo de informações do pedido",
-        help=("Grupo de informações do pedido de emissão da Nota Fiscal Fácil"),
+        help=(
+            "Grupo de informações do pedido de emissão da Nota Fiscal Fácil"
+        ),
     )
 
     cte40_infPAA = fields.Many2one(
@@ -3243,6 +3421,7 @@ class TcteInfCte(models.AbstractModel):
 
 class TcteIde(models.AbstractModel):
     "Identificação da GTV-e"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcte_ide"
     _inherit = "spec.mixin.cte"
@@ -3292,12 +3471,16 @@ class TcteIde(models.AbstractModel):
         help="Série do CT-e\nPreencher com '0' no caso de série única",
     )
 
-    cte40_nCT = fields.Char(string="Número do CT-e", xsd_required=True, xsd_type="TNF")
+    cte40_nCT = fields.Char(
+        string="Número do CT-e", xsd_required=True, xsd_type="TNF"
+    )
 
     cte40_dhEmi = fields.Char(
         string="Data e hora de emissão do CT-e",
         xsd_required=True,
-        help=("Data e hora de emissão do CT-e\nFormato AAAA-MM-DDTHH:MM:DD TZD"),
+        help=(
+            "Data e hora de emissão do CT-e\nFormato AAAA-MM-DDTHH:MM:DD TZD"
+        ),
     )
 
     cte40_tpImp = fields.Selection(
@@ -3337,7 +3520,9 @@ class TcteIde(models.AbstractModel):
         string="Tipo do Ambiente",
         xsd_required=True,
         xsd_type="TAmb",
-        help=("Tipo do Ambiente\nPreencher com:1 - Produção; 2 - Homologação."),
+        help=(
+            "Tipo do Ambiente\nPreencher com:1 - Produção; 2 - Homologação."
+        ),
     )
 
     cte40_tpCTe = fields.Selection(
@@ -3460,7 +3645,8 @@ class TcteIde(models.AbstractModel):
         xsd_required=True,
         xsd_type="TUf",
         help=(
-            "UF do início da prestação\nInformar 'EX' para operações com o " "exterior."
+            "UF do início da prestação\nInformar 'EX' para operações com o "
+            "exterior."
         ),
     )
 
@@ -3543,7 +3729,9 @@ class TcteIde(models.AbstractModel):
         ),
     )
 
-    cte40_xJust = fields.Char(string="Justificativa da entrada em contingência")
+    cte40_xJust = fields.Char(
+        string="Justificativa da entrada em contingência"
+    )
 
 
 class Toma3(models.AbstractModel):
@@ -3637,6 +3825,7 @@ class TcteToma4(models.AbstractModel):
 
 class TcteCompl(models.AbstractModel):
     "Dados complementares da GTV-e para fins operacionais ou comerciais"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcte_compl"
     _inherit = "spec.mixin.cte"
@@ -3731,7 +3920,9 @@ class Fluxo(models.AbstractModel):
         ),
     )
 
-    cte40_pass = fields.One2many("cte.40.pass", "cte40_pass_fluxo_id", string="pass")
+    cte40_pass = fields.One2many(
+        "cte.40.pass", "cte40_pass_fluxo_id", string="pass"
+    )
 
     cte40_xDest = fields.Char(
         string="Sigla ou código interno (xDest)",
@@ -3773,6 +3964,7 @@ class Pass(models.AbstractModel):
 
 class Entrega(models.AbstractModel):
     "Informações ref. a previsão de entrega"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.entrega"
     _inherit = "spec.mixin.cte"
@@ -3784,7 +3976,8 @@ class Entrega(models.AbstractModel):
         choice="entrega",
         xsd_choice_required=True,
         help=(
-            "Entrega sem data definida\nEsta opção é proibida para o modal " "aéreo."
+            "Entrega sem data definida\nEsta opção é proibida para o modal "
+            "aéreo."
         ),
     )
 
@@ -3837,12 +4030,16 @@ class SemData(models.AbstractModel):
         SEMDATA_TPPER,
         string="Tipo de data/período programado",
         xsd_required=True,
-        help=("Tipo de data/período programado para entrega\n0- Sem data " "definida"),
+        help=(
+            "Tipo de data/período programado para entrega\n0- Sem data "
+            "definida"
+        ),
     )
 
 
 class ComData(models.AbstractModel):
     "Entrega com data definida"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.comdata"
     _inherit = "spec.mixin.cte"
@@ -3870,6 +4067,7 @@ class ComData(models.AbstractModel):
 
 class NoPeriodo(models.AbstractModel):
     "Entrega no período definido"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.noperiodo"
     _inherit = "spec.mixin.cte"
@@ -3899,6 +4097,7 @@ class NoPeriodo(models.AbstractModel):
 
 class SemHora(models.AbstractModel):
     "Entrega sem hora definida"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.semhora"
     _inherit = "spec.mixin.cte"
@@ -3914,6 +4113,7 @@ class SemHora(models.AbstractModel):
 
 class ComHora(models.AbstractModel):
     "Entrega com hora definida"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.comhora"
     _inherit = "spec.mixin.cte"
@@ -3942,6 +4142,7 @@ class ComHora(models.AbstractModel):
 
 class NoInter(models.AbstractModel):
     "Entrega no intervalo de horário definido"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.nointer"
     _inherit = "spec.mixin.cte"
@@ -3983,7 +4184,9 @@ class TcteObsCont(models.AbstractModel):
     )
     cte40_xTexto = fields.Char(string="Conteúdo do campo", xsd_required=True)
 
-    cte40_xCampo = fields.Char(string="Identificação do campo", xsd_required=True)
+    cte40_xCampo = fields.Char(
+        string="Identificação do campo", xsd_required=True
+    )
 
 
 class TcteObsFisco(models.AbstractModel):
@@ -4000,11 +4203,14 @@ class TcteObsFisco(models.AbstractModel):
     )
     cte40_xTexto = fields.Char(string="Conteúdo do campo", xsd_required=True)
 
-    cte40_xCampo = fields.Char(string="Identificação do campo", xsd_required=True)
+    cte40_xCampo = fields.Char(
+        string="Identificação do campo", xsd_required=True
+    )
 
 
 class TcteEmit(models.AbstractModel):
     "Identificação do Emitente da GTV-e"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcte_emit"
     _inherit = "spec.mixin.cte"
@@ -4037,7 +4243,8 @@ class TcteEmit(models.AbstractModel):
     )
 
     cte40_IEST = fields.Char(
-        string="Inscrição Estadual", help="Inscrição Estadual do Substituto Tributário"
+        string="Inscrição Estadual",
+        help="Inscrição Estadual do Substituto Tributário",
     )
 
     cte40_xNome = fields.Char(
@@ -4128,6 +4335,7 @@ class TcteRem(models.AbstractModel):
 
 class Exped(models.AbstractModel):
     "Informações do Expedidor da Carga"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.exped"
     _inherit = "spec.mixin.cte"
@@ -4180,6 +4388,7 @@ class Exped(models.AbstractModel):
 
 class Receb(models.AbstractModel):
     "Informações do Recebedor da Carga"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.receb"
     _inherit = "spec.mixin.cte"
@@ -4297,6 +4506,7 @@ class TcteDest(models.AbstractModel):
 
 class TcteVPrest(models.AbstractModel):
     "Valores da Prestação de Serviço"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcte_vprest"
     _inherit = "spec.mixin.cte"
@@ -4329,13 +4539,16 @@ class TcteVPrest(models.AbstractModel):
 
 class TcteVPrestComp(models.AbstractModel):
     "Componentes do Valor da Prestação"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcte_vprest_comp"
     _inherit = "spec.mixin.cte"
     _binding_type = "Tcte.InfCte.VPrest.Comp"
 
     cte40_Comp_vPrest_id = fields.Many2one(
-        comodel_name="cte.40.tcte_vprest", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcte_vprest",
+        xsd_implicit=True,
+        ondelete="cascade",
     )
     cte40_xNome = fields.Char(
         string="Nome do componente",
@@ -4356,6 +4569,7 @@ class TcteVPrestComp(models.AbstractModel):
 
 class TcteImp(models.AbstractModel):
     "Informações relativas aos Impostos"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcte_imp"
     _inherit = "spec.mixin.cte"
@@ -4393,7 +4607,9 @@ class TcteAutXml(models.AbstractModel):
     _binding_type = "Tcte.InfCte.AutXml"
 
     cte40_autXML_infCte_id = fields.Many2one(
-        comodel_name="cte.40.tcte_infcte", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcte_infcte",
+        xsd_implicit=True,
+        ondelete="cascade",
     )
     cte40_CNPJ = fields.Char(
         string="CNPJ do autorizado",
@@ -4414,6 +4630,7 @@ class TcteAutXml(models.AbstractModel):
 
 class TcteInfSolicNff(models.AbstractModel):
     "Grupo de informações do pedido de emissão da Nota Fiscal Fácil"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcte_infsolicnff"
     _inherit = "spec.mixin.cte"
@@ -4432,6 +4649,7 @@ class TcteInfSolicNff(models.AbstractModel):
 
 class TcteInfPaa(models.AbstractModel):
     "Grupo de Informação do Provedor de Assinatura e Autorização"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcte_infpaa"
     _inherit = "spec.mixin.cte"
@@ -4454,6 +4672,7 @@ class TcteInfPaa(models.AbstractModel):
 
 class TctePaasignature(models.AbstractModel):
     "Assinatura RSA do Emitente para DFe gerados por PAA"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcte_paasignature"
     _inherit = "spec.mixin.cte"
@@ -4480,6 +4699,7 @@ class TctePaasignature(models.AbstractModel):
 
 class TcteInfCteNorm(models.AbstractModel):
     "Grupo de informações do CT-e Normal e Substituto"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcte_infctenorm"
     _inherit = "spec.mixin.cte"
@@ -4504,7 +4724,8 @@ class TcteInfCteNorm(models.AbstractModel):
     )
 
     cte40_docAnt = fields.Many2one(
-        comodel_name="cte.40.docant", string="Documentos de Transporte Anterior"
+        comodel_name="cte.40.docant",
+        string="Documentos de Transporte Anterior",
     )
 
     cte40_infModal = fields.Many2one(
@@ -4529,7 +4750,8 @@ class TcteInfCteNorm(models.AbstractModel):
     )
 
     cte40_infGlobalizado = fields.Many2one(
-        comodel_name="cte.40.infglobalizado", string="Informações do CT-e Globalizado"
+        comodel_name="cte.40.infglobalizado",
+        string="Informações do CT-e Globalizado",
     )
 
     cte40_infServVinc = fields.Many2one(
@@ -4541,6 +4763,7 @@ class TcteInfCteNorm(models.AbstractModel):
 
 class InfCarga(models.AbstractModel):
     "Informações da Carga do CT-e"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.infcarga"
     _inherit = "spec.mixin.cte"
@@ -4559,7 +4782,10 @@ class InfCarga(models.AbstractModel):
     cte40_proPred = fields.Char(
         string="Produto predominante",
         xsd_required=True,
-        help=("Produto predominante\nInformar a descrição do produto " "predominante"),
+        help=(
+            "Produto predominante\nInformar a descrição do produto "
+            "predominante"
+        ),
     )
 
     cte40_xOutCat = fields.Char(
@@ -4702,7 +4928,9 @@ class TcteInfNf(models.AbstractModel):
     _binding_type = "Tcte.InfCte.InfCteNorm.InfDoc.InfNf"
 
     cte40_infNF_infDoc_id = fields.Many2one(
-        comodel_name="cte.40.tcte_infdoc", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcte_infdoc",
+        xsd_implicit=True,
+        ondelete="cascade",
     )
     cte40_nRoma = fields.Char(string="Número do Romaneio da NF")
 
@@ -4835,13 +5063,16 @@ class TcteInfNf(models.AbstractModel):
 
 class TcteInfNfe(models.AbstractModel):
     "Informações das NF-e"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcte_infnfe"
     _inherit = "spec.mixin.cte"
     _binding_type = "Tcte.InfCte.InfCteNorm.InfDoc.InfNfe"
 
     cte40_infNFe_infDoc_id = fields.Many2one(
-        comodel_name="cte.40.tcte_infdoc", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcte_infdoc",
+        xsd_implicit=True,
+        ondelete="cascade",
     )
     cte40_chave = fields.Char(
         string="Chave de acesso da NF-e", xsd_required=True, xsd_type="TChDFe"
@@ -4891,13 +5122,16 @@ class TcteInfNfe(models.AbstractModel):
 
 class InfOutros(models.AbstractModel):
     "Informações dos demais documentos"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.infoutros"
     _inherit = "spec.mixin.cte"
     _binding_type = "Tcte.InfCte.InfCteNorm.InfDoc.InfOutros"
 
     cte40_infOutros_infDoc_id = fields.Many2one(
-        comodel_name="cte.40.tcte_infdoc", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcte_infdoc",
+        xsd_implicit=True,
+        ondelete="cascade",
     )
     cte40_tpDoc = fields.Selection(
         INFOUTROS_TPDOC,
@@ -4967,6 +5201,7 @@ class InfOutros(models.AbstractModel):
 
 class DocAnt(models.AbstractModel):
     "Documentos de Transporte Anterior"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.docant"
     _inherit = "spec.mixin.cte"
@@ -4981,6 +5216,7 @@ class DocAnt(models.AbstractModel):
 
 class EmiDocAnt(models.AbstractModel):
     "Emissor do documento anterior"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.emidocant"
     _inherit = "spec.mixin.cte"
@@ -5027,12 +5263,16 @@ class EmiDocAnt(models.AbstractModel):
         "cte.40.iddocant",
         "cte40_idDocAnt_emiDocAnt_id",
         string="Informações de identificação",
-        help=("Informações de identificação dos documentos de Transporte " "Anterior"),
+        help=(
+            "Informações de identificação dos documentos de Transporte "
+            "Anterior"
+        ),
     )
 
 
 class IdDocAnt(models.AbstractModel):
     "Informações de identificação dos documentos de Transporte Anterior"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.iddocant"
     _inherit = "spec.mixin.cte"
@@ -5062,10 +5302,13 @@ class IdDocAnt(models.AbstractModel):
 
 class IdDocAntPap(models.AbstractModel):
     "Documentos de transporte anterior em papel"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.iddocantpap"
     _inherit = "spec.mixin.cte"
-    _binding_type = "Tcte.InfCte.InfCteNorm.DocAnt.EmiDocAnt.IdDocAnt.IdDocAntPap"
+    _binding_type = (
+        "Tcte.InfCte.InfCteNorm.DocAnt.EmiDocAnt.IdDocAnt.IdDocAntPap"
+    )
 
     cte40_idDocAntPap_idDocAnt_id = fields.Many2one(
         comodel_name="cte.40.iddocant", xsd_implicit=True, ondelete="cascade"
@@ -5084,23 +5327,32 @@ class IdDocAntPap(models.AbstractModel):
         ),
     )
 
-    cte40_serie = fields.Char(string="Série do Documento Fiscal", xsd_required=True)
+    cte40_serie = fields.Char(
+        string="Série do Documento Fiscal", xsd_required=True
+    )
 
     cte40_subser = fields.Char(string="Série do Documento Fiscal (subser)")
 
-    cte40_nDoc = fields.Char(string="Número do Documento Fiscal", xsd_required=True)
+    cte40_nDoc = fields.Char(
+        string="Número do Documento Fiscal", xsd_required=True
+    )
 
     cte40_dEmi = fields.Date(
-        string="Data de emissão (AAAA-MM-DD)", xsd_required=True, xsd_type="TData"
+        string="Data de emissão (AAAA-MM-DD)",
+        xsd_required=True,
+        xsd_type="TData",
     )
 
 
 class IdDocAntEle(models.AbstractModel):
     "Documentos de transporte anterior eletrônicos"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.iddocantele"
     _inherit = "spec.mixin.cte"
-    _binding_type = "Tcte.InfCte.InfCteNorm.DocAnt.EmiDocAnt.IdDocAnt.IdDocAntEle"
+    _binding_type = (
+        "Tcte.InfCte.InfCteNorm.DocAnt.EmiDocAnt.IdDocAnt.IdDocAntEle"
+    )
 
     cte40_idDocAntEle_idDocAnt_id = fields.Many2one(
         comodel_name="cte.40.iddocant", xsd_implicit=True, ondelete="cascade"
@@ -5112,6 +5364,7 @@ class IdDocAntEle(models.AbstractModel):
 
 class TcteInfModal(models.AbstractModel):
     "Informações do modal"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcte_infmodal"
     _inherit = "spec.mixin.cte"
@@ -5126,13 +5379,16 @@ class TcteInfModal(models.AbstractModel):
 
 class VeicNovos(models.AbstractModel):
     "informações dos veículos transportados"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.veicnovos"
     _inherit = "spec.mixin.cte"
     _binding_type = "Tcte.InfCte.InfCteNorm.VeicNovos"
 
     cte40_veicNovos_infCTeNorm_id = fields.Many2one(
-        comodel_name="cte.40.tcte_infctenorm", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcte_infctenorm",
+        xsd_implicit=True,
+        ondelete="cascade",
     )
     cte40_chassi = fields.Char(string="Chassi do veículo", xsd_required=True)
 
@@ -5167,6 +5423,7 @@ class VeicNovos(models.AbstractModel):
 
 class TcteCobr(models.AbstractModel):
     "Dados da cobrança do CT-e"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcte_cobr"
     _inherit = "spec.mixin.cte"
@@ -5183,6 +5440,7 @@ class TcteCobr(models.AbstractModel):
 
 class TcteFat(models.AbstractModel):
     "Dados da fatura"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcte_fat"
     _inherit = "spec.mixin.cte"
@@ -5211,6 +5469,7 @@ class TcteFat(models.AbstractModel):
 
 class TcteDup(models.AbstractModel):
     "Dados das duplicatas"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcte_dup"
     _inherit = "spec.mixin.cte"
@@ -5236,6 +5495,7 @@ class TcteDup(models.AbstractModel):
 
 class TcteInfCteSub(models.AbstractModel):
     "Informações do CT-e de substituição"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcte_infctesub"
     _inherit = "spec.mixin.cte"
@@ -5248,12 +5508,14 @@ class TcteInfCteSub(models.AbstractModel):
     )
 
     cte40_indAlteraToma = fields.Selection(
-        INFCTESUB_INDALTERATOMA, string="Indicador de CT-e Alteração de Tomador"
+        INFCTESUB_INDALTERATOMA,
+        string="Indicador de CT-e Alteração de Tomador",
     )
 
 
 class InfGlobalizado(models.AbstractModel):
     "Informações do CT-e Globalizado"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.infglobalizado"
     _inherit = "spec.mixin.cte"
@@ -5268,6 +5530,7 @@ class InfGlobalizado(models.AbstractModel):
 
 class InfServVinc(models.AbstractModel):
     "Informações do Serviço Vinculado a Multimodal"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.infservvinc"
     _inherit = "spec.mixin.cte"
@@ -5282,13 +5545,16 @@ class InfServVinc(models.AbstractModel):
 
 class InfCteMultimodal(models.AbstractModel):
     "informações do CT-e multimodal vinculado"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.infctemultimodal"
     _inherit = "spec.mixin.cte"
     _binding_type = "Tcte.InfCte.InfCteNorm.InfServVinc.InfCteMultimodal"
 
     cte40_infCTeMultimodal_infServVinc_id = fields.Many2one(
-        comodel_name="cte.40.infservvinc", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.infservvinc",
+        xsd_implicit=True,
+        ondelete="cascade",
     )
     cte40_chCTeMultimodal = fields.Char(
         string="Chave de acesso do CT-e Multimodal",
@@ -5299,21 +5565,27 @@ class InfCteMultimodal(models.AbstractModel):
 
 class TcteInfCteComp(models.AbstractModel):
     "Detalhamento do CT-e complementado"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcte_infctecomp"
     _inherit = "spec.mixin.cte"
     _binding_type = "Tcte.InfCte.InfCteComp"
 
     cte40_infCteComp_infCte_id = fields.Many2one(
-        comodel_name="cte.40.tcte_infcte", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcte_infcte",
+        xsd_implicit=True,
+        ondelete="cascade",
     )
     cte40_chCTe = fields.Char(
-        string="Chave do CT-e complementado", xsd_required=True, xsd_type="TChDFe"
+        string="Chave do CT-e complementado",
+        xsd_required=True,
+        xsd_type="TChDFe",
     )
 
 
 class TcteInfCteSupl(models.AbstractModel):
     "Informações suplementares da GTV-e"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tcte_infctesupl"
     _inherit = "spec.mixin.cte"

--- a/l10n_br_cte_spec/models/v4_0/evento_cte_tipos_basico_v4_00.py
+++ b/l10n_br_cte_spec/models/v4_0/evento_cte_tipos_basico_v4_00.py
@@ -25,13 +25,16 @@ TMODTRANSP = [
 
 class Tevento(models.AbstractModel):
     "Tipo Evento"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tevento"
     _inherit = "spec.mixin.cte"
     _binding_type = "Tevento"
 
     cte40_infEvento = fields.Many2one(
-        comodel_name="cte.40.tevento_infevento", string="infEvento", xsd_required=True
+        comodel_name="cte.40.tevento_infevento",
+        string="infEvento",
+        xsd_required=True,
     )
 
     cte40_versao = fields.Char(
@@ -142,6 +145,7 @@ class TeventoInfEvento(models.AbstractModel):
 
 class DetEvento(models.AbstractModel):
     "Detalhamento do evento específico"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.detevento"
     _inherit = "spec.mixin.cte"
@@ -172,6 +176,7 @@ class TeventoInfSolicNff(models.AbstractModel):
 
 class TeventoInfPaa(models.AbstractModel):
     "Grupo de Informação do Provedor de Assinatura e Autorização"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tevento_infpaa"
     _inherit = "spec.mixin.cte"
@@ -194,6 +199,7 @@ class TeventoInfPaa(models.AbstractModel):
 
 class TeventoPaasignature(models.AbstractModel):
     "Assinatura RSA do Emitente para DFe gerados por PAA"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tevento_paasignature"
     _inherit = "spec.mixin.cte"
@@ -220,6 +226,7 @@ class TeventoPaasignature(models.AbstractModel):
 
 class TretEvento(models.AbstractModel):
     "Tipo retorno do Evento"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tretevento"
     _inherit = "spec.mixin.cte"
@@ -309,6 +316,7 @@ class TretEventoInfEvento(models.AbstractModel):
 
 class TprocEvento(models.AbstractModel):
     "Tipo procEvento"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.tprocevento"
     _inherit = "spec.mixin.cte"
@@ -335,7 +343,9 @@ class TprocEvento(models.AbstractModel):
     cte40_ipTransmissor = fields.Char(
         string="IP do transmissor",
         xsd_type="TIPv4",
-        help=("IP do transmissor do documento fiscal para o ambiente autorizador"),
+        help=(
+            "IP do transmissor do documento fiscal para o ambiente autorizador"
+        ),
     )
 
     cte40_nPortaCon = fields.Char(

--- a/l10n_br_cte_spec/models/v4_0/tipos_geral_cte_v4_00.py
+++ b/l10n_br_cte_spec/models/v4_0/tipos_geral_cte_v4_00.py
@@ -194,6 +194,7 @@ TTIPOUNIDTRANSP = [
 
 class TrsakeyValueType(models.AbstractModel):
     "Tipo que representa uma chave publica padrão RSA"
+
     _description = textwrap.dedent("    %s" % (__doc__,))
     _name = "cte.40.trsakeyvaluetype"
     _inherit = "spec.mixin.cte"

--- a/l10n_br_cte_spec/readme/DESCRIPTION.rst
+++ b/l10n_br_cte_spec/readme/DESCRIPTION.rst
@@ -2,11 +2,7 @@ Este módulo contem a estrutura de dados do Conhecimento de Transporte Eletrôni
 Este módulo não faz nada sozinho, ele precisaria de um modulo `l10n_br_cte` que mapearia esses mixins
 nos documentos fiscais Odoo de forma semelhante a forma como o módulo `l10n_br_nfe` faz como o módulo `l10n_br_nfe_spec`.
 
-Este módulo inclue os principais leiautes persistantes de CT-e:
-
-* CT-e (Conhecimento de Transporte Eletrônico)
-* CT-e OS (Conhecimento de transporte eletrônico para outros serviço
-
+Este módulo inclui os principais layouts persistentes do CT-e (Conhecimento de Transporte Eletrônico).
 
 Geração
 ~~~~~~~
@@ -18,5 +14,5 @@ https://github.com/akretion/xsdata-odoo
 
 O comando usado foi::
 
-  export XSDATA_SCHEMA=cte; export XSDATA_VERSION=30; export XSDATA_SKIP="^ICMS\d+|^ICMSSN+|ICMSOutraUF|ICMSUFFim"; export XSDATA_LANG="portuguese"
+  export XSDATA_SCHEMA=cte; export XSDATA_VERSION=40; export XSDATA_SKIP="^ICMS\d+|^ICMSSN+|ICMSOutraUF|ICMSUFFim"; export XSDATA_LANG="portuguese"
   xsdata generate nfelib/cte/schemas/v4_0 --package nfelib.cte.odoo.v4_0 --output=odoo


### PR DESCRIPTION
Atualizacao referente a atualizacao CTe NT2024.002 - Publicado em 08/04/2024 dos esquemas de CTe. Na nfelib eu tinha feito a atualizacao um tempo atras ja aqui: https://github.com/akretion/nfelib/pull/99

Ja que tem pessoas mexendo na CTe de novo, vale a pena atualizar. Novamente sao coisas triviais de sincronizar com as branches mais novas depois.

Eu tambem aproveitei para corrigir o summary no l10n_br_mdfe_spec num outro commit.

cc @marcelsavegnago @renatonlima @mileo @antoniospneto @felipemotter 