### PR TITLE
[14.0][FIX+IMP] l10n_br_account_payment_order, l10n_br_account_payment_brcobranca: Código de Desconto no caso UNICRED 400 e possibilidade de informar códigos além do 0 e 1

### DIFF
--- a/l10n_br_account_payment_brcobranca/__manifest__.py
+++ b/l10n_br_account_payment_brcobranca/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Boletos e CNAB de cobrança",
     "summary": "receivable Boletos and CNAB using the BRCobranca lib",
-    "version": "14.0.7.0.1",
+    "version": "14.0.7.0.2",
     "license": "AGPL-3",
     "author": "Akretion, Odoo Community Association (OCA)",
     "maintainers": ["rvalyi", "mbcosta"],

--- a/l10n_br_account_payment_order/__manifest__.py
+++ b/l10n_br_account_payment_order/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Brazilian Payment Order",
-    "version": "14.0.7.0.1",
+    "version": "14.0.8.0.0",
     "license": "AGPL-3",
     "author": "KMEE, Akretion, Odoo Community Association (OCA)",
     "maintainers": ["mbcosta"],
@@ -36,6 +36,13 @@
         # Boleto Wallet Code
         "data/cnab_codes/banco_santander_boleto_wallet_code.xml",
         "data/cnab_codes/banco_bradesco_boleto_wallet_code.xml",
+        # CNAB Discount Codes
+        "data/cnab_codes/banco_ailos_240_boleto_discount_code.xml",
+        "data/cnab_codes/banco_bradesco_240_boleto_discount_code.xml",
+        "data/cnab_codes/banco_cef_240_boleto_discount_code.xml",
+        "data/cnab_codes/banco_santander_240_boleto_discount_code.xml",
+        "data/cnab_codes/banco_sicredi_240_boleto_discount_code.xml",
+        "data/cnab_codes/banco_unicred_240_400_boleto_discount_code.xml",
         # Wizards
         "wizards/account_payment_line_create_view.xml",
         "wizards/account_move_line_change.xml",

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_ailos_240_boleto_discount_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_ailos_240_boleto_discount_code.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright (C) 2024-Today - Akretion (<http://www.akretion.com>).
+  @author Magno Costa <magno.costa@akretion.com.br>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo noupdate="1">
+
+    <!-- Código de Desconto Banco AILOS -->
+    <record id="ailos_240_boleto_discount_code_0" model="l10n_br_cnab.code">
+        <field name="name">Não assumirá Desconto</field>
+        <field name="code">0</field>
+        <field name="code_type">discount_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+    <record id="ailos_240_boleto_discount_code_1" model="l10n_br_cnab.code">
+        <field name="name">Valor Fixo Até a Data Informada</field>
+        <field name="code">1</field>
+        <field name="code_type">discount_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+        <field name="comment">Para o código '1' será obrigatório a informação da Data.
+        </field>
+
+    </record>
+
+</odoo>

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_bradesco_240_boleto_discount_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_bradesco_240_boleto_discount_code.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright (C) 2024-Today - Akretion (<http://www.akretion.com>).
+  @author Magno Costa <magno.costa@akretion.com.br>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo noupdate="1">
+
+    <!-- Código de Desconto Banco Bradesco -->
+    <!-- 240 -->
+    <record id="bradesco_240_boleto_discount_code_1" model="l10n_br_cnab.code">
+        <field name="name">Valor Fixo Até a Data Informada</field>
+        <field name="code">1</field>
+        <field name="code_type">discount_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+        <field
+            name="comment"
+        >Para os códigos '1' e '2' será obrigatório a informação da Data.
+        </field>
+    </record>
+
+    <record id="bradesco_240_boleto_discount_code_2" model="l10n_br_cnab.code">
+        <field name="name">Percentual Até a Data Informada</field>
+        <field name="code">2</field>
+        <field name="code_type">discount_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+        <field
+            name="comment"
+        >Para os códigos '1' e '2' será obrigatório a informação da Data.
+        </field>
+    </record>
+
+    <record id="bradesco_240_boleto_discount_code_3" model="l10n_br_cnab.code">
+        <field name="name">Valor por Antecipação Dia Corrido</field>
+        <field name="code">3</field>
+        <field name="code_type">discount_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+    <record id="bradesco_240_boleto_discount_code_4" model="l10n_br_cnab.code">
+        <field name="name">Valor por Antecipação Dia Útil</field>
+        <field name="code">4</field>
+        <field name="code_type">discount_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+    <record id="bradesco_240_boleto_discount_code_5" model="l10n_br_cnab.code">
+        <field name="name">Percentual Sobre o Valor Nominal Dia Corrido</field>
+        <field name="code">5</field>
+        <field name="code_type">discount_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+    <record id="bradesco_240_boleto_discount_code_6" model="l10n_br_cnab.code">
+        <field name="name">Percentual Sobre o Valor Nominal Dia Útil</field>
+        <field name="code">6</field>
+        <field name="code_type">discount_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+    <record id="bradesco_240_boleto_discount_code_7" model="l10n_br_cnab.code">
+        <field name="name">Cancelamento de Desconto</field>
+        <field name="code">7</field>
+        <field name="code_type">discount_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+        <field
+            name="comment"
+        >Para o código '7', somente será válido para o código de movimento '31' - Alteração de Dados
+        </field>
+    </record>
+
+</odoo>

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_cef_240_boleto_discount_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_cef_240_boleto_discount_code.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright (C) 2024-Today - Akretion (<http://www.akretion.com>).
+  @author Magno Costa <magno.costa@akretion.com.br>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo noupdate="1">
+
+    <!-- Código de Desconto Banco Caixa Economica Federal -->
+    <record id="cef_240_boleto_discount_code_0" model="l10n_br_cnab.code">
+        <field name="name">Sem Desconto</field>
+        <field name="code">0</field>
+        <field name="code_type">discount_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+    <record id="cef_240_boleto_discount_code_1" model="l10n_br_cnab.code">
+        <field name="name">Valor Fixo até a data informada</field>
+        <field name="code">1</field>
+        <field name="code_type">discount_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+    <record id="cef_240_boleto_discount_code_2" model="l10n_br_cnab.code">
+        <field name="name">Percentual até a data informada</field>
+        <field name="code">2</field>
+        <field name="code_type">discount_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+</odoo>

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_santander_240_boleto_discount_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_santander_240_boleto_discount_code.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright (C) 2024-Today - Akretion (<http://www.akretion.com>).
+  @author Magno Costa <magno.costa@akretion.com.br>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo noupdate="1">
+
+    <!-- Códigos de Desconto Santader -->
+    <!-- 240 -->
+    <record id="santander_240_boleto_discount_code_0" model="l10n_br_cnab.code">
+        <field name="name">ISENTO</field>
+        <field name="code">0</field>
+        <field name="code_type">discount_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+    <record id="santander_240_boleto_discount_code_1" model="l10n_br_cnab.code">
+        <field name="name">Valor fixo ate a data informada</field>
+        <field name="code">1</field>
+        <field name="code_type">discount_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+        <field
+            name="comment"
+        >Informar o valor no campo “valor de desconto a ser concedido”.
+        </field>
+    </record>
+
+    <record id="santander_240_boleto_discount_code_2" model="l10n_br_cnab.code">
+        <field name="name">Percentual ate a data informada</field>
+        <field name="code">2</field>
+        <field name="code_type">discount_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+        <field
+            name="comment"
+        >Informar o percentual no campo “percentual de desconto a ser concedido”
+        </field>
+    </record>
+
+    <record id="santander_240_boleto_discount_code_3" model="l10n_br_cnab.code">
+        <field
+            name="name"
+        >Valor por antecipação por dia corrido - Informar o valor no campo “valor de desconto a ser concedido”</field>
+        <field name="code">3</field>
+        <field name="code_type">discount_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+    <record id="santander_240_boleto_discount_code_4" model="l10n_br_cnab.code">
+        <field name="name">Valor por antecipação dia útil</field>
+        <field name="code">4</field>
+        <field name="code_type">discount_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+        <field
+            name="comment"
+        >Informar o valor no campo “valor de desconto a ser concedido”.
+        </field>
+    </record>
+
+</odoo>

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_sicredi_240_boleto_discount_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_sicredi_240_boleto_discount_code.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright (C) 2024-Today - Akretion (<http://www.akretion.com>).
+  @author Magno Costa <magno.costa@akretion.com.br>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo noupdate="1">
+
+    <!-- Código de Desconto Sicredi -->
+    <!-- 240 -->
+    <record id="sicred_240_boleto_discount_code_1" model="l10n_br_cnab.code">
+        <field name="name">Valor fixo até a data informada</field>
+        <field name="code">1</field>
+        <field name="code_type">discount_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+        <field
+            name="comment"
+        >Para os códigos '1' e '2', será obrigatório a informação da data.
+        </field>
+    </record>
+
+    <record id="sicred_240_boleto_discount_code_2" model="l10n_br_cnab.code">
+        <field name="name">Percentual até a data informada</field>
+        <field name="code">2</field>
+        <field name="code_type">discount_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+        <field
+            name="comment"
+        >Para os códigos '1' e '2', será obrigatório a informação da data.
+        </field>
+    </record>
+
+    <record id="sicred_240_boleto_discount_code_3" model="l10n_br_cnab.code">
+        <field name="name">Valor por antecipação dia corrido</field>
+        <field name="code">3</field>
+        <field name="code_type">discount_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+        <field
+            name="comment"
+        >Quando utilizado o desconto “3 – Valor por antecipação dia corrido” só
+         poderá ser enviada uma regra para desconto, ou seja, não poderá  ser
+         enviado as regras dos descontos 2 e 3 (Desc2 e Desc3 do segmento R).
+        </field>
+    </record>
+
+    <record id="sicred_240_boleto_discount_code_7" model="l10n_br_cnab.code">
+        <field name="name">Cancelamento de desconto</field>
+        <field name="code">7</field>
+        <field name="code_type">discount_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+        <field
+            name="comment"
+        >O '7' somente será válido para o código de movimento '31' - Alteração
+de dados.
+        </field>
+    </record>
+
+</odoo>

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_unicred_240_400_boleto_discount_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_unicred_240_400_boleto_discount_code.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright (C) 2024-Today - Akretion (<http://www.akretion.com>).
+  @author Magno Costa <magno.costa@akretion.com.br>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo noupdate="1">
+
+    <!-- Código de Desconto Padrão UNICRED -->
+    <record id="unicred_240_400_boleto_discount_code_0" model="l10n_br_cnab.code">
+        <field name="name">Isento</field>
+        <field name="code">0</field>
+        <field name="code_type">discount_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+    <record id="unicred_240_400_boleto_discount_code_1" model="l10n_br_cnab.code">
+        <field name="name">Valor Fixo</field>
+        <field name="code">1</field>
+        <field name="code_type">discount_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+</odoo>

--- a/l10n_br_account_payment_order/demo/l10n_br_cnab_config_demo.xml
+++ b/l10n_br_account_payment_order/demo/l10n_br_cnab_config_demo.xml
@@ -56,9 +56,13 @@
         <field name="boleto_modality">DM</field>
         <field name="boleto_variation">19</field>
         <field name="boleto_accept">S</field>
+        <field
+            name="boleto_discount_code_id"
+            ref="bradesco_240_boleto_discount_code_6"
+        />
+        <field name="boleto_discount_perc">1</field>
         <field name="cnab_sequence_id" ref="sequence_cnab_number_bradesco_240" />
         <field name="own_number_sequence_id" ref="sequence_own_number_bradesco_240" />
-        <field name="boleto_discount_perc">1</field>
         <field
             name="tariff_charge_account_id"
             ref="1_account_template_32302_avoid_travis_error"
@@ -127,6 +131,10 @@
         <field name="boleto_interest_perc">2</field>
         <field name="boleto_fee_code">2</field>
         <field name="boleto_fee_perc">2</field>
+        <field
+            name="boleto_discount_code_id"
+            ref="unicred_240_400_boleto_discount_code_1"
+        />
         <field name="boleto_discount_perc">1</field>
         <field
             name="tariff_charge_account_id"
@@ -185,6 +193,10 @@
         <field name="boleto_modality">DM</field>
         <field name="boleto_variation">19</field>
         <field name="boleto_accept">N</field>
+        <field
+            name="boleto_discount_code_id"
+            ref="unicred_240_400_boleto_discount_code_1"
+        />
         <field name="boleto_discount_perc">1</field>
         <field name="cnab_sequence_id" ref="sequence_cnab_number_unicred_240" />
         <field name="own_number_sequence_id" ref="sequence_own_number_unicred_240" />
@@ -248,6 +260,8 @@
         <field name="own_number_sequence_id" ref="sequence_own_number_ailos_240" />
         <field name="boleto_protest_code">3</field>
         <field name="boleto_days_protest">5</field>
+        <field name="boleto_discount_code_id" ref="ailos_240_boleto_discount_code_1" />
+        <field name="boleto_discount_perc">1</field>
         <field name="cnab_company_bank_code">101004</field>
         <field
             name="tariff_charge_account_id"
@@ -389,6 +403,7 @@
         <field name="boleto_modality">DM</field>
         <field name="boleto_variation">19</field>
         <field name="boleto_accept">S</field>
+        <field name="boleto_discount_code_id" ref="cef_240_boleto_discount_code_2" />
         <field name="boleto_discount_perc">1</field>
         <field name="cnab_sequence_id" ref="sequence_cnab_number_cef_240" />
         <field name="own_number_sequence_id" ref="sequence_own_number_cef_240" />
@@ -483,6 +498,7 @@
         <field name="boleto_modality">DM</field>
         <field name="boleto_variation">19</field>
         <field name="boleto_accept">S</field>
+        <field name="boleto_discount_code_id" ref="sicred_240_boleto_discount_code_3" />
         <field name="boleto_discount_perc">1</field>
         <field name="cnab_sequence_id" ref="sequence_cnab_number_sicredi_240" />
         <field name="own_number_sequence_id" ref="sequence_own_number_sicredi_240" />
@@ -709,6 +725,10 @@
         <field name="boleto_modality">DM</field>
         <field name="boleto_variation">35</field>
         <field name="boleto_accept">S</field>
+        <field
+            name="boleto_discount_code_id"
+            ref="santander_240_boleto_discount_code_4"
+        />
         <field name="boleto_discount_perc">1</field>
         <field name="cnab_sequence_id" ref="sequence_cnab_number_santander_240" />
         <field name="own_number_sequence_id" ref="sequence_own_number_santander_240" />

--- a/l10n_br_account_payment_order/migrations/14.0.8.0.0/post-migration.py
+++ b/l10n_br_account_payment_order/migrations/14.0.8.0.0/post-migration.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2024-Today - Akretion (<http://www.akretion.com>).
+# @author Magno Costa <magno.costa@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+def update_payment_mode_discount_code(env):
+    """Atualiza o Código de Desconto"""
+    env.cr.execute(
+        """
+        SELECT id FROM account_payment_mode WHERE payment_method_id IN
+        (SELECT id FROM account_payment_method WHERE code IN ('240', '400', '500')
+        AND payment_type = 'inbound');
+        """
+    )
+    for row in env.cr.fetchall():
+        payment_mode = env["account.payment.mode"].browse(row[0])
+        cnab_config = payment_mode.cnab_config_id
+
+        discount_value = "0"
+        if cnab_config.boleto_discount_perc > 0.0:
+            discount_value = "1"
+
+        discount_code = env["l10n_br_cnab.code"].search(
+            [
+                ("bank_ids", "in", payment_mode.bank_id.ids),
+                ("payment_method_ids", "in", payment_mode.payment_method_id.ids),
+                ("code_type", "=", "discount_code"),
+                ("code", "=", discount_value),
+            ]
+        )
+        if discount_code:
+            cnab_config.boleto_discount_code_id = discount_code
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if not version:
+        return
+    update_payment_mode_discount_code(env)

--- a/l10n_br_account_payment_order/models/l10n_br_cnab_boleto_fields.py
+++ b/l10n_br_account_payment_order/models/l10n_br_cnab_boleto_fields.py
@@ -179,6 +179,12 @@ class L10nBrCNABBoletoFields(models.AbstractModel):
         tracking=True,
     )
 
+    boleto_discount_code_id = fields.Many2one(
+        comodel_name="l10n_br_cnab.code",
+        string="Boleto Discount Code",
+        tracking=True,
+    )
+
     boleto_discount_perc = fields.Float(
         string="Percentual de Desconto até a Data de Vencimento",
         digits="Account",

--- a/l10n_br_account_payment_order/views/l10n_br_cnab_config_view.xml
+++ b/l10n_br_account_payment_order/views/l10n_br_cnab_config_view.xml
@@ -148,6 +148,12 @@
                                 <field name="boleto_fee_perc" />
                             </group>
                             <group name="desconto" string="Configuração de Desconto">
+                                <field
+                                        name="boleto_discount_code_id"
+                                        domain="['&amp;', ('payment_method_ids', 'in', payment_method_id),
+                                                ('bank_ids', 'in', bank_id), ('code_type', '=', 'discount_code')]"
+                                    />
+
                                 <field name="boleto_discount_perc" />
                             </group>
                             <group


### PR DESCRIPTION
Inform Discount Code for case UNICRED 400 and allow use other Codes besides 0 and 1.

Volta informar o "Código de Desconto" no caso UNICRED 400 e passa a permitir informar outros códigos além do 0 e 1, esse PR depende do https://github.com/OCA/l10n-brazil/pull/3243 os commits foram incluídos aqui para poder validar o PR, depois do merge será feito o rebase e esses commits deverão sair, mesmo assim já é possível revisar o PR olhando os dois últimos commits.

**FIX**

A alteração no PR https://github.com/OCA/l10n-brazil/pull/3121 acabou incluindo uma regressão o caso UNICRED 400 deixou de preencher o Código de Desconto 1 quando havia valor, infelizmente hoje não existe uma forma de testar, porque o valor é preenchido apenas no momento da criação do Arquivo Remessa, estou considerando incluir esses e outros campos de Códigos no account.payment.line para poder validar isso e assim evitar regressões como essa.

**IMP**

Como comentei no PR https://github.com/OCA/l10n-brazil/pull/3121 apesar das Documentações de cada Banco dizer que "Seguem o Padrão FEBRABAN" a realidade:

```bash
            # Banco     | Cod Banco | Possíveis Códigos de Desconto |
            #           |           | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |
            # ----------|-----------|---|---|---|---|---|---|---|---|
            # Ailos     |    085    | X | X |   |   |   |   |   |   |
            # Bradesco  |    237    |   | X | X | X | X | X | X | X |
            # CEF       |    104    | X | X | X |   |   |   |   |   |
            # Santander |    033    | X | X | X | X |   |   |   |   |
            # Sicred    |    748    |   | X | X | X |   |   |   | X |
            # Unicred   |    136    | X | X |   |   |   |   |   |   |
```

No caso do "Código de Desconto" antes não existia um CHAR para informar o código apenas verificava se o campo **dicount_value** tinha Valor e se sim preenchia 1, mas isso não permitia usar os outros "Código de Desconto", exemplo:

Bradesco 240
2 - Percentual Até a Data Informada
3- Valor por Antecipação Dia Corrido
4 - Valor por Antecipação Dia Útil


Com esse PR isso passa a ser possível.

O script de migração vai buscar preencher o "Código de Desconto" em cada "Configuração CNAB" existente dependendo do valor do campo **boleto_discount_perc** se for maior que Zero deverá preencher com o "Código 1", mas apenas se o script encontrar o Código, hoje apenas os casos dos Bancos na tabela acima tem essa informação ( caso o Banco que você está vendo não esteja aqui considere fazer um PR incluindo esse e os outros Dados).

Para evitar erros inicialmente caso o Valor de Desconto **discount_value** tenha valor mas não tem o "Código de Desconto" vai preencher com o "padrão" 1 mas no futuro podemos considerar em remover isso é obrigar o cadastro com um Warning ou validando na Configuração do CNAB.

Segue imagens:

Cadastro nos **Códigos CNAB**

![image](https://github.com/user-attachments/assets/bce0da6b-752c-4ccf-a30d-8185e6bcfec9)

Cadastro nas **Configurações CNAB**

![image](https://github.com/user-attachments/assets/9aacd5d7-e083-4d5a-b565-6b7a5726f0fd)

![image](https://github.com/user-attachments/assets/1116bd38-e0bf-4f93-b9a0-ae08cd7d1659)

Caso onde existe apenas duas possibilidades

![image](https://github.com/user-attachments/assets/b9bbf831-f027-48bb-a318-3e4207d64f92)


cc @rvalyi @renatonlima @marcelsavegnago @mileo @kaynnan 