### PR TITLE
[14.0][IMP] l10n_br_account_payment_brcobranca: Código de instrução de protesto não pode ter apenas 1 char

### DIFF
--- a/l10n_br_account_payment_brcobranca/models/account_payment_line.py
+++ b/l10n_br_account_payment_brcobranca/models/account_payment_line.py
@@ -61,9 +61,10 @@ class AccountPaymentLine(models.Model):
             self.mov_instruction_code_id.code
             == payment_mode_id.cnab_sending_code_id.code
         ):
-            linhas_pagamentos["cod_primeira_instrucao"] = (
-                payment_mode_id.boleto_protest_code or "00"
-            )
+            instruction = "00"
+            if payment_mode_id.boleto_protest_code:
+                instruction = payment_mode_id.boleto_protest_code.zfill(2)
+            linhas_pagamentos["cod_primeira_instrucao"] = instruction
 
     def _prepare_bank_line_itau(self, payment_mode_id, linhas_pagamentos):
         if payment_mode_id.payment_method_code == "400":


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/009bfe4a-ba5b-4cee-8be2-718700c51f14)

Caso a instrução de protesto (no cadastro do diário do banco) tenha apenas um dígito, as linhas de detalhe do arquivo ficam com um caracter a menos.

Com a correção:
![image](https://github.com/user-attachments/assets/1f4073b8-451b-4bab-8c51-d2e7b1e3980f)
