### PR TITLE
[14.0][spec_driven_model][l10n_br_nfe] multi schemas support - round 2

### DIFF
--- a/l10n_br_account_nfe/tests/test_nfce_contingency.py
+++ b/l10n_br_account_nfe/tests/test_nfce_contingency.py
@@ -7,8 +7,6 @@ from odoo.tests import TransactionCase
 class TestAccountNFCeContingency(TransactionCase):
     def setUp(self):
         super().setUp()
-        # this hook is required to test l10n_br_account_nfe alone:
-        self.env["spec.mixin.nfe"]._register_hook()
         self.document_id = self.env.ref("l10n_br_nfe.demo_nfce_same_state")
         self.prepare_account_move_nfce()
 

--- a/l10n_br_nfe/hooks.py
+++ b/l10n_br_nfe/hooks.py
@@ -14,7 +14,6 @@ _logger = logging.getLogger(__name__)
 
 def post_init_hook(cr, registry):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    env["nfe.40.infnfe"]._register_hook()
     cr.execute("select demo from ir_module_module where name='l10n_br_nfe';")
     is_demo = cr.fetchone()[0]
     if is_demo:

--- a/l10n_br_nfe/hooks.py
+++ b/l10n_br_nfe/hooks.py
@@ -37,7 +37,7 @@ def post_init_hook(cr, registry):
             nfe = (
                 env["nfe.40.infnfe"]
                 .with_context(tracking_disable=True, edoc_type="in")
-                .build_from_binding(binding.NFe.infNFe)
+                .build_from_binding("nfe", "40", binding.NFe.infNFe)
             )
             _logger.info(nfe.nfe40_emit.nfe40_CNPJ)
         except ValidationError:

--- a/l10n_br_nfe/models/__init__.py
+++ b/l10n_br_nfe/models/__init__.py
@@ -21,3 +21,6 @@ from . import cfop
 from . import invalidate_number
 from . import dfe
 from . import mde
+
+spec_schema = "nfe"
+spec_version = "40"

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -79,19 +79,17 @@ def filter_processador_edoc_nfe(record):
 class NFe(spec_models.StackedModel):
     _name = "l10n_br_fiscal.document"
     _inherit = ["l10n_br_fiscal.document", "nfe.40.infnfe", "nfe.40.fat"]
-    _nfe40_spec_settings = {
-        "module": "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00",
-        "stacking_mixin": "nfe.40.infnfe",
-        "stacking_points": {},
-        # all m2o at this level will be stacked even if not required:
-        "stacking_force_paths": (
-            "infnfe.total",
-            "infnfe.infAdic",
-            "infnfe.exporta",
-            "infnfe.cobr",
-            "infnfe.cobr.fat",
-        ),
-    }
+
+    _nfe40_odoo_module = "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00"
+    _nfe40_stacking_mixin = "nfe.40.infnfe"
+    # all m2o at this level will be stacked even if not required:
+    _nfe40_stacking_force_paths = (
+        "infnfe.total",
+        "infnfe.infAdic",
+        "infnfe.exporta",
+        "infnfe.cobr",
+        "infnfe.cobr.fat",
+    )
     _nfe_search_keys = ["nfe40_Id"]
 
     # When dynamic stacking is applied the NFe structure is:

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -898,11 +898,11 @@ class NFe(spec_models.StackedModel):
         ):
             record.flush()
             record.invalidate_cache()
-            inf_nfe = record.export_ds("nfe", "40")[0]
+            inf_nfe = record._build_binding("nfe", "40")
 
             inf_nfe_supl = None
             if record.nfe40_infNFeSupl:
-                inf_nfe_supl = record.nfe40_infNFeSupl.export_ds("nfe", "40")[0]
+                inf_nfe_supl = record.nfe40_infNFeSupl._build_binding("nfe", "40")
 
             nfe = Nfe(infNFe=inf_nfe, infNFeSupl=inf_nfe_supl, signature=None)
             edocs.append(nfe)

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -78,7 +78,7 @@ def filter_processador_edoc_nfe(record):
 
 class NFe(spec_models.StackedModel):
     _name = "l10n_br_fiscal.document"
-    _inherit = ["l10n_br_fiscal.document", "nfe.40.infnfe", "nfe.40.fat"]
+    _inherit = ["l10n_br_fiscal.document", "nfe.40.infnfe"]
 
     _nfe40_odoo_module = "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00"
     _nfe40_stacking_mixin = "nfe.40.infnfe"
@@ -685,7 +685,7 @@ class NFe(spec_models.StackedModel):
                 fields = [
                     f
                     for f in comodel._fields
-                    if f.startswith(self._field_prefix)
+                    if f.startswith(self._spec_prefix())
                     and f in self._fields.keys()
                     and f
                     # don't try to nfe40_fat id when reading nfe40_cobr for instance
@@ -695,7 +695,7 @@ class NFe(spec_models.StackedModel):
                 if not any(
                     v
                     for k, v in sub_tag_read.items()
-                    if k.startswith(self._field_prefix)
+                    if k.startswith(self._spec_prefix())
                 ):
                     return False
 
@@ -1069,9 +1069,8 @@ class NFe(spec_models.StackedModel):
         return super()._exec_after_SITUACAO_EDOC_AUTORIZADA(old_state, new_state)
 
     def _generate_key(self):
+        super()._generate_key()
         for record in self.filtered(filter_processador_edoc_nfe):
-            date = fields.Datetime.context_timestamp(record, record.document_date)
-
             required_fields_gen_edoc = []
             if not record.company_cnpj_cpf:
                 required_fields_gen_edoc.append("CNPJ/CPF")
@@ -1089,6 +1088,7 @@ class NFe(spec_models.StackedModel):
                     _("To Generate EDoc Key, you need to fill the %s field.") % field
                 )
 
+            date = fields.Datetime.context_timestamp(record, record.document_date)
             chave_edoc = ChaveEdoc(
                 ano_mes=date.strftime("%y%m").zfill(4),
                 cnpj_cpf_emitente=record.company_cnpj_cpf,

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -70,12 +70,14 @@ class NFeLine(spec_models.StackedModel):
 
     _name = "l10n_br_fiscal.document.line"
     _inherit = ["l10n_br_fiscal.document.line", "nfe.40.det"]
-    _stacked = "nfe.40.det"
-    _spec_module = "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00"
-    _stacking_points = {}
-    # all m2o below this level will be stacked even if not required:
-    _force_stack_paths = ("det.imposto.",)
-    _stack_skip = ("nfe40_det_infNFe_id",)
+    _nfe40_spec_settings = {
+        "module": "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00",
+        "stacking_mixin": "nfe.40.det",
+        "stacking_points": {},
+        # all m2o below this level will be stacked even if not required:
+        "stacking_force_paths": ("det.imposto.",),
+        "stacking_skip_paths": ("nfe40_det_infNFe_id",),
+    }
 
     # When dynamic stacking is applied, the NFe line has the following structure:
     DET_TREE = """

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -70,14 +70,12 @@ class NFeLine(spec_models.StackedModel):
 
     _name = "l10n_br_fiscal.document.line"
     _inherit = ["l10n_br_fiscal.document.line", "nfe.40.det"]
-    _nfe40_spec_settings = {
-        "module": "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00",
-        "stacking_mixin": "nfe.40.det",
-        "stacking_points": {},
-        # all m2o below this level will be stacked even if not required:
-        "stacking_force_paths": ("det.imposto.",),
-        "stacking_skip_paths": ("nfe40_det_infNFe_id",),
-    }
+
+    _nfe40_odoo_module = "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00"
+    _nfe40_stacking_mixin = "nfe.40.det"
+    # all m2o below this level will be stacked even if not required:
+    _nfe40_stacking_force_paths = ("det.imposto.",)
+    _nfe40_stacking_skip_paths = ("nfe40_det_infNFe_id",)
 
     # When dynamic stacking is applied, the NFe line has the following structure:
     DET_TREE = """
@@ -516,7 +514,7 @@ class NFeLine(spec_models.StackedModel):
             .replace("ICMS", "Icms")
             .replace("IcmsSN", "Icmssn")
         )
-        binding_module = sys.modules[self._binding_module]
+        binding_module = sys.modules[self._get_spec_property("binding_module")]
         # Tnfe.InfNfe.Det.Imposto.Icms.Icms00
         # see https://stackoverflow.com/questions/31174295/
         # getattr-and-setattr-on-nested-subobjects-chained-properties

--- a/l10n_br_nfe/models/document_related.py
+++ b/l10n_br_nfe/models/document_related.py
@@ -20,10 +20,12 @@ from odoo.addons.spec_driven_model.models import spec_models
 class NFeRelated(spec_models.StackedModel):
     _name = "l10n_br_fiscal.document.related"
     _inherit = ["l10n_br_fiscal.document.related", "nfe.40.nfref"]
-    _stacked = "nfe.40.nfref"
-    _stacking_points = {}
-    _spec_module = "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00"
-    _stack_skip = ("nfe40_NFref_ide_id",)
+    _nfe40_spec_settings = {
+        "module": "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00",
+        "stacking_mixin": "nfe.40.nfref",
+        "stacking_points": {},
+        "stacking_skip_paths": ("nfe40_NFref_ide_id",),
+    }
     # all m2o below this level will be stacked even if not required:
     _rec_name = "nfe40_refNFe"
 

--- a/l10n_br_nfe/models/document_related.py
+++ b/l10n_br_nfe/models/document_related.py
@@ -20,13 +20,11 @@ from odoo.addons.spec_driven_model.models import spec_models
 class NFeRelated(spec_models.StackedModel):
     _name = "l10n_br_fiscal.document.related"
     _inherit = ["l10n_br_fiscal.document.related", "nfe.40.nfref"]
-    _nfe40_spec_settings = {
-        "module": "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00",
-        "stacking_mixin": "nfe.40.nfref",
-        "stacking_points": {},
-        "stacking_skip_paths": ("nfe40_NFref_ide_id",),
-    }
+
+    _nfe40_odoo_module = "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00"
+    _nfe40_stacking_mixin = "nfe.40.nfref"
     # all m2o below this level will be stacked even if not required:
+    _nfe40_stacking_skip_paths = ("nfe40_NFref_ide_id",)
     _rec_name = "nfe40_refNFe"
 
     # When dynamic stacking is applied, this class has the following structure:

--- a/l10n_br_nfe/models/document_supplement.py
+++ b/l10n_br_nfe/models/document_supplement.py
@@ -9,8 +9,6 @@ class NFeSupplement(spec_models.StackedModel):
     _name = "l10n_br_fiscal.document.supplement"
     _description = "NFe Supplement Document"
     _inherit = "nfe.40.infnfesupl"
-    _nfe40_spec_settings = {
-        "module": "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00",
-        "stacking_mixin": "nfe.40.infnfesupl",
-        "stacking_points": {},
-    }
+
+    _nfe40_odoo_module = "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00"
+    _nfe40_stacking_mixin = "nfe.40.infnfesupl"

--- a/l10n_br_nfe/models/document_supplement.py
+++ b/l10n_br_nfe/models/document_supplement.py
@@ -9,6 +9,8 @@ class NFeSupplement(spec_models.StackedModel):
     _name = "l10n_br_fiscal.document.supplement"
     _description = "NFe Supplement Document"
     _inherit = "nfe.40.infnfesupl"
-    _stacked = "nfe.40.infnfesupl"
-    _stacking_points = {}
-    _spec_module = "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00"
+    _nfe40_spec_settings = {
+        "module": "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00",
+        "stacking_mixin": "nfe.40.infnfesupl",
+        "stacking_points": {},
+    }

--- a/l10n_br_nfe/tests/test_nfe_import.py
+++ b/l10n_br_nfe/tests/test_nfe_import.py
@@ -32,7 +32,7 @@ class NFeImportTest(SavepointCase):
         nfe = (
             self.env["nfe.40.infnfe"]
             .with_context(tracking_disable=True, edoc_type="in")
-            .build_from_binding(binding.NFe.infNFe, dry_run=True)
+            .build_from_binding("nfe", "40", binding.NFe.infNFe, dry_run=True)
         )
         assert isinstance(nfe.id, NewId)
         self._check_nfe(nfe)
@@ -51,7 +51,7 @@ class NFeImportTest(SavepointCase):
         nfe = (
             self.env["nfe.40.infnfe"]
             .with_context(tracking_disable=True, edoc_type="in")
-            .build_from_binding(binding.NFe.infNFe, dry_run=False)
+            .build_from_binding("nfe", "40", binding.NFe.infNFe, dry_run=False)
         )
 
         assert isinstance(nfe.id, int)

--- a/l10n_br_nfe/tests/test_nfe_import.py
+++ b/l10n_br_nfe/tests/test_nfe_import.py
@@ -11,11 +11,6 @@ _logger = logging.getLogger(__name__)
 
 
 class NFeImportTest(SavepointCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.env["spec.mixin.nfe"]._register_hook()
-
     def test_import_in_nfe_dry_run(self):
         res_items = (
             "nfe",

--- a/l10n_br_nfe/tests/test_nfe_serialize.py
+++ b/l10n_br_nfe/tests/test_nfe_serialize.py
@@ -18,7 +18,6 @@ _logger = logging.getLogger(__name__)
 class TestNFeExport(TransactionCase):
     def setUp(self, nfe_list):
         super().setUp()
-        self.env["spec.mixin.nfe"]._register_hook()
         self.nfe_list = nfe_list
         for nfe_data in self.nfe_list:
             nfe = self.env.ref(nfe_data["record_ref"])

--- a/l10n_br_nfe/tests/test_nfe_structure.py
+++ b/l10n_br_nfe/tests/test_nfe_structure.py
@@ -26,11 +26,14 @@ class NFeStructure(SavepointCase):
         # ≡ means o2m. Eventually followd by the mapped Odoo model
         """
         spec_module = "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00"
-        node = SpecModel._odoo_name_to_class(klass._stacked, spec_module)
+        stacking_settings = klass._nfe40_spec_settings
+        node = SpecModel._odoo_name_to_class(
+            stacking_settings["stacking_mixin"], spec_module
+        )
         tree = StringIO()
         visited = set()
         for kind, n, path, field_path, child_concrete in klass._visit_stack(
-            cls.env, node
+            cls.env, node, stacking_settings
         ):
             visited.add(n)
             path_items = path.split(".")
@@ -118,7 +121,13 @@ class NFeStructure(SavepointCase):
             "nfe40_cobr",
             "nfe40_fat",
         ]
-        keys = [k for k in self.env["l10n_br_fiscal.document"]._stacking_points.keys()]
+        keys = [
+            k
+            for k in self.env["l10n_br_fiscal.document"]
+            .with_context(spec_schema="nfe", spec_version="40")
+            ._get_stacking_points()
+            .keys()
+        ]
         self.assertEqual(sorted(keys), sorted(doc_keys))
 
     def test_doc_tree(self):
@@ -154,7 +163,11 @@ class NFeStructure(SavepointCase):
             "nfe40_prod",
         ]
         keys = [
-            k for k in self.env["l10n_br_fiscal.document.line"]._stacking_points.keys()
+            k
+            for k in self.env["l10n_br_fiscal.document.line"]
+            .with_context(spec_schema="nfe", spec_version="40")
+            ._get_stacking_points()
+            .keys()
         ]
         self.assertEqual(sorted(keys), line_keys)
 

--- a/l10n_br_nfe/tests/test_nfe_structure.py
+++ b/l10n_br_nfe/tests/test_nfe_structure.py
@@ -26,7 +26,18 @@ class NFeStructure(SavepointCase):
         # ≡ means o2m. Eventually followd by the mapped Odoo model
         """
         spec_module = "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00"
-        stacking_settings = klass._nfe40_spec_settings
+        spec_prefix = "nfe40"
+        stacking_settings = {
+            "odoo_module": getattr(klass, f"_{spec_prefix}_odoo_module"),
+            "stacking_mixin": getattr(klass, f"_{spec_prefix}_stacking_mixin"),
+            "stacking_points": getattr(klass, f"_{spec_prefix}_stacking_points"),
+            "stacking_skip_paths": getattr(
+                klass, f"_{spec_prefix}_stacking_skip_paths", []
+            ),
+            "stacking_force_paths": getattr(
+                klass, f"_{spec_prefix}_stacking_force_paths", []
+            ),
+        }
         node = SpecModel._odoo_name_to_class(
             stacking_settings["stacking_mixin"], spec_module
         )

--- a/l10n_br_nfe/tests/test_nfe_structure.py
+++ b/l10n_br_nfe/tests/test_nfe_structure.py
@@ -16,7 +16,6 @@ class NFeStructure(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.env["spec.mixin.nfe"]._register_hook()
 
     @classmethod
     def get_stacked_tree(cls, klass):

--- a/l10n_br_nfe_spec/models/__init__.py
+++ b/l10n_br_nfe_spec/models/__init__.py
@@ -1,2 +1,2 @@
-from . import spec_models
+from . import spec_mixin
 from . import v4_0

--- a/l10n_br_nfe_spec/models/spec_mixin.py
+++ b/l10n_br_nfe_spec/models/spec_mixin.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 Akretion - Raphael Valyi <raphael.valyi@akretion.com>
+# Copyright 2019-TODAY Akretion - Raphaël Valyi <raphael.valyi@akretion.com>
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
 
 from odoo import fields, models
@@ -7,13 +7,8 @@ from odoo import fields, models
 class NfeSpecMixin(models.AbstractModel):
     _description = "Abstract Model"
     _name = "spec.mixin.nfe"
-    _field_prefix = "nfe40_"
-    _schema_name = "nfe"
-    _schema_version = "4.0.0"
-    _odoo_module = "l10n_br_nfe"
-    _spec_module = "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00"
+    _nfe40_odoo_module = "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00"
     _nfe40_binding_module = "nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00"
-    _spec_tab_name = "NFe"
 
     brl_currency_id = fields.Many2one(
         comodel_name="res.currency",

--- a/l10n_br_nfe_spec/models/spec_models.py
+++ b/l10n_br_nfe_spec/models/spec_models.py
@@ -12,7 +12,7 @@ class NfeSpecMixin(models.AbstractModel):
     _schema_version = "4.0.0"
     _odoo_module = "l10n_br_nfe"
     _spec_module = "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00"
-    _binding_module = "nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00"
+    _nfe40_binding_module = "nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00"
     _spec_tab_name = "NFe"
 
     brl_currency_id = fields.Many2one(

--- a/spec_driven_model/README.rst
+++ b/spec_driven_model/README.rst
@@ -31,7 +31,7 @@ Spec Driven Model
 Intro
 ~~~~~
 
-This module is a databinding framework for Odoo and XML data: it allows to go from XML to Odoo objects back and forth. This module started with the `GenerateDS <https://www.davekuhlman.org/generateDS.html>`_  pure Python databinding framework and is now being migrated to xsdata. So a good starting point is to read `the xsdata documentation here <https://xsdata.readthedocs.io/>`_
+This module is a databinding framework for Odoo and XML data: it allows to go from XML to Odoo objects back and forth. While having no hard dependency with it, it has been designed to be used with xsdata. So a good starting point is to read `the xsdata documentation here <https://xsdata.readthedocs.io/>`_
 
 But what if instead of only generating Python structures from XML files you could actually generate full blown Odoo objects or serialize Odoo objects back to XML? This is what this module is for!
 
@@ -56,7 +56,7 @@ Now that you have generated these Odoo abstract bindings you should tell Odoo ho
 
 Notice you should inherit from `spec_models.SpecModel` and not the usual `models.Model`.
 
-**Field mapping**: You can then define two ways mapping between fields by overriding fields from Odoo or from the binding and using `_compute=` , `_inverse=` or simply `related=`.
+**Field mapping**: You can then define two ways mapping between fields by overriding fields from Odoo or from the binding using `_compute=` , `_inverse=` or simply `related=`.
 
 **Relational fields**: simple fields are easily mapped this way. However what about relational fields? In your XSD schema, your electronic invoice is related to the `partner.binding.mixin` not to an Odoo `res.partner`. Don't worry, when `SpecModel` classes are instanciated for all relational fields, we look if their comodel have been injected into some existing Odoo model and if so we remap them to the proper Odoo model.
 
@@ -66,7 +66,7 @@ Notice you should inherit from `spec_models.SpecModel` and not the usual `models
 StackedModel
 ~~~~~~~~~~~~
 
-Sadly real life XML is a bit more complex than that. Often XML structures are deeply nested just because it makes it easier for XSD schemas to validate them! for instance an electronic invoice line can be a nested structure with lots of tax details and product details. In a relational model like Odoo however you often want flatter data structures. This is where `StackedModel` comes to the rescue! It inherits from `SpecModel` and when you inherit from `StackedModel` you can inherit from all the generated mixins corresponding to the nested XML tags below some tag (here `invoice.line.binding.mixin`). All the fields corresponding to these XML tag attributes will be collected in your model and the XML parsing and serialization will happen as expected::
+Sadly real life XML is a bit more complex than that. Often XML structures are deeply nested just because it makes it easier for XSD schemas to validate them! for instance an electronic invoice line can be a nested structure with lots of tax details and product details. In a relational model like Odoo however you often want flatter data structures. This is where `StackedModel` comes to the rescue! It inherits from `SpecModel` and when you inherit from `StackedModel` you can inherit from all the generated mixins corresponding to the nested XML tags below some tag (here `invoice.line.binding.mixin`). All the fields corresponding to these XML tag attributes will be collected in your model and the XML parsing and serialization will happen as expected. Here is an example inspired from the Brazilian Electronic Invoice where the schema is called `nfe` and where we use the 2 digits `40` for its short version::
 
 
   from odoo.addons.spec_driven_model.models import spec_models
@@ -75,17 +75,24 @@ Sadly real life XML is a bit more complex than that. Often XML structures are de
   class InvoiceLine(spec_models.StackedModel):
       _inherit = [
           'account.move.line',
-          'invoice.line.binding.mixin',
+          'nfe.40.det',
       ]
-      _stacked = 'invoice.line.binding.mixin'
+      _nfe40_spec_settings = {
+          "module": "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00",
+          "stacking_mixin": "nfe.40.det",
+          "stacking_points": {},
+          # all m2o below this level will be stacked even if not required:
+          "stacking_force_paths": ("det.imposto.",),
+          "stacking_skip_paths": ("nfe40_det_infNFe_id",),
+      }
 
-All many2one fields that are required in the XSD (xsd_required=True) will get their model stacked automatically and recursively. You can force non required many2one fields to be stacked using the `_force_stack_paths` attribute. On the contrary, you can avoid some required many2one fields to be stacked using the `stack_skip` attribute.
+All many2one fields that are required in the XSD (xsd_required=True) will get their model stacked automatically and recursively. You can force non required many2one fields to be stacked using the `stacking_force_paths` attribute. On the contrary, you can avoid some required many2one fields to be stacked using the `stacking_skip_paths` attribute.
 
 
-Hooks
-~~~~~
+Initialization hook
+~~~~~~~~~~~~~~~~~~~
 
-Because XSD schemas can define lot's of different models, spec_driven_model comes with handy hooks that will automatically make all XSD mixins turn into concrete Odoo model (eg with a table) if you didn't inject them into existing Odoo models.
+Because XSD schemas can define lot's of different models, spec_driven_model comes with a handy _register_hook that will automatically make all XSD mixins turn into concrete Odoo model (eg with a table) if you didn't inject them into existing Odoo models.
 
 **Table of contents**
 

--- a/spec_driven_model/__manifest__.py
+++ b/spec_driven_model/__manifest__.py
@@ -3,12 +3,11 @@
 
 {
     "name": "Spec Driven Model",
-    "summary": """
-        Tools for specifications driven mixins (from xsd for instance)""",
+    "summary": """XML binding for Odoo: XML to Odoo models and models to XML.""",
     "version": "14.0.5.5.3",
     "maintainers": ["rvalyi"],
     "license": "LGPL-3",
-    "author": "Akretion,Odoo Community Association (OCA)",
+    "author": "Akretion, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-brazil",
     "depends": [],
     "data": [],

--- a/spec_driven_model/models/spec_export.py
+++ b/spec_driven_model/models/spec_export.py
@@ -33,7 +33,7 @@ class SpecMixinExport(models.AbstractModel):
         for c in set(classes):
             if c is None:
                 continue
-            if not c.startswith(f"{self._schema_name}."):
+            if not c.startswith(f"{self._context['spec_schema']}."):
                 continue
             # the following filter to fields to show
             # when several XSD class are injected in the same object
@@ -202,6 +202,7 @@ class SpecMixinExport(models.AbstractModel):
         self.ensure_one()
         if spec_schema and spec_version:
             self = self.with_context(spec_schema=spec_schema, spec_version=spec_version)
+            self.env[f"spec.mixin.{spec_schema}"]._register_hook()
         if not class_name:
             class_name = self._get_spec_property("stacking_mixin", self._name)
 
@@ -210,9 +211,7 @@ class SpecMixinExport(models.AbstractModel):
         xsd_fields = (
             i
             for i in class_obj._fields
-            if class_obj._fields[i].name.startswith(
-                f"{self._spec_prefix(self._context)}_"
-            )
+            if class_obj._fields[i].name.startswith(f"{self._spec_prefix()}_")
             and "_choice" not in class_obj._fields[i].name
         )
 

--- a/spec_driven_model/models/spec_import.py
+++ b/spec_driven_model/models/spec_import.py
@@ -21,7 +21,7 @@ class SpecMixinImport(models.AbstractModel):
     _name = "spec.mixin_import"
     _description = """
     A recursive Odoo object builder that works along with the
-    GenerateDS object builder from the parsed XML.
+    xsdata object builder from the parsed XML.
     Here we take into account the concrete Odoo objects where the schema
     mixins where injected and possible matcher or builder overrides.
     """
@@ -31,7 +31,7 @@ class SpecMixinImport(models.AbstractModel):
         """
         Build an instance of an Odoo Model from a pre-populated
         Python binding object. Binding object such as the ones generated using
-        generateDS can indeed be automatically populated from an XML file.
+        xsdata can indeed be automatically populated from an XML file.
         This build method bridges the gap to build the Odoo object.
 
         It uses a pre-order tree traversal of the Python bindings and for each

--- a/spec_driven_model/models/spec_import.py
+++ b/spec_driven_model/models/spec_import.py
@@ -27,7 +27,7 @@ class SpecMixinImport(models.AbstractModel):
     """
 
     @api.model
-    def build_from_binding(self, node, dry_run=False):
+    def build_from_binding(self, spec_schema, spec_version, node, dry_run=False):
         """
         Build an instance of an Odoo Model from a pre-populated
         Python binding object. Binding object such as the ones generated using
@@ -42,8 +42,12 @@ class SpecMixinImport(models.AbstractModel):
 
         Defaults values and control options are meant to be passed in the context.
         """
-        model = self._get_concrete_model(self._name)
-        attrs = model.with_context(dry_run=dry_run).build_attrs(node)
+        model = self.with_context(
+            spec_schema=spec_schema, spec_version=spec_version
+        )._get_concrete_model(self._name)
+        attrs = model.with_context(
+            dry_run=dry_run, spec_schema=spec_schema, spec_version=spec_version
+        ).build_attrs(node)
         if dry_run:
             return model.new(attrs)
         else:

--- a/spec_driven_model/models/spec_import.py
+++ b/spec_driven_model/models/spec_import.py
@@ -42,12 +42,12 @@ class SpecMixinImport(models.AbstractModel):
 
         Defaults values and control options are meant to be passed in the context.
         """
-        model = self.with_context(
-            spec_schema=spec_schema, spec_version=spec_version
-        )._get_concrete_model(self._name)
-        attrs = model.with_context(
-            dry_run=dry_run, spec_schema=spec_schema, spec_version=spec_version
-        ).build_attrs(node)
+        self = self.with_context(
+            spec_schema=spec_schema, spec_version=spec_version, dry_run=dry_run
+        )
+        self._register_hook()
+        model = self._get_concrete_model(self._name)
+        attrs = model.build_attrs(node)
         if dry_run:
             return model.new(attrs)
         else:
@@ -73,7 +73,7 @@ class SpecMixinImport(models.AbstractModel):
         value = getattr(node, attr[0])
         if value is None or value == []:
             return False
-        prefix = f"{self._spec_prefix(self._context)}"
+        prefix = f"{self._spec_prefix()}"
         key = f"{prefix}_{attr[1].metadata.get('name', attr[0])}"
         child_path = f"{path}.{key}"
 
@@ -193,7 +193,7 @@ class SpecMixinImport(models.AbstractModel):
 
         related_many2ones = {}
         fields = model._fields
-        field_prefix = f"{self._spec_prefix(self._context)}_"
+        field_prefix = f"{self._spec_prefix()}_"
         for k, v in fields.items():
             # select schema choices for a friendly UI:
             if k.startswith(f"{field_prefix}choice"):

--- a/spec_driven_model/models/spec_mixin.py
+++ b/spec_driven_model/models/spec_mixin.py
@@ -21,6 +21,7 @@ class SpecMixin(models.AbstractModel):
     _description = "root abstract model meant for xsd generated fiscal models"
     _name = "spec.mixin"
     _inherit = ["spec.mixin_export", "spec.mixin_import"]
+    _is_spec_driven = True
 
     def _valid_field_parameter(self, field, name):
         if name in (

--- a/spec_driven_model/models/spec_mixin.py
+++ b/spec_driven_model/models/spec_mixin.py
@@ -2,7 +2,6 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
 
 from odoo import api, models
-from odoo.tools import frozendict
 
 from .spec_models import SPEC_MIXIN_MAPPINGS, SpecModel, StackedModel
 
@@ -22,20 +21,6 @@ class SpecMixin(models.AbstractModel):
     _description = "root abstract model meant for xsd generated fiscal models"
     _name = "spec.mixin"
     _inherit = ["spec.mixin_export", "spec.mixin_import"]
-
-    # actually _stacking_points are model and even schema specific
-    # but the legacy code used it extensively so a first defensive
-    # action we can take is to use a frozendict so it is readonly
-    # at least. In the future the whole stacking system should be
-    # scoped under a given schema and version as in
-    # https://github.com/OCA/l10n-brazil/pull/3424
-    _stacking_points = frozendict({})
-
-    # _spec_module = 'override.with.your.python.module'
-    # _binding_module = 'your.pyhthon.binding.module'
-    # _odoo_module = 'your.odoo_module'
-    # _field_prefix = 'your_field_prefix_'
-    # _schema_name = 'your_schema_name'
 
     def _valid_field_parameter(self, field, name):
         if name in (
@@ -114,6 +99,8 @@ class SpecMixin(models.AbstractModel):
                     "_module": self._odoo_module,
                 },
             )
+            model_type._schema_name = self._schema_name
+            model_type._schema_version = self._schema_version
             models.MetaModel.module_to_models[self._odoo_module] += [model_type]
 
             # now we init these models properly

--- a/spec_driven_model/models/spec_models.py
+++ b/spec_driven_model/models/spec_models.py
@@ -67,12 +67,6 @@ class SpecModel(models.Model):
                 rec.display_name = _("Abrir...")
         return res
 
-    def _get_stacking_points(self):
-        key = f"_{self._spec_prefix(self._context)}_spec_settings"
-        if hasattr(self, key):
-            return getattr(self, key)["stacking_points"]
-        return {}
-
     @classmethod
     def _spec_prefix(cls, context=None, spec_schema=None, spec_version=None):
         if context and context.get("spec_schema"):
@@ -80,6 +74,14 @@ class SpecModel(models.Model):
         if context and context.get("spec_version"):
             spec_version = context.get("spec_version")
         return "%s%s" % (spec_schema, spec_version.replace(".", "")[:2])
+
+    def _get_spec_property(self, spec_property="", fallback=None):
+        return getattr(
+            self, f"_{self._spec_prefix(self._context)}_{spec_property}", fallback
+        )
+
+    def _get_stacking_points(self):
+        return self._get_spec_property("stacking_points", {})
 
     @classmethod
     def _build_model(cls, pool, cr):
@@ -99,11 +101,9 @@ class SpecModel(models.Model):
             else:
                 super_parents = super_parents or []
             for super_parent in super_parents:
-                if (
-                    not super_parent.startswith("spec.mixin.")
-                    or not hasattr(pool[super_parent], "_odoo_module")
-                    or "spec.mixin" in [c._name for c in pool[super_parent].__bases__]
-                ):
+                if not super_parent.startswith("spec.mixin.") or "spec.mixin" in [
+                    c._name for c in pool[super_parent].__bases__
+                ]:
                     continue
                 pool[super_parent]._inherit = list(pool[super_parent]._inherit) + [
                     "spec.mixin"
@@ -130,12 +130,7 @@ class SpecModel(models.Model):
         """
         cls = type(self)
         for klass in cls.__bases__:
-            if (
-                not hasattr(klass, "_name")
-                or not hasattr(klass, "_fields")
-                or klass._name is None
-                or not klass._name.startswith(self.env[cls._name]._schema_name)
-            ):
+            if not hasattr(klass, "_is_spec_driven"):
                 continue
             if klass._name != cls._name:
                 cls._map_concrete(self.env.cr.dbname, klass._name, cls._name)
@@ -254,11 +249,22 @@ class StackedModel(SpecModel):
             schema = mod.spec_schema
             version = mod.spec_version.replace(".", "")[:2]
         spec_prefix = cls._spec_prefix(spec_schema=schema, spec_version=version)
-        stacking_settings = getattr(cls, "_%s_spec_settings" % (spec_prefix,))
+        setattr(cls, f"_{spec_prefix}_stacking_points", {})
+        stacking_settings = {
+            "odoo_module": getattr(cls, f"_{spec_prefix}_odoo_module"),  # TODO inherit?
+            "stacking_mixin": getattr(cls, f"_{spec_prefix}_stacking_mixin"),
+            "stacking_points": getattr(cls, f"_{spec_prefix}_stacking_points"),
+            "stacking_skip_paths": getattr(
+                cls, f"_{spec_prefix}_stacking_skip_paths", []
+            ),
+            "stacking_force_paths": getattr(
+                cls, f"_{spec_prefix}_stacking_force_paths", []
+            ),
+        }
         # inject all stacked m2o as inherited classes
         _logger.info(f"building StackedModel {cls._name} {cls}")
         node = cls._odoo_name_to_class(
-            stacking_settings["stacking_mixin"], stacking_settings["module"]
+            stacking_settings["stacking_mixin"], stacking_settings["odoo_module"]
         )
         env = api.Environment(cr, SUPERUSER_ID, {})
         for kind, klass, _path, _field_path, _child_concrete in cls._visit_stack(
@@ -270,16 +276,18 @@ class StackedModel(SpecModel):
 
     @api.model
     def _add_field(self, name, field):
-        for cls in type(self).mro():
-            if issubclass(cls, StackedModel):
-                if hasattr(self, "_schema_name"):
-                    prefix = self._spec_prefix(
-                        None, self._schema_name, self._schema_version
-                    )
-                    key = f"_{prefix}_spec_settings"
-                    stacking_points = getattr(self, key)["stacking_points"]
-                    if name in stacking_points.keys():
-                        return
+        """
+        Overriden to avoid adding many2one fields that are in fact "stacking points"
+        """
+        if field.type == "many2one":
+            for cls in type(self).mro():
+                if issubclass(cls, StackedModel):
+                    for attr in dir(cls):
+                        if attr != "_get_stacking_points" and attr.endswith(
+                            "_stacking_points"
+                        ):
+                            if name in getattr(cls, attr).keys():
+                                return
         return super()._add_field(name, field)
 
     @classmethod
@@ -326,12 +334,12 @@ class StackedModel(SpecModel):
                 # TODO change for view or export
                 continue
             child = cls._odoo_name_to_class(
-                f["comodel_name"], stacking_settings["module"]
+                f["comodel_name"], stacking_settings["odoo_module"]
             )
             if child is None:  # Not a spec field
                 continue
             child_concrete = SPEC_MIXIN_MAPPINGS[env.cr.dbname].get(child._name)
-            field_path = name.replace(env[node._name]._field_prefix, "")
+            field_path = name.split("_")[1]  # remove schema prefix
 
             if f["type"] == "one2many":
                 yield "one2many", node, path, field_path, child_concrete
@@ -339,7 +347,7 @@ class StackedModel(SpecModel):
 
             force_stacked = any(
                 stack_path in path + "." + field_path
-                for stack_path in stacking_settings.get("stacking_force_paths", "")
+                for stack_path in stacking_settings.get("stacking_force_paths", [])
             )
 
             # many2one

--- a/spec_driven_model/models/spec_models.py
+++ b/spec_driven_model/models/spec_models.py
@@ -4,6 +4,7 @@
 import logging
 import sys
 from collections import OrderedDict, defaultdict
+from importlib import import_module
 from inspect import getmembers, isclass
 
 from odoo import SUPERUSER_ID, _, api, models
@@ -65,6 +66,20 @@ class SpecModel(models.Model):
             if rec.display_name == "False" or not rec.display_name:
                 rec.display_name = _("Abrir...")
         return res
+
+    def _get_stacking_points(self):
+        key = f"_{self._spec_prefix(self._context)}_spec_settings"
+        if hasattr(self, key):
+            return getattr(self, key)["stacking_points"]
+        return {}
+
+    @classmethod
+    def _spec_prefix(cls, context=None, spec_schema=None, spec_version=None):
+        if context and context.get("spec_schema"):
+            spec_schema = context.get("spec_schema")
+        if context and context.get("spec_version"):
+            spec_version = context.get("spec_version")
+        return "%s%s" % (spec_schema, spec_version.replace(".", "")[:2])
 
     @classmethod
     def _build_model(cls, pool, cr):
@@ -190,7 +205,6 @@ class SpecModel(models.Model):
         Cache the list of spec_module classes to save calls to
         slow reflection API.
         """
-
         spec_module_attr = f"_spec_cache_{spec_module.replace('.', '_')}"
         if not hasattr(cls, spec_module_attr):
             setattr(
@@ -215,8 +229,9 @@ class StackedModel(SpecModel):
 
     By inheriting from StackModel instead, your models.Model can
     instead inherit all the mixins that would correspond to the nested xsd
-    nodes starting from the _stacked node. _stack_skip allows you to avoid
-    stacking specific nodes.
+    nodes starting from the stacking_mixin. stacking_skip_paths allows you to avoid
+    stacking specific nodes while stacking_force_paths will stack many2one
+    entities even if they are not required.
 
     In Brazil it allows us to have mostly the fiscal
     document objects and the fiscal document line object with many details
@@ -228,24 +243,26 @@ class StackedModel(SpecModel):
 
     _register = False  # forces you to inherit StackeModel properly
 
-    # define _stacked in your submodel to define the model of the XML tags
-    # where we should start to
-    # stack models of nested tags in the same object.
-    _stacked = False
-    _stack_path = ""
-    _stack_skip = ()
-    # all m2o below these paths will be stacked even if not required:
-    _force_stack_paths = ()
-    _stacking_points = {}
-
     @classmethod
     def _build_model(cls, pool, cr):
+        mod = import_module(".".join(cls.__module__.split(".")[:-1]))
+        if hasattr(cls, "_schema_name"):
+            schema = cls._schema_name
+            version = cls._schema_version.replace(".", "")[:2]
+        else:
+            mod = import_module(".".join(cls.__module__.split(".")[:-1]))
+            schema = mod.spec_schema
+            version = mod.spec_version.replace(".", "")[:2]
+        spec_prefix = cls._spec_prefix(spec_schema=schema, spec_version=version)
+        stacking_settings = getattr(cls, "_%s_spec_settings" % (spec_prefix,))
         # inject all stacked m2o as inherited classes
         _logger.info(f"building StackedModel {cls._name} {cls}")
-        node = cls._odoo_name_to_class(cls._stacked, cls._spec_module)
+        node = cls._odoo_name_to_class(
+            stacking_settings["stacking_mixin"], stacking_settings["module"]
+        )
         env = api.Environment(cr, SUPERUSER_ID, {})
         for kind, klass, _path, _field_path, _child_concrete in cls._visit_stack(
-            env, node
+            env, node, stacking_settings
         ):
             if kind == "stacked" and klass not in cls.__bases__:
                 cls.__bases__ = (klass,) + cls.__bases__
@@ -255,12 +272,18 @@ class StackedModel(SpecModel):
     def _add_field(self, name, field):
         for cls in type(self).mro():
             if issubclass(cls, StackedModel):
-                if name in type(self)._stacking_points.keys():
-                    return
+                if hasattr(self, "_schema_name"):
+                    prefix = self._spec_prefix(
+                        None, self._schema_name, self._schema_version
+                    )
+                    key = f"_{prefix}_spec_settings"
+                    stacking_points = getattr(self, key)["stacking_points"]
+                    if name in stacking_points.keys():
+                        return
         return super()._add_field(name, field)
 
     @classmethod
-    def _visit_stack(cls, env, node, path=None):
+    def _visit_stack(cls, env, node, stacking_settings, path=None):
         """Pre-order traversal of the stacked models tree.
         1. This method is used to dynamically inherit all the spec models
         stacked together from an XML hierarchy.
@@ -272,7 +295,7 @@ class StackedModel(SpecModel):
         # https://github.com/OCA/l10n-brazil/pull/1272#issuecomment-821806603
         node._description = None
         if path is None:
-            path = cls._stacked.split(".")[-1]
+            path = stacking_settings["stacking_mixin"].split(".")[-1]
         cls._map_concrete(env.cr.dbname, node._name, cls._name, quiet=True)
         yield "stacked", node, path, None, None
 
@@ -296,10 +319,15 @@ class StackedModel(SpecModel):
                 and i[1].xsd_choice_required,
             }
         for name, f in fields.items():
-            if f["type"] not in ["many2one", "one2many"] or name in cls._stack_skip:
+            if f["type"] not in [
+                "many2one",
+                "one2many",
+            ] or name in stacking_settings.get("stacking_skip_paths", ""):
                 # TODO change for view or export
                 continue
-            child = cls._odoo_name_to_class(f["comodel_name"], cls._spec_module)
+            child = cls._odoo_name_to_class(
+                f["comodel_name"], stacking_settings["module"]
+            )
             if child is None:  # Not a spec field
                 continue
             child_concrete = SPEC_MIXIN_MAPPINGS[env.cr.dbname].get(child._name)
@@ -311,7 +339,7 @@ class StackedModel(SpecModel):
 
             force_stacked = any(
                 stack_path in path + "." + field_path
-                for stack_path in cls._force_stack_paths
+                for stack_path in stacking_settings.get("stacking_force_paths", "")
             )
 
             # many2one
@@ -320,8 +348,10 @@ class StackedModel(SpecModel):
             ):
                 # then we will STACK the child in the current class
                 child._stack_path = path
-                child_path = f"{path}.{field_path}"
-                cls._stacking_points[name] = env[node._name]._fields.get(name)
-                yield from cls._visit_stack(env, child, child_path)
+                child_path = "%s.%s" % (path, field_path)
+                stacking_settings["stacking_points"][name] = env[
+                    node._name
+                ]._fields.get(name)
+                yield from cls._visit_stack(env, child, stacking_settings, child_path)
             else:
                 yield "many2one", node, path, field_path, child_concrete

--- a/spec_driven_model/models/spec_view.py
+++ b/spec_driven_model/models/spec_view.py
@@ -133,7 +133,7 @@ class SpecViewMixin(models.AbstractModel):
     # TODO required only if visible
     @api.model
     def build_arch(self, lib_node, view_node, fields, depth=0):
-        """Creates a view arch from an generateds lib model arch"""
+        """Creates a view arch from an xsdata lib model arch"""
         # _logger.info("BUILD ARCH", lib_node)
         choices = set()
         wrapper_group = None

--- a/spec_driven_model/readme/DESCRIPTION.rst
+++ b/spec_driven_model/readme/DESCRIPTION.rst
@@ -1,7 +1,7 @@
 Intro
 ~~~~~
 
-This module is a databinding framework for Odoo and XML data: it allows to go from XML to Odoo objects back and forth. This module started with the `GenerateDS <https://www.davekuhlman.org/generateDS.html>`_  pure Python databinding framework and is now being migrated to xsdata. So a good starting point is to read `the xsdata documentation here <https://xsdata.readthedocs.io/>`_
+This module is a databinding framework for Odoo and XML data: it allows to go from XML to Odoo objects back and forth. While having no hard dependency with it, it has been designed to be used with xsdata. So a good starting point is to read `the xsdata documentation here <https://xsdata.readthedocs.io/>`_
 
 But what if instead of only generating Python structures from XML files you could actually generate full blown Odoo objects or serialize Odoo objects back to XML? This is what this module is for!
 
@@ -26,7 +26,7 @@ Now that you have generated these Odoo abstract bindings you should tell Odoo ho
 
 Notice you should inherit from `spec_models.SpecModel` and not the usual `models.Model`.
 
-**Field mapping**: You can then define two ways mapping between fields by overriding fields from Odoo or from the binding and using `_compute=` , `_inverse=` or simply `related=`.
+**Field mapping**: You can then define two ways mapping between fields by overriding fields from Odoo or from the binding using `_compute=` , `_inverse=` or simply `related=`.
 
 **Relational fields**: simple fields are easily mapped this way. However what about relational fields? In your XSD schema, your electronic invoice is related to the `partner.binding.mixin` not to an Odoo `res.partner`. Don't worry, when `SpecModel` classes are instanciated for all relational fields, we look if their comodel have been injected into some existing Odoo model and if so we remap them to the proper Odoo model.
 
@@ -36,7 +36,7 @@ Notice you should inherit from `spec_models.SpecModel` and not the usual `models
 StackedModel
 ~~~~~~~~~~~~
 
-Sadly real life XML is a bit more complex than that. Often XML structures are deeply nested just because it makes it easier for XSD schemas to validate them! for instance an electronic invoice line can be a nested structure with lots of tax details and product details. In a relational model like Odoo however you often want flatter data structures. This is where `StackedModel` comes to the rescue! It inherits from `SpecModel` and when you inherit from `StackedModel` you can inherit from all the generated mixins corresponding to the nested XML tags below some tag (here `invoice.line.binding.mixin`). All the fields corresponding to these XML tag attributes will be collected in your model and the XML parsing and serialization will happen as expected::
+Sadly real life XML is a bit more complex than that. Often XML structures are deeply nested just because it makes it easier for XSD schemas to validate them! for instance an electronic invoice line can be a nested structure with lots of tax details and product details. In a relational model like Odoo however you often want flatter data structures. This is where `StackedModel` comes to the rescue! It inherits from `SpecModel` and when you inherit from `StackedModel` you can inherit from all the generated mixins corresponding to the nested XML tags below some tag (here `invoice.line.binding.mixin`). All the fields corresponding to these XML tag attributes will be collected in your model and the XML parsing and serialization will happen as expected. Here is an example inspired from the Brazilian Electronic Invoice where the schema is called `nfe` and where we use the 2 digits `40` for its short version::
 
 
   from odoo.addons.spec_driven_model.models import spec_models
@@ -45,14 +45,21 @@ Sadly real life XML is a bit more complex than that. Often XML structures are de
   class InvoiceLine(spec_models.StackedModel):
       _inherit = [
           'account.move.line',
-          'invoice.line.binding.mixin',
+          'nfe.40.det',
       ]
-      _stacked = 'invoice.line.binding.mixin'
+      _nfe40_spec_settings = {
+          "module": "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00",
+          "stacking_mixin": "nfe.40.det",
+          "stacking_points": {},
+          # all m2o below this level will be stacked even if not required:
+          "stacking_force_paths": ("det.imposto.",),
+          "stacking_skip_paths": ("nfe40_det_infNFe_id",),
+      }
 
-All many2one fields that are required in the XSD (xsd_required=True) will get their model stacked automatically and recursively. You can force non required many2one fields to be stacked using the `_force_stack_paths` attribute. On the contrary, you can avoid some required many2one fields to be stacked using the `stack_skip` attribute.
+All many2one fields that are required in the XSD (xsd_required=True) will get their model stacked automatically and recursively. You can force non required many2one fields to be stacked using the `stacking_force_paths` attribute. On the contrary, you can avoid some required many2one fields to be stacked using the `stacking_skip_paths` attribute.
 
 
-Hooks
-~~~~~
+Initialization hook
+~~~~~~~~~~~~~~~~~~~
 
-Because XSD schemas can define lot's of different models, spec_driven_model comes with handy hooks that will automatically make all XSD mixins turn into concrete Odoo model (eg with a table) if you didn't inject them into existing Odoo models.
+Because XSD schemas can define lot's of different models, spec_driven_model comes with a handy _register_hook that will automatically make all XSD mixins turn into concrete Odoo model (eg with a table) if you didn't inject them into existing Odoo models.

--- a/spec_driven_model/static/description/index.html
+++ b/spec_driven_model/static/description/index.html
@@ -372,7 +372,7 @@ ul.auto-toc {
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/lgpl-3.0-standalone.html"><img alt="License: LGPL-3" src="https://img.shields.io/badge/licence-LGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/l10n-brazil/tree/14.0/spec_driven_model"><img alt="OCA/l10n-brazil" src="https://img.shields.io/badge/github-OCA%2Fl10n--brazil-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/l10n-brazil-14-0/l10n-brazil-14-0-spec_driven_model"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/l10n-brazil&amp;target_branch=14.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <div class="section" id="intro">
 <h1>Intro</h1>
-<p>This module is a databinding framework for Odoo and XML data: it allows to go from XML to Odoo objects back and forth. This module started with the <a class="reference external" href="https://www.davekuhlman.org/generateDS.html">GenerateDS</a>  pure Python databinding framework and is now being migrated to xsdata. So a good starting point is to read <a class="reference external" href="https://xsdata.readthedocs.io/">the xsdata documentation here</a></p>
+<p>This module is a databinding framework for Odoo and XML data: it allows to go from XML to Odoo objects back and forth. While having no hard dependency with it, it has been designed to be used with xsdata. So a good starting point is to read <a class="reference external" href="https://xsdata.readthedocs.io/">the xsdata documentation here</a></p>
 <p>But what if instead of only generating Python structures from XML files you could actually generate full blown Odoo objects or serialize Odoo objects back to XML? This is what this module is for!</p>
 <p>First you should generate xsdata Python binding libraries you would generate for your specific XSD grammar, the Brazilian Electronic Invoicing for instance, or UBL.</p>
 <p>Second you should generate Odoo abstract mixins for all these pure Python bindings. This can be achieved using <a class="reference external" href="https://github.com/akretion/xsdata-odoo">xsdata-odoo</a>. An example is OCA/l10n-brazil/l10n_br_nfe_spec for the Brazilian Electronic Invoicing.</p>
@@ -391,13 +391,13 @@ class ResPartner(spec_models.SpecModel):
     ]
 </pre>
 <p>Notice you should inherit from <cite>spec_models.SpecModel</cite> and not the usual <cite>models.Model</cite>.</p>
-<p><strong>Field mapping</strong>: You can then define two ways mapping between fields by overriding fields from Odoo or from the binding and using <cite>_compute=</cite> , <cite>_inverse=</cite> or simply <cite>related=</cite>.</p>
+<p><strong>Field mapping</strong>: You can then define two ways mapping between fields by overriding fields from Odoo or from the binding using <cite>_compute=</cite> , <cite>_inverse=</cite> or simply <cite>related=</cite>.</p>
 <p><strong>Relational fields</strong>: simple fields are easily mapped this way. However what about relational fields? In your XSD schema, your electronic invoice is related to the <cite>partner.binding.mixin</cite> not to an Odoo <cite>res.partner</cite>. Don’t worry, when <cite>SpecModel</cite> classes are instanciated for all relational fields, we look if their comodel have been injected into some existing Odoo model and if so we remap them to the proper Odoo model.</p>
 <p><strong>Field prefixes</strong>: to avoid field collision between the Odoo fields and the XSD fields, the XSD fields are prefixed with the name of the schema and a few digits representing the schema version (typically 2 digits). So if your schema get a minor version upgrade, the same fields and classes are used. For a major upgrade however new fields and classes may be used so data of several major versions could co-exist inside your Odoo database.</p>
 </div>
 <div class="section" id="stackedmodel">
 <h1>StackedModel</h1>
-<p>Sadly real life XML is a bit more complex than that. Often XML structures are deeply nested just because it makes it easier for XSD schemas to validate them! for instance an electronic invoice line can be a nested structure with lots of tax details and product details. In a relational model like Odoo however you often want flatter data structures. This is where <cite>StackedModel</cite> comes to the rescue! It inherits from <cite>SpecModel</cite> and when you inherit from <cite>StackedModel</cite> you can inherit from all the generated mixins corresponding to the nested XML tags below some tag (here <cite>invoice.line.binding.mixin</cite>). All the fields corresponding to these XML tag attributes will be collected in your model and the XML parsing and serialization will happen as expected:</p>
+<p>Sadly real life XML is a bit more complex than that. Often XML structures are deeply nested just because it makes it easier for XSD schemas to validate them! for instance an electronic invoice line can be a nested structure with lots of tax details and product details. In a relational model like Odoo however you often want flatter data structures. This is where <cite>StackedModel</cite> comes to the rescue! It inherits from <cite>SpecModel</cite> and when you inherit from <cite>StackedModel</cite> you can inherit from all the generated mixins corresponding to the nested XML tags below some tag (here <cite>invoice.line.binding.mixin</cite>). All the fields corresponding to these XML tag attributes will be collected in your model and the XML parsing and serialization will happen as expected. Here is an example inspired from the Brazilian Electronic Invoice where the schema is called <cite>nfe</cite> and where we use the 2 digits <cite>40</cite> for its short version:</p>
 <pre class="literal-block">
 from odoo.addons.spec_driven_model.models import spec_models
 
@@ -405,15 +405,22 @@ from odoo.addons.spec_driven_model.models import spec_models
 class InvoiceLine(spec_models.StackedModel):
     _inherit = [
         'account.move.line',
-        'invoice.line.binding.mixin',
+        'nfe.40.det',
     ]
-    _stacked = 'invoice.line.binding.mixin'
+    _nfe40_spec_settings = {
+        &quot;module&quot;: &quot;odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00&quot;,
+        &quot;stacking_mixin&quot;: &quot;nfe.40.det&quot;,
+        &quot;stacking_points&quot;: {},
+        # all m2o below this level will be stacked even if not required:
+        &quot;stacking_force_paths&quot;: (&quot;det.imposto.&quot;,),
+        &quot;stacking_skip_paths&quot;: (&quot;nfe40_det_infNFe_id&quot;,),
+    }
 </pre>
-<p>All many2one fields that are required in the XSD (xsd_required=True) will get their model stacked automatically and recursively. You can force non required many2one fields to be stacked using the <cite>_force_stack_paths</cite> attribute. On the contrary, you can avoid some required many2one fields to be stacked using the <cite>stack_skip</cite> attribute.</p>
+<p>All many2one fields that are required in the XSD (xsd_required=True) will get their model stacked automatically and recursively. You can force non required many2one fields to be stacked using the <cite>stacking_force_paths</cite> attribute. On the contrary, you can avoid some required many2one fields to be stacked using the <cite>stacking_skip_paths</cite> attribute.</p>
 </div>
-<div class="section" id="hooks">
-<h1>Hooks</h1>
-<p>Because XSD schemas can define lot’s of different models, spec_driven_model comes with handy hooks that will automatically make all XSD mixins turn into concrete Odoo model (eg with a table) if you didn’t inject them into existing Odoo models.</p>
+<div class="section" id="initialization-hook">
+<h1>Initialization hook</h1>
+<p>Because XSD schemas can define lot’s of different models, spec_driven_model comes with a handy _register_hook that will automatically make all XSD mixins turn into concrete Odoo model (eg with a table) if you didn’t inject them into existing Odoo models.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">

--- a/spec_driven_model/tests/__init__.py
+++ b/spec_driven_model/tests/__init__.py
@@ -1,1 +1,4 @@
 from . import test_spec_model
+
+spec_schema = "poxsd"
+spec_version = "10"

--- a/spec_driven_model/tests/fake_mixin.py
+++ b/spec_driven_model/tests/fake_mixin.py
@@ -7,12 +7,9 @@ from odoo import fields, models
 class PoXsdMixin(models.AbstractModel):
     _description = "Abstract Model for PO XSD"
     _name = "spec.mixin.poxsd"
-    _field_prefix = "poxsd10_"
-    _schema_name = "poxsd"
-    _schema_version = "1.0"
-    _odoo_module = "poxsd"
-    _spec_module = "odoo.addons.spec_driven_model.tests.spec_poxsd"
-    _binding_module = "odoo.addons.spec_driven_model.tests.purchase_order_lib"
+
+    _poxsd10_odoo_module = "odoo.addons.spec_driven_model.tests.spec_poxsd"
+    _poxsd10_binding_module = "odoo.addons.spec_driven_model.tests.purchase_order_lib"
 
     # TODO rename
     brl_currency_id = fields.Many2one(

--- a/spec_driven_model/tests/spec_purchase.py
+++ b/spec_driven_model/tests/spec_purchase.py
@@ -41,10 +41,11 @@ class PurchaseOrder(spec_models.StackedModel):
 
     _name = "fake.purchase.order"
     _inherit = ["fake.purchase.order", "poxsd.10.purchaseordertype"]
-    _spec_module = "odoo.addons.spec_driven_model.tests.spec_poxsd"
-    _stacked = "poxsd.10.purchaseordertype"
-    _stacking_points = {}
-    _poxsd10_spec_module_classes = None
+    _poxsd10_spec_settings = {
+        "module": "odoo.addons.spec_driven_model.tests.spec_poxsd",
+        "stacking_mixin": "poxsd.10.purchaseordertype",
+        "stacking_points": {},
+    }
 
     poxsd10_orderDate = fields.Date(compute="_compute_date")
     poxsd10_confirmDate = fields.Date(related="date_approve")

--- a/spec_driven_model/tests/spec_purchase.py
+++ b/spec_driven_model/tests/spec_purchase.py
@@ -41,11 +41,9 @@ class PurchaseOrder(spec_models.StackedModel):
 
     _name = "fake.purchase.order"
     _inherit = ["fake.purchase.order", "poxsd.10.purchaseordertype"]
-    _poxsd10_spec_settings = {
-        "module": "odoo.addons.spec_driven_model.tests.spec_poxsd",
-        "stacking_mixin": "poxsd.10.purchaseordertype",
-        "stacking_points": {},
-    }
+
+    _poxsd10_odoo_module = "odoo.addons.spec_driven_model.tests.spec_poxsd"
+    _poxsd10_stacking_mixin = "poxsd.10.purchaseordertype"
 
     poxsd10_orderDate = fields.Date(compute="_compute_date")
     poxsd10_confirmDate = fields.Date(related="date_approve")

--- a/spec_driven_model/tests/test_spec_model.py
+++ b/spec_driven_model/tests/test_spec_model.py
@@ -51,18 +51,6 @@ class TestSpecModel(SavepointCase, FakeModelLoader):
         cls.loader.restore_registry()
         super(TestSpecModel, cls).tearDownClass()
 
-    # def test_loading_hook(self):
-    #
-    #     remaining_spec_models = get_remaining_spec_models(
-    #         self.env.cr,
-    #         self.env.registry,
-    #         "spec_driven_model",
-    #         "odoo.addons.spec_driven_model.tests.spec_poxsd",
-    #     )
-    #     self.assertEqual(
-    #         remaining_spec_models, {"poxsd.10.purchaseorder", "poxsd.10.comment"}
-    #     )
-
     def test_spec_models(self):
         self.assertTrue(
             set(self.env["res.partner"]._fields.keys()).issuperset(
@@ -79,7 +67,11 @@ class TestSpecModel(SavepointCase, FakeModelLoader):
     def test_stacked_model(self):
         po_fields_or_stacking = set(self.env["fake.purchase.order"]._fields.keys())
         po_fields_or_stacking.update(
-            set(self.env["fake.purchase.order"]._stacking_points.keys())
+            set(
+                self.env["fake.purchase.order"]
+                ._poxsd10_spec_settings["stacking_points"]
+                .keys()
+            )
         )
         self.assertTrue(
             po_fields_or_stacking.issuperset(
@@ -87,7 +79,11 @@ class TestSpecModel(SavepointCase, FakeModelLoader):
             )
         )
         self.assertEqual(
-            list(self.env["fake.purchase.order"]._stacking_points.keys()),
+            list(
+                self.env["fake.purchase.order"]
+                ._poxsd10_spec_settings["stacking_points"]
+                .keys()
+            ),
             ["poxsd10_items"],
         )
 
@@ -128,7 +124,11 @@ class TestSpecModel(SavepointCase, FakeModelLoader):
 
         # 2nd we serialize it into a binding object:
         # (that could be further XML serialized)
-        po_binding = po._build_generateds()
+        po_binding = po._build_generateds(spec_schema="poxsd", spec_version="10")
+        self.assertEqual(
+            [s.__name__ for s in type(po_binding).mro()],
+            ["PurchaseOrderType", "object"],
+        )
         self.assertEqual(po_binding.bill_to.name, "Wood Corner")
         self.assertEqual(po_binding.items.item[0].product_name, "Some product desc")
         self.assertEqual(po_binding.items.item[0].quantity, 42)
@@ -175,12 +175,14 @@ class TestSpecModel(SavepointCase, FakeModelLoader):
         # 4th we import an Odoo PO from this binding object
         # first we will do a dry run import:
         imported_po_dry_run = self.env["fake.purchase.order"].build_from_binding(
-            po_binding, dry_run=True
+            "poxsd", "10", po_binding, dry_run=True
         )
         assert isinstance(imported_po_dry_run.id, NewId)
 
         # now a real import:
-        imported_po = self.env["fake.purchase.order"].build_from_binding(po_binding)
+        imported_po = self.env["fake.purchase.order"].build_from_binding(
+            "poxsd", "10", po_binding
+        )
         self.assertEqual(imported_po.partner_id.name, "Wood Corner")
         self.assertEqual(
             imported_po.partner_id.id, self.env.ref("base.res_partner_1").id

--- a/spec_driven_model/tests/test_spec_model.py
+++ b/spec_driven_model/tests/test_spec_model.py
@@ -124,7 +124,7 @@ class TestSpecModel(SavepointCase, FakeModelLoader):
 
         # 2nd we serialize it into a binding object:
         # (that could be further XML serialized)
-        po_binding = po._build_generateds(spec_schema="poxsd", spec_version="10")
+        po_binding = po._build_binding(spec_schema="poxsd", spec_version="10")
         self.assertEqual(
             [s.__name__ for s in type(po_binding).mro()],
             ["PurchaseOrderType", "object"],

--- a/spec_driven_model/tests/test_spec_model.py
+++ b/spec_driven_model/tests/test_spec_model.py
@@ -69,7 +69,7 @@ class TestSpecModel(SavepointCase, FakeModelLoader):
         po_fields_or_stacking.update(
             set(
                 self.env["fake.purchase.order"]
-                ._poxsd10_spec_settings["stacking_points"]
+                ._poxsd10_stacking_points
                 .keys()
             )
         )
@@ -81,7 +81,7 @@ class TestSpecModel(SavepointCase, FakeModelLoader):
         self.assertEqual(
             list(
                 self.env["fake.purchase.order"]
-                ._poxsd10_spec_settings["stacking_points"]
+                ._poxsd10_stacking_points
                 .keys()
             ),
             ["poxsd10_items"],


### PR DESCRIPTION
https://github.com/OCA/l10n-brazil/pull/3424 was a first step but here I went further:

1. scope every mapping settings by schema and version
2. don't use a dict like _nfe40_spec_settings to scope dynamic mapping attributes like in #3424 because values inside the dict were not easy to inherit. So I flattened everything and prefixed directly what were the dict keys in #3424 
3. refactor some poor XML serialization code (specially renamed `export_ds` to `_buid_binding`, notice that the public `export_ds` was possibly also small security issue...)

**EDIT: explanations**

So the general idea, is StackedModel's have special mapping settings like to which generated "spec" mixin they map (like l10n_br_fiscal.document.line maps on nfe.40.det, where is the Python binding xsdata package they should use for XML serialization and deserialization, which many2one fields should be de-normalized into the stacked object even if they are optional (stacking_force_paths) which required many2one should on the contrary not be stacked (stacking_skip_paths))
These mapping settings attributes are schema specific so they should not mixed between NFe, CTe, MDFe etc... even when some objects like l10n_br_fiscal.document or l10n_br_fiscal_document.line should be mapped on the same objects)

So I scoped all these mapping settings attributes. And the the challenge was to ensure that mapping methods use the proper mapping attributes. These mapping methods have roughly 3 entry points:

1. building the "Stacked" data model when _build_model is called
2. importing XML Fiscal documents (`build_from_binding`)
3. exporting XML Fiscal documents (`_build_binding`)

For all these entry points I ensured the schema name and versions are passed in:

- as parameters
- or as class attributes for _build_model

Once the entry point are entered with the proper schema name and version it sets it into the context so sub mapping methods will be have access to the proper schemas and version.