### PR TITLE
[16.0][spec_driven_model][MIG] spec_driven_model: no more deprecated method

### DIFF
--- a/spec_driven_model/models/spec_mixin.py
+++ b/spec_driven_model/models/spec_mixin.py
@@ -82,14 +82,13 @@ class SpecMixin(models.AbstractModel):
             if spec_class is None:
                 continue
             spec_class._module = "fiscal"  # TODO use python_module ?
-            fields = self.env[spec_class._name].fields_get_keys()
             rec_name = next(
                 filter(
                     lambda x: (
                         x.startswith(self.env[spec_class._name]._field_prefix)
                         and "_choice" not in x
                     ),
-                    fields,
+                    self.env[spec_class._name]._fields,
                 )
             )
             model_type = type(


### PR DESCRIPTION
fields_get_keys() esta deprecated na 16.0. Isso tira um warning dos logs... Eh relativamente independente dos outros forward ports em curso.