### PR TITLE
[16.0][REF] l10n_br_cnpj_search: move res partner fields to mixin

### DIFF
--- a/l10n_br_cnpj_search/models/l10n_br_base_party_mixin.py
+++ b/l10n_br_cnpj_search/models/l10n_br_base_party_mixin.py
@@ -3,12 +3,29 @@
 # Copyright (C) 2024-Today - Engenere (<https://engenere.one>).
 # @author Cristiano Mafra Junior
 
-from odoo import _, api, models
+from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 
 class PartyMixin(models.AbstractModel):
     _inherit = "l10n_br_base.party.mixin"
+
+    equity_capital = fields.Monetary(currency_field="company_currency_id")
+
+    cnae_main_id = fields.Many2one(comodel_name="l10n_br_fiscal.cnae")
+
+    legal_nature = fields.Char()
+
+    company_id = fields.Many2one(
+        "res.company", required=True, default=lambda self: self.env.company
+    )
+
+    company_currency_id = fields.Many2one(
+        comodel_name="res.currency",
+        related="company_id.currency_id",
+        string="Company Currency",
+        readonly=True,
+    )
 
     def action_open_cnpj_search_wizard(self):
         if not self.cnpj_cpf:

--- a/l10n_br_cnpj_search/models/l10n_br_base_party_mixin.py
+++ b/l10n_br_cnpj_search/models/l10n_br_base_party_mixin.py
@@ -10,19 +10,15 @@ from odoo.exceptions import UserError
 class PartyMixin(models.AbstractModel):
     _inherit = "l10n_br_base.party.mixin"
 
-    equity_capital = fields.Monetary(currency_field="company_currency_id")
+    equity_capital = fields.Monetary(currency_field="br_currency_id")
 
     cnae_main_id = fields.Many2one(comodel_name="l10n_br_fiscal.cnae")
 
     legal_nature = fields.Char()
 
-    company_id = fields.Many2one(
-        "res.company", required=True, default=lambda self: self.env.company
-    )
-
-    company_currency_id = fields.Many2one(
+    br_currency_id = fields.Many2one(
         comodel_name="res.currency",
-        related="company_id.currency_id",
+        default=lambda self: self.env.ref("base.BRL"),
         string="Company Currency",
         readonly=True,
     )

--- a/l10n_br_cnpj_search/models/res_partner.py
+++ b/l10n_br_cnpj_search/models/res_partner.py
@@ -7,8 +7,6 @@ from odoo import fields, models
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
-    equity_capital = fields.Monetary(currency_field="company_currency_id")
-
     cnae_secondary_ids = fields.Many2many(
         comodel_name="l10n_br_fiscal.cnae",
         relation="res_partner_fiscal_cnae_rel",
@@ -16,13 +14,4 @@ class ResPartner(models.Model):
         column2="cnae_id",
         domain="[('internal_type', '=', 'normal'), ('id', '!=', cnae_main_id)]",
         string="Secondary CNAE",
-    )
-
-    legal_nature = fields.Char()
-
-    company_currency_id = fields.Many2one(
-        comodel_name="res.currency",
-        related="company_id.currency_id",
-        string="Company Currency",
-        readonly=True,
     )


### PR DESCRIPTION
Mudança dos campos do res partner para o party mixin requisitado pelo @mileo no [PR 3289](https://github.com/OCA/l10n-brazil/pull/3289)