### PR TITLE
[14.0][FIX] l10n_br_fiscal: Preencher document_date apenas na confirmação do documento

### DIFF
--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -341,13 +341,6 @@ class Document(models.Model):
     def _compute_amount(self):
         return super()._compute_amount()
 
-    @api.model_create_multi
-    def create(self, vals_list):
-        for values in vals_list:
-            if not values.get("document_date"):
-                values["document_date"] = self._date_server_format()
-        return super().create(vals_list)
-
     def unlink(self):
         forbidden_states_unlink = [
             SITUACAO_EDOC_AUTORIZADA,


### PR DESCRIPTION
Este PR corrige o problema onde a data de emissão da nota fiscal (`document_date`) é preenchida no momento da criação, mesmo quando o documento está em rascunho. Agora, a data só será definida ao confirmar o documento.

O bug é notado quando o documento é criado e permanece em rascunho por mais de um dia antes da confirmação, resultando em uma data de emissão incorreta.

