### PR TITLE
[14.0][IMP] l10n_br_nfe: set nfe40_IEST

### DIFF
--- a/l10n_br_fiscal/models/document_move_mixin.py
+++ b/l10n_br_fiscal/models/document_move_mixin.py
@@ -145,6 +145,10 @@ class DocumentMoveMixin(models.AbstractModel):
         related="company_id.inscr_est",
     )
 
+    company_inscr_est_st = fields.Char(
+        string="Company ST State Tax Number",
+    )
+
     company_inscr_mun = fields.Char(
         string="Company Municipal Tax Number",
         related="company_id.inscr_mun",

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -312,6 +312,7 @@
                   <field name="company_name" readonly="1" />
                   <field name="company_cnpj_cpf" readonly="1" />
                   <field name="company_inscr_est" readonly="1" />
+                  <field name="company_inscr_est_st" readonly="1" />
                   <field name="company_street" readonly="1" />
                   <field name="company_number" readonly="1" />
                   <field name="company_street2" readonly="1" />

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -431,6 +431,19 @@ class NFe(spec_models.StackedModel):
                 doc.nfe40_dest = None
             else:
                 doc.nfe40_dest = doc.partner_id
+            doc._set_nfe40_IEST()
+
+    def _set_nfe40_IEST(self):
+        self.ensure_one()
+        iest = ""
+        if self.partner_id:
+            dest_state_id = self.partner_id.state_id
+            if dest_state_id in self.company_id.state_tax_number_ids.mapped("state_id"):
+                stn_id = self.company_id.state_tax_number_ids.filtered(
+                    lambda stn: stn.state_id == dest_state_id
+                )
+                iest = stn_id.inscr_est
+        self.company_inscr_est_st = iest
 
     ##########################
     # NF-e tag: entrega


### PR DESCRIPTION
## Objetivo

Definir o campo nfe40_IEST nos casos em que o estado de destino tenha um state_tax_number definido no cadastro da empresa.


### Adicionei o campo no doc fiscal aqui:
![image](https://github.com/user-attachments/assets/8d500442-8a8f-405d-afd6-5a1edd9839b5)

### XML + DANFE:
![image](https://github.com/user-attachments/assets/dbe02fad-e072-4620-9e74-18c77ee2185e)
