### PR TITLE
[14.0][IMP] l10n_br_fiscal,nfe: gCred tag for cBenef (Crédito Presumido)

### DIFF
--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -356,8 +356,20 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     )
 
     icms_tax_benefit_code = fields.Char(
-        string="Tax Benefit Code", related="icms_tax_benefit_id.code", store=True
+        string="Tax Benefit Code",
+        store=True,
+        readonly=True,
     )
+
+    icms_tax_benefit_type = fields.Selection(
+        string="Tax Benefit Type", related="icms_tax_benefit_id.benefit_type"
+    )
+
+    icms_tax_benefit_percent = fields.Float(
+        readonly=True,
+    )
+
+    icms_tax_benefit_value = fields.Monetary(compute="_compute_tax_benefit_value")
 
     icms_base_type = fields.Selection(
         selection=ICMS_BASE_TYPE,

--- a/l10n_br_fiscal/models/document_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_line_mixin_methods.py
@@ -585,6 +585,26 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             "icms_relief_value": tax_dict.get("icms_relief", 0.0),
         }
 
+    @api.onchange("icms_tax_benefit_id")
+    def _onchange_tax_benefit_id(self):
+        if self.icms_tax_benefit_id:
+            self.icms_tax_benefit_code = self.icms_tax_benefit_id.code
+            self.icms_tax_benefit_type = self.icms_tax_benefit_id.benefit_type
+            self.icms_tax_benefit_percent = (
+                self.icms_tax_benefit_id.presumed_credit_percent
+            )
+        else:
+            self.icms_tax_benefit_code = False
+            self.icms_tax_benefit_type = False
+            self.icms_tax_benefit_percent = 0.0
+
+    @api.depends("icms_value", "icms_tax_benefit_percent")
+    def _compute_tax_benefit_value(self):
+        for record in self:
+            record.icms_tax_benefit_value = (
+                record.icms_value * record.icms_tax_benefit_percent
+            ) / 100
+
     @api.onchange(
         "icms_base",
         "icms_percent",

--- a/l10n_br_fiscal/models/tax_definition.py
+++ b/l10n_br_fiscal/models/tax_definition.py
@@ -281,6 +281,10 @@ class TaxDefinition(models.Model):
         states={"draft": [("readonly", False)]},
     )
 
+    presumed_credit_percent = fields.Float(
+        string="Porcentagem do crédito presumido",
+    )
+
     def _get_search_domain(self, tax_definition):
         """Create domain to be used in contraints methods"""
         domain = [

--- a/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
@@ -180,6 +180,19 @@
                                         attrs="{'readonly': ['|', ('icms_tax_id', '!=', False), ('icmssn_tax_id', '!=', False)]}"
                                     />
                     <field name="icms_tax_benefit_id" force_save="1" />
+                    <field name="icms_tax_benefit_code" force_save="1" />
+                    <field name="icms_tax_benefit_type" force_save="1" invisible="1" />
+                    <field
+                                        name="icms_tax_benefit_percent"
+                                        force_save="1"
+                                        attrs="{'invisible': [('icms_tax_benefit_type', '!=', '5')]}"
+                                    />
+
+                    <field
+                                        name="icms_tax_benefit_value"
+                                        force_save="1"
+                                        attrs="{'invisible': [('icms_tax_benefit_type', '!=', '5')]}"
+                                    />
                   </group>
                   <group>
                       <group>

--- a/l10n_br_fiscal/views/tax_definition_view.xml
+++ b/l10n_br_fiscal/views/tax_definition_view.xml
@@ -117,7 +117,10 @@
                             name="benefit_type"
                             attrs="{'required': [('is_benefit', '!=', False)]}"
                         />
-
+            <field
+                            name="presumed_credit_percent"
+                            attrs="{'invisible': [('benefit_type', '!=', '5')]}"
+                        />
           </group>
           <group name="state" string="State">
             <field

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -143,7 +143,7 @@ class NFeLine(spec_models.StackedModel):
 
     # CNPJFab TODO
 
-    nfe40_cBenef = fields.Char(related="icms_tax_benefit_code")
+    nfe40_cBenef = fields.Char()
 
     # TODO em uma importação de XML deve considerar esse campo na busca do
     # ncm_id
@@ -221,6 +221,46 @@ class NFeLine(spec_models.StackedModel):
 
         nfe40_cEAN = self.product_id.barcode or "SEM GTIN"
         export_dict["cEAN"] = export_dict["cEANTrib"] = nfe40_cEAN
+
+    #####################################################
+    # NF-e tag: gCred
+    # Grupo I05g. Grupo de informações sobre o Crédito Presumido
+    #####################################################
+
+    nfe40_gCred = fields.One2many(
+        "nfe.40.gcred",
+        "nfe40_gCred_prod_id",
+        string="Grupo de informações sobre",
+        compute="_compute_nfe40_gCred",
+    )
+
+    ##########################
+    # NF-e tag: gCred
+    # Compute Methods
+    ##########################
+
+    @api.depends(
+        "icms_tax_benefit_type",
+        "icms_tax_benefit_percent",
+        "icms_tax_benefit_value",
+        "icms_tax_benefit_code",
+    )
+    def _compute_nfe40_gCred(self):
+        for record in self:
+            record.nfe40_gCred.unlink()
+
+            if record.icms_tax_benefit_type == "5":
+                gCred_values = [
+                    {
+                        "nfe40_pCredPresumido": record.icms_tax_benefit_percent,
+                        "nfe40_vCredPresumido": record.icms_tax_benefit_value,
+                        "nfe40_cCredPresumido": record.icms_tax_benefit_code,
+                        "nfe40_gCred_prod_id": record.id,
+                    }
+                ]
+                record.nfe40_gCred = self.env["nfe.40.gcred"].create(gCred_values)
+            else:
+                record.nfe40_cBenef = record.icms_tax_benefit_code
 
     ###########################################################
     # NF-e tag: DI


### PR DESCRIPTION
Esse PR insere as tags gCred, cCredPresumido, pCredPresumido e vCredPresumido quando há um produto cujo tipo de benefício fiscal é credito presumido.