### PR TITLE
[14.0][IMP][l10n_br_account_payment_order][l10n_br_account_payment_brcobranca]: Add boleto write-off and devolution codes for Santander CNAB 240

### DIFF
--- a/l10n_br_account_payment_brcobranca/models/account_payment_line.py
+++ b/l10n_br_account_payment_brcobranca/models/account_payment_line.py
@@ -102,6 +102,13 @@ class AccountPaymentLine(models.Model):
 
             dv = self.modulo11(nosso_numero, 9, 0)
             linhas_pagamentos["nosso_numero"] = str(nosso_numero) + str(dv)
+        elif cnab_config.payment_method_id.code == "240":
+            linhas_pagamentos[
+                "codigo_baixa"
+            ] = cnab_config.write_off_devolution_code_id.code
+            linhas_pagamentos["dias_baixa"] = str(
+                cnab_config.write_off_devolution_number_of_days
+            )
 
     def prepare_bank_payment_line(self, bank_name_brcobranca):
         cnab_config = self.order_id.payment_mode_id.cnab_config_id

--- a/l10n_br_account_payment_order/__manifest__.py
+++ b/l10n_br_account_payment_order/__manifest__.py
@@ -43,6 +43,8 @@
         "data/cnab_codes/banco_santander_240_boleto_discount_code.xml",
         "data/cnab_codes/banco_sicredi_240_boleto_discount_code.xml",
         "data/cnab_codes/banco_unicred_240_400_boleto_discount_code.xml",
+        # Boleto Write Off Devolution
+        "data/cnab_codes/banco_santander_240_boleto_write_off_devolution.xml",
         # Wizards
         "wizards/account_payment_line_create_view.xml",
         "wizards/account_move_line_change.xml",

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_santander_240_boleto_write_off_devolution.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_santander_240_boleto_write_off_devolution.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+
+    <!-- Tipo de Cobrança ou Código da Carteira -->
+    <!-- Santander 240 -->
+    <record id="santander_240_boleto_write_off_devolution_1" model="l10n_br_cnab.code">
+        <field name="name">BAIXAR / DEVOLVER</field>
+        <field name="code">1</field>
+        <field name="code_type">boleto_write_off_devolution</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+    <record id="santander_240_boleto_write_off_devolution_2" model="l10n_br_cnab.code">
+        <field name="name">NAO BAIXAR / NAO DEVOLVER</field>
+        <field name="code">2</field>
+        <field name="code_type">boleto_write_off_devolution</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+    <record id="santander_240_boleto_write_off_devolution_3" model="l10n_br_cnab.code">
+        <field name="name">UTILIZAR PERFIL BENEFICIARIO</field>
+        <field name="code">3</field>
+        <field name="code_type">boleto_write_off_devolution</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+</odoo>

--- a/l10n_br_account_payment_order/demo/l10n_br_cnab_config_demo.xml
+++ b/l10n_br_account_payment_order/demo/l10n_br_cnab_config_demo.xml
@@ -772,6 +772,12 @@
         <field name="cancel_rebate_code_id" ref="santander_240_instruction_05" />
         <field name="grant_discount_code_id" ref="santander_240_instruction_10" />
         <field name="cancel_discount_code_id" ref="santander_240_instruction_11" />
+        <!-- Código de Baixa / Devolução 240 -->
+        <field
+            name="write_off_devolution_code_id"
+            ref="santander_240_boleto_write_off_devolution_3"
+        />
+        <field name="write_off_devolution_number_of_days">0</field>
     </record>
 
     <!-- CNAB Manual Test -->

--- a/l10n_br_account_payment_order/models/l10n_br_cnab_boleto_fields.py
+++ b/l10n_br_account_payment_order/models/l10n_br_cnab_boleto_fields.py
@@ -351,3 +351,19 @@ class L10nBrCNABBoletoFields(models.AbstractModel):
         string="Boleto Wallet Code",
         tracking=True,
     )
+
+    # Código para Instrução de Devolução - Santander 240
+    write_off_devolution_code_id = fields.Many2one(
+        comodel_name="l10n_br_cnab.code",
+        string="Devolution Instruction Code",
+        help="CNAB code used for devolution instruction.",
+        tracking=True,
+    )
+
+    # Número de Dias para Devolução - Santander 240
+    write_off_devolution_number_of_days = fields.Char(
+        string="Number of Days for Devolution",
+        size=2,
+        help="Specifies the number of days allowed for devolution.",
+        tracking=True,
+    )

--- a/l10n_br_account_payment_order/models/l10n_br_cnab_code.py
+++ b/l10n_br_account_payment_order/models/l10n_br_cnab_code.py
@@ -45,6 +45,7 @@ class L10nBrCNABCode(models.Model):
             ("boleto_wallet", "Boleto Wallet"),
             ("boleto_modality", "Boleto Modality"),
             ("boleto_variation", "Boleto Variation"),
+            ("boleto_write_off_devolution", "Boleto Write Off Devolution"),
         ],
     )
 

--- a/l10n_br_account_payment_order/views/l10n_br_cnab_config_view.xml
+++ b/l10n_br_account_payment_order/views/l10n_br_cnab_config_view.xml
@@ -189,6 +189,11 @@
                                             name="wallet_code_id"
                                             domain="['&amp;', ('payment_method_ids', 'in', payment_method_id), ('bank_ids', 'in', bank_id), ('code_type', '=', 'wallet_code')]"
                                         />
+                                    <field
+                                            name="write_off_devolution_code_id"
+                                            domain="['&amp;', ('payment_method_ids', 'in', payment_method_id), ('bank_ids', 'in', bank_id), ('code_type', '=', 'boleto_write_off_devolution')]"
+                                        />
+                                    <field name="write_off_devolution_number_of_days" />
                                  </group>
                                  <group
                                         name="bradesco"


### PR DESCRIPTION
cc @WesleyOliveira98 @douglascstd @marcelsavegnago @antoniospneto

Após o commit [Santander Remessa 240: Adiciona código e dias da baixa/devolução](https://github.com/kivanio/brcobranca/pull/261), o arquivo CNAB está preenchendo o código da baixa com 0. Como resultado, o Santander identifica um erro no arquivo CNAB e não o processa.

Exemplo:

Antes da inclusão dos campos "Código de Baixa e Dias de Baixas",, com o código de protesto e dias de protesto definidos como (2, 5):

`205300000`

Após a inclusão, mantendo o mesmo código de protesto e dias, mas agora definindo 0 dias para a baixa e 3 para o código de baixa:

`205000000`
