### PR TITLE
[14.0][spec_driven_model][REF] spec_driven_model: clean inherit+import

### DIFF
--- a/spec_driven_model/models/__init__.py
+++ b/spec_driven_model/models/__init__.py
@@ -1,6 +1,6 @@
+from . import spec_export
+from . import spec_import
 from . import spec_mixin
 
 # from . import spec_view
 from . import spec_models
-from . import spec_import
-from . import spec_export

--- a/spec_driven_model/models/spec_export.py
+++ b/spec_driven_model/models/spec_export.py
@@ -9,8 +9,9 @@ from odoo import api, fields, models
 _logger = logging.getLogger(__name__)
 
 
-class AbstractSpecMixin(models.AbstractModel):
-    _inherit = "spec.mixin"
+class SpecMixinExport(models.AbstractModel):
+    _name = "spec.mixin_export"
+    _description = "a mixin providing serialization features"
 
     @api.model
     def _get_binding_class(self, class_obj):

--- a/spec_driven_model/models/spec_mixin.py
+++ b/spec_driven_model/models/spec_mixin.py
@@ -11,6 +11,7 @@ class SpecMixin(models.AbstractModel):
 
     _description = "root abstract model meant for xsd generated fiscal models"
     _name = "spec.mixin"
+    _inherit = ["spec.mixin_export", "spec.mixin_import"]
     _stacking_points = {}
     # _spec_module = 'override.with.your.python.module'
     # _binding_module = 'your.pyhthon.binding.module'

--- a/spec_driven_model/models/spec_models.py
+++ b/spec_driven_model/models/spec_models.py
@@ -29,7 +29,7 @@ class SelectionMuteLogger(mute_logger):
         return super().filter(record)
 
 
-class SpecModel(models.AbstractModel):
+class SpecModel(models.Model):
     """When you inherit this Model, then your model becomes concrete just like
     models.Model and it can use _inherit to inherit from several xsd generated
     spec mixins.

--- a/spec_driven_model/models/spec_view.py
+++ b/spec_driven_model/models/spec_view.py
@@ -16,7 +16,7 @@ _logger = logging.getLogger(__name__)
 
 
 class SpecViewMixin(models.AbstractModel):
-    _inherit = "spec.mixin"
+    _name = "spec.mixin_view"
 
     @api.model
     def fields_view_get(


### PR DESCRIPTION
backport de mudanças que foram necessarias para a migraçao para a v15 (e entao para a v16): https://github.com/OCA/l10n-brazil/pull/2876