### PR TITLE
[IMP] l10n_br_cnpj_search: add valid cnpj in tests.

### DIFF
--- a/l10n_br_cnpj_search/tests/common.py
+++ b/l10n_br_cnpj_search/tests/common.py
@@ -67,60 +67,8 @@ class TestCnpjCommon(TransactionCase):
             "socios": [
                 {
                     "tipoSocio": "2",
-                    "cpf": "07119488449",
+                    "cpf": "38729752000160",
                     "nome": "LUIZA ARAUJO DE OLIVEIRA",
-                    "qualificacao": "49",
-                    "dataInclusao": "2014-01-01",
-                    "pais": {"codigo": "105", "descricao": "BRASIL"},
-                    "representanteLegal": {
-                        "cpf": "00000000000",
-                        "nome": "",
-                        "qualificacao": "00",
-                    },
-                },
-                {
-                    "tipoSocio": "2",
-                    "cpf": "23982012600",
-                    "nome": "JOANA ALVES MUNDIM PENA",
-                    "qualificacao": "49",
-                    "dataInclusao": "2014-01-01",
-                    "pais": {"codigo": "105", "descricao": "BRASIL"},
-                    "representanteLegal": {
-                        "cpf": "00000000000",
-                        "nome": "",
-                        "qualificacao": "00",
-                    },
-                },
-                {
-                    "tipoSocio": "2",
-                    "cpf": "13946994415",
-                    "nome": "LUIZA BARBOSA BEZERRA",
-                    "qualificacao": "49",
-                    "dataInclusao": "2014-01-01",
-                    "pais": {"codigo": "105", "descricao": "BRASIL"},
-                    "representanteLegal": {
-                        "cpf": "00000000000",
-                        "nome": "",
-                        "qualificacao": "00",
-                    },
-                },
-                {
-                    "tipoSocio": "2",
-                    "cpf": "00031298702",
-                    "nome": "MARCELO ANTONIO BARROS DE CICCO",
-                    "qualificacao": "49",
-                    "dataInclusao": "2014-01-01",
-                    "pais": {"codigo": "105", "descricao": "BRASIL"},
-                    "representanteLegal": {
-                        "cpf": "00000000000",
-                        "nome": "",
-                        "qualificacao": "00",
-                    },
-                },
-                {
-                    "tipoSocio": "2",
-                    "cpf": "76822320300",
-                    "nome": "LUIZA ALDENORA",
                     "qualificacao": "49",
                     "dataInclusao": "2014-01-01",
                     "pais": {"codigo": "105", "descricao": "BRASIL"},
@@ -163,7 +111,7 @@ class TestCnpjCommon(TransactionCase):
             "socios": [
                 {
                     "tipoSocio": "2",
-                    "cpf": "07119488449",
+                    "cpf": "42806249000562",
                     "nome": "LUIZA ARAUJO DE OLIVEIRA",
                     "qualificacao": "49",
                     "dataInclusao": "2014-01-01",
@@ -176,7 +124,7 @@ class TestCnpjCommon(TransactionCase):
                 },
                 {
                     "tipoSocio": "2",
-                    "cpf": "23982012600",
+                    "cpf": "50745238000114",
                     "nome": "JOANA ALVES MUNDIM PENA",
                     "qualificacao": "49",
                     "dataInclusao": "2014-01-01",
@@ -189,7 +137,7 @@ class TestCnpjCommon(TransactionCase):
                 },
                 {
                     "tipoSocio": "2",
-                    "cpf": "13946994415",
+                    "cpf": "42887406000340",
                     "nome": "LUIZA BARBOSA BEZERRA",
                     "qualificacao": "49",
                     "dataInclusao": "2014-01-01",
@@ -202,7 +150,7 @@ class TestCnpjCommon(TransactionCase):
                 },
                 {
                     "tipoSocio": "2",
-                    "cpf": "00031298702",
+                    "cpf": "39367267000157",
                     "nome": "MARCELO ANTONIO BARROS DE CICCO",
                     "qualificacao": "49",
                     "dataInclusao": "2014-01-01",
@@ -215,7 +163,7 @@ class TestCnpjCommon(TransactionCase):
                 },
                 {
                     "tipoSocio": "2",
-                    "cpf": "76822320300",
+                    "cpf": "62157094000245",
                     "nome": "LUIZA ALDENORA",
                     "qualificacao": "49",
                     "dataInclusao": "2014-01-01",


### PR DESCRIPTION
No teste `test_serpro_empresa`, está sendo criado um partner do tipo "Company" para cada sócio. Porém até então os dados de mock do campo "cpf" não são CNPJs válidos, em alguns testes automáticos isso tem sido um problema, pois a constrain `_check_cnpj_inscr_est` vai retornar um erro.

Esse PR altera os "cpf" dos sócios do mock específico para esse teste, trocando por CNPJs válidos, e também apaga alguns dados do mock que não são relevantes para o teste.