### PR TITLE
[16.0][FIX] l10n_br_account_payment_order: Teste de Alteração da Data de Vencimento, erro no CI

### DIFF
--- a/l10n_br_account_payment_order/tests/test_base_class.py
+++ b/l10n_br_account_payment_order/tests/test_base_class.py
@@ -102,7 +102,7 @@ class TestL10nBrAccountPaymentOder(TransactionCase):
         ) as f:
             f.change_type = code_to_send
             if code_to_send == "change_date_maturity":
-                new_date = date.today() + timedelta(days=30)
+                new_date = date.today() + timedelta(days=40)
                 payment_cheque = self.env.ref(
                     "l10n_br_account_payment_order." "payment_mode_cheque"
                 )

--- a/l10n_br_account_payment_order/tests/test_payment_order_change.py
+++ b/l10n_br_account_payment_order/tests/test_payment_order_change.py
@@ -61,7 +61,7 @@ class TestPaymentOrderChange(TestL10nBrAccountPaymentOder):
     def test_change_date_maturity_multiple(self):
         """Test Creation of a Payment Order an change MULTIPLE due date"""
         date_maturity = self.financial_move_line_ids.mapped("date_maturity")
-        new_date = date.today() + timedelta(days=30)
+        new_date = date.today() + timedelta(days=40)
         self._send_and_check_new_cnab_code(
             self.invoice_auto,
             self.financial_move_line_ids,
@@ -77,7 +77,7 @@ class TestPaymentOrderChange(TestL10nBrAccountPaymentOder):
     def test_change_date_maturity_one(self):
         """Test Creation of a Payment Order an change ONE due date"""
         date_maturity = self.financial_move_line_0.mapped("date_maturity")
-        new_date = date.today() + timedelta(days=30)
+        new_date = date.today() + timedelta(days=40)
         self._send_and_check_new_cnab_code(
             self.invoice_auto,
             self.financial_move_line_0,


### PR DESCRIPTION
Test Due Date.

Teste de Alteração da Data de Vencimento passou a retornar erro agora a noite no PR https://github.com/OCA/l10n-brazil/pull/3599 , o LOG pode ser visto em 

https://github.com/OCA/l10n-brazil/actions/runs/13021744581/job/36323658172?pr=3599#step:9:2865

```bash
2025-01-29 00:05:30,190 407 ERROR odoo odoo.addons.l10n_br_account_payment_order.tests.test_payment_order_change: ERROR: TestPaymentOrderChange.test_change_date_maturity_multiple
Traceback (most recent call last):
  File "/__w/l10n-brazil/l10n-brazil/l10n_br_account_payment_order/tests/test_payment_order_change.py", line 65, in test_change_date_maturity_multiple
    self._send_and_check_new_cnab_code(
  File "/__w/l10n-brazil/l10n-brazil/l10n_br_account_payment_order/tests/test_base_class.py", line 136, in _send_and_check_new_cnab_code
    self._send_new_cnab_code(aml_to_change, code_to_send, warning_error)
  File "/__w/l10n-brazil/l10n-brazil/l10n_br_account_payment_order/tests/test_base_class.py", line 126, in _send_new_cnab_code
    change_wizard.doit()
  File "/__w/l10n-brazil/l10n-brazil/l10n_br_account_payment_order/wizards/account_move_line_change.py", line 63, in doit
    self.account_move_line_ids._identify_cnab_change(
  File "/__w/l10n-brazil/l10n-brazil/l10n_br_account_payment_order/models/l10n_br_cnab_change_methods.py", line 33, in _identify_cnab_change
    cnab_code = record._get_cnab_date_maturity(new_date)
  File "/__w/l10n-brazil/l10n-brazil/l10n_br_account_payment_order/models/l10n_br_cnab_change_methods.py", line 206, in _get_cnab_date_maturity
    raise UserError(
odoo.exceptions.UserError: New Date Maturity 2025-02-28 is equal to actual Date Maturity 2025-02-28
```

Não parece ser algum problema do método em si apenas do teste, talvez por uma questão de calendário ( alguma relação com o mês de Fevereiro? ) porque a solução até simples foi alterar a **quantidade de dias somados de 30 para 40**, pelos testes locais isso deve corrigir.

cc @OCA/local-brazil-maintainers 