### PR TITLE
[14.0][FIX] l10n_br_nfe: local_entrega only if not equal to partner_id

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -455,6 +455,9 @@ class NFe(spec_models.StackedModel):
                 and rec.partner_shipping_id.is_anonymous_consumer
             ):
                 rec.nfe40_entrega = None
+            elif rec.partner_id == rec.partner_shipping_id:
+                # local de entrega: informar apenas se diferente do destinatário
+                rec.nfe40_entrega = None
             else:
                 rec.nfe40_entrega = rec.partner_shipping_id
 


### PR DESCRIPTION
## Objetivo

- Corrige tag _entrega_ da NFe para não ser adicionada no documento caso shipping_address == partner_id  (veja imagem 3)
- Indiretamente corrige erro de endereço inválido para casos no exterior (veja detalhamento)


## Detalhamento do bug 2:

1. Crie uma fatura com operação de Venda na empresa lucro presumido
2. Adicione um parceiro com endereço no exterior
3. Confirme a nota e acesse os detalhes fiscais
4. Confirme que Partner e Shipping Address estão definidos com o mesmo endereço no exterior
5. Se confirmar a nota deverá obter um erro como
    `Element '{http://www.portalfiscal.inf.br/nfe}xLgr': This element is not expected. Expected is one of ( {http://www.portalfiscal.inf.br/nfe}CNPJ, {http://www.portalfiscal.inf.br/nfe}CPF ).`

O problema ocorre pois a tag _entrega_ requer um **CNPJ** ou **CPF**. Esse comportamento é diferente da tag _dest_, por exemplo, que permite a utilização do elemento **idEstrangeiro** como substituição ao **CNPJ/CPF**

Esse PR ajuda no sentido que caso o **shipping address** seja preenchido automaticamente com o mesmo valor do **partner**, então a tag _entrega_ não será preenchida no documento fiscal.

## Imagens


1. Print do erro:
![image](https://github.com/user-attachments/assets/ede3a8ad-3238-44f2-b98c-b17b2c712621)


2. Partner e Shipping Address usados para simular o erro:
![image](https://github.com/user-attachments/assets/fd0a93b8-65ac-48f6-951c-86ce2f5dd9fa)


3. Descrição do campo entrega:
![image](https://github.com/user-attachments/assets/c4172ef8-4232-4078-b3d0-58958315a220)

