### PR TITLE
[16.0][FIX+MIG+FWD] l10n_br_stock_account: Adaptando a Visão para a v16 e FWD 3528

### DIFF
--- a/l10n_br_stock_account/models/stock_picking.py
+++ b/l10n_br_stock_account/models/stock_picking.py
@@ -48,30 +48,10 @@ class StockPicking(models.Model):
             picking._compute_amount()
 
     @api.model
-    def fields_view_get(
-        self, view_id=None, view_type="form", toolbar=False, submenu=False
-    ):
-        order_view = super().fields_view_get(view_id, view_type, toolbar, submenu)
-
-        if view_type == "form":
-            view = self.env["ir.ui.view"]
-
-            sub_form_view = order_view["fields"]["move_ids_without_package"]["views"][
-                "form"
-            ]["arch"]
-
-            sub_form_node = self.env["stock.move"].inject_fiscal_fields(sub_form_view)
-
-            sub_arch, sub_fields = view.postprocess_and_fields(
-                sub_form_node, "stock.move"
-            )
-
-            order_view["fields"]["move_ids_without_package"]["views"]["form"] = {
-                "fields": sub_fields,
-                "arch": sub_arch,
-            }
-
-        return order_view
+    def _get_view(self, view_id=None, view_type="form", **options):
+        arch, view = super()._get_view(view_id, view_type, **options)
+        arch = self.env["stock.move"].inject_fiscal_fields(arch)
+        return arch, view
 
     def _put_in_pack(self, move_line_ids, create_package_level=True):
         package = super()._put_in_pack(move_line_ids, create_package_level)

--- a/l10n_br_stock_account/views/stock_picking.xml
+++ b/l10n_br_stock_account/views/stock_picking.xml
@@ -226,26 +226,42 @@
 
                 </group>
             </xpath>
-            <xpath expr="//page[@name='page_invoicing']" position="inside">
+            <xpath expr="//group[div[field[@name='scheduled_date']]]" position="after">
                 <!-- Estes campos são read only momentaneamente, pode ser que em
                 um segundo momento essas informações também sejam relevantes para
                 pickings de entrada com relação com documentos fiscais ainda não
                 importados no sistema.
-            -->
-                <!--group name="document_info" string="Fiscal Document Info">
-                    <field name="document_key" readonly="1" />
+                -->
+                <group
+                    name="document_info"
+                    string="Fiscal Document"
+                    colspan="2"
+                    attrs="{'invisible': ['|', ('invoice_state', 'in', ['none', False]), ('fiscal_operation_id', '=', False)]}"
+                >
+                    <group colspan="2">
+                        <field name="document_type_id" string="Type" readonly="1" />
+                        <field name="document_key" readonly="1" />
+                    </group>
+                    <group>
+                        <field name="document_serie_id" string="Serie" readonly="1" />
+                    </group>
+                    <group>
+                        <field name="document_number" string="Number" readonly="1" />
+                    </group>
                 </group>
-                <group>
-                    <group>
-                        <field name="document_type_id" readonly="1" />
-                        <field name="document_serie_id" readonly="1" />
-                    </group>
-                    <group>
-                        <field name="document_serie" readonly="1" />
-                        <field name="document_number" readonly="1" />
-                    </group>
-                </group-->
             </xpath>
+        </field>
+    </record>
+
+    <record id="stock_picking_tree" model="ir.ui.view">
+        <field name="name">l10n_br_stock_account.picking.tree</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.vpicktree" />
+        <field name="priority">99</field>
+        <field name="arch" type="xml">
+            <field name="company_id" position="before">
+                <field name="document_number" readonly="1" />
+            </field>
         </field>
     </record>
 

--- a/l10n_br_stock_account/views/stock_picking.xml
+++ b/l10n_br_stock_account/views/stock_picking.xml
@@ -66,7 +66,7 @@
                     name="fiscal"
                     string="Fiscal"
                     attrs="{'invisible': ['|', ('invoice_state', 'in', [False, 'none']), ('parent.fiscal_operation_id', '=', False)]}"
-                    colspan="4"
+                    colspan="2"
                 >
                     <field name="invoice_state" readonly="1" force_save="1" />
                     <field name="fiscal_operation_type" invisible="1" />
@@ -118,9 +118,10 @@
                     <field name="partner_id" invisible="1" />
                     <field name="company_id" invisible="1" />
                 </group>
-                <group colspan="4">
+                <group>
                     <notebook
                         attrs="{'invisible': ['|', ('invoice_state', 'in', [False, 'none']), ('parent.fiscal_operation_id', '=', False)], 'readonly': [('invoice_state', '=', 'invoiced')]}"
+                        colspan="2"
                     >
                         <group name="fiscal_fields" invisible="1">
                             <field
@@ -161,7 +162,6 @@
                             <group
                                 name="invoice_lines"
                                 string="Invoicing"
-                                colspan="4"
                                 groups="base.group_no_one"
                                 attrs="{'invisible': [('invoice_state', 'in', [False, 'none'])]}"
                             >
@@ -169,6 +169,7 @@
                                     name="invoice_line_ids"
                                     readonly="1"
                                     nolabel="1"
+                                    colspan="2"
                                 />
                             </group>
                         </page>
@@ -193,7 +194,7 @@
                 <group
                     name="invoice_lines"
                     string="Invoicing"
-                    colspan="4"
+                    colspan="2"
                     groups="base.group_no_one"
                     attrs="{'invisible': ['|', ('fiscal_operation_line_id', '!=', False), ('invoice_state', 'in', [False, 'none'])]}"
                 >


### PR DESCRIPTION
 Fix mig adapt view for v16 and FWD https://github.com/OCA/l10n-brazil/pull/3528

PR simples:

* Port Foward [[14.0][IMP] l10n_br_stock_account: displays tax document information outside of tabs](https://github.com/OCA/l10n-brazil/pull/3528)

![image](https://github.com/user-attachments/assets/5268a3a5-9d43-4ffa-95b7-2c5c27b97a9b)


* E na migração https://github.com/OCA/l10n-brazil/pull/3275 faltou adaptar a Visão para a v16, que passou a ser necessário informar o **colspan="2"** sempre 2 e tornou necessário informa o colspan para os casos **nolabel="1"**, hoje a visão está assim

![image](https://github.com/user-attachments/assets/a895c4ac-0967-40cf-9583-4ed6fbc56aec)

Mas mesmo corrigindo a Visão alguns campos ainda não eram mostrados

![image](https://github.com/user-attachments/assets/f1e1d7d3-4a16-4608-b364-ed9dedcfd386)

É isso acontece porque o método **field_views_get** passou para **_get_view**

![image](https://github.com/user-attachments/assets/9b189a5f-c24b-4cfb-bd77-d63ab52218bb)

Talvez seja necessário rever as outras Visões, e até pensei em fazer isso antes de subir o PR, porém acredito que é melhor já resolver esse caso para deixar a Tela funcional, também pensei em separar o Port Foward mas é muito simples e esse PR pode ser testado apenas abrindo a tela e confirmando que os campos aparecem de forma correta.

cc @OCA/local-brazil-maintainers 