### PR TITLE
[16.0][REF][l10n_br_base] inscr_ie -> l10n_br_ie_code

### DIFF
--- a/l10n_br_base/models/party_mixin.py
+++ b/l10n_br_base/models/party_mixin.py
@@ -29,11 +29,14 @@ class PartyMixin(models.AbstractModel):
         index=True,
     )
 
-    inscr_est = fields.Char(
+    l10n_br_ie_code = fields.Char(
         string="State Tax Number",
         size=17,
         unaccent=False,
     )
+
+    # compat with legacy code:
+    inscr_est = fields.Char(related="l10n_br_ie_code", readonly=False)
 
     rg = fields.Char(
         string="RG",

--- a/l10n_br_base/models/res_company.py
+++ b/l10n_br_base/models/res_company.py
@@ -17,7 +17,7 @@ class Company(models.Model):
         return partner_fields + [
             "legal_name",
             "cnpj_cpf",
-            "inscr_est",
+            "l10n_br_ie_code",
             "inscr_mun",
             "district",
             "city_id",
@@ -52,10 +52,10 @@ class Company(models.Model):
         for company in self:
             company.partner_id.cnpj_cpf = company.cnpj_cpf
 
-    def _inverse_inscr_est(self):
+    def _inverse_l10n_br_ie_code(self):
         """Write the l10n_br specific functional fields."""
         for company in self:
-            company.partner_id.inscr_est = company.inscr_est
+            company.partner_id.l10n_br_ie_code = company.l10n_br_ie_code
 
     def _inverse_state(self):
         """Write the l10n_br specific functional fields."""
@@ -118,9 +118,9 @@ class Company(models.Model):
         inverse="_inverse_cnpj_cpf",
     )
 
-    inscr_est = fields.Char(
+    l10n_br_ie_code = fields.Char(
         compute="_compute_address",
-        inverse="_inverse_inscr_est",
+        inverse="_inverse_l10n_br_ie_code",
     )
 
     state_tax_number_ids = fields.One2many(
@@ -176,7 +176,7 @@ class Company(models.Model):
     @api.onchange("state_id")
     def _onchange_state_id(self):
         res = super()._onchange_state_id()
-        self.inscr_est = False
-        self.partner_id.inscr_est = False
+        self.l10n_br_ie_code = False
+        self.partner_id.l10n_br_ie_code = False
         self.partner_id.state_id = self.state_id
         return res

--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -108,8 +108,8 @@ class Partner(models.Model):
         sync_children._compute_commercial_partner()
         return res
 
-    @api.constrains("vat", "inscr_est")
-    def _check_cnpj_inscr_est(self):
+    @api.constrains("vat", "l10n_br_ie_code")
+    def _check_cnpj_l10n_br_ie_code(self):
         for record in self:
             domain = []
 
@@ -144,8 +144,8 @@ class Partner(models.Model):
                     if allow_cnpj_multi_ie == "True":
                         for partner in record.env["res.partner"].search(domain):
                             if (
-                                partner.inscr_est == record.inscr_est
-                                and record.inscr_est
+                                partner.l10n_br_ie_code == record.l10n_br_ie_code
+                                and record.l10n_br_ie_code
                             ):
                                 raise ValidationError(
                                     _(
@@ -187,7 +187,7 @@ class Partner(models.Model):
                 record.country_id,
             )
 
-    @api.constrains("inscr_est", "state_id", "is_company")
+    @api.constrains("l10n_br_ie_code", "state_id", "is_company")
     def _check_ie(self):
         """Checks if company register number in field insc_est is valid,
         this method call others methods because this validation is State wise
@@ -197,7 +197,10 @@ class Partner(models.Model):
         for record in self:
             if record.is_company:
                 check_ie(
-                    record.env, record.inscr_est, record.state_id, record.country_id
+                    record.env,
+                    record.l10n_br_ie_code,
+                    record.state_id,
+                    record.country_id,
                 )
 
     @api.constrains("state_tax_number_ids")
@@ -260,7 +263,7 @@ class Partner(models.Model):
         if res and self.is_br_partner:
             parent = self.parent_id
             parent.legal_name = parent.name
-            parent.inscr_est = self.inscr_est
+            parent.l10n_br_ie_code = self.l10n_br_ie_code
             parent.inscr_mun = self.inscr_mun
         return res
 

--- a/l10n_br_base/views/res_company_view.xml
+++ b/l10n_br_base/views/res_company_view.xml
@@ -25,7 +25,7 @@
                     attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
                 />
                 <field
-                    name="inscr_est"
+                    name="l10n_br_ie_code"
                     placeholder="State Tax Number..."
                     attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
                 />

--- a/l10n_br_base/views/res_partner_view.xml
+++ b/l10n_br_base/views/res_partner_view.xml
@@ -27,7 +27,7 @@
             <field name="display_name" position="after">
                 <field name="legal_name" />
                 <field name="cnpj_cpf" />
-                <field name="inscr_est" />
+                <field name="l10n_br_ie_code" />
             </field>
         </field>
     </record>
@@ -91,16 +91,16 @@
                     nolabel="1"
                     attrs="{'invisible': [('is_company','=', True)]}"
                 />
-                <div name="inscr_est">
+                <div name="l10n_br_ie_code">
                          <label
-                        for="inscr_est"
+                        for="l10n_br_ie_code"
                         string="IE"
                         attrs="{'invisible': [('is_company','=', False), ('parent_id', '!=', False)]}"
                     />
                 </div>
                      <field
                     colspan="4"
-                    name="inscr_est"
+                    name="l10n_br_ie_code"
                     nolabel="1"
                     attrs="{'invisible': [('is_company','=', False), ('parent_id', '!=', False)]}"
                 />

--- a/l10n_br_fiscal/models/document_move_mixin.py
+++ b/l10n_br_fiscal/models/document_move_mixin.py
@@ -1,0 +1,261 @@
+# Copyright (C) 2021  Renato Lima - Akretion <renato.lima@akretion.com.br>
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import api, fields, models
+
+from ..constants.fiscal import DOCUMENT_ISSUER_COMPANY
+
+
+class DocumentMoveMixin(models.AbstractModel):
+    _name = "l10n_br_fiscal.document.move.mixin"
+    _inherit = [
+        "l10n_br_fiscal.document.mixin.methods",
+    ]
+    _description = "Move Document Fiscal Mixin"
+
+    partner_id = fields.Many2one(
+        comodel_name="res.partner",
+    )
+
+    partner_legal_name = fields.Char(
+        string="Legal Name",
+        related="partner_id.legal_name",
+    )
+
+    partner_name = fields.Char(
+        string="Partner Name",
+        related="partner_id.name",
+    )
+
+    partner_cnpj_cpf = fields.Char(
+        string="CNPJ",
+        related="partner_id.cnpj_cpf",
+    )
+
+    partner_inscr_est = fields.Char(
+        string="State Tax Number",
+        related="partner_id.l10n_br_ie_code",
+    )
+
+    partner_ind_ie_dest = fields.Selection(
+        string="Contribuinte do ICMS",
+        related="partner_id.ind_ie_dest",
+    )
+
+    partner_inscr_mun = fields.Char(
+        string="Municipal Tax Number",
+        related="partner_id.inscr_mun",
+    )
+
+    partner_suframa = fields.Char(
+        string="Suframa",
+        related="partner_id.suframa",
+    )
+
+    partner_cnae_main_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.cnae",
+        string="Main CNAE",
+        related="partner_id.cnae_main_id",
+    )
+
+    partner_tax_framework = fields.Selection(
+        string="Tax Framework",
+        related="partner_id.tax_framework",
+    )
+
+    partner_street = fields.Char(
+        string="Partner Street",
+        related="partner_id.street",
+    )
+
+    partner_number = fields.Char(
+        string="Partner Number",
+        related="partner_id.street_number",
+    )
+
+    partner_street2 = fields.Char(
+        string="Partner Street2",
+        related="partner_id.street2",
+    )
+
+    partner_district = fields.Char(
+        string="Partner District",
+        related="partner_id.district",
+    )
+
+    partner_country_id = fields.Many2one(
+        comodel_name="res.country",
+        string="Partner Country",
+        related="partner_id.country_id",
+    )
+
+    partner_state_id = fields.Many2one(
+        comodel_name="res.country.state",
+        string="Partner State",
+        related="partner_id.state_id",
+    )
+
+    partner_city_id = fields.Many2one(
+        comodel_name="res.city",
+        string="Partner City",
+        related="partner_id.city_id",
+    )
+
+    partner_zip = fields.Char(
+        string="Partner Zip",
+        related="partner_id.zip",
+    )
+
+    partner_phone = fields.Char(
+        string="Partner Phone",
+        related="partner_id.phone",
+    )
+
+    partner_is_company = fields.Boolean(
+        string="Partner Is Company?",
+        related="partner_id.is_company",
+    )
+
+    company_id = fields.Many2one(
+        comodel_name="res.company",
+    )
+
+    processador_edoc = fields.Selection(
+        related="company_id.processador_edoc",
+    )
+
+    company_legal_name = fields.Char(
+        string="Company Legal Name",
+        related="company_id.legal_name",
+    )
+
+    company_name = fields.Char(
+        string="Company Name",
+        size=128,
+        related="company_id.name",
+    )
+
+    company_cnpj_cpf = fields.Char(
+        string="Company CNPJ",
+        related="company_id.cnpj_cpf",
+    )
+
+    company_inscr_est = fields.Char(
+        string="Company State Tax Number",
+        related="company_id.l10n_br_ie_code",
+    )
+
+    company_inscr_est_st = fields.Char(
+        string="Company ST State Tax Number",
+    )
+
+    company_inscr_mun = fields.Char(
+        string="Company Municipal Tax Number",
+        related="company_id.inscr_mun",
+    )
+
+    company_suframa = fields.Char(
+        string="Company Suframa",
+        related="company_id.suframa",
+    )
+
+    company_cnae_main_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.cnae",
+        string="Company Main CNAE",
+        related="company_id.cnae_main_id",
+    )
+
+    company_tax_framework = fields.Selection(
+        string="Company Tax Framework",
+        related="company_id.tax_framework",
+    )
+
+    company_street = fields.Char(
+        string="Company Street",
+        related="company_id.street",
+    )
+
+    company_number = fields.Char(
+        string="Company Number",
+        related="company_id.street_number",
+    )
+
+    company_street2 = fields.Char(
+        string="Company Street2",
+        related="company_id.street2",
+    )
+
+    company_district = fields.Char(
+        string="Company District",
+        related="company_id.district",
+    )
+
+    company_country_id = fields.Many2one(
+        comodel_name="res.country",
+        string="Company Country",
+        related="company_id.country_id",
+    )
+
+    company_state_id = fields.Many2one(
+        comodel_name="res.country.state",
+        string="Company State",
+        related="company_id.state_id",
+    )
+
+    company_city_id = fields.Many2one(
+        comodel_name="res.city",
+        string="Company City",
+        related="company_id.city_id",
+    )
+
+    company_zip = fields.Char(
+        string="Company ZIP",
+        related="company_id.zip",
+    )
+
+    company_phone = fields.Char(
+        string="Company Phone",
+        related="company_id.phone",
+    )
+
+    @api.onchange("document_type_id")
+    def _onchange_document_type_id(self):
+        if self.document_type_id and self.issuer == DOCUMENT_ISSUER_COMPANY:
+            self.document_serie_id = self.document_type_id.get_document_serie(
+                self.company_id, self.fiscal_operation_id
+            )
+
+    @api.onchange("document_serie_id")
+    def _onchange_document_serie_id(self):
+        if self.document_serie_id and self.issuer == DOCUMENT_ISSUER_COMPANY:
+            self.document_serie = self.document_serie_id.code
+
+    @api.onchange("fiscal_operation_id")
+    def _onchange_fiscal_operation_id(self):
+        result = super()._onchange_fiscal_operation_id()
+        if self.fiscal_operation_id:
+            self.fiscal_operation_type = self.fiscal_operation_id.fiscal_operation_type
+            self.edoc_purpose = self.fiscal_operation_id.edoc_purpose
+
+            if self.issuer == DOCUMENT_ISSUER_COMPANY and not self.document_type_id:
+                self.document_type_id = self.company_id.document_type_id
+
+            subsequent_documents = [(6, 0, {})]
+            for subsequent_id in self.fiscal_operation_id.mapped(
+                "operation_subsequent_ids"
+            ):
+                subsequent_documents.append(
+                    (
+                        0,
+                        0,
+                        {
+                            "source_document_id": self.id,
+                            "subsequent_operation_id": subsequent_id.id,
+                            "fiscal_operation_id": (
+                                subsequent_id.subsequent_operation_id.id
+                            ),
+                        },
+                    )
+                )
+            self.document_subsequent_ids = subsequent_documents
+        return result

--- a/l10n_br_fiscal/models/res_partner.py
+++ b/l10n_br_fiscal/models/res_partner.py
@@ -87,7 +87,7 @@ class ResPartner(models.Model):
         tracking=True,
     )
 
-    inscr_est = fields.Char(
+    l10n_br_ie_code = fields.Char(
         tracking=True,
     )
 
@@ -128,7 +128,7 @@ class ResPartner(models.Model):
     def _onchange_ind_ie_dest(self):
         for p in self:
             if p.ind_ie_dest == NFE_IND_IE_DEST_9:
-                p.inscr_est = False
+                p.l10n_br_ie_code = False
                 p.state_tax_number_ids = False
 
     @api.model
@@ -139,6 +139,6 @@ class ResPartner(models.Model):
             "ind_ie_dest",
             "fiscal_profile_id",
             "ind_final",
-            "inscr_est",
+            "l10n_br_ie_code",
             "inscr_mun",
         ]

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -406,7 +406,7 @@ class NFe(spec_models.StackedModel):
                 stn_id = self.company_id.state_tax_number_ids.filtered(
                     lambda stn: stn.state_id == dest_state_id
                 )
-                iest = stn_id.inscr_est
+                iest = stn_id.l10n_br_ie_code
                 iest = re.sub("[^0-9]+", "", iest)
         self.company_inscr_est_st = iest
 
@@ -1550,7 +1550,7 @@ class NFe(spec_models.StackedModel):
 
     def _prepare_nfce_danfe_values(self):
         return {
-            "company_ie": self.company_id.inscr_est,
+            "company_ie": self.company_id.l10n_br_ie_code,
             "company_cnpj": self.company_id.cnpj_cpf,
             "company_legal_name": self.company_id.legal_name,
             "company_street": self.company_id.street,

--- a/l10n_br_nfe/models/document_related.py
+++ b/l10n_br_nfe/models/document_related.py
@@ -114,7 +114,7 @@ class NFeRelated(spec_models.StackedModel):
                         rec.nfe40_CPF = rec.cnpj_cpf
                     else:
                         rec.nfe40_CNPJ = rec.cnpj_cpf
-                    rec.nfe40_IE = rec.inscr_est
+                    rec.nfe40_IE = rec.l10n_br_ie_code
                     rec.nfe40_mod = rec.document_type_id.code
                     rec.nfe40_serie = document.document_serie
                     rec.nfe40_nNF = document.document_number

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -202,7 +202,7 @@ class ResPartner(spec_models.SpecModel):
         for rec in self:
             rec.nfe40_enderDest = rec.id
 
-    @api.depends("company_type", "inscr_est", "cnpj_cpf", "country_id")
+    @api.depends("company_type", "l10n_br_ie_code", "cnpj_cpf", "country_id")
     def _compute_nfe_data(self):
         """Set schema data which are not just related fields"""
         for rec in self:
@@ -236,8 +236,8 @@ class ResPartner(spec_models.SpecModel):
                 rec.nfe40_CNPJ = ""
                 rec.nfe40_CPF = ""
 
-            if rec.inscr_est:
-                rec.nfe40_IE = punctuation_rm(rec.inscr_est)
+            if rec.l10n_br_ie_code:
+                rec.nfe40_IE = punctuation_rm(rec.l10n_br_ie_code)
             else:
                 rec.nfe40_IE = None
 
@@ -276,7 +276,7 @@ class ResPartner(spec_models.SpecModel):
     def _inverse_nfe40_IE(self):
         for rec in self:
             if rec.nfe40_IE:
-                rec.inscr_est = str(rec.nfe40_IE)
+                rec.l10n_br_ie_code = str(rec.nfe40_IE)
 
     def _inverse_nfe40_CEP(self):
         for rec in self:


### PR DESCRIPTION
ré-abertura de https://github.com/OCA/l10n-brazil/pull/3569 depois do https://github.com/OCA/l10n-brazil/issues/3490

o objetivo é que o campo inscr_est usado até então vira um alias do campo l10n_br_ie_code padronizado pela Odoo SA a partir da v16:
https://github.com/odoo/odoo/blob/16.0/addons/l10n_br/models/res_partner.py

ver tb #3566 e #3568