### PR TITLE
[12.0][FIX][l10n_br_account_payment_order] harden migr script

### DIFF
--- a/l10n_br_account_payment_order/migrations/12.0.3.0.0/pre-migration.py
+++ b/l10n_br_account_payment_order/migrations/12.0.3.0.0/pre-migration.py
@@ -18,5 +18,6 @@ _model_renames = [
 
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
-    openupgrade.rename_tables(env.cr, _table_renames)
+    if openupgrade.table_exists(env.cr, "cnab_return_move_code"):
+        openupgrade.rename_tables(env.cr, _table_renames)
     openupgrade.rename_models(env.cr, _model_renames)


### PR DESCRIPTION
tive esse erro sem isso ao migrar um banco antigo:

```
  File "/odoo/external-src/l10n-brazil.updated/l10n_br_account_payment_order/migrations/12.0.3.0.0/pre-migration.py", line 21, in migrate
    openupgrade.rename_tables(env.cr, _table_renames)
  File "/src/openupgradelib/openupgradelib/openupgrade.py", line 702, in rename_tables
    cr.execute('ALTER TABLE "%s" RENAME TO "%s"' % (old, new,))
  File "/odoo/src/odoo/sql_db.py", line 148, in wrapper
    return f(self, *args, **kwargs)
  File "/odoo/src/odoo/sql_db.py", line 225, in execute
    res = self._obj.execute(query, params)
psycopg2.ProgrammingError: relation "cnab_return_move_code" does not exist
```
