### PR TITLE
[16.0][muitos modulos] - WIP: inscr_est -> l10n_br_ie_code 

### DIFF
--- a/l10n_br_account/i18n/l10n_br_account.pot
+++ b/l10n_br_account/i18n/l10n_br_account.pot
@@ -791,7 +791,7 @@ msgid "Company State"
 msgstr ""
 
 #. module: l10n_br_account
-#: model:ir.model.fields,field_description:l10n_br_account.field_account_move__company_inscr_est
+#: model:ir.model.fields,field_description:l10n_br_account.field_account_move__company_l10n_br_ie_code
 msgid "Company State Tax Number"
 msgstr ""
 
@@ -3649,7 +3649,7 @@ msgid "Situação e-doc"
 msgstr ""
 
 #. module: l10n_br_account
-#: model:ir.model.fields,field_description:l10n_br_account.field_account_move__partner_inscr_est
+#: model:ir.model.fields,field_description:l10n_br_account.field_account_move__partner_l10n_br_ie_code
 #: model_terms:ir.ui.view,arch_db:l10n_br_account.fiscal_invoice_search
 #: model_terms:ir.ui.view,arch_db:l10n_br_account.invoice_search
 msgid "State Tax Number"

--- a/l10n_br_account/i18n/pt_BR.po
+++ b/l10n_br_account/i18n/pt_BR.po
@@ -795,7 +795,7 @@ msgid "Company State"
 msgstr "Estado da Empresa"
 
 #. module: l10n_br_account
-#: model:ir.model.fields,field_description:l10n_br_account.field_account_move__company_inscr_est
+#: model:ir.model.fields,field_description:l10n_br_account.field_account_move__company_l10n_br_ie_code
 msgid "Company State Tax Number"
 msgstr "Número da Inscrição Estadual da Empresa"
 
@@ -3681,7 +3681,7 @@ msgid "Situação e-doc"
 msgstr ""
 
 #. module: l10n_br_account
-#: model:ir.model.fields,field_description:l10n_br_account.field_account_move__partner_inscr_est
+#: model:ir.model.fields,field_description:l10n_br_account.field_account_move__partner_l10n_br_ie_code
 #: model_terms:ir.ui.view,arch_db:l10n_br_account.fiscal_invoice_search
 #: model_terms:ir.ui.view,arch_db:l10n_br_account.invoice_search
 msgid "State Tax Number"

--- a/l10n_br_account/views/account_invoice_view.xml
+++ b/l10n_br_account/views/account_invoice_view.xml
@@ -14,7 +14,7 @@
             <field name="partner_id" position="before">
                 <field name="partner_legal_name" string="Legal Name" />
                 <field name="partner_cnpj_cpf" string="CNPJ/CPF" />
-                <field name="partner_inscr_est" string="State Tax Number" />
+                <field name="partner_l10n_br_ie_code" string="State Tax Number" />
             </field>
             <field name="name" position="attributes">
                 <attribute

--- a/l10n_br_account/views/fiscal_invoice_view.xml
+++ b/l10n_br_account/views/fiscal_invoice_view.xml
@@ -16,7 +16,7 @@
               <field name="name" string="Account Number" invisible="1" />
               <field name="partner_legal_name" string="Legal Name" />
               <field name="partner_cnpj_cpf" string="CNPJ/CPF" />
-              <field name="partner_inscr_est" string="State Tax Number" />
+              <field name="partner_l10n_br_ie_code" string="State Tax Number" />
           </xpath>
         </field>
     </record>

--- a/l10n_br_base/demo/l10n_br_base_demo.xml
+++ b/l10n_br_base/demo/l10n_br_base_demo.xml
@@ -25,7 +25,7 @@
         <field name="website">www.intel.com.br</field>
         <field name="phone">(11) 3365-5500</field>
         <field name="email">teste@teste.com.br</field>
-        <field name="inscr_est">623.343.911.173</field>
+        <field name="l10n_br_ie_code">623.343.911.173</field>
         <field name="is_company" eval="1" />
         <field name="active" eval="1" />
     </record>
@@ -48,7 +48,7 @@
         <field name="website">www.amd.com/br</field>
         <field name="phone">(55-11) 3478-2150</field>
         <field name="email">teste@teste.com.br</field>
-        <field name="inscr_est">621.240.850.633</field>
+        <field name="l10n_br_ie_code">621.240.850.633</field>
         <field name="is_company" eval="1" />
         <field name="active" eval="1" />
     </record>
@@ -71,7 +71,7 @@
         <field name="website">www.lg.com/br</field>
         <field name="phone">(92) 2129-8710</field>
         <field name="email">teste@teste.com.br</field>
-        <field name="inscr_est">86.015.623-0</field>
+        <field name="l10n_br_ie_code">86.015.623-0</field>
         <field name="suframa">550309012</field>
         <field name="is_company" eval="1" />
         <field name="active" eval="1" />
@@ -95,7 +95,7 @@
         <field name="website">www.samsung.com/br</field>
         <field name="phone">(81) 1111-1111</field>
         <field name="email">teste@teste.com.br</field>
-        <field name="inscr_est">4386525-92</field>
+        <field name="l10n_br_ie_code">4386525-92</field>
         <field name="suframa" />
         <field name="is_company" eval="1" />
         <field name="active" eval="1" />
@@ -119,7 +119,7 @@
         <field name="website">www.positivoinformatica.com.br</field>
         <field name="phone">(41) 3316-7700</field>
         <field name="email">teste@teste.com.br</field>
-        <field name="inscr_est">80320143-90</field>
+        <field name="l10n_br_ie_code">80320143-90</field>
         <field name="suframa" />
         <field name="is_company" eval="1" />
         <field name="active" eval="1" />
@@ -143,7 +143,7 @@
         <field name="website">www.dell.com.br</field>
         <field name="phone">(51) 3320-3500</field>
         <field name="email">teste@teste.com.br</field>
-        <field name="inscr_est">074/2864251</field>
+        <field name="l10n_br_ie_code">074/2864251</field>
         <field name="suframa" />
         <field name="is_company" eval="1" />
         <field name="active" eval="1" />
@@ -167,7 +167,7 @@
         <field name="website">www.infobahia.com.br</field>
         <field name="phone">(71) 3321-9652</field>
         <field name="email">teste@teste.com.br</field>
-        <field name="inscr_est">2004915-45</field>
+        <field name="l10n_br_ie_code">2004915-45</field>
         <field name="suframa" />
         <field name="is_company" eval="1" />
         <field name="active" eval="1" />
@@ -191,7 +191,7 @@
         <field name="website">www.infomanuas.com/br</field>
         <field name="phone">(92) 2129-8720</field>
         <field name="email">teste@teste.com.br</field>
-        <field name="inscr_est">78.002.376-5</field>
+        <field name="l10n_br_ie_code">78.002.376-5</field>
         <field name="suframa">101160100</field>
         <field name="is_company" eval="1" />
         <field name="active" eval="1" />
@@ -215,7 +215,7 @@
         <field name="website">www.cliente1.com/br</field>
         <field name="phone">(55-11) 3478-2150</field>
         <field name="email">cliente1@cliente1.com.br</field>
-        <field name="inscr_est">460.429.771.334</field>
+        <field name="l10n_br_ie_code">460.429.771.334</field>
         <field name="is_company" eval="1" />
         <field name="active" eval="1" />
     </record>
@@ -238,7 +238,7 @@
         <field name="website">www.cliente2.com.br</field>
         <field name="phone">(11) 7777-7777</field>
         <field name="email">cliente2@cliente2.com.br</field>
-        <field name="inscr_est">887.273.429.152</field>
+        <field name="l10n_br_ie_code">887.273.429.152</field>
         <field name="is_company" eval="1" />
         <field name="active" eval="1" />
     </record>
@@ -261,7 +261,7 @@
         <field name="website">www.cliente2.com.br</field>
         <field name="phone">(11) 7777-7777</field>
         <field name="email">cliente2@cliente2.com.br</field>
-        <field name="inscr_est">811.510.100.755</field>
+        <field name="l10n_br_ie_code">811.510.100.755</field>
         <!-- Necessário company_type person para o metodo address_get
         identificar como sendo o Partner to Shipping
         TODO: A localização deveria sobreescrever o metodo address_get
@@ -293,7 +293,7 @@
         <field name="website">www.cliente3.com/br</field>
         <field name="phone">(92) 2145-9999</field>
         <field name="email">cliente3@cliente3.com.br</field>
-        <field name="inscr_est">78.217.504-0</field>
+        <field name="l10n_br_ie_code">78.217.504-0</field>
         <field name="suframa">101362102</field>
         <field name="is_company" eval="1" />
         <field name="active" eval="1" />
@@ -317,7 +317,7 @@
         <field name="website">www.cliente3.com/br</field>
         <field name="phone">(92) 2145-8888</field>
         <field name="email">cliente4@cliente4.com.br</field>
-        <field name="inscr_est">09.569.321-1</field>
+        <field name="l10n_br_ie_code">09.569.321-1</field>
         <field name="suframa">100695108</field>
         <field name="is_company" eval="1" />
         <field name="active" eval="1" />
@@ -341,7 +341,7 @@
         <field name="website">www.cliente5.com/br</field>
         <field name="phone">(81) 1111-1111</field>
         <field name="email">cliente5@cliente5.com.br</field>
-        <field name="inscr_est">8700737-10</field>
+        <field name="l10n_br_ie_code">8700737-10</field>
         <field name="suframa" />
         <field name="is_company" eval="1" />
         <field name="active" eval="1" />
@@ -365,7 +365,7 @@
         <field name="website">www.cliente5.com/br</field>
         <field name="phone">(81) 1111-1111</field>
         <field name="email">cliente6@cliente6.com.br</field>
-        <field name="inscr_est">7055493-56</field>
+        <field name="l10n_br_ie_code">7055493-56</field>
         <field name="suframa" />
         <field name="is_company" eval="1" />
         <field name="active" eval="1" />
@@ -389,7 +389,7 @@
         <field name="website">www.cliente7.com.br</field>
         <field name="phone">(51) 3320-7777</field>
         <field name="email">cliente7@cliente7.com.br</field>
-        <field name="inscr_est">176/1256758</field>
+        <field name="l10n_br_ie_code">176/1256758</field>
         <field name="suframa" />
         <field name="is_company" eval="1" />
         <field name="active" eval="1" />
@@ -413,7 +413,7 @@
         <field name="website">www.cliente7.com.br</field>
         <field name="phone">(11) 7777-7777</field>
         <field name="email">cliente2@cliente7.com.br</field>
-        <field name="inscr_est">845/2345834</field>
+        <field name="l10n_br_ie_code">845/2345834</field>
         <!-- Necessário company_type person para o metodo address_get
         identificar como sendo o Partner to Invoice
         TODO: A localização deveria sobreescrever o metodo address_get
@@ -445,7 +445,7 @@
         <field name="website">www.cliente8.com.br</field>
         <field name="phone">(51) 3320-8888</field>
         <field name="email">cliente8@cliente8.com.br</field>
-        <field name="inscr_est">383/4127240</field>
+        <field name="l10n_br_ie_code">383/4127240</field>
         <field name="suframa" />
         <field name="is_company" eval="1" />
         <field name="active" eval="1" />

--- a/l10n_br_base/demo/res_company_demo.xml
+++ b/l10n_br_base/demo/res_company_demo.xml
@@ -16,7 +16,7 @@
         <field name="website">www.example.com</field>
         <field name="is_company" eval="True" />
         <field name="cnpj_cpf">97.231.608/0001-69</field>
-        <field name="inscr_est">454.504.604.553</field>
+        <field name="l10n_br_ie_code">454.504.604.553</field>
     </record>
     <function model="res.partner" name="_onchange_city_id">
         <value eval="[ref('base.main_partner')]" />
@@ -44,7 +44,7 @@
         <field name="email">info@suaempresa.com.br</field>
         <field name="is_company" eval="True" />
         <field name="cnpj_cpf">81.583.054/0001-29</field>
-        <field name="inscr_est">078.016.350.838</field>
+        <field name="l10n_br_ie_code">078.016.350.838</field>
     </record>
     <function model="res.partner" name="_onchange_city_id">
         <value eval="[ref('lucro_presumido_partner')]" />
@@ -73,7 +73,7 @@
         <field name="website">www.example.com</field>
         <field name="is_company" eval="True" />
         <field name="cnpj_cpf">59.594.315/0001-57</field>
-        <field name="inscr_est">755.338.250.133</field>
+        <field name="l10n_br_ie_code">755.338.250.133</field>
     </record>
     <function model="res.partner" name="_onchange_city_id">
         <value eval="[ref('simples_nacional_partner')]" />

--- a/l10n_br_base/i18n/l10n_br_base.pot
+++ b/l10n_br_base/i18n/l10n_br_base.pot
@@ -23317,11 +23317,11 @@ msgid "State"
 msgstr ""
 
 #. module: l10n_br_base
-#: model:ir.model.fields,field_description:l10n_br_base.field_l10n_br_base_party_mixin__inscr_est
-#: model:ir.model.fields,field_description:l10n_br_base.field_res_company__inscr_est
-#: model:ir.model.fields,field_description:l10n_br_base.field_res_partner__inscr_est
-#: model:ir.model.fields,field_description:l10n_br_base.field_res_users__inscr_est
-#: model:ir.model.fields,field_description:l10n_br_base.field_state_tax_numbers__inscr_est
+#: model:ir.model.fields,field_description:l10n_br_base.field_l10n_br_base_party_mixin__l10n_br_ie_code
+#: model:ir.model.fields,field_description:l10n_br_base.field_res_company__l10n_br_ie_code
+#: model:ir.model.fields,field_description:l10n_br_base.field_res_partner__l10n_br_ie_code
+#: model:ir.model.fields,field_description:l10n_br_base.field_res_users__l10n_br_ie_code
+#: model:ir.model.fields,field_description:l10n_br_base.field_state_tax_numbers__l10n_br_ie_code
 msgid "State Tax Number"
 msgstr ""
 

--- a/l10n_br_base/i18n/pt_BR.po
+++ b/l10n_br_base/i18n/pt_BR.po
@@ -23327,11 +23327,11 @@ msgid "State"
 msgstr "Estado"
 
 #. module: l10n_br_base
-#: model:ir.model.fields,field_description:l10n_br_base.field_l10n_br_base_party_mixin__inscr_est
-#: model:ir.model.fields,field_description:l10n_br_base.field_res_company__inscr_est
-#: model:ir.model.fields,field_description:l10n_br_base.field_res_partner__inscr_est
-#: model:ir.model.fields,field_description:l10n_br_base.field_res_users__inscr_est
-#: model:ir.model.fields,field_description:l10n_br_base.field_state_tax_numbers__inscr_est
+#: model:ir.model.fields,field_description:l10n_br_base.field_l10n_br_base_party_mixin__l10n_br_ie_code
+#: model:ir.model.fields,field_description:l10n_br_base.field_res_company__l10n_br_ie_code
+#: model:ir.model.fields,field_description:l10n_br_base.field_res_partner__l10n_br_ie_code
+#: model:ir.model.fields,field_description:l10n_br_base.field_res_users__l10n_br_ie_code
+#: model:ir.model.fields,field_description:l10n_br_base.field_state_tax_numbers__l10n_br_ie_code
 msgid "State Tax Number"
 msgstr "Número da Inscrição Estadual"
 

--- a/l10n_br_base/models/party_mixin.py
+++ b/l10n_br_base/models/party_mixin.py
@@ -26,7 +26,7 @@ class PartyMixin(models.AbstractModel):
         unaccent=False,
     )
 
-    inscr_est = fields.Char(
+    l10n_br_ie_code = fields.Char(
         string="State Tax Number",
         size=17,
         unaccent=False,

--- a/l10n_br_base/models/res_company.py
+++ b/l10n_br_base/models/res_company.py
@@ -19,7 +19,7 @@ class Company(models.Model):
         return partner_fields + [
             "legal_name",
             "cnpj_cpf",
-            "inscr_est",
+            "l10n_br_ie_code",
             "inscr_mun",
             "district",
             "city_id",
@@ -54,10 +54,10 @@ class Company(models.Model):
         for company in self:
             company.partner_id.cnpj_cpf = company.cnpj_cpf
 
-    def _inverse_inscr_est(self):
+    def _inverse_l10n_br_ie_code(self):
         """Write the l10n_br specific functional fields."""
         for company in self:
-            company.partner_id.inscr_est = company.inscr_est
+            company.partner_id.l10n_br_ie_code = company.l10n_br_ie_code
 
     def _inverse_state(self):
         """Write the l10n_br specific functional fields."""
@@ -120,9 +120,9 @@ class Company(models.Model):
         inverse="_inverse_cnpj_cpf",
     )
 
-    inscr_est = fields.Char(
+    l10n_br_ie_code = fields.Char(
         compute="_compute_address",
-        inverse="_inverse_inscr_est",
+        inverse="_inverse_l10n_br_ie_code",
     )
 
     state_tax_number_ids = fields.One2many(
@@ -167,7 +167,7 @@ class Company(models.Model):
     @api.onchange("state_id")
     def _onchange_state_id(self):
         res = super()._onchange_state_id()
-        self.inscr_est = False
-        self.partner_id.inscr_est = False
+        self.l10n_br_ie_code = False
+        self.partner_id.l10n_br_ie_code = False
         self.partner_id.state_id = self.state_id
         return res

--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -61,8 +61,8 @@ class Partner(models.Model):
         help="Indicate if is a Brazilian partner",
     )
 
-    @api.constrains("cnpj_cpf", "inscr_est")
-    def _check_cnpj_inscr_est(self):
+    @api.constrains("cnpj_cpf", "l10n_br_ie_code")
+    def _check_cnpj_l10n_br_ie_code(self):
         for record in self:
             domain = []
 
@@ -93,8 +93,8 @@ class Partner(models.Model):
                     if allow_cnpj_multi_ie == "True":
                         for partner in record.env["res.partner"].search(domain):
                             if (
-                                partner.inscr_est == record.inscr_est
-                                and not record.inscr_est
+                                partner.l10n_br_ie_code == record.l10n_br_ie_code
+                                and not record.l10n_br_ie_code
                             ):
                                 raise ValidationError(
                                     _(
@@ -120,7 +120,7 @@ class Partner(models.Model):
                 record.country_id,
             )
 
-    @api.constrains("inscr_est", "state_id", "is_company")
+    @api.constrains("l10n_br_ie_code", "state_id", "is_company")
     def _check_ie(self):
         """Checks if company register number in field insc_est is valid,
         this method call others methods because this validation is State wise
@@ -130,7 +130,10 @@ class Partner(models.Model):
         for record in self:
             if record.is_company:
                 check_ie(
-                    record.env, record.inscr_est, record.state_id, record.country_id
+                    record.env,
+                    record.l10n_br_ie_code,
+                    record.state_id,
+                    record.country_id,
                 )
 
     @api.constrains("state_tax_number_ids")
@@ -140,15 +143,15 @@ class Partner(models.Model):
         :Return: True or False.
         """
         for record in self:
-            for inscr_est_line in record.state_tax_number_ids:
+            for l10n_br_ie_code_line in record.state_tax_number_ids:
                 check_ie(
                     record.env,
-                    inscr_est_line.inscr_est,
-                    inscr_est_line.state_id,
+                    l10n_br_ie_code_line.l10n_br_ie_code,
+                    l10n_br_ie_code_line.state_id,
                     record.country_id,
                 )
 
-                if inscr_est_line.state_id.id == record.state_id.id:
+                if l10n_br_ie_code_line.state_id.id == record.state_id.id:
                     raise ValidationError(
                         _(
                             "There can only be one state tax"
@@ -157,8 +160,8 @@ class Partner(models.Model):
                     )
                 duplicate_ie = record.search(
                     [
-                        ("state_id", "=", inscr_est_line.state_id.id),
-                        ("inscr_est", "=", inscr_est_line.inscr_est),
+                        ("state_id", "=", l10n_br_ie_code_line.state_id.id),
+                        ("l10n_br_ie_code", "=", l10n_br_ie_code_line.l10n_br_ie_code),
                     ]
                 )
                 if duplicate_ie:

--- a/l10n_br_base/models/state_tax_numbers.py
+++ b/l10n_br_base/models/state_tax_numbers.py
@@ -23,7 +23,7 @@ class StateTaxNumbers(models.Model):
         ondelete="cascade",
     )
 
-    inscr_est = fields.Char(string="State Tax Number", size=16, required=True)
+    l10n_br_ie_code = fields.Char(string="State Tax Number", size=16, required=True)
 
     state_id = fields.Many2one(
         comodel_name="res.country.state", string="State", required=True

--- a/l10n_br_base/tests/test_other_ie.py
+++ b/l10n_br_base/tests/test_other_ie.py
@@ -20,7 +20,7 @@ class OtherIETest(TransactionCase):
                 "name": "Akretion Sao Paulo",
                 "legal_name": "Akretion Sao Paulo",
                 "cnpj_cpf": "26.905.703/0001-52",
-                "inscr_est": "932.446.119.086",
+                "l10n_br_ie_code": "932.446.119.086",
                 "street": "Rua Paulo Dias",
                 "street_number": "586",
                 "district": "Alumínio",
@@ -45,7 +45,7 @@ class OtherIETest(TransactionCase):
                         0,
                         {
                             "state_id": self.env.ref("base.state_br_ba").id,
-                            "inscr_est": 41902653,
+                            "l10n_br_ie_code": 41902653,
                         },
                     )
                 ]
@@ -54,7 +54,7 @@ class OtherIETest(TransactionCase):
         self.assertTrue(result, "Error to included valid IE.")
         for line in self.company.partner_id.state_tax_number_ids:
             result = False
-            if line.inscr_est == "41902653":
+            if line.l10n_br_ie_code == "41902653":
                 result = True
             self.assertTrue(result, "Error in method to update other IE(s) on partner.")
 
@@ -67,7 +67,7 @@ class OtherIETest(TransactionCase):
                             0,
                             {
                                 "state_id": self.env.ref("base.state_br_ba").id,
-                                "inscr_est": 67729139,
+                                "l10n_br_ie_code": 67729139,
                             },
                         )
                     ]
@@ -90,7 +90,7 @@ class OtherIETest(TransactionCase):
                             0,
                             {
                                 "state_id": self.env.ref("base.state_br_am").id,
-                                "inscr_est": "042933681",
+                                "l10n_br_ie_code": "042933681",
                             },
                         )
                     ]
@@ -110,7 +110,7 @@ class OtherIETest(TransactionCase):
                             0,
                             {
                                 "state_id": self.env.ref("base.state_br_sp").id,
-                                "inscr_est": 692015742119,
+                                "l10n_br_ie_code": 692015742119,
                             },
                         )
                     ]
@@ -132,7 +132,7 @@ class OtherIETest(TransactionCase):
                         0,
                         {
                             "state_id": self.env.ref("base.state_br_ba").id,
-                            "inscr_est": 41902653,
+                            "l10n_br_ie_code": 41902653,
                         },
                     )
                 ]
@@ -141,6 +141,6 @@ class OtherIETest(TransactionCase):
         self.assertTrue(result, "Error to included valid IE.")
         for line in self.company.state_tax_number_ids:
             result = False
-            if line.inscr_est == "41902653":
+            if line.l10n_br_ie_code == "41902653":
                 result = True
             self.assertTrue(result, "Error in method to update other IE(s) on Company.")

--- a/l10n_br_base/tests/test_valid_createid.py
+++ b/l10n_br_base/tests/test_valid_createid.py
@@ -17,7 +17,7 @@ class ValidCreateIdTest(TransactionCase):
             "name": "Company Test 1",
             "legal_name": "Company Testc 1 Ltda",
             "cnpj_cpf": "02.960.895/0001-31",
-            "inscr_est": "081.981.37-6",
+            "l10n_br_ie_code": "081.981.37-6",
             "street": "Rod BR-101 Norte Contorno",
             "street_number": "955",
             "street2": "Portão 1",
@@ -36,7 +36,7 @@ class ValidCreateIdTest(TransactionCase):
             "name": "Company Test 2",
             "legal_name": "Company Testc 2 Ltda",
             "cnpj_cpf": "14.018.406/0001-93",
-            "inscr_est": "385.611.86-2",
+            "l10n_br_ie_code": "385.611.86-2",
             "street": "Rod BR-101 Norte Contorno",
             "street_number": "955",
             "street2": "Portão 1",
@@ -51,11 +51,11 @@ class ValidCreateIdTest(TransactionCase):
             "website": "www.companytest.com.br",
         }
 
-        cls.company_invalid_inscr_est = {
+        cls.company_invalid_l10n_br_ie_code = {
             "name": "Company Test 3",
             "legal_name": "Company Testc 3 Ltda",
             "cnpj_cpf": "31.295.101/0001-60",
-            "inscr_est": "924.511.27-0",
+            "l10n_br_ie_code": "924.511.27-0",
             "street": "Rod BR-101 Norte Contorno",
             "street_number": "955",
             "street2": "Portão 1",
@@ -74,7 +74,7 @@ class ValidCreateIdTest(TransactionCase):
             "name": "Partner Test 1",
             "legal_name": "Partner Testc 1 Ltda",
             "cnpj_cpf": "734.419.622-06",
-            "inscr_est": "176.754.07-5",
+            "l10n_br_ie_code": "176.754.07-5",
             "street": "Rod BR-101 Norte Contorno",
             "street_number": "955",
             "street2": "Portão 1",
@@ -93,7 +93,7 @@ class ValidCreateIdTest(TransactionCase):
             "name": "Partner Test 2",
             "legal_name": "Partner Testc 2 Ltda",
             "cnpj_cpf": "734.419.622-07",
-            "inscr_est": "538.759.92-5",
+            "l10n_br_ie_code": "538.759.92-5",
             "street": "Rod BR-101 Norte Contorno",
             "street_number": "955",
             "street2": "Portão 1",
@@ -130,12 +130,12 @@ class ValidCreateIdTest(TransactionCase):
                 self.company_invalid_cnpj
             )
 
-    def test_comp_invalid_inscr_est(self):
+    def test_comp_invalid_l10n_br_ie_code(self):
         """Test if ValidationError raised with correct CNPJ
         and invalid Inscricao Estadual"""
         with self.assertRaises(ValidationError):
             self.env["res.company"].with_context(tracking_disable=True).create(
-                self.company_invalid_inscr_est
+                self.company_invalid_l10n_br_ie_code
             )
 
     # Tests on partners

--- a/l10n_br_base/tools.py
+++ b/l10n_br_base/tools.py
@@ -11,17 +11,17 @@ from odoo import _
 from odoo.exceptions import ValidationError
 
 
-def check_ie(env, inscr_est, state, country):
+def check_ie(env, l10n_br_ie_code, state, country):
     """
     Checks if 'Inscrição Estadual' field is valid
     using erpbrasil library
     :param env:
-    :param inscr_est:
+    :param l10n_br_ie_code:
     :param state:
     :param country:
     :return:
     """
-    if env and inscr_est and state and country:
+    if env and l10n_br_ie_code and state and country:
         if country != env.ref("base.br"):
             return  # skip check
 
@@ -35,14 +35,14 @@ def check_ie(env, inscr_est, state, country):
         # TODO: em aberto debate sobre:
         #  Se no caso da empresa ser 'isenta' do IE o campo
         #  deve estar vazio ou pode ter algum valor como abaixo
-        if inscr_est in ("isento", "isenta", "ISENTO", "ISENTA"):
+        if l10n_br_ie_code in ("isento", "isenta", "ISENTO", "ISENTA"):
             return  # skip check
 
-        if not ie.validar(state.code.lower(), inscr_est):
+        if not ie.validar(state.code.lower(), l10n_br_ie_code):
             raise ValidationError(
                 _(
                     "Estadual Inscription %(inscr)s Invalid for State %(state)s!",
-                    inscr=inscr_est,
+                    inscr=l10n_br_ie_code,
                     state=state.name,
                 )
             )

--- a/l10n_br_base/views/res_company_view.xml
+++ b/l10n_br_base/views/res_company_view.xml
@@ -25,7 +25,7 @@
                     attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
                 />
                 <field
-                    name="inscr_est"
+                    name="l10n_br_ie_code"
                     placeholder="State Tax Number..."
                     attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
                 />
@@ -45,7 +45,7 @@
                 >
                     <tree editable="bottom">
                         <field name="company_id" invisible="1" />
-                        <field name="inscr_est" />
+                        <field name="l10n_br_ie_code" />
                         <field
                             name="state_id"
                             domain="[('country_id', '=', %(base.br)d)]"

--- a/l10n_br_base/views/res_partner_view.xml
+++ b/l10n_br_base/views/res_partner_view.xml
@@ -27,7 +27,7 @@
             <field name="display_name" position="after">
                 <field name="legal_name" />
                 <field name="cnpj_cpf" />
-                <field name="inscr_est" />
+                <field name="l10n_br_ie_code" />
             </field>
         </field>
     </record>
@@ -80,10 +80,10 @@
                     nolabel="1"
                     attrs="{'invisible': [('is_company','=', True)]}"
                 />
-                <div name="inscr_est">
-                    <label for="inscr_est" name="inscr_est" string="IE" />
+                <div name="l10n_br_ie_code">
+                    <label for="l10n_br_ie_code" name="l10n_br_ie_code" string="IE" />
                 </div>
-                <field name="inscr_est" nolabel="1" />
+                <field name="l10n_br_ie_code" nolabel="1" />
             </xpath>
             <page position="after" name="sales_purchases">
                 <page string="Fiscal" name="fiscal">
@@ -104,7 +104,7 @@
                             >
                                 <tree editable="bottom">
                                     <field name="partner_id" invisible="1" />
-                                    <field name="inscr_est" />
+                                    <field name="l10n_br_ie_code" />
                                     <field
                                         name="state_id"
                                         domain="[('country_id', '=', %(base.br)d)]"

--- a/l10n_br_cnpj_search/i18n/l10n_br_cnpj_search.pot
+++ b/l10n_br_cnpj_search/i18n/l10n_br_cnpj_search.pot
@@ -195,7 +195,7 @@ msgid "Identification"
 msgstr ""
 
 #. module: l10n_br_cnpj_search
-#: model:ir.model.fields,field_description:l10n_br_cnpj_search.field_partner_search_wizard__inscr_est
+#: model:ir.model.fields,field_description:l10n_br_cnpj_search.field_partner_search_wizard__l10n_br_ie_code
 msgid "Inscr Est"
 msgstr ""
 

--- a/l10n_br_cnpj_search/i18n/pt_BR.po
+++ b/l10n_br_cnpj_search/i18n/pt_BR.po
@@ -202,7 +202,7 @@ msgid "Identification"
 msgstr "Identificação"
 
 #. module: l10n_br_cnpj_search
-#: model:ir.model.fields,field_description:l10n_br_cnpj_search.field_partner_search_wizard__inscr_est
+#: model:ir.model.fields,field_description:l10n_br_cnpj_search.field_partner_search_wizard__l10n_br_ie_code
 msgid "Inscr Est"
 msgstr "Inscr Estadual"
 

--- a/l10n_br_cnpj_search/wizard/partner_cnpj_search_wizard.py
+++ b/l10n_br_cnpj_search/wizard/partner_cnpj_search_wizard.py
@@ -21,7 +21,7 @@ class PartnerCnpjSearchWizard(models.TransientModel):
     cnpj_cpf = fields.Char()
     legal_name = fields.Char()
     name = fields.Char()
-    inscr_est = fields.Char()
+    l10n_br_ie_code = fields.Char()
     zip = fields.Char()
     street_name = fields.Char()
     street_number = fields.Char()
@@ -96,7 +96,7 @@ class PartnerCnpjSearchWizard(models.TransientModel):
         values_to_update = {
             "legal_name": self.legal_name,
             "name": self.name,
-            "inscr_est": self.inscr_est,
+            "l10n_br_ie_code": self.l10n_br_ie_code,
             "zip": self.zip,
             "street_name": self.street_name,
             "street_number": self.street_number,

--- a/l10n_br_cnpj_search/wizard/partner_cnpj_search_wizard.xml
+++ b/l10n_br_cnpj_search/wizard/partner_cnpj_search_wizard.xml
@@ -18,7 +18,7 @@
                         <field name="name" />
                         <field name="legal_name" />
                         <field name="cnpj_cpf" readonly="1" string="CNPJ" />
-                        <field name="inscr_est" string="IE" />
+                        <field name="l10n_br_ie_code" string="IE" />
                     </group>
 
                     <group name="Contacts" string="Contacts">

--- a/l10n_br_crm/i18n/es.po
+++ b/l10n_br_crm/i18n/es.po
@@ -122,7 +122,7 @@ msgid "Show L10N Br"
 msgstr ""
 
 #. module: l10n_br_crm
-#: model:ir.model.fields,field_description:l10n_br_crm.field_crm_lead__inscr_est
+#: model:ir.model.fields,field_description:l10n_br_crm.field_crm_lead__l10n_br_ie_code
 msgid "State Tax Number"
 msgstr "Número de identificación fiscal estatal"
 

--- a/l10n_br_crm/i18n/l10n_br_crm.pot
+++ b/l10n_br_crm/i18n/l10n_br_crm.pot
@@ -119,7 +119,7 @@ msgid "Show L10N Br"
 msgstr ""
 
 #. module: l10n_br_crm
-#: model:ir.model.fields,field_description:l10n_br_crm.field_crm_lead__inscr_est
+#: model:ir.model.fields,field_description:l10n_br_crm.field_crm_lead__l10n_br_ie_code
 msgid "State Tax Number"
 msgstr ""
 

--- a/l10n_br_crm/i18n/pt_BR.po
+++ b/l10n_br_crm/i18n/pt_BR.po
@@ -123,7 +123,7 @@ msgid "Show L10N Br"
 msgstr "Exibir L10N Br"
 
 #. module: l10n_br_crm
-#: model:ir.model.fields,field_description:l10n_br_crm.field_crm_lead__inscr_est
+#: model:ir.model.fields,field_description:l10n_br_crm.field_crm_lead__l10n_br_ie_code
 msgid "State Tax Number"
 msgstr "Número de inscrição estadual"
 

--- a/l10n_br_crm/models/crm_lead.py
+++ b/l10n_br_crm/models/crm_lead.py
@@ -79,7 +79,7 @@ class Lead(models.Model):
         for record in self:
             check_cnpj_cpf(record.env, record.cpf, record.country_id)
 
-    @api.constrains("inscr_est")
+    @api.constrains("l10n_br_ie_code")
     def _check_ie(self):
         """Checks if company register number in field insc_est is valid,
         this method call others methods because this validation is State wise
@@ -87,7 +87,9 @@ class Lead(models.Model):
         :Return: True or False.
         """
         for record in self:
-            check_ie(record.env, record.inscr_est, record.state_id, record.country_id)
+            check_ie(
+                record.env, record.l10n_br_ie_code, record.state_id, record.country_id
+            )
 
     @api.onchange("cnpj", "country_id")
     def _onchange_cnpj(self):
@@ -131,14 +133,16 @@ class Lead(models.Model):
             if self.partner_id.is_company:
                 result["legal_name"] = self.partner_id.legal_name
                 result["cnpj"] = self.partner_id.cnpj_cpf
-                result["inscr_est"] = self.partner_id.inscr_est
+                result["l10n_br_ie_code"] = self.partner_id.l10n_br_ie_code
                 result["inscr_mun"] = self.partner_id.inscr_mun
                 result["suframa"] = self.partner_id.suframa
             else:
                 result["partner_name"] = self.partner_id.parent_id.name or False
                 result["legal_name"] = self.partner_id.parent_id.legal_name or False
                 result["cnpj"] = self.partner_id.parent_id.cnpj_cpf or False
-                result["inscr_est"] = self.partner_id.parent_id.inscr_est or False
+                result["l10n_br_ie_code"] = (
+                    self.partner_id.parent_id.l10n_br_ie_code or False
+                )
                 result["inscr_mun"] = self.partner_id.parent_id.inscr_mun or False
                 result["suframa"] = self.partner_id.parent_id.suframa or False
                 result["website"] = self.partner_id.parent_id.website or False
@@ -169,7 +173,7 @@ class Lead(models.Model):
             values.update(
                 {
                     "cnpj_cpf": self.cnpj,
-                    "inscr_est": self.inscr_est,
+                    "l10n_br_ie_code": self.l10n_br_ie_code,
                     "inscr_mun": self.inscr_mun,
                     "suframa": self.suframa,
                 }
@@ -178,7 +182,7 @@ class Lead(models.Model):
             values.update(
                 {
                     "cnpj_cpf": self.cpf,
-                    "inscr_est": self.rg,
+                    "l10n_br_ie_code": self.rg,
                     "rg": self.rg,
                 }
             )

--- a/l10n_br_crm/tests/test_crm_lead.py
+++ b/l10n_br_crm/tests/test_crm_lead.py
@@ -19,7 +19,7 @@ class CrmLeadTest(TransactionCase):
                 "cnpj": "56.647.352/0001-98",
                 "stage_id": self.env.ref("crm.stage_lead1").id,
                 "partner_name": "Test Partner",
-                "inscr_est": "079.798.013.363",
+                "l10n_br_ie_code": "079.798.013.363",
                 "inscr_mun": "99999999",
             }
         )
@@ -43,7 +43,7 @@ class CrmLeadTest(TransactionCase):
                 "cnpj": "57.240.310/0001-09",
                 "stage_id": self.env.ref("crm.stage_lead1").id,
                 "partner_name": "Test Partner 1",
-                "inscr_est": "041.092.540.590",
+                "l10n_br_ie_code": "041.092.540.590",
                 "inscr_mun": "99999999",
                 "country_id": self.env.ref("base.br").id,
                 "state_id": self.env.ref("base.state_br_sp").id,
@@ -56,7 +56,7 @@ class CrmLeadTest(TransactionCase):
                 "name": "Test Lead Partner",
                 "legal_name": "Test Lead Partner",
                 "cnpj_cpf": "22.898.817/0001-61",
-                "inscr_est": "041.092.540.590",
+                "l10n_br_ie_code": "041.092.540.590",
                 "inscr_mun": "99999999",
                 "suframa": "99999999",
                 "street_number": "1225",
@@ -116,7 +116,8 @@ class CrmLeadTest(TransactionCase):
         )
         self.assertTrue(self.obj_partner.cnpj_cpf, "The field CNPJ not was filled.")
         self.assertTrue(
-            self.obj_partner.inscr_est, "The field Inscrição Estadual not was filled"
+            self.obj_partner.l10n_br_ie_code,
+            "The field Inscrição Estadual not was filled",
         )
         self.assertTrue(
             self.obj_partner.inscr_mun, "The field Inscrição Municipal not was filled"
@@ -169,7 +170,7 @@ class CrmLeadTest(TransactionCase):
 
         self.assertTrue(self.obj_partner.name, "The field Name was not filled.")
         self.assertTrue(self.obj_partner.cnpj_cpf, "The field CNPJ was not filled.")
-        self.assertTrue(self.obj_partner.inscr_est, "The field RG was not filled")
+        self.assertTrue(self.obj_partner.l10n_br_ie_code, "The field RG was not filled")
 
     def test_lead_won_contact(self):
         """Test to mark the Lead as won"""
@@ -194,7 +195,8 @@ class CrmLeadTest(TransactionCase):
         )
         self.assertTrue(self.obj_partner.cnpj_cpf, "The field CNPJ not was filled.")
         self.assertTrue(
-            self.obj_partner.inscr_est, "The field Inscrição Estadual not was filled"
+            self.obj_partner.l10n_br_ie_code,
+            "The field Inscrição Estadual not was filled",
         )
         self.assertTrue(
             self.obj_partner.inscr_mun, "The field Inscrição Municipal not was filled"
@@ -225,10 +227,10 @@ class CrmLeadTest(TransactionCase):
         )
 
         self.assertEqual(
-            self.crm_lead_company_1.inscr_est,
+            self.crm_lead_company_1.l10n_br_ie_code,
             "041.092.540.590",
             "In the change of the partner \
-                         the field inscr_est was not automatically filled.",
+                         the field l10n_br_ie_code was not automatically filled.",
         )
 
         self.assertEqual(

--- a/l10n_br_crm/views/crm_lead_view.xml
+++ b/l10n_br_crm/views/crm_lead_view.xml
@@ -39,7 +39,7 @@
                     attrs="{'invisible': [('show_l10n_br', '=', False)]}"
                 />
                 <field
-                    name="inscr_est"
+                    name="l10n_br_ie_code"
                     attrs="{'invisible': [('show_l10n_br', '=', False)]}"
                 />
             </xpath>
@@ -71,7 +71,7 @@
                     attrs="{'invisible': [('show_l10n_br', '=', False)]}"
                 />
                 <field
-                    name="inscr_est"
+                    name="l10n_br_ie_code"
                     attrs="{'invisible': [('show_l10n_br', '=', False)]}"
                 />
             </xpath>

--- a/l10n_br_crm/views/crm_quick_create_opportunity_form.xml
+++ b/l10n_br_crm/views/crm_quick_create_opportunity_form.xml
@@ -9,7 +9,7 @@
             <xpath expr="//group" position="inside">
                 <field name="legal_name" invisible="1" />
                 <field name="cnpj" invisible="1" />
-                <field name="inscr_est" invisible="1" />
+                <field name="l10n_br_ie_code" invisible="1" />
                 <field name="inscr_mun" invisible="1" />
                 <field name="suframa" invisible="1" />
                 <field name="name_surname" invisible="1" />

--- a/l10n_br_fiscal/demo/fiscal_document_nfse_demo.xml
+++ b/l10n_br_fiscal/demo/fiscal_document_nfse_demo.xml
@@ -13,7 +13,7 @@
         <field name="partner_legal_name">Cliente 1 SP</field>
         <field name="partner_name">Cliente 1 SP Contribuinte</field>
         <field name="partner_cnpj_cpf">81.493.979/0001-89</field>
-        <field name="partner_inscr_est">454.504.604.553</field>
+        <field name="partner_l10n_br_ie_code">454.504.604.553</field>
         <field name="partner_tax_framework">3</field>
         <field name="fiscal_operation_type">out</field>
     </record>

--- a/l10n_br_fiscal/i18n/l10n_br_fiscal.pot
+++ b/l10n_br_fiscal/i18n/l10n_br_fiscal.pot
@@ -1882,8 +1882,8 @@ msgid "Company State"
 msgstr ""
 
 #. module: l10n_br_fiscal
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document__company_inscr_est
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_move_mixin__company_inscr_est
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document__company_l10n_br_ie_code
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_move_mixin__company_l10n_br_ie_code
 msgid "Company State Tax Number"
 msgstr ""
 
@@ -5093,7 +5093,7 @@ msgid "Input"
 msgstr ""
 
 #. module: l10n_br_fiscal
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_related__inscr_est
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_related__l10n_br_ie_code
 msgid "Inscr. Estadual/RG"
 msgstr ""
 
@@ -7608,10 +7608,10 @@ msgid "State"
 msgstr ""
 
 #. module: l10n_br_fiscal
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document__partner_inscr_est
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_move_mixin__partner_inscr_est
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_res_partner__inscr_est
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_res_users__inscr_est
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document__partner_l10n_br_ie_code
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_move_mixin__partner_l10n_br_ie_code
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_res_partner__l10n_br_ie_code
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_res_users__l10n_br_ie_code
 msgid "State Tax Number"
 msgstr ""
 

--- a/l10n_br_fiscal/i18n/pt_BR.po
+++ b/l10n_br_fiscal/i18n/pt_BR.po
@@ -1944,8 +1944,8 @@ msgid "Company State"
 msgstr "Estado da Empresa"
 
 #. module: l10n_br_fiscal
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document__company_inscr_est
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_move_mixin__company_inscr_est
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document__company_l10n_br_ie_code
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_move_mixin__company_l10n_br_ie_code
 msgid "Company State Tax Number"
 msgstr "Número da Inscrição Estadual"
 
@@ -5162,7 +5162,7 @@ msgid "Input"
 msgstr "Entrada"
 
 #. module: l10n_br_fiscal
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_related__inscr_est
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_related__l10n_br_ie_code
 msgid "Inscr. Estadual/RG"
 msgstr "O Inscr. Estadual/RG"
 
@@ -7696,10 +7696,10 @@ msgid "State"
 msgstr "Estado"
 
 #. module: l10n_br_fiscal
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document__partner_inscr_est
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_move_mixin__partner_inscr_est
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_res_partner__inscr_est
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_res_users__inscr_est
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document__partner_l10n_br_ie_code
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_move_mixin__partner_l10n_br_ie_code
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_res_partner__l10n_br_ie_code
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_res_users__l10n_br_ie_code
 msgid "State Tax Number"
 msgstr "Número do Imposto Estadual/RG"
 

--- a/l10n_br_fiscal/models/document_move_mixin.py
+++ b/l10n_br_fiscal/models/document_move_mixin.py
@@ -32,9 +32,9 @@ class DocumentMoveMixin(models.AbstractModel):
         related="partner_id.cnpj_cpf",
     )
 
-    partner_inscr_est = fields.Char(
+    partner_l10n_br_ie_code = fields.Char(
         string="State Tax Number",
-        related="partner_id.inscr_est",
+        related="partner_id.l10n_br_ie_code",
     )
 
     partner_ind_ie_dest = fields.Selection(
@@ -140,9 +140,9 @@ class DocumentMoveMixin(models.AbstractModel):
         related="company_id.cnpj_cpf",
     )
 
-    company_inscr_est = fields.Char(
+    company_l10n_br_ie_code = fields.Char(
         string="Company State Tax Number",
-        related="company_id.inscr_est",
+        related="company_id.l10n_br_ie_code",
     )
 
     company_inscr_mun = fields.Char(

--- a/l10n_br_fiscal/models/document_related.py
+++ b/l10n_br_fiscal/models/document_related.py
@@ -56,7 +56,7 @@ class DocumentRelated(models.Model):
         default="cnpj",
     )
 
-    inscr_est = fields.Char(string="Inscr. Estadual/RG", size=16)
+    l10n_br_ie_code = fields.Char(string="Inscr. Estadual/RG", size=16)
 
     document_date = fields.Date(string="Data")
 
@@ -78,11 +78,14 @@ class DocumentRelated(models.Model):
         for record in self:
             check_cnpj_cpf(record.env, record.cnpj_cpf, self.env.ref("base.br"))
 
-    @api.constrains("inscr_est", "state_id")
+    @api.constrains("l10n_br_ie_code", "state_id")
     def _check_ie(self):
         for record in self:
             check_ie(
-                record.env, record.inscr_est, record.state_id, self.env.ref("base.br")
+                record.env,
+                record.l10n_br_ie_code,
+                record.state_id,
+                self.env.ref("base.br"),
             )
 
     @api.onchange("document_related_id")
@@ -101,7 +104,7 @@ class DocumentRelated(models.Model):
             self.cnpj_cpf = False
             self.cpfcnpj_type = False
             self.document_date = False
-            self.inscr_est = False
+            self.l10n_br_ie_code = False
 
         if related.document_type_id.code in ("01", "04"):
             self.access_key = False
@@ -124,8 +127,8 @@ class DocumentRelated(models.Model):
             self.document_date = related.document_date
 
         if related.document_type_id.code == "04":
-            self.inscr_est = (
-                related.partner_id and related.partner_id.inscr_est or False
+            self.l10n_br_ie_code = (
+                related.partner_id and related.partner_id.l10n_br_ie_code or False
             )
 
     @api.onchange("cnpj_cpf", "cpfcnpj_type")

--- a/l10n_br_fiscal/models/res_partner.py
+++ b/l10n_br_fiscal/models/res_partner.py
@@ -76,7 +76,7 @@ class ResPartner(models.Model):
         tracking=True,
     )
 
-    inscr_est = fields.Char(
+    l10n_br_ie_code = fields.Char(
         tracking=True,
     )
 
@@ -117,7 +117,7 @@ class ResPartner(models.Model):
     def _onchange_ind_ie_dest(self):
         for p in self:
             if p.ind_ie_dest == NFE_IND_IE_DEST_9:
-                p.inscr_est = False
+                p.l10n_br_ie_code = False
                 p.state_tax_number_ids = False
 
     @api.model
@@ -128,6 +128,6 @@ class ResPartner(models.Model):
             "ind_ie_dest",
             "fiscal_profile_id",
             "ind_final",
-            "inscr_est",
+            "l10n_br_ie_code",
             "inscr_mun",
         ]

--- a/l10n_br_fiscal/tests/test_icms_regulation.py
+++ b/l10n_br_fiscal/tests/test_icms_regulation.py
@@ -61,8 +61,8 @@ class TestICMSRegulation(TransactionCase):
 
     def find_icms_tax(self, in_state_id, out_state_id, ncm_id, ind_final):
         self.partner.state_id = in_state_id
-        self.company.partner_id.inscr_est = False
-        self.company.inscr_est = False
+        self.company.partner_id.l10n_br_ie_code = False
+        self.company.l10n_br_ie_code = False
         self.company.state_id = out_state_id
         self.product.ncm_id = ncm_id
 

--- a/l10n_br_fiscal/views/document_related_view.xml
+++ b/l10n_br_fiscal/views/document_related_view.xml
@@ -64,7 +64,7 @@
                         attrs="{'required': [('document_type_code', 'in', ('01', '04'))], 'invisible': [('document_type_code', '=', '07')]}"
                     />
             <field
-                        name="inscr_est"
+                        name="l10n_br_ie_code"
                         attrs="{'invisible': [('document_type_code', '!=', '04')]}"
                     />
         </group>

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -309,7 +309,7 @@
                   <field name="company_legal_name" readonly="1" />
                   <field name="company_name" readonly="1" />
                   <field name="company_cnpj_cpf" readonly="1" />
-                  <field name="company_inscr_est" readonly="1" />
+                  <field name="company_l10n_br_ie_code" readonly="1" />
                   <field name="company_street" readonly="1" />
                   <field name="company_number" readonly="1" />
                   <field name="company_street2" readonly="1" />
@@ -337,7 +337,7 @@
                   <field name="partner_legal_name" readonly="1" />
                   <field name="partner_name" readonly="1" />
                   <field name="partner_cnpj_cpf" readonly="1" />
-                  <field name="partner_inscr_est" readonly="1" />
+                  <field name="partner_l10n_br_ie_code" readonly="1" />
                   <field name="partner_ind_ie_dest" readonly="1" />
                   <field name="partner_street" readonly="1" />
                   <field name="partner_number" readonly="1" />

--- a/l10n_br_hr/i18n/pt_BR.po
+++ b/l10n_br_hr/i18n/pt_BR.po
@@ -1689,7 +1689,7 @@ msgid "State"
 msgstr "Estado"
 
 #. module: l10n_br_hr
-#: model:ir.model.fields,field_description:l10n_br_hr.field_hr_employee_dependent__inscr_est
+#: model:ir.model.fields,field_description:l10n_br_hr.field_hr_employee_dependent__l10n_br_ie_code
 msgid "State Tax Number"
 msgstr "Número da Inscrição Estadual"
 

--- a/l10n_br_hr/models/hr_employee.py
+++ b/l10n_br_hr/models/hr_employee.py
@@ -57,7 +57,7 @@ class HrEmployee(models.Model):
     rg = fields.Char(
         string="RG",
         store=True,
-        related="address_home_id.inscr_est",
+        related="address_home_id.l10n_br_ie_code",
         help="National ID number",
         groups="hr.group_hr_user",
     )

--- a/l10n_br_ie_search/models/sefaz_webservice.py
+++ b/l10n_br_ie_search/models/sefaz_webservice.py
@@ -32,7 +32,7 @@ class SefazWebservice(models.AbstractModel):
             if "IE" in el.tag:
                 IE = el.text
         res = {
-            "inscr_est": IE,
+            "l10n_br_ie_code": IE,
         }
         return res
 
@@ -74,7 +74,7 @@ class SefazWebservice(models.AbstractModel):
     @api.model
     def _sintegra_import_data(self, data):
         res = {
-            "inscr_est": self.get_data(data, "inscricao_estadual"),
+            "l10n_br_ie_code": self.get_data(data, "inscricao_estadual"),
         }
         return res
 

--- a/l10n_br_ie_search/tests/test_sefaz.py
+++ b/l10n_br_ie_search/tests/test_sefaz.py
@@ -131,4 +131,4 @@ class TestSefaz(TransactionCase):
                 .create({})
             ).save()
             wizard.action_update_partner()
-            self.assertEqual(dummy.inscr_est, "528388258640")
+            self.assertEqual(dummy.l10n_br_ie_code, "528388258640")

--- a/l10n_br_ie_search/tests/test_sintegra.py
+++ b/l10n_br_ie_search/tests/test_sintegra.py
@@ -87,4 +87,4 @@ class TestSintegra(TransactionCase):
             self.env["partner.search.wizard"].with_context(**wizard_context).create({})
         ).save()
         wizard.action_update_partner()
-        self.assertEqual(dummy.inscr_est, "149848403115")
+        self.assertEqual(dummy.l10n_br_ie_code, "149848403115")

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -1511,7 +1511,7 @@ class NFe(spec_models.StackedModel):
 
     def _prepare_nfce_danfe_values(self):
         return {
-            "company_ie": self.company_id.inscr_est,
+            "company_ie": self.company_id.l10n_br_ie_code,
             "company_cnpj": self.company_id.cnpj_cpf,
             "company_legal_name": self.company_id.legal_name,
             "company_street": self.company_id.street,

--- a/l10n_br_nfe/models/document_related.py
+++ b/l10n_br_nfe/models/document_related.py
@@ -118,7 +118,7 @@ class NFeRelated(spec_models.StackedModel):
                         rec.nfe40_CPF = rec.cnpj_cpf
                     else:
                         rec.nfe40_CNPJ = rec.cnpj_cpf
-                    rec.nfe40_IE = rec.inscr_est
+                    rec.nfe40_IE = rec.l10n_br_ie_code
                     rec.nfe40_mod = rec.document_type_id.code
                     rec.nfe40_serie = document.document_serie
                     rec.nfe40_nNF = document.document_number

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -202,7 +202,7 @@ class ResPartner(spec_models.SpecModel):
         for rec in self:
             rec.nfe40_enderDest = rec.id
 
-    @api.depends("company_type", "inscr_est", "cnpj_cpf", "country_id")
+    @api.depends("company_type", "l10n_br_ie_code", "cnpj_cpf", "country_id")
     def _compute_nfe_data(self):
         """Set schema data which are not just related fields"""
         for rec in self:
@@ -236,8 +236,8 @@ class ResPartner(spec_models.SpecModel):
                 rec.nfe40_CNPJ = ""
                 rec.nfe40_CPF = ""
 
-            if rec.inscr_est:
-                rec.nfe40_IE = punctuation_rm(rec.inscr_est)
+            if rec.l10n_br_ie_code:
+                rec.nfe40_IE = punctuation_rm(rec.l10n_br_ie_code)
             else:
                 rec.nfe40_IE = None
 
@@ -276,7 +276,7 @@ class ResPartner(spec_models.SpecModel):
     def _inverse_nfe40_IE(self):
         for rec in self:
             if rec.nfe40_IE:
-                rec.inscr_est = str(rec.nfe40_IE)
+                rec.l10n_br_ie_code = str(rec.nfe40_IE)
 
     def _inverse_nfe40_CEP(self):
         for rec in self:

--- a/l10n_br_nfse/models/res_partner.py
+++ b/l10n_br_nfse/models/res_partner.py
@@ -37,7 +37,8 @@ class ResPartner(models.Model):
             "cpf": tomador_cpf,
             "email": email,
             "inscricao_municipal": misc.punctuation_rm(self.inscr_mun or "") or None,
-            "inscricao_estadual": misc.punctuation_rm(self.inscr_est or "") or None,
+            "inscricao_estadual": misc.punctuation_rm(self.l10n_br_ie_code or "")
+            or None,
             "razao_social": str(self.legal_name[:60] or ""),
             "endereco": str(self.street_name or self.street or ""),
             "numero": self.street_number or "",

--- a/l10n_br_nfse/tests/test_fiscal_document_nfse_common.py
+++ b/l10n_br_nfse/tests/test_fiscal_document_nfse_common.py
@@ -21,7 +21,7 @@ class TestFiscalDocumentNFSeCommon(TransactionCase):
 
         cls.company.processador_edoc = PROCESSADOR_OCA
         cls.company.partner_id.inscr_mun = "35172"
-        cls.company.partner_id.inscr_est = ""
+        cls.company.partner_id.l10n_br_ie_code = ""
         cls.company.partner_id.state_id = cls.env.ref("base.state_br_mg")
         cls.company.partner_id.city_id = cls.env.ref("l10n_br_base.city_3132404")
         cls.company.icms_regulation_id = cls.env.ref(

--- a/l10n_br_purchase/models/purchase_order.py
+++ b/l10n_br_purchase/models/purchase_order.py
@@ -48,7 +48,7 @@ class PurchaseOrder(models.Model):
 
     ie = fields.Char(
         string="State Tax Number/RG",
-        related="partner_id.inscr_est",
+        related="partner_id.l10n_br_ie_code",
     )
 
     comment_ids = fields.Many2many(

--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -58,7 +58,7 @@ class SaleOrder(models.Model):
 
     ie = fields.Char(
         string="State Tax Number/RG",
-        related="partner_id.inscr_est",
+        related="partner_id.l10n_br_ie_code",
     )
 
     discount_rate = fields.Float(

--- a/l10n_br_stock/README.rst
+++ b/l10n_br_stock/README.rst
@@ -70,7 +70,7 @@ Changelog
 14.0.2.0.0 (2022-06-07)
 -----------------------
 
--  [REF] Renomeado campo Inscrição Estadual de ie para inscr_est.
+-  [REF] Renomeado campo Inscrição Estadual de ie para l10n_br_ie_code.
 
 14.0.1.0.0 (2021-12-31)
 -----------------------

--- a/l10n_br_stock/i18n/es.po
+++ b/l10n_br_stock/i18n/es.po
@@ -64,7 +64,7 @@ msgid "Receipts"
 msgstr "Recibos"
 
 #. module: l10n_br_stock
-#: model:ir.model.fields,field_description:l10n_br_stock.field_stock_picking__inscr_est
+#: model:ir.model.fields,field_description:l10n_br_stock.field_stock_picking__l10n_br_ie_code
 msgid "State Tax Number"
 msgstr "Número de identificación fiscal estatal"
 

--- a/l10n_br_stock/i18n/l10n_br_stock.pot
+++ b/l10n_br_stock/i18n/l10n_br_stock.pot
@@ -61,7 +61,7 @@ msgid "Receipts"
 msgstr ""
 
 #. module: l10n_br_stock
-#: model:ir.model.fields,field_description:l10n_br_stock.field_stock_picking__inscr_est
+#: model:ir.model.fields,field_description:l10n_br_stock.field_stock_picking__l10n_br_ie_code
 msgid "State Tax Number"
 msgstr ""
 

--- a/l10n_br_stock/i18n/pt_BR.po
+++ b/l10n_br_stock/i18n/pt_BR.po
@@ -65,7 +65,7 @@ msgid "Receipts"
 msgstr "Recebimentos"
 
 #. module: l10n_br_stock
-#: model:ir.model.fields,field_description:l10n_br_stock.field_stock_picking__inscr_est
+#: model:ir.model.fields,field_description:l10n_br_stock.field_stock_picking__l10n_br_ie_code
 msgid "State Tax Number"
 msgstr "Número da Inscrição Estadual"
 

--- a/l10n_br_stock/models/stock_picking.py
+++ b/l10n_br_stock/models/stock_picking.py
@@ -9,4 +9,6 @@ class StockPicking(models.Model):
 
     cnpj_cpf = fields.Char(string="CNPJ/CPF", related="partner_id.cnpj_cpf")
     legal_name = fields.Char(string="Legal Name", related="partner_id.legal_name")
-    inscr_est = fields.Char(string="State Tax Number", related="partner_id.inscr_est")
+    l10n_br_ie_code = fields.Char(
+        string="State Tax Number", related="partner_id.l10n_br_ie_code"
+    )

--- a/l10n_br_stock/readme/HISTORY.md
+++ b/l10n_br_stock/readme/HISTORY.md
@@ -1,6 +1,6 @@
 ## 14.0.2.0.0 (2022-06-07)
 
-- \[REF\] Renomeado campo Inscrição Estadual de ie para inscr_est.
+- \[REF\] Renomeado campo Inscrição Estadual de ie para l10n_br_ie_code.
 
 ## 14.0.1.0.0 (2021-12-31)
 

--- a/l10n_br_stock/static/description/index.html
+++ b/l10n_br_stock/static/description/index.html
@@ -420,7 +420,7 @@ Social or&nbsp;Inscrição Estadual.</p>
 <div class="section" id="section-1">
 <h2><a class="toc-backref" href="#toc-entry-5">14.0.2.0.0 (2022-06-07)</a></h2>
 <ul class="simple">
-<li>[REF] Renomeado campo Inscrição Estadual de ie para inscr_est.</li>
+<li>[REF] Renomeado campo Inscrição Estadual de ie para l10n_br_ie_code.</li>
 </ul>
 </div>
 <div class="section" id="section-2">

--- a/l10n_br_stock/views/stock_picking_view.xml
+++ b/l10n_br_stock/views/stock_picking_view.xml
@@ -8,7 +8,7 @@
             <field name="name" position="after">
                 <field name="legal_name" />
                 <field name="cnpj_cpf" />
-                <field name="inscr_est" />
+                <field name="l10n_br_ie_code" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
WIP - a ideia é segurar esse PR até sincronizar mais coisas vindo da v14...
mudança do campo inscr_est -> l10n_br_ie_code para seguir o modelo de dados nativo da Odoo desde a v16 e até a v18:
https://github.com/odoo/odoo/blob/16.0/addons/l10n_br/models/res_partner.py

`find . -type f -exec sed -i 's/incr_est/l10n_br_ie_code/g' {} \;`

TODO botar um script de migração