### PR TITLE
[16.0][IMP] l10n_br_account: rename proxy fields (port from 3307 and 2815)

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -131,7 +131,7 @@ class AccountMove(models.Model):
             if move.document_type_id and not move.fiscal_document_id:
                 fiscal_doc_vals = {}
                 for field in self._shadowed_fields():
-                    fiscal_doc_vals[f"fiscal_{field}"] = getattr(move, field)
+                    fiscal_doc_vals[f"fiscal_proxy_{field}"] = getattr(move, field)
                 move.fiscal_document_id = (
                     self.env["l10n_br_fiscal.document"].create(fiscal_doc_vals).id
                 )

--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -199,7 +199,7 @@ class AccountMove(models.Model):
         for vals in vals_list:
             for field in self._shadowed_fields():
                 if field in vals:
-                    vals["fiscal_%s" % (field,)] = vals[field]
+                    vals["fiscal_proxy_%s" % (field,)] = vals[field]
 
     def ensure_one_doc(self):
         self.ensure_one()

--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -169,7 +169,7 @@ class AccountMoveLine(models.Model):
         for vals in vals_list:
             for field in self._shadowed_fields():
                 if field in vals:
-                    vals["fiscal_%s" % (field,)] = vals[field]
+                    vals["fiscal_proxy_%s" % (field,)] = vals[field]
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/l10n_br_account/models/fiscal_document.py
+++ b/l10n_br_account/models/fiscal_document.py
@@ -26,22 +26,22 @@ class FiscalDocument(models.Model):
     # proxy fields to enable writing the related (shadowed) fields
     # to the fiscal document from the account.move through the _inherits system
     # despite they have the same names.
-    fiscal_partner_id = fields.Many2one(
+    fiscal_proxy_partner_id = fields.Many2one(
         string="Fiscal Partner",
         related="partner_id",
         readonly=False,
     )
-    fiscal_company_id = fields.Many2one(
+    fiscal_proxy_company_id = fields.Many2one(
         string="Fiscal Company",
         related="company_id",
         readonly=False,
     )
-    fiscal_currency_id = fields.Many2one(
+    fiscal_proxy_currency_id = fields.Many2one(
         string="Fiscal Currency",
         related="currency_id",
         readonly=False,
     )
-    fiscal_user_id = fields.Many2one(
+    fiscal_proxy_user_id = fields.Many2one(
         string="Fiscal User",
         related="user_id",
         readonly=False,

--- a/l10n_br_account/models/fiscal_document_line.py
+++ b/l10n_br_account/models/fiscal_document_line.py
@@ -17,22 +17,22 @@ class FiscalDocumentLine(models.Model):
     # proxy fields to enable writing the related (shadowed) fields
     # to the fiscal doc line from the aml through the _inherits system
     # despite they have the same names.
-    fiscal_name = fields.Text(
+    fiscal_proxy_name = fields.Text(
         string="Fiscal Name",
         related="name",
         readonly=False,
     )
-    fiscal_product_id = fields.Many2one(
+    fiscal_proxy_product_id = fields.Many2one(
         string="Fiscal Product",
         related="product_id",
         readonly=False,
     )
-    fiscal_quantity = fields.Float(
+    fiscal_proxy_quantity = fields.Float(
         string="Fiscal Quantity",
         related="quantity",
         readonly=False,
     )
-    fiscal_price_unit = fields.Float(
+    fiscal_proxy_price_unit = fields.Float(
         string="Fiscal Price Unit",
         related="price_unit",
         readonly=False,

--- a/l10n_br_sale/models/__init__.py
+++ b/l10n_br_sale/models/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2015  Renato Lima - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+from . import account_move
+from . import fiscal_document
 from . import res_company
 from . import res_config_settings
 from . import sale_order

--- a/l10n_br_sale/models/account_move.py
+++ b/l10n_br_sale/models/account_move.py
@@ -1,0 +1,12 @@
+# Copyright 2023 Akretion (Raphaël Valyi <raphael.valyi@akretion.com>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    @api.model
+    def _shadowed_fields(self):
+        return super()._shadowed_fields() + ["partner_shipping_id"]

--- a/l10n_br_sale/models/fiscal_document.py
+++ b/l10n_br_sale/models/fiscal_document.py
@@ -1,0 +1,17 @@
+# Copyright 2023 Akretion (Raphaël Valyi <raphael.valyi@akretion.com>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class FiscalDocument(models.Model):
+    _inherit = "l10n_br_fiscal.document"
+
+    # proxy field used to handle partner_shipping_id
+    # in l10n_br_fiscal.document while the sale module
+    # also brings a partner_shipping_id field to account.move.
+    fiscal_partner_shipping_id = fields.Many2one(
+        string="Fiscal Partner Shipping",
+        related="partner_shipping_id",
+        readonly=False,
+    )

--- a/l10n_br_sale/models/fiscal_document.py
+++ b/l10n_br_sale/models/fiscal_document.py
@@ -10,7 +10,7 @@ class FiscalDocument(models.Model):
     # proxy field used to handle partner_shipping_id
     # in l10n_br_fiscal.document while the sale module
     # also brings a partner_shipping_id field to account.move.
-    fiscal_partner_shipping_id = fields.Many2one(
+    fiscal_proxy_partner_shipping_id = fields.Many2one(
         string="Fiscal Partner Shipping",
         related="partner_shipping_id",
         readonly=False,


### PR DESCRIPTION
Port from https://github.com/OCA/l10n-brazil/pull/3307
Port from https://github.com/OCA/l10n-brazil/pull/2815

Nem todos os commits foram portados, um dos commits da 2815 aparentemente não precisa e falta a migração do módulo l10n_br_delivery para portar o commit dele.