### PR TITLE
[14.0][REF] l10n_br_purchase_stock: Informando o campo ind_final nos Dados de Demonstração para evitar erros

### DIFF
--- a/l10n_br_purchase_stock/demo/purchase_order.xml
+++ b/l10n_br_purchase_stock/demo/purchase_order.xml
@@ -40,6 +40,7 @@
         <field
             name="manual_fiscal_additional_data"
         >TESTE - FISCAL ADDITIONAL DATA</field>
+        <field name="ind_final">0</field>
     </record>
 
     <function model="purchase.order" name="_onchange_fiscal_operation_id">
@@ -112,6 +113,7 @@
         <field
             name="manual_fiscal_additional_data"
         >TESTE - FISCAL ADDITIONAL DATA</field>
+        <field name="ind_final">0</field>
     </record>
 
     <function model="purchase.order" name="_onchange_fiscal_operation_id">
@@ -185,6 +187,7 @@
         <field
             name="manual_fiscal_additional_data"
         >TESTE - FISCAL ADDITIONAL DATA</field>
+        <field name="ind_final">0</field>
     </record>
 
     <function model="purchase.order" name="_onchange_fiscal_operation_id">
@@ -210,6 +213,7 @@
         <field name="insurance_value">10</field>
         <field name="other_value">10</field>
         <field name="freight_value">10</field>
+        <field name="ind_final">0</field>
     </record>
 
     <function model="purchase.order.line" name="_onchange_product_id_fiscal">
@@ -256,6 +260,7 @@
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
         <field name="user_id" ref="base.user_admin" />
         <field name="company_id" ref="base.main_company" />
+        <field name="ind_final">0</field>
     </record>
 
     <function model="purchase.order" name="_onchange_fiscal_operation_id">
@@ -292,6 +297,7 @@
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
         <field name="user_id" ref="base.user_admin" />
         <field name="company_id" ref="base.main_company" />
+        <field name="ind_final">0</field>
     </record>
 
     <function model="purchase.order" name="_onchange_fiscal_operation_id">


### PR DESCRIPTION
Demo Data, Purchase Orders inform ind_final to avoid mistakes.

Informando o campo ind_final nos Dados de demonstração para evitar erros, PR simples extração do PR https://github.com/OCA/l10n-brazil/pull/3145 buscando tornar a revisão do PR menor.

cc @rvalyi @renatonlima @marcelsavegnago @mileo 