### PR TITLE
[16.0][REF] l10n_br_stock: Carregando os Dados de Demonstração pelo post_init_hook 

### DIFF
--- a/l10n_br_stock/README.rst
+++ b/l10n_br_stock/README.rst
@@ -45,8 +45,8 @@ Installation
 
 This module depends on:
 
-- l10n_br_base
-- stock
+-  l10n_br_base
+-  stock
 
 Configuration
 =============
@@ -70,12 +70,12 @@ Changelog
 14.0.2.0.0 (2022-06-07)
 -----------------------
 
-- [REF] Renomeado campo Inscrição Estadual de ie para inscr_est.
+-  [REF] Renomeado campo Inscrição Estadual de ie para inscr_est.
 
 14.0.1.0.0 (2021-12-31)
 -----------------------
 
-- [MIG] Migração para a versão 14.0.
+-  [MIG] Migração para a versão 14.0.
 
 Bug Tracker
 ===========
@@ -98,9 +98,14 @@ Authors
 Contributors
 ------------
 
-- Hendrix Costa
-- Luis Felipe Mileo <mileo@kmee.com.br>
-- Marcel Savegnago <marcel.savegnago@escodoo.com.br>
+-  `KMEE <https://kmee.com.br>`__:
+
+   -  Hendrix Costa
+   -  Luis Felipe Mileo <mileo@kmee.com.br>
+
+-  `ESCODOO <https://escodoo.com.br>`__:
+
+   -  Marcel Savegnago <marcel.savegnago@escodoo.com.br>
 
 Maintainers
 -----------

--- a/l10n_br_stock/__init__.py
+++ b/l10n_br_stock/__init__.py
@@ -4,3 +4,4 @@
 
 from . import models
 from .hooks import pre_init_hook
+from .hooks import post_init_hook

--- a/l10n_br_stock/__manifest__.py
+++ b/l10n_br_stock/__manifest__.py
@@ -7,13 +7,8 @@
     "version": "16.0.1.0.4",
     "depends": ["stock", "l10n_br_base"],
     "data": ["views/stock_picking_view.xml"],
-    "demo": [
-        "demo/res_users_demo.xml",
-        "demo/stock_location_demo.xml",
-        "demo/stock_inventory_demo.xml",
-        "demo/res_company_demo.xml",
-    ],
     "installable": True,
     "auto_install": False,
     "pre_init_hook": "pre_init_hook",
+    "post_init_hook": "post_init_hook",
 }

--- a/l10n_br_stock/hooks.py
+++ b/l10n_br_stock/hooks.py
@@ -87,3 +87,47 @@ def pre_init_hook(cr):
         env = api.Environment(cr, SUPERUSER_ID, {})
         set_stock_warehouse_external_ids(env, "l10n_br_base.empresa_simples_nacional")
         set_stock_warehouse_external_ids(env, "l10n_br_base.empresa_lucro_presumido")
+
+
+def post_init_hook(cr, registry):
+    if not tools.config["without_demo"]:
+        _logger.info(_("Loading l10n_br_stock/demo/res_users_demo.xml ..."))
+        tools.convert_file(
+            cr,
+            "l10n_br_stock",
+            "demo/res_users_demo.xml",
+            None,
+            mode="init",
+            noupdate=True,
+            kind="init",
+        )
+        _logger.info(_("Loading l10n_br_stock/demo/stock_location_demo.xml ..."))
+        tools.convert_file(
+            cr,
+            "l10n_br_stock",
+            "demo/stock_location_demo.xml",
+            None,
+            mode="init",
+            noupdate=True,
+            kind="init",
+        )
+        _logger.info(_("Loading l10n_br_stock/demo/stock_inventory_demo.xml ..."))
+        tools.convert_file(
+            cr,
+            "l10n_br_stock",
+            "demo/stock_inventory_demo.xml",
+            None,
+            mode="init",
+            noupdate=True,
+            kind="init",
+        )
+        _logger.info(_("Loading l10n_br_stock/demo/res_company_demo.xml ..."))
+        tools.convert_file(
+            cr,
+            "l10n_br_stock",
+            "demo/res_company_demo.xml",
+            None,
+            mode="init",
+            noupdate=True,
+            kind="init",
+        )

--- a/l10n_br_stock/readme/CONTRIBUTORS.md
+++ b/l10n_br_stock/readme/CONTRIBUTORS.md
@@ -1,3 +1,5 @@
-- Hendrix Costa
-- Luis Felipe Mileo \<<mileo@kmee.com.br>\>
-- Marcel Savegnago \<<marcel.savegnago@escodoo.com.br>\>
+- [KMEE](https://kmee.com.br):
+  - Hendrix Costa
+  - Luis Felipe Mileo \<<mileo@kmee.com.br>\>
+- [ESCODOO](https://escodoo.com.br):
+  - Marcel Savegnago \<<marcel.savegnago@escodoo.com.br>\>

--- a/l10n_br_stock/static/description/index.html
+++ b/l10n_br_stock/static/description/index.html
@@ -449,9 +449,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="contributors">
 <h2><a class="toc-backref" href="#toc-entry-10">Contributors</a></h2>
 <ul class="simple">
+<li><a class="reference external" href="https://kmee.com.br">KMEE</a>:<ul>
 <li>Hendrix Costa</li>
 <li>Luis Felipe Mileo &lt;<a class="reference external" href="mailto:mileo&#64;kmee.com.br">mileo&#64;kmee.com.br</a>&gt;</li>
+</ul>
+</li>
+<li><a class="reference external" href="https://escodoo.com.br">ESCODOO</a>:<ul>
 <li>Marcel Savegnago &lt;<a class="reference external" href="mailto:marcel.savegnago&#64;escodoo.com.br">marcel.savegnago&#64;escodoo.com.br</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
Load demo data by post init hook.

Alterações do PR:

* Carregando os Dados de Demonstração pelo **post_init_hook**, alteração simples mas necessária porque ao instalar duas vezes o modulo, como o CI faz em alguns PRs, por exemplo o PR de migração do [l10n_br_delivery](https://github.com/OCA/l10n-brazil/pull/3571) o **noupdate=1** dos XML parece ser ignorado e acaba retornando um Warning 

https://github.com/OCA/l10n-brazil/actions/runs/13035384911/job/36364402057?pr=3571#step:9:260

```bash
2025-01-29 16:08:51,161 701 WARNING odoo odoo.modules.loading: Module l10n_br_stock demo data failed to install, installed without demo data 
Traceback (most recent call last):
  File "/opt/odoo/odoo/tools/convert.py", line 698, in _tag_root
    f(rec)
  File "/opt/odoo/odoo/tools/convert.py", line 599, in _tag_record
    record = model._load_records([data], self.mode == 'update')
  File "/opt/odoo/odoo/models.py", line 4412, in _load_records
    data['record']._load_records_write(data['values'])
  File "/opt/odoo/addons/stock/models/stock_quant.py", line 307, in _load_records_write
    return super(StockQuant, self.with_context(inventory_mode=True))._load_records_write(values)
  File "/opt/odoo/odoo/models.py", line 4343, in _load_records_write
    self.write(values)
  File "/opt/odoo/addons/stock/models/stock_quant.py", line 351, in write
    raise UserError(_("Quant's editing is restricted, you can't do this operation."))
odoo.exceptions.UserError: Quant's editing is restricted, you can't do this operation.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/odoo/modules/loading.py", line 90, in load_demo
    load_data(cr, idref, mode, kind='demo', package=package)
  File "/opt/odoo/odoo/modules/loading.py", line 72, in load_data
    tools.convert_file(cr, package.name, filename, idref, mode, noupdate, kind)
  File "/opt/odoo/odoo/tools/convert.py", line 763, in convert_file
    convert_xml_import(cr, module, fp, idref, mode, noupdate)
  File "/opt/odoo/odoo/tools/convert.py", line 829, in convert_xml_import
    obj.parse(doc.getroot())
  File "/opt/odoo/odoo/tools/convert.py", line 749, in parse
    self._tag_root(de)
  File "/opt/odoo/odoo/tools/convert.py", line 711, in _tag_root
    raise ParseError('while parsing %s:%s, somewhere inside\n%s' % (
odoo.tools.convert.ParseError: while parsing /opt/odoo-venv/lib/python3.10/site-packages/odoo/addons/l10n_br_stock/demo/stock_inventory_demo.xml:9, somewhere inside
<record id="stock_inventory_sn_1" model="stock.quant">
            <field name="product_id" ref="product.product_product_24"/>
            <field name="inventory_quantity">16.0</field>
            <field name="location_id" model="stock.location" eval="obj().env.ref('l10n_br_stock.wh_empresa_simples_nacional').lot_stock_id.id"/>
        </record>
```
Isso acontece porque o módulo já foi instalado antes no **Initialize test db**
https://github.com/OCA/l10n-brazil/actions/runs/13035384911/job/36364402057?pr=3571#step:8:969

![image](https://github.com/user-attachments/assets/0207582f-64dd-4a7c-bc03-f3475bc7a27d)

Carregando dessa forma o erro não acontece.

* Ao rodar o **pre-commit** alguns arquivos foram alterados e aproveitei para fazer algo simples que é incluir as Empresas no CONTIBUTORS.md  o que tem sido feito em outros módulos.

Revendo o módulo surgiram algumas questões o arquivo [l10n_br_stock/__init__.py](https://github.com/OCA/l10n-brazil/blob/16.0/l10n_br_stock/__init__.py) e o [l10n_br_stock/models/__init__.py](https://github.com/OCA/l10n-brazil/blob/16.0/l10n_br_stock/models/__init__.py) estão com o Cabeçalho de Licença, o que está sendo removido em outros PRs porém eu não removi porque o [l10n_br_stock/__manifest__.py](https://github.com/OCA/l10n-brazil/blob/16.0/l10n_br_stock/__manifest__.py) está sem o cabeçalho, o @renatonlima  consta como autor com data de 2009 em um dos __init__ mas ele não está no README, isso está certo? O Cabeçalho de Licença deveria ser movido dos arquivos **init** para o **manifest**? Isso é algo que pode ser visto em outro PR especifico ou se acreditarem que pode ser resolvido aqui posso ver de incluir essa alteração.

cc @OCA/local-brazil-maintainers  