### PR TITLE
[16.0][MIG][spec_driven_model] fields_get_keys is deprecated

### DIFF
--- a/spec_driven_model/hooks.py
+++ b/spec_driven_model/hooks.py
@@ -102,7 +102,7 @@ def register_hook(env, module_name, spec_module, force=False):
     for name in remaining_models:
         spec_class = StackedModel._odoo_name_to_class(name, spec_module)
         spec_class._module = "fiscal"  # TODO use python_module ?
-        fields = env[spec_class._name].fields_get_keys()
+        fields = env[spec_class._name]._fields.keys()
         rec_name = next(
             filter(
                 lambda x: (


### PR DESCRIPTION
evita esses warnings nos logs:

```
2024-07-30 21:36:35,868 332 WARNING tecesa py.warnings: /odoo/external-src/l10n-brazil/spec_driven_model/hooks.py:105: DeprecationWarning: fields_get_keys() method is deprecated, use `_fields` or `get_views`
 instead
  File "/env/bin/odoo", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/odoo/src/setup/odoo", line 8, in <module>
    odoo.cli.main()
  File "/odoo/src/odoo/cli/command.py", line 66, in main
    o.run(args)
  File "/odoo/src/odoo/cli/server.py", line 180, in run
    main(args)
  File "/odoo/src/odoo/cli/server.py", line 173, in main
    rc = odoo.service.server.start(preload=preload, stop=stop)
  File "/odoo/src/odoo/service/server.py", line 1410, in start
    rc = server.run(preload, stop)
  File "/odoo/src/odoo/service/server.py", line 590, in run
    rc = preload_registries(preload)
  File "/odoo/src/odoo/service/server.py", line 1310, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/env/lib/python3.10/site-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
  File "/odoo/src/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "/odoo/src/odoo/modules/registry.py", line 90, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/odoo/src/odoo/modules/loading.py", line 619, in load_modules
    model._register_hook()
  File "/odoo/external-src/l10n-brazil/spec_driven_model/models/spec_models.py", line 228, in _register_hook
    hooks.register_hook(self.env, self._odoo_module, self._spec_module)
  File "/odoo/external-src/l10n-brazil/spec_driven_model/hooks.py", line 105, in register_hook
    fields = env[spec_class._name].fields_get_keys()
```