### PR TITLE
[14.0][IMP] l10n_br_account_payment_cobranca: add seg. R details

### DIFF
--- a/l10n_br_account_payment_brcobranca/models/account_payment_line.py
+++ b/l10n_br_account_payment_brcobranca/models/account_payment_line.py
@@ -109,6 +109,12 @@ class AccountPaymentLine(models.Model):
             linhas_pagamentos["dias_baixa"] = str(
                 cnab_config.write_off_devolution_number_of_days
             )
+            # Os dados de multa e desconto também são obrigatórios no segmento R
+            linhas_pagamentos["codigo_multa"] = cnab_config.boleto_fee_code or "0"
+            linhas_pagamentos["percentual_multa"] = cnab_config.boleto_fee_perc or 0.0
+            if self.discount_value:
+                linhas_pagamentos["data_desconto"] = self.date.strftime("%Y/%m/%d")
+                linhas_pagamentos["valor_desconto"] = self.discount_value
 
     def prepare_bank_payment_line(self, bank_name_brcobranca):
         cnab_config = self.order_id.payment_mode_id.cnab_config_id

--- a/l10n_br_account_payment_order/demo/l10n_br_cnab_config_demo.xml
+++ b/l10n_br_account_payment_order/demo/l10n_br_cnab_config_demo.xml
@@ -778,6 +778,8 @@
             ref="santander_240_boleto_write_off_devolution_3"
         />
         <field name="write_off_devolution_number_of_days">0</field>
+        <field name="boleto_fee_code">0</field>
+        <field name="boleto_fee_perc">0.00</field>
     </record>
 
     <!-- CNAB Manual Test -->


### PR DESCRIPTION
Para o caso do boleto 240 do Santander alguns campos obrigatórios não estavam sendo preenchidas nas instruções de Baixa e Abatimento:

- codigo_multa
- percentual_multa
- tipo_mora
- valor_mora

Adicionei as duas instruções no trecho de código que popula esses campos, antes apenas a instrução de Registro passava no trecho.

## Testes

- Erro com o código atual - operação de baixa/abatimento (cursor na pos 66)

![image](https://github.com/user-attachments/assets/5f924654-55d3-4985-8bf6-ee6d00a8ccd8)
![image](https://github.com/user-attachments/assets/01104223-437a-4e22-afe4-049215bfd101)


- Com a alteração - operação de baixa/abatimento (cursor na pos 66)

![image](https://github.com/user-attachments/assets/debaf779-e2e7-49fc-917f-37c4971410d8)
![image](https://github.com/user-attachments/assets/ec618a7c-3c90-4eaa-a57f-c8a6b81acb94)
