### PR TITLE
[16.0][l10n_br_base][l10n_br_fiscal][l10n_br_crm][l10n_br_nfe][l10n_br_hr] - WIP: suframa -> l10n_br_isuf_code

### DIFF
--- a/l10n_br_base/demo/l10n_br_base_demo.xml
+++ b/l10n_br_base/demo/l10n_br_base_demo.xml
@@ -72,7 +72,7 @@
         <field name="phone">(92) 2129-8710</field>
         <field name="email">teste@teste.com.br</field>
         <field name="inscr_est">86.015.623-0</field>
-        <field name="suframa">550309012</field>
+        <field name="l10n_br_isuf_code">550309012</field>
         <field name="is_company" eval="1" />
         <field name="active" eval="1" />
     </record>
@@ -96,7 +96,7 @@
         <field name="phone">(81) 1111-1111</field>
         <field name="email">teste@teste.com.br</field>
         <field name="inscr_est">4386525-92</field>
-        <field name="suframa" />
+        <field name="l10n_br_isuf_code" />
         <field name="is_company" eval="1" />
         <field name="active" eval="1" />
     </record>
@@ -120,7 +120,7 @@
         <field name="phone">(41) 3316-7700</field>
         <field name="email">teste@teste.com.br</field>
         <field name="inscr_est">80320143-90</field>
-        <field name="suframa" />
+        <field name="l10n_br_isuf_code" />
         <field name="is_company" eval="1" />
         <field name="active" eval="1" />
     </record>
@@ -144,7 +144,7 @@
         <field name="phone">(51) 3320-3500</field>
         <field name="email">teste@teste.com.br</field>
         <field name="inscr_est">074/2864251</field>
-        <field name="suframa" />
+        <field name="l10n_br_isuf_code" />
         <field name="is_company" eval="1" />
         <field name="active" eval="1" />
     </record>
@@ -168,7 +168,7 @@
         <field name="phone">(71) 3321-9652</field>
         <field name="email">teste@teste.com.br</field>
         <field name="inscr_est">2004915-45</field>
-        <field name="suframa" />
+        <field name="l10n_br_isuf_code" />
         <field name="is_company" eval="1" />
         <field name="active" eval="1" />
     </record>
@@ -192,7 +192,7 @@
         <field name="phone">(92) 2129-8720</field>
         <field name="email">teste@teste.com.br</field>
         <field name="inscr_est">78.002.376-5</field>
-        <field name="suframa">101160100</field>
+        <field name="l10n_br_isuf_code">101160100</field>
         <field name="is_company" eval="1" />
         <field name="active" eval="1" />
     </record>
@@ -294,7 +294,7 @@
         <field name="phone">(92) 2145-9999</field>
         <field name="email">cliente3@cliente3.com.br</field>
         <field name="inscr_est">78.217.504-0</field>
-        <field name="suframa">101362102</field>
+        <field name="l10n_br_isuf_code">101362102</field>
         <field name="is_company" eval="1" />
         <field name="active" eval="1" />
     </record>
@@ -318,7 +318,7 @@
         <field name="phone">(92) 2145-8888</field>
         <field name="email">cliente4@cliente4.com.br</field>
         <field name="inscr_est">09.569.321-1</field>
-        <field name="suframa">100695108</field>
+        <field name="l10n_br_isuf_code">100695108</field>
         <field name="is_company" eval="1" />
         <field name="active" eval="1" />
     </record>
@@ -342,7 +342,7 @@
         <field name="phone">(81) 1111-1111</field>
         <field name="email">cliente5@cliente5.com.br</field>
         <field name="inscr_est">8700737-10</field>
-        <field name="suframa" />
+        <field name="l10n_br_isuf_code" />
         <field name="is_company" eval="1" />
         <field name="active" eval="1" />
     </record>
@@ -366,7 +366,7 @@
         <field name="phone">(81) 1111-1111</field>
         <field name="email">cliente6@cliente6.com.br</field>
         <field name="inscr_est">7055493-56</field>
-        <field name="suframa" />
+        <field name="l10n_br_isuf_code" />
         <field name="is_company" eval="1" />
         <field name="active" eval="1" />
     </record>
@@ -390,7 +390,7 @@
         <field name="phone">(51) 3320-7777</field>
         <field name="email">cliente7@cliente7.com.br</field>
         <field name="inscr_est">176/1256758</field>
-        <field name="suframa" />
+        <field name="l10n_br_isuf_code" />
         <field name="is_company" eval="1" />
         <field name="active" eval="1" />
     </record>
@@ -446,7 +446,7 @@
         <field name="phone">(51) 3320-8888</field>
         <field name="email">cliente8@cliente8.com.br</field>
         <field name="inscr_est">383/4127240</field>
-        <field name="suframa" />
+        <field name="l10n_br_isuf_code" />
         <field name="is_company" eval="1" />
         <field name="active" eval="1" />
     </record>
@@ -555,7 +555,7 @@
         <field name="website">www.cliente9.com.br</field>
         <field name="phone">(35) 3622-7085</field>
         <field name="email">cliente9@cliente9.com.br</field>
-        <field name="suframa" />
+        <field name="l10n_br_isuf_code" />
         <field name="is_company" eval="1" />
         <field name="active" eval="1" />
     </record>
@@ -578,7 +578,7 @@
         <field name="website">www.cliente10.com.br</field>
         <field name="phone">(35) 3622-7085</field>
         <field name="email">cliente10@cliente10.com.br</field>
-        <field name="suframa" />
+        <field name="l10n_br_isuf_code" />
         <field name="is_company" eval="0" />
         <field name="active" eval="1" />
     </record>
@@ -644,7 +644,7 @@
         <field name="website">www.cliente11.com.br</field>
         <field name="phone">(11) 3881-7417</field>
         <field name="email">cliente11@cliente11.com.br</field>
-        <field name="suframa" />
+        <field name="l10n_br_isuf_code" />
         <field name="is_company" eval="0" />
         <field name="active" eval="1" />
     </record>

--- a/l10n_br_base/i18n/l10n_br_base.pot
+++ b/l10n_br_base/i18n/l10n_br_base.pot
@@ -23390,10 +23390,10 @@ msgid "Sud Mennucci"
 msgstr ""
 
 #. module: l10n_br_base
-#: model:ir.model.fields,field_description:l10n_br_base.field_l10n_br_base_party_mixin__suframa
-#: model:ir.model.fields,field_description:l10n_br_base.field_res_company__suframa
-#: model:ir.model.fields,field_description:l10n_br_base.field_res_partner__suframa
-#: model:ir.model.fields,field_description:l10n_br_base.field_res_users__suframa
+#: model:ir.model.fields,field_description:l10n_br_base.field_l10n_br_base_party_mixin__l10n_br_isuf_code
+#: model:ir.model.fields,field_description:l10n_br_base.field_res_company__l10n_br_isuf_code
+#: model:ir.model.fields,field_description:l10n_br_base.field_res_partner__l10n_br_isuf_code
+#: model:ir.model.fields,field_description:l10n_br_base.field_res_users__l10n_br_isuf_code
 #: model_terms:ir.ui.view,arch_db:l10n_br_base.l10n_br_base_res_company_form
 msgid "Suframa"
 msgstr ""

--- a/l10n_br_base/i18n/pt_BR.po
+++ b/l10n_br_base/i18n/pt_BR.po
@@ -23400,10 +23400,10 @@ msgid "Sud Mennucci"
 msgstr "Sud Mennucci"
 
 #. module: l10n_br_base
-#: model:ir.model.fields,field_description:l10n_br_base.field_l10n_br_base_party_mixin__suframa
-#: model:ir.model.fields,field_description:l10n_br_base.field_res_company__suframa
-#: model:ir.model.fields,field_description:l10n_br_base.field_res_partner__suframa
-#: model:ir.model.fields,field_description:l10n_br_base.field_res_users__suframa
+#: model:ir.model.fields,field_description:l10n_br_base.field_l10n_br_base_party_mixin__l10n_br_isuf_code
+#: model:ir.model.fields,field_description:l10n_br_base.field_res_company__l10n_br_isuf_code
+#: model:ir.model.fields,field_description:l10n_br_base.field_res_partner__l10n_br_isuf_code
+#: model:ir.model.fields,field_description:l10n_br_base.field_res_users__l10n_br_isuf_code
 #: model_terms:ir.ui.view,arch_db:l10n_br_base.l10n_br_base_res_company_form
 msgid "Suframa"
 msgstr "Suframa"

--- a/l10n_br_base/models/party_mixin.py
+++ b/l10n_br_base/models/party_mixin.py
@@ -49,7 +49,7 @@ class PartyMixin(models.AbstractModel):
         unaccent=False,
     )
 
-    suframa = fields.Char(
+    l10n_br_isuf_code = fields.Char(
         size=18,
         unaccent=False,
     )

--- a/l10n_br_base/models/res_company.py
+++ b/l10n_br_base/models/res_company.py
@@ -23,7 +23,7 @@ class Company(models.Model):
             "inscr_mun",
             "district",
             "city_id",
-            "suframa",
+            "l10n_br_isuf_code",
             "state_tax_number_ids",
             "street_number",
             "street_name",
@@ -82,10 +82,10 @@ class Company(models.Model):
         for company in self:
             company.partner_id.city_id = company.city_id
 
-    def _inverse_suframa(self):
+    def _inverse_l10n_br_isuf_code(self):
         """Write the l10n_br specific functional fields."""
         for company in self:
-            company.partner_id.suframa = company.suframa
+            company.partner_id.l10n_br_isuf_code = company.l10n_br_isuf_code
 
     legal_name = fields.Char(
         compute="_compute_address",
@@ -138,9 +138,9 @@ class Company(models.Model):
         inverse="_inverse_inscr_mun",
     )
 
-    suframa = fields.Char(
+    l10n_br_isuf_code = fields.Char(
         compute="_compute_address",
-        inverse="_inverse_suframa",
+        inverse="_inverse_l10n_br_isuf_code",
     )
 
     @api.model

--- a/l10n_br_base/tests/test_base_onchange.py
+++ b/l10n_br_base/tests/test_base_onchange.py
@@ -66,11 +66,11 @@ class L10nBrBaseOnchangeTest(TransactionCase):
             "692015742119",
             "The inverse function to field inscr_mun failed.",
         )
-        self.company_01.suframa = "1234"
+        self.company_01.l10n_br_isuf_code = "1234"
         self.assertEqual(
-            self.company_01.partner_id.suframa,
+            self.company_01.partner_id.l10n_br_isuf_code,
             "1234",
-            "The inverse function to field suframa failed.",
+            "The inverse function to field l10n_br_isuf_code failed.",
         )
 
     def test_display_address(self):

--- a/l10n_br_base/views/res_company_view.xml
+++ b/l10n_br_base/views/res_company_view.xml
@@ -35,7 +35,7 @@
                     attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
                 />
                 <field
-                    name="suframa"
+                    name="l10n_br_isuf_code"
                     placeholder="Suframa"
                     attrs="{'invisible': [('state_id', '!=', %(base.state_br_am)d)]}"
                 />

--- a/l10n_br_base/views/res_partner_view.xml
+++ b/l10n_br_base/views/res_partner_view.xml
@@ -95,7 +95,7 @@
                                 attrs="{'invisible': [('is_company','!=', True)]}"
                             />
                             <field
-                                name="suframa"
+                                name="l10n_br_isuf_code"
                                 attrs="{'invisible': [('is_company','!=', True)]}"
                             />
                             <field

--- a/l10n_br_crm/i18n/es.po
+++ b/l10n_br_crm/i18n/es.po
@@ -137,7 +137,7 @@ msgid "Street Number"
 msgstr "Número de la calle"
 
 #. module: l10n_br_crm
-#: model:ir.model.fields,field_description:l10n_br_crm.field_crm_lead__suframa
+#: model:ir.model.fields,field_description:l10n_br_crm.field_crm_lead__l10n_br_isuf_code
 msgid "Suframa"
 msgstr "Subframa"
 

--- a/l10n_br_crm/i18n/l10n_br_crm.pot
+++ b/l10n_br_crm/i18n/l10n_br_crm.pot
@@ -134,7 +134,7 @@ msgid "Street Number"
 msgstr ""
 
 #. module: l10n_br_crm
-#: model:ir.model.fields,field_description:l10n_br_crm.field_crm_lead__suframa
+#: model:ir.model.fields,field_description:l10n_br_crm.field_crm_lead__l10n_br_isuf_code
 msgid "Suframa"
 msgstr ""
 

--- a/l10n_br_crm/i18n/pt_BR.po
+++ b/l10n_br_crm/i18n/pt_BR.po
@@ -138,7 +138,7 @@ msgid "Street Number"
 msgstr "Número"
 
 #. module: l10n_br_crm
-#: model:ir.model.fields,field_description:l10n_br_crm.field_crm_lead__suframa
+#: model:ir.model.fields,field_description:l10n_br_crm.field_crm_lead__l10n_br_isuf_code
 msgid "Suframa"
 msgstr "Suframa"
 

--- a/l10n_br_crm/models/crm_lead.py
+++ b/l10n_br_crm/models/crm_lead.py
@@ -133,14 +133,16 @@ class Lead(models.Model):
                 result["cnpj"] = self.partner_id.cnpj_cpf
                 result["inscr_est"] = self.partner_id.inscr_est
                 result["inscr_mun"] = self.partner_id.inscr_mun
-                result["suframa"] = self.partner_id.suframa
+                result["l10n_br_isuf_code"] = self.partner_id.l10n_br_isuf_code
             else:
                 result["partner_name"] = self.partner_id.parent_id.name or False
                 result["legal_name"] = self.partner_id.parent_id.legal_name or False
                 result["cnpj"] = self.partner_id.parent_id.cnpj_cpf or False
                 result["inscr_est"] = self.partner_id.parent_id.inscr_est or False
                 result["inscr_mun"] = self.partner_id.parent_id.inscr_mun or False
-                result["suframa"] = self.partner_id.parent_id.suframa or False
+                result["l10n_br_isuf_code"] = (
+                    self.partner_id.parent_id.l10n_br_isuf_code or False
+                )
                 result["website"] = self.partner_id.parent_id.website or False
                 result["cpf"] = self.partner_id.cnpj_cpf
                 result["rg"] = self.partner_id.rg
@@ -171,7 +173,7 @@ class Lead(models.Model):
                     "cnpj_cpf": self.cnpj,
                     "inscr_est": self.inscr_est,
                     "inscr_mun": self.inscr_mun,
-                    "suframa": self.suframa,
+                    "l10n_br_isuf_code": self.l10n_br_isuf_code,
                 }
             )
         else:

--- a/l10n_br_crm/tests/test_crm_lead.py
+++ b/l10n_br_crm/tests/test_crm_lead.py
@@ -58,7 +58,7 @@ class CrmLeadTest(TransactionCase):
                 "cnpj_cpf": "22.898.817/0001-61",
                 "inscr_est": "041.092.540.590",
                 "inscr_mun": "99999999",
-                "suframa": "99999999",
+                "l10n_br_isuf_code": "99999999",
                 "street_number": "1225",
                 "district": "centro",
                 "city_id": self.env.ref("l10n_br_base.city_4205407").id,
@@ -239,10 +239,10 @@ class CrmLeadTest(TransactionCase):
         )
 
         self.assertEqual(
-            self.crm_lead_company_1.suframa,
+            self.crm_lead_company_1.l10n_br_isuf_code,
             "99999999",
             "In the change of the partner \
-                         the field suframa was not automatically filled.",
+                         the field l10n_br_isuf_code was not automatically filled.",
         )
 
         self.assertEqual(

--- a/l10n_br_crm/views/crm_lead_view.xml
+++ b/l10n_br_crm/views/crm_lead_view.xml
@@ -53,7 +53,7 @@
                     attrs="{'invisible': [('show_l10n_br', '=', False)]}"
                 />
                 <field
-                    name="suframa"
+                    name="l10n_br_isuf_code"
                     attrs="{'invisible': [('show_l10n_br', '=', False)]}"
                 />
             </xpath>
@@ -84,7 +84,7 @@
                     attrs="{'invisible': [('show_l10n_br', '=', False)]}"
                 />
                 <field
-                    name="suframa"
+                    name="l10n_br_isuf_code"
                     attrs="{'invisible': [('show_l10n_br', '=', False)]}"
                 />
             </xpath>

--- a/l10n_br_crm/views/crm_quick_create_opportunity_form.xml
+++ b/l10n_br_crm/views/crm_quick_create_opportunity_form.xml
@@ -11,7 +11,7 @@
                 <field name="cnpj" invisible="1" />
                 <field name="inscr_est" invisible="1" />
                 <field name="inscr_mun" invisible="1" />
-                <field name="suframa" invisible="1" />
+                <field name="l10n_br_isuf_code" invisible="1" />
                 <field name="name_surname" invisible="1" />
                 <field name="cpf" invisible="1" />
                 <field name="rg" invisible="1" />

--- a/l10n_br_fiscal/models/document_move_mixin.py
+++ b/l10n_br_fiscal/models/document_move_mixin.py
@@ -49,7 +49,7 @@ class DocumentMoveMixin(models.AbstractModel):
 
     partner_suframa = fields.Char(
         string="Suframa",
-        related="partner_id.suframa",
+        related="partner_id.l10n_br_isuf_code",
     )
 
     partner_cnae_main_id = fields.Many2one(
@@ -152,7 +152,7 @@ class DocumentMoveMixin(models.AbstractModel):
 
     company_suframa = fields.Char(
         string="Company Suframa",
-        related="company_id.suframa",
+        related="company_id.l10n_br_isuf_code",
     )
 
     company_cnae_main_id = fields.Many2one(

--- a/l10n_br_hr/i18n/pt_BR.po
+++ b/l10n_br_hr/i18n/pt_BR.po
@@ -1727,7 +1727,7 @@ msgid "Street2"
 msgstr "Complemento"
 
 #. module: l10n_br_hr
-#: model:ir.model.fields,field_description:l10n_br_hr.field_hr_employee_dependent__suframa
+#: model:ir.model.fields,field_description:l10n_br_hr.field_hr_employee_dependent__l10n_br_isuf_code
 msgid "Suframa"
 msgstr "Suframa"
 

--- a/l10n_br_hr/views/res_company_view.xml
+++ b/l10n_br_hr/views/res_company_view.xml
@@ -6,7 +6,7 @@
         <field name="model">res.company</field>
         <field name="inherit_id" ref="l10n_br_base.l10n_br_base_res_company_form" />
         <field name="arch" type="xml">
-            <field name="suframa" position="after">
+            <field name="l10n_br_isuf_code" position="after">
                 <field name="cnpj_cei" />
             </field>
         </field>

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -134,7 +134,7 @@ class ResPartner(spec_models.SpecModel):
         inverse="_inverse_nfe40_IE",
         compute_sudo=True,
     )
-    nfe40_ISUF = fields.Char(related="suframa")
+    nfe40_ISUF = fields.Char(related="l10n_br_isuf_code")
     nfe40_email = fields.Char(related="email")
     nfe40_xEnder = fields.Char(compute="_compute_nfe40_xEnder")
 


### PR DESCRIPTION
WIP - a ideia é segurar esse PR até sincronizar mais coisas vindo da v14...
mudança do campo suframa -> l10n_br_isuf_code para seguir o modelo de dados nativo da Odoo desde a v16 e até a v18:
https://github.com/odoo/odoo/blob/16.0/addons/l10n_br/models/res_partner.py

`find . -type f -exec sed -i 's/suframa/l10n_br_isuf_code/g' {} ;`

TODO botar um script de migração
