### PR TITLE
[14.0][spec_driven_model][l10n_br_nfe] multi-schemas compatibility - round 1

### DIFF
--- a/l10n_br_nfe/hooks.py
+++ b/l10n_br_nfe/hooks.py
@@ -37,7 +37,7 @@ def post_init_hook(cr, registry):
             nfe = (
                 env["nfe.40.infnfe"]
                 .with_context(tracking_disable=True, edoc_type="in")
-                .build_from_binding(binding.NFe.infNFe)
+                .build_from_binding("nfe", "40", binding.NFe.infNFe)
             )
             _logger.info(nfe.nfe40_emit.nfe40_CNPJ)
         except ValidationError:

--- a/l10n_br_nfe/models/__init__.py
+++ b/l10n_br_nfe/models/__init__.py
@@ -21,3 +21,6 @@ from . import cfop
 from . import invalidate_number
 from . import dfe
 from . import mde
+
+spec_schema = "nfe"
+spec_version = "40"

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -898,11 +898,11 @@ class NFe(spec_models.StackedModel):
         ):
             record.flush()
             record.invalidate_cache()
-            inf_nfe = record.export_ds("nfe", "40")[0]
+            inf_nfe = record._build_binding("nfe", "40")
 
             inf_nfe_supl = None
             if record.nfe40_infNFeSupl:
-                inf_nfe_supl = record.nfe40_infNFeSupl.export_ds("nfe", "40")[0]
+                inf_nfe_supl = record.nfe40_infNFeSupl._build_binding("nfe", "40")
 
             nfe = Nfe(infNFe=inf_nfe, infNFeSupl=inf_nfe_supl, signature=None)
             edocs.append(nfe)

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -70,12 +70,14 @@ class NFeLine(spec_models.StackedModel):
 
     _name = "l10n_br_fiscal.document.line"
     _inherit = ["l10n_br_fiscal.document.line", "nfe.40.det"]
-    _stacked = "nfe.40.det"
-    _spec_module = "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00"
-    _stacking_points = {}
-    # all m2o below this level will be stacked even if not required:
-    _force_stack_paths = ("det.imposto.",)
-    _stack_skip = ("nfe40_det_infNFe_id",)
+    _nfe40_spec_settings = {
+        "module": "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00",
+        "stacking_mixin": "nfe.40.det",
+        "stacking_points": {},
+        # all m2o below this level will be stacked even if not required:
+        "stacking_force_paths": ("det.imposto.",),
+        "stacking_skip_paths": ("nfe40_det_infNFe_id",),
+    }
 
     # When dynamic stacking is applied, the NFe line has the following structure:
     DET_TREE = """

--- a/l10n_br_nfe/models/document_related.py
+++ b/l10n_br_nfe/models/document_related.py
@@ -20,10 +20,12 @@ from odoo.addons.spec_driven_model.models import spec_models
 class NFeRelated(spec_models.StackedModel):
     _name = "l10n_br_fiscal.document.related"
     _inherit = ["l10n_br_fiscal.document.related", "nfe.40.nfref"]
-    _stacked = "nfe.40.nfref"
-    _stacking_points = {}
-    _spec_module = "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00"
-    _stack_skip = ("nfe40_NFref_ide_id",)
+    _nfe40_spec_settings = {
+        "module": "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00",
+        "stacking_mixin": "nfe.40.nfref",
+        "stacking_points": {},
+        "stacking_skip_paths": ("nfe40_NFref_ide_id",),
+    }
     # all m2o below this level will be stacked even if not required:
     _rec_name = "nfe40_refNFe"
 

--- a/l10n_br_nfe/models/document_supplement.py
+++ b/l10n_br_nfe/models/document_supplement.py
@@ -9,6 +9,8 @@ class NFeSupplement(spec_models.StackedModel):
     _name = "l10n_br_fiscal.document.supplement"
     _description = "NFe Supplement Document"
     _inherit = "nfe.40.infnfesupl"
-    _stacked = "nfe.40.infnfesupl"
-    _stacking_points = {}
-    _spec_module = "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00"
+    _nfe40_spec_settings = {
+        "module": "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00",
+        "stacking_mixin": "nfe.40.infnfesupl",
+        "stacking_points": {},
+    }

--- a/l10n_br_nfe/tests/test_nfe_import.py
+++ b/l10n_br_nfe/tests/test_nfe_import.py
@@ -32,7 +32,7 @@ class NFeImportTest(SavepointCase):
         nfe = (
             self.env["nfe.40.infnfe"]
             .with_context(tracking_disable=True, edoc_type="in")
-            .build_from_binding(binding.NFe.infNFe, dry_run=True)
+            .build_from_binding("nfe", "40", binding.NFe.infNFe, dry_run=True)
         )
         assert isinstance(nfe.id, NewId)
         self._check_nfe(nfe)
@@ -51,7 +51,7 @@ class NFeImportTest(SavepointCase):
         nfe = (
             self.env["nfe.40.infnfe"]
             .with_context(tracking_disable=True, edoc_type="in")
-            .build_from_binding(binding.NFe.infNFe, dry_run=False)
+            .build_from_binding("nfe", "40", binding.NFe.infNFe, dry_run=False)
         )
 
         assert isinstance(nfe.id, int)

--- a/l10n_br_nfe/tests/test_nfe_structure.py
+++ b/l10n_br_nfe/tests/test_nfe_structure.py
@@ -26,11 +26,14 @@ class NFeStructure(SavepointCase):
         # ≡ means o2m. Eventually followd by the mapped Odoo model
         """
         spec_module = "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00"
-        node = SpecModel._odoo_name_to_class(klass._stacked, spec_module)
+        stacking_settings = klass._nfe40_spec_settings
+        node = SpecModel._odoo_name_to_class(
+            stacking_settings["stacking_mixin"], spec_module
+        )
         tree = StringIO()
         visited = set()
         for kind, n, path, field_path, child_concrete in klass._visit_stack(
-            cls.env, node
+            cls.env, node, stacking_settings
         ):
             visited.add(n)
             path_items = path.split(".")
@@ -118,7 +121,13 @@ class NFeStructure(SavepointCase):
             "nfe40_cobr",
             "nfe40_fat",
         ]
-        keys = [k for k in self.env["l10n_br_fiscal.document"]._stacking_points.keys()]
+        keys = [
+            k
+            for k in self.env["l10n_br_fiscal.document"]
+            .with_context(spec_schema="nfe", spec_version="40")
+            ._get_stacking_points()
+            .keys()
+        ]
         self.assertEqual(sorted(keys), sorted(doc_keys))
 
     def test_doc_tree(self):
@@ -154,7 +163,11 @@ class NFeStructure(SavepointCase):
             "nfe40_prod",
         ]
         keys = [
-            k for k in self.env["l10n_br_fiscal.document.line"]._stacking_points.keys()
+            k
+            for k in self.env["l10n_br_fiscal.document.line"]
+            .with_context(spec_schema="nfe", spec_version="40")
+            ._get_stacking_points()
+            .keys()
         ]
         self.assertEqual(sorted(keys), line_keys)
 

--- a/spec_driven_model/models/spec_export.py
+++ b/spec_driven_model/models/spec_export.py
@@ -51,7 +51,7 @@ class SpecMixinExport(models.AbstractModel):
         This method implements a dynamic dispatch checking if there is any
         method called _export_fields_CLASS_NAME to update the xsd_fields
         and export_dict variables, this way we allow controlling the
-        flow of fields to export or injecting specific values ​​in the
+        flow of fields to export or injecting specific values in the
         field export.
         """
         self.ensure_one()
@@ -118,10 +118,6 @@ class SpecMixinExport(models.AbstractModel):
                 if field.comodel_name not in self._get_spec_classes():
                     return False
             if hasattr(field, "xsd_choice_required"):
-                # NOTE generateds-odoo would abusively have xsd_required=True
-                # already in the spec file in this case.
-                # In xsdata-odoo we introduced xsd_choice_required.
-                # Here we make the legacy code compatible with xsdata-odoo:
                 xsd_required = True
             return self._export_many2one(xsd_field, xsd_required, class_obj)
         elif self._fields[xsd_field].type == "one2many":
@@ -135,7 +131,7 @@ class SpecMixinExport(models.AbstractModel):
             and self[xsd_field] is not False
         ):
             if hasattr(field, "xsd_choice_required"):
-                xsd_required = True  # NOTE compat, see previous NOTE
+                xsd_required = True
             return self._export_float_monetary(
                 xsd_field, xsd_type, class_obj, xsd_required, export_value
             )
@@ -147,19 +143,19 @@ class SpecMixinExport(models.AbstractModel):
     def _export_many2one(self, field_name, xsd_required, class_obj=None):
         self.ensure_one()
         if field_name in self._get_stacking_points().keys():
-            return self._build_generateds(
+            return self._build_binding(
                 class_name=self._get_stacking_points()[field_name].comodel_name
             )
         else:
-            return (self[field_name] or self)._build_generateds(
-                class_obj._fields[field_name].comodel_name
+            return (self[field_name] or self)._build_binding(
+                class_name=class_obj._fields[field_name].comodel_name
             )
 
     def _export_one2many(self, field_name, class_obj=None):
         self.ensure_one()
         relational_data = []
         for relational_field in self[field_name]:
-            field_data = relational_field._build_generateds(
+            field_data = relational_field._build_binding(
                 class_name=class_obj._fields[field_name].comodel_name
             )
             relational_data.append(field_data)
@@ -192,8 +188,7 @@ class SpecMixinExport(models.AbstractModel):
             ).isoformat("T")
         )
 
-    # TODO rename _build_binding
-    def _build_generateds(self, class_name=False, spec_schema=None, spec_version=None):
+    def _build_binding(self, spec_schema=None, spec_version=None, class_name=None):
         """
         Iterate over an Odoo record and its m2o and o2m sub-records
         using a pre-order tree traversal and map the Odoo record values
@@ -205,9 +200,7 @@ class SpecMixinExport(models.AbstractModel):
         """
         self.ensure_one()
         if spec_schema and spec_version:
-            self = self.with_context(
-                self.env, spec_schema=spec_schema, spec_version=spec_version
-            )
+            self = self.with_context(spec_schema=spec_schema, spec_version=spec_version)
         spec_prefix = self._spec_prefix(self._context)
         if not class_name:
             if hasattr(self, f"_{spec_prefix}_spec_settings"):
@@ -229,27 +222,9 @@ class SpecMixinExport(models.AbstractModel):
         kwargs = {}
         binding_class = self._get_binding_class(class_obj)
         self._export_fields(xsd_fields, class_obj, export_dict=kwargs)
-        if kwargs:
-            sliced_kwargs = {
-                key: kwargs.get(key)
-                for key in binding_class.__dataclass_fields__.keys()
-                if kwargs.get(key)
-            }
-            binding_instance = binding_class(**sliced_kwargs)
-            return binding_instance
-
-    def export_xml(self):
-        self.ensure_one()
-        result = []
-        if hasattr(self, f"_{self._spec_prefix(self._context)}_spec_settings"):
-            binding_instance = self._build_generateds()
-            result.append(binding_instance)
-        return result
-
-    def export_ds(
-        self, spec_schema, spec_version
-    ):  # TODO change name -> export_binding!
-        self.ensure_one()
-        return self.with_context(
-            spec_schema=spec_schema, spec_version=spec_version
-        ).export_xml()
+        sliced_kwargs = {
+            key: kwargs.get(key)
+            for key in binding_class.__dataclass_fields__.keys()
+            if kwargs.get(key)
+        }
+        return binding_class(**sliced_kwargs)

--- a/spec_driven_model/models/spec_import.py
+++ b/spec_driven_model/models/spec_import.py
@@ -21,7 +21,7 @@ class SpecMixinImport(models.AbstractModel):
     _name = "spec.mixin_import"
     _description = """
     A recursive Odoo object builder that works along with the
-    GenerateDS object builder from the parsed XML.
+    xsdata object builder from the parsed XML.
     Here we take into account the concrete Odoo objects where the schema
     mixins where injected and possible matcher or builder overrides.
     """
@@ -31,7 +31,7 @@ class SpecMixinImport(models.AbstractModel):
         """
         Build an instance of an Odoo Model from a pre-populated
         Python binding object. Binding object such as the ones generated using
-        generateDS can indeed be automatically populated from an XML file.
+        xsdata can indeed be automatically populated from an XML file.
         This build method bridges the gap to build the Odoo object.
 
         It uses a pre-order tree traversal of the Python bindings and for each

--- a/spec_driven_model/models/spec_import.py
+++ b/spec_driven_model/models/spec_import.py
@@ -27,7 +27,7 @@ class SpecMixinImport(models.AbstractModel):
     """
 
     @api.model
-    def build_from_binding(self, node, dry_run=False):
+    def build_from_binding(self, spec_schema, spec_version, node, dry_run=False):
         """
         Build an instance of an Odoo Model from a pre-populated
         Python binding object. Binding object such as the ones generated using
@@ -42,8 +42,12 @@ class SpecMixinImport(models.AbstractModel):
 
         Defaults values and control options are meant to be passed in the context.
         """
-        model = self._get_concrete_model(self._name)
-        attrs = model.with_context(dry_run=dry_run).build_attrs(node)
+        model = self.with_context(
+            spec_schema=spec_schema, spec_version=spec_version
+        )._get_concrete_model(self._name)
+        attrs = model.with_context(
+            dry_run=dry_run, spec_schema=spec_schema, spec_version=spec_version
+        ).build_attrs(node)
         if dry_run:
             return model.new(attrs)
         else:

--- a/spec_driven_model/models/spec_mixin.py
+++ b/spec_driven_model/models/spec_mixin.py
@@ -2,7 +2,6 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
 
 from odoo import api, models
-from odoo.tools import frozendict
 
 from .spec_models import SPEC_MIXIN_MAPPINGS, SpecModel, StackedModel
 
@@ -22,20 +21,6 @@ class SpecMixin(models.AbstractModel):
     _description = "root abstract model meant for xsd generated fiscal models"
     _name = "spec.mixin"
     _inherit = ["spec.mixin_export", "spec.mixin_import"]
-
-    # actually _stacking_points are model and even schema specific
-    # but the legacy code used it extensively so a first defensive
-    # action we can take is to use a frozendict so it is readonly
-    # at least. In the future the whole stacking system should be
-    # scoped under a given schema and version as in
-    # https://github.com/OCA/l10n-brazil/pull/3424
-    _stacking_points = frozendict({})
-
-    # _spec_module = 'override.with.your.python.module'
-    # _binding_module = 'your.pyhthon.binding.module'
-    # _odoo_module = 'your.odoo_module'
-    # _field_prefix = 'your_field_prefix_'
-    # _schema_name = 'your_schema_name'
 
     def _valid_field_parameter(self, field, name):
         if name in (
@@ -114,6 +99,8 @@ class SpecMixin(models.AbstractModel):
                     "_module": self._odoo_module,
                 },
             )
+            model_type._schema_name = self._schema_name
+            model_type._schema_version = self._schema_version
             models.MetaModel.module_to_models[self._odoo_module] += [model_type]
 
             # now we init these models properly

--- a/spec_driven_model/models/spec_models.py
+++ b/spec_driven_model/models/spec_models.py
@@ -4,6 +4,7 @@
 import logging
 import sys
 from collections import OrderedDict, defaultdict
+from importlib import import_module
 from inspect import getmembers, isclass
 
 from odoo import SUPERUSER_ID, _, api, models
@@ -65,6 +66,20 @@ class SpecModel(models.Model):
             if rec.display_name == "False" or not rec.display_name:
                 rec.display_name = _("Abrir...")
         return res
+
+    def _get_stacking_points(self):
+        key = f"_{self._spec_prefix(self._context)}_spec_settings"
+        if hasattr(self, key):
+            return getattr(self, key)["stacking_points"]
+        return {}
+
+    @classmethod
+    def _spec_prefix(cls, context=None, spec_schema=None, spec_version=None):
+        if context and context.get("spec_schema"):
+            spec_schema = context.get("spec_schema")
+        if context and context.get("spec_version"):
+            spec_version = context.get("spec_version")
+        return "%s%s" % (spec_schema, spec_version.replace(".", "")[:2])
 
     @classmethod
     def _build_model(cls, pool, cr):
@@ -190,7 +205,6 @@ class SpecModel(models.Model):
         Cache the list of spec_module classes to save calls to
         slow reflection API.
         """
-
         spec_module_attr = f"_spec_cache_{spec_module.replace('.', '_')}"
         if not hasattr(cls, spec_module_attr):
             setattr(
@@ -215,8 +229,9 @@ class StackedModel(SpecModel):
 
     By inheriting from StackModel instead, your models.Model can
     instead inherit all the mixins that would correspond to the nested xsd
-    nodes starting from the _stacked node. _stack_skip allows you to avoid
-    stacking specific nodes.
+    nodes starting from the stacking_mixin. stacking_skip_paths allows you to avoid
+    stacking specific nodes while stacking_force_paths will stack many2one
+    entities even if they are not required.
 
     In Brazil it allows us to have mostly the fiscal
     document objects and the fiscal document line object with many details
@@ -228,24 +243,26 @@ class StackedModel(SpecModel):
 
     _register = False  # forces you to inherit StackeModel properly
 
-    # define _stacked in your submodel to define the model of the XML tags
-    # where we should start to
-    # stack models of nested tags in the same object.
-    _stacked = False
-    _stack_path = ""
-    _stack_skip = ()
-    # all m2o below these paths will be stacked even if not required:
-    _force_stack_paths = ()
-    _stacking_points = {}
-
     @classmethod
     def _build_model(cls, pool, cr):
+        mod = import_module(".".join(cls.__module__.split(".")[:-1]))
+        if hasattr(cls, "_schema_name"):
+            schema = cls._schema_name
+            version = cls._schema_version.replace(".", "")[:2]
+        else:
+            mod = import_module(".".join(cls.__module__.split(".")[:-1]))
+            schema = mod.spec_schema
+            version = mod.spec_version.replace(".", "")[:2]
+        spec_prefix = cls._spec_prefix(spec_schema=schema, spec_version=version)
+        stacking_settings = getattr(cls, "_%s_spec_settings" % (spec_prefix,))
         # inject all stacked m2o as inherited classes
         _logger.info(f"building StackedModel {cls._name} {cls}")
-        node = cls._odoo_name_to_class(cls._stacked, cls._spec_module)
+        node = cls._odoo_name_to_class(
+            stacking_settings["stacking_mixin"], stacking_settings["module"]
+        )
         env = api.Environment(cr, SUPERUSER_ID, {})
         for kind, klass, _path, _field_path, _child_concrete in cls._visit_stack(
-            env, node
+            env, node, stacking_settings
         ):
             if kind == "stacked" and klass not in cls.__bases__:
                 cls.__bases__ = (klass,) + cls.__bases__
@@ -255,12 +272,18 @@ class StackedModel(SpecModel):
     def _add_field(self, name, field):
         for cls in type(self).mro():
             if issubclass(cls, StackedModel):
-                if name in type(self)._stacking_points.keys():
-                    return
+                if hasattr(self, "_schema_name"):
+                    prefix = self._spec_prefix(
+                        None, self._schema_name, self._schema_version
+                    )
+                    key = f"_{prefix}_spec_settings"
+                    stacking_points = getattr(self, key)["stacking_points"]
+                    if name in stacking_points.keys():
+                        return
         return super()._add_field(name, field)
 
     @classmethod
-    def _visit_stack(cls, env, node, path=None):
+    def _visit_stack(cls, env, node, stacking_settings, path=None):
         """Pre-order traversal of the stacked models tree.
         1. This method is used to dynamically inherit all the spec models
         stacked together from an XML hierarchy.
@@ -272,7 +295,7 @@ class StackedModel(SpecModel):
         # https://github.com/OCA/l10n-brazil/pull/1272#issuecomment-821806603
         node._description = None
         if path is None:
-            path = cls._stacked.split(".")[-1]
+            path = stacking_settings["stacking_mixin"].split(".")[-1]
         cls._map_concrete(env.cr.dbname, node._name, cls._name, quiet=True)
         yield "stacked", node, path, None, None
 
@@ -296,10 +319,15 @@ class StackedModel(SpecModel):
                 and i[1].xsd_choice_required,
             }
         for name, f in fields.items():
-            if f["type"] not in ["many2one", "one2many"] or name in cls._stack_skip:
+            if f["type"] not in [
+                "many2one",
+                "one2many",
+            ] or name in stacking_settings.get("stacking_skip_paths", ""):
                 # TODO change for view or export
                 continue
-            child = cls._odoo_name_to_class(f["comodel_name"], cls._spec_module)
+            child = cls._odoo_name_to_class(
+                f["comodel_name"], stacking_settings["module"]
+            )
             if child is None:  # Not a spec field
                 continue
             child_concrete = SPEC_MIXIN_MAPPINGS[env.cr.dbname].get(child._name)
@@ -311,7 +339,7 @@ class StackedModel(SpecModel):
 
             force_stacked = any(
                 stack_path in path + "." + field_path
-                for stack_path in cls._force_stack_paths
+                for stack_path in stacking_settings.get("stacking_force_paths", "")
             )
 
             # many2one
@@ -320,8 +348,10 @@ class StackedModel(SpecModel):
             ):
                 # then we will STACK the child in the current class
                 child._stack_path = path
-                child_path = f"{path}.{field_path}"
-                cls._stacking_points[name] = env[node._name]._fields.get(name)
-                yield from cls._visit_stack(env, child, child_path)
+                child_path = "%s.%s" % (path, field_path)
+                stacking_settings["stacking_points"][name] = env[
+                    node._name
+                ]._fields.get(name)
+                yield from cls._visit_stack(env, child, stacking_settings, child_path)
             else:
                 yield "many2one", node, path, field_path, child_concrete

--- a/spec_driven_model/models/spec_view.py
+++ b/spec_driven_model/models/spec_view.py
@@ -133,7 +133,7 @@ class SpecViewMixin(models.AbstractModel):
     # TODO required only if visible
     @api.model
     def build_arch(self, lib_node, view_node, fields, depth=0):
-        """Creates a view arch from an generateds lib model arch"""
+        """Creates a view arch from an xsdata lib model arch"""
         # _logger.info("BUILD ARCH", lib_node)
         choices = set()
         wrapper_group = None

--- a/spec_driven_model/readme/DESCRIPTION.rst
+++ b/spec_driven_model/readme/DESCRIPTION.rst
@@ -1,7 +1,7 @@
 Intro
 ~~~~~
 
-This module is a databinding framework for Odoo and XML data: it allows to go from XML to Odoo objects back and forth. This module started with the `GenerateDS <https://www.davekuhlman.org/generateDS.html>`_  pure Python databinding framework and is now being migrated to xsdata. So a good starting point is to read `the xsdata documentation here <https://xsdata.readthedocs.io/>`_
+This module is a databinding framework for Odoo and XML data: it allows to go from XML to Odoo objects back and forth. While having no hard dependency with it, it has been designed to be used with xsdata. So a good starting point is to read `the xsdata documentation here <https://xsdata.readthedocs.io/>`_
 
 But what if instead of only generating Python structures from XML files you could actually generate full blown Odoo objects or serialize Odoo objects back to XML? This is what this module is for!
 
@@ -26,7 +26,7 @@ Now that you have generated these Odoo abstract bindings you should tell Odoo ho
 
 Notice you should inherit from `spec_models.SpecModel` and not the usual `models.Model`.
 
-**Field mapping**: You can then define two ways mapping between fields by overriding fields from Odoo or from the binding and using `_compute=` , `_inverse=` or simply `related=`.
+**Field mapping**: You can then define two ways mapping between fields by overriding fields from Odoo or from the binding using `_compute=` , `_inverse=` or simply `related=`.
 
 **Relational fields**: simple fields are easily mapped this way. However what about relational fields? In your XSD schema, your electronic invoice is related to the `partner.binding.mixin` not to an Odoo `res.partner`. Don't worry, when `SpecModel` classes are instanciated for all relational fields, we look if their comodel have been injected into some existing Odoo model and if so we remap them to the proper Odoo model.
 
@@ -36,7 +36,7 @@ Notice you should inherit from `spec_models.SpecModel` and not the usual `models
 StackedModel
 ~~~~~~~~~~~~
 
-Sadly real life XML is a bit more complex than that. Often XML structures are deeply nested just because it makes it easier for XSD schemas to validate them! for instance an electronic invoice line can be a nested structure with lots of tax details and product details. In a relational model like Odoo however you often want flatter data structures. This is where `StackedModel` comes to the rescue! It inherits from `SpecModel` and when you inherit from `StackedModel` you can inherit from all the generated mixins corresponding to the nested XML tags below some tag (here `invoice.line.binding.mixin`). All the fields corresponding to these XML tag attributes will be collected in your model and the XML parsing and serialization will happen as expected::
+Sadly real life XML is a bit more complex than that. Often XML structures are deeply nested just because it makes it easier for XSD schemas to validate them! for instance an electronic invoice line can be a nested structure with lots of tax details and product details. In a relational model like Odoo however you often want flatter data structures. This is where `StackedModel` comes to the rescue! It inherits from `SpecModel` and when you inherit from `StackedModel` you can inherit from all the generated mixins corresponding to the nested XML tags below some tag (here `invoice.line.binding.mixin`). All the fields corresponding to these XML tag attributes will be collected in your model and the XML parsing and serialization will happen as expected. Here is an example inspired from the Brazilian Electronic Invoice where the schema is called `nfe` and where we use the 2 digits `40` for its short version::
 
 
   from odoo.addons.spec_driven_model.models import spec_models
@@ -45,14 +45,21 @@ Sadly real life XML is a bit more complex than that. Often XML structures are de
   class InvoiceLine(spec_models.StackedModel):
       _inherit = [
           'account.move.line',
-          'invoice.line.binding.mixin',
+          'nfe.40.det',
       ]
-      _stacked = 'invoice.line.binding.mixin'
+      _nfe40_spec_settings = {
+          "module": "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00",
+          "stacking_mixin": "nfe.40.det",
+          "stacking_points": {},
+          # all m2o below this level will be stacked even if not required:
+          "stacking_force_paths": ("det.imposto.",),
+          "stacking_skip_paths": ("nfe40_det_infNFe_id",),
+      }
 
-All many2one fields that are required in the XSD (xsd_required=True) will get their model stacked automatically and recursively. You can force non required many2one fields to be stacked using the `_force_stack_paths` attribute. On the contrary, you can avoid some required many2one fields to be stacked using the `stack_skip` attribute.
+All many2one fields that are required in the XSD (xsd_required=True) will get their model stacked automatically and recursively. You can force non required many2one fields to be stacked using the `stacking_force_paths` attribute. On the contrary, you can avoid some required many2one fields to be stacked using the `stacking_skip_paths` attribute.
 
 
-Hooks
-~~~~~
+Initialization hook
+~~~~~~~~~~~~~~~~~~~
 
-Because XSD schemas can define lot's of different models, spec_driven_model comes with handy hooks that will automatically make all XSD mixins turn into concrete Odoo model (eg with a table) if you didn't inject them into existing Odoo models.
+Because XSD schemas can define lot's of different models, spec_driven_model comes with a handy _register_hook that will automatically make all XSD mixins turn into concrete Odoo model (eg with a table) if you didn't inject them into existing Odoo models.

--- a/spec_driven_model/tests/__init__.py
+++ b/spec_driven_model/tests/__init__.py
@@ -1,1 +1,4 @@
 from . import test_spec_model
+
+spec_schema = "poxsd"
+spec_version = "10"

--- a/spec_driven_model/tests/spec_purchase.py
+++ b/spec_driven_model/tests/spec_purchase.py
@@ -41,10 +41,11 @@ class PurchaseOrder(spec_models.StackedModel):
 
     _name = "fake.purchase.order"
     _inherit = ["fake.purchase.order", "poxsd.10.purchaseordertype"]
-    _spec_module = "odoo.addons.spec_driven_model.tests.spec_poxsd"
-    _stacked = "poxsd.10.purchaseordertype"
-    _stacking_points = {}
-    _poxsd10_spec_module_classes = None
+    _poxsd10_spec_settings = {
+        "module": "odoo.addons.spec_driven_model.tests.spec_poxsd",
+        "stacking_mixin": "poxsd.10.purchaseordertype",
+        "stacking_points": {},
+    }
 
     poxsd10_orderDate = fields.Date(compute="_compute_date")
     poxsd10_confirmDate = fields.Date(related="date_approve")

--- a/spec_driven_model/tests/test_spec_model.py
+++ b/spec_driven_model/tests/test_spec_model.py
@@ -51,18 +51,6 @@ class TestSpecModel(SavepointCase, FakeModelLoader):
         cls.loader.restore_registry()
         super(TestSpecModel, cls).tearDownClass()
 
-    # def test_loading_hook(self):
-    #
-    #     remaining_spec_models = get_remaining_spec_models(
-    #         self.env.cr,
-    #         self.env.registry,
-    #         "spec_driven_model",
-    #         "odoo.addons.spec_driven_model.tests.spec_poxsd",
-    #     )
-    #     self.assertEqual(
-    #         remaining_spec_models, {"poxsd.10.purchaseorder", "poxsd.10.comment"}
-    #     )
-
     def test_spec_models(self):
         self.assertTrue(
             set(self.env["res.partner"]._fields.keys()).issuperset(
@@ -79,7 +67,11 @@ class TestSpecModel(SavepointCase, FakeModelLoader):
     def test_stacked_model(self):
         po_fields_or_stacking = set(self.env["fake.purchase.order"]._fields.keys())
         po_fields_or_stacking.update(
-            set(self.env["fake.purchase.order"]._stacking_points.keys())
+            set(
+                self.env["fake.purchase.order"]
+                ._poxsd10_spec_settings["stacking_points"]
+                .keys()
+            )
         )
         self.assertTrue(
             po_fields_or_stacking.issuperset(
@@ -87,7 +79,11 @@ class TestSpecModel(SavepointCase, FakeModelLoader):
             )
         )
         self.assertEqual(
-            list(self.env["fake.purchase.order"]._stacking_points.keys()),
+            list(
+                self.env["fake.purchase.order"]
+                ._poxsd10_spec_settings["stacking_points"]
+                .keys()
+            ),
             ["poxsd10_items"],
         )
 
@@ -128,7 +124,11 @@ class TestSpecModel(SavepointCase, FakeModelLoader):
 
         # 2nd we serialize it into a binding object:
         # (that could be further XML serialized)
-        po_binding = po._build_generateds()
+        po_binding = po._build_generateds(spec_schema="poxsd", spec_version="10")
+        self.assertEqual(
+            [s.__name__ for s in type(po_binding).mro()],
+            ["PurchaseOrderType", "object"],
+        )
         self.assertEqual(po_binding.bill_to.name, "Wood Corner")
         self.assertEqual(po_binding.items.item[0].product_name, "Some product desc")
         self.assertEqual(po_binding.items.item[0].quantity, 42)
@@ -175,12 +175,14 @@ class TestSpecModel(SavepointCase, FakeModelLoader):
         # 4th we import an Odoo PO from this binding object
         # first we will do a dry run import:
         imported_po_dry_run = self.env["fake.purchase.order"].build_from_binding(
-            po_binding, dry_run=True
+            "poxsd", "10", po_binding, dry_run=True
         )
         assert isinstance(imported_po_dry_run.id, NewId)
 
         # now a real import:
-        imported_po = self.env["fake.purchase.order"].build_from_binding(po_binding)
+        imported_po = self.env["fake.purchase.order"].build_from_binding(
+            "poxsd", "10", po_binding
+        )
         self.assertEqual(imported_po.partner_id.name, "Wood Corner")
         self.assertEqual(
             imported_po.partner_id.id, self.env.ref("base.res_partner_1").id

--- a/spec_driven_model/tests/test_spec_model.py
+++ b/spec_driven_model/tests/test_spec_model.py
@@ -124,7 +124,7 @@ class TestSpecModel(SavepointCase, FakeModelLoader):
 
         # 2nd we serialize it into a binding object:
         # (that could be further XML serialized)
-        po_binding = po._build_generateds(spec_schema="poxsd", spec_version="10")
+        po_binding = po._build_binding(spec_schema="poxsd", spec_version="10")
         self.assertEqual(
             [s.__name__ for s in type(po_binding).mro()],
             ["PurchaseOrderType", "object"],


### PR DESCRIPTION
This PR is intended to make the spec_driven_model StackedModel behavior work well when using several schemas (or even versions) at the same time, for instance NFe with CTe and MDFe...

While working in this I found issues that I fixed in separated PR's:

- https://github.com/OCA/l10n-brazil/pull/3426
- https://github.com/OCA/l10n-brazil/pull/3427

EDIT: In the last commits, I replaced the references to generateDS by xsdata in the spec_driven_model methods and README.