### PR TITLE
[16.0][FIX] l10n_br_fiscal: fix redundant field defaults / duplicate field labels

### DIFF
--- a/l10n_br_account/models/document_line.py
+++ b/l10n_br_account/models/document_line.py
@@ -25,22 +25,22 @@ class FiscalDocumentLine(models.Model):
     # to the fiscal doc line from the aml through the _inherits system
     # despite they have the same names.
     fiscal_proxy_name = fields.Text(
-        string="Fiscal Name",
+        string="Fiscal Proxy Name",
         related="name",
         readonly=False,
     )
     fiscal_proxy_product_id = fields.Many2one(
-        string="Fiscal Product",
+        string="Fiscal Proxy Product",
         related="product_id",
         readonly=False,
     )
     fiscal_proxy_quantity = fields.Float(
-        string="Fiscal Quantity",
+        string="Fiscal Proxy Quantity",
         related="quantity",
         readonly=False,
     )
     fiscal_proxy_price_unit = fields.Float(
-        string="Fiscal Price Unit",
+        string="Fiscal Proxy Price Unit",
         related="price_unit",
         readonly=False,
     )

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -177,6 +177,12 @@ class Document(models.Model):
         copy=False,
     )
 
+    currency_id = fields.Many2one(
+        comodel_name="res.currency",
+        string="Currency",
+        compute="_compute_currency_id",
+    )
+
     # this related "state" field is required for the status bar widget
     # while state_edoc avoids colliding with the state field
     # of objects where the fiscal mixin might be injected.
@@ -269,6 +275,11 @@ class Document(models.Model):
                         number=record.document_number,
                     )
                 )
+
+    @api.depends("company_id")
+    def _compute_currency_id(self):
+        for doc in self:
+            doc.currency_id = doc.company_id.currency_id or self.env.company.currency_id
 
     def _compute_document_name(self):
         self.ensure_one()
@@ -368,11 +379,6 @@ class Document(models.Model):
             )
 
         return super().unlink()
-
-    @api.onchange("company_id")
-    def _onchange_company_id(self):
-        if self.company_id:
-            self.currency_id = self.company_id.currency_id
 
     def _create_return(self):
         return_docs = self.env[self._name]

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -33,11 +33,7 @@ class DocumentLine(models.Model):
         store=True,
     )
 
-    currency_id = fields.Many2one(
-        comodel_name="res.currency",
-        related="company_id.currency_id",
-        string="Currency",
-    )
+    quantity = fields.Float(default=1.0)
 
     ind_final = fields.Selection(related="document_id.ind_final")
 

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -80,7 +80,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     currency_id = fields.Many2one(
         comodel_name="res.currency",
         string="Currency",
-        default=lambda self: self.env.ref("base.BRL"),
+        compute="_compute_currency_id",
     )
 
     product_id = fields.Many2one(
@@ -112,7 +112,6 @@ class FiscalDocumentLineMixin(models.AbstractModel):
 
     quantity = fields.Float(
         digits="Product Unit of Measure",
-        default=1.0,
     )
 
     fiscal_type = fields.Selection(selection=PRODUCT_FISCAL_TYPE)
@@ -147,6 +146,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     )
 
     fiscal_operation_type = fields.Selection(
+        string="Operation Type",
         related="fiscal_operation_id.fiscal_operation_type",
         readonly=True,
     )
@@ -884,3 +884,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         comodel_name="l10n_br_fiscal.cnae",
         string="CNAE Code",
     )
+
+    @api.depends("company_id")
+    def _compute_currency_id(self):
+        for doc_line in self:
+            doc_line.currency_id = doc_line.company_id.currency_id or self.env.ref(
+                "base.BRL"
+            )

--- a/l10n_br_fiscal/models/document_mixin_fields.py
+++ b/l10n_br_fiscal/models/document_mixin_fields.py
@@ -56,7 +56,6 @@ class FiscalDocumentMixinFields(models.AbstractModel):
 
     fiscal_operation_type = fields.Selection(
         related="fiscal_operation_id.fiscal_operation_type",
-        string="Fiscal Operation Type",
         readonly=True,
     )
 
@@ -95,9 +94,8 @@ class FiscalDocumentMixinFields(models.AbstractModel):
 
     currency_id = fields.Many2one(
         comodel_name="res.currency",
+        string="Currency",
         default=lambda self: self.env.company.currency_id,
-        store=True,
-        readonly=True,
     )
 
     amount_price_gross = fields.Monetary(

--- a/l10n_br_fiscal/tests/test_subsequent_operation.py
+++ b/l10n_br_fiscal/tests/test_subsequent_operation.py
@@ -26,7 +26,6 @@ class TestSubsequentOperation(TransactionCase):
         """Test Fiscal Subsequent Operation Simples Faturamento"""
 
         self.nfe_simples_faturamento._onchange_fiscal_operation_id()
-        self.nfe_simples_faturamento._onchange_company_id()
         self.nfe_simples_faturamento._onchange_document_serie_id()
 
         for line in self.nfe_simples_faturamento.fiscal_line_ids:

--- a/l10n_br_fiscal_closing/tests/test_fiscal_closing.py
+++ b/l10n_br_fiscal_closing/tests/test_fiscal_closing.py
@@ -47,7 +47,6 @@ class TestFiscalClosing(TransactionCase):
             xml_file=xml_file,
             document_id=self.nfe_export,
         )
-        self.nfe_export._onchange_company_id()
         event_id.set_done(
             status_code="101",
             response="Teste Autorizado",

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -897,8 +897,8 @@ class NFe(spec_models.StackedModel):
         for record in self.with_context(lang="pt_BR").filtered(
             filter_processador_edoc_nfe
         ):
-            record.flush()
-            record.invalidate_cache()
+            record.flush_model()
+            self.env.invalidate_all()
             inf_nfe = record.export_ds()[0]
 
             inf_nfe_supl = None

--- a/l10n_br_purchase/models/purchase_order.py
+++ b/l10n_br_purchase/models/purchase_order.py
@@ -24,7 +24,7 @@ class PurchaseOrder(models.Model):
 
     active_company_country_id = fields.Many2one(
         comodel_name="res.country",
-        string="Company",
+        string="Active Company Country",
         default=lambda self: self.env.company.country_id,
     )
 


### PR DESCRIPTION
remove warning with redundant field (also defined in document_line_mixin.py)