### PR TITLE
[14.0][FIX] l10n_br_sale_stock: use picking doc no. over SO doc no.

### DIFF
--- a/l10n_br_sale_stock/wizards/stock_invoice_onshipping.py
+++ b/l10n_br_sale_stock/wizards/stock_invoice_onshipping.py
@@ -49,6 +49,15 @@ class StockInvoiceOnshipping(models.TransientModel):
                 fiscal_data.add(fiscal_additional_data)
                 values["manual_fiscal_additional_data"] = fiscal_additional_data
 
+                # O sale_stock_picking_invoicing deleta o document_number em:
+                # `account-invoicing/sale_stock_picking_invoicing/wizards/
+                # stock_invoice_onshipping.py:104`
+                # uma vez que o valor do sale_id.document_number é False.
+                # Aqui estamos recuperando o valor do document_number do picking.
+                if picking.document_number and not values.get("document_number", False):
+                    values["document_number"] = picking.document_number
+                    values["document_serie"] = picking.document_serie
+
             # Fields to join
             if len(sale_pickings) > 1:
                 values.update(


### PR DESCRIPTION
## Objetivo

Corrige a reserva de document number (veja pre_generate_fiscal_document_number) para os casos em que o picking tem uma SO relacionada.

## Explicação

Isso é necessário pois o módulo `sale_stock_picking_invoicing` sobrescreve o valor reservado no picking aqui:

`account-invoicing/sale_stock_picking_invoicing/wizards/stock_invoice_onshipping.py:104`
```py
values.update(sale_values_rm)
```

A solução mais simples que encontrei foi forçar o `document_number `e `document_serie` após rodar o super