### PR TITLE
[16.0][REM] l10n_br_nfe: remove dead nbm code

### DIFF
--- a/l10n_br_nfe/models/__init__.py
+++ b/l10n_br_nfe/models/__init__.py
@@ -7,7 +7,6 @@ from . import res_company
 from . import product_product
 from . import product_supplierinfo
 from . import ncm
-from . import nbm
 from . import cest
 from . import tax_ipi_guideline
 from . import document_type

--- a/l10n_br_nfe/models/nbm.py
+++ b/l10n_br_nfe/models/nbm.py
@@ -1,9 +1,0 @@
-# Copyright (C) 2021  Renato Lima - Akretion <renato.lima@akretion.com.br>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-
-from odoo import models
-
-
-class Nbm(models.Model):
-    _inherit = "l10n_br_fiscal.nbm"
-    _nfe_search_keys = ["code_unmasked"]


### PR DESCRIPTION
mesmo que o NBM possa ser usado para definir algumas isenções ou ST (ver https://github.com/OCA/l10n-brazil/pull/3575#issuecomment-2576457157 ), aqui no modulo l10n_br_nfe esse codigo nunca tava usado: não existe busca de NBM para mapear algum nbm_id ao importar uma NFe por exemplo). Isso pode ser removido então.