### PR TITLE
[16.0][FIX] l10n_br_base: Form padding 0 - Visualização do Endereço

### DIFF
--- a/l10n_br_base/views/res_partner_address_view.xml
+++ b/l10n_br_base/views/res_partner_address_view.xml
@@ -6,7 +6,8 @@
         <field name="model">res.partner</field>
         <field name="priority">999</field>
         <field name="arch" type="xml">
-            <form>
+            <!-- Leaving padding as 0 because it is getting unnecessary spacing -->
+            <form style="padding: 0 !important;">
                 <div class="o_address_format">
                     <field name="street" class="oe_read_only" invisible="1" />
                     <field


### PR DESCRIPTION
Corrigindo a Issue #3331 

Deixando o `padding: 0 !important` para não ter o espaçamento

![3222](https://github.com/user-attachments/assets/a143c691-b083-48aa-ae95-249029fc953d)
