### PR TITLE
[14.0][IMP] l10n_br_nfe: computed impostoDevol added to nfe

### DIFF
--- a/l10n_br_account_nfe/tests/test_nfe_with_ipi.py
+++ b/l10n_br_account_nfe/tests/test_nfe_with_ipi.py
@@ -50,3 +50,44 @@ class TestNFeWithIPI(AccountMoveBRCommon):
         self.assertEqual(self.move_out_venda.nfe40_vIPI, 50.0)
         self.assertEqual(self.move_out_venda.nfe40_vProd, 1000.00)
         self.assertEqual(self.move_out_venda.nfe40_vNF, 1050.00)
+
+    def test_nfe_credit_note(self):
+        """
+        Test fiscal document field: nfe40_impostoDevol (no demo)
+        """
+        partner_a = self.env["res.partner"].create({"name": "Test partner A"})
+        fiscal_doc = self.env["l10n_br_fiscal.document"].create(
+            {
+                "fiscal_operation_id": self.env.ref(
+                    "l10n_br_fiscal.fo_devolucao_venda"
+                ).id,
+                "document_type_id": self.env.ref("l10n_br_fiscal.document_55").id,
+                "edoc_purpose": "4",
+                "issuer": "company",
+                "partner_id": partner_a.id,
+                "fiscal_operation_type": "in",
+            }
+        )
+        product_id = self.env.ref("product.product_product_10")
+        fiscal_doc_line = self.env["l10n_br_fiscal.document.line"].create(
+            {
+                "document_id": fiscal_doc.id,
+                "name": "Return - credit note",
+                "product_id": product_id.id,
+                "fiscal_operation_type": "in",
+                "fiscal_operation_id": self.env.ref(
+                    "l10n_br_fiscal.fo_devolucao_venda"
+                ).id,
+                "fiscal_operation_line_id": self.env.ref(
+                    "l10n_br_fiscal.fo_devolucao_venda_devolucao_venda"
+                ).id,
+                "p_devol": 50,
+                "ipi_devol_value": 1,
+            }
+        )
+        fiscal_doc_line._onchange_product_id_fiscal()
+
+        self.assertEqual(fiscal_doc_line.nfe40_impostoDevol.nfe40_pDevol, 50.00)
+        self.assertEqual(
+            fiscal_doc_line.nfe40_impostoDevol.nfe40_IPI.nfe40_vIPIDevol, 1.00
+        )

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -50,3 +50,7 @@ class DocumentLine(models.Model):
     force_compute_delivery_costs_by_total = fields.Boolean(
         related="document_id.force_compute_delivery_costs_by_total"
     )
+
+    edoc_purpose = fields.Selection(
+        related="document_id.edoc_purpose",
+    )

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -151,6 +151,11 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         readonly=True,
     )
 
+    operation_fiscal_type = fields.Selection(
+        related="fiscal_operation_id.fiscal_type",
+        readonly=True,
+    )
+
     fiscal_operation_line_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.operation.line",
         string="Operation Line",
@@ -567,6 +572,11 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         domain="['|', ('cst_in_id', '=', ipi_cst_id),"
         "('cst_out_id', '=', ipi_cst_id)]",
     )
+
+    # IPI Devolvido Fields
+    p_devol = fields.Float(string="Percentual de mercadoria devolvida")
+
+    ipi_devol_value = fields.Monetary(string="Valor do IPI devolvido")
 
     # II Fields
     ii_tax_id = fields.Many2one(

--- a/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
@@ -9,6 +9,7 @@
         <group name="fiscal_fields" invisible="1">
           <field name="currency_id" force_save="1" invisible="1" />
           <field name="fiscal_operation_type" force_save="1" invisible="1" />
+          <field name="operation_fiscal_type" force_save="1" invisible="1" />
           <field name="company_id" force_save="1" invisible="1" />
           <field name="partner_id" force_save="1" invisible="1" />
           <field name="fiscal_type" force_save="1" invisible="1" />
@@ -495,6 +496,13 @@
                                             attrs="{'readonly': [('ipi_tax_id', '!=', False)]}"
                                         />
                       </group>
+                  </group>
+                  <group
+                                    string="Devolução do IPI"
+                                    attrs="{'invisible': [('operation_fiscal_type', 'in', ['purchase', 'sale'])]}"
+                                >
+                    <field name="p_devol" />
+                    <field name="ipi_devol_value" />
                   </group>
               </page>
               <page


### PR DESCRIPTION
## Objetivo

Adiciona suporte para a definição dos campos nfe40_vIPIDevol e nfe40_pDevol na linha do documento fiscal. Os valores definidos para esses campos também serão corretamente exportados para o XML da NFe.

![image](https://github.com/user-attachments/assets/a26f640a-5af9-4d47-8ee9-b7c72824b91e)

![image](https://github.com/user-attachments/assets/fd32f549-5fe2-40ca-81f3-4fd37190b17b)
