### PR TITLE
[14.0][FIX] l10n_br_nfse_focus: fix make pdf and transmission

### DIFF
--- a/l10n_br_nfse_focus/models/document.py
+++ b/l10n_br_nfse_focus/models/document.py
@@ -133,7 +133,8 @@ class FocusnfeNfse(models.AbstractModel):
         service_info = service.get("service")
         recipient_info = recipient.get("recipient")
         recipient_identification = self._identify_service_recipient(recipient_info)
-        return {
+
+        vals = {
             "prestador": self._prepare_provider_data(rps_info, company),
             "servico": self._prepare_service_data(service_info, company),
             "tomador": self._prepare_recipient_data(
@@ -145,9 +146,17 @@ class FocusnfeNfse(models.AbstractModel):
             "natureza_operacao": rps_info.get("natureza_operacao"),
             "optante_simples_nacional": rps_info.get("optante_simples_nacional", False),
             "status": rps_info.get("status"),
-            "codigo_obra": rps_info.get("codigo_obra", ""),
-            "art": rps_info.get("art", ""),
         }
+        codigo_obra = rps_info.get("codigo_obra", False)
+        art = rps_info.get("art", False)
+
+        if codigo_obra:
+            vals["codigo_obra"] = codigo_obra
+
+        if art:
+            vals["art"] = art
+
+        return vals
 
     def _prepare_provider_data(self, rps, company):
         """Construct the provider section of the payload.
@@ -336,7 +345,7 @@ class Document(models.Model):
             filter_focusnfe
         ):
             event_id = record.event_ids.create_event_save_xml(
-                company_id=self.company_id,
+                company_id=record.company_id,
                 environment=(
                     EVENT_ENV_PROD if record.nfse_environment == "1" else EVENT_ENV_HML
                 ),
@@ -361,15 +370,22 @@ class Document(models.Model):
             filter_focusnfe
         ):
             ref = "rps" + record.rps_number
-            response = self.env["focusnfe.nfse"].query_focus_nfse_by_rps(
+            response = record.env["focusnfe.nfse"].query_focus_nfse_by_rps(
                 ref, 0, record.company_id, record.nfse_environment
             )
 
             json = response.json()
 
+            edoc_states = ["a_enviar", "enviada", "rejeitada"]
+            if record.company_id.focusnfe_nfse_update_authorized_document_status:
+                edoc_states.append("autorizada")
+
             if response.status_code == 200:
-                if record.state in ["a_enviar", "enviada", "rejeitada"]:
-                    if json["status"] == "autorizado":
+                if record.state in edoc_states:
+                    if (
+                        json["status"] == "autorizado"
+                        and record.state_edoc != SITUACAO_EDOC_AUTORIZADA
+                    ):
                         aware_datetime = datetime.strptime(
                             json["data_emissao"], "%Y-%m-%dT%H:%M:%S%z"
                         )
@@ -388,20 +404,6 @@ class Document(models.Model):
                             + json["caminho_xml_nota_fiscal"],
                             timeout=TIMEOUT,
                         ).content.decode("utf-8")
-                        pdf_content = (
-                            requests.get(
-                                json["url"],
-                                timeout=TIMEOUT,
-                                verify=record.company_id.nfse_ssl_verify,
-                            ).content
-                            or requests.get(
-                                json["url_danfse"],
-                                timeout=TIMEOUT,
-                                verify=record.company_id.nfse_ssl_verify,
-                            ).content
-                        )
-
-                        record.make_focus_nfse_pdf(pdf_content)
 
                         if not record.authorization_event_id:
                             record._document_export()
@@ -409,12 +411,32 @@ class Document(models.Model):
                         if record.authorization_event_id:
                             record.authorization_event_id.set_done(
                                 status_code=4,
-                                response=_("Processado com Sucesso"),
+                                response=_("Successfully Processed"),
                                 protocol_date=record.authorization_date,
                                 protocol_number=record.authorization_protocol,
                                 file_response_xml=xml,
                             )
                             record._change_state(SITUACAO_EDOC_AUTORIZADA)
+                            if record.company_id.focusnfe_nfse_force_odoo_danfse:
+                                record.make_pdf()
+                            else:
+                                pdf_content = requests.get(
+                                    json["url"],
+                                    timeout=TIMEOUT,
+                                    verify=record.company_id.nfse_ssl_verify,
+                                ).content
+                                if not pdf_content.startswith(
+                                    b"%PDF-"
+                                ) and not pdf_content.strip().endswith(b"%%EOF"):
+                                    pdf_content = requests.get(
+                                        json["url_danfse"],
+                                        timeout=TIMEOUT,
+                                        verify=record.company_id.nfse_ssl_verify,
+                                    ).content
+                                if pdf_content.startswith(
+                                    b"%PDF-"
+                                ) and pdf_content.strip().endswith(b"%%EOF"):
+                                    record.make_focus_nfse_pdf(pdf_content)
 
                     elif json["status"] == "erro_autorizacao":
                         record.write(
@@ -424,12 +446,73 @@ class Document(models.Model):
                         )
                         record._change_state(SITUACAO_EDOC_REJEITADA)
                     elif json["status"] == "cancelado":
-                        record._change_state(SITUACAO_EDOC_CANCELADA)
+                        if record.state_edoc != SITUACAO_EDOC_CANCELADA:
+                            record._document_cancel(record.cancel_reason)
 
                 result = _(json["status"])
             else:
                 result = "Unable to retrieve the document status."
+
         return result
+
+    def create_cancel_event(self, status_json, record):
+        """Create a cancel event and process it.
+
+        Parameters:
+            record: The NFSe record that is being canceled.
+
+        Returns:
+            The created event.
+        """
+
+        xml = requests.get(
+            NFSE_URL[record.nfse_environment] + status_json["caminho_xml_cancelamento"],
+            timeout=TIMEOUT,
+        ).content.decode("utf-8")
+
+        event = record.event_ids.create_event_save_xml(
+            company_id=record.company_id,
+            environment=(
+                EVENT_ENV_PROD if record.nfse_environment == "1" else EVENT_ENV_HML
+            ),
+            event_type="2",
+            xml_file="",
+            document_id=record,
+        )
+        event.set_done(
+            status_code=4,
+            response=_("Successfully Processed"),
+            protocol_date=fields.Datetime.to_string(fields.Datetime.now()),
+            protocol_number="",
+            file_response_xml=xml,
+        )
+        return event
+
+    def fetch_and_verify_pdf_content(self, status_json, record):
+        """Fetch and verify the PDF content from the provided URL.
+
+        Parameters:
+            status_json: JSON response containing the URLs for the PDF.
+            record: The NFSe record for which the PDF is being retrieved.
+
+        Returns:
+            None. Updates the record with the PDF content if valid.
+        """
+        pdf_content = requests.get(
+            status_json["url"],
+            timeout=TIMEOUT,
+            verify=record.company_id.nfse_ssl_verify,
+        ).content
+        if not pdf_content.startswith(b"%PDF-") and not pdf_content.strip().endswith(
+            b"%%EOF"
+        ):
+            pdf_content = requests.get(
+                status_json["url_danfse"],
+                timeout=TIMEOUT,
+                verify=record.company_id.nfse_ssl_verify,
+            ).content
+        if pdf_content.startswith(b"%PDF-") and pdf_content.strip().endswith(b"%%EOF"):
+            record.make_focus_nfse_pdf(pdf_content)
 
     def cancel_document_focus(self):
         """Cancel a NFSe document with the Focus NFSe provider.
@@ -444,7 +527,27 @@ class Document(models.Model):
             filter_focusnfe
         ):
             ref = "rps" + record.rps_number
-            response = self.env["focusnfe.nfse"].cancel_focus_nfse_document(
+
+            status_response = record.env["focusnfe.nfse"].query_focus_nfse_by_rps(
+                ref, 0, record.company_id, record.nfse_environment
+            )
+            status_json = status_response.json()
+
+            if status_response.status_code == 200:
+                if (
+                    status_json["status"] == "cancelado"
+                    and record.state_edoc != SITUACAO_EDOC_CANCELADA
+                ):
+                    record.cancel_event_id = record.create_cancel_event(
+                        status_json, record
+                    )
+                    if record.company_id.focusnfe_nfse_force_odoo_danfse:
+                        record.make_pdf()
+                    else:
+                        record.fetch_and_verify_pdf_content(status_json, record)
+                    return status_response
+
+            response = record.env["focusnfe.nfse"].cancel_focus_nfse_document(
                 ref, record.cancel_reason, record.company_id, record.nfse_environment
             )
 
@@ -480,43 +583,18 @@ class Document(models.Model):
                         code = "nfe_cancelada"
 
                 if code == "nfe_cancelada" or status == "cancelado":
-                    record.cancel_event_id = record.event_ids.create_event_save_xml(
-                        company_id=record.company_id,
-                        environment=(
-                            EVENT_ENV_PROD
-                            if record.nfse_environment == "1"
-                            else EVENT_ENV_HML
-                        ),
-                        event_type="2",
-                        xml_file="",
-                        document_id=record,
-                    )
-
-                    record.cancel_event_id.set_done(
-                        status_code=4,
-                        response=_("Processado com Sucesso"),
-                        protocol_date=fields.Datetime.to_string(fields.Datetime.now()),
-                        protocol_number="",
-                        file_response_xml="",
-                    )
-
-                    status_rps = self.env["focusnfe.nfse"].query_focus_nfse_by_rps(
+                    status_rps = record.env["focusnfe.nfse"].query_focus_nfse_by_rps(
                         ref, 0, record.company_id, record.nfse_environment
                     )
                     status_json = status_rps.json()
-                    pdf_content = (
-                        requests.get(
-                            status_json["url"],
-                            timeout=TIMEOUT,
-                            verify=record.company_id.nfse_ssl_verify,
-                        ).content
-                        or requests.get(
-                            status_json["url_danfse"],
-                            timeout=TIMEOUT,
-                            verify=record.company_id.nfse_ssl_verify,
-                        ).content
+
+                    record.cancel_event_id = record.create_cancel_event(
+                        status_json, record
                     )
-                    record.make_focus_nfse_pdf(pdf_content)
+                    if record.company_id.focusnfe_nfse_force_odoo_danfse:
+                        record.make_pdf()
+                    else:
+                        record.fetch_and_verify_pdf_content(status_json, record)
 
                     return response
 

--- a/l10n_br_nfse_focus/models/res_company.py
+++ b/l10n_br_nfse_focus/models/res_company.py
@@ -40,6 +40,22 @@ class ResCompany(models.Model):
         default="codigo_cnae",
     )
 
+    focusnfe_nfse_update_authorized_document_status = fields.Boolean(
+        string="Include Authorized Documents in Status Check",
+        help="If checked, authorized documents will be included in the status check "
+        "wizard. The system will verify the status of the documents with Focus NFE, "
+        "and if there are discrepancies with the status in Odoo, it will automatically "
+        "update the status in the system.",
+        default=False,
+    )
+
+    focusnfe_nfse_force_odoo_danfse = fields.Boolean(
+        string="Force Odoo DANFSE",
+        help="If checked, the system will always use the Odoo DANFSE instead of the "
+        "Focus DANFSE.",
+        default=False,
+    )
+
     def get_focusnfe_token(self):
         """
         Retrieve the appropriate FocusNFe API token based on the current NFSe

--- a/l10n_br_nfse_focus/views/res_company.xml
+++ b/l10n_br_nfse_focus/views/res_company.xml
@@ -27,6 +27,14 @@
                     name="focusnfe_nfse_cnae_code_value"
                     attrs="{'invisible': [('provedor_nfse','!=', 'focusnfe')]}"
                 />
+                <field
+                    name="focusnfe_nfse_update_authorized_document_status"
+                    attrs="{'invisible': [('provedor_nfse','!=', 'focusnfe')]}"
+                />
+                <field
+                    name="focusnfe_nfse_force_odoo_danfse"
+                    attrs="{'invisible': [('provedor_nfse','!=', 'focusnfe')]}"
+                />
             </field>
             <xpath expr="//field[@name='nfse_ssl_verify']" position="attributes">
                 <attribute name="invisible">0</attribute>


### PR DESCRIPTION
This pull request introduces several enhancements and bug fixes to the `l10n_br_nfse_focus` module, focusing on improving the handling of document status updates, cancellations, and PDF content verification. The most critical changes include modifications to the `_prepare_payload`, `_document_status`, and `cancel_document_focus` methods, as well as the addition of new fields in the `ResCompany` model.

### Enhancements to document processing:

* [`l10n_br_nfse_focus/models/document.py`](diffhunk://#diff-787684de500e7c4c1f6be4e0433995f07463299b45bfbfc7ebea1072c2807775L148-R159): Refactored the `_prepare_payload` method to conditionally include `codigo_obra` and `art` fields only when they are present.
* [`l10n_br_nfse_focus/models/document.py`](diffhunk://#diff-787684de500e7c4c1f6be4e0433995f07463299b45bfbfc7ebea1072c2807775L364-R388): Improved the `_document_status` method to handle additional document states and introduced a new method `fetch_and_verify_pdf_content` for better PDF content validation. [[1]](diffhunk://#diff-787684de500e7c4c1f6be4e0433995f07463299b45bfbfc7ebea1072c2807775L364-R388) [[2]](diffhunk://#diff-787684de500e7c4c1f6be4e0433995f07463299b45bfbfc7ebea1072c2807775L427-R516)

### Enhancements to document cancellation:

* [`l10n_br_nfse_focus/models/document.py`](diffhunk://#diff-787684de500e7c4c1f6be4e0433995f07463299b45bfbfc7ebea1072c2807775L447-R550): Enhanced the `cancel_document_focus` method to create a cancel event if the document is already canceled and introduced a new method `create_cancel_event` to handle event creation. [[1]](diffhunk://#diff-787684de500e7c4c1f6be4e0433995f07463299b45bfbfc7ebea1072c2807775L447-R550) [[2]](diffhunk://#diff-787684de500e7c4c1f6be4e0433995f07463299b45bfbfc7ebea1072c2807775L483-R597)

### New fields in `ResCompany` model:

* [`l10n_br_nfse_focus/models/res_company.py`](diffhunk://#diff-f12beb3627b0305b4cc8fba680c06ae6a6343e027740b803bd5ddc690d34cf8fR43-R58): Added `focusnfe_nfse_update_authorized_document_status` and `focusnfe_nfse_force_odoo_danfse` fields to control document status updates and PDF generation behavior.
* [`l10n_br_nfse_focus/views/res_company.xml`](diffhunk://#diff-9ed7e7c45752c897d9c5378f48af5675170705aa4e1e74710339d64ba32f522fR30-R37): Updated the view to include the new fields `focusnfe_nfse_update_authorized_document_status` and `focusnfe_nfse_force_odoo_danfse`.