### PR TITLE
[14.0][IMP] l10n_br_fiscal: tax.definition states usability / CBENEF

### DIFF
--- a/l10n_br_fiscal/views/tax_definition_view.xml
+++ b/l10n_br_fiscal/views/tax_definition_view.xml
@@ -122,14 +122,11 @@
                         />
 
           </group>
-          <group
-                        name="state"
-                        string="State"
-                        attrs="{'invisible': [('icms_regulation_id', '=', False)]}"
-                    >
+          <group name="state" string="State">
             <field
                             name="state_from_id"
                             options="{'no_create': True, 'no_create_edit': True}"
+                            attrs="{'required': [('is_benefit', '=', True)]}"
                         />
             <field name="state_to_ids" options="{'no_create': True}" />
           </group>


### PR DESCRIPTION
## Objetivo 
Esse PR permite configurar **benefício fiscal (CBENEF)** e facilita a configuração fiscal permitindo definir **state_from/state_to** sem precisar estar dentro do regulamento do ICMS.


### CBENEF - crítico

Atualmente, é impossível configurar um CBENEF por fora do regulamento do ICMS, pois o código verifica se os dois primeiros caracteres do CBENEF code (ex SC123456) batem com o código do estado de origem (ex SC). Isso é um problema pois o campo state_from_id só fica visível se o tax.definition tiver um icms_regulation_id.

Veja o erro que o sistema apresenta ao tentar cadastrar um tax.definition que seja um benefício fiscal pela linha da operação fiscal:

![image](https://github.com/user-attachments/assets/87736114-a480-4483-ab75-a60f5a1aae92)

<details><summary>Odoo Server Error</summary>
<p>
Odoo Server Error
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 696, in dispatch
    result = self._call_function(**self.params)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 370, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 358, in checked_call
    result = self.endpoint(*a, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 919, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 544, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 1370, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 1362, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 406, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 391, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/auto/addons/mail/models/mail_thread.py", line 322, in write
    result = super(MailThread, self).write(values)
  File "/opt/odoo/auto/addons/mail/models/mail_activity.py", line 788, in write
    return super(MailActivityMixin, self).write(vals)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3694, in write
    field.write(self, vals[fname])
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 3056, in write
    return self.write_batch([(records, value)])
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 3077, in write_batch
    return self.write_real(records_commands_list, create)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 3240, in write_real
    comodel.browse(command[1]).write(command[2])
  File "/opt/odoo/auto/addons/mail/models/mail_thread.py", line 322, in write
    result = super(MailThread, self).write(values)
  File "/opt/odoo/auto/addons/mail/models/mail_activity.py", line 788, in write
    return super(MailActivityMixin, self).write(vals)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3694, in write
    field.write(self, vals[fname])
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 3056, in write
    return self.write_batch([(records, value)])
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 3077, in write_batch
    return self.write_real(records_commands_list, create)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 3261, in write_real
    flush()
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 3223, in flush
    comodel.create(to_create)
  File "<decorator-gen-174>", line 2, in create
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 353, in _model_create_multi
    return create(self, arg)
  File "/opt/odoo/auto/addons/l10n_br_fiscal/models/tax_definition.py", line 328, in create
    create_super = super().create(vals_list)
  File "<decorator-gen-131>", line 2, in create
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 353, in _model_create_multi
    return create(self, arg)
  File "/opt/odoo/auto/addons/mail/models/mail_thread.py", line 264, in create
    threads = super(MailThread, self).create(vals_list)
  File "<decorator-gen-65>", line 2, in create
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 353, in _model_create_multi
    return create(self, arg)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_fields.py", line 534, in create
    recs = super().create(vals_list)
  File "<decorator-gen-15>", line 2, in create
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 353, in _model_create_multi
    return create(self, arg)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3899, in create
    records = self._create(data_list)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 4072, in _create
    records._validate_fields(name for data in data_list for name in data['stored'])
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 1277, in _validate_fields
    check(self)
  File "/opt/odoo/auto/addons/l10n_br_fiscal/models/tax_definition_benefit.py", line 107, in _check_tax_benefit_code
    if record.code[:2].upper() != record.state_from_id.code.upper():
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 652, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 317, in _handle_exception
    raise exception.with_traceback(None) from new_cause
AttributeError: 'bool' object has no attribute 'upper'
</p>
</details> 

O problema é que o CBENEF não depende tanto dos estados de origem/destino quanto da CFOP, o que faz com que o local ideal para cadastrar esses tax.definitions não seja no regulamento do ICMS.


Por isso, removi o invisible do grupo: `attrs="{'invisible': [('icms_regulation_id', '=', False)]}"`
E adicionei um required: `attrs="{'required': [('is_benefit', '=', True)]}"`, caso contrário o usuário pode receber o mesmo erro que mostrei aqui.

### Usabilidade - opcional

Quanto a usabilidade, deixei o grupo `name="state"` sem nenhum invisible, ou seja, isso permite utilizar a lógica de state_from e state_to de qualquer tax definition e fica 100% a critério do usuário.

Esse ponto, embora não crítico para o funcionamento do sistema, achei que ficou legal


