### PR TITLE
[14.0][RFC] l10n_br_nfe: refactor nfce qrcode methods

### DIFF
--- a/l10n_br_account_nfe/models/document.py
+++ b/l10n_br_account_nfe/models/document.py
@@ -162,5 +162,7 @@ class DocumentNfe(models.Model):
         res = super()._update_nfce_for_offline_contingency()
         if self.move_ids:
             copy_invoice = self.move_ids[0].copy()
+            copy_invoice.fiscal_document_id.processador_edoc = self.processador_edoc
+            copy_invoice.fiscal_document_id.nfe_transmission = self.nfe_transmission
             copy_invoice.action_post()
         return res

--- a/l10n_br_account_nfe/models/document.py
+++ b/l10n_br_account_nfe/models/document.py
@@ -162,7 +162,9 @@ class DocumentNfe(models.Model):
         res = super()._update_nfce_for_offline_contingency()
         if self.move_ids:
             copy_invoice = self.move_ids[0].copy()
+
             copy_invoice.fiscal_document_id.processador_edoc = self.processador_edoc
-            copy_invoice.fiscal_document_id.nfe_transmission = self.nfe_transmission
+            copy_invoice.processador_edoc = self.processador_edoc
+
             copy_invoice.action_post()
         return res

--- a/l10n_br_account_nfe/tests/test_nfce_contingency.py
+++ b/l10n_br_account_nfe/tests/test_nfce_contingency.py
@@ -1,6 +1,7 @@
 # Copyright 2023 KMEE (Felipe Zago Rodrigues <felipe.zago@kmee.com.br>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
+from odoo import fields
 from odoo.tests import TransactionCase
 
 
@@ -54,8 +55,24 @@ class TestAccountNFCeContingency(TransactionCase):
                 "payment_mode_id": payment_mode.id,
                 "company_id": self.env.ref("base.main_company").id,
                 "line_ids": [
-                    (0, 0, {"account_id": receivable_account_id.id, "credit": 10}),
-                    (0, 0, {"account_id": payable_account_id.id, "debit": 10}),
+                    (
+                        0,
+                        0,
+                        {
+                            "date_maturity": fields.Date.today(),
+                            "account_id": receivable_account_id.id,
+                            "credit": 10,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "date_maturity": fields.Date.today(),
+                            "account_id": payable_account_id.id,
+                            "debit": 10,
+                        },
+                    ),
                 ],
             }
         )

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -1226,13 +1226,22 @@ class NFe(spec_models.StackedModel):
 
     def _prepare_nfce_send(self):
         self.ensure_one()
-        self._prepare_payments_for_nfce()
-        self.nfe40_infNFeSupl = self.env["l10n_br_fiscal.document.supplement"].create(
-            {
-                "nfe40_qrCode": self.get_nfce_qrcode(),
-                "nfe40_urlChave": self.get_nfce_qrcode_url(),
-            }
+        self.nfe40_detPag.filtered(lambda p: p.nfe40_tPag == "99").write(
+            {"nfe40_xPag": "Outros"}
         )
+
+    def _document_qrcode(self):
+        super()._document_qrcode()
+
+        for record in self.filtered(lambda d: d.document_type == MODELO_FISCAL_NFCE):
+            record.nfe40_infNFeSupl = self.env[
+                "l10n_br_fiscal.document.supplement"
+            ].create(
+                {
+                    "qrcode": record.get_nfce_qrcode(),
+                    "url_key": record.get_nfce_qrcode_url(),
+                }
+            )
 
     def _eletronic_document_send(self):
         super()._eletronic_document_send()
@@ -1527,12 +1536,6 @@ class NFe(spec_models.StackedModel):
             return
 
         return self._edoc_processor().consulta_qrcode_url
-
-    def _prepare_payments_for_nfce(self):
-        for rec in self.filtered(lambda d: d.document_type == MODELO_FISCAL_NFCE):
-            rec.nfe40_detPag.filtered(lambda p: p.nfe40_tPag == "99").write(
-                {"nfe40_xPag": "Outros"}
-            )
 
     def action_danfe_nfce_report(self):
         return (

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -1528,6 +1528,8 @@ class NFe(spec_models.StackedModel):
         processador = self._edoc_processor()
         if self.nfe_transmission == "1":
             return processador.monta_qrcode(self.document_key)
+        if not self.serialize() or not len(self.serialize()):
+            return
 
         serialized_doc = self.serialize()[0]
         xml = processador.assina_raiz(serialized_doc, serialized_doc.infNFe.Id)
@@ -1535,6 +1537,8 @@ class NFe(spec_models.StackedModel):
 
     def get_nfce_qrcode_url(self):
         if self.document_type != MODELO_FISCAL_NFCE:
+            return
+        if self._edoc_processor() is None:
             return
 
         return self._edoc_processor().consulta_qrcode_url

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -896,9 +896,16 @@ class NFe(spec_models.StackedModel):
         for record in self.with_context(lang="pt_BR").filtered(
             filter_processador_edoc_nfe
         ):
+            processor = record.processador_edoc
+
+            # TODO: Avaliar a possibilidade de remover esse flush e invalidate
             record.flush()
             record.invalidate_cache()
             inf_nfe = record._build_binding("nfe", "40")
+
+            if hasattr(record, "move_ids") and record.move_ids:
+                record.move_ids.processador_edoc = processor
+            record.processador_edoc = processor
 
             inf_nfe_supl = None
             if record.nfe40_infNFeSupl:

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -1234,6 +1234,8 @@ class NFe(spec_models.StackedModel):
         super()._document_qrcode()
 
         for record in self.filtered(lambda d: d.document_type == MODELO_FISCAL_NFCE):
+            if record.nfe40_infNFeSupl:
+                record.nfe40_infNFeSupl.unlink()
             record.nfe40_infNFeSupl = self.env[
                 "l10n_br_fiscal.document.supplement"
             ].create(

--- a/l10n_br_nfe/tests/test_nfce.py
+++ b/l10n_br_nfe/tests/test_nfce.py
@@ -44,8 +44,8 @@ class TestNFCe(TestNFeExport):
             }
         )
         self.document_id.company_id.certificate_nfe_id = certificate_id
-        self.document_id.company_id.nfce_csc_token = "DUMMY"
-        self.document_id.company_id.nfce_csc_code = "DUMMY"
+        self.document_id.company_id.nfce_csc_token = "1"
+        self.document_id.company_id.nfce_csc_code = "1"
 
         self.prepare_test_nfe(self.document_id)
 


### PR DESCRIPTION
RFC #3522 + fix duplicate inf.supl

Esse PR corrige um bug atual na geração na NFCe que resulta em falha de schema de XML por falta de inf.supl