### PR TITLE
[12.0][spec_driven_model][FIX] spec_driven_model: disable automatic views

### DIFF
--- a/spec_driven_model/models/__init__.py
+++ b/spec_driven_model/models/__init__.py
@@ -1,5 +1,5 @@
 from . import spec_mixin
-from . import spec_view
+# from . import spec_view
 from . import spec_models
 from . import spec_import
 from . import spec_export


### PR DESCRIPTION
This feature has been broken when preparing for the xsdata transistion for the 14.0 branch and not fixed since then. Whithout this partner and company views are broken. It's also disabled in the 14.0 branch as for now.