### PR TITLE
[14.0][FIX] l10n_br_fiscal_edi: fix warnings - bp 3400

### DIFF
--- a/l10n_br_fiscal_edi/__manifest__.py
+++ b/l10n_br_fiscal_edi/__manifest__.py
@@ -20,11 +20,9 @@
         "views/document_view.xml",
         "views/invalidate_number_view.xml",
         "views/document_event_view.xml",
-        "views/document_event_report.xml",
         "views/document_event_template.xml",
         # Reports
         "views/document_event_report.xml",
-        "views/document_event_template.xml",
         # Wizards
         "wizards/document_cancel_wizard.xml",
         "wizards/document_correction_wizard.xml",

--- a/l10n_br_fiscal_edi/security/ir.model.access.csv
+++ b/l10n_br_fiscal_edi/security/ir.model.access.csv
@@ -1,7 +1,8 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
-"l10n_br_fiscal_event_user","Fiscal Document Event for User","model_l10n_br_fiscal_event","l10n_br_fiscal.group_user",1,1,1,0
-"l10n_br_fiscal_invalidate_number_user","user_l10n_br_fiscal_invalidate_number","model_l10n_br_fiscal_invalidate_number","l10n_br_fiscal.group_user",1,0,0,0
-"l10n_br_fiscal_invalidate_number_manager","manager_l10n_br_fiscal_invalidate_number","model_l10n_br_fiscal_invalidate_number","l10n_br_fiscal.group_manager",1,1,1,1
+"l10n_br_fiscal_event_user","Fiscal Document Event for User",model_l10n_br_fiscal_event,l10n_br_fiscal.group_user,1,1,1,0
+"l10n_br_fiscal_invalidate_number_user","user_l10n_br_fiscal_invalidate_number",model_l10n_br_fiscal_invalidate_number,l10n_br_fiscal.group_user,1,0,0,0
+"l10n_br_fiscal_invalidate_number_manager","manager_l10n_br_fiscal_invalidate_number",model_l10n_br_fiscal_invalidate_number,l10n_br_fiscal.group_manager,1,1,1,1
+"l10n_br_fiscal_invalidate_number_wizard_user",l10n_br_fiscal_invalidate_number_wizard,model_l10n_br_fiscal_invalidate_number_wizard,base.group_user,1,1,1,1
 "l10n_br_fiscal_document_cancel_wizard_user",l10n_br_fiscal_document_cancel_wizard,model_l10n_br_fiscal_document_cancel_wizard,base.group_user,1,1,1,1
 "l10n_br_fiscal_document_correction_wizard_user",l10n_br_fiscal_document_correction_wizard,model_l10n_br_fiscal_document_correction_wizard,base.group_user,1,1,1,1
 "l10n_br_fiscal_document_import_wizard_mixin_user",l10n_br_fiscal_document_import_wizard_mixin_user,model_l10n_br_fiscal_document_import_wizard_mixin,base.group_user,1,1,1,1

--- a/l10n_br_fiscal_edi/views/document_view.xml
+++ b/l10n_br_fiscal_edi/views/document_view.xml
@@ -51,6 +51,7 @@
                                 <field name="state" />
                                 <button
                                         name="print_document_event"
+                                        title="Print Document Event"
                                         icon="fa-print"
                                         type="object"
                                     />


### PR DESCRIPTION
backport de #3400 
Eu imagino que foi na gingada de resolução de conflitos nos rebases no momento da extração do l10n_br_fiscal_edi que eu errei nisso.