### PR TITLE
[14.0][FIX][l10n_br_nfse_paulistana] Status consulta

### DIFF
--- a/l10n_br_nfse_paulistana/models/document.py
+++ b/l10n_br_nfse_paulistana/models/document.py
@@ -395,18 +395,21 @@ class Document(models.Model):
                 cnpj_prest=misc.punctuation_rm(record.company_id.partner_id.cnpj_cpf),
             )
             consulta = processador.analisa_retorno_consulta(processo)
+            data_emissao = datetime.strptime(
+                consulta["data_emissao"], "%Y-%m-%dT%H:%M:%S"
+            )
             if isinstance(consulta, dict):
                 record.write(
                     {
                         "verify_code": consulta["codigo_verificacao"],
                         "document_number": consulta["numero"],
-                        "authorization_date": consulta["data_emissao"],
+                        "authorization_date": data_emissao,
                     }
                 )
                 record.authorization_event_id.set_done(
                     status_code=4,
                     response=_("Procesado com Sucesso"),
-                    protocol_date=consulta["data_emissao"],
+                    protocol_date=data_emissao,
                     protocol_number=record.authorization_protocol,
                     file_response_xml=processo.retorno,
                 )


### PR DESCRIPTION
```
  File "/opt/odoo/auto/addons/l10n_br_fiscal/wizards/document_status_wizard.py", line 26, in doit
    return wizard.get_document_status()
  File "/opt/odoo/auto/addons/l10n_br_fiscal/wizards/document_status_wizard.py", line 17, in get_document_status
    "document_status": self.document_id._document_status(),
  File "/opt/odoo/auto/addons/l10n_br_nfse_paulistana/models/document.py", line 399, in _document_status
    record.write(
  File "/opt/odoo/auto/addons/auditlog/models/rule.py", line 427, in write_fast
    result = write_fast.origin(self, vals, **kwargs)
  File "/opt/odoo/auto/addons/mail/models/mail_thread.py", line 322, in write
    result = super(MailThread, self).write(values)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3694, in write
    field.write(self, vals[fname])
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 952, in write
    cache_value = self.convert_to_cache(value, records)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1949, in convert_to_cache
    return self.to_datetime(value)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1929, in to_datetime
    return datetime.strptime(value, DATETIME_FORMAT[:len(value)-2])
  File "/usr/local/lib/python3.8/_strptime.py", line 568, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
  File "/usr/local/lib/python3.8/_strptime.py", line 349, in _strptime
    raise ValueError("time data %r does not match format %r" %
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 652, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 317, in _handle_exception
    raise exception.with_traceback(None) from new_cause
ValueError: time data '2024-12-02T09:06:12' does not match format '%Y-%m-%d %H:%M:%S'
```