### PR TITLE
[14.0][FIX] l10n_br_fiscal: fix validation error message

### DIFF
--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -349,7 +349,7 @@ class Document(models.Model):
             raise ValidationError(
                 _(
                     "You cannot delete fiscal document number %(number)s with "
-                    "the status: %(state)!",
+                    "the status: %(state)s!",
                     number=record.document_number,
                     state=record.state_edoc,
                 )


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 652, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 317, in _handle_exception
    raise exception.with_traceback(None) from new_cause
ValueError: unsupported format character '!' (0x21) at index 77
```