### PR TITLE
[14.0][WIP] l10n_br_fiscal, nfe: Adição da tag cBenef no XML

### DIFF
--- a/l10n_br_fiscal/data/l10n_br_fiscal_comment_data.xml
+++ b/l10n_br_fiscal/data/l10n_br_fiscal_comment_data.xml
@@ -42,4 +42,14 @@
         <field name="comment_type">fiscal</field>
         <field name="object">l10n_br_fiscal.document.mixin</field>
     </record>
+
+    <record
+        id="fiscal_comment_codigo_do_beneficio_fiscal"
+        model="l10n_br_fiscal.comment"
+    >
+        <field name="name">Código de benefício fiscal</field>
+        <field name="comment"> cBenef: ${benefit_code}</field>
+        <field name="comment_type">fiscal</field>
+        <field name="object">l10n_br_fiscal.document.line.mixin</field>
+    </record>
 </odoo>

--- a/l10n_br_fiscal/models/document_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_line_mixin_methods.py
@@ -340,6 +340,20 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
 
         self.price_unit = price.get(self.fiscal_operation_id.default_price_unit, 0.00)
 
+    def _get_benefit_code(self):
+        self.ensure_one()
+        document_lines = self.env["l10n_br_fiscal.document.line"].search(
+            [("document_id", "=", self.document_id.id)]
+        )
+
+        unique_benefit_codes = set()
+
+        for line in document_lines:
+            if line.icms_tax_benefit_id and line.icms_tax_benefit_id.code:
+                unique_benefit_codes.add(line.icms_tax_benefit_id.code)
+
+        return "|".join(unique_benefit_codes)
+
     def __document_comment_vals(self):
         self.ensure_one()
         return {
@@ -351,8 +365,12 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
 
     def _document_comment(self):
         for d in self:
+            benefit_code = d._get_benefit_code()
+
+            comment_vals = d.__document_comment_vals()
+            comment_vals["benefit_code"] = benefit_code
             d.additional_data = d.comment_ids.compute_message(
-                d.__document_comment_vals(), d.manual_additional_data
+                comment_vals, d.manual_additional_data
             )
 
     def _get_fiscal_partner(self):


### PR DESCRIPTION
Esta PR adiciona a tag cBenef no XML, considerando que, a partir de 01/02/2024, será obrigatório o preenchimento dessa tag no estado de Santa Catarina. Na tag de informações adicionais do produto, deverão ser informados os códigos de benefício fiscal, caso existam mais de um.

Algumas melhorias podem ser feitas futuramente:

1. Controle da visibilidade do campo do código de benefício fiscal se baseando no state_id da empresa e do cst/csosn informado no imposto
2. Introduzir os códigos de benefício fiscal de cada estado que preenche o cBenef (DF, GO, PR, RJ, RS e SC)