### PR TITLE
[16.0] remove oca_dependencies.txt

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,4 +1,0 @@
-web
-account-payment
-account-reconcile
-odoo-test-helper


### PR DESCRIPTION
## Objetivo da PR

Conforme sua falado nessa publicação  https://odoo-community.org/groups/contributors-15/contributors-1927945 a utilização do arquivo oca_dependencies.txt ficou inutilizável.