### PR TITLE
[16.0][FIX] l10n_br_base, l10n_br_zip: Visões dinâmicas do endereço

### DIFF
--- a/l10n_br_base/models/format_address_mixin.py
+++ b/l10n_br_base/models/format_address_mixin.py
@@ -7,8 +7,12 @@ from odoo import models
 class FormatAddressMixin(models.AbstractModel):
     _inherit = "format.address.mixin"
 
-    def _fields_view_get_address(self, arch):
+    def _view_get_address(self, arch):
+        # By default, the functionality to dynamically alter the view of address fields
+        # only works for the `res.partner`. This workaround clears the model
+        # reference in the view, enabling any model that extends the abstract
+        # 'format.address.mixin' to have its address view dynamically modified as well.
         address_view_id = self.env.company.country_id.address_view_id.sudo()
         if address_view_id.model != self._name:
             address_view_id.model = None
-        return super()._fields_view_get_address(arch)
+        return super()._view_get_address(arch)

--- a/l10n_br_base/models/res_company.py
+++ b/l10n_br_base/models/res_company.py
@@ -149,7 +149,7 @@ class Company(models.Model):
     ):
         res = super()._fields_view_get(view_id, view_type, toolbar, submenu)
         if view_type == "form":
-            res["arch"] = self._fields_view_get_address(res["arch"])
+            res["arch"] = self._view_get_address(res["arch"])
         return res
 
     def write(self, values):

--- a/l10n_br_base/views/res_partner_address_view.xml
+++ b/l10n_br_base/views/res_partner_address_view.xml
@@ -8,9 +8,7 @@
         <field name="arch" type="xml">
             <form>
                 <div class="o_address_format">
-                    <div>
-                        <field name="street" class="oe_read_only" invisible="1" />
-                    </div>
+                    <field name="street" class="oe_read_only" invisible="1" />
                     <field
                         name="zip"
                         placeholder="Zip code..."
@@ -71,5 +69,4 @@
             </form>
         </field>
     </record>
-
 </odoo>

--- a/l10n_br_zip/models/format_address_mixin.py
+++ b/l10n_br_zip/models/format_address_mixin.py
@@ -11,9 +11,10 @@ class FormatAddressMixin(models.AbstractModel):
         self.ensure_one()
         return self.env["l10n_br.zip"].zip_search(self)
 
-    def _fields_view_get_address(self, arch):
+    def _view_get_address(self, arch):
+        # Clears the model reference in the inherited views.
         address_view_id = self.env.company.country_id.address_view_id.sudo()
         for rec in address_view_id.inherit_children_ids:
             if rec.model != self._name:
                 rec.model = None
-        return super()._fields_view_get_address(arch)
+        return super()._view_get_address(arch)


### PR DESCRIPTION
Esta PR corrige as visões dinâmicas do endereço, resolvendo o problema no módulo CRM onde o campo "Cidade" (city_id) não era exibido como uma lista de seleção.

Detalhes da Correção:

O método `_fields_view_get_address` foi renomeado para `_view_get_address` para refletir as alterações da versão 16.0

Esta PR substitui a PR #3326.

