### PR TITLE
[16.0][FIX] l10n_br_account_payment_order: Teste CNAB de Alteração da Data de Vencimento de mais de 1 linha 

### DIFF
--- a/l10n_br_account_payment_order/tests/test_base_class.py
+++ b/l10n_br_account_payment_order/tests/test_base_class.py
@@ -4,7 +4,9 @@
 # @author Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from datetime import date, timedelta
+from datetime import date
+
+from dateutil.relativedelta import relativedelta
 
 from odoo.exceptions import UserError
 from odoo.fields import Date
@@ -102,7 +104,7 @@ class TestL10nBrAccountPaymentOder(TransactionCase):
         ) as f:
             f.change_type = code_to_send
             if code_to_send == "change_date_maturity":
-                new_date = date.today() + timedelta(days=40)
+                new_date = date.today() + relativedelta(years=1)
                 payment_cheque = self.env.ref(
                     "l10n_br_account_payment_order." "payment_mode_cheque"
                 )

--- a/l10n_br_account_payment_order/tests/test_payment_order_change.py
+++ b/l10n_br_account_payment_order/tests/test_payment_order_change.py
@@ -4,7 +4,9 @@
 # @author Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from datetime import date, timedelta
+from datetime import date
+
+from dateutil.relativedelta import relativedelta
 
 from odoo.tests import tagged
 
@@ -61,7 +63,7 @@ class TestPaymentOrderChange(TestL10nBrAccountPaymentOder):
     def test_change_date_maturity_multiple(self):
         """Test Creation of a Payment Order an change MULTIPLE due date"""
         date_maturity = self.financial_move_line_ids.mapped("date_maturity")
-        new_date = date.today() + timedelta(days=40)
+        new_date = date.today() + relativedelta(years=1)
         self._send_and_check_new_cnab_code(
             self.invoice_auto,
             self.financial_move_line_ids,
@@ -77,7 +79,7 @@ class TestPaymentOrderChange(TestL10nBrAccountPaymentOder):
     def test_change_date_maturity_one(self):
         """Test Creation of a Payment Order an change ONE due date"""
         date_maturity = self.financial_move_line_0.mapped("date_maturity")
-        new_date = date.today() + timedelta(days=40)
+        new_date = date.today() + relativedelta(years=1)
         self._send_and_check_new_cnab_code(
             self.invoice_auto,
             self.financial_move_line_0,


### PR DESCRIPTION
Test Due Date

Teste CNAB de Alteração da Data de Vencimento de mais de 1 linha, eu já tinha visto esse erro e buscado resolver aqui https://github.com/OCA/l10n-brazil/pull/3600 mas voltou acontecer https://github.com/OCA/l10n-brazil/pull/3632, o problema é no Teste para alterar mais de uma Data de uma vez e o que acontece e que algumas vezes e que acaba coincidindo as Datas, para buscar evitar que esse erro volte acontecer eu estou somando a **Data Atual + 1 Ano**, isso deve tornar remota a possibilidade desse problema voltar a acontecer, a conferir, nesse teste não importa se estamos alterado Dias, Meses ou Anos porque queremos apenas validar que a Alteração da Data de Vencimento esta atualizando a data na Linha/account.move.line.

 cc @OCA/local-brazil-maintainers 