### PR TITLE
[14.0][IMP] l10n_br_fiscal: Add onchange for Service Type in Document Line Mixin

### DIFF
--- a/l10n_br_fiscal/models/document_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_line_mixin_methods.py
@@ -901,6 +901,11 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             if self.city_taxation_code_id.city_id:
                 self.update({"issqn_fg_city_id": self.city_taxation_code_id.city_id})
 
+    @api.onchange("service_type_id")
+    def _onchange_service_type_id(self):
+        if self.service_type_id:
+            self._onchange_fiscal_operation_id()
+
     @api.model
     def _add_fields_to_amount(self):
         fields_to_amount = ["insurance_value", "other_value", "freight_value"]


### PR DESCRIPTION
cc @marcelsavegnago @douglascstd @rvalyi @mileo @WesleyOliveira98 

Conforme mencionado pelo @douglascstd, no [comentário](https://github.com/OCA/l10n-brazil/pull/3471#pullrequestreview-2405338603) da [PR 3471](https://github.com/OCA/l10n-brazil/pull/3471) estava pendente a criação do onchange para que, ao selecionar um Service Type, o calculo da taxa configurada seja definido conforme o esperado. Esta PR aborda essa necessidade.