### PR TITLE
[16.0][REF] l10n_br_stock_account: Usando o Common Test do stock_picking_invoicing e removendo campo já informado

### DIFF
--- a/l10n_br_stock_account/models/stock_rule.py
+++ b/l10n_br_stock_account/models/stock_rule.py
@@ -71,5 +71,4 @@ class StockRule(models.Model):
             for key in self.env["l10n_br_fiscal.document.line.mixin"]._fields.keys()
             if key != "product_id"
         ]
-        custom_move_fields += ["invoice_state"]
         return custom_move_fields

--- a/l10n_br_stock_account/tests/common.py
+++ b/l10n_br_stock_account/tests/common.py
@@ -2,10 +2,10 @@
 # @author Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests.common import Form, TransactionCase
+from odoo.addons.stock_picking_invoicing.tests.common import TestPickingInvoicingCommon
 
 
-class TestBrPickingInvoicingCommon(TransactionCase):
+class TestBrPickingInvoicingCommon(TestPickingInvoicingCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -14,10 +14,13 @@ class TestBrPickingInvoicingCommon(TransactionCase):
         self.env.user.company_ids += company
         self.env.user.company_id = company
 
-    def _run_fiscal_onchanges(self, record):
+    def _run_picking_onchanges(self, record):
+        result = super()._run_picking_onchanges(record)
         record._onchange_fiscal_operation_id()
+        return result
 
-    def _run_fiscal_line_onchanges(self, record):
+    def _run_line_onchanges(self, record):
+        result = super()._run_line_onchanges(record)
         # Mixin Fiscal
         record._onchange_commercial_quantity()
 
@@ -25,60 +28,4 @@ class TestBrPickingInvoicingCommon(TransactionCase):
         record._onchange_product_id_fiscal()
         record._onchange_fiscal_taxes()
         record._onchange_product_quantity()
-
-    def picking_move_state(self, picking):
-        self._run_fiscal_onchanges(picking)
-        picking.action_confirm()
-        # Check product availability
-        picking.action_assign()
-        # Force product availability
-        for move in picking.move_ids_without_package:
-            self._run_fiscal_line_onchanges(move)
-            move.quantity_done = move.product_uom_qty
-        picking.button_validate()
-
-    def create_invoice_wizard(self, pickings):
-        wizard_obj = self.env["stock.invoice.onshipping"].with_context(
-            active_ids=pickings.ids,
-            active_model=pickings._name,
-        )
-        fields_list = wizard_obj.fields_get().keys()
-        wizard_values = wizard_obj.default_get(fields_list)
-        # One invoice per partner but group products
-        wizard_values.update({"group": "partner_product"})
-        wizard = wizard_obj.create(wizard_values)
-        wizard.onchange_group()
-        wizard.action_generate()
-        domain = [("picking_ids", "in", pickings.ids)]
-        invoice = self.env["account.move"].search(domain)
-        return invoice
-
-    def return_picking_wizard(self, picking):
-        # Return Picking
-        return_wizard_form = Form(
-            self.env["stock.return.picking"].with_context(
-                **dict(active_id=picking.id, active_model="stock.picking")
-            )
-        )
-        return_wizard_form.invoice_state = "2binvoiced"
-        self.return_wizard = return_wizard_form.save()
-
-        result_wizard = self.return_wizard.create_returns()
-        self.assertTrue(result_wizard, "Create returns wizard fail.")
-        picking_devolution = self.env["stock.picking"].browse(
-            result_wizard.get("res_id")
-        )
-        return picking_devolution
-
-    def create_backorder_wizard(self, picking):
-        res_dict_for_back_order = picking.button_validate()
-        backorder_wizard = Form(
-            self.env[res_dict_for_back_order["res_model"]].with_context(
-                **res_dict_for_back_order["context"]
-            )
-        ).save()
-        backorder_wizard.process()
-        backorder = self.env["stock.picking"].search(
-            [("backorder_id", "=", picking.id)]
-        )
-        return backorder
+        return result

--- a/l10n_br_stock_account/tests/test_invoicing_picking.py
+++ b/l10n_br_stock_account/tests/test_invoicing_picking.py
@@ -272,10 +272,10 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
         self._change_user_company(self.env.ref("base.main_company"))
         picking2 = self.env.ref("l10n_br_stock_account.main_company-picking_2")
 
-        self._run_fiscal_onchanges(picking2)
+        self._run_picking_onchanges(picking2)
 
         for line in picking2.move_ids:
-            self._run_fiscal_line_onchanges(line)
+            self._run_line_onchanges(line)
 
         picking2.action_confirm()
         picking2.action_assign()
@@ -509,10 +509,11 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
         Test of compatible with international case, create Invoice but not for Brazil.
         """
         picking = self.env.ref("stock_picking_invoicing.stock_picking_invoicing_2")
-        self._run_fiscal_onchanges(picking)
+        self._run_picking_onchanges(picking)
+        picking.fiscal_operation_id = False
         # Force product availability
         for move in picking.move_ids_without_package:
-            self._run_fiscal_line_onchanges(move)
+            self._run_line_onchanges(move)
             # test split
             move.product_uom_qty = 2
             move.quantity_done = 1
@@ -549,10 +550,10 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
         self._change_user_company(self.env.ref("base.main_company"))
         picking = self.env.ref("l10n_br_stock_account.main_company-picking_2")
 
-        self._run_fiscal_onchanges(picking)
+        self._run_picking_onchanges(picking)
 
         for line in picking.move_ids:
-            self._run_fiscal_line_onchanges(line)
+            self._run_line_onchanges(line)
             # Force Split
             line.quantity_done = 10
 
@@ -620,11 +621,11 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
         nb_invoice_before = self.env["account.move"].search_count([])
         picking.picking_type_id.pre_generate_fiscal_document_number = "pack"
 
-        self._run_fiscal_onchanges(picking)
+        self._run_picking_onchanges(picking)
         picking.action_confirm()
         picking.action_assign()
         for move in picking.move_ids_without_package:
-            self._run_fiscal_line_onchanges(move)
+            self._run_line_onchanges(move)
             move.quantity_done = move.product_uom_qty
 
         picking.action_put_in_pack()


### PR DESCRIPTION
Use common tests from stock_picking_invoicing.


PR com duas alterações simples:

*  Usando o Common Test do **stock_picking_invoicing**, a partir da v16 é possível herdar de uma forma melhor os Testes do [stock_picking_invoicing](https://github.com/OCA/account-invoicing/blob/16.0/stock_picking_invoicing/tests/common.py) e com isso podemos reduzir código na Localização 

* Durante a Revisão do **sale_stock_picking_invoicing** foi visto que era melhor mover o que era feito no objeto **stock_rule** para o modulo **stock_picking_invoicing** e com isso podemos retirar a Linha que informa o **invoice_state** porque isso já está sendo informado aqui https://github.com/OCA/account-invoicing/blob/16.0/stock_picking_invoicing/models/stock_rule.py#L13 . 

Olhando o código que existe no **stock_rule** dentro da Localização surgiu uma questão que é se devemos mover esse código para o **stock_picking_invoicing** e com isso adicionar essa funcionalidade de poder definir a partir do **Stock Rule** com qual **invoice_state** o Picking deve ser criado, o que vocês acham? Isso não precisa ser feito agora e pode ser apenas um Roadmap


cc @OCA/local-brazil-maintainers 
