### PR TITLE
[16.0][MIG][l10n_br_nfe] _render_qweb_* methods migration

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -1305,7 +1305,9 @@ class NFe(spec_models.StackedModel):
             "type": "binary",
         }
         report = self.env.ref("l10n_br_nfe.report_danfe")
-        pdf_data = report._render_qweb_pdf(self.fiscal_line_ids.document_id.ids)
+        pdf_data = report._render_qweb_pdf(
+            "l10n_br_nfe.main_template_danfe", self.fiscal_line_ids.document_id.ids
+        )
         attachment_data["datas"] = base64.b64encode(pdf_data[0])
         file_pdf = self.file_report_id
         self.file_report_id = False

--- a/l10n_br_nfe/report/ir_actions_report.py
+++ b/l10n_br_nfe/report/ir_actions_report.py
@@ -37,18 +37,17 @@ class IrActionsReport(models.Model):
         new_root.append(protNFe_node)
         return etree.tostring(new_root)
 
-    def _render_qweb_html(self, res_ids, data=None):
-        if self.report_name == "main_template_danfe":
+    def _render_qweb_html(self, report_ref, res_ids, data=None):
+        if report_ref == "l10n_br_nfe.main_template_danfe":
             return
 
-        return super()._render_qweb_html(res_ids, data=data)
+        return super()._render_qweb_html(report_ref, res_ids, data=data)
 
-    def _render_qweb_pdf(self, res_ids, data=None):
-        if self.report_name not in ["main_template_danfe"]:
-            return super()._render_qweb_pdf(res_ids, data=data)
+    def _render_qweb_pdf(self, report_ref, res_ids, data=None):
+        if report_ref not in ["l10n_br_nfe.main_template_danfe"]:
+            return super()._render_qweb_pdf(report_ref, res_ids, data=data)
 
         nfe = self.env["l10n_br_fiscal.document"].search([("id", "in", res_ids)])
-
         return self._render_danfe(nfe)
 
     def _render_danfe(self, nfe):

--- a/l10n_br_nfe/tests/test_nfe_danfe.py
+++ b/l10n_br_nfe/tests/test_nfe_danfe.py
@@ -37,7 +37,7 @@ class TestDanfeGeneration(TransactionCase):
         nfe.document_type_id = self.env.ref("l10n_br_fiscal.document_01")
         nfe.action_document_confirm()
         with self.assertRaises(UserError) as captured_exception:
-            danfe_report._render_qweb_pdf([nfe.id])
+            danfe_report._render_qweb_pdf("l10n_br_nfe.main_template_danfe", [nfe.id])
         self.assertEqual(
             captured_exception.exception.args[0],
             "You can only print a DANFE of a NFe(55).",


### PR DESCRIPTION
- na v14 e na v15 era assim: https://github.com/odoo/odoo/blob/14.0/odoo/addons/base/models/ir_actions_report.py#L818
- mas na v16 mudou para: https://github.com/odoo/odoo/blob/16.0/odoo/addons/base/models/ir_actions_report.py#L868

REF https://github.com/odoo/odoo/commit/ffc525419a71aeb05ede6b59dda9e62286a5e66e#diff-7ce69a093ea1fb1cf2989e24d52cb8e717ab4f2b3c2006ba5cc67503a3df1affL774

Sem isso pega erro tipo "got multiple values for data" ao tentar imprimir qualquer relatorio.

cc @antoniospneto 
