### PR TITLE
[14.0][REF] l10n_br_fiscal: Manter os preços no teste unitário.

### DIFF
--- a/l10n_br_fiscal/tests/test_fiscal_document_generic.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_generic.py
@@ -49,7 +49,16 @@ class TestFiscalDocumentGeneric(SavepointCase):
         self.nfe_same_state._onchange_fiscal_operation_id()
 
         for line in self.nfe_same_state.fiscal_line_ids:
+            # Save the original price_unit value of the line as defined in
+            # the NFe demo data.
+            original_price_unit = line.price_unit
+
             line._onchange_product_id_fiscal()
+
+            # Restore the original price_unit value,
+            # as the product change might have altered it.
+            line.price_unit = original_price_unit
+
             line._onchange_commercial_quantity()
             line._onchange_ncm_id()
             line._onchange_fiscal_operation_id()
@@ -178,7 +187,7 @@ class TestFiscalDocumentGeneric(SavepointCase):
         )
 
         # Total value of the products
-        self.assertEqual(self.nfe_same_state.amount_price_gross, 3965)
+        self.assertEqual(self.nfe_same_state.amount_price_gross, 200)
 
         result = self.nfe_same_state.action_document_cancel()
         self.assertTrue(result)


### PR DESCRIPTION
Pequena refatoração nos testes, para que os preços definido nos dados de demonstração se mantenham.

Antes, ao chamar o onchange do produto nos testes, o preço definido na nfe estavam sendo descartados e o preço era atualizado conforme estava no cadastro do produto.

Dessa forma, conseguimos manter o mesmo teste sem quebrar na versão 15/16.0 pois lá o preço nesses produtos estão diferentes.