### PR TITLE
[14.0][IMP] l10n_br_cte: add insurance fields on fiscal document form

### DIFF
--- a/l10n_br_cte/views/document.xml
+++ b/l10n_br_cte/views/document.xml
@@ -63,6 +63,9 @@
                     <field name="cte40_proPred" />
                     <field name="cte40_xOutCat" />
                     <field name="cte40_vCargaAverb" />
+                    <field name="partner_insurance_id" />
+                    <field name="insurance_policy" />
+                    <field name="insurance_endorsement" />
                     <field name="cte40_infQ">
                         <tree>
                             <field name="cte40_cUnid" />


### PR DESCRIPTION
This pull request includes changes to the `l10n_br_cte/views/document.xml` file to add new insurance-related fields to the form. 

The most important changes include:

* Added `partner_insurance_id` field to capture the insurance partner information.
* Added `insurance_policy` field to record the insurance policy details.
* Added `insurance_endorsement` field to include the insurance endorsement information.