### PR TITLE
[14.0][FIX] l10n_br_stock_account, l10n_br_purchase_stock, l10n_br_sale_stock: Método para obter a Operação Fiscal Padrão

### DIFF
--- a/l10n_br_purchase_stock/models/__init__.py
+++ b/l10n_br_purchase_stock/models/__init__.py
@@ -4,3 +4,4 @@ from . import purchase_order_line
 from . import stock_rule
 from . import res_config_settings
 from . import stock_move
+from . import stock_picking

--- a/l10n_br_purchase_stock/models/stock_picking.py
+++ b/l10n_br_purchase_stock/models/stock_picking.py
@@ -1,0 +1,23 @@
+# Copyright (C) 2024-Today - Akretion (<http://www.akretion.com>).
+# @author Magno Costa <magno.costa@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    def _get_default_fiscal_operation(self):
+        fiscal_operation = super()._get_default_fiscal_operation()
+        if self.purchase_id:
+            if self.purchase_id.fiscal_operation_id:
+                # Evita a inconsistência de ter o Pedido de Compras com uma
+                # OP Fiscal e a Ordem de Seleção outra, quando o campo
+                # invoice_state é alterado, o usuário pode alterar o campo
+                # mas dessa forma forçamos a decisão de não usar a mesma
+                # do Pedido.
+                if fiscal_operation != self.purchase_id.fiscal_operation_id:
+                    fiscal_operation = self.purchase_id.fiscal_operation_id
+
+        return fiscal_operation

--- a/l10n_br_purchase_stock/tests/test_l10n_br_purchase_stock.py
+++ b/l10n_br_purchase_stock/tests/test_l10n_br_purchase_stock.py
@@ -3,6 +3,8 @@
 #   Renato Lima <renato.lima@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from odoo.tests import Form
+
 from odoo.addons.l10n_br_stock_account.tests.common import TestBrPickingInvoicingCommon
 
 
@@ -446,3 +448,22 @@ class L10nBrPurchaseStockBase(TestBrPickingInvoicingCommon):
             invoice.partner_id,
             "The Invoice Partner and Partner to Shipping should be the same.",
         )
+
+    def test_form_stock_picking(self):
+        """Test Stock Picking with Form"""
+        purchase = self.env.ref("l10n_br_purchase_stock.main_po_only_products_1")
+        purchase.button_confirm()
+        picking = purchase.picking_ids
+        self.picking_move_state(picking)
+        picking_form = Form(picking)
+
+        # Alterando a OP Fiscal apenas para forçar a diferença
+        picking.company_id.stock_in_fiscal_operation_id = False
+
+        # Apesar do metodo onchange retornar uma OP Fiscal padrão,
+        # quando existe um Pedido de Venda associado deve usar retornar
+        # a mesma OP Fiscal do Pedido.
+        picking_form.invoice_state = "none"
+        picking_form.invoice_state = "2binvoiced"
+        self.assertEqual(purchase.fiscal_operation_id, picking.fiscal_operation_id)
+        picking_form.save()

--- a/l10n_br_sale_stock/models/stock_picking.py
+++ b/l10n_br_sale_stock/models/stock_picking.py
@@ -26,3 +26,17 @@ class StockPicking(models.Model):
         if partner != self._get_partner_to_invoice():
             partner = self._get_partner_to_invoice()
         return partner
+
+    def _get_default_fiscal_operation(self):
+        fiscal_operation = super()._get_default_fiscal_operation()
+        if self.sale_id:
+            if self.sale_id.fiscal_operation_id:
+                # Evita a inconsistência de ter o Pedido de Vendas com uma
+                # OP Fiscal e a Ordem de Seleção outra, quando o campo
+                # invoice_state é alterado, o usuário pode alterar o campo
+                # mas dessa forma forçamos a decisão de não usar a mesma
+                # do Pedido.
+                if fiscal_operation != self.sale_id.fiscal_operation_id:
+                    fiscal_operation = self.sale_id.fiscal_operation_id
+
+        return fiscal_operation

--- a/l10n_br_stock_account/models/stock_picking.py
+++ b/l10n_br_stock_account/models/stock_picking.py
@@ -9,23 +9,6 @@ class StockPicking(models.Model):
     _inherit = [_name, "l10n_br_fiscal.document.mixin"]
 
     @api.model
-    def _default_fiscal_operation(self):
-        company = self.env.company
-        fiscal_operation = False
-        if self.env.company.country_id == self.env.ref("base.br"):
-            fiscal_operation = company.stock_fiscal_operation_id
-            picking_type_id = self.env.context.get("default_picking_type_id")
-            if picking_type_id:
-                picking_type = self.env["stock.picking.type"].browse(picking_type_id)
-                fiscal_operation = picking_type.fiscal_operation_id or (
-                    company.stock_in_fiscal_operation_id
-                    if picking_type.code == "incoming"
-                    else company.stock_out_fiscal_operation_id
-                )
-
-        return fiscal_operation
-
-    @api.model
     def _fiscal_operation_domain(self):
         # TODO Check in context to define in or out move default.
         domain = [("state", "=", "approved")]
@@ -35,7 +18,6 @@ class StockPicking(models.Model):
         comodel_name="l10n_br_fiscal.operation",
         readonly=True,
         states={"draft": [("readonly", False)]},
-        default=_default_fiscal_operation,
         domain=lambda self: self._fiscal_operation_domain(),
     )
 
@@ -139,3 +121,54 @@ class StockPicking(models.Model):
                 partner.address_get(["invoice"]).get("invoice")
             )
         return partner
+
+    def _get_default_fiscal_operation(self):
+        """
+        Meant to be overriden in modules such as
+        l10n_br_sale_stock
+        l10n_br_purchase_stock
+        """
+        company = self.env.company
+        fiscal_operation = company.stock_fiscal_operation_id
+        picking_type_id = self.picking_type_id.id
+        if not picking_type_id:
+            # Quando isso é necessário? Testes não passam aqui,
+            # dependendo ver de remover
+            picking_type_id = self.env.context.get("default_picking_type_id")
+        if picking_type_id:
+            picking_type = self.env["stock.picking.type"].browse(picking_type_id)
+            fiscal_operation = picking_type.fiscal_operation_id or (
+                company.stock_in_fiscal_operation_id
+                if picking_type.code == "incoming"
+                else company.stock_out_fiscal_operation_id
+            )
+
+        return fiscal_operation
+
+    @api.onchange("invoice_state")
+    def _onchange_invoice_state(self):
+        for record in self:
+            # TODO: Na v16 chamar o super() o update_invoice_state já é
+            #  chamado https://github.com/OCA/account-invoicing/blob/16.0/
+            #  stock_picking_invoicing/models/stock_picking.py#L47
+            record._update_invoice_state(record.invoice_state)
+            record.mapped("move_lines")._update_invoice_state(record.invoice_state)
+
+            if record.partner_id and record.env.company.country_id == record.env.ref(
+                "base.br"
+            ):
+                fiscal_operation = record._get_default_fiscal_operation()
+                if fiscal_operation:
+                    record.fiscal_operation_id = fiscal_operation
+
+    def set_to_be_invoiced(self):
+        """
+        Update invoice_state of current pickings to "2binvoiced".
+        :return: dict
+        """
+        # Necessário para preencher a OP Fiscal Padrão quando
+        # ao inves de selecionar o invoice_state pelo campo
+        # é feito pelo botão
+        self._onchange_invoice_state()
+
+        return super().set_to_be_invoiced()


### PR DESCRIPTION
Fix stock default op fiscal.

Método para obter a Operação Fiscal Padrão na Ordem de Seleção/ stock.picking, depende do https://github.com/OCA/l10n-brazil/pull/3325 .

Apesar de envolver mais de um modulo o PR é simples, ao invés de usar o método default para obter a Operação Fiscal Padrão isso passou para um Onchange do campo invoice_state isso foi necessário porque não encontrei outra forma de resolver um problema do caso Sem Operação Fiscal ou Internacional

![image](https://github.com/user-attachments/assets/37cd4fbf-970f-44a4-b87b-3c8e57c4abed)

![image](https://github.com/user-attachments/assets/64662ffd-a17e-4209-962e-dad6b9c74849)

Eu tinha buscado resolver esse problema com os hasattrs mas como foi visto no PR https://github.com/OCA/l10n-brazil/pull/3288 isso gerava outro erro, a Ordem de Seleção não trazia a o Operação Fiscal Padrão, o caso de Compras até foi resolvido mas o de Vendas como estava sem o teste acabou passando, esse erro ocorre porque no momento da criação do stock.picking o metodo default era chamado mas o **self.sale_id** sempre era vazio.

Com esse PR ao alterar o **invoice_state** a Operação Fiscal deverá ser preenchida com a Padrão e buscando evitar  o possível problema de ter no Pedido uma Operação Fiscal e a Ordem de Seleção outra sempre que tiver um Pedido de Vendas ou Compras associado a Operação Fiscal padrão será a mesma do Pedido,  o usuário pode alterar o campo mas dessa forma forçamos a decisão de não usar a mesma do Pedido.

Separei os commits com Testes para caso alguém queira ver de buscar outra solução, se necessário também posso ver de dividir esse PR para cada modulo especifico se acharem melhor.

cc @rvalyi @renatonlima @marcelsavegnago @mileo @antoniospneto @DiegoParadeda 
