### PR TITLE
[14.0][FIX] l10n_br_account_payment_brcobranca: Santander parser

### DIFF
--- a/l10n_br_account_payment_brcobranca/parser/cnab_file_parser.py
+++ b/l10n_br_account_payment_brcobranca/parser/cnab_file_parser.py
@@ -104,8 +104,8 @@ class CNABFileParser(FileParser):
     def _get_date_format(self, bank_name_brcobranca):
         # TODO: Idealmente o JSON de Retorno do BRCobranca deveria vir
         #  padronizado para não ser necessário ser feito esse tratamento aqui
-        if bank_name_brcobranca == "ailos":
-            # No Banco AILOS o formato da Data é completo com os 4 digitos.
+        if bank_name_brcobranca in ("ailos", "santander"):
+            # No Banco AILOS e Santander o formato da Data é completo com os 4 digitos.
             zeros_date = "00000000"
             date_format = "%d%m%Y"
         else:
@@ -182,8 +182,8 @@ class CNABFileParser(FileParser):
 
         bank_name_brcobranca = dict_brcobranca_bank[self.bank.code_bc]
 
-        if bank_name_brcobranca == "ailos":
-            # No AILOS o código de registro onde ficam as linhas CNAB é o 3.
+        if bank_name_brcobranca in ("ailos", "santander"):
+            # No AILOS e Santander o código de registro onde ficam as linhas CNAB é o 3.
             registration_code_allowed = 3
         elif bank_name_brcobranca == "banco_brasil":
             # No Banco do Brasil o código do registro principal é o 7.


### PR DESCRIPTION
cc @marcelsavegnago @douglascstd @antoniospneto 

Ao validar o arquivo de retorno de um cliente nosso, a importação exibia a mensagem: `Nada a importar: O arquivo está vazio`.

Para solucionar, testei primeiramente a importação no diário do Ailos CNAB 240, utilizando o arquivo de retorno do Santander. Analisei a estrutura pelo API do `Kivanio/brcobranca` e percebi que, em relação ao código de registro e às datas com 4 dígitos, ambos eram idênticos (Santander e Ailos), por isso o teste no diário do Ailos.

Entretanto, essas informações estavam ausentes na validação do parser, o que impossibilitava a importação do arquivo de retorno para o Santander.
