### PR TITLE
[14.0][RFC] l10n_br_fiscal/l10n_br_cte: fields refactor

### DIFF
--- a/l10n_br_cte/models/__init__.py
+++ b/l10n_br_cte/models/__init__.py
@@ -17,6 +17,7 @@ from . import res_country
 from . import document_type
 from . import res_country_state
 from . import res_city
+from . import document_mixin_fields
 
 spec_schema = "cte"
 spec_version = "40"

--- a/l10n_br_cte/models/document_mixin_fields.py
+++ b/l10n_br_cte/models/document_mixin_fields.py
@@ -1,0 +1,55 @@
+# Copyright 2024 - TODAY, Marcel Savegnago <marcel.savegnago@escodoo.com.br>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class DocumentMixinFields(models.AbstractModel):
+    _inherit = "l10n_br_fiscal.document.mixin.fields"
+
+    # Sender (Remetente)
+    partner_sendering_id = fields.Many2one(
+        "res.partner",
+        string="Sender Address",
+        help="The partner responsible for sending the goods, typically the issuer of "
+        "the document. This field is primarily used when issuing the CT-e.",
+    )
+
+    # Shipper (Expedidor)
+    partner_shippering_id = fields.Many2one(
+        "res.partner",
+        string="Shipper Address",
+        help="The partner responsible for delivering the cargo to the carrier, if not "
+        "done directly by the sender. This field is primarily used when issuing "
+        "the CT-e.",
+    )
+
+    # Receiver (Recebedor)
+    partner_receivering_id = fields.Many2one(
+        "res.partner",
+        string="Receiver Address",
+        help="The intermediary partner who receives the goods before they reach the "
+        "final recipient, often involved in verification, temporary storage, or "
+        "further distribution. This field is primarily used when issuing the "
+        "CT-e.",
+    )
+
+    partner_insurance_id = fields.Many2one(
+        "res.partner",
+        string="Insurance Provider",
+        help="The partner providing insurance coverage for the transported goods. "
+        "This field is primarily used when issuing the CT-e.",
+    )
+
+    insurance_policy = fields.Char(
+        string="Insurance Policy",
+        help="The insurance policy number covering the transported goods. "
+        "This field is primarily used when issuing the CT-e.",
+    )
+
+    insurance_endorsement = fields.Char(
+        string="Insurance Endorsement",
+        help="The endorsement number associated with the insurance policy, indicating "
+        "any modifications or adjustments to the coverage. This field is "
+        "primarily used when issuing the CT-e.",
+    )

--- a/l10n_br_fiscal/models/document_mixin_fields.py
+++ b/l10n_br_fiscal/models/document_mixin_fields.py
@@ -471,33 +471,3 @@ class FiscalDocumentMixinFields(models.AbstractModel):
     key_random_code = fields.Char(string="Document Key Random Code")
     key_check_digit = fields.Char(string="Document Key Check Digit")
     total_weight = fields.Float(string="Total Weight")
-
-    ## CTE
-
-    # commitment_date = fields.Datetime("Delivery Date")
-    # expected_date = fields.Datetime("Expected Date")
-
-    # Remetente
-    partner_sendering_id = fields.Many2one(
-        "res.partner",
-        string="Sender Address",
-        help="Responsible for sending the goods, usually the issuer of the NFe.",
-    )
-
-    # Expedidor
-    partner_shippering_id = fields.Many2one(
-        "res.partner",
-        string="Shipper Address",
-        help="The one responsible for delivering the cargo to the carrier when \
-            the shipment is not carried out by the sender.",
-    )
-
-    # Recebedor
-    partner_receivering_id = fields.Many2one(
-        "res.partner",
-        string="Receiver Address",
-        help="Actor who receives the goods. He is considered an intermediary \
-            between the issuer and the final recipient.",
-    )
-
-    partner_insurance_id = fields.Many2one("res.partner", string="Insurance Partner")


### PR DESCRIPTION
This pull request introduces a new mixin to handle additional fields for documents in the `l10n_br_cte` module. The changes are primarily focused on organizing and extending the fields related to document handling, specifically for the CT-e (Electronic Transport Document).

Key changes include:

### Addition of new mixin fields:
* [`l10n_br_cte/models/document_mixin_fields.py`](diffhunk://#diff-ee89202baf809877390092a6f8b11b9cba232223a7081089a7387e64865b4750R1-R55): Introduced a new mixin `DocumentMixinFields` with fields for sender, shipper, receiver, and insurance details. This includes fields such as `partner_sendering_id`, `partner_shippering_id`, `partner_receivering_id`, `partner_insurance_id`, `insurance_policy`, and `insurance_endorsement`.

### Refactoring existing fields:
* [`l10n_br_fiscal/models/document_mixin_fields.py`](diffhunk://#diff-3eb477272111a7819df116fab7a742d4c9c50bbdb37229b75099f3c7425b114bL474-L503): Removed redundant fields related to sender, shipper, receiver, and insurance from the existing mixin to avoid duplication and moved them to the new mixin.

### Updating module imports:
* [`l10n_br_cte/models/__init__.py`](diffhunk://#diff-e8b9e1fd547dab5e9936d068cbf13f972c60b5fb3f8aa449dc6cb13362610207R20): Added import statement for the newly created `document_mixin_fields` module.