### PR TITLE
[14.0][FIX] l10n_br_account: state tests when no EDI

### DIFF
--- a/l10n_br_account/tests/test_account_move_lc.py
+++ b/l10n_br_account/tests/test_account_move_lc.py
@@ -1775,16 +1775,20 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
         self.assertEqual(document_id.state, "em_digitacao")
         self.move_out_venda.action_post()
         self.assertEqual(self.move_out_venda.state, "posted")
-        self.assertEqual(document_id.state, "a_enviar")
-        self.move_out_venda.button_draft()
-        self.assertEqual(self.move_out_venda.state, "draft")
-        self.assertEqual(document_id.state, "em_digitacao")
-        document_id.action_document_confirm()
-        self.assertEqual(self.move_out_venda.state, "posted")
-        self.assertEqual(document_id.state, "a_enviar")
-        document_id.action_document_back2draft()
-        self.assertEqual(self.move_out_venda.state, "draft")
-        self.assertEqual(document_id.state, "em_digitacao")
+        fiscal_edi = self.env["ir.module.module"].search(
+            [("name", "=", "l10n_br_fiscal_edi")]
+        )
+        if fiscal_edi and fiscal_edi.state == "installed":
+            self.assertEqual(document_id.state, "a_enviar")
+            self.move_out_venda.button_draft()
+            self.assertEqual(self.move_out_venda.state, "draft")
+            self.assertEqual(document_id.state, "em_digitacao")
+            document_id.action_document_confirm()
+            self.assertEqual(self.move_out_venda.state, "posted")
+            self.assertEqual(document_id.state, "a_enviar")
+            document_id.action_document_back2draft()
+            self.assertEqual(self.move_out_venda.state, "draft")
+            self.assertEqual(document_id.state, "em_digitacao")
 
     def test_document_deny(self):
         document_id = self.move_out_venda.fiscal_document_id


### PR DESCRIPTION
since https://github.com/OCA/l10n-brazil/pull/3012 when l10n_br_fiscal_edi is not installed, these tests were failing

errors were like:

```
2024-11-16 15:58:18,513 19216 INFO odoo16 odoo.addons.l10n_br_account.tests.test_account_move_lc: Starting AccountMoveLucroPresumido.test_change_states ...
2024-11-16 15:58:18,752 19216 INFO odoo16 odoo.addons.l10n_br_account.tests.test_account_move_lc: ======================================================================
2024-11-16 15:58:18,752 19216 ERROR odoo16 odoo.addons.l10n_br_account.tests.test_account_move_lc: FAIL: AccountMoveLucroPresumido.test_change_states
Traceback (most recent call last):
  File "/home/rvalyi/DEV/odoo16/odoo/external-src/l10n-brazil/l10n_br_account/tests/test_account_move_lc.py", line 1719, in test_change_states
    self.assertEqual(document_id.state, "a_enviar")
AssertionError: 'em_digitacao' != 'a_enviar'
- em_digitacao
+ a_enviar
```

(when l10n_br_fiscal_edi is installed there was no issue but it's still required the l10n_br_account module can be tested independently, when doing migrations for instance)
