### PR TITLE
[14.0][REF][l10n_br_account_nfe] lint

### DIFF
--- a/l10n_br_account_nfe/models/document.py
+++ b/l10n_br_account_nfe/models/document.py
@@ -152,14 +152,15 @@ class DocumentNfe(models.Model):
             if not rec.move_ids.payment_mode_id.fiscal_payment_mode:
                 raise UserError(
                     _(
-                        f"Payment Mode {rec.move_ids.payment_mode_id.name} should has "
-                        "has Fiscal Payment Mode filled to be used in Fiscal Document!"
+                        "Payment Mode %(mode)s should have "
+                        "a Fiscal Payment Mode filled to be used in the Fiscal Document!",
+                        mode=rec.move_ids.payment_mode_id.name,
                     )
                 )
 
     def _update_nfce_for_offline_contingency(self):
-        super()._update_nfce_for_offline_contingency()
-
+        res = super()._update_nfce_for_offline_contingency()
         if self.move_ids:
             copy_invoice = self.move_ids[0].copy()
             copy_invoice.action_post()
+        return res

--- a/l10n_br_account_nfe/tests/test_nfce_contingency.py
+++ b/l10n_br_account_nfe/tests/test_nfce_contingency.py
@@ -3,11 +3,18 @@
 
 from odoo.tests import TransactionCase
 
+from odoo.addons.spec_driven_model import hooks
 
-class TestAccountNFCe(TransactionCase):
+
+class TestAccountNFCeContingency(TransactionCase):
     def setUp(self):
         super().setUp()
-
+        # this hook is required to test l10n_br_account_nfe alone:
+        hooks.register_hook(
+            self.env,
+            "l10n_br_nfe",
+            "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00",
+        )
         self.document_id = self.env.ref("l10n_br_nfe.demo_nfce_same_state")
         self.prepare_account_move_nfce()
 
@@ -64,5 +71,4 @@ class TestAccountNFCe(TransactionCase):
 
     def test_nfce_contingencia(self):
         self.document_id._update_nfce_for_offline_contingency()
-
         self.assertIn(self.document_move_id, self.document_id.move_ids)

--- a/l10n_br_account_nfe/tests/test_nfe_danfe_account.py
+++ b/l10n_br_account_nfe/tests/test_nfe_danfe_account.py
@@ -6,7 +6,7 @@ from odoo.tests import SavepointCase, tagged
 
 
 @tagged("post_install", "-at_install")
-class TestGeneratePaymentInfo(SavepointCase):
+class TestDanfe(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/l10n_br_account_nfe/tests/test_nfe_generate_tags_cobr_dup_pag.py
+++ b/l10n_br_account_nfe/tests/test_nfe_generate_tags_cobr_dup_pag.py
@@ -142,7 +142,6 @@ class TestGeneratePaymentInfo(SavepointCase):
                 check_move_validity=False
             )._onchange_fiscal_operation_line_id()
             line.with_context(check_move_validity=False)._onchange_fiscal_tax_ids()
-        cls.invoice_demo_data.action_post()
 
     def test_nfe_generate_tag_pag(self):
         """Test NFe generate TAG PAG."""
@@ -192,8 +191,15 @@ class TestGeneratePaymentInfo(SavepointCase):
             }
         )
         self.invoice_demo_data.payment_mode_id = self.pay_mode.id
-        with self.assertRaises(UserError):
+        with self.assertRaises(UserError) as captured_exception:
             self.invoice_demo_data.action_post()
+        self.assertEqual(
+            captured_exception.exception.args[0],
+            (
+                "Payment Mode Sem Meio Fiscal should have a "
+                "Fiscal Payment Mode filled to be used in the Fiscal Document!"
+            ),
+        )
 
     def test_invoice_without_payment_mode(self):
         """Test Invoice without Payment Mode."""

--- a/l10n_br_account_nfe/tests/test_nfe_with_ipi.py
+++ b/l10n_br_account_nfe/tests/test_nfe_with_ipi.py
@@ -4,7 +4,7 @@ from odoo.addons.l10n_br_account.tests.common import AccountMoveBRCommon
 
 
 @tagged("post_install", "-at_install")
-class TestAccountAccount(AccountMoveBRCommon):
+class TestNFeWithIPI(AccountMoveBRCommon):
     @classmethod
     def setUpClass(cls, chart_template_ref=None):
         super().setUpClass(chart_template_ref)
@@ -35,7 +35,7 @@ class TestAccountAccount(AccountMoveBRCommon):
             post=False,
         )
         cls.move_out_venda.payment_mode_id = cls.payment_mode
-        cls.move_out_venda.post()
+        cls.move_out_venda.action_post()
 
     def test_nfe_with_ipi(self):
         """


### PR DESCRIPTION
backport do lint [da migraçao para a v15](https://github.com/OCA/l10n-brazil/pull/3271)

algumas explicaçoes:

- tirei um cls.invoice_demo_data.action_post() porque senao o erro era que o move ja tinha sido postado no teste e nao que tinha que prencher um meio fiscal de pagamento. Agora testamos esse UserError mesmo.
- mudei um .post() por action_post() ja que post eh deprecated that v14