### PR TITLE
[16.0][FIX] l10n_br_account_payment_order, l10n_br_account_payment_brcobranca: CNAB Santander 240, campos necessários para outras Instruções, FWD 3624

### DIFF
--- a/l10n_br_account_payment_brcobranca/models/account_payment_line.py
+++ b/l10n_br_account_payment_brcobranca/models/account_payment_line.py
@@ -109,6 +109,12 @@ class AccountPaymentLine(models.Model):
             linhas_pagamentos["dias_baixa"] = str(
                 cnab_config.write_off_devolution_number_of_days
             )
+            # Os dados de multa e desconto também são obrigatórios no segmento R
+            linhas_pagamentos["codigo_multa"] = cnab_config.boleto_fee_code or "0"
+            linhas_pagamentos["percentual_multa"] = cnab_config.boleto_fee_perc or 0.0
+            if self.discount_value:
+                linhas_pagamentos["data_desconto"] = self.date.strftime("%Y/%m/%d")
+                linhas_pagamentos["valor_desconto"] = self.discount_value
 
     def prepare_bank_payment_line(self, bank_name_brcobranca):
         cnab_config = self.order_id.payment_mode_id.cnab_config_id

--- a/l10n_br_account_payment_order/demo/l10n_br_cnab_config_demo.xml
+++ b/l10n_br_account_payment_order/demo/l10n_br_cnab_config_demo.xml
@@ -778,6 +778,8 @@
             ref="santander_240_boleto_write_off_devolution_3"
         />
         <field name="write_off_devolution_number_of_days">0</field>
+        <field name="boleto_fee_code">0</field>
+        <field name="boleto_fee_perc">0.00</field>
     </record>
 
     <!-- CNAB Manual Test -->


### PR DESCRIPTION
Fix cnab santander 240 r details.

Caso Santander 240 precisa informar alguns campos padrões em  **Outras Instruções além da Remessa**, mais detalhes no PR original, Foward Port https://github.com/OCA/l10n-brazil/pull/3624

cc @OCA/local-brazil-maintainers 