### PR TITLE
[14.0][IMP] l10n_br_fiscal_dfe: use xsdata bindings

### DIFF
--- a/l10n_br_fiscal_dfe/tests/test_dfe.py
+++ b/l10n_br_fiscal_dfe/tests/test_dfe.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 from erpbrasil.edoc.resposta import analisar_retorno_raw
 from nfelib.nfe.ws.edoc_legacy import DocumentoElectronicoAdapter
-from nfelib.v4_00 import retDistDFeInt
+from nfelib.nfe_dist_dfe.bindings.v1_0.ret_dist_dfe_int_v1_01 import RetDistDfeInt
 
 from odoo.tests.common import SavepointCase
 
@@ -36,7 +36,7 @@ def mocked_post_success_multiple(*args, **kwargs):
         object(),
         b"<fake_post/>",
         FakeRetorno(response_sucesso_multiplos),
-        retDistDFeInt,
+        RetDistDfeInt,
     )
 
 
@@ -46,7 +46,7 @@ def mocked_post_success_single(*args, **kwargs):
         object(),
         b"<fake_post/>",
         FakeRetorno(response_sucesso_individual),
-        retDistDFeInt,
+        RetDistDfeInt,
     )
 
 
@@ -56,7 +56,7 @@ def mocked_post_error_rejection(*args, **kwargs):
         object(),
         b"<fake_post/>",
         FakeRetorno(response_rejeicao),
-        retDistDFeInt,
+        RetDistDfeInt,
     )
 
 
@@ -66,7 +66,7 @@ def mocked_post_error_status_code(*args, **kwargs):
         object(),
         b"<fake_post/>",
         FakeRetorno(response_rejeicao, status_code=500),
-        retDistDFeInt,
+        RetDistDfeInt,
     )
 
 

--- a/l10n_br_nfe/tests/test_nfe_mde.py
+++ b/l10n_br_nfe/tests/test_nfe_mde.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 from erpbrasil.edoc.resposta import analisar_retorno_raw
 from nfelib.nfe.ws.edoc_legacy import DocumentoElectronicoAdapter
-from nfelib.v4_00 import retEnvEvento
+from nfelib.nfe_evento_generico.bindings.v1_0.ret_env_evento_v1_00 import RetEnvEvento
 
 from odoo.exceptions import ValidationError
 from odoo.tests.common import SavepointCase
@@ -43,7 +43,7 @@ def mocked_post_confirmacao(*args, **kwargs):
         object(),
         b"<fake_post/>",
         FakeRetorno(response_confirmacao_operacao),
-        retEnvEvento,
+        RetEnvEvento,
     )
 
 
@@ -53,7 +53,7 @@ def mocked_post_confirmacao_status_code_error(*args, **kwargs):
         object(),
         b"<fake_post/>",
         FakeRetorno(response_confirmacao_operacao, status_code="500"),
-        retEnvEvento,
+        RetEnvEvento,
     )
 
 
@@ -63,7 +63,7 @@ def mocked_post_confirmacao_invalid_status_error(*args, **kwargs):
         object(),
         b"<fake_post/>",
         FakeRetorno(response_confirmacao_operacao_rejeicao),
-        retEnvEvento,
+        RetEnvEvento,
     )
 
 
@@ -73,7 +73,7 @@ def mocked_post_ciencia(*args, **kwargs):
         object(),
         b"<fake_post/>",
         FakeRetorno(response_ciencia_operacao),
-        retEnvEvento,
+        RetEnvEvento,
     )
 
 
@@ -83,7 +83,7 @@ def mocked_post_desconhecimento(*args, **kwargs):
         object(),
         b"<fake_post/>",
         FakeRetorno(response_desconhecimento_operacao),
-        retEnvEvento,
+        RetEnvEvento,
     )
 
 
@@ -93,7 +93,7 @@ def mocked_post_nao_realizada(*args, **kwargs):
         object(),
         b"<fake_post/>",
         FakeRetorno(response_operacao_nao_realizada),
-        retEnvEvento,
+        RetEnvEvento,
     )
 
 


### PR DESCRIPTION
ate a nfelib 2.0.7 o binding de retorno da DFe era esse binding legacy generateDS https://github.com/akretion/nfelib/blob/2.0.7/nfelib/v4_00/retDistDFeInt.py

Porem desde a nfelib 2.1.1, tirei os bindings legacy generateDS e tem que usar agora: https://github.com/akretion/nfelib/blob/master/nfelib/nfe_dist_dfe/bindings/v1_0/ret_dist_dfe_int_v1_01.py

No segundo commit fiz uma mudança semelhante no teste da MDe.

Aqui no projeto eu comentava sobre essa mudança faz um tempo e aqui eu tinha avisado que eu limparia a nfelib dos bindings legacy generateDS https://github.com/akretion/nfelib/issues/106
O nome da class eh diferente (mais "pythonico") mas os campos do binding sao iguais.

Obs: para a Nfe ja faz mais de 1 ano que eu fiz a migracao no l10n-brazil.