### PR TITLE
[14.0][FIX] l10n_br_account_payment_order: ensure payment_mode_id.cnab_write_off_code_id is defined before comparison

### DIFF
--- a/l10n_br_account_payment_order/models/account_move_line.py
+++ b/l10n_br_account_payment_order/models/account_move_line.py
@@ -163,7 +163,8 @@ class AccountMoveLine(models.Model):
             # Se for uma solicitação de baixa do título é preciso informar o
             # campo debit o codigo original coloca o amount_residual
             if (
-                self.mov_instruction_code_id.id
+                self.payment_mode_id.cnab_write_off_code_id
+                and self.mov_instruction_code_id.id
                 == self.payment_mode_id.cnab_write_off_code_id.id
             ):
                 vals["amount_currency"] = self.credit or self.debit


### PR DESCRIPTION
cc @marcelsavegnago  @douglascstd @WesleyOliveira98 

[HT00527] 

Ao analisar o campo cnab_write_off_code_id no contexto de um modo de pagamento "Outbound", observei que, mesmo na ausência de um valor, o código sempre entra na condicional if. Isso causa um problema específico: quando há um adiantamento para o fornecedor, o sistema ignora o valor pendente (Amount Due) restante. Portanto, foi necessário implementar uma validação anterior que garantisse a existência de um valor, evitando essa falha no processo.