### PR TITLE
[14.0][IMP] l10n_br_nfse_focus: add ssl verification for pdf retrieval in cancellation process

### DIFF
--- a/l10n_br_nfse_focus/models/document.py
+++ b/l10n_br_nfse_focus/models/document.py
@@ -503,9 +503,15 @@ class Document(models.Model):
                     )
                     status_json = status_rps.json()
                     pdf_content = (
-                        requests.get(status_json["url"], timeout=TIMEOUT).content
+                        requests.get(
+                            status_json["url"],
+                            timeout=TIMEOUT,
+                            verify=record.company_id.nfse_ssl_verify,
+                        ).content
                         or requests.get(
-                            status_json["url_danfse"], timeout=TIMEOUT
+                            status_json["url_danfse"],
+                            timeout=TIMEOUT,
+                            verify=record.company_id.nfse_ssl_verify,
                         ).content
                     )
                     record.make_focus_nfse_pdf(pdf_content)


### PR DESCRIPTION
Faltou adicionar a verificação se deve ou nao considerar o ssl no momento de pegar o conteudo do pdf quando a nfse é cancelada.

cc @kaynnan @douglascstd @WesleyOliveira98 @Matthwhy 