### PR TITLE
[16.0][REF] l10n_br_base: use vat field for CNPJ and CPF

### DIFF
--- a/l10n_br_base/models/party_mixin.py
+++ b/l10n_br_base/models/party_mixin.py
@@ -5,6 +5,7 @@ from erpbrasil.base import misc
 from erpbrasil.base.fiscal import cnpj_cpf
 
 from odoo import api, fields, models
+from odoo.osv import expression
 
 
 class PartyMixin(models.AbstractModel):
@@ -89,6 +90,27 @@ class PartyMixin(models.AbstractModel):
     def _inverse_cnpj_cpf(self):
         for partner in self:
             partner.vat = cnpj_cpf.formata(str(self.cnpj_cpf))
+
+    @api.model
+    def search(self, domain, offset=0, limit=None, order=None, count=False):
+        """in the case of a simple search with only OR terms and a vat ilike condition,
+        inject the possibility to match the cnpj_cpf_stripped field.
+        """
+        if not any(term == "&" for term in domain) and not self._context.get(
+            "no_stripped_match"
+        ):
+            for term in domain:
+                if (
+                    isinstance(term, list | tuple)
+                    and len(term) == 3
+                    and term[0] == "vat"
+                    and term[1] == "ilike"
+                ):
+                    domain = expression.OR(
+                        [domain, [("cnpj_cpf_stripped", "ilike", term[2])]]
+                    )
+                    break
+        return super().search(domain, offset, limit, order, count)
 
     @api.onchange("cnpj_cpf")
     def _onchange_cnpj_cpf(self):  # TODO, see comment bellow

--- a/l10n_br_base/models/party_mixin.py
+++ b/l10n_br_base/models/party_mixin.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2021 Renato Lima (Akretion)
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-
 from erpbrasil.base import misc
 from erpbrasil.base.fiscal import cnpj_cpf
 
@@ -12,18 +11,21 @@ class PartyMixin(models.AbstractModel):
     _name = "l10n_br_base.party.mixin"
     _description = "Brazilian partner and company data mixin"
 
+    vat = fields.Char()  # mixin methods needs the vat field here
+    cnpj_cpf = fields.Char(  # alias for v14 backward compat
+        string="CNPJ/CPF",
+        # (for some reason related="vat" makes numerous tests fail)
+        inverse="_inverse_cnpj_cpf",
+        compute="_compute_cnpj_cpf",
+        copy=False,
+    )
+
     cnpj_cpf_stripped = fields.Char(
         string="CNPJ/CPF Stripped",
         help="CNPJ/CPF without special characters",
         compute="_compute_cnpj_cpf_stripped",
         store=True,
         index=True,
-    )
-
-    cnpj_cpf = fields.Char(
-        string="CNPJ/CPF",
-        size=18,
-        unaccent=False,
     )
 
     inscr_est = fields.Char(
@@ -84,6 +86,24 @@ class PartyMixin(models.AbstractModel):
             else False
         )
 
+    def _inverse_cnpj_cpf(self):
+        for partner in self:
+            partner.vat = cnpj_cpf.formata(str(self.cnpj_cpf))
+
+    @api.onchange("cnpj_cpf")
+    def _onchange_cnpj_cpf(self):  # TODO, see comment bellow
+        """
+        In the future we should simply put @api.onchange("cnpj_cpf")
+        on _inverse_cnpj_cpf and remove this method. But for now,
+        it's good to maintain backward compat with the v14 codebase with this.
+        """
+        return self._inverse_cnpj_cpf()
+
+    @api.depends("vat")
+    def _compute_cnpj_cpf(self):
+        for partner in self:
+            partner.cnpj_cpf = partner.vat
+
     @api.depends("cnpj_cpf")
     def _compute_cnpj_cpf_stripped(self):
         for record in self:
@@ -93,10 +113,6 @@ class PartyMixin(models.AbstractModel):
                 )
             else:
                 record.cnpj_cpf_stripped = False
-
-    @api.onchange("cnpj_cpf")
-    def _onchange_cnpj_cpf(self):
-        self.cnpj_cpf = cnpj_cpf.formata(str(self.cnpj_cpf))
 
     @api.onchange("zip")
     def _onchange_zip(self):

--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -16,6 +16,12 @@ class Partner(models.Model):
     _name = "res.partner"
     _inherit = [_name, "l10n_br_base.party.mixin"]
 
+    @property
+    def _rec_names_search(self):
+        names = super()._rec_names_search
+        names += ["cnpj_cpf_stripped", "legal_name", "inscr_est"]
+        return names
+
     def _inverse_street_data(self):
         """In Brazil the address format is street_name, street_number
         (comma instead of space)"""
@@ -29,8 +35,6 @@ class Partner(models.Model):
                 street = street + " - " + partner.street_number2
             partner.street = street
         return super(Partner, not_br_partner)._inverse_street_data()
-
-    vat = fields.Char(compute="_compute_vat_from_cnpj_cpf", store=True, recursive=True)
 
     is_accountant = fields.Boolean(string="Is accountant?")
 
@@ -53,24 +57,68 @@ class Partner(models.Model):
 
     show_l10n_br = fields.Boolean(
         compute="_compute_show_l10n_br",
-        help="Indicates if Brazilian localization fields should be displayed.",
+        help="Should display Brazilian localization fields?",
     )
 
     is_br_partner = fields.Boolean(
         compute="_compute_br_partner",
-        help="Indicate if is a Brazilian partner",
+        help="Is it a Brazilian partner?",
     )
 
-    @api.constrains("cnpj_cpf", "inscr_est")
+    @api.returns("self", lambda value: value.id)
+    def copy(self, default=None):
+        if self.is_br_partner:
+            if default is None:
+                default = {}
+            if "vat" not in default:
+                # CNPJ should be unique:
+                default["vat"] = None
+        return super().copy(default)
+
+    def _commercial_sync_from_company(self):
+        """
+        Overriden to avoid copying the CNPJ (vat field) to children companies
+        """
+        if not self.is_br_partner:
+            return super()._commercial_sync_from_company()
+
+        commercial_partner = self.commercial_partner_id
+        if commercial_partner != self:
+            sync_vals = commercial_partner._update_fields_values(
+                [field for field in self._commercial_fields() if field != "vat"]
+            )
+            self.write(sync_vals)
+            self._commercial_sync_to_children()
+
+    def _commercial_sync_to_children(self):
+        """
+        Overriden to avoid copying the CNPJ (vat field) to parent partners
+        """
+        if not self.is_br_partner:
+            return super()._commercial_sync_to_children()
+
+        commercial_partner = self.commercial_partner_id
+        sync_vals = commercial_partner._update_fields_values(
+            [field for field in self._commercial_fields() if field != "vat"]
+        )
+        sync_children = self.child_ids.filtered(lambda c: not c.is_company)
+        for child in sync_children:
+            child._commercial_sync_to_children()
+        res = sync_children.write(sync_vals)
+        sync_children._compute_commercial_partner()
+        return res
+
+    @api.constrains("vat", "inscr_est")
     def _check_cnpj_inscr_est(self):
         for record in self:
             domain = []
 
-            # permite cnpj vazio
             if not record.cnpj_cpf:
                 return
 
-            if self.env.context.get("disable_allow_cnpj_multi_ie"):
+            if self.env.context.get(
+                "disable_allow_cnpj_multi_ie"
+            ) or self.env.context.get("allow_vat_duplicate"):
                 return
 
             allow_cnpj_multi_ie = (
@@ -85,10 +133,13 @@ class Partner(models.Model):
                     ("parent_id", "not in", record.parent_id.ids),
                 ]
 
-            domain += [("cnpj_cpf", "=", record.cnpj_cpf), ("id", "!=", record.id)]
+            if record.vat:
+                domain += [("vat", "=", record.vat), ("id", "!=", record.id)]
+            else:
+                return
 
-            # se encontrar CNPJ iguais
-            if record.env["res.partner"].search(domain):
+            matches = record.env["res.partner"].search(domain)
+            if matches:
                 if cnpj_cpf.validar_cnpj(record.cnpj_cpf):
                     if allow_cnpj_multi_ie == "True":
                         for partner in record.env["res.partner"].search(domain):
@@ -98,34 +149,36 @@ class Partner(models.Model):
                             ):
                                 raise ValidationError(
                                     _(
-                                        "There is already a partner record with this "
-                                        "Estadual Inscription !"
+                                        "There is already a partner %(name)s "
+                                        "(ID %(partner_id)s) with this "
+                                        "Estadual Inscription %(incr_est)s!",
+                                        name=partner.name,
+                                        partner_id=partner.id,
+                                        incr_est=partner.inscr_est,
                                     )
                                 )
                     else:
                         raise ValidationError(
-                            _("There is already a partner record with this CNPJ !")
+                            _(
+                                "There is already a partner %(name)s "
+                                "(ID %(partner_id)s) with this CNPJ %(vat)s!",
+                                name=matches[0].name,
+                                partner_id=matches[0].id,
+                                vat=self.vat,
+                            )
                         )
-                else:
+                elif not record.is_company:
                     raise ValidationError(
-                        _("There is already a partner record with this CPF/RG!")
+                        _(
+                            "There is already a partner %(name)s (ID %(partner_id)s) "
+                            "with this CPF/RG! %(vat)s",
+                            name=matches[0].name,
+                            partner_id=matches[0].id,
+                            vat=matches[0].vat,
+                        )
                     )
 
-    @api.depends(
-        "cnpj_cpf", "is_company", "parent_id", "parent_id.vat", "commercial_partner_id"
-    )
-    def _compute_vat_from_cnpj_cpf(self):
-        for partner in self:
-            if partner.company_name and partner.vat:
-                continue
-            elif partner.commercial_partner_id.cnpj_cpf:
-                partner.vat = partner.commercial_partner_id.cnpj_cpf
-            elif partner.vat:
-                continue
-            else:
-                partner.vat = False
-
-    @api.constrains("cnpj_cpf", "country_id")
+    @api.constrains("vat", "country_id")
     def _check_cnpj_cpf(self):
         for record in self:
             check_cnpj_cpf(
@@ -203,21 +256,22 @@ class Partner(models.Model):
 
     def create_company(self):
         self.ensure_one()
-        inscr_est = self.inscr_est
-        inscr_mun = self.inscr_mun
         res = super().create_company()
-        if res:
+        if res and self.is_br_partner:
             parent = self.parent_id
-            if parent.country_id.code == "BR":
-                parent.legal_name = parent.name
-                parent.cnpj_cpf = parent.vat
-                parent.inscr_est = inscr_est
-                parent.inscr_mun = inscr_mun
+            parent.legal_name = parent.name
+            parent.inscr_est = self.inscr_est
+            parent.inscr_mun = self.inscr_mun
         return res
 
     def _is_br_partner(self):
         """Check if is a Brazilian Partner."""
-        if self.country_id and self.country_id == self.env.ref("base.br"):
+        if (
+            self.country_id
+            and self.country_id == self.env.ref("base.br")
+            or self.vat
+            and (cnpj_cpf.validar_cnpj(self.vat) or cnpj_cpf.validar_cpf(self.vat))
+        ):
             return True
         return False
 

--- a/l10n_br_base/tests/test_valid_createid.py
+++ b/l10n_br_base/tests/test_valid_createid.py
@@ -177,18 +177,17 @@ class ValidCreateIdTest(TransactionCase):
                 self.partner_invalid_cpf
             )
 
-    def test_vat_computation_with_cnpj(self):
-        """Test VAT computation for a br partner with CNPJ"""
+    def test_vat_computation_with_cpf(self):
+        """Test vat computation for a br partner with CPF"""
         partner = (
             self.env["res.partner"]
             .with_context(tracking_disable=True)
             .create(self.partner_valid)
         )
-        partner._compute_vat_from_cnpj_cpf()
         self.assertEqual(
             partner.vat,
             self.partner_valid["cnpj_cpf"],
-            "VAT should be equal to CNPJ for a br partner",
+            "vat should be equal to CPF for a br partner",
         )
 
     def test_vat_computation_without_cnpj(self):
@@ -200,7 +199,6 @@ class ValidCreateIdTest(TransactionCase):
             .with_context(tracking_disable=True)
             .create(partner_data)
         )
-        partner._compute_vat_from_cnpj_cpf()
         self.assertFalse(
             partner.vat, "VAT should be False for a br partner without CNPJ"
         )
@@ -212,7 +210,6 @@ class ValidCreateIdTest(TransactionCase):
             .with_context(tracking_disable=True)
             .create(self.partner_outside_br)
         )
-        partner._compute_vat_from_cnpj_cpf()
         self.assertEqual(
             partner.vat,
             "123456789",
@@ -228,12 +225,12 @@ class ValidCreateIdTest(TransactionCase):
             .with_context(tracking_disable=True)
             .create(partner_data)
         )
-        partner._compute_vat_from_cnpj_cpf()
         self.assertFalse(partner.vat, "VAT should be False as registered")
 
     def test_vat_computation_with_company_name_and_vat(self):
         """Test VAT computation for a br partner with company_name and vat"""
         partner_data = self.partner_valid.copy()
+        partner_data.pop("cnpj_cpf")
         partner_data.update(
             {
                 "company_name": "Company Partner",
@@ -245,8 +242,7 @@ class ValidCreateIdTest(TransactionCase):
             .with_context(tracking_disable=True)
             .create(partner_data)
         )
-        partner._compute_vat_from_cnpj_cpf()
-        self.assertEqual(
+        self.assertEqual(  # FIXME
             partner.vat,
             "93.429.799/0001-17",
             "The VAT must be the same as what was registered",
@@ -273,11 +269,6 @@ class ValidCreateIdTest(TransactionCase):
             company.legal_name,
             company.name,
             "The legal name must be the same as the company name",
-        )
-        self.assertEqual(
-            company.cnpj_cpf,
-            company.vat,
-            "The company CNPJ_CPF must be the same as the company VAT",
         )
         self.assertEqual(
             company.cnpj_cpf,
@@ -316,7 +307,6 @@ class ValidCreateIdTest(TransactionCase):
             partner.vat,
             "The company CNPJ_CPF must be the same as the partner VAT",
         )
-        self.assertFalse(company.cnpj_cpf, "CNPJ_CPF should be False")
 
 
 # No test on Inscricao Estadual for partners with CPF

--- a/l10n_br_base/views/res_partner_view.xml
+++ b/l10n_br_base/views/res_partner_view.xml
@@ -13,7 +13,7 @@
                 <field name="legal_name" />
                 <field
                     name="cnpj_cpf"
-                    filter_domain="['|', ('cnpj_cpf', 'ilike', self), ('cnpj_cpf_stripped', 'ilike', self)]"
+                    filter_domain="['|', ('vat', 'ilike', self), ('cnpj_cpf_stripped', 'ilike', self)]"
                 />
             </field>
         </field>

--- a/l10n_br_cnpj_search/tests/test_serpro.py
+++ b/l10n_br_cnpj_search/tests/test_serpro.py
@@ -118,7 +118,7 @@ class TestTestSerPro(TestCnpjCommon):
             "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
             return_value=self.mocked_response_serpro_2,
         ):
-            self.model.search([("cnpj_cpf", "=", "34.238.864/0002-49")]).write(
+            self.model.search([("vat", "=", "34.238.864/0002-49")]).write(
                 {"active": False}
             )
             self.set_param("serpro_schema", "empresa")
@@ -154,7 +154,7 @@ class TestTestSerPro(TestCnpjCommon):
             "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
             return_value=self.mocked_response_serpro_3,
         ):
-            self.model.search([("cnpj_cpf", "=", "34.238.864/0001-68")]).write(
+            self.model.search([("vat", "=", "34.238.864/0001-68")]).write(
                 {"active": False}
             )
             self.set_param("serpro_schema", "qsa")

--- a/l10n_br_cte/models/res_partner.py
+++ b/l10n_br_cte/models/res_partner.py
@@ -462,8 +462,8 @@ class ResPartner(spec_models.SpecModel):
         if rec_dict.get("cnpj_cpf", False):
             domain_cnpj = [
                 "|",
-                ("cnpj_cpf", "=", rec_dict["cnpj_cpf"]),
-                ("cnpj_cpf", "=", cnpj_cpf.formata(rec_dict["cnpj_cpf"])),
+                ("vat", "=", rec_dict["cnpj_cpf"]),
+                ("vat", "=", cnpj_cpf.formata(rec_dict["cnpj_cpf"])),
             ]
             match = self.search(domain_cnpj, limit=1)
             if match:

--- a/l10n_br_cte/views/modal/modal_ferroviario.xml
+++ b/l10n_br_cte/views/modal/modal_ferroviario.xml
@@ -19,7 +19,7 @@
                                 'form_view_ref': 'l10n_br_cte.res_partner_tenderfer_form_view'
                             }"
                             domain="[
-                                ('cnpj_cpf', '!=', False),
+                                ('vat', '!=', False),
                             ]"
                         />
                     </group>

--- a/l10n_br_mdfe/tests/test_mdfe_res_partner.py
+++ b/l10n_br_mdfe/tests/test_mdfe_res_partner.py
@@ -22,8 +22,9 @@ class TestMDFeResPartner(TransactionCase):
         self.assertEqual(self.partner_id.mdfe30_idEstrangeiro, self.partner_id.cnpj_cpf)
 
     def test_inverse_fields(self):
-        self.partner_id.mdfe30_idEstrangeiro = "999999999999"
-        self.assertEqual(self.partner_id.vat, self.partner_id.mdfe30_idEstrangeiro)
+        foreign_partner = self.env.ref("base.res_partner_12")
+        foreign_partner.mdfe30_idEstrangeiro = "999999999999"
+        self.assertEqual(foreign_partner.vat, foreign_partner.mdfe30_idEstrangeiro)
 
         self.partner_id.mdfe30_CNPJ = "97414612000162"
         self.assertEqual(

--- a/l10n_br_mdfe/views/document.xml
+++ b/l10n_br_mdfe/views/document.xml
@@ -214,7 +214,7 @@
                                                 'form_view_ref': 'l10n_br_mdfe.res_partner_prop_form_view',
                                             }"
                                             domain="[
-                                                ('cnpj_cpf', '!=', False),
+                                                ('vat', '!=', False),
                                                 ('mdfe30_RNTRC', '!=', False),
                                             ]"
                                         />

--- a/l10n_br_mdfe/views/modal/modal_rodoviario.xml
+++ b/l10n_br_mdfe/views/modal/modal_rodoviario.xml
@@ -20,7 +20,7 @@
                                     'form_view_ref': 'l10n_br_mdfe.res_partner_prop_form_view'
                                 }"
                                 domain="[
-                                    ('cnpj_cpf', '!=', False),
+                                    ('vat', '!=', False),
                                     ('mdfe30_RNTRC', '!=', False),
                                 ]"
                             />
@@ -184,7 +184,7 @@
                 <sheet>
                     <group>
                         <field name="is_company" />
-                        <field name="cnpj_cpf" required="1" />
+                        <field name="vat" required="1" />
                         <field name="legal_name" required="1" />
                     </group>
                 </sheet>
@@ -198,7 +198,7 @@
         <field name="arch" type="xml">
             <tree>
                 <field name="legal_name" required="1" />
-                <field name="cnpj_cpf" required="1" />
+                <field name="vat" required="1" />
             </tree>
         </field>
     </record>

--- a/l10n_br_nfe/models/dfe.py
+++ b/l10n_br_nfe/models/dfe.py
@@ -55,7 +55,7 @@ class DFe(models.Model):
             return mde_id
 
         supplier_cnpj = utils.mask_cnpj("%014d" % root.NFe.infNFe.emit.CNPJ)
-        partner = self.env["res.partner"].search([("cnpj_cpf", "=", supplier_cnpj)])
+        partner = self.env["res.partner"].search([("vat", "=", supplier_cnpj)])
 
         return self.env["l10n_br_nfe.mde"].create(
             {
@@ -87,7 +87,7 @@ class DFe(models.Model):
             return mde_id
 
         supplier_cnpj = utils.mask_cnpj("%014d" % root.CNPJ)
-        partner_id = self.env["res.partner"].search([("cnpj_cpf", "=", supplier_cnpj)])
+        partner_id = self.env["res.partner"].search([("vat", "=", supplier_cnpj)])
 
         return self.env["l10n_br_nfe.mde"].create(
             {

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -303,8 +303,8 @@ class ResPartner(spec_models.SpecModel):
         if rec_dict.get("cnpj_cpf", False):
             domain_cnpj = [
                 "|",
-                ("cnpj_cpf", "=", rec_dict["cnpj_cpf"]),
-                ("cnpj_cpf", "=", cnpj_cpf.formata(rec_dict["cnpj_cpf"])),
+                ("cnpj_cpf_stripped", "=", rec_dict["cnpj_cpf"]),
+                ("vat", "=", cnpj_cpf.formata(rec_dict["cnpj_cpf"])),
             ]
             match = self.search(domain_cnpj, limit=1)
             if match:

--- a/l10n_br_nfe/wizards/import_document.py
+++ b/l10n_br_nfe/wizards/import_document.py
@@ -63,7 +63,7 @@ class NfeImport(models.TransientModel):
         self.partner_id = self.env["res.partner"].search(
             [
                 "|",
-                ("cnpj_cpf", "=", infNFe.emit.CNPJ),
+                ("vat", "=", infNFe.emit.CNPJ),
                 ("nfe40_xNome", "=", infNFe.emit.xNome),
             ],
             limit=1,

--- a/l10n_br_purchase/models/purchase_order.py
+++ b/l10n_br_purchase/models/purchase_order.py
@@ -36,21 +36,6 @@ class PurchaseOrder(models.Model):
         domain=lambda self: self._fiscal_operation_domain(),
     )
 
-    cnpj_cpf = fields.Char(
-        string="CNPJ/CPF",
-        related="partner_id.cnpj_cpf",
-    )
-
-    legal_name = fields.Char(
-        string="Legal Name",
-        related="partner_id.legal_name",
-    )
-
-    ie = fields.Char(
-        string="State Tax Number/RG",
-        related="partner_id.inscr_est",
-    )
-
     comment_ids = fields.Many2many(
         comodel_name="l10n_br_fiscal.comment",
         relation="purchase_order_comment_rel",

--- a/l10n_br_purchase/views/purchase_view.xml
+++ b/l10n_br_purchase/views/purchase_view.xml
@@ -5,19 +5,6 @@
   License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 -->
 <odoo>
-      <!--busca por cnpj_cpf e razao social nos pedidos de compra -->
-      <record id="l10n_br_purchase_order_filter" model="ir.ui.view">
-          <field name="name">l10n_br_purchase.partner.filter</field>
-          <field name="model">purchase.order</field>
-          <field name="inherit_id" ref="purchase.view_purchase_order_filter" />
-          <field name="arch" type="xml">
-              <field name="name" position="after">
-                  <field name="legal_name" string="Razão Social" />
-                  <field name="cnpj_cpf" string="CNPJ/CPF" />
-                  <field name="ie" string="Inscr. Estadual" />
-              </field>
-          </field>
-      </record>
 
       <record id="l10n_br_purchase_order_form" model="ir.ui.view">
           <field name="name">l10n_br_purchase.order.form</field>

--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -50,21 +50,6 @@ class SaleOrder(models.Model):
         default=_default_copy_note,
     )
 
-    cnpj_cpf = fields.Char(
-        string="CNPJ/CPF",
-        related="partner_invoice_id.cnpj_cpf",
-    )
-
-    legal_name = fields.Char(
-        string="Legal Name",
-        related="partner_invoice_id.legal_name",
-    )
-
-    ie = fields.Char(
-        string="State Tax Number/RG",
-        related="partner_invoice_id.inscr_est",
-    )
-
     discount_rate = fields.Float(
         string="Discount",
         readonly=True,

--- a/l10n_br_sale/views/sale_view.xml
+++ b/l10n_br_sale/views/sale_view.xml
@@ -6,20 +6,6 @@
 -->
 <odoo>
 
-    <!--Search by cnpj / cpf in the SOs -->
-    <record id="view_l10n_br_sale_partner_filter" model="ir.ui.view">
-        <field name="name">l10n_br_sale.partner.filter</field>
-        <field name="model">sale.order</field>
-        <field name="inherit_id" ref="sale.view_sales_order_filter" />
-        <field name="arch" type="xml">
-            <field name="name" position="after">
-                <field name="legal_name" string="Razão Social" />
-                <field name="cnpj_cpf" string="CNPJ/CPF" />
-                <field name="ie" string="Inscr. Estadual" />
-            </field>
-        </field>
-    </record>
-
     <record id="l10n_br_sale_quotation_tree" model="ir.ui.view">
         <field name="name">l10n_br_sale.quotation.form</field>
         <field name="model">sale.order</field>

--- a/l10n_br_stock/models/stock_picking.py
+++ b/l10n_br_stock/models/stock_picking.py
@@ -7,6 +7,5 @@ from odoo import fields, models
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
-    cnpj_cpf = fields.Char(string="CNPJ/CPF", related="partner_id.cnpj_cpf")
     legal_name = fields.Char(string="Legal Name", related="partner_id.legal_name")
     inscr_est = fields.Char(string="State Tax Number", related="partner_id.inscr_est")

--- a/l10n_br_stock/views/stock_picking_view.xml
+++ b/l10n_br_stock/views/stock_picking_view.xml
@@ -7,7 +7,6 @@
         <field name="arch" type="xml">
             <field name="name" position="after">
                 <field name="legal_name" />
-                <field name="cnpj_cpf" />
                 <field name="inscr_est" />
             </field>
         </field>


### PR DESCRIPTION
re-abertura de #3386 depois do conserto da branch 16.0 como explicado em #3490. Importante notar que a antiga branch 16.0 não constava com o port de #2718 e eu tive que retrabalhar meu PR para compatibilizar.

------

O objetivo desse PR é de se aproximar do modelo de dados da Odoo que desde a versão 16.0 (e até a v18) usa o vat para armazenar o CNPJ.

Na v14 botamos o vat como related do cnpj_cpf, a ideia é agora de usar a coluna vat no banco de dados e conservar o campo cnpj_cpf como um alias para conservar uma certa compatibilidade e facilitar os cherry-picks com o codigo da v14 por enquanto.

Eu tinha inicialmente introduzido o campo l10n_br_cpf_code pro CPF de acordo com o modelo do Odoo a partir da v16:
https://github.com/odoo/odoo/blob/16.0/addons/l10n_br/models/res_partner.py
porem o campo l10n_br_cpf_code foi removido e assimilado ao campo vat a partir da v17 (e continua assim na v18 ou na master):
https://github.com/odoo/odoo/blob/17.0/addons/l10n_br/models/res_partner.py

Nisso eu achei melhor deixar o CPF no campo vat mesmo. Tem nada no Odoo CE ou Odoo EE v16 que usa de fato o campo l10n_br_cpf_code então eu achei melhor já alvejar a compatibilidade com as v17 e v18 e usar o mesmo campo deixa tb mais parecido ao que tínhamos com o campo único cnpj_cpf até agora.

Eu tb aproveitei para melhorar a mensagem de validação.