### PR TITLE
[14.0][FIX][l10n_br_nfe] falha no cancelamento de nota fiscal sem retorno

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -1352,6 +1352,13 @@ class NFe(spec_models.StackedModel):
         return etree.tostring(new_root)
 
     def _document_cancel(self, justificative):
+        if self.document_type_id.code in [MODELO_FISCAL_NFE]:
+            if not justificative or len(justificative) < 15:
+                raise ValidationError(
+                    _(
+                        "Please enter a justification that is at least 15 characters long."
+                    )
+                )
         result = super()._document_cancel(justificative)
         online_event = self.filtered(filter_processador_edoc_nfe)
         if online_event:


### PR DESCRIPTION
Acredito que o commit https://github.com/OCA/l10n-brazil/commit/f6d0e9e9cdf061bb03d2b54be4e3f382de59751c tenha trazido resultados não desejados uma vez que o campo justificativa (no cancelamento da nota fiscal) precisa ter no mínimo 15 caracteres.

Essa propriedade passava despercebida e, com o commit, o erro passou a ocorrer sem nenhum tipo de retorno para o usuário.

Esse PR trava o cancelamento da nota fiscal caso o tamanho mínimo da justificativa não tenha sido atendida:

![image](https://github.com/user-attachments/assets/7f5b8de8-b041-4607-a8b5-3ddf96462b90)
