### PR TITLE
[16.0][muitos modulos] - WIP: inscr_mun -> l10n_br_im_code

### DIFF
--- a/l10n_br_account/i18n/l10n_br_account.pot
+++ b/l10n_br_account/i18n/l10n_br_account.pot
@@ -766,7 +766,7 @@ msgid "Company Main CNAE"
 msgstr ""
 
 #. module: l10n_br_account
-#: model:ir.model.fields,field_description:l10n_br_account.field_account_move__company_inscr_mun
+#: model:ir.model.fields,field_description:l10n_br_account.field_account_move__company_l10n_br_im_code
 msgid "Company Municipal Tax Number"
 msgstr ""
 
@@ -2954,7 +2954,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_br_account
-#: model:ir.model.fields,field_description:l10n_br_account.field_account_move__partner_inscr_mun
+#: model:ir.model.fields,field_description:l10n_br_account.field_account_move__partner_l10n_br_im_code
 msgid "Municipal Tax Number"
 msgstr ""
 

--- a/l10n_br_account/i18n/pt_BR.po
+++ b/l10n_br_account/i18n/pt_BR.po
@@ -770,7 +770,7 @@ msgid "Company Main CNAE"
 msgstr "CNAE Principal da Empresa"
 
 #. module: l10n_br_account
-#: model:ir.model.fields,field_description:l10n_br_account.field_account_move__company_inscr_mun
+#: model:ir.model.fields,field_description:l10n_br_account.field_account_move__company_l10n_br_im_code
 msgid "Company Municipal Tax Number"
 msgstr "Número de Inscrição Municipal da Empresa"
 
@@ -2983,7 +2983,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_br_account
-#: model:ir.model.fields,field_description:l10n_br_account.field_account_move__partner_inscr_mun
+#: model:ir.model.fields,field_description:l10n_br_account.field_account_move__partner_l10n_br_im_code
 msgid "Municipal Tax Number"
 msgstr "Numero Inscrição Municipal"
 

--- a/l10n_br_base/demo/l10n_br_base_demo.xml
+++ b/l10n_br_base/demo/l10n_br_base_demo.xml
@@ -513,7 +513,7 @@
     <record id="res_partner_address_ak3" model="res.partner">
         <field name="title" ref="res_partner_title_pvt_ltd" />
         <field name="cnpj_cpf">11.034.414/0003-10</field>
-        <field name="inscr_mun">1448</field>
+        <field name="l10n_br_im_code">1448</field>
         <field eval="0" name="employee" />
         <field eval="1" name="active" />
         <field name="is_company" eval="1" />

--- a/l10n_br_base/i18n/l10n_br_base.pot
+++ b/l10n_br_base/i18n/l10n_br_base.pot
@@ -15901,10 +15901,10 @@ msgid "Munhoz de Melo"
 msgstr ""
 
 #. module: l10n_br_base
-#: model:ir.model.fields,field_description:l10n_br_base.field_l10n_br_base_party_mixin__inscr_mun
-#: model:ir.model.fields,field_description:l10n_br_base.field_res_company__inscr_mun
-#: model:ir.model.fields,field_description:l10n_br_base.field_res_partner__inscr_mun
-#: model:ir.model.fields,field_description:l10n_br_base.field_res_users__inscr_mun
+#: model:ir.model.fields,field_description:l10n_br_base.field_l10n_br_base_party_mixin__l10n_br_im_code
+#: model:ir.model.fields,field_description:l10n_br_base.field_res_company__l10n_br_im_code
+#: model:ir.model.fields,field_description:l10n_br_base.field_res_partner__l10n_br_im_code
+#: model:ir.model.fields,field_description:l10n_br_base.field_res_users__l10n_br_im_code
 msgid "Municipal Tax Number"
 msgstr ""
 

--- a/l10n_br_base/i18n/pt_BR.po
+++ b/l10n_br_base/i18n/pt_BR.po
@@ -15911,10 +15911,10 @@ msgid "Munhoz de Melo"
 msgstr "Munhoz de Melo"
 
 #. module: l10n_br_base
-#: model:ir.model.fields,field_description:l10n_br_base.field_l10n_br_base_party_mixin__inscr_mun
-#: model:ir.model.fields,field_description:l10n_br_base.field_res_company__inscr_mun
-#: model:ir.model.fields,field_description:l10n_br_base.field_res_partner__inscr_mun
-#: model:ir.model.fields,field_description:l10n_br_base.field_res_users__inscr_mun
+#: model:ir.model.fields,field_description:l10n_br_base.field_l10n_br_base_party_mixin__l10n_br_im_code
+#: model:ir.model.fields,field_description:l10n_br_base.field_res_company__l10n_br_im_code
+#: model:ir.model.fields,field_description:l10n_br_base.field_res_partner__l10n_br_im_code
+#: model:ir.model.fields,field_description:l10n_br_base.field_res_users__l10n_br_im_code
 msgid "Municipal Tax Number"
 msgstr "Número da Inscrição Municipal"
 

--- a/l10n_br_base/models/party_mixin.py
+++ b/l10n_br_base/models/party_mixin.py
@@ -43,7 +43,7 @@ class PartyMixin(models.AbstractModel):
         inverse_name="partner_id",
     )
 
-    inscr_mun = fields.Char(
+    l10n_br_im_code = fields.Char(
         string="Municipal Tax Number",
         size=18,
         unaccent=False,

--- a/l10n_br_base/models/res_company.py
+++ b/l10n_br_base/models/res_company.py
@@ -20,7 +20,7 @@ class Company(models.Model):
             "legal_name",
             "cnpj_cpf",
             "inscr_est",
-            "inscr_mun",
+            "l10n_br_im_code",
             "district",
             "city_id",
             "suframa",
@@ -72,10 +72,10 @@ class Company(models.Model):
                 state_tax_number_ids |= ies
             company.partner_id.state_tax_number_ids = state_tax_number_ids
 
-    def _inverse_inscr_mun(self):
+    def _inverse_l10n_br_im_code(self):
         """Write the l10n_br specific functional fields."""
         for company in self:
-            company.partner_id.inscr_mun = company.inscr_mun
+            company.partner_id.l10n_br_im_code = company.l10n_br_im_code
 
     def _inverse_city_id(self):
         """Write the l10n_br specific functional fields."""
@@ -133,9 +133,9 @@ class Company(models.Model):
         inverse="_inverse_state_tax_number_ids",
     )
 
-    inscr_mun = fields.Char(
+    l10n_br_im_code = fields.Char(
         compute="_compute_address",
-        inverse="_inverse_inscr_mun",
+        inverse="_inverse_l10n_br_im_code",
     )
 
     suframa = fields.Char(

--- a/l10n_br_base/tests/test_base_onchange.py
+++ b/l10n_br_base/tests/test_base_onchange.py
@@ -60,11 +60,11 @@ class L10nBrBaseOnchangeTest(TransactionCase):
         self.partner_01._onchange_state_id()
 
     def test_inverse_fields(self):
-        self.company_01.inscr_mun = "692015742119"
+        self.company_01.l10n_br_im_code = "692015742119"
         self.assertEqual(
-            self.company_01.partner_id.inscr_mun,
+            self.company_01.partner_id.l10n_br_im_code,
             "692015742119",
-            "The inverse function to field inscr_mun failed.",
+            "The inverse function to field l10n_br_im_code failed.",
         )
         self.company_01.suframa = "1234"
         self.assertEqual(

--- a/l10n_br_base/views/res_company_view.xml
+++ b/l10n_br_base/views/res_company_view.xml
@@ -30,7 +30,7 @@
                     attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
                 />
                 <field
-                    name="inscr_mun"
+                    name="l10n_br_im_code"
                     placeholder="Municipal Tax Number..."
                     attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
                 />

--- a/l10n_br_base/views/res_partner_view.xml
+++ b/l10n_br_base/views/res_partner_view.xml
@@ -91,7 +91,7 @@
                         <group string="Fiscal Infos" name="fiscal_numbers">
                             <field name="cei_code" />
                             <field
-                                name="inscr_mun"
+                                name="l10n_br_im_code"
                                 attrs="{'invisible': [('is_company','!=', True)]}"
                             />
                             <field

--- a/l10n_br_crm/i18n/es.po
+++ b/l10n_br_crm/i18n/es.po
@@ -92,7 +92,7 @@ msgid "Legal Nature"
 msgstr ""
 
 #. module: l10n_br_crm
-#: model:ir.model.fields,field_description:l10n_br_crm.field_crm_lead__inscr_mun
+#: model:ir.model.fields,field_description:l10n_br_crm.field_crm_lead__l10n_br_im_code
 msgid "Municipal Tax Number"
 msgstr "Número de identificación fiscal municipal"
 

--- a/l10n_br_crm/i18n/l10n_br_crm.pot
+++ b/l10n_br_crm/i18n/l10n_br_crm.pot
@@ -89,7 +89,7 @@ msgid "Legal Nature"
 msgstr ""
 
 #. module: l10n_br_crm
-#: model:ir.model.fields,field_description:l10n_br_crm.field_crm_lead__inscr_mun
+#: model:ir.model.fields,field_description:l10n_br_crm.field_crm_lead__l10n_br_im_code
 msgid "Municipal Tax Number"
 msgstr ""
 

--- a/l10n_br_crm/i18n/pt_BR.po
+++ b/l10n_br_crm/i18n/pt_BR.po
@@ -93,7 +93,7 @@ msgid "Legal Nature"
 msgstr "Natureza jurídica"
 
 #. module: l10n_br_crm
-#: model:ir.model.fields,field_description:l10n_br_crm.field_crm_lead__inscr_mun
+#: model:ir.model.fields,field_description:l10n_br_crm.field_crm_lead__l10n_br_im_code
 msgid "Municipal Tax Number"
 msgstr "Cod. Municipal"
 

--- a/l10n_br_crm/models/crm_lead.py
+++ b/l10n_br_crm/models/crm_lead.py
@@ -132,14 +132,16 @@ class Lead(models.Model):
                 result["legal_name"] = self.partner_id.legal_name
                 result["cnpj"] = self.partner_id.cnpj_cpf
                 result["inscr_est"] = self.partner_id.inscr_est
-                result["inscr_mun"] = self.partner_id.inscr_mun
+                result["l10n_br_im_code"] = self.partner_id.l10n_br_im_code
                 result["suframa"] = self.partner_id.suframa
             else:
                 result["partner_name"] = self.partner_id.parent_id.name or False
                 result["legal_name"] = self.partner_id.parent_id.legal_name or False
                 result["cnpj"] = self.partner_id.parent_id.cnpj_cpf or False
                 result["inscr_est"] = self.partner_id.parent_id.inscr_est or False
-                result["inscr_mun"] = self.partner_id.parent_id.inscr_mun or False
+                result["l10n_br_im_code"] = (
+                    self.partner_id.parent_id.l10n_br_im_code or False
+                )
                 result["suframa"] = self.partner_id.parent_id.suframa or False
                 result["website"] = self.partner_id.parent_id.website or False
                 result["cpf"] = self.partner_id.cnpj_cpf
@@ -170,7 +172,7 @@ class Lead(models.Model):
                 {
                     "cnpj_cpf": self.cnpj,
                     "inscr_est": self.inscr_est,
-                    "inscr_mun": self.inscr_mun,
+                    "l10n_br_im_code": self.l10n_br_im_code,
                     "suframa": self.suframa,
                 }
             )

--- a/l10n_br_crm/tests/test_crm_lead.py
+++ b/l10n_br_crm/tests/test_crm_lead.py
@@ -20,7 +20,7 @@ class CrmLeadTest(TransactionCase):
                 "stage_id": self.env.ref("crm.stage_lead1").id,
                 "partner_name": "Test Partner",
                 "inscr_est": "079.798.013.363",
-                "inscr_mun": "99999999",
+                "l10n_br_im_code": "99999999",
             }
         )
 
@@ -44,7 +44,7 @@ class CrmLeadTest(TransactionCase):
                 "stage_id": self.env.ref("crm.stage_lead1").id,
                 "partner_name": "Test Partner 1",
                 "inscr_est": "041.092.540.590",
-                "inscr_mun": "99999999",
+                "l10n_br_im_code": "99999999",
                 "country_id": self.env.ref("base.br").id,
                 "state_id": self.env.ref("base.state_br_sp").id,
             }
@@ -57,7 +57,7 @@ class CrmLeadTest(TransactionCase):
                 "legal_name": "Test Lead Partner",
                 "cnpj_cpf": "22.898.817/0001-61",
                 "inscr_est": "041.092.540.590",
-                "inscr_mun": "99999999",
+                "l10n_br_im_code": "99999999",
                 "suframa": "99999999",
                 "street_number": "1225",
                 "district": "centro",
@@ -119,7 +119,8 @@ class CrmLeadTest(TransactionCase):
             self.obj_partner.inscr_est, "The field Inscrição Estadual not was filled"
         )
         self.assertTrue(
-            self.obj_partner.inscr_mun, "The field Inscrição Municipal not was filled"
+            self.obj_partner.l10n_br_im_code,
+            "The field Inscrição Municipal not was filled",
         )
 
     def test_lead_won(self):
@@ -197,7 +198,8 @@ class CrmLeadTest(TransactionCase):
             self.obj_partner.inscr_est, "The field Inscrição Estadual not was filled"
         )
         self.assertTrue(
-            self.obj_partner.inscr_mun, "The field Inscrição Municipal not was filled"
+            self.obj_partner.l10n_br_im_code,
+            "The field Inscrição Municipal not was filled",
         )
         self.assertTrue(self.obj_partner.country_id, "The field Country not was filled")
         self.assertTrue(self.obj_partner.state_id, "The field State not was filled")
@@ -232,10 +234,10 @@ class CrmLeadTest(TransactionCase):
         )
 
         self.assertEqual(
-            self.crm_lead_company_1.inscr_mun,
+            self.crm_lead_company_1.l10n_br_im_code,
             "99999999",
             "In the change of the partner \
-                         the field inscr_mun was not automatically filled.",
+                         the field l10n_br_im_code was not automatically filled.",
         )
 
         self.assertEqual(

--- a/l10n_br_crm/views/crm_lead_view.xml
+++ b/l10n_br_crm/views/crm_lead_view.xml
@@ -49,7 +49,7 @@
                 position="before"
             >
                 <field
-                    name="inscr_mun"
+                    name="l10n_br_im_code"
                     attrs="{'invisible': [('show_l10n_br', '=', False)]}"
                 />
                 <field
@@ -80,7 +80,7 @@
                 position='before'
             >
                 <field
-                    name="inscr_mun"
+                    name="l10n_br_im_code"
                     attrs="{'invisible': [('show_l10n_br', '=', False)]}"
                 />
                 <field

--- a/l10n_br_crm/views/crm_quick_create_opportunity_form.xml
+++ b/l10n_br_crm/views/crm_quick_create_opportunity_form.xml
@@ -10,7 +10,7 @@
                 <field name="legal_name" invisible="1" />
                 <field name="cnpj" invisible="1" />
                 <field name="inscr_est" invisible="1" />
-                <field name="inscr_mun" invisible="1" />
+                <field name="l10n_br_im_code" invisible="1" />
                 <field name="suframa" invisible="1" />
                 <field name="name_surname" invisible="1" />
                 <field name="cpf" invisible="1" />

--- a/l10n_br_fiscal/i18n/l10n_br_fiscal.pot
+++ b/l10n_br_fiscal/i18n/l10n_br_fiscal.pot
@@ -1852,8 +1852,8 @@ msgid "Company Main CNAE"
 msgstr ""
 
 #. module: l10n_br_fiscal
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document__company_inscr_mun
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_move_mixin__company_inscr_mun
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document__company_l10n_br_im_code
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_move_mixin__company_l10n_br_im_code
 msgid "Company Municipal Tax Number"
 msgstr ""
 
@@ -5690,10 +5690,10 @@ msgid "Move Settings"
 msgstr ""
 
 #. module: l10n_br_fiscal
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document__partner_inscr_mun
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_move_mixin__partner_inscr_mun
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_res_partner__inscr_mun
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_res_users__inscr_mun
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document__partner_l10n_br_im_code
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_move_mixin__partner_l10n_br_im_code
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_res_partner__l10n_br_im_code
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_res_users__l10n_br_im_code
 msgid "Municipal Tax Number"
 msgstr ""
 

--- a/l10n_br_fiscal/i18n/pt_BR.po
+++ b/l10n_br_fiscal/i18n/pt_BR.po
@@ -1914,8 +1914,8 @@ msgid "Company Main CNAE"
 msgstr "CNAE Principal da Empresa"
 
 #. module: l10n_br_fiscal
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document__company_inscr_mun
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_move_mixin__company_inscr_mun
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document__company_l10n_br_im_code
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_move_mixin__company_l10n_br_im_code
 msgid "Company Municipal Tax Number"
 msgstr "Número de Impostos Municipais da Empresa"
 
@@ -5768,10 +5768,10 @@ msgid "Move Settings"
 msgstr "Configurações de movimento"
 
 #. module: l10n_br_fiscal
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document__partner_inscr_mun
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_move_mixin__partner_inscr_mun
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_res_partner__inscr_mun
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_res_users__inscr_mun
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document__partner_l10n_br_im_code
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_move_mixin__partner_l10n_br_im_code
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_res_partner__l10n_br_im_code
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_res_users__l10n_br_im_code
 msgid "Municipal Tax Number"
 msgstr "Número de Impostos Municipais"
 

--- a/l10n_br_fiscal/models/document_move_mixin.py
+++ b/l10n_br_fiscal/models/document_move_mixin.py
@@ -42,9 +42,9 @@ class DocumentMoveMixin(models.AbstractModel):
         related="partner_id.ind_ie_dest",
     )
 
-    partner_inscr_mun = fields.Char(
+    partner_l10n_br_im_code = fields.Char(
         string="Municipal Tax Number",
-        related="partner_id.inscr_mun",
+        related="partner_id.l10n_br_im_code",
     )
 
     partner_suframa = fields.Char(
@@ -145,9 +145,9 @@ class DocumentMoveMixin(models.AbstractModel):
         related="company_id.inscr_est",
     )
 
-    company_inscr_mun = fields.Char(
+    company_l10n_br_im_code = fields.Char(
         string="Company Municipal Tax Number",
-        related="company_id.inscr_mun",
+        related="company_id.l10n_br_im_code",
     )
 
     company_suframa = fields.Char(

--- a/l10n_br_fiscal/models/res_partner.py
+++ b/l10n_br_fiscal/models/res_partner.py
@@ -80,7 +80,7 @@ class ResPartner(models.Model):
         tracking=True,
     )
 
-    inscr_mun = fields.Char(
+    l10n_br_im_code = fields.Char(
         tracking=True,
     )
 
@@ -129,5 +129,5 @@ class ResPartner(models.Model):
             "fiscal_profile_id",
             "ind_final",
             "inscr_est",
-            "inscr_mun",
+            "l10n_br_im_code",
         ]

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -316,7 +316,7 @@
                   <field name="company_district" readonly="1" />
                 </group>
                 <group name="company_right">
-                  <field name="company_inscr_mun" readonly="1" />
+                  <field name="company_l10n_br_im_code" readonly="1" />
                   <field name="company_suframa" readonly="1" />
                   <field name="company_cnae_main_id" readonly="1" />
                   <field name="company_tax_framework" readonly="1" />
@@ -345,7 +345,7 @@
                   <field name="partner_district" readonly="1" />
                 </group>
                 <group name="partner_right">
-                  <field name="partner_inscr_mun" readonly="1" />
+                  <field name="partner_l10n_br_im_code" readonly="1" />
                   <field name="partner_suframa" readonly="1" />
                   <field name="partner_cnae_main_id" readonly="1" />
                   <field name="partner_tax_framework" readonly="1" />

--- a/l10n_br_hr/i18n/pt_BR.po
+++ b/l10n_br_hr/i18n/pt_BR.po
@@ -1248,7 +1248,7 @@ msgid "Mother Name"
 msgstr "Nome da mãe"
 
 #. module: l10n_br_hr
-#: model:ir.model.fields,field_description:l10n_br_hr.field_hr_employee_dependent__inscr_mun
+#: model:ir.model.fields,field_description:l10n_br_hr.field_hr_employee_dependent__l10n_br_im_code
 msgid "Municipal Tax Number"
 msgstr "Número da Inscrição Municipal"
 

--- a/l10n_br_nfse/models/document.py
+++ b/l10n_br_nfse/models/document.py
@@ -107,7 +107,7 @@ class Document(models.Model):
             cidade_ibge=int(self.company_id.partner_id.city_id.ibge_code),
             cnpj_prestador=misc.punctuation_rm(self.company_id.partner_id.cnpj_cpf),
             im_prestador=misc.punctuation_rm(
-                self.company_id.partner_id.inscr_mun or ""
+                self.company_id.partner_id.l10n_br_im_code or ""
             ),
         )
 
@@ -239,7 +239,7 @@ class Document(models.Model):
         return {
             "cnpj": misc.punctuation_rm(self.company_id.partner_id.cnpj_cpf),
             "inscricao_municipal": misc.punctuation_rm(
-                self.company_id.partner_id.inscr_mun or ""
+                self.company_id.partner_id.l10n_br_im_code or ""
             )
             or None,
             "id": "rps" + str(num_rps),

--- a/l10n_br_nfse/models/res_partner.py
+++ b/l10n_br_nfse/models/res_partner.py
@@ -36,7 +36,8 @@ class ResPartner(models.Model):
             "cnpj": tomador_cnpj,
             "cpf": tomador_cpf,
             "email": email,
-            "inscricao_municipal": misc.punctuation_rm(self.inscr_mun or "") or None,
+            "inscricao_municipal": misc.punctuation_rm(self.l10n_br_im_code or "")
+            or None,
             "inscricao_estadual": misc.punctuation_rm(self.inscr_est or "") or None,
             "razao_social": str(self.legal_name[:60] or ""),
             "endereco": str(self.street_name or self.street or ""),

--- a/l10n_br_nfse/report/danfse.xml
+++ b/l10n_br_nfse/report/danfse.xml
@@ -218,7 +218,7 @@ row {
                             Insc. Municipal
                         </div>
                         <div class="col-2 linha centro bl bb">
-                            <span t-field="doc.company_id.inscr_mun" />
+                            <span t-field="doc.company_id.l10n_br_im_code" />
                         </div>
                         <div class="col-1 rotulo bl bb">
                             Município
@@ -289,7 +289,7 @@ row {
                     Insc. Municipal
                 </div>
                 <div class="col-2 linha centro br">
-                    <span t-field="doc.partner_id.inscr_mun" />
+                    <span t-field="doc.partner_id.l10n_br_im_code" />
                 </div>
                 <div class="col-1 rotulo br">
                     Município

--- a/l10n_br_nfse/tests/test_fiscal_document_nfse_common.py
+++ b/l10n_br_nfse/tests/test_fiscal_document_nfse_common.py
@@ -20,7 +20,7 @@ class TestFiscalDocumentNFSeCommon(TransactionCase):
         cls.company = cls.env.ref("l10n_br_base.empresa_simples_nacional")
 
         cls.company.processador_edoc = PROCESSADOR_OCA
-        cls.company.partner_id.inscr_mun = "35172"
+        cls.company.partner_id.l10n_br_im_code = "35172"
         cls.company.partner_id.inscr_est = ""
         cls.company.partner_id.state_id = cls.env.ref("base.state_br_mg")
         cls.company.partner_id.city_id = cls.env.ref("l10n_br_base.city_3132404")


### PR DESCRIPTION
WIP - a ideia é segurar esse PR até sincronizar mais coisas vindo da v14...
mudança do campo inscr_mun -> l10n_br_im_code para seguir o modelo de dados nativo da Odoo desde a v16 e até a v18:
https://github.com/odoo/odoo/blob/16.0/addons/l10n_br/models/res_partner.py

`find . -type f -exec sed -i 's/incr_mun/l10n_br_im_code/g' {} \;`

TODO botar um script de migração
