### PR TITLE
[14.0][FIX] l10n_br_pos_nfce: fiscal map must be related to product

### DIFF
--- a/l10n_br_pos_nfce/models/pos_order.py
+++ b/l10n_br_pos_nfce/models/pos_order.py
@@ -184,9 +184,11 @@ class PosOrderLine(models.Model):
 
     def _prepare_nfce_tax_dict(self):
         # Get fiscal map for this product
-        fiscal_map_id = self.product_id.pos_fiscal_map_ids.search(
-            [("pos_config_id", "=", self.order_id.config_id.id)], limit=1
+        fiscal_map_id = self.product_id.pos_fiscal_map_ids.filtered(
+            lambda pfm: pfm.pos_config_id == self.order_id.config_id
         )
+        if fiscal_map_id and len(fiscal_map_id) > 1:
+            fiscal_map_id = fields.first(fiscal_map_id)
 
         # Create base tax_dict
         tax_dict = {


### PR DESCRIPTION
Esse PR corrige a fatura do pos nfce, que atualmente pode ter problemas por falta de fiscal map no produto.

Em resumo, o seguinte search ignora o `product_id `da linha:

`self.product_id.pos_fiscal_map_ids.search([])`

![image](https://github.com/user-attachments/assets/b3a50c83-e347-44cc-9c7d-726abfdf9252)
