### PR TITLE
[16.0][l10n_br_base] oca-port: blacklist PR(s) 2868, 3545 for l10n_br_base

### DIFF
--- a/.oca/oca-port/blacklist/l10n_br_base.json
+++ b/.oca/oca-port/blacklist/l10n_br_base.json
@@ -1,0 +1,6 @@
+{
+  "pull_requests": {
+    "OCA/l10n-brazil#2868": "done in https://github.com/OCA/l10n-brazil/commit/b1d76019cf8b50a76e1f5314961d79e1ed922c67",
+    "OCA/l10n-brazil#3545": "done in #3564"
+  }
+}


### PR DESCRIPTION
blacklist the port of 2 commits there were actually already ported (and likely missed by ocaport due to #3490)