### PR TITLE
[14.0][FIX] l10n_br_stock_account: Ao "Marcar para Faturar" é preciso atualizar as linhas com a Operação Fiscal e a Linha de Operação Fiscal

### DIFF
--- a/l10n_br_stock_account/models/stock_picking.py
+++ b/l10n_br_stock_account/models/stock_picking.py
@@ -160,6 +160,9 @@ class StockPicking(models.Model):
                 fiscal_operation = record._get_default_fiscal_operation()
                 if fiscal_operation:
                     record.fiscal_operation_id = fiscal_operation
+                    for line in record.move_lines:
+                        line.fiscal_operation_id = fiscal_operation
+                        line._onchange_product_id_fiscal()
 
     def set_to_be_invoiced(self):
         """


### PR DESCRIPTION
Update line Fiscal OP

Ao "Marcar para Faturar" é preciso atualizar as linhas com a Operação Fiscal, PR simples mas aqui é preciso confirmar se atende as possibilidades de formas de uso, por exemplo se o Usuário inicialmente já definir que uma **Ordem de Seleção/Picking** deve ser Faturada o problema não aparecia e na visão tanto do picking quanto nas Linhas já são mostradas as informações Fiscais

![image](https://github.com/user-attachments/assets/66365018-048e-41bf-b262-5bf9921ac1fd)

![image](https://github.com/user-attachments/assets/b62fe89e-d44b-4b2c-8c37-c7144fb29a20)

O que parece ser a melhor forma de usar por já mostrar esses campos, porém existe outras formas de uso como foi descrito no issue https://github.com/OCA/l10n-brazil/issues/3478 que é 

![image](https://github.com/user-attachments/assets/1a5721de-9983-487a-889b-1aeef7e626ee)

Perceba que o **Marcar para Faturar** é definido no final do processo e da forma que o código estava as Linhas não eram atualizadas com a **Operação Fiscal** isso criava uma **Fatura sem Documento Fiscal** e uma vez criada dessa forma não é possível associar a Fatura a um Documento Fiscal.

Agora com esse PR mesmo que o **Marcar para Faturar** seja informado no final do processo as Linhas serão atualizadas 

![image](https://github.com/user-attachments/assets/61baa50f-6ac4-4efd-8aa0-0de4af8b421c)

![image](https://github.com/user-attachments/assets/7c958bec-783d-4d45-8b90-3afdcb313dc6)
 
Como não foi informado antes que o Picking vai gerar uma Fatura os Dados Fiscais não são mostrados
![image](https://github.com/user-attachments/assets/8fac3816-906d-48cf-8802-a3daa78c4402)

![image](https://github.com/user-attachments/assets/ec419003-cdb5-4832-9277-6feadb1bcdf7)

![image](https://github.com/user-attachments/assets/064a01ef-dd59-4e90-86ea-e59e71cc3d9b)

Agora ao **Marcar para Faturar** o programa vai preencher a **Operação Fiscal** e  chamar o **_onchange_product_id_fiscal** e assim preencher a **Linha de Operação fiscal**

![image](https://github.com/user-attachments/assets/7d625dbb-191d-4f05-92c9-4e6975f5a26a)

Com isso a Fatura criada já deverá ter os Dados Fiscais informados nas Linhas e o Documento Fiscal também será criado

![image](https://github.com/user-attachments/assets/0affa00d-4fa0-409b-b2c3-693a2a1e1286)

![image](https://github.com/user-attachments/assets/8fee164f-def3-47db-a7ae-e083910ab2e6)


Esse PR deve resolver o issue https://github.com/OCA/l10n-brazil/issues/3295 e de certa forma vai evitar o erro visto no issue https://github.com/OCA/l10n-brazil/issues/3478 , porque apesar do Douglas não ter relacionado o erro era justamente a falta da **Operação Fiscal** que causava o problema

![image](https://github.com/user-attachments/assets/5ca152e1-e1c8-49ed-97a4-cfd4ffa51d42)

**OBS.:** Sobre o issue https://github.com/OCA/l10n-brazil/issues/3478 é preciso avaliar se esse caso onde **A partir de uma Fatura gerada de um objeto Sem Operação Fiscal deve ser possível Associar/Criar um Documento Fiscal** é um problema/issue que pode ser resolvido ou mesmo se isso é algo sem solução devido a forma que foi feita a implementação,  e nesse caso incluir um **Warning** para Confirmar com o Usuário se deve ou não Gerar um Documento Fiscal e assim evitar o problema. As alterações que foram feitas nos módulos **l10n_br_sale, l10n_br_purchase, l10n_br_stock_account e derivados** para que a Localização atenda tanto os casos das **Faturas Com ou Sem Documento Fiscal** acabaram gerando essa situação, porque antes estava sempre criando um Documento Fiscal, e hoje o programa usa a **Operação Fiscal** para identificar se deve Criar ou Não o Documento Fiscal, então em todos os casos tanto no Pedido de Vendas, Compras ou Ordem de Seleção onde se quer gerar um Documento Fiscal é preciso informar a Operação Fiscal para não ter esse problema, isso já havia sido debatido em outro issue [[14.0][BUG][l10n_br_account] Impossibilidade de inserir impostos em uma fatura gerada por uma SO que não tem operação declarada.](https://github.com/OCA/l10n-brazil/issues/2877) e no PR https://github.com/OCA/l10n-brazil/pull/3327 o Wesley também comentou sobre isso com a recomendação de um **Warning**

![image](https://github.com/user-attachments/assets/aa3d8145-1b6c-4954-ad4b-7a6936760e62) 

Mas isso é algo fora do escopo desse PR, já que uma vez informado a **Operação Fiscal** no objeto que vai gerar a **Fatura** essa necessidade de associar/criar um Documento Fiscal deixa de existir.


@douglascstd @kaynnan por favor verifiquem se essas alterações resolvem os erros dos issues mencionados

cc @OCA/local-brazil-maintainers @WesleyOliveira98 
