### PR TITLE
[14.0][FIX][spec_driven_model] define access_fields before loop

### DIFF
--- a/spec_driven_model/hooks.py
+++ b/spec_driven_model/hooks.py
@@ -134,8 +134,10 @@ def register_hook(env, module_name, spec_module, force=False):
         env[name]._setup_base()
         env[name]._setup_fields()
         env[name]._setup_complete()
+        model._auto_fill_access_data(env, module_name, access_data)
 
-        access_fields = [
+    env["ir.model.access"].load(
+        [
             "id",
             "name",
             "model_id/id",
@@ -144,10 +146,9 @@ def register_hook(env, module_name, spec_module, force=False):
             "perm_write",
             "perm_create",
             "perm_unlink",
-        ]
-        model._auto_fill_access_data(env, module_name, access_data)
-
-    env["ir.model.access"].load(access_fields, access_data)
+        ],
+        access_data,
+    )
     hook_key = "_%s_need_hook" % (module_name,)
     if hasattr(env.registry, hook_key) and getattr(env.registry, hook_key):
         env.registry.init_models(env.cr, remaining_models, {"module": module_name})


### PR DESCRIPTION
o access_fields tem que ser definido antes do loop caso nao haja modelos abstratos sobrando para tornar concretos.
Foi um erro no meu ultimo PR https://github.com/OCA/l10n-brazil/pull/3215

cc @marcelsavegnago 