### PR TITLE
[14.0][FIX] l10n_br_nfe: ignore check key date if there is no doc date

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -849,7 +849,7 @@ class NFe(spec_models.StackedModel):
     @api.constrains("document_date", "document_key", "state_edoc")
     def _check_document_date_key(self):
         for rec in self:
-            if rec.document_key:
+            if rec.document_key and rec.document_date:
                 key_date_str = rec.document_key[2:6]
                 key_date = datetime.strptime(key_date_str, "%y%m")
 


### PR DESCRIPTION
Foto do erro que acontece com uma NFe(55) emitida pelo parceiro criada do zero manualmente.... antigamente sempre haveria uma data do documento, porém recentemente foi alterado para essa data ser definida somente depois da fatura confirmada. Segue foto do erro corrigido:

![image](https://github.com/user-attachments/assets/86c35b7a-edf6-405e-ae21-7e8d9d518583)