### PR TITLE
[12.0][l10n_br_nfe][REF] l10n_br_nfe: nfelib<=2.0.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ erpbrasil.edoc
 erpbrasil.edoc.pdf
 erpbrasil.transmissao
 febraban
-nfelib
+nfelib<=2.0.7
 nfselib.ginfes
 nfselib.issnet
 nfselib.paulistana


### PR DESCRIPTION
on v12, l10n_br_nfe is still using the legacy generateDS bindings in nfelib, so unless the xsdata support is backported from v14, nfelib 2.0.7 will be the last supported version for the 12.0 branch.