### PR TITLE
[14.0][IMP] l10n_br_fiscal: add operation line/product tags match

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -57,6 +57,7 @@
         "views/ncm_view.xml",
         "views/nbm_view.xml",
         "views/nbs_view.xml",
+        "views/product_tag_view.xml",
         "views/service_type_view.xml",
         "views/cest_view.xml",
         "views/product_genre_view.xml",

--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -63,6 +63,7 @@
         "views/ncm_view.xml",
         "views/nbm_view.xml",
         "views/nbs_view.xml",
+        "views/product_tag_view.xml",
         "views/service_type_view.xml",
         "views/cest_view.xml",
         "views/product_genre_view.xml",

--- a/l10n_br_fiscal/data/operation_data.xml
+++ b/l10n_br_fiscal/data/operation_data.xml
@@ -42,6 +42,49 @@
         <field name="product_type">00</field>
     </record>
 
+    <record id="fo_venda_venda_st_substituto" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="name">Venda ST contribuinte substituto</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5401" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6401" />
+        <field name="state">approved</field>
+        <field name="product_type">04</field>
+    </record>
+
+    <record id="fo_venda_revenda_st_substituto" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="name">Revenda ST contribuinte substituto</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5403" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6403" />
+        <field name="state">approved</field>
+        <field name="product_type">00</field>
+    </record>
+
+    <record id="fo_venda_revenda_st_substituido" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="name">Revenda ST contribuinte substituído</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5405" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6404" />
+        <field name="state">approved</field>
+        <field name="product_type">00</field>
+    </record>
+
+    <record
+        id="fo_venda_revenda_st_substituido_sn"
+        model="l10n_br_fiscal.operation.line"
+    >
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="name">Revenda ST contribuinte substituído SN</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5405" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6404" />
+        <field name="state">approved</field>
+        <field name="product_type">00</field>
+    </record>
+
     <record id="fo_venda_venda_nao_contribuinte" model="l10n_br_fiscal.operation.line">
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
         <field name="name">Venda não Contribuinte</field>

--- a/l10n_br_fiscal/data/operation_data.xml
+++ b/l10n_br_fiscal/data/operation_data.xml
@@ -81,7 +81,7 @@
         <field name="state">approved</field>
         <field name="product_type">04</field>
         <field
-            name="product_fiscal_tag_ids"
+            name="fiscal_product_tag_ids"
             eval="[(6,0,[ref('l10n_br_fiscal.product_tag_st_6401')])]"
         />
         <field name="tax_icms_or_issqn">icms</field>
@@ -122,7 +122,7 @@
         <field name="state">approved</field>
         <field name="product_type">00</field>
         <field
-            name="product_fiscal_tag_ids"
+            name="fiscal_product_tag_ids"
             eval="[(6,0,[ref('l10n_br_fiscal.product_tag_st_6404')])]"
         />
         <field name="tax_icms_or_issqn">icms</field>

--- a/l10n_br_fiscal/data/operation_data.xml
+++ b/l10n_br_fiscal/data/operation_data.xml
@@ -42,6 +42,36 @@
         <field name="product_type">00</field>
     </record>
 
+    <record id="product_tag_st_6404" model="l10n_br_fiscal.product.tag">
+        <field name="name">ST CFOP 6404</field>
+    </record>
+    <record id="product_tag_st_6401" model="l10n_br_fiscal.product.tag">
+        <field name="name">ST CFOP 6401</field>
+    </record>
+
+    <record
+        id="tax_icms_regulation_other_state_st_1"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icms" />
+        <field name="is_taxed" eval="True" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_12_st" />
+        <field name="state">approved</field>
+    </record>
+        <record
+        id="tax_icms_regulation_other_state_st_2"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmsst" />
+        <field name="is_taxed" eval="True" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icmsst_p30_50" />
+        <field name="state">approved</field>
+    </record>
+
     <record id="fo_venda_venda_st_substituto" model="l10n_br_fiscal.operation.line">
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
         <field name="name">Venda ST contribuinte substituto</field>
@@ -50,6 +80,15 @@
         <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6401" />
         <field name="state">approved</field>
         <field name="product_type">04</field>
+        <field
+            name="product_fiscal_tag_ids"
+            eval="[(6,0,[ref('l10n_br_fiscal.product_tag_st_6401')])]"
+        />
+        <field name="tax_icms_or_issqn">icms</field>
+        <field
+            name="tax_definition_ids"
+            eval="[(6, 0, [ref('l10n_br_fiscal.tax_icms_regulation_other_state_st_1'),ref('l10n_br_fiscal.tax_icms_regulation_other_state_st_2')])]"
+        />
     </record>
 
     <record id="fo_venda_revenda_st_substituto" model="l10n_br_fiscal.operation.line">
@@ -62,6 +101,18 @@
         <field name="product_type">00</field>
     </record>
 
+    <record
+        id="tax_icms_regulation_other_state_st"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icms" />
+        <field name="is_taxed" eval="True" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_antst" />
+        <field name="state">approved</field>
+    </record>
+
     <record id="fo_venda_revenda_st_substituido" model="l10n_br_fiscal.operation.line">
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
         <field name="name">Revenda ST contribuinte substituído</field>
@@ -70,6 +121,15 @@
         <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6404" />
         <field name="state">approved</field>
         <field name="product_type">00</field>
+        <field
+            name="product_fiscal_tag_ids"
+            eval="[(6,0,[ref('l10n_br_fiscal.product_tag_st_6404')])]"
+        />
+        <field name="tax_icms_or_issqn">icms</field>
+        <field
+            name="tax_definition_ids"
+            eval="[(6, 0, [ref('l10n_br_fiscal.tax_icms_regulation_other_state_st')])]"
+        />
     </record>
 
     <record

--- a/l10n_br_fiscal/demo/fiscal_document_demo.xml
+++ b/l10n_br_fiscal/demo/fiscal_document_demo.xml
@@ -22,7 +22,7 @@
         <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
         <field name="user_id" ref="base.user_demo" />
         <field name="fiscal_operation_type">out</field>
-<!--        <field name="file_xml_autorizacao_id" ref="dummy_file_1"/> FIXME: Este é um campo related!!!!-->
+        <!--        <field name="file_xml_autorizacao_id" ref="dummy_file_1"/> FIXME: Este é um campo related!!!!-->
     </record>
 
     <record id="demo_nfe_line_same_state_1-1" model="l10n_br_fiscal.document.line">
@@ -285,7 +285,7 @@
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
         <field name="document_serie">1</field>
-                <field name="partner_id" ref="l10n_br_base.res_partner_cliente9_mg" />
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente9_mg" />
         <field name="user_id" ref="base.user_demo" />
         <field name="fiscal_operation_type">out</field>
     </record>
@@ -385,7 +385,7 @@
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
         <field name="document_serie">1</field>
-                <field name="partner_id" ref="l10n_br_base.res_partner_cliente9_mg" />
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente9_mg" />
         <field name="user_id" ref="base.user_demo" />
         <field name="fiscal_operation_type">out</field>
     </record>
@@ -946,5 +946,116 @@
         <value eval="[ref('demo_nfe_purchase_line_same_state_1-1')]" />
     </function>
 
+    <!-- NFe Test - Empresa Contribuinte - Outro Estado ST - CFOP 6404 . -->
+    <record id="demo_nfe_other_state_st_6404" model="l10n_br_fiscal.document">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
+        <field
+            name="document_serie_id"
+            ref="l10n_br_fiscal.empresa_lc_document_55_serie_1"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+        <field name="document_serie">1</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente5_pe" />
+        <field name="user_id" ref="base.user_demo" />
+        <field name="fiscal_operation_type">out</field>
+    </record>
+
+    <record
+        id="demo_nfe_line_other_state_st_6404_1-1"
+        model="l10n_br_fiscal.document.line"
+    >
+        <field name="document_id" ref="demo_nfe_other_state_st_6404" />
+        <field name="name">Teste ST</field>
+        <field name="product_id" ref="l10n_br_fiscal.product_delivery_02_st_6404" />
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="price_unit">100</field>
+        <field name="quantity">1</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="icms_tax_id" ref="l10n_br_fiscal.tax_icms_antst" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_venda_revenda_st_substituido"
+        />
+    </record>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('demo_nfe_line_other_state_st_6404_1-1')]" />
+    </function>
+
+    <record
+        id="demo_nfe_line_other_state_st_6404_1-1"
+        model="l10n_br_fiscal.document.line"
+    >
+        <field name="price_unit">100</field>
+    </record>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('demo_nfe_line_other_state_st_6404_1-1')]" />
+    </function>
+
+    <function
+        model="l10n_br_fiscal.document.line"
+        name="_onchange_fiscal_operation_line_id"
+    >
+        <value eval="[ref('demo_nfe_line_other_state_st_6404_1-1')]" />
+    </function>
+
+    <!-- NFe Test - Empresa Contribuinte - Outro Estado ST - CFOP 6401 -->
+    <record id="demo_nfe_other_state_st_6401" model="l10n_br_fiscal.document">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
+        <field
+            name="document_serie_id"
+            ref="l10n_br_fiscal.empresa_lc_document_55_serie_1"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+        <field name="document_serie">1</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente5_pe" />
+        <field name="user_id" ref="base.user_demo" />
+        <field name="fiscal_operation_type">out</field>
+    </record>
+
+    <record
+        id="demo_nfe_line_other_state_st_6401_1-1"
+        model="l10n_br_fiscal.document.line"
+    >
+        <field name="document_id" ref="demo_nfe_other_state_st_6401" />
+        <field name="name">Teste ST</field>
+        <field name="product_id" ref="l10n_br_fiscal.product_delivery_02_st_6401" />
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="price_unit">100</field>
+        <field name="quantity">1</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="icms_tax_id" ref="l10n_br_fiscal.tax_icms_antst" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_venda_revenda_st_substituido"
+        />
+    </record>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('demo_nfe_line_other_state_st_6401_1-1')]" />
+    </function>
+
+    <record
+        id="demo_nfe_line_other_state_st_6401_1-1"
+        model="l10n_br_fiscal.document.line"
+    >
+        <field name="price_unit">100</field>
+    </record>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('demo_nfe_line_other_state_st_6401_1-1')]" />
+    </function>
+
+    <function
+        model="l10n_br_fiscal.document.line"
+        name="_onchange_fiscal_operation_line_id"
+    >
+        <value eval="[ref('demo_nfe_line_other_state_st_6401_1-1')]" />
+    </function>
 
 </odoo>

--- a/l10n_br_fiscal/demo/product_demo.xml
+++ b/l10n_br_fiscal/demo/product_demo.xml
@@ -1978,4 +1978,126 @@
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
 
+    <!-- Product ST CFOP 6404 -->
+    <record id="product_delivery_02_st_6404" model="product.product">
+        <field name="name">Office Lamp ST 6404</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="categ_id" ref="product.product_category_5" />
+        <field name="standard_price">35.0</field>
+        <field name="list_price">40.0</field>
+        <field name="type">consu</field>
+        <field name="weight">0.01</field>
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="uom_po_id" ref="uom.product_uom_unit" />
+        <field name="default_code">FURN_8889</field>
+        <field
+            name="operation_line_tag_ids"
+            eval="[(6,0,[ref('l10n_br_fiscal.product_tag_st_6404')])]"
+        />
+        <field
+            name="image_1920"
+            type="base64"
+            file="product/static/img/product_lamp.png"
+        />
+        <field name="ncm_id" ref="l10n_br_fiscal.ncm_94052000" />
+        <field name="cest_id" ref="l10n_br_fiscal.cest_2112400" />
+        <field name="fiscal_genre_id" ref="l10n_br_fiscal.product_genre_94" />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+    <!-- fiscal_type property for product_delivery_02_st_6404 for lucro presumido company -->
+    <record
+        forcecreate="True"
+        id="fiscal_type_product_delivery_02_st_6404"
+        model="ir.property"
+    >
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">00</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('l10n_br_fiscal.product_delivery_02_st_6404').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+        <!-- icms_origin property for product_delivery_02_st_6404 for simples nacional company -->
+    <record
+        forcecreate="True"
+        id="icms_origin_product_delivery_02_st_6404"
+        model="ir.property"
+    >
+        <field name="name">icms_origin</field>
+        <field name="fields_id" ref="field_product_template__icms_origin" />
+        <field name="value">5</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('l10n_br_fiscal.product_delivery_02_st_6404').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+
+
+    <!-- Product ST CFOP 6401 -->
+    <record id="product_delivery_02_st_6401" model="product.product">
+        <field name="name">Office Lamp ST 6401</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="categ_id" ref="product.product_category_5" />
+        <field name="standard_price">35.0</field>
+        <field name="list_price">40.0</field>
+        <field name="type">consu</field>
+        <field name="weight">0.01</field>
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="uom_po_id" ref="uom.product_uom_unit" />
+        <field name="default_code">FURN_8880</field>
+        <field
+            name="operation_line_tag_ids"
+            eval="[(6,0,[ref('l10n_br_fiscal.product_tag_st_6401')])]"
+        />
+        <field
+            name="image_1920"
+            type="base64"
+            file="product/static/img/product_lamp.png"
+        />
+        <field name="ncm_id" ref="l10n_br_fiscal.ncm_94052000" />
+        <field name="cest_id" ref="l10n_br_fiscal.cest_2112400" />
+        <field name="fiscal_genre_id" ref="l10n_br_fiscal.product_genre_94" />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+    <!-- fiscal_type property for product_delivery_02_st_6401 for lucro presumido company -->
+    <record
+        forcecreate="True"
+        id="fiscal_type_product_delivery_02_st_6401"
+        model="ir.property"
+    >
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">04</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('l10n_br_fiscal.product_delivery_02_st_6401').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+        <!-- icms_origin property for product_delivery_02_st_6401 for simples nacional company -->
+    <record
+        forcecreate="True"
+        id="icms_origin_product_delivery_02_st_6401"
+        model="ir.property"
+    >
+        <field name="name">icms_origin</field>
+        <field name="fields_id" ref="field_product_template__icms_origin" />
+        <field name="value">5</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('l10n_br_fiscal.product_delivery_02_st_6401').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
 </odoo>

--- a/l10n_br_fiscal/demo/product_demo.xml
+++ b/l10n_br_fiscal/demo/product_demo.xml
@@ -1991,7 +1991,7 @@
         <field name="uom_po_id" ref="uom.product_uom_unit" />
         <field name="default_code">FURN_8889</field>
         <field
-            name="operation_line_tag_ids"
+            name="fiscal_product_tag_ids"
             eval="[(6,0,[ref('l10n_br_fiscal.product_tag_st_6404')])]"
         />
         <field
@@ -2053,7 +2053,7 @@
         <field name="uom_po_id" ref="uom.product_uom_unit" />
         <field name="default_code">FURN_8880</field>
         <field
-            name="operation_line_tag_ids"
+            name="fiscal_product_tag_ids"
             eval="[(6,0,[ref('l10n_br_fiscal.product_tag_st_6401')])]"
         />
         <field

--- a/l10n_br_fiscal/models/__init__.py
+++ b/l10n_br_fiscal/models/__init__.py
@@ -20,6 +20,7 @@ from . import service_type
 from . import ncm
 from . import nbm
 from . import cest
+from . import product_tag
 from . import tax_group
 from . import tax
 from . import tax_pis_cofins

--- a/l10n_br_fiscal/models/__init__.py
+++ b/l10n_br_fiscal/models/__init__.py
@@ -19,6 +19,7 @@ from . import service_type
 from . import ncm
 from . import nbm
 from . import cest
+from . import product_tag
 from . import tax_group
 from . import tax
 from . import tax_pis_cofins

--- a/l10n_br_fiscal/models/operation.py
+++ b/l10n_br_fiscal/models/operation.py
@@ -235,6 +235,12 @@ class Operation(models.Model):
             ("icms_origin", "=", False),
         ]
 
+        domain += [
+            "|",
+            ("product_fiscal_tag_ids", "in", product.operation_line_tag_ids.ids),
+            ("product_fiscal_tag_ids", "=", False),
+        ]
+
         return domain
 
     def line_definition(self, company, partner, product):
@@ -258,6 +264,7 @@ class Operation(models.Model):
                 "product_type",
                 "tax_icms_or_issqn",
                 "icms_origin",
+                "product_fiscal_tag_ids",
             ]
             return sum(1 for field in fields if getattr(line, field))
 

--- a/l10n_br_fiscal/models/operation.py
+++ b/l10n_br_fiscal/models/operation.py
@@ -236,6 +236,12 @@ class Operation(models.Model):
             ("icms_origin", "=", False),
         ]
 
+        domain += [
+            "|",
+            ("product_fiscal_tag_ids", "in", product.operation_line_tag_ids.ids),
+            ("product_fiscal_tag_ids", "=", False),
+        ]
+
         return domain
 
     def line_definition(self, company, partner, product):
@@ -259,6 +265,7 @@ class Operation(models.Model):
                 "product_type",
                 "tax_icms_or_issqn",
                 "icms_origin",
+                "product_fiscal_tag_ids",
             ]
             return sum(1 for field in fields if getattr(line, field))
 

--- a/l10n_br_fiscal/models/operation.py
+++ b/l10n_br_fiscal/models/operation.py
@@ -238,8 +238,8 @@ class Operation(models.Model):
 
         domain += [
             "|",
-            ("product_fiscal_tag_ids", "in", product.operation_line_tag_ids.ids),
-            ("product_fiscal_tag_ids", "=", False),
+            ("fiscal_product_tag_ids", "in", product.fiscal_product_tag_ids.ids),
+            ("fiscal_product_tag_ids", "=", False),
         ]
 
         return domain
@@ -265,7 +265,7 @@ class Operation(models.Model):
                 "product_type",
                 "tax_icms_or_issqn",
                 "icms_origin",
-                "product_fiscal_tag_ids",
+                "fiscal_product_tag_ids",
             ]
             return sum(1 for field in fields if getattr(line, field))
 

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -105,6 +105,14 @@ class OperationLine(models.Model):
         selection=PRODUCT_FISCAL_TYPE, string="Product Fiscal Type"
     )
 
+    product_fiscal_tag_ids = fields.Many2many(
+        comodel_name="l10n_br_fiscal.product.tag",
+        string="Fiscal Product Tags",
+        help="If enabled, only products that share a product tag with this line can "
+        "auto-select this operation line. When other factors are equal, a match will "
+        "be preferred over a line without this setting.",
+    )
+
     company_tax_framework = fields.Selection(selection=TAX_FRAMEWORK)
 
     add_to_amount = fields.Boolean(string="Add to Document Amount?", default=True)

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -110,12 +110,14 @@ class OperationLine(models.Model):
         selection=PRODUCT_FISCAL_TYPE, string="Product Fiscal Type"
     )
 
-    product_fiscal_tag_ids = fields.Many2many(
+    fiscal_product_tag_ids = fields.Many2many(
         comodel_name="l10n_br_fiscal.product.tag",
         string="Fiscal Product Tags",
-        help="If enabled, only products that share a product tag with this line can "
-        "auto-select this operation line. When other factors are equal, a match will "
-        "be preferred over a line without this setting.",
+        help="Restricts this line to products carrying at least one of these "
+        "fiscal tags. Leave empty for a generic line, eligible for any product. "
+        "A tagged line wins over a generic one when both match, so use it for "
+        "cases the other criteria cannot tell apart, such as goods under tax "
+        "substitution needing their own CFOP.",
     )
 
     company_tax_framework = fields.Selection(selection=TAX_FRAMEWORK)

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -110,6 +110,14 @@ class OperationLine(models.Model):
         selection=PRODUCT_FISCAL_TYPE, string="Product Fiscal Type"
     )
 
+    product_fiscal_tag_ids = fields.Many2many(
+        comodel_name="l10n_br_fiscal.product.tag",
+        string="Fiscal Product Tags",
+        help="If enabled, only products that share a product tag with this line can "
+        "auto-select this operation line. When other factors are equal, a match will "
+        "be preferred over a line without this setting.",
+    )
+
     company_tax_framework = fields.Selection(selection=TAX_FRAMEWORK)
 
     add_to_amount = fields.Boolean(string="Add to Document Amount?", default=True)

--- a/l10n_br_fiscal/models/product_tag.py
+++ b/l10n_br_fiscal/models/product_tag.py
@@ -1,0 +1,19 @@
+# Copyright (C) 2024  Diego Paradeda - KMEE
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import _, fields, models
+
+
+class ProductTag(models.Model):
+    _name = "l10n_br_fiscal.product.tag"
+    _description = "Fiscal Product Tags"
+
+    name = fields.Char()
+
+    _sql_constraints = [
+        (
+            "fiscal_tag_name_uniq",
+            "unique (name)",
+            _("Fiscal Product Tag already exists with this code !"),
+        )
+    ]

--- a/l10n_br_fiscal/models/product_tag.py
+++ b/l10n_br_fiscal/models/product_tag.py
@@ -6,14 +6,17 @@ from odoo import _, fields, models
 
 class ProductTag(models.Model):
     _name = "l10n_br_fiscal.product.tag"
-    _description = "Fiscal Product Tags"
+    _description = "Fiscal Product Tag"
+    _order = "name"
 
-    name = fields.Char()
+    name = fields.Char(required=True)
+
+    active = fields.Boolean(default=True)
 
     _sql_constraints = [
         (
             "fiscal_tag_name_uniq",
             "unique (name)",
-            _("Fiscal Product Tag already exists with this code !"),
+            _("Fiscal Product Tag already exists with this name !"),
         )
     ]

--- a/l10n_br_fiscal/models/product_template.py
+++ b/l10n_br_fiscal/models/product_template.py
@@ -67,6 +67,10 @@ class ProductTemplate(models.Model):
         comodel_name="l10n_br_fiscal.product.genre", string="Fiscal Product Genre"
     )
 
+    operation_line_tag_ids = fields.Many2many(
+        comodel_name="l10n_br_fiscal.product.tag", string="Operation Line Tags"
+    )
+
     service_type_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.service.type",
         string="Service Type LC 166",

--- a/l10n_br_fiscal/models/product_template.py
+++ b/l10n_br_fiscal/models/product_template.py
@@ -67,8 +67,12 @@ class ProductTemplate(models.Model):
         comodel_name="l10n_br_fiscal.product.genre", string="Fiscal Product Genre"
     )
 
-    operation_line_tag_ids = fields.Many2many(
-        comodel_name="l10n_br_fiscal.product.tag", string="Operation Line Tags"
+    fiscal_product_tag_ids = fields.Many2many(
+        comodel_name="l10n_br_fiscal.product.tag",
+        string="Fiscal Product Tags",
+        help="Fiscal groups this product belongs to, used to auto-select the "
+        "fiscal operation line that requires the same tag (for instance a line "
+        "with its own CFOP for goods under tax substitution).",
     )
 
     service_type_id = fields.Many2one(

--- a/l10n_br_fiscal/security/ir.model.access.csv
+++ b/l10n_br_fiscal/security/ir.model.access.csv
@@ -38,6 +38,9 @@
 "l10n_br_fiscal_product_genre_user","Fiscal Fiscal Product Genre for User","model_l10n_br_fiscal_product_genre","l10n_br_fiscal.group_user",1,0,0,0
 "l10n_br_fiscal_product_genre_manager","Fiscal Fiscal Product Genre for Manager","model_l10n_br_fiscal_product_genre","l10n_br_fiscal.group_manager",1,0,0,0
 "l10n_br_fiscal_product_genre_maintenance","Fiscal Fiscal Product Genre for Maintenance","model_l10n_br_fiscal_product_genre","l10n_br_fiscal.group_data_maintenance",1,1,1,1
+"l10n_br_fiscal_product_tag_user","Fiscal Fiscal Product Tag for User","model_l10n_br_fiscal_product_tag","l10n_br_fiscal.group_user",1,0,0,0
+"l10n_br_fiscal_product_tag_manager","Fiscal Fiscal Product Tag for Manager","model_l10n_br_fiscal_product_tag","l10n_br_fiscal.group_manager",1,1,1,1
+"l10n_br_fiscal_product_tag_maintenance","Fiscal Fiscal Product Tag for Maintenance","model_l10n_br_fiscal_product_tag","l10n_br_fiscal.group_data_maintenance",1,1,1,1
 "l10n_br_fiscal_document_type_user","Fiscal Document Type for User","model_l10n_br_fiscal_document_type","l10n_br_fiscal.group_user",1,0,0,0
 "l10n_br_fiscal_document_type_manager","Fiscal Document Type for Manager","model_l10n_br_fiscal_document_type","l10n_br_fiscal.group_manager",1,0,0,0
 "l10n_br_fiscal_document_type_maintenance","Fiscal Document Type for Maintenance","model_l10n_br_fiscal_document_type","l10n_br_fiscal.group_data_maintenance",1,1,1,1

--- a/l10n_br_fiscal/security/ir.model.access.csv
+++ b/l10n_br_fiscal/security/ir.model.access.csv
@@ -44,6 +44,9 @@
 "l10n_br_fiscal_product_genre_user","Fiscal Fiscal Product Genre for User","model_l10n_br_fiscal_product_genre","l10n_br_fiscal.group_user",1,0,0,0
 "l10n_br_fiscal_product_genre_manager","Fiscal Fiscal Product Genre for Manager","model_l10n_br_fiscal_product_genre","l10n_br_fiscal.group_manager",1,0,0,0
 "l10n_br_fiscal_product_genre_maintenance","Fiscal Fiscal Product Genre for Maintenance","model_l10n_br_fiscal_product_genre","l10n_br_fiscal.group_data_maintenance",1,1,1,1
+"l10n_br_fiscal_product_tag_user","Fiscal Fiscal Product Tag for User","model_l10n_br_fiscal_product_tag","l10n_br_fiscal.group_user",1,0,0,0
+"l10n_br_fiscal_product_tag_manager","Fiscal Fiscal Product Tag for Manager","model_l10n_br_fiscal_product_tag","l10n_br_fiscal.group_manager",1,1,1,1
+"l10n_br_fiscal_product_tag_maintenance","Fiscal Fiscal Product Tag for Maintenance","model_l10n_br_fiscal_product_tag","l10n_br_fiscal.group_data_maintenance",1,1,1,1
 "l10n_br_fiscal_document_type_user","Fiscal Document Type for User","model_l10n_br_fiscal_document_type","l10n_br_fiscal.group_user",1,0,0,0
 "l10n_br_fiscal_document_type_manager","Fiscal Document Type for Manager","model_l10n_br_fiscal_document_type","l10n_br_fiscal.group_manager",1,0,0,0
 "l10n_br_fiscal_document_type_maintenance","Fiscal Document Type for Maintenance","model_l10n_br_fiscal_document_type","l10n_br_fiscal.group_data_maintenance",1,1,1,1

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -16,5 +16,6 @@ from . import (
     test_subsequent_operation,
     test_uom_uom,
     test_operation,
+    test_operation_line_product_tag,
     test_document_email,
 )

--- a/l10n_br_fiscal/tests/test_fiscal_document_generic.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_generic.py
@@ -308,7 +308,6 @@ class TestFiscalDocumentGeneric(SavepointCase):
             line.with_company(
                 empresa_lucro_presumido.id
             )._onchange_commercial_quantity()
-            line.with_company(empresa_lucro_presumido.id)._onchange_ncm_id()
             line.with_company(
                 empresa_lucro_presumido.id
             )._onchange_fiscal_operation_id()
@@ -350,7 +349,6 @@ class TestFiscalDocumentGeneric(SavepointCase):
             line.with_company(
                 empresa_lucro_presumido.id
             )._onchange_commercial_quantity()
-            line.with_company(empresa_lucro_presumido.id)._onchange_ncm_id()
             line.with_company(
                 empresa_lucro_presumido.id
             )._onchange_fiscal_operation_id()

--- a/l10n_br_fiscal/tests/test_fiscal_document_generic.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_generic.py
@@ -16,6 +16,12 @@ class TestFiscalDocumentGeneric(SavepointCase):
         # Contribuinte
         cls.nfe_same_state = cls.env.ref("l10n_br_fiscal.demo_nfe_same_state")
         cls.nfe_other_state = cls.env.ref("l10n_br_fiscal.demo_nfe_other_state")
+        cls.nfe_other_state_st_6404 = cls.env.ref(
+            "l10n_br_fiscal.demo_nfe_other_state_st_6404"
+        )
+        cls.nfe_other_state_st_6401 = cls.env.ref(
+            "l10n_br_fiscal.demo_nfe_other_state_st_6401"
+        )
         cls.nfe_not_taxpayer = cls.env.ref("l10n_br_fiscal.demo_nfe_nao_contribuinte")
 
         cls.nfe_not_taxpayer_pf = cls.env.ref(
@@ -289,6 +295,96 @@ class TestFiscalDocumentGeneric(SavepointCase):
                 "Error to mapping CST 01 -"
                 " Operação Tributável com Alíquota Básica"
                 "from COFINS 3% for Venda de Contribuinte p/ Fora do Estado.",
+            )
+
+    def test_nfe_other_state_st_6404(self):
+        """Testing NFe in another state with tax substitution."""
+        empresa_lucro_presumido = self.env.ref("l10n_br_base.empresa_lucro_presumido")
+        self.nfe_other_state_st_6404._onchange_document_serie_id()
+        self.nfe_other_state_st_6404._onchange_fiscal_operation_id()
+
+        for line in self.nfe_other_state_st_6404.fiscal_line_ids:
+            line.with_company(empresa_lucro_presumido.id)._onchange_product_id_fiscal()
+            line.with_company(
+                empresa_lucro_presumido.id
+            )._onchange_commercial_quantity()
+            line.with_company(empresa_lucro_presumido.id)._onchange_ncm_id()
+            line.with_company(
+                empresa_lucro_presumido.id
+            )._onchange_fiscal_operation_id()
+            line.with_company(
+                empresa_lucro_presumido.id
+            )._onchange_fiscal_operation_line_id()
+            line.with_company(empresa_lucro_presumido.id)._onchange_fiscal_taxes()
+
+            self.assertEqual(
+                line.cfop_id.code,
+                "6404",
+                "Error to mapping CFOP 6404"
+                " for Revenda de Contribuinte p/ Fora do Estado.",
+            )
+
+            # ICMS
+            line.with_company(empresa_lucro_presumido.id)._onchange_fiscal_taxes()
+            self.assertEqual(
+                line.icms_tax_id.id,
+                self.env.ref("l10n_br_fiscal.tax_icms_antst").id,
+                "Error to mapping ICMS Cobrado Ant. por ST"
+                " for Venda de Contribuinte p/ Fora do Estado.",
+            )
+            self.assertEqual(
+                line.icms_cst_id.code,
+                "60",
+                "Error to mapping CST 60 from ICMS Cobrado Ant. por ST"
+                " for Venda de Contribuinte p/ Fora do Estado.",
+            )
+
+    def test_nfe_other_state_st_6401(self):
+        """Testing NFe in another state with tax substitution."""
+        empresa_lucro_presumido = self.env.ref("l10n_br_base.empresa_lucro_presumido")
+        self.nfe_other_state_st_6401._onchange_document_serie_id()
+        self.nfe_other_state_st_6401._onchange_fiscal_operation_id()
+
+        for line in self.nfe_other_state_st_6401.fiscal_line_ids:
+            line.with_company(empresa_lucro_presumido.id)._onchange_product_id_fiscal()
+            line.with_company(
+                empresa_lucro_presumido.id
+            )._onchange_commercial_quantity()
+            line.with_company(empresa_lucro_presumido.id)._onchange_ncm_id()
+            line.with_company(
+                empresa_lucro_presumido.id
+            )._onchange_fiscal_operation_id()
+            line.with_company(
+                empresa_lucro_presumido.id
+            )._onchange_fiscal_operation_line_id()
+            line.with_company(empresa_lucro_presumido.id)._onchange_fiscal_taxes()
+
+            self.assertEqual(
+                line.cfop_id.code,
+                "6401",
+                "Error to mapping CFOP 6401"
+                " for Venda de Contribuinte p/ Fora do Estado.",
+            )
+
+            # ICMS
+            line.with_company(empresa_lucro_presumido.id)._onchange_fiscal_taxes()
+            self.assertEqual(
+                line.icms_tax_id.id,
+                self.env.ref("l10n_br_fiscal.tax_icms_12_st").id,
+                "Error to mapping ICMS 010 12%"
+                " for Venda de Contribuinte p/ Fora do Estado.",
+            )
+            self.assertEqual(
+                line.icmsst_tax_id.id,
+                self.env.ref("l10n_br_fiscal.tax_icmsst_p30_50").id,
+                "Error to mapping ICMS 30% MVA 50"
+                " for Venda de Contribuinte p/ Fora do Estado.",
+            )
+            self.assertEqual(
+                line.icms_cst_id.code,
+                "10",
+                "Error to mapping CST 10 from ICMS 010 12%"
+                " for Venda de Contribuinte p/ Fora do Estado.",
             )
 
     def test_nfe_not_taxpayer(self):

--- a/l10n_br_fiscal/tests/test_fiscal_document_generic.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_generic.py
@@ -15,6 +15,12 @@ class TestFiscalDocumentGeneric(SavepointCase):
         # Contribuinte
         cls.nfe_same_state = cls.env.ref("l10n_br_fiscal.demo_nfe_same_state")
         cls.nfe_other_state = cls.env.ref("l10n_br_fiscal.demo_nfe_other_state")
+        cls.nfe_other_state_st_6404 = cls.env.ref(
+            "l10n_br_fiscal.demo_nfe_other_state_st_6404"
+        )
+        cls.nfe_other_state_st_6401 = cls.env.ref(
+            "l10n_br_fiscal.demo_nfe_other_state_st_6401"
+        )
         cls.nfe_not_taxpayer = cls.env.ref("l10n_br_fiscal.demo_nfe_nao_contribuinte")
 
         cls.nfe_not_taxpayer_pf = cls.env.ref(
@@ -289,6 +295,96 @@ class TestFiscalDocumentGeneric(SavepointCase):
                 "Error to mapping CST 01 -"
                 " Operação Tributável com Alíquota Básica"
                 "from COFINS 3% for Venda de Contribuinte p/ Fora do Estado.",
+            )
+
+    def test_nfe_other_state_st_6404(self):
+        """Testing NFe in another state with tax substitution."""
+        empresa_lucro_presumido = self.env.ref("l10n_br_base.empresa_lucro_presumido")
+        self.nfe_other_state_st_6404._onchange_document_serie_id()
+        self.nfe_other_state_st_6404._onchange_fiscal_operation_id()
+
+        for line in self.nfe_other_state_st_6404.fiscal_line_ids:
+            line.with_company(empresa_lucro_presumido.id)._onchange_product_id_fiscal()
+            line.with_company(
+                empresa_lucro_presumido.id
+            )._onchange_commercial_quantity()
+            line.with_company(empresa_lucro_presumido.id)._onchange_ncm_id()
+            line.with_company(
+                empresa_lucro_presumido.id
+            )._onchange_fiscal_operation_id()
+            line.with_company(
+                empresa_lucro_presumido.id
+            )._onchange_fiscal_operation_line_id()
+            line.with_company(empresa_lucro_presumido.id)._onchange_fiscal_taxes()
+
+            self.assertEqual(
+                line.cfop_id.code,
+                "6404",
+                "Error to mapping CFOP 6404"
+                " for Revenda de Contribuinte p/ Fora do Estado.",
+            )
+
+            # ICMS
+            line.with_company(empresa_lucro_presumido.id)._onchange_fiscal_taxes()
+            self.assertEqual(
+                line.icms_tax_id.id,
+                self.env.ref("l10n_br_fiscal.tax_icms_antst").id,
+                "Error to mapping ICMS Cobrado Ant. por ST"
+                " for Venda de Contribuinte p/ Fora do Estado.",
+            )
+            self.assertEqual(
+                line.icms_cst_id.code,
+                "60",
+                "Error to mapping CST 60 from ICMS Cobrado Ant. por ST"
+                " for Venda de Contribuinte p/ Fora do Estado.",
+            )
+
+    def test_nfe_other_state_st_6401(self):
+        """Testing NFe in another state with tax substitution."""
+        empresa_lucro_presumido = self.env.ref("l10n_br_base.empresa_lucro_presumido")
+        self.nfe_other_state_st_6401._onchange_document_serie_id()
+        self.nfe_other_state_st_6401._onchange_fiscal_operation_id()
+
+        for line in self.nfe_other_state_st_6401.fiscal_line_ids:
+            line.with_company(empresa_lucro_presumido.id)._onchange_product_id_fiscal()
+            line.with_company(
+                empresa_lucro_presumido.id
+            )._onchange_commercial_quantity()
+            line.with_company(empresa_lucro_presumido.id)._onchange_ncm_id()
+            line.with_company(
+                empresa_lucro_presumido.id
+            )._onchange_fiscal_operation_id()
+            line.with_company(
+                empresa_lucro_presumido.id
+            )._onchange_fiscal_operation_line_id()
+            line.with_company(empresa_lucro_presumido.id)._onchange_fiscal_taxes()
+
+            self.assertEqual(
+                line.cfop_id.code,
+                "6401",
+                "Error to mapping CFOP 6401"
+                " for Venda de Contribuinte p/ Fora do Estado.",
+            )
+
+            # ICMS
+            line.with_company(empresa_lucro_presumido.id)._onchange_fiscal_taxes()
+            self.assertEqual(
+                line.icms_tax_id.id,
+                self.env.ref("l10n_br_fiscal.tax_icms_12_st").id,
+                "Error to mapping ICMS 010 12%"
+                " for Venda de Contribuinte p/ Fora do Estado.",
+            )
+            self.assertEqual(
+                line.icmsst_tax_id.id,
+                self.env.ref("l10n_br_fiscal.tax_icmsst_p30_50").id,
+                "Error to mapping ICMS 30% MVA 50"
+                " for Venda de Contribuinte p/ Fora do Estado.",
+            )
+            self.assertEqual(
+                line.icms_cst_id.code,
+                "10",
+                "Error to mapping CST 10 from ICMS 010 12%"
+                " for Venda de Contribuinte p/ Fora do Estado.",
             )
 
     def test_nfe_not_taxpayer(self):

--- a/l10n_br_fiscal/tests/test_operation_line_product_tag.py
+++ b/l10n_br_fiscal/tests/test_operation_line_product_tag.py
@@ -1,0 +1,160 @@
+# Copyright (C) 2026 KMEE
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from psycopg2 import IntegrityError
+
+from odoo.tests import SavepointCase
+from odoo.tools import mute_logger
+
+
+class TestOperationLineProductTag(SavepointCase):
+    """Automatic operation line match by product fiscal tag.
+
+    The tag discriminates groups of products that need their own CFOP and
+    that no other operation line criterion tells apart. The reference case
+    is tax substitution: 5401/6401 (substitute) and 5405/6404 (substituted)
+    share the same fiscal item type, partner IE indicator and tax framework,
+    so only a product level marker can select between them.
+
+    These tests exercise the resolver itself (``_line_domain`` and
+    ``_select_best_line``), which the document level tests reach only
+    indirectly.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.ref("l10n_br_base.empresa_lucro_presumido")
+        # Same partner as the demo ST documents: ICMS contributor in another
+        # state, so the external CFOP applies and the lines, which require
+        # ind_ie_dest=1, are eligible.
+        cls.partner = cls.env.ref("l10n_br_base.res_partner_cliente5_pe")
+        cls.operation = cls.env.ref("l10n_br_fiscal.fo_venda")
+
+        cls.tag_6401 = cls.env.ref("l10n_br_fiscal.product_tag_st_6401")
+        cls.tag_6404 = cls.env.ref("l10n_br_fiscal.product_tag_st_6404")
+
+        cls.line_st_substituto = cls.env.ref(
+            "l10n_br_fiscal.fo_venda_venda_st_substituto"
+        )
+        cls.line_st_substituido = cls.env.ref(
+            "l10n_br_fiscal.fo_venda_revenda_st_substituido"
+        )
+        cls.line_venda = cls.env.ref("l10n_br_fiscal.fo_venda_venda")
+        cls.line_revenda = cls.env.ref("l10n_br_fiscal.fo_venda_revenda")
+
+    def _create_product(self, fiscal_type, tags=None):
+        """Product with a company dependent fiscal type and optional tags."""
+        product = self.env["product.product"].create(
+            {"name": "Product fiscal tag test"}
+        )
+        product = product.with_company(self.company)
+        product.fiscal_type = fiscal_type
+        if tags:
+            product.fiscal_product_tag_ids = [(6, 0, tags.ids)]
+        return product
+
+    def _resolve(self, product):
+        return self.operation.with_company(self.company).line_definition(
+            self.company, self.partner, product
+        )
+
+    def test_tagged_product_selects_st_substituto_line(self):
+        """Own production tagged as ST substitute resolves to CFOP 6401."""
+        product = self._create_product("04", self.tag_6401)
+        line = self._resolve(product)
+        self.assertEqual(line, self.line_st_substituto)
+        self.assertEqual(line.cfop_external_id.code, "6401")
+
+    def test_tagged_product_selects_st_substituido_line(self):
+        """Resale tagged as ST substituted resolves to CFOP 6404."""
+        product = self._create_product("00", self.tag_6404)
+        line = self._resolve(product)
+        self.assertEqual(line, self.line_st_substituido)
+        self.assertEqual(line.cfop_external_id.code, "6404")
+
+    def test_untagged_product_never_selects_a_tagged_line(self):
+        """A product without tags must not fall into an ST line.
+
+        This is the isolation guarantee of the feature: tagging a line
+        restricts it, it never widens the match.
+        """
+        product = self._create_product("00")
+        line = self._resolve(product)
+        self.assertFalse(
+            line.fiscal_product_tag_ids,
+            "An untagged product selected a tagged operation line.",
+        )
+
+    def test_unknown_tag_falls_back_to_untagged_line(self):
+        """A tag used by no line degrades to the plain line, not to nothing."""
+        orphan_tag = self.env["l10n_br_fiscal.product.tag"].create(
+            {"name": "Tag used by no operation line"}
+        )
+        product = self._create_product("00", orphan_tag)
+        line = self._resolve(product)
+        self.assertTrue(line, "Resolution returned no line at all.")
+        self.assertFalse(line.fiscal_product_tag_ids)
+
+    def test_product_with_several_tags_matches_line_sharing_one(self):
+        """Matching is by intersection: one tag in common is enough."""
+        orphan_tag = self.env["l10n_br_fiscal.product.tag"].create(
+            {"name": "Extra tag with no line"}
+        )
+        product = self._create_product("00", orphan_tag | self.tag_6404)
+        line = self._resolve(product)
+        self.assertEqual(line, self.line_st_substituido)
+
+    def test_tagged_line_outscores_untagged_line(self):
+        """Documented preference: on equal terms, the tagged line wins.
+
+        Checked on ``_select_best_line`` directly so the assertion does not
+        depend on which lines the domain happens to return.
+        """
+        candidates = self.line_revenda | self.line_st_substituido
+        best = self.operation._select_best_line(candidates)
+        self.assertEqual(best, self.line_st_substituido)
+
+    def test_select_best_line_without_candidates(self):
+        """No candidate returns an empty recordset, not an error."""
+        empty = self.env["l10n_br_fiscal.operation.line"]
+        self.assertEqual(self.operation._select_best_line(empty), empty)
+
+    def test_line_domain_includes_the_tag_clause(self):
+        """The domain offers the line either sharing a tag or having none."""
+        product = self._create_product("00", self.tag_6404)
+        domain = self.operation._line_domain(self.company, self.partner, product)
+        self.assertIn(("fiscal_product_tag_ids", "in", self.tag_6404.ids), domain)
+        self.assertIn(("fiscal_product_tag_ids", "=", False), domain)
+
+    @mute_logger("odoo.sql_db")
+    def test_tag_name_is_unique(self):
+        """Tags are keyed by name, so duplicates must be rejected."""
+        self.env["l10n_br_fiscal.product.tag"].create({"name": "Duplicated tag"})
+        with self.assertRaises(IntegrityError), self.cr.savepoint():
+            self.env["l10n_br_fiscal.product.tag"].create({"name": "Duplicated tag"})
+            self.env["l10n_br_fiscal.product.tag"].flush()
+
+    @mute_logger("odoo.sql_db")
+    def test_tag_name_is_required(self):
+        """A nameless tag would defeat the unique constraint.
+
+        Postgres allows any number of NULLs in a unique index, so without
+        ``required`` the tag list could fill up with unnamed entries.
+        """
+        with self.assertRaises(IntegrityError), self.cr.savepoint():
+            self.env["l10n_br_fiscal.product.tag"].create({})
+
+    def test_inactive_tag_is_not_offered(self):
+        """Archiving a tag takes it out of the resolution silently.
+
+        Documents the consequence of ``active``: an archived tag no longer
+        pulls its line, so the product falls back to the generic line.
+        """
+        tag = self.env["l10n_br_fiscal.product.tag"].create({"name": "To archive"})
+        product = self._create_product("00", tag | self.tag_6404)
+        self.assertEqual(self._resolve(product), self.line_st_substituido)
+        self.tag_6404.active = False
+        product.invalidate_cache()
+        line = self._resolve(product)
+        self.assertFalse(line.fiscal_product_tag_ids)

--- a/l10n_br_fiscal/views/l10n_br_fiscal_action.xml
+++ b/l10n_br_fiscal/views/l10n_br_fiscal_action.xml
@@ -516,6 +516,23 @@
         </field>
     </record>
 
+    <!-- Product Tag -->
+    <record id="product_tag_action" model="ir.actions.act_window">
+        <field name="name">Product Tag</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">l10n_br_fiscal.product.tag</field>
+        <field name="view_mode">tree</field>
+        <field name="view_id" ref="product_tag_tree" />
+        <field name="search_view_id" ref="product_tag_search" />
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create a new Product Tag
+            </p><p>
+                Product Tags assist in matching Operation Lines with their corresponding products, ensuring accurate identification and organization within the system.
+            </p>
+        </field>
+    </record>
+
     <!-- Subsequent Document-->
     <record id="subsequent_document_action" model="ir.actions.act_window">
         <field name="name">Subsequent Document</field>

--- a/l10n_br_fiscal/views/l10n_br_fiscal_action.xml
+++ b/l10n_br_fiscal/views/l10n_br_fiscal_action.xml
@@ -548,6 +548,23 @@
         </field>
     </record>
 
+    <!-- Product Tag -->
+    <record id="product_tag_action" model="ir.actions.act_window">
+        <field name="name">Product Tag</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">l10n_br_fiscal.product.tag</field>
+        <field name="view_mode">tree</field>
+        <field name="view_id" ref="product_tag_tree" />
+        <field name="search_view_id" ref="product_tag_search" />
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create a new Product Tag
+            </p><p>
+                Product Tags assist in matching Operation Lines with their corresponding products, ensuring accurate identification and organization within the system.
+            </p>
+        </field>
+    </record>
+
     <!-- Subsequent Document-->
     <record id="subsequent_document_action" model="ir.actions.act_window">
         <field name="name">Subsequent Document</field>

--- a/l10n_br_fiscal/views/l10n_br_fiscal_menu.xml
+++ b/l10n_br_fiscal/views/l10n_br_fiscal_menu.xml
@@ -524,6 +524,15 @@
         sequence="30"
     />
 
+    <!-- Product Tag -->
+    <menuitem
+        id="product_tag_menu"
+        action="product_tag_action"
+        groups="l10n_br_fiscal.group_manager"
+        parent="operations_config_menu"
+        sequence="45"
+    />
+
     <!-- Others Settings -->
     <menuitem
         id="others_config_menu"

--- a/l10n_br_fiscal/views/l10n_br_fiscal_menu.xml
+++ b/l10n_br_fiscal/views/l10n_br_fiscal_menu.xml
@@ -568,6 +568,15 @@
         sequence="30"
     />
 
+    <!-- Product Tag -->
+    <menuitem
+        id="product_tag_menu"
+        action="product_tag_action"
+        groups="l10n_br_fiscal.group_manager"
+        parent="operations_config_menu"
+        sequence="45"
+    />
+
     <!-- Others Settings -->
     <menuitem
         id="others_config_menu"

--- a/l10n_br_fiscal/views/operation_line_view.xml
+++ b/l10n_br_fiscal/views/operation_line_view.xml
@@ -49,6 +49,11 @@
                             <field name="product_type" />
                             <field name="tax_icms_or_issqn" />
                             <field name="icms_origin" />
+                            <field
+                                name="product_fiscal_tag_ids"
+                                widget="many2many_tags"
+                                options="{'no_create_edit': False}"
+                            />
                         </group>
                     </group>
                     <notebook>

--- a/l10n_br_fiscal/views/operation_line_view.xml
+++ b/l10n_br_fiscal/views/operation_line_view.xml
@@ -50,7 +50,7 @@
                             <field name="tax_icms_or_issqn" />
                             <field name="icms_origin" />
                             <field
-                                name="product_fiscal_tag_ids"
+                                name="fiscal_product_tag_ids"
                                 widget="many2many_tags"
                                 options="{'no_create_edit': False}"
                             />

--- a/l10n_br_fiscal/views/product_product_view.xml
+++ b/l10n_br_fiscal/views/product_product_view.xml
@@ -102,6 +102,11 @@
                                 name="ipi_control_seal_id"
                                 attrs="{'invisible': [('fiscal_type', '=', '09')]}"
                             />
+                            <field
+                                name="operation_line_tag_ids"
+                                widget="many2many_tags"
+                                options="{'no_create': True, 'no_create_edit': True}"
+                            />
                         </group>
                         <group string="Tax UOM">
                             <field name="uoe_id" />

--- a/l10n_br_fiscal/views/product_product_view.xml
+++ b/l10n_br_fiscal/views/product_product_view.xml
@@ -108,6 +108,11 @@
                                 name="ipi_control_seal_id"
                                 attrs="{'invisible': [('fiscal_type', '=', '09')]}"
                             />
+                            <field
+                                name="operation_line_tag_ids"
+                                widget="many2many_tags"
+                                options="{'no_create': True, 'no_create_edit': True}"
+                            />
                         </group>
                         <group string="Tax UOM">
                             <field name="uoe_id" />

--- a/l10n_br_fiscal/views/product_product_view.xml
+++ b/l10n_br_fiscal/views/product_product_view.xml
@@ -109,7 +109,7 @@
                                 attrs="{'invisible': [('fiscal_type', '=', '09')]}"
                             />
                             <field
-                                name="operation_line_tag_ids"
+                                name="fiscal_product_tag_ids"
                                 widget="many2many_tags"
                                 options="{'no_create': True, 'no_create_edit': True}"
                             />

--- a/l10n_br_fiscal/views/product_tag_view.xml
+++ b/l10n_br_fiscal/views/product_tag_view.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+Copyright (C) 2024-Today - KMEE (<http://www.kmee.com.br>).
+@author Diego Paradeda <diego.paradeda@kmee.com.br>
+License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record id="product_tag_search" model="ir.ui.view">
+        <field name="name">l10n_br_fiscal.product_tag.search</field>
+        <field name="model">l10n_br_fiscal.product.tag</field>
+        <field name="arch" type="xml">
+            <search string="Product Tag">
+                <field name="name" />
+            </search>
+        </field>
+    </record>
+
+    <record id="product_tag_tree" model="ir.ui.view">
+        <field name="name">l10n_br_fiscal.product_tag.tree</field>
+        <field name="model">l10n_br_fiscal.product.tag</field>
+        <field name="arch" type="xml">
+            <tree editable="top">
+                <field name="name" />
+                <field name="create_uid" />
+                <field name="create_date" />
+            </tree>
+        </field>
+    </record>
+
+</odoo>

--- a/l10n_br_fiscal/views/product_template_view.xml
+++ b/l10n_br_fiscal/views/product_template_view.xml
@@ -123,6 +123,11 @@
                                 attrs="{'invisible': [('fiscal_type', '!=', '09')]}"
                                 options="{'no_create': True, 'no_create_edit': True}"
                             />
+                            <field
+                                name="operation_line_tag_ids"
+                                widget="many2many_tags"
+                                options="{'no_create': True, 'no_create_edit': True}"
+                            />
                         </group>
                         <group string="Tax UOM">
                             <field

--- a/l10n_br_fiscal/views/product_template_view.xml
+++ b/l10n_br_fiscal/views/product_template_view.xml
@@ -135,7 +135,7 @@
                                 options="{'no_create': True, 'no_create_edit': True}"
                             />
                             <field
-                                name="operation_line_tag_ids"
+                                name="fiscal_product_tag_ids"
                                 widget="many2many_tags"
                                 options="{'no_create': True, 'no_create_edit': True}"
                             />

--- a/l10n_br_fiscal/views/product_template_view.xml
+++ b/l10n_br_fiscal/views/product_template_view.xml
@@ -134,6 +134,11 @@
                                 attrs="{'invisible': [('fiscal_type', '!=', '09')]}"
                                 options="{'no_create': True, 'no_create_edit': True}"
                             />
+                            <field
+                                name="operation_line_tag_ids"
+                                widget="many2many_tags"
+                                options="{'no_create': True, 'no_create_edit': True}"
+                            />
                         </group>
                         <group string="Tax UOM">
                             <field

--- a/l10n_br_pos/tests/test_l10n_br_pos_config.py
+++ b/l10n_br_pos/tests/test_l10n_br_pos_config.py
@@ -16,8 +16,7 @@ class TestL10nBrPosConfig(TransactionCase):
             "l10n_br_fiscal.fo_venda"
         )
         self.pos_config._compute_allowed_tax()
-        self.assertEqual(
-            4,
+        self.assertTrue(
             len(self.pos_config.out_pos_fiscal_operation_line_ids),
             "Tax operations lines were not found.",
         )


### PR DESCRIPTION
## Objetivo

Este PR introduz o modelo `product.tag` para aprimorar a capacidade de combinação automática das linhas de operação fiscal por produto.
