### PR TITLE
[16.0][REF] l10n_br_base: inscr_mun -> l10n_br_im_code

### DIFF
--- a/l10n_br_base/models/party_mixin.py
+++ b/l10n_br_base/models/party_mixin.py
@@ -46,11 +46,14 @@ class PartyMixin(models.AbstractModel):
         inverse_name="partner_id",
     )
 
-    inscr_mun = fields.Char(
+    l10n_br_im_code = fields.Char(
         string="Municipal Tax Number",
         size=18,
         unaccent=False,
     )
+
+    # backward compat with v14:
+    inscr_mun = fields.Char(related="l10n_br_im_code", readonly=False)
 
     suframa = fields.Char(
         size=18,

--- a/l10n_br_base/models/res_company.py
+++ b/l10n_br_base/models/res_company.py
@@ -18,7 +18,7 @@ class Company(models.Model):
             "legal_name",
             "cnpj_cpf",
             "inscr_est",
-            "inscr_mun",
+            "l10n_br_im_code",
             "district",
             "city_id",
             "suframa",
@@ -70,10 +70,10 @@ class Company(models.Model):
                 state_tax_number_ids |= ies
             company.partner_id.state_tax_number_ids = state_tax_number_ids
 
-    def _inverse_inscr_mun(self):
+    def _inverse_l10n_br_im_code(self):
         """Write the l10n_br specific functional fields."""
         for company in self:
-            company.partner_id.inscr_mun = company.inscr_mun
+            company.partner_id.l10n_br_im_code = company.l10n_br_im_code
 
     def _inverse_city_id(self):
         """Write the l10n_br specific functional fields."""
@@ -131,9 +131,9 @@ class Company(models.Model):
         inverse="_inverse_state_tax_number_ids",
     )
 
-    inscr_mun = fields.Char(
+    l10n_br_im_code = fields.Char(
         compute="_compute_address",
-        inverse="_inverse_inscr_mun",
+        inverse="_inverse_l10n_br_im_code",
     )
 
     suframa = fields.Char(

--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -261,7 +261,7 @@ class Partner(models.Model):
             parent = self.parent_id
             parent.legal_name = parent.name
             parent.inscr_est = self.inscr_est
-            parent.inscr_mun = self.inscr_mun
+            parent.l10n_br_im_code = self.l10n_br_im_code
         return res
 
     def _is_br_partner(self):

--- a/l10n_br_base/views/res_company_view.xml
+++ b/l10n_br_base/views/res_company_view.xml
@@ -30,7 +30,7 @@
                     attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
                 />
                 <field
-                    name="inscr_mun"
+                    name="l10n_br_im_code"
                     placeholder="Municipal Tax Number..."
                     attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
                 />

--- a/l10n_br_base/views/res_partner_view.xml
+++ b/l10n_br_base/views/res_partner_view.xml
@@ -111,7 +111,7 @@
                         <group string="Fiscal Infos" name="fiscal_numbers">
                             <field name="cei_code" />
                             <field
-                                name="inscr_mun"
+                                name="l10n_br_im_code"
                                 attrs="{'invisible': [('is_company','!=', True)]}"
                             />
                             <field


### PR DESCRIPTION
ré-abertura de #3568 depois do [fix da branch 16.0](https://github.com/OCA/l10n-brazil/issues/3490)

o objetivo é que o campo inscr_mun usado até então vira um alias do campo padronizado pela Odoo SA l10n_br_im_code a partir da v16:  
https://github.com/odoo/odoo/blob/16.0/addons/l10n_br/models/res_partner.py

ver tb https://github.com/OCA/l10n-brazil/pull/3566 e https://github.com/OCA/l10n-brazil/pull/3569