### PR TITLE
[14.0][FIX] l10n_br_base: check ie only partner is_company

### DIFF
--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -115,7 +115,7 @@ class Partner(models.Model):
                 record.country_id,
             )
 
-    @api.constrains("inscr_est", "state_id")
+    @api.constrains("inscr_est", "state_id", "is_company")
     def _check_ie(self):
         """Checks if company register number in field insc_est is valid,
         this method call others methods because this validation is State wise
@@ -123,7 +123,10 @@ class Partner(models.Model):
         :Return: True or False.
         """
         for record in self:
-            check_ie(record.env, record.inscr_est, record.state_id, record.country_id)
+            if record.is_company:
+                check_ie(
+                    record.env, record.inscr_est, record.state_id, record.country_id
+                )
 
     @api.constrains("state_tax_number_ids")
     def _check_state_tax_number_ids(self):


### PR DESCRIPTION
A verificação atual da inscrição estadual impacta os casos em que o parceiro possui um parceiro filho de outro estado. Como os dados da inscrição estadual e outras informações são replicados do parent_id para os filhos, isso impede a alteração do estado de um contato que seja diferente do parent_id.