### PR TITLE
[14.0][REF][spec_driven_model]: rm dead code; + XML tests

### DIFF
--- a/spec_driven_model/models/spec_export.py
+++ b/spec_driven_model/models/spec_export.py
@@ -2,7 +2,6 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
 import logging
 import sys
-from io import StringIO
 
 from odoo import api, fields, models
 
@@ -41,18 +40,6 @@ class SpecMixinExport(models.AbstractModel):
                 continue
             spec_classes.append(c)
         return spec_classes
-
-    @api.model
-    def _print_xml(self, binding_instance):
-        if not binding_instance:
-            return
-        output = StringIO()
-        binding_instance.export(
-            output,
-            0,
-            pretty_print=True,
-        )
-        output.close()
 
     def _export_fields(self, xsd_fields, class_obj, export_dict):
         """
@@ -241,25 +228,15 @@ class SpecMixinExport(models.AbstractModel):
             binding_instance = binding_class(**sliced_kwargs)
             return binding_instance
 
-    def export_xml(self, print_xml=True):
+    def export_xml(self):
         self.ensure_one()
         result = []
 
         if hasattr(self, "_stacked"):
             binding_instance = self._build_generateds()
-            if print_xml:
-                self._print_xml(binding_instance)
             result.append(binding_instance)
-
-        else:
-            spec_classes = self._get_spec_classes()
-            for class_name in spec_classes:
-                binding_instance = self._build_generateds(class_name)
-                if print:
-                    self._print_xml(binding_instance)
-                result.append(binding_instance)
         return result
 
-    def export_ds(self):
+    def export_ds(self):  # TODO rename export_binding!
         self.ensure_one()
-        return self.export_xml(print_xml=False)
+        return self.export_xml()

--- a/spec_driven_model/tests/test_spec_model.py
+++ b/spec_driven_model/tests/test_spec_model.py
@@ -112,6 +112,7 @@ class TestSpecModel(SavepointCase, FakeModelLoader):
         po = self.env["fake.purchase.order"].create(
             {
                 "name": "PO XSD",
+                "date_order": "2024-10-08",
                 "partner_id": self.env.ref("base.res_partner_1").id,
                 "dest_address_id": self.env.ref("base.res_partner_1").id,
             }
@@ -133,7 +134,45 @@ class TestSpecModel(SavepointCase, FakeModelLoader):
         self.assertEqual(po_binding.items.item[0].quantity, 42)
         self.assertEqual(po_binding.items.item[0].usprice, "13")  # FIXME
 
-        # 3rd we import an Odoo PO from this binding object
+        # 3rd we serialize po_binding as XML and check the output:
+        try:
+            from xsdata.formats.dataclass.serializers import XmlSerializer
+            from xsdata.formats.dataclass.serializers.config import SerializerConfig
+
+            serializer = XmlSerializer(config=SerializerConfig(indent="  "))
+            xml = serializer.render(obj=po_binding, ns_map=None)
+            expected_xml = """<?xml version="1.0" encoding="UTF-8"?>
+<PurchaseOrderType orderDate="2024-10-08">
+  <ns0:shipTo xmlns:ns0="http://tempuri.org/PurchaseOrderSchema.xsd" country="US">
+    <ns0:name>Wood Corner</ns0:name>
+    <ns0:street>1839 Arbor Way</ns0:street>
+    <ns0:city>Turlock</ns0:city>
+    <ns0:state>California</ns0:state>
+    <ns0:zip>0</ns0:zip>
+  </ns0:shipTo>
+  <ns0:billTo xmlns:ns0="http://tempuri.org/PurchaseOrderSchema.xsd" country="US">
+    <ns0:name>Wood Corner</ns0:name>
+    <ns0:street>1839 Arbor Way</ns0:street>
+    <ns0:city>Turlock</ns0:city>
+    <ns0:state>California</ns0:state>
+    <ns0:zip>0</ns0:zip>
+  </ns0:billTo>
+  <ns0:items xmlns:ns0="http://tempuri.org/PurchaseOrderSchema.xsd">
+    <ns0:item>
+      <ns0:productName>Some product desc</ns0:productName>
+      <ns0:quantity>42</ns0:quantity>
+      <ns0:USPrice>13</ns0:USPrice>
+      <ns0:comment>0</ns0:comment>
+    </ns0:item>
+  </ns0:items>
+</PurchaseOrderType>
+"""
+            self.assertEqual(xml, expected_xml)
+
+        except ImportError:
+            _logger.error(_("xsdata Python lib not installed, skipping XML test!"))
+
+        # 4th we import an Odoo PO from this binding object
         # first we will do a dry run import:
         imported_po_dry_run = self.env["fake.purchase.order"].build_from_binding(
             po_binding, dry_run=True


### PR DESCRIPTION
1. remove dead code, como pode ser verificado aqui: https://app.codecov.io/gh/OCA/l10n-brazil/blob/14.0/spec_driven_model%2Fmodels%2Fspec_export.py (sim aquele if print tava feião mesmo....)
2. testa a serialização XML melhor já no spec_driven_model, isso ta me ajudando a caçar os bugs em #3424

vale a pena dizer que nos mixins de PurchaseOrder de demo, tem uns campos com o tipo zoado. Isso ja era assim e não ta zoado nos mixins fiscais, apenas neste do PurchaseOrder.xsd. Logguei o bug aqui https://github.com/akretion/xsdata-odoo/issues/15 para investigar depois. Mas por enquanto podemos deixar assim na localização e fazer os testes que eu fiz aqui mesmo assim.