### PR TITLE
[16.0][FIX] l10n_br_sale: nothing  to invoice error

### DIFF
--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -169,7 +169,7 @@ class SaleOrder(models.Model):
                 pass
 
         if not moves:
-            raise self._nothing_to_invoice_error()
+            raise UserError(self._nothing_to_invoice_error_message())
 
         return moves
 


### PR DESCRIPTION
Correção para o método `_nothing_to_invoice_error` que foi refatorado na 16.0