### PR TITLE
[16.0][REF][l10n_br_account_payment_order] no tracking in tests

### DIFF
--- a/l10n_br_account_payment_order/tests/test_base_class.py
+++ b/l10n_br_account_payment_order/tests/test_base_class.py
@@ -12,7 +12,7 @@ class TestL10nBrAccountPaymentOder(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
         cls.move_line_change_id = cls.env["account.move.line.cnab.change"]
 
         cls.chance_view_id = (

--- a/l10n_br_account_payment_order/tests/test_cnab_codes.py
+++ b/l10n_br_account_payment_order/tests/test_cnab_codes.py
@@ -11,6 +11,7 @@ class TestPaymentOrder(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
         cls.instruction_unicred_01 = cls.env.ref(
             "l10n_br_account_payment_order.unicred_240_400_instruction_01"
         )

--- a/l10n_br_account_payment_order/tests/test_invoice_normal_workflow.py
+++ b/l10n_br_account_payment_order/tests/test_invoice_normal_workflow.py
@@ -11,6 +11,7 @@ class TestPaymentOrder(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
         # Get Invoice for test
         cls.invoice_customer_without_paymeny_mode = cls.env.ref(
             "l10n_br_account_payment_order." "demo_invoice_no_payment_mode"

--- a/l10n_br_account_payment_order/tests/test_payment_order.py
+++ b/l10n_br_account_payment_order/tests/test_payment_order.py
@@ -10,6 +10,7 @@ class TestPaymentOrder(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
 
         cls.invoice_cheque = cls.env.ref(
             "l10n_br_account_payment_order.demo_invoice_payment_order_cheque"

--- a/l10n_br_account_payment_order/tests/test_payment_order_inbound.py
+++ b/l10n_br_account_payment_order/tests/test_payment_order_inbound.py
@@ -15,6 +15,7 @@ class TestPaymentOrderInbound(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
 
         cls.register_payments_model = cls.env["account.payment.register"].with_context(
             active_model="account.move"


### PR DESCRIPTION
faster tests

antes:
l10n_br_account_payment_order: 49 tests 9.91s 8922 queries 

depois:
l10n_br_account_payment_order: 49 tests 8.58s 8612 queries 

obs: quando vai ser testado o modulo l10n_br_account depois do merge https://github.com/OCA/l10n-brazil/pull/2865 vai ter mais modulos instalados e parece que o ganho sera um pouco maior. O outro modulo que ta demorando um pouco nos testes na 16.0 eh o l10n_br_cnab_structure mas a Engenere ja fez a otimizaçao qdo migrou. Tb fiz no PR da migracao do l10n_br_account: https://github.com/OCA/l10n-brazil/pull/2865
Os testes nos outros modulos da 16.0 sao bastante rapidos, nao faria diferença.