### PR TITLE
[14.0][IMP] l10n_br_nfse: add ISSQN city validation in report

### DIFF
--- a/l10n_br_nfse/report/danfse.xml
+++ b/l10n_br_nfse/report/danfse.xml
@@ -163,9 +163,18 @@ row {
                     Local da Prestação
                 </div>
                 <div class="col-2 linha centro">
-                    <span t-field="doc.company_id.city_id" /> - <span
-                        t-field="doc.company_id.state_id.code"
-                    />
+                    <t t-if="doc.fiscal_line_ids[0].issqn_fg_city_id">
+                        <span
+                            t-field="doc.fiscal_line_ids[0].issqn_fg_city_id"
+                        /> - <span
+                            t-field="doc.fiscal_line_ids[0].issqn_fg_city_id.state_id.code"
+                        />
+                    </t>
+                    <t t-else="">
+                        <span t-field="doc.company_id.city_id" /> - <span
+                            t-field="doc.company_id.state_id.code"
+                        />
+                    </t>
                 </div>
             </div>
 


### PR DESCRIPTION
cc @marcelsavegnago @WesleyOliveira98 @Matthwhy @douglascstd 

O objetivo dessa PR é implementar uma melhoria no template do relatório para exibir a cidade do ISSQN e o código do estado, se disponíveis. Caso contrário, mostra a cidade e o código do estado da empresa.