### PR TITLE
[16.0][MIG] l10n_br_account_nfe: _render_qweb_* migration

### DIFF
--- a/l10n_br_account_nfe/report/ir_actions_report.py
+++ b/l10n_br_account_nfe/report/ir_actions_report.py
@@ -10,14 +10,14 @@ class IrActionsReport(models.Model):
     def temp_xml_autorizacao(self, xml_string):
         return super().temp_xml_autorizacao(xml_string=xml_string)
 
-    def _render_qweb_html(self, res_ids, data=None):
-        if self.report_name == "main_template_danfe_account":
+    def _render_qweb_html(self, report_ref, res_ids, data=None):
+        if report_ref == "main_template_danfe_account":
             return
-        return super()._render_qweb_html(res_ids, data=data)
+        return super()._render_qweb_html(report_ref, res_ids, data=data)
 
-    def _render_qweb_pdf(self, res_ids, data=None):
-        if self.report_name not in ["main_template_danfe_account"]:
-            return super()._render_qweb_pdf(res_ids, data=data)
+    def _render_qweb_pdf(self, report_ref, res_ids, data=None):
+        if report_ref not in ["main_template_danfe_account"]:
+            return super()._render_qweb_pdf(report_ref, res_ids, data=data)
 
         nfe = self.env["account.move"].search([("id", "in", res_ids)])
 

--- a/l10n_br_account_nfe/tests/test_nfe_danfe_account.py
+++ b/l10n_br_account_nfe/tests/test_nfe_danfe_account.py
@@ -18,7 +18,9 @@ class TestDanfe(TransactionCase):
         danfe_report = self.env["ir.actions.report"].search(
             [("report_name", "=", "main_template_danfe_account")]
         )
-        danfe_pdf = danfe_report._render_qweb_pdf([nfe.id])
+        danfe_pdf = danfe_report._render_qweb_pdf(
+            "main_template_danfe_account", [nfe.id]
+        )
         self.assertTrue(danfe_pdf)
 
     def test_generate_danfe_erpbrasil_edoc(self):
@@ -33,5 +35,7 @@ class TestDanfe(TransactionCase):
             danfe_report = self.env["ir.actions.report"].search(
                 [("report_name", "=", "main_template_danfe_account")]
             )
-            danfe_pdf = danfe_report._render_qweb_pdf([nfe.id])
+            danfe_pdf = danfe_report._render_qweb_pdf(
+                "main_template_danfe_account", [nfe.id]
+            )
             self.assertTrue(danfe_pdf)

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -1337,7 +1337,7 @@ class NFe(spec_models.StackedModel):
         }
         report = self.env.ref("l10n_br_nfe.report_danfe")
         pdf_data = report._render_qweb_pdf(
-            "l10n_br_nfe.main_template_danfe", self.fiscal_line_ids.document_id.ids
+            "main_template_danfe", self.fiscal_line_ids.document_id.ids
         )
         attachment_data["datas"] = base64.b64encode(pdf_data[0])
         file_pdf = self.file_report_id

--- a/l10n_br_nfe/report/ir_actions_report.py
+++ b/l10n_br_nfe/report/ir_actions_report.py
@@ -38,13 +38,13 @@ class IrActionsReport(models.Model):
         return etree.tostring(new_root)
 
     def _render_qweb_html(self, report_ref, res_ids, data=None):
-        if report_ref == "l10n_br_nfe.main_template_danfe":
+        if report_ref == "main_template_danfe":
             return
 
         return super()._render_qweb_html(report_ref, res_ids, data=data)
 
     def _render_qweb_pdf(self, report_ref, res_ids, data=None):
-        if report_ref not in ["l10n_br_nfe.main_template_danfe"]:
+        if report_ref not in ["main_template_danfe"]:
             return super()._render_qweb_pdf(report_ref, res_ids, data=data)
 
         nfe = self.env["l10n_br_fiscal.document"].search([("id", "in", res_ids)])

--- a/l10n_br_nfe/tests/test_nfe_danfe.py
+++ b/l10n_br_nfe/tests/test_nfe_danfe.py
@@ -37,7 +37,7 @@ class TestDanfeGeneration(TransactionCase):
         nfe.document_type_id = self.env.ref("l10n_br_fiscal.document_01")
         nfe.action_document_confirm()
         with self.assertRaises(UserError) as captured_exception:
-            danfe_report._render_qweb_pdf("l10n_br_nfe.main_template_danfe", [nfe.id])
+            danfe_report._render_qweb_pdf("main_template_danfe", [nfe.id])
         self.assertEqual(
             captured_exception.exception.args[0],
             "You can only print a DANFE of a NFe(55).",


### PR DESCRIPTION
## Objetivo da PR

Esta PR resolve a Issue #3432, que causava o erro "got multiple values for data" ao tentar imprimir qualquer relatório.

Esse erro é similar ao corrigido anteriormente na PR #3255.

