### PR TITLE
[14.0][FIX] nfce - serie and check anonymous customer

### DIFF
--- a/l10n_br_fiscal/models/res_partner.py
+++ b/l10n_br_fiscal/models/res_partner.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2020 - TODAY Luis Felipe Mileo - KMEE
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 
 from ..constants.fiscal import (
     FINAL_CUSTOMER,
@@ -136,3 +136,9 @@ class ResPartner(models.Model):
             "inscr_est",
             "inscr_mun",
         ]
+
+    @api.constrains("is_anonymous_consumer")
+    def _check_anonymous_consumer(self):
+        for p in self:
+            if p.is_anonymous_consumer and p.cnpj_cpf:
+                raise ValueError(_("Anonymous consumer cannot have a CNPJ/CPF number."))

--- a/l10n_br_pos_nfce/models/pos_config.py
+++ b/l10n_br_pos_nfce/models/pos_config.py
@@ -27,18 +27,12 @@ class PosConfig(models.Model):
 
     nfce_document_serie_sequence_number_next = fields.Integer(
         string="Document Serie Number",
-        default=lambda self: self._default_next_number(),
+        related="nfce_document_serie_id.internal_sequence_id.number_next_actual",
     )
 
     nfce_city_ibge_code = fields.Char(
         related="company_id.city_id.ibge_code",
     )
-
-    def _default_next_number(self):
-        if not self.nfce_document_serie_id:
-            return 1
-
-        return self.nfce_document_serie_id.internal_sequence_id.number_next_actual
 
     def update_nfce_serie_number(self, serie_number):
         if self.nfce_document_serie_sequence_number_next < serie_number:


### PR DESCRIPTION
This pull request includes changes to the `l10n_br_fiscal` and `l10n_br_pos_nfce` modules to enhance validation and simplify the codebase. The most important changes include adding a constraint to ensure anonymous consumers cannot have a CNPJ/CPF number and modifying how the next document series number is determined.

### Enhancements to validation:

* [`l10n_br_fiscal/models/res_partner.py`](diffhunk://#diff-acc6a5b5358060a68613b5842abf1003fb21dd7c1a07d9d9dde9c964426cc284R139-R144): Added a constraint in the `_check_anonymous_consumer` method to ensure that anonymous consumers cannot have a CNPJ/CPF number.

### Codebase simplification:

* [`l10n_br_pos_nfce/models/pos_config.py`](diffhunk://#diff-c86a677f5f453247ccc9709d9b26499714ce726b7e4699555dfaa62f8c11643cL30-L42): Removed the `_default_next_number` method and updated the `nfce_document_serie_sequence_number_next` field to use a related field for determining the next document series number.

### Minor changes:

* [`l10n_br_fiscal/models/res_partner.py`](diffhunk://#diff-acc6a5b5358060a68613b5842abf1003fb21dd7c1a07d9d9dde9c964426cc284L5-R5): Added the `_` function to the import statement for translations.