### PR TITLE
[14.0][FIX] l10n_br_sale_stock: Caso do Pedido de Venda Sem Operação ou Internacional não deve incluir os Dados Fiscais do Brasil

### DIFF
--- a/l10n_br_sale_stock/models/sale_order_line.py
+++ b/l10n_br_sale_stock/models/sale_order_line.py
@@ -10,7 +10,9 @@ class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
     def _prepare_procurement_values(self, group_id=False):
-        values = self._prepare_br_fiscal_dict()
+        values = {}
+        if self.order_id.fiscal_operation_id:
+            values = self._prepare_br_fiscal_dict()
         values.update(super()._prepare_procurement_values(group_id))
         # Incluir o invoice_state
         if self.order_id.company_id.sale_create_invoice_policy == "stock_picking":

--- a/l10n_br_sale_stock/models/stock_move.py
+++ b/l10n_br_sale_stock/models/stock_move.py
@@ -27,8 +27,9 @@ class StockMove(models.Model):
         values = {}
         fiscal_operation = False
         if self.sale_line_id:
-            values = self.sale_line_id.order_id._prepare_br_fiscal_dict()
-            fiscal_operation = self.sale_line_id.order_id.fiscal_operation_id
+            if self.sale_line_id.order_id.fiscal_operation_id:
+                fiscal_operation = self.sale_line_id.order_id.fiscal_operation_id
+                values = self.sale_line_id.order_id._prepare_br_fiscal_dict()
 
         values.update(super()._get_new_picking_values())
         # O self pode conter mais de uma stock.move por isso a Operação Fiscal


### PR DESCRIPTION
Case without Fiscal OP.

Caso do Pedido de Venda Sem Operação ou Internacional não deve incluir os Dados Fiscais do Brasil.

Aqui ainda não está sendo incluído o teste porque ocorre um erro com o método Default do stock.picking como precisei alterar isso vou fazer em outro PR logo em seguida, assim deve facilitar a revisão.

EDIT.: Esse PR está buscando extrair partes das alterações do PR de Extração para o sale_stock_picking_invoicing https://github.com/OCA/l10n-brazil/pull/2955

cc @rvalyi @renatonlima @marcelsavegnago @mileo @antoniospneto 