### PR TITLE
[14.0][FIX] l10n_br_sale: fix partner used to invoicing

### DIFF
--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -200,6 +200,12 @@ class SaleOrder(models.Model):
         if self.fiscal_operation_id:
             result.update(self._prepare_br_fiscal_dict())
 
+            # By default, the value of the partner_id field should be the same
+            # as the partner_invoice_id field. The _prepare_br_fiscal_dict()
+            # method changes the partner_id value in the super result to the
+            # value of the partner_id field from the sale.order model.
+            result["partner_id"] = self.partner_invoice_id.id
+
             document_type_id = self._context.get("document_type_id")
 
             if not document_type_id:

--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -67,7 +67,7 @@ class SaleOrderLine(models.Model):
 
     partner_id = fields.Many2one(
         comodel_name="res.partner",
-        related="order_id.partner_id",
+        related="order_id.partner_invoice_id",
         string="Partner",
     )
 


### PR DESCRIPTION
Por padrão, o valor do campo partner_id deve ser o mesmo do campo partner_invoice_id. O método _prepare_br_fiscal_dict() altera o valor de partner_id no resultado do super para o valor do campo partner_id do modelo sale.order.