### PR TITLE
[14.0][FIX] l10n_br_sale_stock: _get_fiscal_partner method returning integer instead of partner object

### DIFF
--- a/l10n_br_sale_stock/models/stock_picking.py
+++ b/l10n_br_sale_stock/models/stock_picking.py
@@ -23,6 +23,7 @@ class StockPicking(models.Model):
     def _get_fiscal_partner(self):
         self.ensure_one()
         partner = super()._get_fiscal_partner()
-        if partner != self._get_partner_to_invoice():
-            partner = self._get_partner_to_invoice()
+        partner_to_invoice = self._get_partner_to_invoice()
+        if partner.id != partner_to_invoice:
+            partner = self.env["res.partner"].browse(partner_to_invoice)
         return partner


### PR DESCRIPTION
Resolve #3413 

cc: @marcelsavegnago @kaynnan @douglascstd @mbcosta 