### PR TITLE
[16.0][FWD+REF] l10n_br_zip: Desnecessário usar o TRY para importar Bibliotecas, FWD 2744

### DIFF
--- a/l10n_br_zip/__manifest__.py
+++ b/l10n_br_zip/__manifest__.py
@@ -21,5 +21,10 @@
     ],
     "installable": True,
     "development_status": "Mature",
-    "external_dependencies": {"python": ["brazilcep"]},
+    "external_dependencies": {
+        "python": [
+            "brazilcep",
+            "erpbrasil.base>=2.3.0",
+        ]
+    },
 }

--- a/l10n_br_zip/models/l10n_br_zip.py
+++ b/l10n_br_zip/models/l10n_br_zip.py
@@ -116,7 +116,6 @@ class L10nBrZip(models.Model):
             cep_ws_providers = {
                 "apicep": WebService.APICEP,
                 "viacep": WebService.VIACEP,
-                "correios": WebService.CORREIOS,
             }
             cep_ws_provide = str(
                 self.env["ir.config_parameter"]

--- a/l10n_br_zip/models/l10n_br_zip.py
+++ b/l10n_br_zip/models/l10n_br_zip.py
@@ -1,24 +1,12 @@
 # Copyright (C) 2012  Renato Lima (Akretion)
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-import logging
+
+from brazilcep import WebService, get_address_from_cep
+from erpbrasil.base import misc
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
-
-_logger = logging.getLogger(__name__)
-
-try:
-    from erpbrasil.base import misc
-except ImportError:
-    _logger.error("Library erpbrasil.base not installed!")
-
-_logger = logging.getLogger(__name__)
-
-try:
-    from brazilcep import WebService, get_address_from_cep
-except ImportError:
-    _logger.warning("Python Library brazilcep not installed !")
 
 
 class L10nBrZip(models.Model):


### PR DESCRIPTION
Foward Port, unnecessary try to import and remove option 'Correios' as webservice

Desnecessário usar o TRY para importar Bibliotecas, Foward Port do https://github.com/OCA/l10n-brazil/pull/2744 commit especifico https://github.com/OCA/l10n-brazil/commit/1740fc451ee476ee53769c39b3a83002f26a3ab8 , mais detalhes no PR, com isso foi incluído no manifest a dependência do erpbrasil.base.

Uma segunda mudança foi remover a opção 'Correios' como WebService isso parece complementar o PR https://github.com/OCA/l10n-brazil/pull/3169 que apesar de ter removido a opção na Configuração ainda restava no método, 
![image](https://github.com/user-attachments/assets/4c547716-024e-401c-943e-31f77d0fc18c)

Ou teria algum motivo para mante-lo? Parece que não porque o BRazilCEP não tem mais essa opção

https://github.com/mstuttgart/brazilcep

![image](https://github.com/user-attachments/assets/5e223c1f-3beb-425c-86ac-6051da12be1d)


cc @OCA/local-brazil-maintainers 