### PR TITLE
[16.0][FIX][l10n_br_sale] fix landed costs

### DIFF
--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -95,15 +95,15 @@ class SaleOrder(models.Model):
         """Get object lines instaces used to compute fields"""
         return self.mapped("order_line")
 
-    @api.depends("order_line")
-    def _compute_amount(self):
-        return super()._compute_amount()
-
-    @api.depends("order_line.price_total")
-    def _amount_all(self):
+    @api.depends(
+        "order_line.price_subtotal", "order_line.price_tax", "order_line.price_total"
+    )
+    def _compute_amounts(self):
         """Compute the total amounts of the SO."""
         for order in self:
             order._compute_amount()
+
+    # TODO v16 override _compute_tax_totals ?
 
     @api.model
     def _get_view(self, view_id=None, view_type="form", **options):

--- a/l10n_br_sale/tests/test_l10n_br_sale.py
+++ b/l10n_br_sale/tests/test_l10n_br_sale.py
@@ -520,8 +520,7 @@ class L10nBrSaleBaseTest(TransactionCase):
         # Devem existir duas Faturas/Documentos Fiscais
         self.assertEqual(2, self.so_product_service.invoice_count)
 
-    # TODO MIGRATE TO v16!
-    def TODO_test_fields_freight_insurance_other_costs(self):
+    def test_fields_freight_insurance_other_costs(self):
         """Test fields Freight, Insurance and Other Costs when
         defined or By Line or By Total in Sale Order.
         """


### PR DESCRIPTION
os testes de frete, seguros e outros custos em vendas tinham sido desativados na migração para a v16. Aqui eu resolvei o que faltava resolver e habilitei os testes de novo. Eu tb testei com #3518 localmente e passou do mesmo jeito.