### PR TITLE
[14.0][FIX] l10n_br_sale: Mapear o campo ind_final no Pedido de Venda

### DIFF
--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -269,3 +269,12 @@ class SaleOrder(models.Model):
             partner = self.partner_invoice_id
 
         return partner
+
+    @api.onchange("partner_id")
+    def _onchange_partner_id_fiscal(self):
+        if self.partner_id:
+            # Necessário chamar o onchange para preencher o partner_invoice_id
+            # antes do Mix Fiscal e ter o ind_final correto
+            # TODO: teria outra forma com menos código?
+            self.onchange_partner_id()
+            return super()._onchange_partner_id_fiscal()


### PR DESCRIPTION
No PR https://github.com/OCA/l10n-brazil/pull/2849 acabou passando um problema ao mapear o campo **ind_final** e foi aberto um issue sobre isso https://github.com/OCA/l10n-brazil/issues/3449

![image](https://github.com/user-attachments/assets/814abb6d-4313-43dd-85df-06b8f4403d34)

![image](https://github.com/user-attachments/assets/bab18f30-c366-4f65-b90f-99a8b429e4eb)

O erro acontece porque o método que faz esse mapeamento [_onchange_partner_fiscal_id no módulo l10n_br_fiscal](https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_fiscal/models/document_mixin_methods.py#L110) é chamando antes do método que preenche o campo **partner_invoice_id** [onchange_partner_id no módulo sale](https://github.com/OCA/OCB/blob/14.0/addons/sale/models/sale.py#L390) e com isso o método que retorna o **res.partner** retorna **False**, para resolver eu apenas inclui o **_onchange_partner_fiscal_id** no **sale.order** para chamar antes o método que preenche o **partner_invoice_id**, deixei um comentário para deixar claro o problema e avaliar em futuras versões se é possível resolver com menos código.

cc @OCA/local-brazil-maintainers @DiegoParadeda 