### PR TITLE
[14.0][FIX] l10n_br_nfe: export nfe40_iest to XML and PDF

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -399,6 +399,19 @@ class NFe(spec_models.StackedModel):
         for doc in self:  # TODO if out
             doc.nfe40_emit = doc.company_id
 
+    def _set_nfe40_IEST(self):
+        self.ensure_one()
+        iest = ""
+        if self.partner_id:
+            dest_state_id = self.partner_id.state_id
+            if dest_state_id in self.company_id.state_tax_number_ids.mapped("state_id"):
+                stn_id = self.company_id.state_tax_number_ids.filtered(
+                    lambda stn: stn.state_id == dest_state_id
+                )
+                iest = stn_id.inscr_est
+                iest = re.sub("[^0-9]+", "", iest)
+        self.company_inscr_est_st = iest
+
     ##########################
     # NF-e tag: dest
     ##########################
@@ -431,19 +444,6 @@ class NFe(spec_models.StackedModel):
                 doc.nfe40_dest = None
             else:
                 doc.nfe40_dest = doc.partner_id
-            doc._set_nfe40_IEST()
-
-    def _set_nfe40_IEST(self):
-        self.ensure_one()
-        iest = ""
-        if self.partner_id:
-            dest_state_id = self.partner_id.state_id
-            if dest_state_id in self.company_id.state_tax_number_ids.mapped("state_id"):
-                stn_id = self.company_id.state_tax_number_ids.filtered(
-                    lambda stn: stn.state_id == dest_state_id
-                )
-                iest = stn_id.inscr_est
-        self.company_inscr_est_st = iest
 
     ##########################
     # NF-e tag: entrega
@@ -700,6 +700,17 @@ class NFe(spec_models.StackedModel):
                     if k.startswith(self._field_prefix)
                 ):
                     return False
+
+        if (
+            field_name == "nfe40_emit"
+            and self.fiscal_operation_type == "out"
+            and self.issuer == "company"
+        ):
+            self._set_nfe40_IEST()
+            res = super()._export_many2one(field_name, xsd_required, class_obj)
+            if self.company_inscr_est_st:
+                res.IEST = self.company_inscr_est_st
+            return res
 
         return super()._export_many2one(field_name, xsd_required, class_obj)
 


### PR DESCRIPTION
Pessoal, acabei tendo um falso-positivo no #3341, na realidade faltou exportar o valor para os documentos XML e PDF.

Durante meus testes estava setando o valor do campo nfe40_iest mais ou menos assim:

```python
self.company_inscr_est_st = iest # escrevendo no l10n_br_fiscal.document
self.nfe40_emit.nfe40_IEST = iest # exportando para XML/PDF
``` 

Mas isso não é legal pois ficaria toda hora sobreescrevendo o valor no ```res.company().nfe40_IEST```.

Nesse PR fiz uma alteração apenas no método do **export** para corrigir o problema e também limpar os caracteres especiais que podem ter sido registrados no cadastro da empresa