### PR TITLE
[14.0][REM][l10n_br_account] remove dummy document leftover

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -614,16 +614,6 @@ class AccountMove(models.Model):
         self.ensure_one_doc()
         return self.fiscal_document_id.action_send_email()
 
-    @api.onchange("document_type_id")
-    def _onchange_document_type_id(self):
-        # We need to ensure that invoices without a fiscal document have the
-        # document_number blank, as all invoices without a fiscal document share this
-        # same field, they are linked to the same dummy fiscal document.
-        # Otherwise, in the tree view, this field will be displayed with the same value
-        # for all these invoices.
-        if not self.document_type_id:
-            self.document_number = ""
-
     def _reverse_moves(self, default_values_list=None, cancel=False):
         new_moves = super()._reverse_moves(
             default_values_list=default_values_list, cancel=cancel


### PR DESCRIPTION
limpando o codigo na v16 #3305 (que ficou absurdamente mais limpo) me dei conta de que tinha esse onchange da epoca que ainda existia os documentos fiscais "dummy" e que pode ser removido.