### PR TITLE
[15.0][l10n_br_base][FIX] Avoid res.partner.vat warning message - bcp 3540

### DIFF
--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -16,7 +16,7 @@ class Partner(models.Model):
     _name = "res.partner"
     _inherit = [_name, "l10n_br_base.party.mixin"]
 
-    vat = fields.Char(compute="_compute_vat_from_cnpj_cpf", store=True)
+    vat = fields.Char(compute="_compute_vat_from_cnpj_cpf", store=True, recursive=True)
 
     is_accountant = fields.Boolean(string="Is accountant?")
 


### PR DESCRIPTION
backport de #3540

cc @renatonlima @antoniospneto 