### PR TITLE
[16.0][FIX+IMP] l10n_br_sale: Casos Sem Operação Fiscal ou Fora do Brasil

### DIFF
--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -15,7 +15,11 @@ class SaleOrder(models.Model):
 
     @api.model
     def _default_fiscal_operation(self):
-        return self.env.company.sale_fiscal_operation_id
+        # O IF permite testar casos Sem OP Fiscal, por exemplo o módulo delivery
+        # TODO: Avaliar a necessidade do IF depois da separação entre
+        #   os Testes e os Dados de Demonstração
+        if self.env.company.country_id.code == "BR":
+            return self.env.company.sale_fiscal_operation_id
 
     @api.model
     def _default_copy_note(self):

--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -104,8 +104,10 @@ class SaleOrder(models.Model):
     )
     def _compute_amounts(self):
         """Compute the total amounts of the SO."""
-        for order in self:
+        result = super()._compute_amounts()
+        for order in self.filtered(lambda ln: ln.fiscal_operation_id):
             order._compute_fiscal_amount()
+        return result
 
     # TODO v16 override _compute_tax_totals ?
 

--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -180,7 +180,7 @@ class SaleOrderLine(models.Model):
     def _compute_amount(self):
         """Compute the amounts of the SO line."""
         result = super()._compute_amount()
-        for line in self:
+        for line in self.filtered(lambda ln: ln.fiscal_operation_id):
             # Update taxes fields
             line._update_fiscal_taxes()
             # Call mixin compute method

--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -11,7 +11,7 @@ class SaleOrderLine(models.Model):
 
     @api.model
     def _default_fiscal_operation(self):
-        return self.env.company.sale_fiscal_operation_id
+        return self.order_id.fiscal_operation_id
 
     @api.model
     def _fiscal_operation_domain(self):


### PR DESCRIPTION
Cases without Fiscal Operation.

Alterações feitas:

* No Pedido de Vendas informa a **Operação Fiscal Padrão** apenas para o caso da Empresa ser do Brasil, nas Linhas informa apenas quando a Operação estiver preenchida no Pedido 

Sobre a **Operação Fiscal Padrão na Linha** surgiu uma questão que é se na Linha não deveria ser Operação informada no Pedido ao invés de ser a Padrão de Vendas da Empresa já que se o Usuário alterar a Operação no Pedido logo não deveria trazer essa Operação na Linha? Deixei como estava mas posso ver de alterar

* Calculo dos **Totais** volta a chamar o **super** e apenas chama os métodos Fiscais do Brasil no caso de ter a **Operação Fiscal** informada

PR simples e uma continuação do que foi feito na v14  , mas isso é necessário porque está causando erro nos testes do módulo [delivery](https://github.com/OCA/OCB/tree/16.0/addons/delivery) e consequentemente na migração do [l10n_br_delivery](https://github.com/OCA/l10n-brazil/pull/3571) 

```bash
2025-01-28 16:45:41,056 18 ERROR test_br odoo.addons.delivery.tests.test_delivery_cost: FAIL: TestDeliveryCost.test_00_delivery_cost
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/odoo/addons/delivery/tests/test_delivery_cost.py", line 109, in test_00_delivery_cost
    self.assertEqual(len(line), 1, "Delivery cost is not Added")
AssertionError: 0 != 1 : Delivery cost is not Added

2025-01-28 17:06:29,522 24 ERROR test_br odoo.addons.delivery.tests.test_delivery_cost: FAIL: TestDeliveryCost.test_01_taxes_on_delivery_cost
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/odoo/addons/delivery/tests/test_delivery_cost.py", line 293, in test_01_taxes_on_delivery_cost
    self.assertRecordValues(sale_order.order_line, [{'price_subtotal': 9.09, 'price_total': 10.45}])
  File "/usr/local/lib/python3.10/site-packages/odoo/tests/common.py", line 611, in assertRecordValues
    self.fail('\n'.join(errors))
AssertionError: The records and expected_values do not match.

==== Differences at index 0 ====
--- 

+++ 

@@ -1 +1 @@

-price_total:9.09
+price_total:10.450000000000001
 


2025-01-28 17:06:41,952 24 ERROR test_br odoo.addons.delivery.tests.test_delivery_cost: FAIL: TestDeliveryCost.test_delivery_real_cost
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/odoo/addons/delivery/tests/test_delivery_cost.py", line 364, in test_delivery_real_cost
    self.assertEqual(delivery_line.price_unit, picking.carrier_price)
AssertionError: 0.0 != 40.0


2025-01-28 17:07:14,559 24 ERROR test_br odoo.addons.delivery.tests.test_delivery_stock_move: FAIL: StockMoveInvoice.test_01_delivery_stock_move
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/odoo/addons/delivery/tests/test_delivery_stock_move.py", line 98, in test_01_delivery_stock_move
    self.assertEqual(moves[0].move_line_ids.sale_price, 1725.0, 'wrong shipping value')
AssertionError: 1500.0 != 1725.0 : wrong shipping value


2025-01-28 17:07:17,937 24 ERROR test_br odoo.addons.delivery.tests.test_delivery_stock_move: FAIL: StockMoveInvoice.test_02_delivery_stock_move
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/odoo/addons/delivery/tests/test_delivery_stock_move.py", line 141, in test_02_delivery_stock_move
    self.assertEqual(moves[0].move_line_ids[0].sale_price, 862.5, 'wrong shipping value')
AssertionError: 750.0 != 862.5 : wrong shipping value
```

**OBS:** Para corrigir os erros do LOG acima ainda é preciso alterar o **l10n_br_stock_account** e o **l10n_br_delivery** no mesmo sentido, vou subir isso logo em seguida

cc @OCA/local-brazil-maintainers 