### PR TITLE
[14.0][FIX] l10n_br_hr: fix employee rg number

### DIFF
--- a/l10n_br_hr/models/hr_employee.py
+++ b/l10n_br_hr/models/hr_employee.py
@@ -74,7 +74,7 @@ class HrEmployee(models.Model):
     rg = fields.Char(
         string="RG",
         store=True,
-        related="address_home_id.inscr_est",
+        related="address_home_id.rg",
         help="National ID number",
         groups="hr.group_hr_user",
     )


### PR DESCRIPTION
Ticket: HT00961

The rg field in the employee model was related to `address_home_id.inscr_est`, however the `inscr_est` field is for partners who are companies, if we have individual partners the field is not displayed and we have the `rg` field available

cc: @marcelsavegnago @kaynnan @douglascstd 