### PR TITLE
[16.0][FIX+IMP] l10n_br_sale_stock: Inform Fields that should not be used from Sale 'prepare' methods, tests, FWD 3619

### DIFF
--- a/l10n_br_sale_stock/tests/test_sale_stock.py
+++ b/l10n_br_sale_stock/tests/test_sale_stock.py
@@ -512,3 +512,17 @@ class TestSaleStock(TestBrPickingInvoicingCommon):
         )
         assert down_payment_line, "Invoice without Down Payment line."
         invoice.action_post()
+
+    def test_generate_document_number_on_invoice_create_wizard(self):
+        """Test Invoicing Picking with Document Number"""
+        sale_order = self.env.ref("l10n_br_sale_stock.main_company-sale_order_1")
+        sale_order.action_confirm()
+        picking = sale_order.picking_ids
+        picking.picking_type_id.pre_generate_fiscal_document_number = "validate"
+        self.picking_move_state(picking)
+        self.assertTrue(picking.document_number)
+        invoice = self.create_invoice_wizard(picking)
+        self.assertEqual(picking.document_number, invoice.document_number)
+        self.assertEqual(
+            picking.document_number, invoice.fiscal_document_id.document_number
+        )

--- a/l10n_br_sale_stock/wizards/stock_invoice_onshipping.py
+++ b/l10n_br_sale_stock/wizards/stock_invoice_onshipping.py
@@ -7,6 +7,17 @@ from odoo import models
 class StockInvoiceOnshipping(models.TransientModel):
     _inherit = "stock.invoice.onshipping"
 
+    def _get_fields_not_used_from_sale(self):
+        """Fields not used from Sale 'prepare' method"""
+        fields_not_used = super()._get_fields_not_used_from_sale()
+        fields_not_used.update(
+            {
+                "document_number",
+                "document_serie",
+            }
+        )
+        return fields_not_used
+
     def _build_invoice_values_from_pickings(self, pickings):
         """
         Build dict to create a new invoice from given pickings


### PR DESCRIPTION
Foward Port https://github.com/OCA/l10n-brazil/pull/3619

Inform Fields that should not be used from Sale 'prepare' methods, depends https://github.com/OCA/account-invoicing/pull/1919

Permite informar campos que vêm dos métodos "prepare" do Sale e do Sale Line mas que não devem ser usados; no caso os campos **Número do Documento e Série** devido ao caso de uso onde os valores já são informados dentro do Picking.

Seria importante uma ajuda no repo do **account-invoicing** na **Revisão** de PRs relacionados ao uso aqui na Localização existe tanto esse PR que na v16 como outros que agradeço se a comunidade puder ajudar 
```bash
FWD PR similar porém na v15
https://github.com/OCA/account-invoicing/pull/1918

FWD Caso DropShipping
Algo simples mas necessário para carregar corretamente o Tipo da Invoice no caso de uso DropShipping
v15
https://github.com/OCA/account-invoicing/pull/1891
v16
https://github.com/OCA/account-invoicing/pull/1892
```

Coloquei dentro do "bash" para não marcar diretamente os PRs por não terem uma relação direta com esse PR , mas como escrevi são melhorias em módulos usados aqui.

cc @OCA/local-brazil-maintainers 
