### PR TITLE
[14.0][FIX] l10n_br_cnpj_search: carregamento do nome da cidade

### DIFF
--- a/l10n_br_cnpj_search/tests/test_receitaws.py
+++ b/l10n_br_cnpj_search/tests/test_receitaws.py
@@ -51,6 +51,7 @@ class TestReceitaWS(TestCnpjCommon):
         self.assertEqual(kilian.phone, "(83) 8665-0905")
         self.assertEqual(kilian.state_id.code, "PB")
         self.assertEqual(kilian.city_id.name, "Campina Grande")
+        self.assertEqual(kilian.city, "Campina Grande")
         self.assertEqual(kilian.equity_capital, 3000)
         self.assertEqual(kilian.cnae_main_id.code, "4751-2/01")
 

--- a/l10n_br_cnpj_search/wizard/partner_cnpj_search_wizard.py
+++ b/l10n_br_cnpj_search/wizard/partner_cnpj_search_wizard.py
@@ -95,6 +95,7 @@ class PartnerCnpjSearchWizard(models.TransientModel):
             "district": self.district,
             "state_id": self.state_id.id,
             "city_id": self.city_id.id,
+            "city": self.city_id.name,
             "country_id": self.country_id.id,
             "phone": self.phone,
             "mobile": self.mobile,


### PR DESCRIPTION
A informação da cidade não está sendo carregada nas visualizações do endereço dos parceiros, quando o cadastro foi feito utilizando a busca do CNPJ.
Isso acontece pois pela busca o onchange do city_id não é acionado.

Para contornar isso, esta PR altera para que além do `city_id` seja carregado para o parceiro também o `city` no método da busca pelo CNPJ.



