### PR TITLE
[14.0][IMP] l10n_br_fiscal: allow operation tax base override

### DIFF
--- a/l10n_br_account/tests/test_account_move_lc.py
+++ b/l10n_br_account/tests/test_account_move_lc.py
@@ -675,6 +675,82 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             move_vals,
         )
 
+    def test_venda_additional_values_included(self):
+        """Tests the inclusion of additional values in IPI tax base and price."""
+        fopl_id = self.env.ref("l10n_br_fiscal.fo_venda_venda")
+
+        # Setup invoice
+        additional_values_invoice = self.init_invoice(
+            "out_invoice",
+            products=[self.product_a],
+            document_type=self.env.ref("l10n_br_fiscal.document_55"),
+            document_serie_id=self.empresa_lc_document_55_serie_1,
+            fiscal_operation=self.env.ref("l10n_br_fiscal.fo_venda"),
+            fiscal_operation_lines=[fopl_id],
+        )
+
+        additional_values_invoice.invoice_line_ids[0].freight_value = 100
+        additional_values_invoice.invoice_line_ids[0].insurance_value = 100
+        additional_values_invoice.invoice_line_ids[0].other_value = 100
+
+        additional_values_invoice.invoice_line_ids._onchange_fiscal_taxes()
+        additional_values_invoice.line_ids._compute_amounts()
+        additional_values_invoice.invoice_line_ids.with_context(
+            check_move_validity=False
+        )._onchange_price_subtotal()
+        additional_values_invoice.with_context(
+            check_move_validity=False
+        )._recompute_dynamic_lines(recompute_all_taxes=True)
+        additional_values_invoice.line_ids._onchange_price_subtotal()
+        additional_values_invoice._check_balanced()
+
+        # Expected inclusive value calculation
+        # expected = (1 + ipi_mult) * (price_unit + additional_value)
+        # expected = (1 + 0.05) * (1000 + 300)
+        expected = 1365
+
+        self.assertEqual(additional_values_invoice.amount_total, expected)
+
+    def test_venda_additional_values_force_excluded(self):
+        """Tests forced exclusion of additional values in IPI tax base."""
+        fopl_id = self.env.ref("l10n_br_fiscal.fo_venda_venda")
+        fopl_id.additional_values_definition = "do_not_add"
+
+        # Setup invoice
+        additional_values_invoice = self.init_invoice(
+            "out_invoice",
+            products=[self.product_a],
+            document_type=self.env.ref("l10n_br_fiscal.document_55"),
+            document_serie_id=self.empresa_lc_document_55_serie_1,
+            fiscal_operation=self.env.ref("l10n_br_fiscal.fo_venda"),
+            fiscal_operation_lines=[fopl_id],
+        )
+
+        additional_values_invoice.invoice_line_ids[0].freight_value = 100
+        additional_values_invoice.invoice_line_ids[0].insurance_value = 100
+        additional_values_invoice.invoice_line_ids[0].other_value = 100
+
+        additional_values_invoice.invoice_line_ids._onchange_fiscal_taxes()
+        additional_values_invoice.line_ids._compute_amounts()
+        additional_values_invoice.invoice_line_ids.with_context(
+            check_move_validity=False
+        )._onchange_price_subtotal()
+        additional_values_invoice.with_context(
+            check_move_validity=False
+        )._recompute_dynamic_lines(recompute_all_taxes=True)
+        additional_values_invoice.line_ids._onchange_price_subtotal()
+        additional_values_invoice._check_balanced()
+
+        # Expected non-inclusive value calculation
+        # expected = (1 + ipi_mult) * price_unit + additional_value
+        # expected = (1 + 0.05) * 1000 + 300
+        expected = 1350
+
+        self.assertEqual(additional_values_invoice.amount_total, expected)
+
+        # Reset FOPL additional values config
+        fopl_id.additional_values_definition = "tax"
+
     def test_simples_remessa(self):
         product_line_vals_1 = {
             "name": self.product_a.display_name,

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -123,6 +123,19 @@ class OperationLine(models.Model):
         copy=True,
     )
 
+    # Behavior for additional values and costs
+    additional_values_definition = fields.Selection(
+        selection=[
+            ("tax", "Defined In Tax (Default)"),
+            ("add", "Include"),
+            ("do_not_add", "Do not Include"),
+        ],
+        default="tax",
+        required=True,
+        string="Include other values in tax base",
+        help="If left unset, value from tax group will be used",
+    )
+
     comment_ids = fields.Many2many(
         comodel_name="l10n_br_fiscal.comment",
         relation="l10n_br_fiscal_operation_line_comment_rel",

--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -193,11 +193,23 @@ class Tax(models.Model):
         insurance_value = kwargs.get("insurance_value", 0.00)
         freight_value = kwargs.get("freight_value", 0.00)
         other_value = kwargs.get("other_value", 0.00)
+        operation_line = kwargs.get("operation_line", False)
 
+        # Initialize additional value to be added to the base
+        add_value_to_base = 0
+
+        # Check if the tax group allows additional values to be included in the base
         if tax.tax_group_id.base_with_additional_values:
-            tax_dict["add_to_base"] += sum(
-                [freight_value, insurance_value, other_value]
-            )
+            add_value_to_base = sum([freight_value, insurance_value, other_value])
+
+        # If oper. line is set, adjust the additional values based on its definition
+        if operation_line:
+            if operation_line.additional_values_definition == "do_not_add":
+                add_value_to_base = 0
+            elif operation_line.additional_values_definition == "add":
+                add_value_to_base = sum([freight_value, insurance_value, other_value])
+
+        tax_dict["add_to_base"] += add_value_to_base
         tax_dict["remove_from_base"] += sum([discount_value])
 
         base = 0.00

--- a/l10n_br_fiscal/views/operation_line_view.xml
+++ b/l10n_br_fiscal/views/operation_line_view.xml
@@ -84,6 +84,9 @@
                                 nolabel="1"
                                 context="{'tree_view_ref': 'l10n_br_fiscal.tax_definition_tree','form_view_ref': 'l10n_br_fiscal.tax_definition_form', 'default_fiscal_operation_line_id': id}"
                             />
+                            <group>
+                                <field name="additional_values_definition" />
+                            </group>
                       </page>
                       <page name="extra_info" string="Extra Info">
                         <group>


### PR DESCRIPTION
## Objetivo

Este PR adiciona a possibilidade de modificar o comportamento da composição da base de cálculo do imposto, definida pelo campo `base_with_additional_values` no modelo `l10n_br_fiscal.tax.group`, permitindo que essa definição seja sobrescrita por meio da **Fiscal Operation Line**.

O principal objetivo é configurar **Linhas de Operação** específicas onde os valores de `freight_value`, `insurance_value` e `other_value` sejam ou não incluídos na base de cálculo dos impostos, sem a necessidade de criar novos grupos de imposto ou múltiplas definições de impostos.

## Exemplo

A operação de **Importação para comercialização** é um exemplo dessa situação. Nessa operação, os impostos são calculados de forma diferente do padrão nacional, fazendo com que o IPI, COFINS e PIS não incluam certos custos adicionais da compra.

No tax.group:
![image](https://github.com/user-attachments/assets/fc5419de-8936-4e4e-87b3-7209e9e95f5c)

Na operation.line:
![image](https://github.com/user-attachments/assets/d7aab5e2-a4fb-4425-b9ff-594accbc0b1d)
