### PR TITLE
[14.0][FIX] l10n_br_nfe: apply context TZ to document_date

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -853,7 +853,9 @@ class NFe(spec_models.StackedModel):
                 key_date_str = rec.document_key[2:6]
                 key_date = datetime.strptime(key_date_str, "%y%m")
 
-                document_date = fields.Datetime.from_string(rec.document_date)
+                document_date = fields.Datetime.context_timestamp(
+                    rec, rec.document_date
+                )
                 if (
                     rec.document_type in ["55", "65"]
                     and rec.state_edoc in ["a_enviar", "autorizada"]


### PR DESCRIPTION
Para testar basta alterar o document date de um doc fiscal para as últimas 3 horas de um mês qualquer e tentar confirmar

# Bug - sem o PR

![image](https://github.com/user-attachments/assets/c3305013-a9d7-48da-81d0-fe91f6fdb367)

# Com o PR - confirmado (apesar de ter dado rejeição, possivelmente outro bug não relacionado)

![image](https://github.com/user-attachments/assets/30044aac-4e40-479e-a6be-92ea6bf4ce98)

