### PR TITLE
[16.0][REF] l10n_br_crm: city to city_id

### DIFF
--- a/l10n_br_crm/views/crm_lead_view.xml
+++ b/l10n_br_crm/views/crm_lead_view.xml
@@ -5,6 +5,7 @@
         <field name="name">l10n_br_crm.leads.form</field>
         <field name="model">crm.lead</field>
         <field name="inherit_id" ref="crm.crm_lead_view_form" />
+        <field name="priority" eval="100" />
         <field name="arch" type="xml">
             <field name="partner_id" position="after">
                 <field name="show_l10n_br" invisible="1" />
@@ -12,6 +13,10 @@
                     name="street"
                     attrs="{'invisible': [('show_l10n_br', '=', False)]}"
                 />
+            </field>
+
+            <field name="city" position="replace">
+                <field name="city_id" />
             </field>
 
             <xpath expr="//group[@name='lead_info']/div" position="after">


### PR DESCRIPTION
Mudança do campo city para city_id, o módulo do crm na localização utiliza o city_id em alguns métodos porém ele não estava presente na view