### PR TITLE
[14.0][REF] l10n_br_purchase: Usando o campo related para o País da Empresa ao invés de um campo função

### DIFF
--- a/l10n_br_purchase/models/purchase_order.py
+++ b/l10n_br_purchase/models/purchase_order.py
@@ -22,11 +22,7 @@ class PurchaseOrder(models.Model):
         ]
         return domain
 
-    active_company_country_id = fields.Many2one(
-        comodel_name="res.country",
-        string="Company",
-        default=lambda self: self.env.company.country_id,
-    )
+    company_country_id = fields.Many2one(related="company_id.country_id")
 
     fiscal_operation_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.operation",

--- a/l10n_br_purchase/views/purchase_view.xml
+++ b/l10n_br_purchase/views/purchase_view.xml
@@ -21,10 +21,10 @@
           <field name="priority">100</field>
           <field name="arch" type="xml">
               <xpath expr="//field[@name='partner_ref']" position="after">
-                  <field name="active_company_country_id" invisible="True" />
+                  <field name="company_country_id" invisible="True" />
                   <field
                     name="fiscal_operation_id"
-                    attrs="{'invisible': [('active_company_country_id', '!=', %(base.br)d)]}"
+                    attrs="{'invisible': [('company_country_id', '!=', %(base.br)d)]}"
                 />
                   <field
                     name="ind_final"


### PR DESCRIPTION
It's unnecessary create a field for Country Company because can be done by related.

Usando o campo related para o País da Empresa ao invés de um campo função, PR simples que corrigi algo que acabou passando por não causar nenhum erro, quando estive testando o caso de compatibilidade com casos internacionais eu precisei validar se o Active Company era o mesmo do Company, o mesmo ocorreu no l10n_br_sale mas corrigi antes do merge, com isso deve desaparecer o warning

WARNING odoo odoo.addons.base.models.ir_model: Two fields (active_company_country_id, company_id) of purchase.order() have the same label: Company.

cc @rvalyi @renatonlima @marcelsavegnago @mileo 