### PR TITLE
[14.0][FIX] l10n_br_fiscal: Os valores do frete, seguro e 'outros' não estão sendo inseridos no valor total da fatura

### DIFF
--- a/l10n_br_fiscal/models/document_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_mixin_methods.py
@@ -159,14 +159,23 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
                 for line in record._get_product_amount_lines():
                     line._onchange_fiscal_taxes()
                 record._fields["amount_total"].compute_value(record)
-                record.write(
-                    {
-                        name: value
-                        for name, value in record._cache.items()
-                        if record._fields[name].compute == "_amount_all"
+
+                # Case Sale, Purchase or POS
+                vals = {}
+                for name, value in record._cache.items():
+                    if (
+                        record._fields[name].compute == "_amount_all"
                         and not record._fields[name].inverse
-                    }
-                )
+                    ):
+                        vals[name] = value
+                if vals:
+                    record.write(vals)
+                elif hasattr(record, "move_ids"):
+                    # Case invoice (account.move has not compute named '_amount_all')
+                    record = record.with_context(check_move_validity=False)
+                    record.move_ids.invoice_line_ids._onchange_price_subtotal()
+                    record.move_ids.invoice_line_ids._onchange_mark_recompute_taxes()
+                    record.move_ids._onchange_invoice_line_ids()
 
     def _inverse_amount_insurance(self):
         for record in self.filtered(lambda doc: doc._get_product_amount_lines()):
@@ -209,14 +218,23 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
                 for line in record._get_product_amount_lines():
                     line._onchange_fiscal_taxes()
                 record._fields["amount_total"].compute_value(record)
-                record.write(
-                    {
-                        name: value
-                        for name, value in record._cache.items()
-                        if record._fields[name].compute == "_amount_all"
+
+                # Case Sale, Purchase or POS
+                vals = {}
+                for name, value in record._cache.items():
+                    if (
+                        record._fields[name].compute == "_amount_all"
                         and not record._fields[name].inverse
-                    }
-                )
+                    ):
+                        vals[name] = value
+                if vals:
+                    record.write(vals)
+                elif hasattr(record, "move_ids"):
+                    # Case invoice (account.move has not compute named '_amount_all')
+                    record = record.with_context(check_move_validity=False)
+                    record.move_ids.invoice_line_ids._onchange_price_subtotal()
+                    record.move_ids.invoice_line_ids._onchange_mark_recompute_taxes()
+                    record.move_ids._onchange_invoice_line_ids()
 
     def _inverse_amount_other(self):
         for record in self.filtered(lambda doc: doc._get_product_amount_lines()):
@@ -259,11 +277,20 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
                 for line in record._get_product_amount_lines():
                     line._onchange_fiscal_taxes()
                 record._fields["amount_total"].compute_value(record)
-                record.write(
-                    {
-                        name: value
-                        for name, value in record._cache.items()
-                        if record._fields[name].compute == "_amount_all"
+
+                # Case Sale, Purchase or POS
+                vals = {}
+                for name, value in record._cache.items():
+                    if (
+                        record._fields[name].compute == "_amount_all"
                         and not record._fields[name].inverse
-                    }
-                )
+                    ):
+                        vals[name] = value
+                if vals:
+                    record.write(vals)
+                elif hasattr(record, "move_ids"):
+                    # Case invoice (account.move has not compute named '_amount_all')
+                    record = record.with_context(check_move_validity=False)
+                    record.move_ids.invoice_line_ids._onchange_price_subtotal()
+                    record.move_ids.invoice_line_ids._onchange_mark_recompute_taxes()
+                    record.move_ids._onchange_invoice_line_ids()


### PR DESCRIPTION
Veja: #2666 

Segui a ideia do @mileo de abrir uma PR para discutirmos a melhor maneira de consertar esse problema.

Resumindo: o inverse desses campos funcionam parcialmente, eles realizam a distribuição proporcional do valor inserido no cabeçalho nas linhas da fatura. Porém, essa inserção dos valores nas linhas apenas atribui um valor ao campo, e não chama todos os métodos necessários para computar o total da fatura, diferente de quando o valor na linha é alterado manualmente.

Nesse commit, adicionei a chamada de um método do core que entrava na pilha de chamadas quando o valor era alterado manualmente na linha, ele adiciona um valor na fatura, mas dá um erro de diferença de débito e crédito.

Vou continuar investigando, acredito que a solução será algo parecido com isso, alguém tem alguma sugestão?

@antoniospneto @rvalyi @marcelsavegnago @mbcosta 
