### PR TITLE
[14.0][CI] workaround vcrpy install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
+      - name: Install vcrpy and work around https://github.com/kevin1024/vcrpy/issues/855
+        run: pip install vcrpy --no-build-isolation
       - name: Install addons and dependencies
         run: oca_install_addons
       - name: Check licenses

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-vcrpy  # Needed by payment_pagseguro
+# vcrpy  # Needed by payment_pagseguro
 odoo-test-helper  # Needed by spec_driven_model
 signxml<3.1.0
 xmldiff


### PR DESCRIPTION
A CI de todas as branches do OCA/l10n-brazil quebrou com a nova versao do 72 setuptools.
Por examplo:

- https://github.com/OCA/l10n-brazil/actions/runs/10141486670/job/28038827348
- https://github.com/OCA/l10n-brazil/pull/3194

```
 + pip install -r test-requirements.txt -c test-constraints.txt
WARNING: The directory '/github/home/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you should use sudo's -H flag.
Looking in indexes: https://wheelhouse.odoo-community.org/oca-simple-and-pypi
Collecting vcrpy (from -r test-requirements.txt (line 1))
  Downloading vcrpy-6.0.1.tar.gz (84 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 84.8/84.8 kB 36.8 MB/s eta 0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'error'
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [17 lines of output]
      Traceback (most recent call last):
        File "/opt/odoo-venv/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/opt/odoo-venv/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/opt/odoo-venv/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/tmp/pip-build-env-lrm6ylbh/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 327, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
        File "/tmp/pip-build-env-lrm6ylbh/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 297, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-lrm6ylbh/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 497, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/tmp/pip-build-env-lrm6ylbh/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 313, in run_setup
          exec(code, locals())
        File "<string>", line 9, in <module>
      ModuleNotFoundError: No module named 'setuptools.command.test'
      [end of output]
```

Tem uma incompatibilidade entre o o novo setuptools e o vcrpy:
https://github.com/kevin1024/vcrpy/issues/855

Aqui tou aplicando esse workaround para destravar as coisas ate talvez uma nova versao do vcrpy ser publicada


cc @renatonlima @marcelsavegnago @antoniospneto 