### PR TITLE
[14.0][CI] l10n_br_account_payment_brcobranca: Github CI with live API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,12 @@ jobs:
           POSTGRES_DB: odoo
         ports:
           - 5432:5432
+      boleto_cnab_api:
+        image: ghcr.io/akretion/boleto_cnab_api:latest
+        ports:
+          - 9292:9292
+    env:
+      BRCOBRANCA_API_URL: http://boleto_cnab_api:9292
     steps:
       - uses: actions/checkout@v3
         with:

--- a/l10n_br_account_payment_brcobranca/tests/test_payment_order.py
+++ b/l10n_br_account_payment_brcobranca/tests/test_payment_order.py
@@ -48,7 +48,7 @@ class TestPaymentOrder(SavepointCase):
         payment_order.draft2open()
 
         # Verifica se deve testar com o mock
-        if os.environ.get("CI"):
+        if os.environ.get("CI_NO_BRCOBRANCA"):
             # Generate
             file_name = get_resource_path(
                 "l10n_br_account_payment_brcobranca",
@@ -92,7 +92,7 @@ class TestPaymentOrder(SavepointCase):
         self.assertEqual(invoice.state, "posted")
 
         # Imprimir Boleto
-        if os.environ.get("CI"):
+        if os.environ.get("CI_NO_BRCOBRANCA"):
             file_name = get_resource_path(
                 "l10n_br_account_payment_brcobranca",
                 "tests",
@@ -119,7 +119,7 @@ class TestPaymentOrder(SavepointCase):
         payment_order.draft2open()
 
         # Verifica se deve testar com o mock
-        if os.environ.get("CI"):
+        if os.environ.get("CI_NO_BRCOBRANCA"):
             # Generate
             file_name = get_resource_path(
                 "l10n_br_account_payment_brcobranca",
@@ -395,7 +395,7 @@ class TestPaymentOrder(SavepointCase):
         # Open payment order
         payment_order.draft2open()
         # Verifica se deve testar com o mock
-        if os.environ.get("CI"):
+        if os.environ.get("CI_NO_BRCOBRANCA"):
             # Generate
             file_name = get_resource_path(
                 "l10n_br_account_payment_brcobranca",
@@ -441,7 +441,7 @@ class TestPaymentOrder(SavepointCase):
         payment_order.draft2open()
 
         # Verifica se deve testar com o mock
-        if os.environ.get("CI"):
+        if os.environ.get("CI_NO_BRCOBRANCA"):
             # Generate
             file_name = get_resource_path(
                 "l10n_br_account_payment_brcobranca",
@@ -491,7 +491,7 @@ class TestPaymentOrder(SavepointCase):
         payment_order.draft2open()
 
         # Verifica se deve testar com o mock
-        if os.environ.get("CI"):
+        if os.environ.get("CI_NO_BRCOBRANCA"):
             # Generate
             file_name = get_resource_path(
                 "l10n_br_account_payment_brcobranca",
@@ -550,7 +550,7 @@ class TestPaymentOrder(SavepointCase):
             self.assertEqual(line.rebate_value, 10.0)
 
         # Verifica se deve testar com o mock
-        if os.environ.get("CI"):
+        if os.environ.get("CI_NO_BRCOBRANCA"):
             # Generate
             file_name = get_resource_path(
                 "l10n_br_account_payment_brcobranca",
@@ -597,7 +597,7 @@ class TestPaymentOrder(SavepointCase):
         payment_order.draft2open()
 
         # Verifica se deve testar com o mock
-        if os.environ.get("CI"):
+        if os.environ.get("CI_NO_BRCOBRANCA"):
             # Generate
             file_name = get_resource_path(
                 "l10n_br_account_payment_brcobranca",
@@ -656,7 +656,7 @@ class TestPaymentOrder(SavepointCase):
             self.assertEqual(line.discount_value, 10.0)
 
         # Verifica se deve testar com o mock
-        if os.environ.get("CI"):
+        if os.environ.get("CI_NO_BRCOBRANCA"):
             # Generate
             file_name = get_resource_path(
                 "l10n_br_account_payment_brcobranca",
@@ -703,7 +703,7 @@ class TestPaymentOrder(SavepointCase):
         payment_order.draft2open()
 
         # Verifica se deve testar com o mock
-        if os.environ.get("CI"):
+        if os.environ.get("CI_NO_BRCOBRANCA"):
             # Generate
             file_name = get_resource_path(
                 "l10n_br_account_payment_brcobranca",
@@ -767,7 +767,7 @@ class TestPaymentOrder(SavepointCase):
         payment_order.draft2open()
 
         # Verifica se deve testar com o mock
-        if os.environ.get("CI"):
+        if os.environ.get("CI_NO_BRCOBRANCA"):
             # Generate
             file_name = get_resource_path(
                 "l10n_br_account_payment_brcobranca",
@@ -822,7 +822,7 @@ class TestPaymentOrder(SavepointCase):
         payment_order.draft2open()
 
         # Verifica se deve testar com o mock
-        if os.environ.get("CI"):
+        if os.environ.get("CI_NO_BRCOBRANCA"):
             # Generate
             file_name = get_resource_path(
                 "l10n_br_account_payment_brcobranca",
@@ -876,7 +876,7 @@ class TestPaymentOrder(SavepointCase):
         payment_order.draft2open()
 
         # Verifica se deve testar com o mock
-        if os.environ.get("CI"):
+        if os.environ.get("CI_NO_BRCOBRANCA"):
             # Generate
             file_name = get_resource_path(
                 "l10n_br_account_payment_brcobranca",


### PR DESCRIPTION
adiciona o serviço do API brcobranca no testes. A CI do Github action faz um set da variável de ambiente CI, mas se trocamos para CI_NO_BRCOBRANCA, aqui no Github a gente vai rodar os testes fazendo os queries no API do brcobranca. E caso alguem quiser rodar os teste em algum ambiente onde não tem o API do brcobranca, basta exportar CI_NO_BRCOBRANCA=1 antes de rodar os testes.   cc @mbcosta 

Infelizmente se a gente quisesse rodar o serviço no Runboat seria mais complexo e mais invasivo, mas talvez já rodar o API de vdd nos testes já ajuda a ter mais confiança neles.

Nota: como a imagem do API esta numa distro Alpine, o impacto para rodar isso na CI é mínimo.