### PR TITLE
[14.0] l10n_br_fiscal: Alteração do nome do método fiscal

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -285,7 +285,7 @@ class AccountMove(models.Model):
                     move.is_invoice(include_receipts=True)
                     and not line.exclude_from_invoice_tab
                 ):
-                    line._update_taxes()
+                    line._update_fiscal_taxes()
 
         result = super()._compute_amount()
         for move in self.filtered(lambda m: m.company_id.country_id.code == "BR"):

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -289,7 +289,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             )
             line.fiscal_tax_ids = fiscal_taxes + taxes
 
-    def _update_taxes(self):
+    def _update_fiscal_taxes(self):
         for line in self:
             compute_result = self._compute_taxes(line.fiscal_tax_ids)
             line.amount_tax_included = compute_result.get("amount_included", 0.0)
@@ -382,7 +382,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         for tax in mapping_result["taxes"].values():
             taxes |= tax
         self.fiscal_tax_ids = taxes
-        self._update_taxes()
+        self._update_fiscal_taxes()
         self.comment_ids = self.fiscal_operation_line_id.comment_ids
 
     @api.onchange("product_id")
@@ -815,7 +815,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
     )
     def _onchange_fiscal_taxes(self):
         self._update_fiscal_tax_ids(self._get_all_tax_id_fields())
-        self._update_taxes()
+        self._update_fiscal_taxes()
 
     @api.model
     def _update_fiscal_quantity(self, product_id, price, quantity, uom_id, uot_id):
@@ -843,7 +843,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
     @api.onchange("ii_customhouse_charges")
     def _onchange_ii_customhouse_charges(self):
         if self.ii_customhouse_charges:
-            self._update_taxes()
+            self._update_fiscal_taxes()
 
     @api.onchange("ncm_id", "nbs_id", "cest_id")
     def _onchange_ncm_id(self):
@@ -851,7 +851,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
 
     @api.onchange("fiscal_tax_ids")
     def _onchange_fiscal_tax_ids(self):
-        self._update_taxes()
+        self._update_fiscal_taxes()
 
     @api.onchange("city_taxation_code_id")
     def _onchange_city_taxation_code_id(self):

--- a/l10n_br_purchase/models/purchase_order_line.py
+++ b/l10n_br_purchase/models/purchase_order_line.py
@@ -96,7 +96,7 @@ class PurchaseOrderLine(models.Model):
         for line in self:
             if line.fiscal_operation_id:
                 # Update taxes fields
-                line._update_taxes()
+                line._update_fiscal_taxes()
                 # Call mixin compute method
                 line._compute_amounts()
                 # Update record

--- a/l10n_br_repair/models/repair_fee.py
+++ b/l10n_br_repair/models/repair_fee.py
@@ -69,7 +69,7 @@ class RepairFee(models.Model):
         result = super()._compute_price_subtotal()
         for line in self:
             # Update taxes fields
-            line._update_taxes()
+            line._update_fiscal_taxes()
             # Call mixin compute method
             line._compute_amounts()
             # Update record

--- a/l10n_br_repair/models/repair_line.py
+++ b/l10n_br_repair/models/repair_line.py
@@ -69,7 +69,7 @@ class RepairLine(models.Model):
         result = super()._compute_price_subtotal()
         for line in self:
             # Update taxes fields
-            line._update_taxes()
+            line._update_fiscal_taxes()
             # Call mixin compute method
             line._compute_amounts()
             # Update record

--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -178,7 +178,7 @@ class SaleOrderLine(models.Model):
         result = super()._compute_amount()
         for line in self:
             # Update taxes fields
-            line._update_taxes()
+            line._update_fiscal_taxes()
             # Call mixin compute method
             line._compute_amounts()
             # Update record

--- a/l10n_br_sale_blanket_order/models/sale_blanket_order_line.py
+++ b/l10n_br_sale_blanket_order/models/sale_blanket_order_line.py
@@ -126,7 +126,7 @@ class SaleBlanketOrderLine(models.Model):
         result = super()._compute_amount()
         for line in self:
             # Update taxes fields
-            line._update_taxes()
+            line._update_fiscal_taxes()
             # Call mixin compute method
             line._compute_amounts()
             # Update record


### PR DESCRIPTION
Na migração do módulo `l10n_br_fiscal` para a versão 16.0 o método `_update_taxes` foi renomeado para `_update_fiscal_taxes`

Esotu trazendo essa alteração para a 14.0 para diminuir o diff e também para evitar os conflitos nos fututos ports de commits e módulos que ainda não foram migrados.
