### PR TITLE
[16.0][MIG+IMP] l10n_br_sale: Migrando o Relatório de Vendas para incluir os campos do Brasil e incluído teste

### DIFF
--- a/l10n_br_sale/tests/__init__.py
+++ b/l10n_br_sale/tests/__init__.py
@@ -4,3 +4,4 @@ from . import test_l10n_br_sale
 from . import test_l10n_br_sale_discount
 from . import test_l10n_br_sale_sn
 from . import test_l10n_br_sale_pricelist
+from . import test_sale_order_report

--- a/l10n_br_sale/tests/test_sale_order_report.py
+++ b/l10n_br_sale/tests/test_sale_order_report.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2025-Today - Akretion (<http://www.akretion.com>).
+# @author Magno Costa <magno.costa@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import Form, tagged
+
+from odoo.addons.sale.tests.common import TestSaleCommon
+
+
+@tagged("post_install", "-at_install")
+class TestSaleReport(TestSaleCommon):
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        sale_form = Form(cls.env["sale.order"])
+        sale_form.partner_id = cls.partner_a
+        sale_form.pricelist_id = cls.company_data["default_pricelist"]
+        sale_form.fiscal_operation_id = cls.env.ref("l10n_br_fiscal.fo_venda")
+        with sale_form.order_line.new() as line:
+            line.name = cls.company_data["product_order_no"].name
+            line.product_id = cls.company_data["product_order_no"]
+            line.fiscal_operation_id = cls.env.ref("l10n_br_fiscal.fo_venda")
+            line.fiscal_operation_line_id = cls.env.ref("l10n_br_fiscal.fo_venda_venda")
+            line.price_unit = cls.company_data["product_order_no"].list_price
+            line.product_uom_qty = 3
+        sale_form.save()
+
+    def test_sale_br_report_sale_order(self):
+        """Test Sale Report for Brazil Case"""
+        self.env["sale.report"].read_group(
+            domain=[],
+            fields=["product_id, quantity, type_id"],
+            groupby="fiscal_operation_id",
+        )


### PR DESCRIPTION
Mig sale report BR fields.

Migrando o Relatório de Vendas para incluir os campos do Brasil, era um TODO da migração então é uma continuação do processo https://github.com/OCA/l10n-brazil/pull/2911 , segue imagens:

![image](https://github.com/user-attachments/assets/2d11b681-23ec-421a-9835-5c4f2eecb4e0)

![image](https://github.com/user-attachments/assets/de4621c0-95c5-4623-8c45-32ce60b4e320)

![image](https://github.com/user-attachments/assets/eac59527-b9c3-4c23-b423-6ad2d85aaf81)

cc @OCA/local-brazil-maintainers 