### PR TITLE
[14.0][REF] l10n_br_purchase_stock: Adaptando o modulo para deixar compatível com os casos Internacionais ou Sem Operação Fiscal

### DIFF
--- a/l10n_br_purchase_stock/models/purchase_order.py
+++ b/l10n_br_purchase_stock/models/purchase_order.py
@@ -42,7 +42,8 @@ class PurchaseOrder(models.Model):
     @api.model
     def _prepare_picking(self):
         values = super()._prepare_picking()
-        values.update(self._prepare_br_fiscal_dict())
+        if self.fiscal_operation_id:
+            values.update(self._prepare_br_fiscal_dict())
         if self.company_id.purchase_create_invoice_policy == "stock_picking":
             values["invoice_state"] = "2binvoiced"
 

--- a/l10n_br_purchase_stock/models/purchase_order_line.py
+++ b/l10n_br_purchase_stock/models/purchase_order_line.py
@@ -15,8 +15,9 @@ class PurchaseOrderLine(models.Model):
         """
         values = super()._prepare_stock_moves(picking)
         for v in values:
-            v.update(self._prepare_br_fiscal_dict())
-            if self.env.company.purchase_create_invoice_policy == "stock_picking":
+            if self.order_id.fiscal_operation_id:
+                v.update(self._prepare_br_fiscal_dict())
+            if self.order_id.purchase_create_invoice_policy == "stock_picking":
                 v["invoice_state"] = "2binvoiced"
         return values
 


### PR DESCRIPTION
Just call method to Prepare BR Fiscal Dict when the Purchase Order has a Fiscal Operation.

Adaptando o modulo para deixar compatível com os casos Internacionais ou Sem Operação Fiscal, PR simples uma extração do PR https://github.com/OCA/l10n-brazil/pull/3145

cc @rvalyi @renatonlima @marcelsavegnago @mileo 