### PR TITLE
[16.0][FIX] equal Estadual Inscription detection

### DIFF
--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -94,7 +94,7 @@ class Partner(models.Model):
                         for partner in record.env["res.partner"].search(domain):
                             if (
                                 partner.inscr_est == record.inscr_est
-                                and not record.inscr_est
+                                and record.inscr_est
                             ):
                                 raise ValidationError(
                                     _(


### PR DESCRIPTION
Quando a opção "Multiple partners with the same CNPJ" está marcada, está sendo possível criar dois parceiros com o mesmo CNPJ e também com a mesma inscrição estadual.

![image](https://github.com/user-attachments/assets/79bb9fed-0cc1-4f23-a876-782c211206d1) 
Porém quando o primeiro registro está com esse campo vazio, o segundo não pode ser criado e a mensagem diz que a IE já está sendo usada.
![image](https://github.com/user-attachments/assets/b9a3b06d-fe42-46e3-b637-f10cf27a5838)

Esse PR apenas altera a condição para que a restrição ocorra quando os campo não são vazios. Pra mim parece prudente permitir que os dois registros estejam com esse campo vazio, pois permite usar essa funcionalidade para casos em que a IE não é relevante para o usuário.
