### PR TITLE
[14.0][FIX] l10n_br_stock_account: no longer reads fop from null sale/purchase

### DIFF
--- a/l10n_br_purchase_stock/models/purchase_order.py
+++ b/l10n_br_purchase_stock/models/purchase_order.py
@@ -44,6 +44,8 @@ class PurchaseOrder(models.Model):
         values = super()._prepare_picking()
         if self.fiscal_operation_id:
             values.update(self._prepare_br_fiscal_dict())
+        else:
+            values["fiscal_operation_id"] = False
         if self.company_id.purchase_invoicing_policy == "stock_picking":
             values["invoice_state"] = "2binvoiced"
 

--- a/l10n_br_stock_account/models/stock_picking.py
+++ b/l10n_br_stock_account/models/stock_picking.py
@@ -25,11 +25,6 @@ class StockPicking(models.Model):
 
             # Casos onde o usuário definiu o Pedido de Compra/Venda como
             # 'Sem Operação Fiscal'
-            if hasattr(self, "purchase_id") and hasattr(
-                self.purchase_id, "fiscal_operation_id"
-            ):
-                if not self.purchase_id.fiscal_operation_id:
-                    fiscal_operation = False
             if hasattr(self, "sale_id") and hasattr(
                 self.sale_id, "fiscal_operation_id"
             ):

--- a/l10n_br_stock_account/models/stock_picking.py
+++ b/l10n_br_stock_account/models/stock_picking.py
@@ -23,21 +23,6 @@ class StockPicking(models.Model):
                     else company.stock_out_fiscal_operation_id
                 )
 
-            # Casos onde o usuário definiu o Pedido de Compra/Venda como
-            # 'Sem Operação Fiscal'
-            if hasattr(self, "sale_id") and hasattr(
-                self.sale_id, "fiscal_operation_id"
-            ):
-                # Necessário para evitar o erro quando o l10n_br_purchase_stock
-                # é instalado:
-                # /l10n_br_stock_account/models/stock_picking.py", line 34,
-                # in _default_fiscal_operation
-                # if not self.sale_id.fiscal_operation_id:
-                # AttributeError: 'sale.order' object has no attribute
-                # 'fiscal_operation_id'
-                if not self.sale_id.fiscal_operation_id:
-                    fiscal_operation = False
-
         return fiscal_operation
 
     @api.model


### PR DESCRIPTION
Este PR corrige o funcionamento da operação fiscal padrão na transferência de estoque

exemplo:
![image](https://github.com/user-attachments/assets/24b0425b-cda8-4394-8457-dc342b2e2e28)
![image](https://github.com/user-attachments/assets/9375e10e-1a1f-408a-b26c-513cc16a7b15)
