### PR TITLE
[14.0][spec_driven_model][FIX] fix MRO + auto access

### DIFF
--- a/l10n_br_nfe/hooks.py
+++ b/l10n_br_nfe/hooks.py
@@ -20,12 +20,6 @@ def post_init_hook(cr, registry):
         env, "l10n_br_nfe", "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00"
     )
 
-    hooks.post_init_hook(
-        cr,
-        registry,
-        "l10n_br_nfe",
-        "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00",
-    )
     cr.execute("select demo from ir_module_module where name='l10n_br_nfe';")
     is_demo = cr.fetchone()[0]
     if is_demo:

--- a/spec_driven_model/hooks.py
+++ b/spec_driven_model/hooks.py
@@ -12,56 +12,6 @@ from .models.spec_models import SpecModel, StackedModel
 _logger = logging.getLogger(__name__)
 
 
-def post_init_hook(cr, registry, module_name, spec_module):
-    """
-    Automatically generate access rules for spec models
-    """
-    env = api.Environment(cr, SUPERUSER_ID, {})
-    remaining_models = get_remaining_spec_models(cr, registry, module_name, spec_module)
-    fields = [
-        "id",
-        "name",
-        "model_id/id",
-        "group_id/id",
-        "perm_read",
-        "perm_write",
-        "perm_create",
-        "perm_unlink",
-    ]
-    access_data = []
-    for model in remaining_models:
-        underline_name = model.replace(".", "_")
-        model_id = "%s_spec.model_%s" % (
-            module_name,
-            underline_name,
-        )
-        access_data.append(
-            [
-                "access_%s_user" % (underline_name,),
-                underline_name,
-                model_id,
-                "%s.group_user" % (module_name,),
-                "1",
-                "0",
-                "0",
-                "0",
-            ]
-        )
-        access_data.append(
-            [
-                "access_%s_manager" % (underline_name,),
-                underline_name,
-                model_id,
-                "%s.group_manager" % (module_name,),
-                "1",
-                "1",
-                "1",
-                "1",
-            ]
-        )
-    env["ir.model.access"].load(fields, access_data)
-
-
 def get_remaining_spec_models(cr, registry, module_name, spec_module):
     """
     Figure out the list of spec models not injected into existing
@@ -144,6 +94,7 @@ def register_hook(env, module_name, spec_module, force=False):
         return
     setattr(env.registry, load_key, True)
 
+    access_data = []
     remaining_models = get_remaining_spec_models(
         env.cr, env.registry, module_name, spec_module
     )
@@ -160,29 +111,43 @@ def register_hook(env, module_name, spec_module, force=False):
                 fields,
             )
         )
-        c = type(
+        model_type = type(
             name,
             (SpecModel, spec_class),
             {
                 "_name": name,
-                "_inherit": [spec_class._inherit, "spec.mixin"],
+                "_inherit": spec_class._inherit,
                 "_original_module": "fiscal",
                 "_odoo_module": module_name,
                 "_spec_module": spec_module,
                 "_rec_name": rec_name,
+                "_module": module_name,
             },
         )
-        models.MetaModel.module_to_models[module_name] += [c]
+        models.MetaModel.module_to_models[module_name] += [model_type]
 
         # now we init these models properly
         # a bit like odoo.modules.loading#load_module_graph would do.
-        c._build_model(env.registry, env.cr)
+        model = model_type._build_model(env.registry, env.cr)
 
         env[name]._prepare_setup()
         env[name]._setup_base()
         env[name]._setup_fields()
         env[name]._setup_complete()
 
+        access_fields = [
+            "id",
+            "name",
+            "model_id/id",
+            "group_id/id",
+            "perm_read",
+            "perm_write",
+            "perm_create",
+            "perm_unlink",
+        ]
+        model._auto_fill_access_data(env, module_name, access_data)
+
+    env["ir.model.access"].load(access_fields, access_data)
     hook_key = "_%s_need_hook" % (module_name,)
     if hasattr(env.registry, hook_key) and getattr(env.registry, hook_key):
         env.registry.init_models(env.cr, remaining_models, {"module": module_name})

--- a/spec_driven_model/models/spec_mixin.py
+++ b/spec_driven_model/models/spec_mixin.py
@@ -30,3 +30,53 @@ class SpecMixin(models.AbstractModel):
             return True
         else:
             return super()._valid_field_parameter(field, name)
+
+    @classmethod
+    def _auto_fill_access_data(cls, env, module_name: str, access_data: list):
+        """
+        Fill access_data with a default user and a default manager access.
+        """
+
+        underline_name = cls._name.replace(".", "_")
+        model_id = "%s_spec.model_%s" % (
+            module_name,
+            underline_name,
+        )
+        user_access_name = f"access_{underline_name}_user"
+        if not env["ir.model.access"].search(
+            [
+                ("name", "in", [underline_name, user_access_name]),
+                ("model_id", "=", model_id),
+            ]
+        ):
+            access_data.append(
+                [
+                    user_access_name,
+                    user_access_name,
+                    model_id,
+                    "%s.group_user" % (module_name,),
+                    "1",
+                    "0",
+                    "0",
+                    "0",
+                ]
+            )
+        manager_access_name = f"access_{underline_name}_manager"
+        if not env["ir.model.access"].search(
+            [
+                ("name", "in", [underline_name, manager_access_name]),
+                ("model_id", "=", model_id),
+            ]
+        ):
+            access_data.append(
+                [
+                    manager_access_name,
+                    manager_access_name,
+                    model_id,
+                    "%s.group_manager" % (module_name,),
+                    "1",
+                    "1",
+                    "1",
+                    "1",
+                ]
+            )


### PR DESCRIPTION
backport from v15 #2874 

- [x] the changes in _build_model avoids a critical Method resolution Order issue in v15+, it also makes the whole class hierarchy simpler: now if nfe.40.vol inherits from spec.mixin.nfe in the l10n_br_nfe_spec module, then spec.mixin nfe will simply inherit from spec.mixin in the l10n_br_nfe module and get the import/export methods for instance.
- [x] the post_init_hook auto access right hook has been refactored so it is simply called from the standard _register_hook for objects that need to be made concrete. It moved to the spec.mixin so it can be overriden. @marcelsavegnago this should fix missing access right issues like you encountered, as now the hook will be triggered upon startup and not only during module installation (access right are added only if missing).

The reason to look if there is a name in [underline_name, user_access_name] is because in v14 I used the same underline_name both for user and manager access record names. This was bad but doing this test we ensure it won't create new records.

As for new databases it now looks like:

```
> select * from ir_model_access where name ilike '%nfe_40_det%';

 id  |                name                | active | model_id | group_id | perm_read | perm_write | perm_create | perm_unlink | create_uid |        create_date        | write_uid |         write_date
-----+------------------------------------+--------+----------+----------+-----------+------------+-------------+-------------+------------+---------------------------+-----------+----------------------------
 413 | access_nfe_40_detpag_user          | t      |      208 |       22 | t         | f          | f           | f           |          1 | 2024-07-24 06:37:57.02618 |         1 | 2024-07-24 07:37:48.266777
 414 | access_nfe_40_detpag_manager       | t      |      208 |       23 | t         | t          | t           | t           |          1 | 2024-07-24 06:37:57.02618 |         1 | 2024-07-24 07:37:48.266777
 489 | access_nfe_40_detexport_user       | t      |      159 |       22 | t         | f          | f           | f           |          1 | 2024-07-24 06:37:57.02618 |         1 | 2024-07-24 07:37:48.266777
 490 | access_nfe_40_detexport_manager    | t      |      159 |       23 | t         | t          | t           | t           |          1 | 2024-07-24 06:37:57.02618 |         1 | 2024-07-24 07:37:48.266777
 411 | access_nfe_40_det_obsfisco_user    | t      |      194 |       22 | t         | f          | f           | f           |          1 | 2024-07-24 06:37:57.02618 |         1 | 2024-07-24 07:37:48.266777
 412 | access_nfe_40_det_obsfisco_manager | t      |      194 |       23 | t         | t          | t           | t           |          1 | 2024-07-24 06:37:57.02618 |         1 | 2024-07-24 07:37:48.266777
 483 | access_nfe_40_det_obscont_user     | t      |      193 |       22 | t         | f          | f           | f           |          1 | 2024-07-24 06:37:57.02618 |         1 | 2024-07-24 07:37:48.266777
 484 | access_nfe_40_det_obscont_manager  | t      |      193 |       23 | t         | t          | t           | t           |          1 | 2024-07-24 06:37:57.02618 |         1 | 2024-07-24 07:37:48.266777
(8 rows)
```