### PR TITLE
[16.0][FIX] l10n_br_fiscal: rename wrong ncm xmlids

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -10,7 +10,7 @@
     "maintainers": ["renatonlima"],
     "website": "https://github.com/OCA/l10n-brazil",
     "development_status": "Production/Stable",
-    "version": "16.0.2.14.0",
+    "version": "16.0.2.15.0",
     "depends": [
         "product",
         "l10n_br_base",

--- a/l10n_br_fiscal/migrations/16.0.2.15.0/pre-migration.py
+++ b/l10n_br_fiscal/migrations/16.0.2.15.0/pre-migration.py
@@ -1,0 +1,19 @@
+# Copyright 2025 Engenere - Antônio S. P. Neto.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    xmlids_renames = [
+        (
+            "l10n_br_fiscal.ncm_70200090_ P",
+            "l10n_br_fiscal.ncm_70200090_P",
+        ),
+        (
+            "l10n_br_fiscal.ncm_68159990_ P",
+            "l10n_br_fiscal.ncm_68159990_P",
+        ),
+    ]
+    openupgrade.rename_xmlids(env.cr, xmlids_renames)


### PR DESCRIPTION
Após o refatoramento dos dados de demonstração (que reabilitou a atualização dos NCMs), começou a ocorrer o seguinte erro ao tentar atualizar o módulo l10n_br_fiscal:

```
ERROR: duplicate key value violates unique constraint "l10n_br_fiscal_ncm_fiscal_ncm_code_exception_uniq"  
DETAIL: Key (code, exception)=(6815.99.90, P) already exists.

ERROR: duplicate key value violates unique constraint "l10n_br_fiscal_ncm_fiscal_ncm_code_exception_uniq"  
DETAIL: Key (code, exception)=(7020.00.90, P) already exists.
```

Originalmente, dois NCMs com XMLIDs incorretos foram corrigidos na PR [#1432](https://github.com/OCA/l10n-brazil/pull/1432), porém, naquela ocasião, faltou criar um script de migração para atualizar os XMLIDs diretamente no banco de dados.

Obs: o erro só acontece com banco de dados criados em 2021 ou antes.