### PR TITLE
[14.0][REF] l10n_br_account_payment_brcobranca: Resolvendo erros PEP8 validados em versões recentes

### DIFF
--- a/l10n_br_account_payment_brcobranca/constants/br_cobranca.py
+++ b/l10n_br_account_payment_brcobranca/constants/br_cobranca.py
@@ -11,6 +11,8 @@ from odoo import _
 from odoo.exceptions import UserError
 from odoo.tools import config
 
+TIMEOUT = 300  # seconds
+
 DICT_BRCOBRANCA_CNAB_TYPE = {
     "240": "cnab240",
     "400": "cnab400",

--- a/l10n_br_account_payment_brcobranca/models/account_move.py
+++ b/l10n_br_account_payment_brcobranca/models/account_move.py
@@ -12,7 +12,7 @@ import requests
 from odoo import _, models
 from odoo.exceptions import UserError
 
-from ..constants.br_cobranca import get_brcobranca_api_url
+from ..constants.br_cobranca import TIMEOUT, get_brcobranca_api_url
 
 logger = logging.getLogger(__name__)
 
@@ -71,7 +71,12 @@ class AccountMove(models.Model):
             brcobranca_service_url,
             self.name,
         )
-        res = requests.post(brcobranca_service_url, data={"type": "pdf"}, files=files)
+        res = requests.post(
+            brcobranca_service_url,
+            data={"type": "pdf"},
+            files=files,
+            timeout=TIMEOUT,
+        )
 
         if str(res.status_code)[0] == "2":
             pdf_string = res.content

--- a/l10n_br_account_payment_brcobranca/models/account_payment_line.py
+++ b/l10n_br_account_payment_brcobranca/models/account_payment_line.py
@@ -122,18 +122,16 @@ class AccountPaymentLine(models.Model):
     def prepare_bank_payment_line(self, bank_name_brcobranca):
         payment_mode_id = self.order_id.payment_mode_id
         linhas_pagamentos = self._prepare_boleto_line_vals()
-        try:
+
+        # Casos onde o Banco além dos principais campos possui campos
+        # específicos, dos casos por enquanto mapeados, se estiver vendo
+        # um caso que está faltando por favor considere fazer um
+        # PR para ajudar
+        if hasattr(self, f"_prepare_bank_line_{bank_name_brcobranca.name}"):
             bank_method = getattr(
                 self, f"_prepare_bank_line_{bank_name_brcobranca.name}"
             )
-            if bank_method:
-                bank_method(payment_mode_id, linhas_pagamentos)
-        except Exception:
-            _logger.warning(
-                f"Error executing method _prepare_bank_line_{bank_name_brcobranca.name}."
-                "Check the bank name and provided parameters.",
-                exc_info=True,
-            )
+            bank_method(payment_mode_id, linhas_pagamentos)
 
         # Cada Banco pode possuir seus Codigos de Instrução
         if (

--- a/l10n_br_account_payment_brcobranca/models/account_payment_order.py
+++ b/l10n_br_account_payment_brcobranca/models/account_payment_order.py
@@ -146,16 +146,13 @@ class PaymentOrder(models.Model):
             "sequencial_remessa": self.file_number,
         }
 
-        try:
+        # Casos onde o Banco além dos principais campos possui campos
+        # específicos, dos casos por enquanto mapeados, se estiver vendo
+        # um caso que está faltando por favor considere fazer um
+        # PR para ajudar
+        if hasattr(self, f"_prepare_remessa_{bank_brcobranca.name}"):
             bank_method = getattr(self, f"_prepare_remessa_{bank_brcobranca.name}")
-            if bank_method:
-                bank_method(remessa_values, cnab_type)
-        except Exception:
-            _logger.warning(
-                f"Error executing method _prepare_remessa_{bank_brcobranca.name}."
-                "Check the bank name and provided parameters.",
-                exc_info=True,
-            )
+            bank_method(remessa_values, cnab_type)
 
         remessa = self._get_brcobranca_remessa(
             bank_brcobranca, remessa_values, cnab_type

--- a/l10n_br_account_payment_brcobranca/models/account_payment_order.py
+++ b/l10n_br_account_payment_brcobranca/models/account_payment_order.py
@@ -16,6 +16,7 @@ from odoo.exceptions import Warning as ValidationError
 
 from ..constants.br_cobranca import (
     DICT_BRCOBRANCA_CNAB_TYPE,
+    TIMEOUT,
     get_brcobranca_api_url,
     get_brcobranca_bank,
 )
@@ -182,6 +183,7 @@ class PaymentOrder(models.Model):
                 "bank": bank_brcobranca.name,
             },
             files=files,
+            timeout=TIMEOUT,
         )
 
         if cnab_type == "240" and "R01" in res.text[242:254]:

--- a/l10n_br_account_payment_brcobranca/parser/cnab_file_parser.py
+++ b/l10n_br_account_payment_brcobranca/parser/cnab_file_parser.py
@@ -13,7 +13,7 @@ from odoo.exceptions import UserError
 
 from odoo.addons.account_move_base_import.parser.file_parser import FileParser
 
-from ..constants.br_cobranca import get_brcobranca_api_url
+from ..constants.br_cobranca import TIMEOUT, get_brcobranca_api_url
 
 logger = logging.getLogger(__name__)
 
@@ -91,6 +91,7 @@ class CNABFileParser(FileParser):
                 "bank": bank_name_brcobranca,
             },
             files=files,
+            timeout=TIMEOUT,
         )
 
         if res.status_code != 201:


### PR DESCRIPTION
Refactoring to solve PEP8 errors in the v16 pre-commit.

Resolvendo erros PEP8 validados em versões recentes do pre-commit  v15 v16:

* **[W8138(except-pass), PaymentOrder.generate_payment_file] pass into block except. If you really need to use the pass consider logging that exception**

Para resolver esse erro foi incluído o logger.Warning no PR https://github.com/OCA/l10n-brazil/pull/3225

```bash
WARNING odoo odoo.addons.l10n_br_account_payment_brcobranca.models.account_payment_line: Error executing method _prepare_bank_line_caixa.Check the bank name and provided parameters. 
Traceback (most recent call last):
  File "/odoo/external-src/l10n-brazil/l10n_br_account_payment_brcobranca/models/account_payment_line.py", line 127, in prepare_bank_payment_line
    self, f"_prepare_bank_line_{bank_name_brcobranca.name}"


WARNING odoo odoo.addons.l10n_br_account_payment_brcobranca.models.account_payment_line: Error executing method _prepare_bank_line_ailos.Check the bank name and provided parameters. 
Traceback (most recent call last):
  File "/odoo/external-src/l10n-brazil/l10n_br_account_payment_brcobranca/models/account_payment_line.py", line 127, in prepare_bank_payment_line
    self, f"_prepare_bank_line_{bank_name_brcobranca.name}"
AttributeError: 'account.payment.line' object has no attribute '_prepare_bank_line_ailos'
```
Mas é desnecessário, acredito que esse TRY foi incluído para evitar a necessidade de vários IF, lendo sobre o porque isso retorna erro pelo o que entendi é que sempre que acontecer "algo inesperado" o código precisar tratar esses casos e não apenas ignorar, uma referencia  https://stackoverflow.com/questions/21553327/why-is-except-pass-a-bad-programming-practice , mas aqui não precisamos do TRY porque já sabemos os casos em que existe um método especifico então um simples IF resolve, com isso LOG também volta a ficar limpo.

* **[E8106(external-request-timeout), CNABFileParser._get_brcobranca_retorno] Use of external request method `requests.post` without timeout. It could wait for a long time**

Aqui tem apenas uma questão que é saber se o valor 5 está razoável? Ou outro valor? Ou se isso deveria ser um parâmetro para permitir alterações?

cc @rvalyi @renatonlima @marcelsavegnago @mileo @antoniospneto @kaynnan 

