### PR TITLE
[16.0] l10n_br_fiscal: Renomeação de métodos compute para evitar ambiguidades em heranças de modelos

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -285,6 +285,7 @@ class AccountMove(models.Model):
     )
     def _compute_amount(self):
         for move in self.filtered(lambda m: m.fiscal_operation_id):
+            move._compute_fiscal_amount()
             for line in move.line_ids:
                 if (
                     move.is_invoice(include_receipts=True)

--- a/l10n_br_account/tests/test_account_move_lc.py
+++ b/l10n_br_account/tests/test_account_move_lc.py
@@ -480,7 +480,7 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
         # Testando com Alivio do ICMS
         self.move_out_venda_with_icms_reduction.invoice_line_ids[0].icms_relief_id = 1
         self.move_out_venda_with_icms_reduction.invoice_line_ids._onchange_fiscal_taxes()
-        self.move_out_venda_with_icms_reduction.line_ids._compute_amounts()
+        self.move_out_venda_with_icms_reduction.line_ids._compute_fiscal_amounts()
 
         product_line_vals_1 = {
             "name": self.product_a.display_name,

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -350,8 +350,8 @@ class Document(models.Model):
         "fiscal_line_ids.amount_tax_not_included",
         "fiscal_line_ids.amount_tax_withholding",
     )
-    def _compute_amount(self):
-        return super()._compute_amount()
+    def _compute_fiscal_amount(self):
+        return super()._compute_fiscal_amount()
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -192,7 +192,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     )
 
     amount_fiscal = fields.Monetary(
-        compute="_compute_amounts",
+        compute="_compute_fiscal_amounts",
     )
 
     price_gross = fields.Monetary(
@@ -201,38 +201,38 @@ class FiscalDocumentLineMixin(models.AbstractModel):
             "Total value of products or services (quantity x unit price)"
             "before any discounts."
         ),
-        compute="_compute_amounts",
+        compute="_compute_fiscal_amounts",
     )
 
     amount_untaxed = fields.Monetary(
-        compute="_compute_amounts",
+        compute="_compute_fiscal_amounts",
     )
 
     amount_tax = fields.Monetary(
-        compute="_compute_amounts",
+        compute="_compute_fiscal_amounts",
     )
 
     amount_taxed = fields.Monetary(
-        compute="_compute_amounts",
+        compute="_compute_fiscal_amounts",
     )
 
     amount_total = fields.Monetary(
-        compute="_compute_amounts",
+        compute="_compute_fiscal_amounts",
     )
 
     financial_total = fields.Monetary(
         string="Amount Financial",
-        compute="_compute_amounts",
+        compute="_compute_fiscal_amounts",
     )
 
     financial_total_gross = fields.Monetary(
         string="Financial Gross Amount",
         help="Total amount before any discounts are applied.",
-        compute="_compute_amounts",
+        compute="_compute_fiscal_amounts",
     )
 
     financial_discount_value = fields.Monetary(
-        compute="_compute_amounts",
+        compute="_compute_fiscal_amounts",
     )
 
     amount_tax_included = fields.Monetary()

--- a/l10n_br_fiscal/models/document_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_line_mixin_methods.py
@@ -128,7 +128,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         "price_unit",
         "quantity",
     )
-    def _compute_amounts(self):
+    def _compute_fiscal_amounts(self):
         for record in self:
             round_curr = record.currency_id or self.env.ref("base.BRL")
 

--- a/l10n_br_fiscal/models/document_mixin_fields.py
+++ b/l10n_br_fiscal/models/document_mixin_fields.py
@@ -99,337 +99,337 @@ class FiscalDocumentMixinFields(models.AbstractModel):
     )
 
     amount_price_gross = fields.Monetary(
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
         string="Amount Gross",
         help="Amount without discount.",
     )
 
     amount_untaxed = fields.Monetary(
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_icms_base = fields.Monetary(
         string="ICMS Base",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_icms_value = fields.Monetary(
         string="ICMS Value",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_icmsst_base = fields.Monetary(
         string="ICMS ST Base",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_icmsst_value = fields.Monetary(
         string="ICMS ST Value",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_icmssn_credit_value = fields.Monetary(
         string="ICMSSN Credit Value",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_icmsfcp_base = fields.Monetary(
         string="ICMS FCP Base",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_icmsfcp_value = fields.Monetary(
         string="ICMS FCP Value",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_icmsfcpst_value = fields.Monetary(
         string="ICMS FCP ST Value",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_icms_destination_value = fields.Monetary(
         string="ICMS Destination Value",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_icms_origin_value = fields.Monetary(
         string="ICMS Origin Value",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_ipi_base = fields.Monetary(
         string="IPI Base",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_ipi_value = fields.Monetary(
         string="IPI Value",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_ii_base = fields.Monetary(
         string="II Base",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_ii_value = fields.Monetary(
         string="II Value",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_ii_customhouse_charges = fields.Monetary(
         string="Customhouse Charges",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_pis_base = fields.Monetary(
         string="PIS Base",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_pis_value = fields.Monetary(
         string="PIS Value",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_pisst_base = fields.Monetary(
         string="PIS ST Base",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_pisst_value = fields.Monetary(
         string="PIS ST Value",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_pis_wh_base = fields.Monetary(
         string="PIS Ret Base",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_pis_wh_value = fields.Monetary(
         string="PIS Ret Value",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_cofins_base = fields.Monetary(
         string="COFINS Base",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_cofins_value = fields.Monetary(
         string="COFINS Value",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_cofinsst_base = fields.Monetary(
         string="COFINS ST Base",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_cofinsst_value = fields.Monetary(
         string="COFINS ST Value",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_cofins_wh_base = fields.Monetary(
         string="COFINS Ret Base",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_cofins_wh_value = fields.Monetary(
         string="COFINS Ret Value",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_issqn_base = fields.Monetary(
         string="ISSQN Base",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_issqn_value = fields.Monetary(
         string="ISSQN Value",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_issqn_wh_base = fields.Monetary(
         string="ISSQN Ret Base",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_issqn_wh_value = fields.Monetary(
         string="ISSQN Ret Value",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_csll_base = fields.Monetary(
         string="CSLL Base",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_csll_value = fields.Monetary(
         string="CSLL Value",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_csll_wh_base = fields.Monetary(
         string="CSLL Ret Base",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_csll_wh_value = fields.Monetary(
         string="CSLL Ret Value",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_irpj_base = fields.Monetary(
         string="IRPJ Base",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_irpj_value = fields.Monetary(
         string="IRPJ Value",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_irpj_wh_base = fields.Monetary(
         string="IRPJ Ret Base",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_irpj_wh_value = fields.Monetary(
         string="IRPJ Ret Value",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_inss_base = fields.Monetary(
         string="INSS Base",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_inss_value = fields.Monetary(
         string="INSS Value",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_inss_wh_base = fields.Monetary(
         string="INSS Ret Base",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_inss_wh_value = fields.Monetary(
         string="INSS Ret Value",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_estimate_tax = fields.Monetary(
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_tax = fields.Monetary(
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_total = fields.Monetary(
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_tax_withholding = fields.Monetary(
         string="Tax Withholding",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_financial_total = fields.Monetary(
         string="Amount Financial",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_discount_value = fields.Monetary(
         string="Amount Discount",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_financial_total_gross = fields.Monetary(
         string="Amount Financial Gross",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_financial_discount_value = fields.Monetary(
         string="Financial Discount Value",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
     )
 
     amount_insurance_value = fields.Monetary(
         string="Insurance Value",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
         inverse="_inverse_amount_insurance",
     )
 
     amount_other_value = fields.Monetary(
         string="Other Costs",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
         inverse="_inverse_amount_other",
     )
 
     amount_freight_value = fields.Monetary(
         string="Freight Value",
-        compute="_compute_amount",
+        compute="_compute_fiscal_amount",
         store=True,
         inverse="_inverse_amount_freight",
     )

--- a/l10n_br_fiscal/models/document_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_mixin_methods.py
@@ -40,7 +40,7 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
         amount_fields = [f for f in fields if f.startswith("amount_")]
         return amount_fields
 
-    def _compute_amount(self):
+    def _compute_fiscal_amount(self):
         fields = self._get_amount_fields()
         for doc in self:
             values = {key: 0.0 for key in fields}

--- a/l10n_br_nfe/tests/test_nfe_serialize.py
+++ b/l10n_br_nfe/tests/test_nfe_serialize.py
@@ -38,7 +38,7 @@ class TestNFeExport(TransactionCase):
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
 
-        nfe._compute_amount()
+        nfe._compute_fiscal_amount()
         nfe.nfe40_detPag = [
             (5, 0, 0),
             (

--- a/l10n_br_purchase/models/purchase_order.py
+++ b/l10n_br_purchase/models/purchase_order.py
@@ -80,12 +80,12 @@ class PurchaseOrder(models.Model):
         return self.mapped("order_line")
 
     @api.depends("order_line")
-    def _compute_amount(self):
-        return super()._compute_amount()
+    def _compute_fiscal_amount(self):
+        return super()._compute_fiscal_amount()
 
     @api.depends("order_line.price_total")
     def _amount_all(self):
-        self._compute_amount()
+        self._compute_fiscal_amount()
 
     def _prepare_invoice(self):
         self.ensure_one()

--- a/l10n_br_purchase/models/purchase_order_line.py
+++ b/l10n_br_purchase/models/purchase_order_line.py
@@ -98,7 +98,7 @@ class PurchaseOrderLine(models.Model):
                 # Update taxes fields
                 line._update_fiscal_taxes()
                 # Call mixin compute method
-                line._compute_amounts()
+                line._compute_fiscal_amounts()
                 # Update record
                 line.update(
                     {

--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -101,7 +101,7 @@ class SaleOrder(models.Model):
     def _compute_amounts(self):
         """Compute the total amounts of the SO."""
         for order in self:
-            order._compute_amount()
+            order._compute_fiscal_amount()
 
     # TODO v16 override _compute_tax_totals ?
 

--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -184,7 +184,7 @@ class SaleOrderLine(models.Model):
             # Update taxes fields
             line._update_fiscal_taxes()
             # Call mixin compute method
-            line._compute_amounts()
+            line._compute_fiscal_amounts()
             # Update record
             line.update(
                 {

--- a/l10n_br_stock_account/models/stock_picking.py
+++ b/l10n_br_stock_account/models/stock_picking.py
@@ -38,14 +38,14 @@ class StockPicking(models.Model):
         return self.mapped("move_ids")
 
     @api.depends("move_ids")
-    def _compute_amount(self):
-        return super()._compute_amount()
+    def _compute_fiscal_amount(self):
+        return super()._compute_fiscal_amount()
 
     @api.depends("move_ids.price_unit")
     def _amount_all(self):
         """Compute the total amounts of the Picking."""
         for picking in self:
-            picking._compute_amount()
+            picking._compute_fiscal_amount()
 
     @api.model
     def fields_view_get(


### PR DESCRIPTION
Esta PR renomeia os métodos compute responsáveis pelos montantes no documento e nas linhas do documento fiscal. A alteração visa evitar ambiguidades e possíveis conflitos durante heranças em modelos nativos do Odoo, que podem surgir devido a nomes de métodos semelhantes.

Extraido da PR #3532 [1]