### PR TITLE
[FIX] l10n_br_account_payment_brcobranca: discount value

### DIFF
--- a/l10n_br_account_payment_brcobranca/models/account_payment_line.py
+++ b/l10n_br_account_payment_brcobranca/models/account_payment_line.py
@@ -188,6 +188,7 @@ class AccountPaymentLine(models.Model):
                     # Casos mapeados que enviam Zero para quando não tem valor
                     discount_code = "0"
 
-            linhas_pagamentos["cod_desconto"] = discount_code
+            if discount_code:
+                linhas_pagamentos["cod_desconto"] = discount_code
 
         return linhas_pagamentos


### PR DESCRIPTION
## Nesse PR estou tentando corrigir o seguinte erro na geração do arquivo de pagamento Itaú CNAB400:

![image](https://github.com/user-attachments/assets/56380cdc-73f7-413b-944a-da75cb78bf56)

## Discussão

@mbcosta você poderia me ajudar com um review desse trecho, por favor? Se entendi corretamente o valor cod_desconto deveria ser False para o banco Itaú, mas daí resulta no erro da lib.

Também debuguei colocando cod_desconto="x" pra ver se o valor "x" aparecia no arquivo de remessa e não **apareceu.** Ou seja, parece que a lib retorna erro se cod_desconto=False porém quando fornecido um valor ela não utiliza para compor o arquivo.

![image](https://github.com/user-attachments/assets/24ba27e8-daed-4afd-a96d-a7a03f7bb361)
