### PR TITLE
[14.0][REF+IMP] l10n_br_purchase_stock: Renomeando o campo da Politica de Fatura e adaptando código para o caso Sem Operação Fiscal

### DIFF
--- a/l10n_br_purchase_stock/__manifest__.py
+++ b/l10n_br_purchase_stock/__manifest__.py
@@ -7,7 +7,7 @@
     "category": "Localisation",
     "author": "Akretion, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-brazil",
-    "version": "14.0.1.3.5",
+    "version": "14.0.2.0.0",
     "depends": [
         "l10n_br_purchase",
         "l10n_br_stock_account",

--- a/l10n_br_purchase_stock/demo/purchase_order.xml
+++ b/l10n_br_purchase_stock/demo/purchase_order.xml
@@ -3,15 +3,15 @@
 
     <!-- Criação da Invoice baseada no Picking.
      Com isso os Picking são criados com o invoice_state 2binvoiced -->
-    <record id="purchase_create_invoice_policy_settings" model="res.config.settings">
-        <field name="purchase_create_invoice_policy">stock_picking</field>
+    <record id="purchase_invoicing_policy_settings" model="res.config.settings">
+        <field name="purchase_invoicing_policy">stock_picking</field>
     </record>
 
     <function model="res.config.settings" name="execute">
         <value
             model="res.config.settings"
             search="[('id', '=',
-                ref('purchase_create_invoice_policy_settings'))]"
+                ref('purchase_invoicing_policy_settings'))]"
         />
     </function>
 

--- a/l10n_br_purchase_stock/migrations/14.0.2.0.0/pre-migration.py
+++ b/l10n_br_purchase_stock/migrations/14.0.2.0.0/pre-migration.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2024-Today - Akretion (<http://www.akretion.com>).
+# @author Magno Costa <magno.costa@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+_column_renames = {
+    "res_company": [
+        ("purchase_create_invoice_policy", "purchase_invoicing_policy"),
+    ],
+}
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    openupgrade.rename_columns(env.cr, _column_renames)

--- a/l10n_br_purchase_stock/models/__init__.py
+++ b/l10n_br_purchase_stock/models/__init__.py
@@ -1,6 +1,3 @@
-# Copyright (C) 2015  Renato Lima - Akretion
-# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
-
 from . import res_company
 from . import purchase_order
 from . import purchase_order_line

--- a/l10n_br_purchase_stock/models/purchase_order.py
+++ b/l10n_br_purchase_stock/models/purchase_order.py
@@ -8,8 +8,8 @@ from odoo import api, fields, models
 class PurchaseOrder(models.Model):
     _inherit = "purchase.order"
 
-    purchase_create_invoice_policy = fields.Selection(
-        related="company_id.purchase_create_invoice_policy",
+    purchase_invoicing_policy = fields.Selection(
+        related="company_id.purchase_invoicing_policy",
     )
 
     # Make Invisible Invoice Button
@@ -30,7 +30,7 @@ class PurchaseOrder(models.Model):
             ):
                 button_create_invoice_invisible = True
             else:
-                if record.purchase_create_invoice_policy == "stock_picking":
+                if record.purchase_invoicing_policy == "stock_picking":
                     # A criação de Fatura de Serviços deve ser possível via Pedido
                     if not any(
                         line.product_id.type == "service" for line in record.order_line
@@ -44,7 +44,7 @@ class PurchaseOrder(models.Model):
         values = super()._prepare_picking()
         if self.fiscal_operation_id:
             values.update(self._prepare_br_fiscal_dict())
-        if self.company_id.purchase_create_invoice_policy == "stock_picking":
+        if self.company_id.purchase_invoicing_policy == "stock_picking":
             values["invoice_state"] = "2binvoiced"
 
         return values

--- a/l10n_br_purchase_stock/models/purchase_order_line.py
+++ b/l10n_br_purchase_stock/models/purchase_order_line.py
@@ -17,7 +17,7 @@ class PurchaseOrderLine(models.Model):
         for v in values:
             if self.order_id.fiscal_operation_id:
                 v.update(self._prepare_br_fiscal_dict())
-            if self.order_id.purchase_create_invoice_policy == "stock_picking":
+            if self.order_id.purchase_invoicing_policy == "stock_picking":
                 v["invoice_state"] = "2binvoiced"
         return values
 

--- a/l10n_br_purchase_stock/models/res_company.py
+++ b/l10n_br_purchase_stock/models/res_company.py
@@ -13,7 +13,7 @@ class Company(models.Model):
         domain=[("state", "=", "approved"), ("fiscal_type", "=", "purchase")],
     )
 
-    purchase_create_invoice_policy = fields.Selection(
+    purchase_invoicing_policy = fields.Selection(
         selection=[
             ("purchase_order", _("Purchase Order")),
             ("stock_picking", _("Stock Picking")),

--- a/l10n_br_purchase_stock/models/res_config_settings.py
+++ b/l10n_br_purchase_stock/models/res_config_settings.py
@@ -7,7 +7,7 @@ from odoo import fields, models
 class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
 
-    purchase_create_invoice_policy = fields.Selection(
-        related="company_id.purchase_create_invoice_policy",
+    purchase_invoicing_policy = fields.Selection(
+        related="company_id.purchase_invoicing_policy",
         readonly=False,
     )

--- a/l10n_br_purchase_stock/views/res_company_view.xml
+++ b/l10n_br_purchase_stock/views/res_company_view.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="base.view_company_form" />
         <field name="arch" type="xml">
             <field name="purchase_fiscal_operation_id" position="before">
-                <field name="purchase_create_invoice_policy" />
+                <field name="purchase_invoicing_policy" />
             </field>
         </field>
     </record>

--- a/l10n_br_purchase_stock/views/res_config_settings.xml
+++ b/l10n_br_purchase_stock/views/res_config_settings.xml
@@ -19,7 +19,7 @@
                 >
                     <div class="o_setting_left_pane" />
                     <div class="o_setting_right_pane">
-                        <label for="purchase_create_invoice_policy" />
+                        <label for="purchase_invoicing_policy" />
                         <span
                             class="fa fa-lg fa-building-o"
                             title="Values set here are company-specific."
@@ -33,7 +33,7 @@
                         <div class="content-group">
                             <div class="mt16">
                                 <field
-                                    name="purchase_create_invoice_policy"
+                                    name="purchase_invoicing_policy"
                                     class="o_light_label"
                                     widget="radio"
                                 />


### PR DESCRIPTION
Renomeando o campo da Politica de Fatura e adaptando código para o caso Sem Operação Fiscal, 

A principal alteração do PR é renomear o campo 'purchase_create_invoice_policy' para 'purchase_invoicing_policy' como os modulos l10n_br_purchase_stock e o l10n_br_sale_stock são semelhantes e no PR de extração do l10n_br_sale_stock https://github.com/OCA/l10n-brazil/pull/2955 foi pedido essa alteração achei melhor seguir nesse mesmo caminho, outras alterações foram feitas aqui e se acharem necessário posso ver de extrair:

* Inclui o ind_final nos dados de demonstração para criar os Pedidos com o valor certo
* Removi o cabeçalho de Licença do arquivo init
* O método _prepare_br_fiscal_dict passou a ser chamado apenas quando o campo da Operação Fiscal estiver definido 
* Desnecessário chamar os métodos _onchange_fiscal_operation_id, _onchange_fiscal_operation_line_id porque o _onchange_product_id_fiscal já chama
* Refatorei os testes para passar a usar o l10n_br_stock_account/tests/common.py reduzindo e evitando código duplicado e inclui o teste do caso Sem Operação Fiscal

cc @rvalyi @renatonlima @marcelsavegnago @mileo 