### PR TITLE
[14.0][IMP] l10n_br_base: filtrar parceiro pelo cnpj, sem formatação.

### DIFF
--- a/l10n_br_base/models/party_mixin.py
+++ b/l10n_br_base/models/party_mixin.py
@@ -12,6 +12,14 @@ class PartyMixin(models.AbstractModel):
     _name = "l10n_br_base.party.mixin"
     _description = "Brazilian partner and company data mixin"
 
+    cnpj_cpf_stripped = fields.Char(
+        string="CNPJ/CPF Stripped",
+        help="CNPJ/CPF without special characters",
+        compute="_compute_cnpj_cpf_stripped",
+        store=True,
+        index=True,
+    )
+
     cnpj_cpf = fields.Char(
         string="CNPJ/CPF",
         size=18,
@@ -60,6 +68,16 @@ class PartyMixin(models.AbstractModel):
     district = fields.Char(
         size=32,
     )
+
+    @api.depends("cnpj_cpf")
+    def _compute_cnpj_cpf_stripped(self):
+        for record in self:
+            if record.cnpj_cpf:
+                record.cnpj_cpf_stripped = "".join(
+                    char for char in record.cnpj_cpf if char.isalnum()
+                )
+            else:
+                record.cnpj_cpf_stripped = False
 
     @api.onchange("cnpj_cpf")
     def _onchange_cnpj_cpf(self):

--- a/l10n_br_base/views/res_partner_view.xml
+++ b/l10n_br_base/views/res_partner_view.xml
@@ -11,7 +11,10 @@
         <field name="arch" type="xml">
             <field name="name" position="after">
                 <field name="legal_name" />
-                <field name="cnpj_cpf" />
+                <field
+                    name="cnpj_cpf"
+                    filter_domain="['|', ('cnpj_cpf', 'ilike', self), ('cnpj_cpf_stripped', 'ilike', self)]"
+                />
             </field>
         </field>
     </record>


### PR DESCRIPTION
Proposta para melhorar a procura do parceiro pelo CNPJ, mesmo que o usuário informe sem formatação.

Em rascunho pois ainda estou avaliando se essa é a melhor ofrma.