### PR TITLE
[16.0][FIX] l10n_br_account: unidade de medida e valor da fatura

### DIFF
--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -299,34 +299,31 @@ class AccountMoveLine(models.Model):
                 not changed("amount_currency") or line not in before
             ):
                 if not line.move_id.fiscal_operation_id:
-                    amount_currency = (
-                        line.move_id.direction_sign
-                        * line.currency_id.round(line.price_subtotal)
+                    unsigned_amount_currency = line.currency_id.round(
+                        line.price_subtotal
                     )
                 else:  # BRAZIL CASE:
                     if line.cfop_id and not line.cfop_id.finance_move:
-                        amount_currency = 0
+                        unsigned_amount_currency = 0
                     else:
                         if line.move_id.fiscal_operation_id.deductible_taxes:
-                            amount_currency = (
+                            unsigned_amount_currency = (
                                 line.amount_total + line.amount_tax_withholding
                             )
                         else:
                             amount_total = (
                                 line.amount_total + line.amount_tax_withholding
                             )
-                            amount_currency = (
-                                line.move_id.direction_sign
-                                * line.currency_id.round(
-                                    amount_total
-                                    - (
-                                        line.amount_tax_included
-                                        - line.amount_tax_withholding
-                                    )
-                                    - line.amount_tax_not_included
-                                    - line.icms_relief_value
+                            unsigned_amount_currency = line.currency_id.round(
+                                amount_total
+                                - (
+                                    line.amount_tax_included
+                                    - line.amount_tax_withholding
                                 )
+                                - line.amount_tax_not_included
+                                - line.icms_relief_value
                             )
+                amount_currency = unsigned_amount_currency * line.move_id.direction_sign
                 if line.amount_currency != amount_currency or line not in before:
                     line.amount_currency = amount_currency
                 if line.currency_id == line.company_id.currency_id:

--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -205,7 +205,6 @@ class AccountMoveLine(models.Model):
                     values.get("uot_id"),
                 )
             )
-            values["uom_id"] = values.get("product_uom_id")
             values["document_id"] = fiscal_doc_id  # pass through the _inherits system
 
         self._inject_shadowed_fields(vals_list)

--- a/l10n_br_account/models/fiscal_document_line.py
+++ b/l10n_br_account/models/fiscal_document_line.py
@@ -14,6 +14,13 @@ class FiscalDocumentLine(models.Model):
         string="Invoice Lines",
     )
 
+    uom_id = fields.Many2one(
+        comodel_name="uom.uom",
+        related="account_line_ids.product_uom_id",
+        store=True,
+        string="UOM",
+    )
+
     # proxy fields to enable writing the related (shadowed) fields
     # to the fiscal doc line from the aml through the _inherits system
     # despite they have the same names.


### PR DESCRIPTION
Duas correções:

1) A unidade de medida fiscal não tava sendo sincronizada com a unidade de medida do account.
2) Em alguns casos, o valor total da fatura estava ficando negativo, impedindo a confirmação da mesma.

Essa PR ajuda a resolver os erros pendentes na migração do **l10n_br_account_nfe**. #3273