### PR TITLE
[16.0][FIX] l10n_br_account: readonly product_id

### DIFF
--- a/l10n_br_account/views/account_move_view.xml
+++ b/l10n_br_account/views/account_move_view.xml
@@ -227,6 +227,7 @@
                 <field name="fiscal_operation_id" invisible="1" />
                 <field name="fiscal_operation_line_id" optional="hide" />
                 <field name="cfop_id" optional="hide" />
+                <field name="product_id" optional="hide" />
                 <field name="city_taxation_code_id" optional="hide" />
                 <field name="service_type_id" optional="hide" />
                 <field name="cnae_id" optional="hide" />


### PR DESCRIPTION
## Objetivo da PR

Adicionando o campo product_id para correção do erro de quando criar um novo lançamento no diário
Correção da Issue #3573
