### PR TITLE
[IMP] l10n_br_cnpj_search: refactors the test mocks

### DIFF
--- a/l10n_br_cnpj_search/tests/common.py
+++ b/l10n_br_cnpj_search/tests/common.py
@@ -54,6 +54,263 @@ class TestCnpjCommon(TransactionCase):
             ],
         }
 
+        cls.mocked_response_serpro_1 = {
+            "ni": "34238864000168",
+            "nomeEmpresarial": "UHIEQKX WHNHIWD NH  FIXKHUUWPHMVX NH NWNXU (UHIFIX)",
+            "nomeFantasia": "UHIFIX UHNH",
+            "telefones": [
+                {"ddd": "61", "numero": "22222222"},
+                {"ddd": "61", "numero": "22222222"},
+            ],
+            "cep": "70836900",
+            "correioEletronico": "EMPRESA@XXXXXX.BR",
+            "socios": [
+                {
+                    "tipoSocio": "2",
+                    "cpf": "07119488449",
+                    "nome": "LUIZA ARAUJO DE OLIVEIRA",
+                    "qualificacao": "49",
+                    "dataInclusao": "2014-01-01",
+                    "pais": {"codigo": "105", "descricao": "BRASIL"},
+                    "representanteLegal": {
+                        "cpf": "00000000000",
+                        "nome": "",
+                        "qualificacao": "00",
+                    },
+                },
+                {
+                    "tipoSocio": "2",
+                    "cpf": "23982012600",
+                    "nome": "JOANA ALVES MUNDIM PENA",
+                    "qualificacao": "49",
+                    "dataInclusao": "2014-01-01",
+                    "pais": {"codigo": "105", "descricao": "BRASIL"},
+                    "representanteLegal": {
+                        "cpf": "00000000000",
+                        "nome": "",
+                        "qualificacao": "00",
+                    },
+                },
+                {
+                    "tipoSocio": "2",
+                    "cpf": "13946994415",
+                    "nome": "LUIZA BARBOSA BEZERRA",
+                    "qualificacao": "49",
+                    "dataInclusao": "2014-01-01",
+                    "pais": {"codigo": "105", "descricao": "BRASIL"},
+                    "representanteLegal": {
+                        "cpf": "00000000000",
+                        "nome": "",
+                        "qualificacao": "00",
+                    },
+                },
+                {
+                    "tipoSocio": "2",
+                    "cpf": "00031298702",
+                    "nome": "MARCELO ANTONIO BARROS DE CICCO",
+                    "qualificacao": "49",
+                    "dataInclusao": "2014-01-01",
+                    "pais": {"codigo": "105", "descricao": "BRASIL"},
+                    "representanteLegal": {
+                        "cpf": "00000000000",
+                        "nome": "",
+                        "qualificacao": "00",
+                    },
+                },
+                {
+                    "tipoSocio": "2",
+                    "cpf": "76822320300",
+                    "nome": "LUIZA ALDENORA",
+                    "qualificacao": "49",
+                    "dataInclusao": "2014-01-01",
+                    "pais": {"codigo": "105", "descricao": "BRASIL"},
+                    "representanteLegal": {
+                        "cpf": "00000000000",
+                        "nome": "",
+                        "qualificacao": "00",
+                    },
+                },
+            ],
+            "endereco": {
+                "tipoLogradouro": "SETOR",
+                "logradouro": "NH BIWMNH WIHW MXIVH",
+                "numero": "Q.601",
+                "complemento": "LOTE V",
+                "cep": "70836900",
+                "bairro": "ASA NORTE",
+                "municipio": {"codigo": "9701", "descricao": "BRASILIA"},
+                "uf": "DF",
+                "pais": {"codigo": "105", "descricao": "BRASIL"},
+            },
+            "naturezaJuridica": {"codigo": "2011", "descricao": "Empresa Pública"},
+            "capitalSocial": 0,
+            "cnaePrincipal": {
+                "codigo": "6204000",
+                "descricao": "Consultoria em tecnologia da informação",
+            },
+        }
+
+        cls.mocked_response_serpro_2 = {
+            "ni": "34238864000249",
+            "nomeEmpresarial": "UHIEQKX WHNHIWD NH  FIXKHUUWPHMVX NH NWNXU (UHIFIX)",
+            "nomeFantasia": "UHIFIX UHNH",
+            "telefones": [
+                {"ddd": "61", "numero": "22222222"},
+                {"ddd": "61", "numero": "22222222"},
+            ],
+            "cep": "70836900",
+            "correioEletronico": "EMPRESA@XXXXXX.BR",
+            "socios": [
+                {
+                    "tipoSocio": "2",
+                    "cpf": "07119488449",
+                    "nome": "LUIZA ARAUJO DE OLIVEIRA",
+                    "qualificacao": "49",
+                    "dataInclusao": "2014-01-01",
+                    "pais": {"codigo": "105", "descricao": "BRASIL"},
+                    "representanteLegal": {
+                        "cpf": "00000000000",
+                        "nome": "",
+                        "qualificacao": "00",
+                    },
+                },
+                {
+                    "tipoSocio": "2",
+                    "cpf": "23982012600",
+                    "nome": "JOANA ALVES MUNDIM PENA",
+                    "qualificacao": "49",
+                    "dataInclusao": "2014-01-01",
+                    "pais": {"codigo": "105", "descricao": "BRASIL"},
+                    "representanteLegal": {
+                        "cpf": "00000000000",
+                        "nome": "",
+                        "qualificacao": "00",
+                    },
+                },
+                {
+                    "tipoSocio": "2",
+                    "cpf": "13946994415",
+                    "nome": "LUIZA BARBOSA BEZERRA",
+                    "qualificacao": "49",
+                    "dataInclusao": "2014-01-01",
+                    "pais": {"codigo": "105", "descricao": "BRASIL"},
+                    "representanteLegal": {
+                        "cpf": "00000000000",
+                        "nome": "",
+                        "qualificacao": "00",
+                    },
+                },
+                {
+                    "tipoSocio": "2",
+                    "cpf": "00031298702",
+                    "nome": "MARCELO ANTONIO BARROS DE CICCO",
+                    "qualificacao": "49",
+                    "dataInclusao": "2014-01-01",
+                    "pais": {"codigo": "105", "descricao": "BRASIL"},
+                    "representanteLegal": {
+                        "cpf": "00000000000",
+                        "nome": "",
+                        "qualificacao": "00",
+                    },
+                },
+                {
+                    "tipoSocio": "2",
+                    "cpf": "76822320300",
+                    "nome": "LUIZA ALDENORA",
+                    "qualificacao": "49",
+                    "dataInclusao": "2014-01-01",
+                    "pais": {"codigo": "105", "descricao": "BRASIL"},
+                    "representanteLegal": {
+                        "cpf": "00000000000",
+                        "nome": "",
+                        "qualificacao": "00",
+                    },
+                },
+            ],
+            "endereco": {
+                "tipoLogradouro": "SETOR",
+                "logradouro": "NH BIWMNH WIHW MXIVH",
+                "numero": "Q.601",
+                "complemento": "LOTE V",
+                "cep": "70836900",
+                "bairro": "ASA NORTE",
+                "municipio": {"codigo": "9701", "descricao": "BRASILIA"},
+                "uf": "DF",
+                "pais": {"codigo": "105", "descricao": "BRASIL"},
+            },
+            "naturezaJuridica": {"codigo": "2011", "descricao": "Empresa Pública"},
+            "capitalSocial": 0,
+            "cnaePrincipal": {
+                "codigo": "6204000",
+                "descricao": "Consultoria em tecnologia da informação",
+            },
+        }
+
+        cls.mocked_response_serpro_3 = {
+            "nomeEmpresarial": "UHIEQKX WHNHIWD NH  FIXKHUUWPHMVX NH NWNXU (UHIFIX)",
+            "nomeFantasia": "UHIFIX UHNH",
+            "telefones": [
+                {"ddd": "61", "numero": "22222222"},
+                {"ddd": "61", "numero": "22222222"},
+            ],
+            "cep": "70836900",
+            "correioEletronico": "EMPRESA@XXXXXX.BR",
+            "socios": [
+                {
+                    "tipoSocio": "2",
+                    "nome": "LUIZA ARAUJO DE OLIVEIRA",
+                    "qualificacao": "49",
+                    "pais": {"codigo": "105", "descricao": "BRASIL"},
+                    "representanteLegal": {"nome": "", "qualificacao": "00"},
+                },
+                {
+                    "tipoSocio": "2",
+                    "nome": "JOANA ALVES MUNDIM PENA",
+                    "qualificacao": "49",
+                    "pais": {"codigo": "105", "descricao": "BRASIL"},
+                    "representanteLegal": {"nome": "", "qualificacao": "00"},
+                },
+                {
+                    "tipoSocio": "2",
+                    "nome": "LUIZA BARBOSA BEZERRA",
+                    "qualificacao": "49",
+                    "pais": {"codigo": "105", "descricao": "BRASIL"},
+                    "representanteLegal": {"nome": "", "qualificacao": "00"},
+                },
+                {
+                    "tipoSocio": "2",
+                    "nome": "MARCELO ANTONIO BARROS DE CICCO",
+                    "qualificacao": "49 ",
+                    "pais": {"codigo": "105", "descricao": "BRASIL"},
+                    "representanteLegal": {"nome": "", "qualificacao": "00"},
+                },
+                {
+                    "tipoSocio": "2",
+                    "nome": "LUIZA ALDENORA",
+                    "qualificacao": "49",
+                    "pais": {"codigo": "105", "descricao": "BRASIL"},
+                    "representanteLegal": {"nome": "", "qualificacao": "00"},
+                },
+            ],
+            "endereco": {
+                "tipoLogradouro": "SETOR",
+                "logradouro": "NH BIWMNH WIHW MXIVH",
+                "numero": "Q.601",
+                "complemento": "LOTE V",
+                "cep": "70836900",
+                "bairro": "ASA NORTE",
+                "municipio": {"codigo": "9701", "descricao": "BRASILIA"},
+                "uf": "DF",
+                "pais": {"codigo": "105", "descricao": "BRASIL"},
+            },
+            "naturezaJuridica": {"codigo": "2011", "descricao": "Empresa Pública"},
+            "capitalSocial": 0,
+            "cnaePrincipal": {
+                "codigo": "6204000",
+                "descricao": "Consultoria em tecnologia da informação",
+            },
+        }
+
     def set_param(self, param_name, param_value):
         (
             self.env["ir.config_parameter"]

--- a/l10n_br_cnpj_search/tests/common.py
+++ b/l10n_br_cnpj_search/tests/common.py
@@ -9,6 +9,50 @@ class TestCnpjCommon(TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.model = cls.env["res.partner"]
+        cls.mocked_response_ws_1 = {
+            "nome": "Kilian Macedo Melcher 08777131460",
+            "fantasia": "Kilian Macedo Melcher 08777131460",
+            "email": "kilian.melcher@gmail.com",
+            "logradouro": "Rua Luiza Bezerra Motta",
+            "complemento": "Bloco E;Apt 302",
+            "numero": "950",
+            "cep": "58.410-410",
+            "bairro": "Catole",
+            "uf": "PB",
+            "telefone": "(83) 8665-0905",
+            "municipio": "CAMPINA GRANDE",
+            "natureza_juridica": "213-5 - Empresário (Individual)",
+            "capital_social": "3000.00",
+            "atividade_principal": [
+                {
+                    "code": "47.51-2-01",
+                    "text": "********",
+                }
+            ],
+        }
+
+        cls.mocked_response_ws_2 = {
+            "nome": "ISLA SEMENTES LTDA.",
+            "fantasia": "",
+            "email": "contabilidade@isla.com.br",
+            "logradouro": "AVENIDA SEVERO DULLIUS",
+            "complemento": "Bloco E;Apt 302",
+            "numero": "124",
+            "cep": "90.200-310",
+            "bairro": "ANCHIETA",
+            "uf": "RS",
+            "telefone": "(51) 9852-9561 / (51) 2136-6600",
+            "municipio": "PORTO ALEGRE",
+            "natureza_juridica": "206-2 - Sociedade Empresária Limitada",
+            "capital_social": "10606804.00",
+            "atividade_principal": [
+                {
+                    "code": "46.89-3-99",
+                    "text": """Comércio atacadista especializado em outros
+                     produtos intermediários não especificados anteriormente""",
+                }
+            ],
+        }
 
     def set_param(self, param_name, param_value):
         (

--- a/l10n_br_cnpj_search/tests/test_receitaws.py
+++ b/l10n_br_cnpj_search/tests/test_receitaws.py
@@ -26,30 +26,9 @@ class TestReceitaWS(TestCnpjCommon):
             }
         )
 
-        mocked_response = {
-            "nome": "Kilian Macedo Melcher 08777131460",
-            "fantasia": "Kilian Macedo Melcher 08777131460",
-            "email": "kilian.melcher@gmail.com",
-            "logradouro": "Rua Luiza Bezerra Motta",
-            "complemento": "Bloco E;Apt 302",
-            "numero": "950",
-            "cep": "58.410-410",
-            "bairro": "Catole",
-            "uf": "PB",
-            "telefone": "(83) 8665-0905",
-            "municipio": "CAMPINA GRANDE",
-            "natureza_juridica": "213-5 - Empresário (Individual)",
-            "capital_social": "3000.00",
-            "atividade_principal": [
-                {
-                    "code": "47.51-2-01",
-                    "text": "********",
-                }
-            ],
-        }
         with mock.patch(
             "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
-            return_value=mocked_response,
+            return_value=self.mocked_response_ws_1,
         ):
             action_wizard = kilian.action_open_cnpj_search_wizard()
             wizard_context = action_wizard.get("context")
@@ -87,31 +66,9 @@ class TestReceitaWS(TestCnpjCommon):
             self.env["partner.search.wizard"].with_context(**wizard_context).create({})
 
     def test_receita_ws_multiple_phones(self):
-        mocked_response = {
-            "nome": "ISLA SEMENTES LTDA.",
-            "fantasia": "",
-            "email": "contabilidade@isla.com.br",
-            "logradouro": "AVENIDA SEVERO DULLIUS",
-            "complemento": "Bloco E;Apt 302",
-            "numero": "124",
-            "cep": "90.200-310",
-            "bairro": "ANCHIETA",
-            "uf": "RS",
-            "telefone": "(51) 9852-9561 / (51) 2136-6600",
-            "municipio": "PORTO ALEGRE",
-            "natureza_juridica": "206-2 - Sociedade Empresária Limitada",
-            "capital_social": "10606804.00",
-            "atividade_principal": [
-                {
-                    "code": "46.89-3-99",
-                    "text": """Comércio atacadista especializado em outros
-                     produtos intermediários não especificados anteriormente""",
-                }
-            ],
-        }
         with mock.patch(
             "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
-            return_value=mocked_response,
+            return_value=self.mocked_response_ws_2,
         ):
             isla = self.model.create({"name": "Isla", "cnpj_cpf": "92.666.056/0001-06"})
             isla._onchange_cnpj_cpf()

--- a/l10n_br_cnpj_search/tests/test_serpro.py
+++ b/l10n_br_cnpj_search/tests/test_serpro.py
@@ -25,104 +25,9 @@ class TestTestSerPro(TestCnpjCommon):
         self.set_param("serpro_schema", "basica")
 
     def test_serpro_basica(self):
-        mocked_response = {
-            "ni": "34238864000168",
-            "nomeEmpresarial": "UHIEQKX WHNHIWD NH  FIXKHUUWPHMVX NH NWNXU (UHIFIX)",
-            "nomeFantasia": "UHIFIX UHNH",
-            "telefones": [
-                {"ddd": "61", "numero": "22222222"},
-                {"ddd": "61", "numero": "22222222"},
-            ],
-            "cep": "70836900",
-            "correioEletronico": "EMPRESA@XXXXXX.BR",
-            "socios": [
-                {
-                    "tipoSocio": "2",
-                    "cpf": "07119488449",
-                    "nome": "LUIZA ARAUJO DE OLIVEIRA",
-                    "qualificacao": "49",
-                    "dataInclusao": "2014-01-01",
-                    "pais": {"codigo": "105", "descricao": "BRASIL"},
-                    "representanteLegal": {
-                        "cpf": "00000000000",
-                        "nome": "",
-                        "qualificacao": "00",
-                    },
-                },
-                {
-                    "tipoSocio": "2",
-                    "cpf": "23982012600",
-                    "nome": "JOANA ALVES MUNDIM PENA",
-                    "qualificacao": "49",
-                    "dataInclusao": "2014-01-01",
-                    "pais": {"codigo": "105", "descricao": "BRASIL"},
-                    "representanteLegal": {
-                        "cpf": "00000000000",
-                        "nome": "",
-                        "qualificacao": "00",
-                    },
-                },
-                {
-                    "tipoSocio": "2",
-                    "cpf": "13946994415",
-                    "nome": "LUIZA BARBOSA BEZERRA",
-                    "qualificacao": "49",
-                    "dataInclusao": "2014-01-01",
-                    "pais": {"codigo": "105", "descricao": "BRASIL"},
-                    "representanteLegal": {
-                        "cpf": "00000000000",
-                        "nome": "",
-                        "qualificacao": "00",
-                    },
-                },
-                {
-                    "tipoSocio": "2",
-                    "cpf": "00031298702",
-                    "nome": "MARCELO ANTONIO BARROS DE CICCO",
-                    "qualificacao": "49",
-                    "dataInclusao": "2014-01-01",
-                    "pais": {"codigo": "105", "descricao": "BRASIL"},
-                    "representanteLegal": {
-                        "cpf": "00000000000",
-                        "nome": "",
-                        "qualificacao": "00",
-                    },
-                },
-                {
-                    "tipoSocio": "2",
-                    "cpf": "76822320300",
-                    "nome": "LUIZA ALDENORA",
-                    "qualificacao": "49",
-                    "dataInclusao": "2014-01-01",
-                    "pais": {"codigo": "105", "descricao": "BRASIL"},
-                    "representanteLegal": {
-                        "cpf": "00000000000",
-                        "nome": "",
-                        "qualificacao": "00",
-                    },
-                },
-            ],
-            "endereco": {
-                "tipoLogradouro": "SETOR",
-                "logradouro": "NH BIWMNH WIHW MXIVH",
-                "numero": "Q.601",
-                "complemento": "LOTE V",
-                "cep": "70836900",
-                "bairro": "ASA NORTE",
-                "municipio": {"codigo": "9701", "descricao": "BRASILIA"},
-                "uf": "DF",
-                "pais": {"codigo": "105", "descricao": "BRASIL"},
-            },
-            "naturezaJuridica": {"codigo": "2011", "descricao": "Empresa Pública"},
-            "capitalSocial": 0,
-            "cnaePrincipal": {
-                "codigo": "6204000",
-                "descricao": "Consultoria em tecnologia da informação",
-            },
-        }
         with mock.patch(
             "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
-            return_value=mocked_response,
+            return_value=self.mocked_response_serpro_1,
         ):
             dummy_basica = self.model.create(
                 {"name": "Dummy Basica", "cnpj_cpf": "34.238.864/0001-68"}
@@ -207,104 +112,9 @@ class TestTestSerPro(TestCnpjCommon):
         self.assertEqual(socios, expected_socios)
 
     def test_serpro_empresa(self):
-        mocked_response = {
-            "ni": "34238864000249",
-            "nomeEmpresarial": "UHIEQKX WHNHIWD NH  FIXKHUUWPHMVX NH NWNXU (UHIFIX)",
-            "nomeFantasia": "UHIFIX UHNH",
-            "telefones": [
-                {"ddd": "61", "numero": "22222222"},
-                {"ddd": "61", "numero": "22222222"},
-            ],
-            "cep": "70836900",
-            "correioEletronico": "EMPRESA@XXXXXX.BR",
-            "socios": [
-                {
-                    "tipoSocio": "2",
-                    "cpf": "07119488449",
-                    "nome": "LUIZA ARAUJO DE OLIVEIRA",
-                    "qualificacao": "49",
-                    "dataInclusao": "2014-01-01",
-                    "pais": {"codigo": "105", "descricao": "BRASIL"},
-                    "representanteLegal": {
-                        "cpf": "00000000000",
-                        "nome": "",
-                        "qualificacao": "00",
-                    },
-                },
-                {
-                    "tipoSocio": "2",
-                    "cpf": "23982012600",
-                    "nome": "JOANA ALVES MUNDIM PENA",
-                    "qualificacao": "49",
-                    "dataInclusao": "2014-01-01",
-                    "pais": {"codigo": "105", "descricao": "BRASIL"},
-                    "representanteLegal": {
-                        "cpf": "00000000000",
-                        "nome": "",
-                        "qualificacao": "00",
-                    },
-                },
-                {
-                    "tipoSocio": "2",
-                    "cpf": "13946994415",
-                    "nome": "LUIZA BARBOSA BEZERRA",
-                    "qualificacao": "49",
-                    "dataInclusao": "2014-01-01",
-                    "pais": {"codigo": "105", "descricao": "BRASIL"},
-                    "representanteLegal": {
-                        "cpf": "00000000000",
-                        "nome": "",
-                        "qualificacao": "00",
-                    },
-                },
-                {
-                    "tipoSocio": "2",
-                    "cpf": "00031298702",
-                    "nome": "MARCELO ANTONIO BARROS DE CICCO",
-                    "qualificacao": "49",
-                    "dataInclusao": "2014-01-01",
-                    "pais": {"codigo": "105", "descricao": "BRASIL"},
-                    "representanteLegal": {
-                        "cpf": "00000000000",
-                        "nome": "",
-                        "qualificacao": "00",
-                    },
-                },
-                {
-                    "tipoSocio": "2",
-                    "cpf": "76822320300",
-                    "nome": "LUIZA ALDENORA",
-                    "qualificacao": "49",
-                    "dataInclusao": "2014-01-01",
-                    "pais": {"codigo": "105", "descricao": "BRASIL"},
-                    "representanteLegal": {
-                        "cpf": "00000000000",
-                        "nome": "",
-                        "qualificacao": "00",
-                    },
-                },
-            ],
-            "endereco": {
-                "tipoLogradouro": "SETOR",
-                "logradouro": "NH BIWMNH WIHW MXIVH",
-                "numero": "Q.601",
-                "complemento": "LOTE V",
-                "cep": "70836900",
-                "bairro": "ASA NORTE",
-                "municipio": {"codigo": "9701", "descricao": "BRASILIA"},
-                "uf": "DF",
-                "pais": {"codigo": "105", "descricao": "BRASIL"},
-            },
-            "naturezaJuridica": {"codigo": "2011", "descricao": "Empresa Pública"},
-            "capitalSocial": 0,
-            "cnaePrincipal": {
-                "codigo": "6204000",
-                "descricao": "Consultoria em tecnologia da informação",
-            },
-        }
         with mock.patch(
             "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
-            return_value=mocked_response,
+            return_value=self.mocked_response_serpro_2,
         ):
             self.model.search([("cnpj_cpf", "=", "34.238.864/0002-49")]).write(
                 {"active": False}
@@ -337,73 +147,9 @@ class TestTestSerPro(TestCnpjCommon):
         dummy_empresa.unlink()
 
     def test_serpro_qsa(self):
-        mocked_response = {
-            "nomeEmpresarial": "UHIEQKX WHNHIWD NH  FIXKHUUWPHMVX NH NWNXU (UHIFIX)",
-            "nomeFantasia": "UHIFIX UHNH",
-            "telefones": [
-                {"ddd": "61", "numero": "22222222"},
-                {"ddd": "61", "numero": "22222222"},
-            ],
-            "cep": "70836900",
-            "correioEletronico": "EMPRESA@XXXXXX.BR",
-            "socios": [
-                {
-                    "tipoSocio": "2",
-                    "nome": "LUIZA ARAUJO DE OLIVEIRA",
-                    "qualificacao": "49",
-                    "pais": {"codigo": "105", "descricao": "BRASIL"},
-                    "representanteLegal": {"nome": "", "qualificacao": "00"},
-                },
-                {
-                    "tipoSocio": "2",
-                    "nome": "JOANA ALVES MUNDIM PENA",
-                    "qualificacao": "49",
-                    "pais": {"codigo": "105", "descricao": "BRASIL"},
-                    "representanteLegal": {"nome": "", "qualificacao": "00"},
-                },
-                {
-                    "tipoSocio": "2",
-                    "nome": "LUIZA BARBOSA BEZERRA",
-                    "qualificacao": "49",
-                    "pais": {"codigo": "105", "descricao": "BRASIL"},
-                    "representanteLegal": {"nome": "", "qualificacao": "00"},
-                },
-                {
-                    "tipoSocio": "2",
-                    "nome": "MARCELO ANTONIO BARROS DE CICCO",
-                    "qualificacao": "49 ",
-                    "pais": {"codigo": "105", "descricao": "BRASIL"},
-                    "representanteLegal": {"nome": "", "qualificacao": "00"},
-                },
-                {
-                    "tipoSocio": "2",
-                    "nome": "LUIZA ALDENORA",
-                    "qualificacao": "49",
-                    "pais": {"codigo": "105", "descricao": "BRASIL"},
-                    "representanteLegal": {"nome": "", "qualificacao": "00"},
-                },
-            ],
-            "endereco": {
-                "tipoLogradouro": "SETOR",
-                "logradouro": "NH BIWMNH WIHW MXIVH",
-                "numero": "Q.601",
-                "complemento": "LOTE V",
-                "cep": "70836900",
-                "bairro": "ASA NORTE",
-                "municipio": {"codigo": "9701", "descricao": "BRASILIA"},
-                "uf": "DF",
-                "pais": {"codigo": "105", "descricao": "BRASIL"},
-            },
-            "naturezaJuridica": {"codigo": "2011", "descricao": "Empresa Pública"},
-            "capitalSocial": 0,
-            "cnaePrincipal": {
-                "codigo": "6204000",
-                "descricao": "Consultoria em tecnologia da informação",
-            },
-        }
         with mock.patch(
             "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
-            return_value=mocked_response,
+            return_value=self.mocked_response_serpro_3,
         ):
             self.model.search([("cnpj_cpf", "=", "34.238.864/0001-68")]).write(
                 {"active": False}

--- a/l10n_br_cnpj_search/tests/test_serpro.py
+++ b/l10n_br_cnpj_search/tests/test_serpro.py
@@ -25,87 +25,6 @@ class TestTestSerPro(TestCnpjCommon):
         self.set_param("serpro_schema", "basica")
 
     def test_serpro_basica(self):
-        dummy_basica = self.model.create(
-            {"name": "Dummy Basica", "cnpj_cpf": "34.238.864/0001-68"}
-        )
-        dummy_basica._onchange_cnpj_cpf()
-
-        action_wizard = dummy_basica.action_open_cnpj_search_wizard()
-        wizard_context = action_wizard.get("context")
-        wizard = (
-            self.env["partner.search.wizard"].with_context(**wizard_context).create({})
-        )
-        wizard.action_update_partner()
-        self.assertEqual(
-            dummy_basica.legal_name,
-            "Uhieqkx Whnhiwd Nh Fixkhuuwphmvx Nh Nwnxu (Uhifix)",
-        )
-        self.assertEqual(dummy_basica.company_type, "company")
-        self.assertEqual(dummy_basica.name, "Uhifix Uhnh")
-        self.assertEqual(dummy_basica.email, "EMPRESA@XXXXXX.BR")
-        self.assertEqual(dummy_basica.street_name, "Nh Biwmnh Wihw Mxivh")
-        self.assertEqual(dummy_basica.street2, "Lote V")
-        self.assertEqual(dummy_basica.street_number, "Q.601")
-        self.assertEqual(dummy_basica.zip, "70836900")
-        self.assertEqual(dummy_basica.district, "Asa Norte")
-        self.assertEqual(dummy_basica.phone, "(61) 22222222")
-        self.assertEqual(dummy_basica.mobile, "(61) 22222222")
-        self.assertEqual(dummy_basica.state_id.code, "DF")
-        self.assertEqual(dummy_basica.equity_capital, 0)
-        self.assertEqual(dummy_basica.cnae_main_id.code, "6204-0/00")
-
-    def test_serpro_not_found(self):
-        # In the Trial version there are only a few registered CNPJ records
-        invalid = self.model.create(
-            {"name": "invalid", "cnpj_cpf": "44.356.113/0001-08"}
-        )
-        invalid._onchange_cnpj_cpf()
-
-        with self.assertRaises(ValidationError):
-            action_wizard = invalid.action_open_cnpj_search_wizard()
-            wizard_context = action_wizard.get("context")
-            self.env["partner.search.wizard"].with_context(**wizard_context).create({})
-
-    def assert_socios(self, partner, expected_cnpjs):
-        socios = self.model.search_read(
-            [("id", "in", partner.child_ids.ids)],
-            fields=["name", "cnpj_cpf", "company_type"],
-        )
-
-        for s in socios:
-            s.pop("id")
-
-        expected_socios = [
-            {
-                "name": "Joana Alves Mundim Pena",
-                "cnpj_cpf": expected_cnpjs["Joana"],
-                "company_type": "person",
-            },
-            {
-                "name": "Luiza Aldenora",
-                "cnpj_cpf": expected_cnpjs["Aldenora"],
-                "company_type": "person",
-            },
-            {
-                "name": "Luiza Araujo De Oliveira",
-                "cnpj_cpf": expected_cnpjs["Araujo"],
-                "company_type": "person",
-            },
-            {
-                "name": "Luiza Barbosa Bezerra",
-                "cnpj_cpf": expected_cnpjs["Barbosa"],
-                "company_type": "person",
-            },
-            {
-                "name": "Marcelo Antonio Barros De Cicco",
-                "cnpj_cpf": expected_cnpjs["Marcelo"],
-                "company_type": "person",
-            },
-        ]
-
-        self.assertEqual(socios, expected_socios)
-
-    def test_serpro_empresa(self):
         mocked_response = {
             "ni": "34238864000168",
             "nomeEmpresarial": "UHIEQKX WHNHIWD NH  FIXKHUUWPHMVX NH NWNXU (UHIFIX)",
@@ -205,13 +124,195 @@ class TestTestSerPro(TestCnpjCommon):
             "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
             return_value=mocked_response,
         ):
-            self.model.search([("cnpj_cpf", "=", "34.238.864/0001-68")]).write(
+            dummy_basica = self.model.create(
+                {"name": "Dummy Basica", "cnpj_cpf": "34.238.864/0001-68"}
+            )
+            dummy_basica._onchange_cnpj_cpf()
+
+            action_wizard = dummy_basica.action_open_cnpj_search_wizard()
+            wizard_context = action_wizard.get("context")
+            wizard = (
+                self.env["partner.search.wizard"]
+                .with_context(**wizard_context)
+                .create({})
+            )
+            wizard.action_update_partner()
+            self.assertEqual(
+                dummy_basica.legal_name,
+                "Uhieqkx Whnhiwd Nh  Fixkhuuwphmvx Nh Nwnxu (Uhifix)",
+            )
+            self.assertEqual(dummy_basica.company_type, "company")
+            self.assertEqual(dummy_basica.name, "Uhifix Uhnh")
+            self.assertEqual(dummy_basica.email, "EMPRESA@XXXXXX.BR")
+            self.assertEqual(dummy_basica.street_name, "Nh Biwmnh Wihw Mxivh")
+            self.assertEqual(dummy_basica.street2, "Lote V")
+            self.assertEqual(dummy_basica.street_number, "Q.601")
+            self.assertEqual(dummy_basica.zip, "70836900")
+            self.assertEqual(dummy_basica.district, "Asa Norte")
+            self.assertEqual(dummy_basica.phone, "(61) 22222222")
+            self.assertEqual(dummy_basica.mobile, "(61) 22222222")
+            self.assertEqual(dummy_basica.state_id.code, "DF")
+            self.assertEqual(dummy_basica.equity_capital, 0)
+            self.assertEqual(dummy_basica.cnae_main_id.code, "6204-0/00")
+
+    def test_serpro_not_found(self):
+        # In the Trial version there are only a few registered CNPJ records
+        invalid = self.model.create(
+            {"name": "invalid", "cnpj_cpf": "44.356.113/0001-08"}
+        )
+        invalid._onchange_cnpj_cpf()
+
+        with self.assertRaises(ValidationError):
+            action_wizard = invalid.action_open_cnpj_search_wizard()
+            wizard_context = action_wizard.get("context")
+            self.env["partner.search.wizard"].with_context(**wizard_context).create({})
+
+    def assert_socios(self, partner, expected_cnpjs):
+        socios = self.model.search_read(
+            [("id", "in", partner.child_ids.ids)],
+            fields=["name", "cnpj_cpf", "company_type"],
+        )
+
+        for s in socios:
+            s.pop("id")
+
+        expected_socios = [
+            {
+                "name": "Joana Alves Mundim Pena",
+                "cnpj_cpf": expected_cnpjs["Joana"],
+                "company_type": "person",
+            },
+            {
+                "name": "Luiza Aldenora",
+                "cnpj_cpf": expected_cnpjs["Aldenora"],
+                "company_type": "person",
+            },
+            {
+                "name": "Luiza Araujo De Oliveira",
+                "cnpj_cpf": expected_cnpjs["Araujo"],
+                "company_type": "person",
+            },
+            {
+                "name": "Luiza Barbosa Bezerra",
+                "cnpj_cpf": expected_cnpjs["Barbosa"],
+                "company_type": "person",
+            },
+            {
+                "name": "Marcelo Antonio Barros De Cicco",
+                "cnpj_cpf": expected_cnpjs["Marcelo"],
+                "company_type": "person",
+            },
+        ]
+
+        self.assertEqual(socios, expected_socios)
+
+    def test_serpro_empresa(self):
+        mocked_response = {
+            "ni": "34238864000249",
+            "nomeEmpresarial": "UHIEQKX WHNHIWD NH  FIXKHUUWPHMVX NH NWNXU (UHIFIX)",
+            "nomeFantasia": "UHIFIX UHNH",
+            "telefones": [
+                {"ddd": "61", "numero": "22222222"},
+                {"ddd": "61", "numero": "22222222"},
+            ],
+            "cep": "70836900",
+            "correioEletronico": "EMPRESA@XXXXXX.BR",
+            "socios": [
+                {
+                    "tipoSocio": "2",
+                    "cpf": "07119488449",
+                    "nome": "LUIZA ARAUJO DE OLIVEIRA",
+                    "qualificacao": "49",
+                    "dataInclusao": "2014-01-01",
+                    "pais": {"codigo": "105", "descricao": "BRASIL"},
+                    "representanteLegal": {
+                        "cpf": "00000000000",
+                        "nome": "",
+                        "qualificacao": "00",
+                    },
+                },
+                {
+                    "tipoSocio": "2",
+                    "cpf": "23982012600",
+                    "nome": "JOANA ALVES MUNDIM PENA",
+                    "qualificacao": "49",
+                    "dataInclusao": "2014-01-01",
+                    "pais": {"codigo": "105", "descricao": "BRASIL"},
+                    "representanteLegal": {
+                        "cpf": "00000000000",
+                        "nome": "",
+                        "qualificacao": "00",
+                    },
+                },
+                {
+                    "tipoSocio": "2",
+                    "cpf": "13946994415",
+                    "nome": "LUIZA BARBOSA BEZERRA",
+                    "qualificacao": "49",
+                    "dataInclusao": "2014-01-01",
+                    "pais": {"codigo": "105", "descricao": "BRASIL"},
+                    "representanteLegal": {
+                        "cpf": "00000000000",
+                        "nome": "",
+                        "qualificacao": "00",
+                    },
+                },
+                {
+                    "tipoSocio": "2",
+                    "cpf": "00031298702",
+                    "nome": "MARCELO ANTONIO BARROS DE CICCO",
+                    "qualificacao": "49",
+                    "dataInclusao": "2014-01-01",
+                    "pais": {"codigo": "105", "descricao": "BRASIL"},
+                    "representanteLegal": {
+                        "cpf": "00000000000",
+                        "nome": "",
+                        "qualificacao": "00",
+                    },
+                },
+                {
+                    "tipoSocio": "2",
+                    "cpf": "76822320300",
+                    "nome": "LUIZA ALDENORA",
+                    "qualificacao": "49",
+                    "dataInclusao": "2014-01-01",
+                    "pais": {"codigo": "105", "descricao": "BRASIL"},
+                    "representanteLegal": {
+                        "cpf": "00000000000",
+                        "nome": "",
+                        "qualificacao": "00",
+                    },
+                },
+            ],
+            "endereco": {
+                "tipoLogradouro": "SETOR",
+                "logradouro": "NH BIWMNH WIHW MXIVH",
+                "numero": "Q.601",
+                "complemento": "LOTE V",
+                "cep": "70836900",
+                "bairro": "ASA NORTE",
+                "municipio": {"codigo": "9701", "descricao": "BRASILIA"},
+                "uf": "DF",
+                "pais": {"codigo": "105", "descricao": "BRASIL"},
+            },
+            "naturezaJuridica": {"codigo": "2011", "descricao": "Empresa Pública"},
+            "capitalSocial": 0,
+            "cnaePrincipal": {
+                "codigo": "6204000",
+                "descricao": "Consultoria em tecnologia da informação",
+            },
+        }
+        with mock.patch(
+            "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
+            return_value=mocked_response,
+        ):
+            self.model.search([("cnpj_cpf", "=", "34.238.864/0002-49")]).write(
                 {"active": False}
             )
             self.set_param("serpro_schema", "empresa")
 
             dummy_empresa = self.model.create(
-                {"name": "Dummy Empresa", "cnpj_cpf": "34.238.864/0001-68"}
+                {"name": "Dummy Empresa", "cnpj_cpf": "34.238.864/0002-49"}
             )
 
             dummy_empresa._onchange_cnpj_cpf()
@@ -233,6 +334,7 @@ class TestTestSerPro(TestCnpjCommon):
         }
 
         self.assert_socios(dummy_empresa, expected_cnpjs)
+        dummy_empresa.unlink()
 
     def test_serpro_qsa(self):
         mocked_response = {


### PR DESCRIPTION
Pessoal, estou trabalhando nos testes do PR https://github.com/OCA/l10n-brazil/pull/3289 e senti uma necessidade de refatorar os mocks do l10n_br_cnpj_search.
O que esse PR faz é tirar os dicionários de mock dos testes e colocar no common.
O que me motivou fazer isso é:
 - Facilitar a reutilização desses mocks em outro módulo (como por exemplo o l10n_br_crm_cnpj_search, que estou trabalhando)
 - Possibilitar futuras refatorações (que posso fazer inclusive nesse PR, caso vejam necessidade), aproveitando a estrutura de dicionário pra refatorar os próprios dicionários. Ao invés de termos vários dicionários grandes e quase idênticos com apenas alguns campos diferentes, teríamos um dicionário e os demais seriam cópias com campos de interesse adicionados/alterados.
 
 Bom, isso é o que eu consegui pensar até agora, estou aberto a sugestões.
 (marquei todos que interagiram no PR https://github.com/OCA/l10n-brazil/pull/3428)
@mileo , @rvalyi , @kaynnan , @CristianoMafraJunior , @antoniospneto 