### PR TITLE
[14.0][FIX+IMP] l10n_br_sale_stock: Inform Fields that should not be used from Sale 'prepare' methods, tests

### DIFF
--- a/l10n_br_sale_stock/tests/test_sale_stock.py
+++ b/l10n_br_sale_stock/tests/test_sale_stock.py
@@ -547,3 +547,18 @@ class TestSaleStock(TestBrPickingInvoicingCommon):
         )
         assert down_payment_line, "Invoice without Down Payment line."
         invoice.action_post()
+
+    def test_generate_document_number_on_invoice_create_wizard(self):
+        """Test Invoicing Picking with Document Number"""
+        self.set_sale_invoicing_policy()
+        sale_order = self.env.ref("l10n_br_sale_stock.main_company-sale_order_1")
+        sale_order.action_confirm()
+        picking = sale_order.picking_ids
+        picking.picking_type_id.pre_generate_fiscal_document_number = "validate"
+        self.picking_move_state(picking)
+        self.assertTrue(picking.document_number)
+        invoice = self.create_invoice_wizard(picking)
+        self.assertEqual(picking.document_number, invoice.document_number)
+        self.assertEqual(
+            picking.document_number, invoice.fiscal_document_id.document_number
+        )

--- a/l10n_br_sale_stock/wizards/stock_invoice_onshipping.py
+++ b/l10n_br_sale_stock/wizards/stock_invoice_onshipping.py
@@ -7,6 +7,17 @@ from odoo import models
 class StockInvoiceOnshipping(models.TransientModel):
     _inherit = "stock.invoice.onshipping"
 
+    def _get_fields_not_used_from_sale(self):
+        """Fields not used from Sale 'prepare' method"""
+        fields_not_used = super()._get_fields_not_used_from_sale()
+        fields_not_used.update(
+            {
+                "document_number",
+                "document_serie",
+            }
+        )
+        return fields_not_used
+
     def _build_invoice_values_from_pickings(self, pickings):
         """
         Build dict to create a new invoice from given pickings


### PR DESCRIPTION
Inform Fields that should not be used from Sale 'prepare' methods, depends https://github.com/OCA/account-invoicing/pull/1906

Esse PR deve resolver o problema reportado aqui https://github.com/OCA/l10n-brazil/pull/3616 , que é o programa deve usar os valores dos campos **Número do Documento e Série** informados no **stock.picking** e não no **sale.order**, acredito que a melhor solução para resolver isso é criando dois método que retornam os **Campos que não usados dos métodos 'prepare' do Sale** e como isso pode ser tanto um problema da Localização também pode acabar sendo um problema para outras Localizações ou mesmo para módulos customizados será melhor resolver a nível do **sale_stock_picking_invocing** ao invés de resolver apenas na Localização Brasileira, então agora basta informar qualquer campo que venha do Sale mas que não deverá ser usado para criar a **Fatura** herdando o método **_get_fields_not_used_from_sale** para os campos do **sale.order** ou o **_get_fields_not_used_from_sale_line** para os campos do **sale.order.line**.

Inclui um teste para esse caso, assim evitamos regressões, mas como o PR depende do  https://github.com/OCA/account-invoicing/pull/1906 o **CI** aqui vai ficar com erro até ocorrer o merge.

cc @OCA/local-brazil-maintainers @DiegoParadeda 
