### PR TITLE
[14.0][ADD] comments_ids in sale.order

### DIFF
--- a/l10n_br_sale/views/sale_view.xml
+++ b/l10n_br_sale/views/sale_view.xml
@@ -110,6 +110,7 @@
                         name="manual_fiscal_additional_data"
                         style="min-width: 590px;"
                     />
+                    <field name="comment_ids" widget="many2many_tags" />
                 </group>
             </field>
             <xpath expr="//field[@name='order_line']" position="attributes">


### PR DESCRIPTION
Hoje os comentários de um pedido criado no pedido de venda não são carregados, não sei o que é melhor colocar na tela ou carregar através de algum método da criação / confirmação do documento fiscal.

Hoje é o que ocorre com a natureza da operação.

```
    @api.onchange("fiscal_operation_id")
    def _onchange_fiscal_operation_id(self):
        if self.fiscal_operation_id:
            self.operation_name = self.fiscal_operation_id.name
            self.comment_ids = self.fiscal_operation_id.comment_ids
```

```
    def _document_number(self):
        self.ensure_one()
        if self.issuer == DOCUMENT_ISSUER_COMPANY:
            if self.document_serie_id:
                self.document_serie = self.document_serie_id.code

                if self.document_type == MODELO_FISCAL_NFSE and not self.rps_number:
                    self.rps_number = self.document_serie_id.next_seq_number()

                if (
                    self.document_type != MODELO_FISCAL_NFSE
                    and not self.document_number
                ):
                    self.document_number = self.document_serie_id.next_seq_number()

            if not self.operation_name:
                self.operation_name = ", ".join(
                    [
                        line.name
                        for line in self.fiscal_line_ids.mapped("fiscal_operation_id")
                    ]
                )

            if self.document_electronic and not self.document_key:
                self._generate_key()
```
