### PR TITLE
[14.0][REF] l10n_br_stock_account: Adaptando o código para os casos Sem Operação Fiscal ou Multi-Localizações

### DIFF
--- a/l10n_br_stock_account/models/stock_move.py
+++ b/l10n_br_stock_account/models/stock_move.py
@@ -225,15 +225,16 @@ class StockMove(models.Model):
     def _onchange_product_id_fiscal(self):
         # Metodo super altera o price_unit
         # TODO: Isso deveria ser resolvido no metodo principal?
-        price_unit = self.price_unit
-        result = super()._onchange_product_id_fiscal()
-        # Valor informado pelo usuario tem prioridade
-        if self.product_id and price_unit == 0.0:
-            price_unit = self._get_price_unit()
+        if self.picking_id.fiscal_operation_id:
+            price_unit = self.price_unit
+            result = super()._onchange_product_id_fiscal()
+            # Valor informado pelo usuario tem prioridade
+            if self.product_id and price_unit == 0.0:
+                price_unit = self._get_price_unit()
 
-        self.price_unit = price_unit
+            self.price_unit = price_unit
 
-        return result
+            return result
 
     def _split(self, qty, restrict_partner_id=False):
         new_moves_vals = super()._split(qty, restrict_partner_id)

--- a/l10n_br_stock_account/tests/common.py
+++ b/l10n_br_stock_account/tests/common.py
@@ -23,8 +23,6 @@ class TestBrPickingInvoicingCommon(TransactionCase):
 
         # Stock Move
         record._onchange_product_id_fiscal()
-        record._onchange_fiscal_operation_id()
-        record._onchange_fiscal_operation_line_id()
         record._onchange_fiscal_taxes()
         record._onchange_product_quantity()
 


### PR DESCRIPTION
Adaptando o código para os casos Sem Operação Fiscal ou Multi-Localizações, PR simples basicamente:

* chamando onchange_product_id_fiscal da stock.move apenas quando o stock.picking tiver a Operação Fiscal 
* O método default da Operação Fiscal do stock.picking retornar False quando o Pedido de Vendas ou Compras não tiver Operação Fiscal para evitar que na criação da Fatura a partir do stock.picking acabe considerando ser um caso "Com Operação Fiscal". Isso está sendo feito no l10n_br_stock_account e não no l10n_br_purchase_stock ou l10n_br_sale_stock porque até onde entendi esses métodos default para serem chamados em outros módulos precisam sobre escrever o campo e parece que deixa de chamar o método original mesmo com o super e também acabaria duplicando código, talvez exista uma forma, por enquanto o attrs parece atender 
* Nos testes removi a chamada dos onhanges _onchange_fiscal_operation_id e _onchange_fiscal_operation_line_id por já serem chamados pelo _onchange_product_id_fiscal

cc @rvalyi @renatonlima @marcelsavegnago @mileo 