### PR TITLE
[14.0][REF][l10n_br_stock_account] lint

### DIFF
--- a/l10n_br_stock_account/demo/account_journal_demo.xml
+++ b/l10n_br_stock_account/demo/account_journal_demo.xml
@@ -12,7 +12,7 @@
 
     <record id="devolucao_vendas_journal_main_company" model="account.journal">
         <field name="name">Diário de Devolução de Vendas</field>
-        <field name="code">DSR</field>
+        <field name="code">DDV</field>
         <field name="type">sale</field>
         <field name="company_id" ref="base.main_company" />
     </record>


### PR DESCRIPTION
backport do lint da migraçao do modulo l10n_br_stock_account [para a v15](https://github.com/OCA/l10n-brazil/pull/3245)

- o codigo do diario de demo DSR tava usado em dobro o que passou a dar problema a partir da v15
- o metodo onchange_group joguei ele para baixo depois da declaraçao dos campos e retornei um valor, algo que eh uma boa pratica e que eh obrigatorio a partir da v15