### PR TITLE
[14.0][FIX] NFC-e

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -884,6 +884,8 @@ class NFe(spec_models.StackedModel):
         for record in self.with_context(lang="pt_BR").filtered(
             filter_processador_edoc_nfe
         ):
+            record.flush()
+            record.invalidate_cache()
             inf_nfe = record.export_ds()[0]
 
             inf_nfe_supl = None

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -898,7 +898,7 @@ class NFe(spec_models.StackedModel):
 
     def _processador(self):
         self._check_nfe_environment()
-        certificado = self.env.company._get_br_ecertificate()
+        certificado = self.company_id._get_br_ecertificate()
         session = Session()
         session.verify = False
 
@@ -911,8 +911,8 @@ class NFe(spec_models.StackedModel):
 
         if self.document_type == MODELO_FISCAL_NFE:
             params.update(
-                envio_sincrono=self.env.company.nfe_enable_sync_transmission,
-                contingencia=self.env.company.nfe_enable_contingency_ws,
+                envio_sincrono=self.company_id.nfe_enable_sync_transmission,
+                contingencia=self.company_id.nfe_enable_contingency_ws,
             )
             return edoc_nfe(**params)
 

--- a/l10n_br_pos_nfce/models/pos_config.py
+++ b/l10n_br_pos_nfce/models/pos_config.py
@@ -10,7 +10,6 @@ class PosConfig(models.Model):
     nfce_document_serie_id = fields.Many2one(
         string="Document Serie",
         comodel_name="l10n_br_fiscal.document.serie",
-        related="company_id.nfe_default_serie_id",
     )
 
     nfce_environment = fields.Selection(
@@ -22,7 +21,7 @@ class PosConfig(models.Model):
 
     nfce_document_serie_code = fields.Char(
         string="Document Serie Code",
-        related="company_id.nfe_default_serie_id.code",
+        related="nfce_document_serie_id.code",
         readonly=True,
     )
 

--- a/l10n_br_pos_nfce/models/pos_order.py
+++ b/l10n_br_pos_nfce/models/pos_order.py
@@ -80,7 +80,6 @@ class PosOrder(models.Model):
             created_order._setup_anonymous_consumer()
 
             try:
-                fiscal_document_id.action_document_confirm()
                 fiscal_document_id.action_document_send()
             except Exception as e:
                 _logger.error("Error sending NFCe document: %s" % e)


### PR DESCRIPTION
1. Remove campos que não devem ser related relacionados a série da NFC-e;
2. Remove chamada do workflow duplicada;
3. Recomputa e Invalida o cache, pois a tag pagamentos não esta sendo salva antes da exportação do XML, debuguei bastante esse erro e apesar de chamar o compute, os valores não eram salvos causando uma rejeição;
4. Corrigi o cancelamento da NFC-e, removendo o uso do env.company do certificado.