### PR TITLE
[14.0][FIX] l10n_br_fiscal, l10n_br_account: refatoração do processo de estorno 

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -617,54 +617,70 @@ class AccountMove(models.Model):
         self.ensure_one_doc()
         return self.fiscal_document_id.action_send_email()
 
-    def _reverse_moves(self, default_values_list=None, cancel=False):
-        new_moves = super()._reverse_moves(
-            default_values_list=default_values_list, cancel=cancel
-        )
+    def _reverse_move_vals(self, default_values, cancel=True):
+        move_vals = super()._reverse_move_vals(default_values, cancel=cancel)
         force_fiscal_operation_id = False
         if self.env.context.get("force_fiscal_operation_id"):
             force_fiscal_operation_id = self.env["l10n_br_fiscal.operation"].browse(
                 self.env.context.get("force_fiscal_operation_id")
             )
+
+        # Skip the addional logic if the document type is not set.
+        if not self.document_type_id:
+            return move_vals
+
+        cfop_obj = self.env["l10n_br_fiscal.cfop"]
+        op_line_obj = self.env["l10n_br_fiscal.operation.line"]
+
+        # set the return fiscal operation
+
+        if force_fiscal_operation_id:
+            return_op_id = force_fiscal_operation_id
+        else:
+            op_id = self.fiscal_operation_id
+            return_op_id = op_id.return_fiscal_operation_id
+        move_vals["fiscal_operation_id"] = return_op_id.id
+        # para manter a imutabilidade o 'operation_name' não é um campo related.
+        move_vals["operation_name"] = return_op_id.name
+        # TODO pegar o edoc_purpose de dentro da operação.
+        move_vals["edoc_purpose"] = "4"
+
+        for vals in move_vals["line_ids"]:
+            line_vals = vals[2]
+
+            # Skip the addional logic if the line is excluded from the invoice tab.
+            if line_vals["exclude_from_invoice_tab"]:
+                continue
+
+            # set the return fiscal operation line
+            if force_fiscal_operation_id:
+                #
+                partner_obj = self.env["res.partner"]
+                product_obj = self.env["product.product"]
+                return_op_line_id = force_fiscal_operation_id.line_definition(
+                    company=self.company_id,
+                    partner=partner_obj.browse(move_vals["partner_id"]),
+                    product=product_obj.browse(line_vals["product_id"]),
+                )
+            else:
+                op_line_id = op_line_obj.browse(line_vals["fiscal_operation_line_id"])
+                return_op_line_id = op_line_id.return_fiscal_operation_line_id
+            line_vals["fiscal_operation_line_id"] = return_op_line_id.id
+
+            # set the return cfop
+            cfop_id = cfop_obj.browse(line_vals["cfop_id"])
+            line_vals["cfop_id"] = cfop_id.cfop_return_id.id
+
+        return move_vals
+
+    def _reverse_moves(self, default_values_list=None, cancel=False):
+        new_moves = super()._reverse_moves(
+            default_values_list=default_values_list, cancel=cancel
+        )
+
         for record in new_moves.filtered(lambda i: i.document_type_id):
-            if (
-                not force_fiscal_operation_id
-                and not record.fiscal_operation_id.return_fiscal_operation_id
-            ):
-                raise UserError(
-                    _("""Document without Return Fiscal Operation! \n Force one!""")
-                )
-
-            record.fiscal_operation_id = (
-                force_fiscal_operation_id
-                or record.fiscal_operation_id.return_fiscal_operation_id
-            )
-            record._onchange_fiscal_operation_id()
-
-            for line in record.invoice_line_ids:
-                if (
-                    not force_fiscal_operation_id
-                    and not line.fiscal_operation_id.return_fiscal_operation_id
-                ):
-                    raise UserError(
-                        _(
-                            """Line without Return Fiscal Operation! \n
-                            Please force one! \n%(name)s""",
-                            name=line.name,
-                        )
-                    )
-
-                line.fiscal_operation_id = (
-                    force_fiscal_operation_id
-                    or line.fiscal_operation_id.return_fiscal_operation_id
-                )
-                line._onchange_fiscal_operation_id()
-
             # Adds the related document to the NF-e.
-            # this is required for correct xml validation
-            if record.document_type_id and record.document_type_id.code in (
-                MODELO_FISCAL_NFE
-            ):
+            if record.document_type_id.code == MODELO_FISCAL_NFE:
                 record.fiscal_document_id._document_reference(
                     record.reversed_entry_id.fiscal_document_id
                 )

--- a/l10n_br_account/tests/test_invoice_refund.py
+++ b/l10n_br_account/tests/test_invoice_refund.py
@@ -2,7 +2,6 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from odoo import fields
-from odoo.exceptions import UserError
 from odoo.tests import SavepointCase
 
 
@@ -107,13 +106,7 @@ class TestInvoiceRefund(SavepointCase):
             .create(reverse_vals)
         )
 
-        with self.assertRaises(UserError):
-            move_reversal.reverse_moves()
-
         invoice["fiscal_operation_id"] = (self.env.ref("l10n_br_fiscal.fo_venda").id,)
-
-        with self.assertRaises(UserError):
-            move_reversal.reverse_moves()
 
         for line_id in invoice.invoice_line_ids:
             line_id["fiscal_operation_id"] = (

--- a/l10n_br_fiscal/data/operation_data.xml
+++ b/l10n_br_fiscal/data/operation_data.xml
@@ -10,6 +10,8 @@
         <field name="active">True</field>
     </record>
 
+
+
     <!-- l10n_br_fiscal.operation -->
     <record id="fo_venda" model="l10n_br_fiscal.operation">
         <field name="code">VD</field>
@@ -17,6 +19,29 @@
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_type">sale</field>
         <field name="default_price_unit">sale_price</field>
+        <field name="state">approved</field>
+    </record>
+
+    <record id="fo_devolucao_venda" model="l10n_br_fiscal.operation">
+        <field name="code">Devolução de Venda</field>
+        <field name="name">Devolução de Venda</field>
+        <field name="fiscal_operation_type">in</field>
+        <field name="fiscal_type">sale_refund</field>
+        <field name="default_price_unit">cost_price</field>
+        <field name="state">approved</field>
+        <field name="edoc_purpose">4</field>
+    </record>
+
+    <record
+        id="fo_devolucao_venda_devolucao_venda"
+        model="l10n_br_fiscal.operation.line"
+    >
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_devolucao_venda" />
+        <field name="name">Devolução de Venda</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1201" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2201" />
+        <field name="cfop_export_id" ref="l10n_br_fiscal.cfop_3201" />
+        <field name="product_type">04</field>
         <field name="state">approved</field>
     </record>
 
@@ -29,6 +54,10 @@
         <field name="cfop_export_id" ref="l10n_br_fiscal.cfop_7101" />
         <field name="state">approved</field>
         <field name="product_type">04</field>
+        <field
+            name="return_fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_devolucao_venda_devolucao_venda"
+        />
     </record>
 
     <record id="fo_venda_revenda" model="l10n_br_fiscal.operation.line">

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -68,11 +68,25 @@ class OperationLine(models.Model):
         readonly=True,
     )
 
+    return_fiscal_operation_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.operation",
+        string="Return Operation",
+        related="fiscal_operation_id.return_fiscal_operation_id",
+    )
+
     fiscal_type = fields.Selection(
         related="fiscal_operation_id.fiscal_type",
         string="Fiscal Type",
         store=True,
         readonly=True,
+    )
+
+    return_fiscal_operation_line_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.operation.line",
+        string="Return Operation Line",
+        readonly=True,
+        states={"draft": [("readonly", False)]},
+        domain="[('fiscal_operation_id', '=', return_fiscal_operation_id)]",
     )
 
     tax_icms_or_issqn = fields.Selection(

--- a/l10n_br_fiscal/views/operation_line_view.xml
+++ b/l10n_br_fiscal/views/operation_line_view.xml
@@ -23,6 +23,7 @@
             <form string="Fiscal Operation Line">
                 <field name="fiscal_type" invisible="1" />
                 <field name="fiscal_operation_type" invisible="1" />
+                <field name="return_fiscal_operation_id" invisible="1" />
                 <header>
                     <button
                         name="action_review"
@@ -56,6 +57,7 @@
                             <group name="gereral_settings">
                                 <field name="document_type_id" />
                                 <field name="add_to_amount" />
+                                <field name="return_fiscal_operation_line_id" />
                             </group>
                             <group
                                 name="general_cfop"


### PR DESCRIPTION
É o mesmo problema descrito na #2629, mas, ao final, permitimos o fechamento, pois achávamos que isso não seria mais necessário.

Os dados chegam embaralhados ao usar o wizard de devolução, sendo utilizados antes de serem preenchidos com os valores corretos.

Não considero isso apenas um problema de REF, pois corrige questões como:

Ao criar uma nota de devolução para anulação de venda (quando a própria empresa gera a devolução de todos os itens), o campo nfe40_dup é populado, fazendo com que a nota seja rejeitada (veja a imagem abaixo):
![image](https://github.com/user-attachments/assets/ea4832d1-617e-4358-9228-c3870b023624)

O correto seria não ter o campo nfe40_dup; portanto, o vDup não deveria nem ser zero.

A origem do erro é que, na hora de validar se é necessário gerar o nfe40_dup, a nota ainda está marcada como tipo "saída". A mudança para "entrada" pelo wizard ocorre apenas depois de os valores de duplicata terem sido gerados incorretamente:
![image](https://github.com/user-attachments/assets/75a5cbcd-9caf-4574-9d41-a61a64b50772)


O mesmo problema ocorre com uma nota de devolução para fornecedor emitida pela empresa: mesmo quando o campo nfe40_dup deveria ser criado, a inconsistência dos dados impede sua criação, gerando nova rejeição.