### PR TITLE
[14.0][REF] l10n_br_purchase_stock: Desnecessário chamar métodos onchange que já são chamados pelo _onchange_product_id_fiscal

### DIFF
--- a/l10n_br_purchase_stock/models/stock_rule.py
+++ b/l10n_br_purchase_stock/models/stock_rule.py
@@ -20,6 +20,5 @@ class StockRule(models.Model):
                         price_unit = line.price_unit
                         line._onchange_product_id_fiscal()
                         line.price_unit = price_unit
-                        line._onchange_fiscal_operation_id()
-                        line._onchange_fiscal_operation_line_id()
+
         return result


### PR DESCRIPTION
Unnecessary call methods because _onchange_product_id_fiscal already call it.

Desnecessário chamar métodos onchange que já são chamados pelo _onchange_product_id_fiscal, PR simples extração do PR https://github.com/OCA/l10n-brazil/pull/3145 buscando tornar a revisão do PR menor, outra  referencia com mais detalhes sobre o  PR https://github.com/OCA/l10n-brazil/pull/2887

cc @rvalyi @renatonlima @marcelsavegnago @mileo 