### PR TITLE
[14.0][IMP] l10n_br_purchase_stock: Tornando a Fatura criada pela Ordem de Seleção/stock.picking semelhante a do Pedido de Compra/purchase.order, evitando "glue modules"

### DIFF
--- a/l10n_br_purchase_stock/__manifest__.py
+++ b/l10n_br_purchase_stock/__manifest__.py
@@ -6,6 +6,7 @@
     "license": "AGPL-3",
     "category": "Localisation",
     "author": "Akretion, Odoo Community Association (OCA)",
+    "maintainers": ["renatonlima", "mbcosta"],
     "website": "https://github.com/OCA/l10n-brazil",
     "version": "14.0.2.0.1",
     "depends": [

--- a/l10n_br_purchase_stock/demo/purchase_order.xml
+++ b/l10n_br_purchase_stock/demo/purchase_order.xml
@@ -97,6 +97,46 @@
         <value eval="[ref('main_pl_only_products_1_2')]" />
     </function>
 
+    <!-- Section -->
+    <record id="main_pl_only_products_1_3" model="purchase.order.line">
+        <field name="order_id" ref="main_po_only_products_1" />
+        <field name="name">TEST SECTION 1</field>
+        <field name="display_type">line_section</field>
+        <field name="product_qty">0</field>
+    </record>
+
+    <!-- Note -->
+    <record id="main_pl_only_products_1_4" model="purchase.order.line">
+        <field name="order_id" ref="main_po_only_products_1" />
+        <field name="name">TEST NOTE 1</field>
+        <field name="display_type">line_note</field>
+        <field name="product_qty">0</field>
+    </record>
+
+    <record id="main_pl_only_products_1_5" model="purchase.order.line">
+        <field name="order_id" ref="main_po_only_products_1" />
+        <field name="product_id" ref="product.product_product_8" />
+        <field name="product_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="price_unit">500</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_compras_compras"
+        />
+        <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
+        <field name="partner_order">999999</field>
+        <field name="partner_order_line">003</field>
+        <field name="manual_additional_data">Teste - Additional Data</field>
+        <field name="insurance_value">10</field>
+        <field name="other_value">10</field>
+        <field name="freight_value">10</field>
+    </record>
+
+    <function model="purchase.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_pl_only_products_1_5')]" />
+    </function>
+
     <!-- Purchase Order with only products test 2 - Teste Agrupamento -->
     <record id="main_po_only_products_2" model="purchase.order">
         <field name="name">Main l10n_br_purchase_stock - teste agrupamento</field>
@@ -168,6 +208,46 @@
 
     <function model="purchase.order.line" name="_onchange_product_id_fiscal">
         <value eval="[ref('main_pl_only_products_2_2')]" />
+    </function>
+
+    <!-- Section -->
+    <record id="main_pl_only_products_2_3" model="purchase.order.line">
+        <field name="order_id" ref="main_po_only_products_2" />
+        <field name="name">TEST SECTION 2</field>
+        <field name="display_type">line_section</field>
+        <field name="product_qty">0</field>
+    </record>
+
+    <!-- Note -->
+    <record id="main_pl_only_products_2_4" model="purchase.order.line">
+        <field name="order_id" ref="main_po_only_products_2" />
+        <field name="name">TEST NOTE 2</field>
+        <field name="display_type">line_note</field>
+        <field name="product_qty">0</field>
+    </record>
+
+    <record id="main_pl_only_products_2_5" model="purchase.order.line">
+        <field name="order_id" ref="main_po_only_products_2" />
+        <field name="product_id" ref="product.product_product_8" />
+        <field name="product_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="price_unit">500</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_compras_compras"
+        />
+        <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
+        <field name="partner_order">999999</field>
+        <field name="partner_order_line">003</field>
+        <field name="manual_additional_data">Teste - Additional Data</field>
+        <field name="insurance_value">10</field>
+        <field name="other_value">10</field>
+        <field name="freight_value">10</field>
+    </record>
+
+    <function model="purchase.order.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('main_pl_only_products_2_5')]" />
     </function>
 
     <!-- Lucro Presumido -->

--- a/l10n_br_purchase_stock/tests/test_l10n_br_purchase_stock.py
+++ b/l10n_br_purchase_stock/tests/test_l10n_br_purchase_stock.py
@@ -52,7 +52,7 @@ class L10nBrPurchaseStockBase(TestBrPickingInvoicingCommon):
         self.assertIn(picking_2, invoice.picking_ids)
 
         # Validar o price_unit usado
-        for inv_line in invoice.invoice_line_ids:
+        for inv_line in invoice.invoice_line_ids.filtered(lambda ln: ln.product_id):
             # TODO: A forma de instalação dos modulos feita no CI
             #  falha o browse aqui
             #  l10n_br_stock_account/models/stock_invoice_onshipping.py:105
@@ -71,6 +71,17 @@ class L10nBrPurchaseStockBase(TestBrPickingInvoicingCommon):
             self.assertTrue(
                 inv_line.fiscal_operation_line_id, "Missing Fiscal Operation Line."
             )
+
+        # Section Lines
+        section_lines = invoice.invoice_line_ids.filtered(
+            lambda ln: ln.display_type == "line_section"
+        )
+        self.assertEqual(len(section_lines), 2)
+        # Note Lines
+        note_lines = invoice.invoice_line_ids.filtered(
+            lambda ln: ln.display_type == "line_note"
+        )
+        self.assertEqual(len(note_lines), 2)
 
         if hasattr(invoice, "document_serie"):
             invoice.document_serie = "1"
@@ -150,7 +161,7 @@ class L10nBrPurchaseStockBase(TestBrPickingInvoicingCommon):
         invoice = self.create_invoice_wizard(picking)
 
         # Validar o price_unit usado
-        for inv_line in invoice.invoice_line_ids:
+        for inv_line in invoice.invoice_line_ids.filtered(lambda ln: ln.product_id):
             # TODO: A forma de instalação dos modulos feita no CI
             #  falha o browse aqui
             #  l10n_br_stock_account/models/stock_invoice_onshipping.py:105

--- a/l10n_br_purchase_stock/wizards/stock_invocing_onshipping.py
+++ b/l10n_br_purchase_stock/wizards/stock_invocing_onshipping.py
@@ -2,7 +2,7 @@
 #   Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import fields, models
+from odoo import models
 
 from odoo.addons.l10n_br_fiscal.constants.fiscal import DOCUMENT_ISSUER_PARTNER
 
@@ -18,16 +18,76 @@ class StockInvoiceOnshipping(models.TransientModel):
         """
         invoice, values = super()._build_invoice_values_from_pickings(pickings)
 
-        pick = fields.first(pickings)
-        if pick.purchase_id:
-            values["purchase_id"] = pick.purchase_id.id
-            values["issuer"] = DOCUMENT_ISSUER_PARTNER
+        purchase_pickings = pickings.filtered(lambda pk: pk.purchase_id)
+        if purchase_pickings and self._get_invoice_type() != "in_refund":
+            # Case more than one Purchase Order the fields below will be join
+            # the others will be overwritting, as done in purchase module,
+            # one more field include here Note
+            payment_refs = set()
+            refs = set()
+            # Include Note/Narration
+            narration = set()
+            for picking in purchase_pickings:
+                # Campos informados em qualquer caso
+                purchase = picking.purchase_id
 
-            if pick.purchase_id.payment_term_id.id != values.get(
-                "invoice_payment_term_id"
-            ):
+                # Campo purchase_id store=false
+                # values["purchase_id"] = purchase.id
+                if picking.fiscal_operation_id:
+                    values["issuer"] = DOCUMENT_ISSUER_PARTNER
+
+                # Refund case don't get values from Purchase Dict
+                # TODO: Should get any value?
+                purchase_values = purchase._prepare_invoice()
+
+                # Fields to Join
+                # origins.add(purchase_values["invoice_origin"])
+                payment_refs.add(purchase_values["payment_reference"])
+                refs.add(purchase_values["ref"])
+                narration.add(purchase_values["narration"])
+
+                # Original dict from purchase module.
+
+                # Fields to get from original dict:
+                # - "ref": self.partner_ref or "",
+                # - "narration": self.notes,
+                # - "currency_id": self.currency_id.id,
+                # - "invoice_user_id": self.user_id and self.user_id.id
+                #    or self.env.user.id,
+                # - "payment_reference": self.partner_ref or "",
+                # - "partner_bank_id": partner_bank_id.id,
+                # - "invoice_payment_term_id": self.payment_term_id.id,
+
+                # Fields to remove from Original Dict
+                vals_to_remove = {
+                    "move_type",
+                    "partner_id",
+                    "fiscal_position_id",
+                    "invoice_origin",
+                    "invoice_line_ids",
+                    "company_id",
+                    # Another fields
+                    "__last_update",
+                    "display_name",
+                }
+
+                purchase_values_rm = {
+                    k: purchase_values[k] for k in set(purchase_values) - vals_to_remove
+                }
+                values.update(purchase_values_rm)
+
+            # Fields to join
+            if len(purchase_pickings) > 1:
                 values.update(
-                    {"invoice_payment_term_id": pick.purchase_id.payment_term_id.id}
+                    {
+                        "ref": ", ".join(refs)[:2000],
+                        # In this case Origin get Pickings Names
+                        # "invoice_origin": ", ".join(origins),
+                        "payment_reference": len(payment_refs) == 1
+                        and payment_refs.pop()
+                        or False,
+                        "narration": ", ".join(narration),
+                    }
                 )
 
         return invoice, values
@@ -40,8 +100,7 @@ class StockInvoiceOnshipping(models.TransientModel):
         """
         key = super()._get_move_key(move)
         if move.purchase_line_id:
-            # TODO: deveria permitir agrupar as linhas ?
-            #  Deveria permitir agrupar Pedidos de Compras ?
+            # Field purchase_line_id in account.move is Many2one
             key = key + (move.purchase_line_id,)
 
         return key
@@ -57,16 +116,45 @@ class StockInvoiceOnshipping(models.TransientModel):
         values = super()._get_invoice_line_values(moves, invoice_values, invoice)
         # Devido ao KEY com purchase_line_id aqui
         # vem somente um registro
-        if len(moves) == 1:
-            # Caso venha apenas uma linha porem sem
-            # purchase_line_id é preciso ignora-la
-            if moves.purchase_line_id:
-                values["purchase_line_id"] = moves.purchase_line_id.id
-                values[
-                    "analytic_account_id"
-                ] = moves.purchase_line_id.account_analytic_id.id
-                values["analytic_tag_ids"] = [
-                    (6, 0, moves.purchase_line_id.analytic_tag_ids.ids)
-                ]
+        purchase_moves = moves.filtered(lambda ln: ln.purchase_line_id)
+        if purchase_moves:
+            purchase_line = purchase_moves.purchase_line_id
+            # Campos informados em qualquer caso
+            values["purchase_line_id"] = purchase_line.id
+            values["analytic_account_id"] = purchase_line.account_analytic_id.id
+            values["analytic_tag_ids"] = [(6, 0, purchase_line.analytic_tag_ids.ids)]
+
+            # Refund case don't get values from Purchase Line Dict
+            # TODO: Should get any value?
+            if self._get_invoice_type() != "in_refund":
+                # Same make above, get fields informed in
+                # original of Purchase Line dict:
+                purchase_line_values = purchase_line._prepare_account_move_line()
+
+                # Fields to get:
+                # "display_type": self.display_type,
+                # "sequence": self.sequence,
+
+                # Fields to remove:
+                vals_to_remove = {
+                    "name",
+                    "product_id",
+                    "product_uom_id",
+                    "quantity",
+                    "price_unit",
+                    "tax_ids",
+                    "analytic_account_id",
+                    "analytic_tag_ids",
+                    "purchase_line_id",
+                    # another fields
+                    "__last_update",
+                    "display_name",
+                }
+
+                purchase_line_values_rm = {
+                    k: purchase_line_values[k]
+                    for k in set(purchase_line_values) - vals_to_remove
+                }
+                values.update(purchase_line_values_rm)
 
         return values


### PR DESCRIPTION
Improve create invoice from purchase stock.

Ao criar uma Fatura/account.move a partir de uma Ordem de Seleção/stock.picking que tenha um Pedido de Compra/purchase.order relacionado o modulo agora chama os métodos que criam os Dicionários de Dados a serem usados para criar a Fatura a partir do Pedido de Compra, tanto do purchase.order quanto o purchase.order.line,  assim a Fatura criada a partir do stock.picking deve ser o mais semelhante possível com a criada a partir do purchase.order, alguns campos não são copiados por serem informados na Ordem de Seleção, mais detalhes no código.

Com isso qualquer módulo que implementa algum novo campo na Fatura criada a partir do Pedido de Compra também deverá ser carregado quando for criado a partir da Ordem de Seleção, com isso evitando a necessidade de "glue modules" (pequenos módulos criados apenas para evitar dependências indiretas).

As Linhas de Seção e Notas que existem no Pedido de Compras também passaram a ser criadas na Fatura a partir da Ordem de Seleção, mantendo a mesma Sequencia das Linhas mesmo quando é criada uma Fatura Agrupada

![image](https://github.com/user-attachments/assets/e2d7b11d-386f-471a-9dce-04f583633161)

![image](https://github.com/user-attachments/assets/f6b15f6e-3db6-4f54-88b5-b38eb00f20b3)

![image](https://github.com/user-attachments/assets/5b88cb5f-ea52-4031-a2d6-f65e8cc20d78)

![image](https://github.com/user-attachments/assets/d5ce5318-7f4a-454a-ab37-9b4d284ca274)

![image](https://github.com/user-attachments/assets/b1c9a4aa-0cb3-48d6-b719-d394579842a8)

Foram incluídas Linhas de de Seção e Notas nos Dados de Demonstração e teste para verificar se a Fatura foi criada com essas linhas.

Essas alterações também estão sendo feitas no modulo **l10n_br_sale_stock** no PR de extração https://github.com/OCA/l10n-brazil/pull/2955 para o **sale_stock_picking_invoicing** https://github.com/OCA/account-invoicing/pull/1025 onde a alteração nesse caso está sendo feita.

Se necessário posso ver de separar o PR para facilitar a revisão.

cc @rvalyi @renatonlima @marcelsavegnago @mileo 