### PR TITLE
[14.0][FIX] l10n_br_fiscal_edi: rename refactored reports

### DIFF
--- a/l10n_br_fiscal_edi/models/document_event.py
+++ b/l10n_br_fiscal_edi/models/document_event.py
@@ -388,5 +388,5 @@ class Event(models.Model):
 
     def print_document_event(self):
         return self.env.ref(
-            "l10n_br_fiscal.action_report_document_event"
+            "l10n_br_fiscal_edi.action_report_document_event"
         ).report_action(self)

--- a/l10n_br_fiscal_edi/views/document_event_report.xml
+++ b/l10n_br_fiscal_edi/views/document_event_report.xml
@@ -4,8 +4,8 @@
         <field name="name">Document Event</field>
         <field name="model">l10n_br_fiscal.event</field>
         <field name="report_type">qweb-pdf</field>
-        <field name="report_name">l10n_br_fiscal.main_report_document_event</field>
-        <field name="report_file">l10n_br_fiscal.report_document_event</field>
+        <field name="report_name">l10n_br_fiscal_edi.main_report_document_event</field>
+        <field name="report_file">l10n_br_fiscal_edi.report_document_event</field>
         <field
             name="print_report_name"
         >dict(object.fields_get(allfields=['type'])['type']['selection'])[object.type]</field>

--- a/l10n_br_fiscal_edi/views/document_event_template.xml
+++ b/l10n_br_fiscal_edi/views/document_event_template.xml
@@ -103,7 +103,7 @@ row {
         <div class="article">
             <t t-foreach="docs" t-as="doc">
                 <t
-                        t-call="l10n_br_fiscal.report_document_event"
+                        t-call="l10n_br_fiscal_edi.report_document_event"
                         t-lang="doc.document_id.partner_id.lang"
                     />
             </t>


### PR DESCRIPTION
## Corrige erro ao imprimir Carta de Correção:

![image](https://github.com/user-attachments/assets/5da9565f-d633-489e-8a7f-07b5e862053c)

<details><summary>Stack</summary>
<p>

Erro:
Odoo Server Error

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 696, in dispatch
    result = self._call_function(**self.params)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 370, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 358, in checked_call
    result = self.endpoint(*a, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 919, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 544, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 1374, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 1362, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 406, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 391, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/auto/addons/l10n_br_fiscal_edi/models/document_event.py", line 390, in print_document_event
    return self.env.ref(
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 527, in ref
    return self['ir.model.data'].xmlid_to_object(xml_id, raise_if_not_found=raise_if_not_found)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_model.py", line 1972, in xmlid_to_object
    t = self.xmlid_to_res_model_res_id(xmlid, raise_if_not_found)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_model.py", line 1956, in xmlid_to_res_model_res_id
    return self.xmlid_lookup(xmlid)[1:3]
  File "<decorator-gen-37>", line 2, in xmlid_lookup
  File "/opt/odoo/custom/src/odoo/odoo/tools/cache.py", line 90, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_model.py", line 1949, in xmlid_lookup
    raise ValueError('External ID not found in the system: %s' % xmlid)
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 652, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 317, in _handle_exception
    raise exception.with_traceback(None) from new_cause
ValueError: External ID not found in the system: l10n_br_fiscal.action_report_document_event

</p>
</details> 