### PR TITLE
[16.0][FIX] l10n_br_account_payment_order: make migration script more fault-tolerant

### DIFF
--- a/l10n_br_account_payment_order/migrations/16.0.2.0.0/post-migration.py
+++ b/l10n_br_account_payment_order/migrations/16.0.2.0.0/post-migration.py
@@ -403,13 +403,18 @@ def migrate(env, version):
     if not version:
         return
 
-    # Verifica se já houve migração, banco de dados migrados na v14
-    payment_mode_migrated = env["account.payment.mode"].search(
-        [
-            ("sending_code_id", "!=", False),
-        ],
-        limit=1,
-    )
+    if "sending_code_id" in env["account.payment.mode"]._fields:
+        # Caso o campo ainda exista,
+        # checamos se já há registros (indicando migração prévia).
+        payment_mode_migrated = env["account.payment.mode"].search(
+            [("sending_code_id", "!=", False)],
+            limit=1,
+        )
+    else:
+        # Caso o campo não exista,
+        # assumimos que a migração já foi suficientemente avançada.
+        payment_mode_migrated = True
+
     if payment_mode_migrated:
         return
 


### PR DESCRIPTION
Na migração de um banco de dados da 14.0 para 16.0, pode acontecer de estarmos migrando a partir de uma 14.0 mais avançanda onde o campo `sending_code_id` não existe mais no modelo `account.payment.mode` essa PR reforça um pouco o script de migração para saber lidar com essa situação, deixando mais tolerante a falhas.