### PR TITLE
[14.0][IMP] l10n_br_account_withholding: handling of partner_id assignment

### DIFF
--- a/l10n_br_account_withholding/README.rst
+++ b/l10n_br_account_withholding/README.rst
@@ -45,12 +45,12 @@ Automatize a conformidade fiscal, reduza erros de entrada manual e
 aprimore seus processos financeiros relacionados à retenção de impostos
 de fornecedores.
 
--  **Automatize a Conformidade Fiscal:** Crie contas a pagar para
-   impostos retidos em compras de fornecedores automaticamente.
--  **Reduza Erros:** Minimize erros manuais e assegure a precisão nas
-   retenções de impostos.
--  **Aprimore a Eficiência:** Melhore seus processos financeiros para
-   lidar com retenções de impostos de fornecedores.
+- **Automatize a Conformidade Fiscal:** Crie contas a pagar para
+  impostos retidos em compras de fornecedores automaticamente.
+- **Reduza Erros:** Minimize erros manuais e assegure a precisão nas
+  retenções de impostos.
+- **Aprimore a Eficiência:** Melhore seus processos financeiros para
+  lidar com retenções de impostos de fornecedores.
 
 Installation
 ============
@@ -60,32 +60,32 @@ Odoo:
 
 1. **Adicione o Repositório:**
 
-   -  Adicione o repositório ``l10n-brazil`` da OCA no seu projeto
-      adicionando a URL: ``https://github.com/OCA/l10n-brazil``.
-   -  Verifique os arquivos requirements.txt e oca_dependencies.txt
-      localizados na raiz do repositório ``l10n-brazil``. Estes arquivos
-      contêm, respectivamente, as dependências Python necessárias para o
-      Odoo e os repositórios da OCA dos quais os módulos da localização
-      brasileira dependem.
+   - Adicione o repositório ``l10n-brazil`` da OCA no seu projeto
+     adicionando a URL: ``https://github.com/OCA/l10n-brazil``.
+   - Verifique os arquivos requirements.txt e oca_dependencies.txt
+     localizados na raiz do repositório ``l10n-brazil``. Estes arquivos
+     contêm, respectivamente, as dependências Python necessárias para o
+     Odoo e os repositórios da OCA dos quais os módulos da localização
+     brasileira dependem.
 
 2. **Configure o Caminho dos Addons:**
 
-   -  Adicione o caminho do repositório na configuração do Odoo em
-      ``addons-path``.
+   - Adicione o caminho do repositório na configuração do Odoo em
+     ``addons-path``.
 
 3. **Atualize a Lista de Módulos:**
 
-   -  Atualize sua lista de módulos para que o Odoo reconheça o novo
-      módulo.
+   - Atualize sua lista de módulos para que o Odoo reconheça o novo
+     módulo.
 
 4. **Busque pelo Módulo:**
 
-   -  Pesquise por ``"L10n Br Account Withholding"`` nos addons do Odoo
-      para localizar o módulo.
+   - Pesquise por ``"L10n Br Account Withholding"`` nos addons do Odoo
+     para localizar o módulo.
 
 5. **Instale o Módulo:**
 
-   -  Prossiga com a instalação do módulo no ambiente Odoo.
+   - Prossiga com a instalação do módulo no ambiente Odoo.
 
 Configuration
 =============
@@ -103,6 +103,9 @@ estes passos:
    se necessário. Se um diário não for especificado, o módulo usará o
    diário da fatura de compra original.
 
+3. **Definir uma Prefeitura para o ISSQN:** Crie ou edite um parceiro,
+   vá até a aba "Fiscal" e marque a opção "É Prefeitura".
+
 Usage
 =====
 
@@ -114,6 +117,12 @@ impostos no Odoo:
 
 2. **Confirmação da Fatura:** Ao confirmar a fatura de compra, o módulo
    gera automaticamente as faturas de retenção de impostos.
+
+3. **Definir uma Prefeitura para o ISSQN:** Ao incluir um imposto de
+   retenção e informar a cidade correspondente para o ISSQN, o módulo
+   busca automaticamente o parceiro marcado como Prefeitura para essa
+   cidade. Caso não o encontre, ele retorna o parceiro padrão definido
+   no Grupo de Impostos.
 
 Bug Tracker
 ===========
@@ -137,13 +146,13 @@ Authors
 Contributors
 ------------
 
--  ``Escodoo <https://www.escodoo.com.br>``\ \_:
+- ``Escodoo <https://www.escodoo.com.br>``\ \_:
 
-   -  Marcel Savegnago marcel.savegnago@escodoo.com.br
+  - Marcel Savegnago marcel.savegnago@escodoo.com.br
 
--  ``Akretion <https://www.akretion.com.br>``\ \_:
+- ``Akretion <https://www.akretion.com.br>``\ \_:
 
-   -  Renato Lima renato.lima@akretion.com.br
+  - Renato Lima renato.lima@akretion.com.br
 
 Maintainers
 -----------

--- a/l10n_br_account_withholding/__manifest__.py
+++ b/l10n_br_account_withholding/__manifest__.py
@@ -14,6 +14,7 @@
         "l10n_br_account",
     ],
     "data": [
+        "views/res_partner.xml",
         "views/l10n_br_fiscal_tax_group.xml",
         "views/account_move.xml",
     ],

--- a/l10n_br_account_withholding/models/__init__.py
+++ b/l10n_br_account_withholding/models/__init__.py
@@ -1,3 +1,4 @@
 from . import account_move
 from . import l10n_br_fiscal_tax_group
 from . import account_move_line
+from . import res_partner

--- a/l10n_br_account_withholding/models/account_move.py
+++ b/l10n_br_account_withholding/models/account_move.py
@@ -77,8 +77,22 @@ class AccountMove(models.Model):
         """
         wh_date_invoice = move_line.move_id.date
         wh_due_invoice = wh_date_invoice.replace(day=fiscal_group.wh_due_day)
+
+        if fiscal_group.tax_scope == "city":
+            city_id = (
+                self.invoice_line_ids[0].issqn_fg_city_id
+                if self.invoice_line_ids[0].issqn_fg_city_id
+                else self.partner_id.city_id
+            )
+            partner_wh = self.env["res.partner"].search(
+                [("city_id", "=", city_id.id), ("wh_cityhall", "=", True)], limit=1
+            )
+            partner_id = partner_wh if partner_wh else fiscal_group.partner_id
+        else:
+            partner_id = fiscal_group.partner_id
+
         values = {
-            "partner_id": fiscal_group.partner_id.id,
+            "partner_id": partner_id.id,
             "date": wh_date_invoice,
             "invoice_date": wh_date_invoice,
             "invoice_date_due": wh_due_invoice + relativedelta(months=1),

--- a/l10n_br_account_withholding/models/res_partner.py
+++ b/l10n_br_account_withholding/models/res_partner.py
@@ -1,0 +1,19 @@
+# Copyright 2024 - TODAY, Kaynnan Lemes <kaynnan.lemes@escodoo.com.br>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    # TODO: Add WH fields for State and Country
+    wh_cityhall = fields.Boolean(string="Is City Hall?")
+
+    _sql_constraints = [
+        (
+            "unique_wh_cityhall",
+            "UNIQUE(city_id, wh_cityhall)",
+            "Only one partner with the same City Hall can exist in the same city.",
+        ),
+    ]

--- a/l10n_br_account_withholding/readme/CONFIGURE.md
+++ b/l10n_br_account_withholding/readme/CONFIGURE.md
@@ -3,3 +3,5 @@ Configure a geração de faturas de retenção de impostos no Odoo seguindo este
 1. **Acesse Configurações Fiscais:** Vá até `Fiscal -> Configurações -> Grupos de Impostos`. Procure por impostos retidos do tipo entrada.
 
 2. **Configure os Impostos Retidos:** Para cada imposto que requer uma fatura de retenção, garanta que esteja corretamente configurado. Defina um fornecedor e o diário para a geração da fatura do imposto se necessário. Se um diário não for especificado, o módulo usará o diário da fatura de compra original.
+
+3. **Definir uma Prefeitura para o ISSQN:** Crie ou edite um parceiro, vá até a aba "Fiscal" e marque a opção "É Prefeitura".

--- a/l10n_br_account_withholding/readme/USAGE.md
+++ b/l10n_br_account_withholding/readme/USAGE.md
@@ -3,3 +3,5 @@ Siga estes passos para utilizar a geração de faturas de retenção de impostos
 1. **Criando uma Fatura de Compra:** Ao criar uma fatura de compra, aplique o imposto retido nas linhas necessárias.
 
 2. **Confirmação da Fatura:** Ao confirmar a fatura de compra, o módulo gera automaticamente as faturas de retenção de impostos.
+
+3. **Definir uma Prefeitura para o ISSQN:** Ao incluir um imposto de retenção e informar a cidade correspondente para o ISSQN, o módulo busca automaticamente o parceiro marcado como Prefeitura para essa cidade. Caso não o encontre, ele retorna o parceiro padrão definido no Grupo de Impostos.

--- a/l10n_br_account_withholding/static/description/index.html
+++ b/l10n_br_account_withholding/static/description/index.html
@@ -453,6 +453,8 @@ fatura de retenção, garanta que esteja corretamente configurado.
 Defina um fornecedor e o diário para a geração da fatura do imposto
 se necessário. Se um diário não for especificado, o módulo usará o
 diário da fatura de compra original.</li>
+<li><strong>Definir uma Prefeitura para o ISSQN:</strong> Crie ou edite um parceiro,
+vá até a aba “Fiscal” e marque a opção “É Prefeitura”.</li>
 </ol>
 </div>
 <div class="section" id="usage">
@@ -464,6 +466,11 @@ impostos no Odoo:</p>
 aplique o imposto retido nas linhas necessárias.</li>
 <li><strong>Confirmação da Fatura:</strong> Ao confirmar a fatura de compra, o módulo
 gera automaticamente as faturas de retenção de impostos.</li>
+<li><strong>Definir uma Prefeitura para o ISSQN:</strong> Ao incluir um imposto de
+retenção e informar a cidade correspondente para o ISSQN, o módulo
+busca automaticamente o parceiro marcado como Prefeitura para essa
+cidade. Caso não o encontre, ele retorna o parceiro padrão definido
+no Grupo de Impostos.</li>
 </ol>
 </div>
 <div class="section" id="bug-tracker">

--- a/l10n_br_account_withholding/views/res_partner.xml
+++ b/l10n_br_account_withholding/views/res_partner.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2024 - TODAY, Kaynnan Lemes <kaynnan.lemes@escodoo.com.br>
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.ui.view" id="partner_form_view">
+        <field
+            name="name"
+        >l10n_br_fiscal.partner.form (in l10n_br_account_withholding)</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="l10n_br_base.l10n_br_base_partner_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='other_infos']" position="inside">
+                <field name="wh_cityhall" />
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
cc @marcelsavegnago @douglascstd @WesleyOliveira98 @Matthwhy 

Esta PR introduz a lógica para determinar o partner_id com base no campo cidade do ISSQN. Quando a cidade do ISSQN está especificada na linha de itens da fatura, o partner_id é definido pelo partner_wh_id associado a essa cidade no modelo `res.city`, permitindo identificar entidades como a Prefeitura de São Paulo. Antes de atribuir o partner_id, valida-se se há um partner_wh_id definido para a cidade no modelo `res.city`. Caso não haja, o partner_id é obtido através do l10n_br_fiscal.tax.group. Se a cidade do ISSQN não estiver preenchida na linha de itens da fatura, o partner_id é obtido com base na cidade do Parceiro da fatura de retenção.

