### PR TITLE
[16.0][FIX] l10n_br_fiscal_edi: Evita erro por chamar o método back2draft duas vezes

### DIFF
--- a/l10n_br_fiscal_edi/models/document_workflow.py
+++ b/l10n_br_fiscal_edi/models/document_workflow.py
@@ -327,7 +327,9 @@ class DocumentWorkflow(models.AbstractModel):
             self.state_edoc = SITUACAO_EDOC_EM_DIGITACAO
 
     def _action_document_back2draft(self):
-        self.document_back2draft()
+        self.filtered(
+            lambda d: d.state_edoc != SITUACAO_EDOC_EM_DIGITACAO
+        ).document_back2draft()
 
     def _document_cancel(self, justificative):
         self.ensure_one()


### PR DESCRIPTION
Avoid call back2draft twice.

Evita erro por chamar o método back2draft duas vezes, esse erro apareceu no [PR de migração do l10n_br_delivery](https://github.com/OCA/l10n-brazil/pull/3571) aqui 

https://github.com/OCA/l10n-brazil/actions/runs/13035384911/job/36364402057?pr=3571#step:9:2768

```bash
2025-01-29 16:13:39,084 701 ERROR odoo odoo.addons.l10n_br_account.tests.test_account_move_lc: ERROR: AccountMoveLucroPresumido.test_change_states
Traceback (most recent call last):
  File "/opt/odoo-venv/lib/python3.10/site-packages/odoo/addons/l10n_br_account/tests/test_account_move_lc.py", line 1732, in test_change_states
    document_id.action_document_back2draft()
  File "/__w/l10n-brazil/l10n-brazil/l10n_br_fiscal_edi/models/document.py", line 186, in action_document_back2draft
    return self._action_document_back2draft()
  File "/__w/l10n-brazil/l10n-brazil/l10n_br_fiscal_edi/models/document_workflow.py", line 330, in _action_document_back2draft
    self.document_back2draft()
  File "/__w/l10n-brazil/l10n-brazil/l10n_br_fiscal_edi/models/document_workflow.py", line 325, in document_back2draft
    self._change_state(SITUACAO_EDOC_EM_DIGITACAO)
  File "/__w/l10n-brazil/l10n-brazil/l10n_br_fiscal_edi/models/document_workflow.py", line 209, in _change_state
    raise UserError(
odoo.exceptions.UserError: Não é possível realizar esta operação,
esta transição não é permitida:

De: em_digitacao

 Para: em_digitacao
```

Pelos o que entendi antes de tentar alterar o **state_edoc** é feita uma validação https://github.com/OCA/l10n-brazil/blob/16.0/l10n_br_account/tests/test_account_move_lc.py#L1731 e o **state_edoc** está como **a_enviar** mas ao chamar **action_document_back2draft** o programa tentar alterar o campo duas vezes e na segunda retorna erro porque o campo já foi alterado, acredito que ao chamar o https://github.com/OCA/l10n-brazil/blob/16.0/l10n_br_account/models/document.py#L209 o método **button_draft** do **account.move** já é feita a alteração aqui https://github.com/OCA/l10n-brazil/blob/16.0/l10n_br_account/models/account_move.py#L514 e na sequencia de de chamadas do **super()** quando chega aqui https://github.com/OCA/l10n-brazil/blob/16.0/l10n_br_fiscal_edi/models/document_workflow.py#L325 o **state_edoc** já foi alterado.

Não sei porque esse erro não apareceu antes, talvez porque o CI instala alguns módulos da localização antes no caso do l10n_br_delivery? Mas a alteração é simples não deve causar nenhum erro, é semelhante com o que já é feito no **button_draft** um filtered evita o erro.

 cc @OCA/local-brazil-maintainers 