### PR TITLE
[14.0][FIX] FCPUFDest

### DIFF
--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -454,9 +454,6 @@ class NFeLine(spec_models.StackedModel):
             "vBCSTRet": str("%.02f" % self.icmsst_wh_base),
             "pST": str("%.04f" % (self.icmsst_wh_percent + self.icmsfcp_wh_percent)),
             "vICMSSTRet": str("%.02f" % self.icmsst_wh_value),
-            "vBCFCPSTRet": str("%.02f" % self.icmsfcp_base_wh),
-            "pFCPSTRet": str("%.04f" % self.icmsfcp_wh_percent),
-            "vFCPSTRet": str("%.02f" % self.icmsfcp_value_wh),
             "pRedBCEfet": str("%.04f" % self.icms_effective_reduction),
             "vBCEfet": str("%.02f" % self.icms_effective_base),
             "pICMSEfet": str("%.04f" % self.icms_effective_percent),
@@ -466,6 +463,15 @@ class NFeLine(spec_models.StackedModel):
             "pCredSN": str("%.04f" % self.icmssn_percent),
             "vCredICMSSN": str("%.02f" % self.icmssn_credit_value),
         }
+        if self.icmsfcp_wh_percent:
+            icms.update(
+                {
+                    # FUNDO DE COMBATE À POBREZA RETIDO
+                    "vBCFCPSTRet": str("%.02f" % self.icmsfcp_base_wh),
+                    "pFCPSTRet": str("%.04f" % self.icmsfcp_wh_percent),
+                    "vFCPSTRet": str("%.02f" % self.icmsfcp_value_wh),
+                }
+            )
         if (
             self.icmsfcp_percent
             and self.ind_final == FINAL_CUSTOMER_NO


### PR DESCRIPTION
1. Remove a FCP normal para venda fora do estado para o consumidor final;
2. Corrige o campo para float
3. Adicionado o PR: https://github.com/OCA/l10n-brazil/pull/3058 pois estava dando conflito os dois separados no aggregate.