### PR TITLE
[14.0][FIX] l10n_br_cte: Hide partner fields(sendering and others) for non-CTE fiscal documents

### DIFF
--- a/l10n_br_cte/views/document.xml
+++ b/l10n_br_cte/views/document.xml
@@ -43,11 +43,20 @@
                 />
             </field>
             <field name="partner_shipping_id" position="before"> <!--cte40_dest-->
-                <field name="partner_sendering_id" /> <!--cte40_rem-->
-                <field name="partner_shippering_id" /> <!--cte40_exped-->
+                <field
+                    name="partner_sendering_id"
+                    attrs="{'invisible': [('document_type', 'not in', ['57'])]}"
+                /> <!--cte40_rem-->
+                <field
+                    name="partner_shippering_id"
+                    attrs="{'invisible': [('document_type', 'not in', ['57'])]}"
+                /> <!--cte40_exped-->
             </field>
             <field name="partner_shipping_id" position="after">
-                <field name="partner_receivering_id" /> <!--cte40_receb-->
+                <field
+                    name="partner_receivering_id"
+                    attrs="{'invisible': [('document_type', 'not in', ['57'])]}"
+                /> <!--cte40_receb-->
             </field>
             <page name="delivery" position="inside">
                 <separator


### PR DESCRIPTION
This pull request includes changes to the `l10n_br_cte/views/document.xml` file to improve the visibility control of certain fields based on the `document_type`. The most important change is the addition of conditional visibility attributes to three fields.

Visibility control improvements:

* Added `attrs` attributes to the `partner_sendering_id`, `partner_shippering_id`, and `partner_receivering_id` fields to make them invisible when `document_type` is not '57'. (`l10n_br_cte/views/document.xml`)