### PR TITLE
[16.0][REF] l10n_br_account_payment_order, l10n_br_account_payment_brcobranca: Alterando o 'Código de Protesto' de Char para Objeto/l10n_br_cnab.code

### DIFF
--- a/l10n_br_account_payment_brcobranca/README.rst
+++ b/l10n_br_account_payment_brcobranca/README.rst
@@ -44,8 +44,8 @@ Installation
 
 O modulo depende do:
 
-- l10n_br_account_payment_order
-- account_move_base_import
+-  l10n_br_account_payment_order
+-  account_move_base_import
 
 Configuration
 =============
@@ -58,14 +58,14 @@ Rodar a biblioteca **BRCobranca** como um micro-serviço
 Informar a variável de ambiente **BRCOBRANCA_API_URL**, existem três
 opções:
 
-- No arquivo de configuração do **Docker Compose File** na seção
-  **enviroment**, por exemplo
-  https://github.com/akretion/docky-odoo-brasil/blob/12.0/docker-compose.yml#L3
-  , incluir: **BRCOBRANCA_API_URL=http://boleto_cnab_api:9292**
-- No arquivo de Configuração do Odoo, incluir:
-  **brcobranca_api_url=http://boleto_cnab_api:9292**
-- No Odoo crie um Parâmetro de Sistema como:
-  **brcobranca_api_url=http://boleto_cnab_api:9292**
+-  No arquivo de configuração do **Docker Compose File** na seção
+   **enviroment**, por exemplo
+   https://github.com/akretion/docky-odoo-brasil/blob/12.0/docker-compose.yml#L3
+   , incluir: **BRCOBRANCA_API_URL=http://boleto_cnab_api:9292**
+-  No arquivo de Configuração do Odoo, incluir:
+   **brcobranca_api_url=http://boleto_cnab_api:9292**
+-  No Odoo crie um Parâmetro de Sistema como:
+   **brcobranca_api_url=http://boleto_cnab_api:9292**
 
 Verifique se os Códigos do CNAB do Banco que será usado existem em:
 
@@ -199,83 +199,89 @@ feito manualmente.
 Known issues / Roadmap
 ======================
 
-- Verificar a posssibilidade de Imprimir o **Boleto** pelo menu
-  **Imprimir** da Fatura, na v16 em diante.
+-  Verificar a posssibilidade de Imprimir o **Boleto** pelo menu
+   **Imprimir** da Fatura, na v16 em diante.
 
 Changelog
 =========
 
+16.0.4.0.0 (2025-03-06)
+-----------------------
+
+-  [REF] Alterado o Código de Protesto de Char para
+   Objeto/l10n_br_cnab.code
+
 16.0.3.0.0 (2024-12-16)
 -----------------------
 
-- [REF] "Foward Port" Separando as Configurações do CNAB do Modo de
-  Pagamento.
+-  [REF] "Foward Port" Separando as Configurações do CNAB do Modo de
+   Pagamento.
 
 16.0.2.0.0 (2024-12-02)
 -----------------------
 
-- [REF] "Foward Port" Unindo os Códigos CNAB em um mesmo objeto.
+-  [REF] "Foward Port" Unindo os Códigos CNAB em um mesmo objeto.
 
 16.0.1.0.0 (2024-08-22)
 -----------------------
 
-- [MIG] Migração para a versão 16.0
+-  [MIG] Migração para a versão 16.0
 
 14.0.9.0.0 (2024-09-19)
 -----------------------
 
-- [REM] Removendo Campos, Visões e Objetos obsoletos.
+-  [REM] Removendo Campos, Visões e Objetos obsoletos.
 
 14.0.8.0.0 (2024-09-18)
 -----------------------
 
-- [IMP] Possibilidade de informar Códigos de Desconto além do 0 e 1.
+-  [IMP] Possibilidade de informar Códigos de Desconto além do 0 e 1.
 
 14.0.7.0.0 (2024-09-13)
 -----------------------
 
-- [REF] Separando as Configurações do CNAB do Modo de Pagamento.
+-  [REF] Separando as Configurações do CNAB do Modo de Pagamento.
 
 14.0.6.0.0 (2024-09-10)
 -----------------------
 
-- [REF] Unindo os Códigos CNAB em um mesmo objeto.
+-  [REF] Unindo os Códigos CNAB em um mesmo objeto.
 
 14.0.1.0.0 (2022-05-26)
 -----------------------
 
-- [MIG] Migration
+-  [MIG] Migration
 
 12.0.1.0.0 (2021-05-07)
 -----------------------
 
-- [MIG] Finish migration
-- [IMP] Integrate with module account_move_base_import used to import
-  CNAB file
-- [IMP] Make possible automatic reconciliation and register the values
-  of Fees, Tariff Bank, Rebate in configured accounts.
+-  [MIG] Finish migration
+-  [IMP] Integrate with module account_move_base_import used to import
+   CNAB file
+-  [IMP] Make possible automatic reconciliation and register the values
+   of Fees, Tariff Bank, Rebate in configured accounts.
 
 12.0.1.0.0 (2020-06-12)
 -----------------------
 
-- [MIG] Start Migration
+-  [MIG] Start Migration
 
 10.0.1.0.0 (2019-05-30)
 -----------------------
 
-- [MIG] Migration
+-  [MIG] Migration
 
 8.0.1.0.0 (2018-01-29)
 ----------------------
 
-- [REF] Maked functional to print Boleto, create CNAB file and import
-  CNAB as Extrat Bank the user should be resolved manully the
-  divergences between the values( Fee, Tariff Bank, Rebate, etc).
+-  [REF] Maked functional to print Boleto, create CNAB file and import
+   CNAB as Extrat Bank the user should be resolved manully the
+   divergences between the values( Fee, Tariff Bank, Rebate, etc).
 
 8.0.1.0.0 (2017-07-01)
 ----------------------
 
-- [NEW] First version
+-  [NEW] First version
 
 Bug Tracker
 ===========
@@ -298,21 +304,21 @@ Authors
 Contributors
 ------------
 
-- `Akretion <https://akretion.com/pt-BR>`__:
+-  `Akretion <https://akretion.com/pt-BR>`__:
 
-  - Raphaël Valyi <raphael.valyi@akretion.com.br>
-  - Magno Costa <magno.costa@akretion.com.br>
+   -  Raphaël Valyi <raphael.valyi@akretion.com.br>
+   -  Magno Costa <magno.costa@akretion.com.br>
 
-- `Engenere <https://engenere.one>`__:
+-  `Engenere <https://engenere.one>`__:
 
-  - Antônio S. Pereira Neto <neto@engenere.one>
+   -  Antônio S. Pereira Neto <neto@engenere.one>
 
 Other credits
 -------------
 
 The development of this module has been financially supported by:
 
-- AKRETION LTDA - https://akretion.com/pt-BR
+-  AKRETION LTDA - https://akretion.com/pt-BR
 
 Maintainers
 -----------

--- a/l10n_br_account_payment_brcobranca/__manifest__.py
+++ b/l10n_br_account_payment_brcobranca/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Boletos e CNAB de cobrança",
     "summary": "receivable Boletos and CNAB using the BRCobranca lib",
-    "version": "16.0.3.2.0",
+    "version": "16.0.4.0.0",
     "license": "AGPL-3",
     "author": "Akretion, Odoo Community Association (OCA)",
     "maintainers": ["rvalyi", "mbcosta"],

--- a/l10n_br_account_payment_brcobranca/models/account_payment_line.py
+++ b/l10n_br_account_payment_brcobranca/models/account_payment_line.py
@@ -22,7 +22,9 @@ class AccountPaymentLine(models.Model):
         #  Isso deveria ser feito para o CNAB de outros Bancos ?
         #  Na criação dos campos houve a opção de deixa-los com o tipo
         #  CHAR ao invês de Selection por essa falta de padrão.
-        linhas_pagamentos["codigo_protesto"] = cnab_config.boleto_protest_code or "3"
+        linhas_pagamentos["codigo_protesto"] = (
+            cnab_config.boleto_protest_code_id.code or "3"
+        )
         linhas_pagamentos["dias_protesto"] = cnab_config.boleto_days_protest or "0"
 
         # Código adotado pela FEBRABAN para identificação
@@ -48,7 +50,7 @@ class AccountPaymentLine(models.Model):
     def _prepare_cod_primeira_instrucao_protest(self, cnab_config, linhas_pagamentos):
         if self.instruction_move_code_id.code == cnab_config.sending_code_id.code:
             linhas_pagamentos["cod_primeira_instrucao"] = (
-                cnab_config.boleto_protest_code or "00"
+                cnab_config.boleto_protest_code_id.code or "00"
             )
 
     def _prepare_bank_line_itau(self, cnab_config, linhas_pagamentos):
@@ -165,8 +167,10 @@ class AccountPaymentLine(models.Model):
                 linhas_pagamentos["valor_desconto"] = self.discount_value
 
             # Protesto
-            if cnab_config.boleto_protest_code:
-                linhas_pagamentos["codigo_protesto"] = cnab_config.boleto_protest_code
+            if cnab_config.boleto_protest_code_id:
+                linhas_pagamentos[
+                    "codigo_protesto"
+                ] = cnab_config.boleto_protest_code_id.code
                 if cnab_config.boleto_days_protest:
                     linhas_pagamentos["dias_protesto"] = cnab_config.boleto_days_protest
 

--- a/l10n_br_account_payment_brcobranca/readme/HISTORY.md
+++ b/l10n_br_account_payment_brcobranca/readme/HISTORY.md
@@ -1,3 +1,7 @@
+## 16.0.4.0.0 (2025-03-06)
+
+- \[REF\] Alterado o Código de Protesto de Char para Objeto/l10n_br_cnab.code
+
 ## 16.0.3.0.0 (2024-12-16)
 
 - \[REF\] "Foward Port" Separando as Configurações do CNAB do Modo de Pagamento.

--- a/l10n_br_account_payment_brcobranca/static/description/index.html
+++ b/l10n_br_account_payment_brcobranca/static/description/index.html
@@ -383,27 +383,28 @@ Micro-Serviço
 <li><a class="reference internal" href="#usage" id="toc-entry-3">Usage</a></li>
 <li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-4">Known issues / Roadmap</a></li>
 <li><a class="reference internal" href="#changelog" id="toc-entry-5">Changelog</a><ul>
-<li><a class="reference internal" href="#section-1" id="toc-entry-6">16.0.3.0.0 (2024-12-16)</a></li>
-<li><a class="reference internal" href="#section-2" id="toc-entry-7">16.0.2.0.0 (2024-12-02)</a></li>
-<li><a class="reference internal" href="#section-3" id="toc-entry-8">16.0.1.0.0 (2024-08-22)</a></li>
-<li><a class="reference internal" href="#section-4" id="toc-entry-9">14.0.9.0.0 (2024-09-19)</a></li>
-<li><a class="reference internal" href="#section-5" id="toc-entry-10">14.0.8.0.0 (2024-09-18)</a></li>
-<li><a class="reference internal" href="#section-6" id="toc-entry-11">14.0.7.0.0 (2024-09-13)</a></li>
-<li><a class="reference internal" href="#section-7" id="toc-entry-12">14.0.6.0.0 (2024-09-10)</a></li>
-<li><a class="reference internal" href="#section-8" id="toc-entry-13">14.0.1.0.0 (2022-05-26)</a></li>
-<li><a class="reference internal" href="#section-9" id="toc-entry-14">12.0.1.0.0 (2021-05-07)</a></li>
-<li><a class="reference internal" href="#section-10" id="toc-entry-15">12.0.1.0.0 (2020-06-12)</a></li>
-<li><a class="reference internal" href="#section-11" id="toc-entry-16">10.0.1.0.0 (2019-05-30)</a></li>
-<li><a class="reference internal" href="#section-12" id="toc-entry-17">8.0.1.0.0 (2018-01-29)</a></li>
-<li><a class="reference internal" href="#section-13" id="toc-entry-18">8.0.1.0.0 (2017-07-01)</a></li>
+<li><a class="reference internal" href="#section-1" id="toc-entry-6">16.0.4.0.0 (2025-03-06)</a></li>
+<li><a class="reference internal" href="#section-2" id="toc-entry-7">16.0.3.0.0 (2024-12-16)</a></li>
+<li><a class="reference internal" href="#section-3" id="toc-entry-8">16.0.2.0.0 (2024-12-02)</a></li>
+<li><a class="reference internal" href="#section-4" id="toc-entry-9">16.0.1.0.0 (2024-08-22)</a></li>
+<li><a class="reference internal" href="#section-5" id="toc-entry-10">14.0.9.0.0 (2024-09-19)</a></li>
+<li><a class="reference internal" href="#section-6" id="toc-entry-11">14.0.8.0.0 (2024-09-18)</a></li>
+<li><a class="reference internal" href="#section-7" id="toc-entry-12">14.0.7.0.0 (2024-09-13)</a></li>
+<li><a class="reference internal" href="#section-8" id="toc-entry-13">14.0.6.0.0 (2024-09-10)</a></li>
+<li><a class="reference internal" href="#section-9" id="toc-entry-14">14.0.1.0.0 (2022-05-26)</a></li>
+<li><a class="reference internal" href="#section-10" id="toc-entry-15">12.0.1.0.0 (2021-05-07)</a></li>
+<li><a class="reference internal" href="#section-11" id="toc-entry-16">12.0.1.0.0 (2020-06-12)</a></li>
+<li><a class="reference internal" href="#section-12" id="toc-entry-17">10.0.1.0.0 (2019-05-30)</a></li>
+<li><a class="reference internal" href="#section-13" id="toc-entry-18">8.0.1.0.0 (2018-01-29)</a></li>
+<li><a class="reference internal" href="#section-14" id="toc-entry-19">8.0.1.0.0 (2017-07-01)</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-19">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-20">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-21">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-22">Contributors</a></li>
-<li><a class="reference internal" href="#other-credits" id="toc-entry-23">Other credits</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-24">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-20">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-21">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-22">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-23">Contributors</a></li>
+<li><a class="reference internal" href="#other-credits" id="toc-entry-24">Other credits</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-25">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -541,56 +542,63 @@ feito manualmente.</p>
 <div class="section" id="changelog">
 <h1><a class="toc-backref" href="#toc-entry-5">Changelog</a></h1>
 <div class="section" id="section-1">
-<h2><a class="toc-backref" href="#toc-entry-6">16.0.3.0.0 (2024-12-16)</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">16.0.4.0.0 (2025-03-06)</a></h2>
+<ul class="simple">
+<li>[REF] Alterado o Código de Protesto de Char para
+Objeto/l10n_br_cnab.code</li>
+</ul>
+</div>
+<div class="section" id="section-2">
+<h2><a class="toc-backref" href="#toc-entry-7">16.0.3.0.0 (2024-12-16)</a></h2>
 <ul class="simple">
 <li>[REF] “Foward Port” Separando as Configurações do CNAB do Modo de
 Pagamento.</li>
 </ul>
 </div>
-<div class="section" id="section-2">
-<h2><a class="toc-backref" href="#toc-entry-7">16.0.2.0.0 (2024-12-02)</a></h2>
+<div class="section" id="section-3">
+<h2><a class="toc-backref" href="#toc-entry-8">16.0.2.0.0 (2024-12-02)</a></h2>
 <ul class="simple">
 <li>[REF] “Foward Port” Unindo os Códigos CNAB em um mesmo objeto.</li>
 </ul>
 </div>
-<div class="section" id="section-3">
-<h2><a class="toc-backref" href="#toc-entry-8">16.0.1.0.0 (2024-08-22)</a></h2>
+<div class="section" id="section-4">
+<h2><a class="toc-backref" href="#toc-entry-9">16.0.1.0.0 (2024-08-22)</a></h2>
 <ul class="simple">
 <li>[MIG] Migração para a versão 16.0</li>
 </ul>
 </div>
-<div class="section" id="section-4">
-<h2><a class="toc-backref" href="#toc-entry-9">14.0.9.0.0 (2024-09-19)</a></h2>
+<div class="section" id="section-5">
+<h2><a class="toc-backref" href="#toc-entry-10">14.0.9.0.0 (2024-09-19)</a></h2>
 <ul class="simple">
 <li>[REM] Removendo Campos, Visões e Objetos obsoletos.</li>
 </ul>
 </div>
-<div class="section" id="section-5">
-<h2><a class="toc-backref" href="#toc-entry-10">14.0.8.0.0 (2024-09-18)</a></h2>
+<div class="section" id="section-6">
+<h2><a class="toc-backref" href="#toc-entry-11">14.0.8.0.0 (2024-09-18)</a></h2>
 <ul class="simple">
 <li>[IMP] Possibilidade de informar Códigos de Desconto além do 0 e 1.</li>
 </ul>
 </div>
-<div class="section" id="section-6">
-<h2><a class="toc-backref" href="#toc-entry-11">14.0.7.0.0 (2024-09-13)</a></h2>
+<div class="section" id="section-7">
+<h2><a class="toc-backref" href="#toc-entry-12">14.0.7.0.0 (2024-09-13)</a></h2>
 <ul class="simple">
 <li>[REF] Separando as Configurações do CNAB do Modo de Pagamento.</li>
 </ul>
 </div>
-<div class="section" id="section-7">
-<h2><a class="toc-backref" href="#toc-entry-12">14.0.6.0.0 (2024-09-10)</a></h2>
+<div class="section" id="section-8">
+<h2><a class="toc-backref" href="#toc-entry-13">14.0.6.0.0 (2024-09-10)</a></h2>
 <ul class="simple">
 <li>[REF] Unindo os Códigos CNAB em um mesmo objeto.</li>
 </ul>
 </div>
-<div class="section" id="section-8">
-<h2><a class="toc-backref" href="#toc-entry-13">14.0.1.0.0 (2022-05-26)</a></h2>
+<div class="section" id="section-9">
+<h2><a class="toc-backref" href="#toc-entry-14">14.0.1.0.0 (2022-05-26)</a></h2>
 <ul class="simple">
 <li>[MIG] Migration</li>
 </ul>
 </div>
-<div class="section" id="section-9">
-<h2><a class="toc-backref" href="#toc-entry-14">12.0.1.0.0 (2021-05-07)</a></h2>
+<div class="section" id="section-10">
+<h2><a class="toc-backref" href="#toc-entry-15">12.0.1.0.0 (2021-05-07)</a></h2>
 <ul class="simple">
 <li>[MIG] Finish migration</li>
 <li>[IMP] Integrate with module account_move_base_import used to import
@@ -599,35 +607,35 @@ CNAB file</li>
 of Fees, Tariff Bank, Rebate in configured accounts.</li>
 </ul>
 </div>
-<div class="section" id="section-10">
-<h2><a class="toc-backref" href="#toc-entry-15">12.0.1.0.0 (2020-06-12)</a></h2>
+<div class="section" id="section-11">
+<h2><a class="toc-backref" href="#toc-entry-16">12.0.1.0.0 (2020-06-12)</a></h2>
 <ul class="simple">
 <li>[MIG] Start Migration</li>
 </ul>
 </div>
-<div class="section" id="section-11">
-<h2><a class="toc-backref" href="#toc-entry-16">10.0.1.0.0 (2019-05-30)</a></h2>
+<div class="section" id="section-12">
+<h2><a class="toc-backref" href="#toc-entry-17">10.0.1.0.0 (2019-05-30)</a></h2>
 <ul class="simple">
 <li>[MIG] Migration</li>
 </ul>
 </div>
-<div class="section" id="section-12">
-<h2><a class="toc-backref" href="#toc-entry-17">8.0.1.0.0 (2018-01-29)</a></h2>
+<div class="section" id="section-13">
+<h2><a class="toc-backref" href="#toc-entry-18">8.0.1.0.0 (2018-01-29)</a></h2>
 <ul class="simple">
 <li>[REF] Maked functional to print Boleto, create CNAB file and import
 CNAB as Extrat Bank the user should be resolved manully the
 divergences between the values( Fee, Tariff Bank, Rebate, etc).</li>
 </ul>
 </div>
-<div class="section" id="section-13">
-<h2><a class="toc-backref" href="#toc-entry-18">8.0.1.0.0 (2017-07-01)</a></h2>
+<div class="section" id="section-14">
+<h2><a class="toc-backref" href="#toc-entry-19">8.0.1.0.0 (2017-07-01)</a></h2>
 <ul class="simple">
 <li>[NEW] First version</li>
 </ul>
 </div>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-19">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-20">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/l10n-brazil/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -635,15 +643,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-20">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-21">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-21">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-22">Authors</a></h2>
 <ul class="simple">
 <li>Akretion</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-22">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-23">Contributors</a></h2>
 <ul class="simple">
 <li><a class="reference external" href="https://akretion.com/pt-BR">Akretion</a>:<ul>
 <li>Raphaël Valyi &lt;<a class="reference external" href="mailto:raphael.valyi&#64;akretion.com.br">raphael.valyi&#64;akretion.com.br</a>&gt;</li>
@@ -657,14 +665,14 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="other-credits">
-<h2><a class="toc-backref" href="#toc-entry-23">Other credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-24">Other credits</a></h2>
 <p>The development of this module has been financially supported by:</p>
 <ul class="simple">
 <li>AKRETION LTDA - <a class="reference external" href="https://akretion.com/pt-BR">https://akretion.com/pt-BR</a></li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-24">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-25">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/l10n_br_account_payment_order/README.rst
+++ b/l10n_br_account_payment_order/README.rst
@@ -31,30 +31,31 @@ Brazilian Payment Order
 O módulo implementa a parte comum da infra-estrutura necessária para o
 uso do CNAB implementando:
 
-- **Códigos CNAB** - códigos de Instrução, Retorno, Carteira e Desconto.
+-  **Códigos CNAB** - códigos de Instrução, Retorno, Carteira e
+   Desconto.
 
-- **Configuração CNAB** - onde serão salvas as informações específicas
-  de cada caso como Convênio, Código do Beneficiário, Modalidade,
-  Percentual de Multa, códigos de Instrução do Movimento de Liquidação
-  de Alteração de Vencimento e etc.
+-  **Configuração CNAB** - onde serão salvas as informações específicas
+   de cada caso como Convênio, Código do Beneficiário, Modalidade,
+   Percentual de Multa, códigos de Instrução do Movimento de Liquidação
+   de Alteração de Vencimento e etc.
 
-- **Modo de Pagamento** - localiza o módulo
-  `account_payment_mode <https://github.com/OCA/bank-payment/tree/16.0/account_payment_mode>`__
-  para associar o **Diário Contábil** referente a **Conta Bancária** do
-  CNAB e informar a **Configuração do CNAB** que será usada, assim ao
-  informar o Modo de Pagamento em um Pedido de Venda, Compras ou
-  Faturamento o programa identifica como sendo um caso CNAB.
+-  **Modo de Pagamento** - localiza o módulo
+   `account_payment_mode <https://github.com/OCA/bank-payment/tree/16.0/account_payment_mode>`__
+   para associar o **Diário Contábil** referente a **Conta Bancária** do
+   CNAB e informar a **Configuração do CNAB** que será usada, assim ao
+   informar o Modo de Pagamento em um Pedido de Venda, Compras ou
+   Faturamento o programa identifica como sendo um caso CNAB.
 
-- **Ordem de Pagamento** - localiza o módulo
-  `account_payment_order <https://github.com/OCA/bank-payment/tree/16.0/account_payment_order>`__
-  que usa a **Ordem de Pagamento**, débito ou crédito, para registrar as
-  **Instruções de Movimento** e onde será criado o **Arquivo CNAB
-  Remessa**.
+-  **Ordem de Pagamento** - localiza o módulo
+   `account_payment_order <https://github.com/OCA/bank-payment/tree/16.0/account_payment_order>`__
+   que usa a **Ordem de Pagamento**, débito ou crédito, para registrar
+   as **Instruções de Movimento** e onde será criado o **Arquivo CNAB
+   Remessa**.
 
-- **Registro do LOG de Eventos** - ao importar um arquivo de retorno
-  CNAB.
+-  **Registro do LOG de Eventos** - ao importar um arquivo de retorno
+   CNAB.
 
-- **Grupos e Permissões de acesso** - CNAB Usuário e Gerente.
+-  **Grupos e Permissões de acesso** - CNAB Usuário e Gerente.
 
 A implementação foi pensada para permitir que seja possível usar
 diferentes Bibliotecas para **Gerar os Boletos, Arquivo CNAB de Remessa
@@ -86,10 +87,10 @@ Installation
 
 Este módulo depende do:
 
-- l10n_br_base
-- account_payment_order
-- account_due_list
-- account_cancel
+-  l10n_br_base
+-  account_payment_order
+-  account_due_list
+-  account_cancel
 
 Configuration
 =============
@@ -201,150 +202,158 @@ a ser utilizada.
 Known issues / Roadmap
 ======================
 
-- Verificar a questão do campos **many2many** que não estão sendo
-  registrados pelo **track_visibility** e se será incluída a dependência
-  do módulo
-  `mail_improved_tracking_value <https://github.com/OCA/social/tree/16.0/mail_improved_tracking_value>`__.
-- Processo de Alteração de Carteira, falta informações sobre o processo.
-- Mapear e incluir os Códigos dos Bancos CNAB 240/400, aqui devido a
-  quantidade de possibilidades se trata de um "roadmap" constante onde
-  contamos com PRs de outros contribuidores que irão implementar um caso
-  que ainda não esteja cadastrado, apesar do código permitir que o
-  cadastro seja feito na tela nesses casos.
-- Processo de "Antecipação do Título junto ao Banco" ou "Venda do Título
-  junto a Factoring" ver as alterações feitas na v14 em diante
-  https://www.odoo.com/pt_BR/forum/ajuda-1/v14-change-in-payment-behavior-how-do-the-suspense-and-outstanding-payment-accounts-change-the-journal-entries-posted-177592.
-- CNAB de Pagamento, verificar a integração com o PR
-  https://github.com/OCA/l10n-brazil/pull/972 e a possibilidade de
-  múltiplos **Modos de Pagamento** na mesma **Ordem de Pagamento**
-  https://github.com/odoo-brazil/l10n-brazil/pull/112
-- Verificar a possibilidade na v16 em diante de remoção do
-  **ondele='restrict'** no campo "move_line_id" e o campo "related"
-  "ml_maturity_date" do **account.payment.line** no módulo dependente
-  https://github.com/OCA/bank-payment/blob/16.0/account_payment_order/models/account_payment_line.py#L39
-  para permitir o processo de **Cancelamento de uma Fatura** quando
-  existe uma **Ordem de Pagamento** já Confirmada/Gerada/Enviada
-  (detalhes
-  l10n_br_account_payment_order/models/account_payment_line.py#L130)
-- Confirmar se existem Bancos que usam os mesmos conjuntos de Códigos
-  CNAB de Instrução e Retorno para caso não existir remover o
-  **many2many** do Banco e deixar apenas o **many2one**.
-- Verificar a possibilidade de usar o objeto **account.payment** no caso
-  CNAB e o módulo
-  https://github.com/OCA/bank-payment/tree/16.0/account_payment_order_return
-  para tratar o **LOG de Retorno do CNAB, RFC**
-  https://github.com/OCA/l10n-brazil/issues/2272.
+-  Verificar a questão do campos **many2many** que não estão sendo
+   registrados pelo **track_visibility** e se será incluída a
+   dependência do módulo
+   `mail_improved_tracking_value <https://github.com/OCA/social/tree/16.0/mail_improved_tracking_value>`__.
+-  Processo de Alteração de Carteira, falta informações sobre o
+   processo.
+-  Mapear e incluir os Códigos dos Bancos CNAB 240/400, aqui devido a
+   quantidade de possibilidades se trata de um "roadmap" constante onde
+   contamos com PRs de outros contribuidores que irão implementar um
+   caso que ainda não esteja cadastrado, apesar do código permitir que o
+   cadastro seja feito na tela nesses casos.
+-  Processo de "Antecipação do Título junto ao Banco" ou "Venda do
+   Título junto a Factoring" ver as alterações feitas na v14 em diante
+   https://www.odoo.com/pt_BR/forum/ajuda-1/v14-change-in-payment-behavior-how-do-the-suspense-and-outstanding-payment-accounts-change-the-journal-entries-posted-177592.
+-  CNAB de Pagamento, verificar a integração com o PR
+   https://github.com/OCA/l10n-brazil/pull/972 e a possibilidade de
+   múltiplos **Modos de Pagamento** na mesma **Ordem de Pagamento**
+   https://github.com/odoo-brazil/l10n-brazil/pull/112
+-  Verificar a possibilidade na v16 em diante de remoção do
+   **ondele='restrict'** no campo "move_line_id" e o campo "related"
+   "ml_maturity_date" do **account.payment.line** no módulo dependente
+   https://github.com/OCA/bank-payment/blob/16.0/account_payment_order/models/account_payment_line.py#L39
+   para permitir o processo de **Cancelamento de uma Fatura** quando
+   existe uma **Ordem de Pagamento** já Confirmada/Gerada/Enviada
+   (detalhes
+   l10n_br_account_payment_order/models/account_payment_line.py#L130)
+-  Confirmar se existem Bancos que usam os mesmos conjuntos de Códigos
+   CNAB de Instrução e Retorno para caso não existir remover o
+   **many2many** do Banco e deixar apenas o **many2one**.
+-  Verificar a possibilidade de usar o objeto **account.payment** no
+   caso CNAB e o módulo
+   https://github.com/OCA/bank-payment/tree/16.0/account_payment_order_return
+   para tratar o **LOG de Retorno do CNAB, RFC**
+   https://github.com/OCA/l10n-brazil/issues/2272.
 
 Changelog
 =========
 
+16.0.6.0.0 (2024-03-06)
+-----------------------
+
+-  [REF] Alterado o Código de Protesto de Char para
+   Objeto/l10n_br_cnab.code
+
 16.0.5.0.0 (2024-12-16)
 -----------------------
 
-- [REM] "Foward Port" Removendo Campos, Visões e Objetos obsoletos.
+-  [REM] "Foward Port" Removendo Campos, Visões e Objetos obsoletos.
 
 16.0.4.0.0 (2024-12-16)
 -----------------------
 
-- [IMP] "Foward Port" Possibilidade de informar Códigos de Desconto além
-  do 0 e 1.
+-  [IMP] "Foward Port" Possibilidade de informar Códigos de Desconto
+   além do 0 e 1.
 
 16.0.3.0.0 (2024-12-16)
 -----------------------
 
-- [REF] "Foward-Port" Separando as Configurações do CNAB do Modo de
-  Pagamento.
+-  [REF] "Foward-Port" Separando as Configurações do CNAB do Modo de
+   Pagamento.
 
 16.0.2.0.0 (2024-12-04)
 -----------------------
 
-- [REF] "Foward-Port" Unindo os Códigos CNAB em um mesmo objeto.
+-  [REF] "Foward-Port" Unindo os Códigos CNAB em um mesmo objeto.
 
 16.0.1.0.0 (2024-09-10)
 -----------------------
 
-- [MIG] Migração para a versão 16.0
+-  [MIG] Migração para a versão 16.0
 
 15.0.1.0.0 (2024-07-25)
 -----------------------
 
-- [MIG] Migração para a versão 15.0
+-  [MIG] Migração para a versão 15.0
 
 14.0.9.0.0 (2024-09-19)
 -----------------------
 
-- [REM] Removendo Campos, Visões e Objetos obsoletos.
+-  [REM] Removendo Campos, Visões e Objetos obsoletos.
 
 14.0.8.0.0 (2024-09-18)
 -----------------------
 
-- [IMP] Possibilidade de informar Códigos de Desconto além do 0 e 1.
+-  [IMP] Possibilidade de informar Códigos de Desconto além do 0 e 1.
 
 14.0.7.0.0 (2024-09-13)
 -----------------------
 
-- [REF] Separando as Configurações do CNAB do Modo de Pagamento.
+-  [REF] Separando as Configurações do CNAB do Modo de Pagamento.
 
 14.0.6.0.0 (2024-09-10)
 -----------------------
 
-- [REF] Unindo os Códigos CNAB em um mesmo objeto.
+-  [REF] Unindo os Códigos CNAB em um mesmo objeto.
 
 14.0.1.0.0 (2022-04-29)
 -----------------------
 
-- [MIG] Migração para a versão 14.0.
+-  [MIG] Migração para a versão 14.0.
 
 13.0.1.0.0 (2022-01-28)
 -----------------------
 
-- [MIG] Migração para a versão 13.0.
+-  [MIG] Migração para a versão 13.0.
 
 12.0.3.0.0 (2021-05-13)
 -----------------------
 
-- [MIG] Migração para a versão 12.0.
-- Incluído a possibilidade de parametrizar o CNAB 240 e 400, devido a
-  falta de padrão cada Banco e CNAB podem ter e usar codigos diferentes.
-- Incluído os metodos para fazer alterações em CNAB já enviados.
-- Incluído dados de demo e testes.
-- Separado o objeto que fazia o Retorno do arquivo e registrava as
-  informações para ter um objeto especifico que registra o Log e assim
-  os modulos que implementam a biblioteca escolhida podem ter um
-  metodo/objeto especifico para essa função.
+-  [MIG] Migração para a versão 12.0.
+-  Incluído a possibilidade de parametrizar o CNAB 240 e 400, devido a
+   falta de padrão cada Banco e CNAB podem ter e usar codigos
+   diferentes.
+-  Incluído os metodos para fazer alterações em CNAB já enviados.
+-  Incluído dados de demo e testes.
+-  Separado o objeto que fazia o Retorno do arquivo e registrava as
+   informações para ter um objeto especifico que registra o Log e assim
+   os modulos que implementam a biblioteca escolhida podem ter um
+   metodo/objeto especifico para essa função.
 
 12.0.1.0.0 (2019-06-06)
 -----------------------
 
-- [MIG] Inicio da Migração para a versão 12.0.
+-  [MIG] Inicio da Migração para a versão 12.0.
 
 10.0.2.0.0 (2018-05-17)
 -----------------------
 
-- [REF] Modulo unido com o l10n_br_account_payment_mode e renomeado para
-  l10n_br_account_payment_order.
+-  [REF] Modulo unido com o l10n_br_account_payment_mode e renomeado
+   para l10n_br_account_payment_order.
 
 10.0.1.0.0 (2018-08-29)
 -----------------------
 
-- [MIG] Migração para a versão 10.
+-  [MIG] Migração para a versão 10.
 
 8.0.1.0.1 (2017-07-14)
 ----------------------
 
-- [NEW] Refatoração e melhorias para suportar a geração de boletos
-  através do br-cobranca (ruby)
+-  [NEW] Refatoração e melhorias para suportar a geração de boletos
+   através do br-cobranca (ruby)
 
 8.0.1.0.0 (2017-07-14)
 ----------------------
 
-- [NEW] Melhorias para suportar a geração de pagamento da folha de
-  pagamento;
+-  [NEW] Melhorias para suportar a geração de pagamento da folha de
+   pagamento;
 
 8.0.0.0.0 (2016-01-18)
 ----------------------
 
-- [NEW] Primeira versão
+-  [NEW] Primeira versão
 
 Bug Tracker
 ===========
@@ -368,31 +377,31 @@ Authors
 Contributors
 ------------
 
-- `KMEE <https://www.kmee.com.br>`__:
+-  `KMEE <https://www.kmee.com.br>`__:
 
-  - Luis Felipe Mileo <mileo@kmee.com.br>
-  - Fernando Marcato
-  - Hendrix Costa <hendrix.costa@kmee.com.br>
+   -  Luis Felipe Mileo <mileo@kmee.com.br>
+   -  Fernando Marcato
+   -  Hendrix Costa <hendrix.costa@kmee.com.br>
 
-- `Akretion <https://www.akretion.com/pt-BR>`__:
+-  `Akretion <https://www.akretion.com/pt-BR>`__:
 
-  - Magno Costa <magno.costa@akretion.com.br>
+   -  Magno Costa <magno.costa@akretion.com.br>
 
-- `Engenere <https://engenere.one>`__:
+-  `Engenere <https://engenere.one>`__:
 
-  - Antônio S. Pereira Neto <neto@engenere.one>
+   -  Antônio S. Pereira Neto <neto@engenere.one>
 
-- `Escodoo <https://www.escodoo.com.br>`__:
+-  `Escodoo <https://www.escodoo.com.br>`__:
 
-  - Marcel Savegnago <marcel.savegnago@escodoo.com.br>
+   -  Marcel Savegnago <marcel.savegnago@escodoo.com.br>
 
 Other credits
 -------------
 
 The development of this module has been financially supported by:
 
-- KMEE INFORMATICA LTDA - `www.kmee.com.br <http://www.kmee.com.br>`__
-- AKRETION LTDA - `www.akretion.com <http://www.akretion.com>`__
+-  KMEE INFORMATICA LTDA - `www.kmee.com.br <http://www.kmee.com.br>`__
+-  AKRETION LTDA - `www.akretion.com <http://www.akretion.com>`__
 
 Maintainers
 -----------

--- a/l10n_br_account_payment_order/__manifest__.py
+++ b/l10n_br_account_payment_order/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Brazilian Payment Order",
-    "version": "16.0.5.3.0",
+    "version": "16.0.6.0.0",
     "license": "AGPL-3",
     "author": "KMEE, Akretion, Odoo Community Association (OCA)",
     "maintainers": ["mbcosta"],
@@ -46,6 +46,14 @@
         "data/cnab_codes/banco_unicred_240_400_boleto_discount_code.xml",
         # Boleto Write Off Devolution
         "data/cnab_codes/banco_santander_240_boleto_write_off_devolution.xml",
+        # Protest code
+        "data/cnab_codes/banco_ailos_240_boleto_protest_code.xml",
+        "data/cnab_codes/banco_bradesco_240_boleto_protest_code.xml",
+        "data/cnab_codes/banco_cef_240_boleto_protest_code.xml",
+        "data/cnab_codes/banco_itau_240_boleto_protest_code.xml",
+        "data/cnab_codes/banco_santander_240_boleto_protest_code.xml",
+        "data/cnab_codes/banco_sicred_240_boleto_protest_code.xml",
+        "data/cnab_codes/banco_unicred_240_400_boleto_protest_code.xml",
         # Wizards
         "wizards/account_payment_line_create_view.xml",
         "wizards/account_move_line_change.xml",

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_ailos_240_boleto_protest_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_ailos_240_boleto_protest_code.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright (C) 2025-Today - Akretion (<http://www.akretion.com>).
+  @author Magno Costa <magno.costa@akretion.com.br>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo noupdate="1">
+
+    <!-- Código de Protesto Banco AILOS -->
+    <record id="ailos_240_boleto_protest_code_1" model="l10n_br_cnab.code">
+        <field
+            name="name"
+        >Protestar Dias Corridos (No Sistema Ailos o prazo para protesto é de 05 a 15).</field>
+        <field name="code">1</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+        <field
+            name="comment"
+        >Particularidade: No Estado do Mato Grosso do Sul os boletos só podem ser enviados para Serasa decorridos 45 dias de seu vencimento.</field>
+    </record>
+
+    <record id="ailos_240_boleto_protest_code_2" model="l10n_br_cnab.code">
+        <field
+            name="name"
+        >Negativação de boletos via Serasa (No Sistema Ailos o prazo para protesto é de 05 a 15).</field>
+        <field name="code">2</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+        <field
+            name="comment"
+        >Particularidade: No Estado do Mato Grosso do Sul os boletos só podem ser enviados para Serasa decorridos 45 dias de seu vencimento.</field>
+    </record>
+
+    <record id="ailos_240_boleto_protest_code_3" model="l10n_br_cnab.code">
+        <field name="name">Não Protestar / Não Negativar</field>
+        <field name="code">3</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+</odoo>

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_bradesco_240_boleto_protest_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_bradesco_240_boleto_protest_code.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright (C) 2025-Today - Akretion (<http://www.akretion.com>).
+  @author Magno Costa <magno.costa@akretion.com.br>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo noupdate="1">
+
+    <!-- Código de Protesto Banco Bradesco -->
+    <!-- 240 -->
+    <record id="bradesco_240_boleto_protest_code_1" model="l10n_br_cnab.code">
+        <field name="name">Protestar Dias Corridos</field>
+        <field name="code">1</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+    <record id="bradesco_240_boleto_protest_code_2" model="l10n_br_cnab.code">
+        <field name="name">Protestar Dias Úteis</field>
+        <field name="code">2</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+    <record id="bradesco_240_boleto_protest_code_3" model="l10n_br_cnab.code">
+        <field name="name">Não Protestar</field>
+        <field name="code">3</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+    <record id="bradesco_240_boleto_protest_code_4" model="l10n_br_cnab.code">
+        <field name="name">Protestar Fim Falimentar - Dias Úteis</field>
+        <field name="code">4</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+    <record id="bradesco_240_boleto_protest_code_5" model="l10n_br_cnab.code">
+        <field name="name">Protestar Fim Falimentar - Dias Corridos</field>
+        <field name="code">5</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+    <record id="bradesco_240_boleto_protest_code_8" model="l10n_br_cnab.code">
+        <field name="name">Negativação sem Protesto (NÃO TRATADO PELO BANCO)</field>
+        <field name="code">8</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+    <record id="bradesco_240_boleto_protest_code_9" model="l10n_br_cnab.code">
+        <field name="name">Cancelamento Protesto Automático</field>
+        <field name="code">9</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+        <field
+            name="comment"
+        >(somente válido p/ CódigoMovimento Remessa = '31' - Descrição C004)
+        </field>
+    </record>
+
+</odoo>

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_cef_240_boleto_protest_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_cef_240_boleto_protest_code.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright (C) 2025-Today - Akretion (<http://www.akretion.com>).
+  @author Magno Costa <magno.costa@akretion.com.br>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo noupdate="1">
+
+    <!-- Código de Protesto Banco Caixa Economica Federal -->
+    <record id="cef_240_boleto_protest_code_1" model="l10n_br_cnab.code">
+        <field name="name">Protestar</field>
+        <field name="code">1</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+        <field
+            name="comment"
+        >Caso o CEP do Pagador não esteja vinculado a uma agência cobradora de protesto (CEP sem praça de
+cobrança), o título será registrado com instrução de devolução, sendo o Prazo de Devolução igual ao Prazo de Protesto, com prazo mínimo de 5 dias.
+         Se Código para Protesto = ‘1’ – Protestar e Código para Baixa / Devolução = ‘1’ – Baixar / Devolver, será acatada a instrução para protesto.
+        </field>
+    </record>
+
+    <record id="cef_240_boleto_protest_code_3" model="l10n_br_cnab.code">
+        <field name="name">Não Protestar</field>
+        <field name="code">3</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+    <record id="cef_240_boleto_protest_code_9" model="l10n_br_cnab.code">
+        <field
+            name="name"
+        >Cancelamento Protesto Automático (Somente válido p/ Código Movimento Remessa = ‘31’ - Alteração de Outros Dados), vide nota C004.</field>
+        <field name="code">2</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+</odoo>

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_itau_240_boleto_protest_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_itau_240_boleto_protest_code.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright (C) 2025-Today - Akretion (<http://www.akretion.com>).
+  @author Magno Costa <magno.costa@akretion.com.br>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo noupdate="1">
+
+    <!-- Código de Protesto Banco Itau 240 -->
+    <record id="itau_240_boleto_protest_code_0" model="l10n_br_cnab.code">
+        <field name="name">Sem instrução</field>
+        <field name="code">0</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+    <record id="itau_240_boleto_protest_code_1" model="l10n_br_cnab.code">
+        <field name="name">Protestar (Dias Corridos)</field>
+        <field name="code">1</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+        <field
+            name="comment"
+        >Informar o prazo de início da negatibação ou do protesto nas posições 222 a 223, a partir do vencimento.
+Caso seja infomrado zeros neste campo de prazo, o processo de negativação ou protesto será acrescido 02
+dias (corridos) após o vencimento, de acordo com a ocorrência.
+        </field>
+    </record>
+
+    <record id="itau_240_boleto_protest_code_2" model="l10n_br_cnab.code">
+        <field name="name">Protestar (Dias Úteis)</field>
+        <field name="code">2</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+        <field
+            name="comment"
+        >Informar o prazo de início da negatibação ou do protesto nas posições 222 a 223, a partir do vencimento.
+Caso seja infomrado zeros neste campo de prazo, o processo de negativação ou protesto será acrescido 02
+dias (corridos) após o vencimento, de acordo com a ocorrência.
+        </field>
+    </record>
+
+    <record id="itau_240_boleto_protest_code_3" model="l10n_br_cnab.code">
+        <field name="name">Não protestar</field>
+        <field name="code">3</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+    <record id="itau_240_boleto_protest_code_7" model="l10n_br_cnab.code">
+        <field name="name">Negativar (Dias Corridos)</field>
+        <field name="code">7</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+        <field
+            name="comment"
+        >Informar o prazo de início da negatibação ou do protesto nas posições 222 a 223, a partir do vencimento.
+Caso seja infomrado zeros neste campo de prazo, o processo de negativação ou protesto será acrescido 02
+dias (corridos) após o vencimento, de acordo com a ocorrência.
+        </field>
+    </record>
+
+    <record id="itau_240_boleto_protest_code_8" model="l10n_br_cnab.code">
+        <field name="name">Não Negativar</field>
+        <field name="code">8</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+</odoo>

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_santander_240_boleto_protest_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_santander_240_boleto_protest_code.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright (C) 2025-Today - Akretion (<http://www.akretion.com>).
+  @author Magno Costa <magno.costa@akretion.com.br>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo noupdate="1">
+
+    <!-- Código de Protesto Banco Santander 240 -->
+    <record id="santander_240_boleto_protest_code_0" model="l10n_br_cnab.code">
+        <field name="name">NAO PROTESTAR</field>
+        <field name="code">0</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+    <record id="santander_240_boleto_protest_code_1" model="l10n_br_cnab.code">
+        <field name="name">PROTESTAR DIAS CORRIDOS</field>
+        <field name="code">1</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+    <record id="santander_240_boleto_protest_code_2" model="l10n_br_cnab.code">
+        <field name="name">PROTESTAR DIAS UTEIS</field>
+        <field name="code">2</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+    <record id="santander_240_boleto_protest_code_3" model="l10n_br_cnab.code">
+        <field name="name">UTILIZAR PERFIL BENEFICIÁRIO</field>
+        <field name="code">3</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+    <record id="santander_240_boleto_protest_code_9" model="l10n_br_cnab.code">
+        <field name="name">CANCELAMENTO DE PROTESTO AUTOMATICO</field>
+        <field name="code">9</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+</odoo>

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_sicred_240_boleto_protest_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_sicred_240_boleto_protest_code.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright (C) 2025-Today - Akretion (<http://www.akretion.com>).
+  @author Magno Costa <magno.costa@akretion.com.br>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo noupdate="1">
+
+    <!-- Código de Protesto -->
+    <record id="sicred_240_boleto_protest_code_1" model="l10n_br_cnab.code">
+        <field name="name">Protestar dias corridos</field>
+        <field name="code">1</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+    <record id="sicred_240_boleto_protest_code_3" model="l10n_br_cnab.code">
+        <field name="name">Não protestar</field>
+        <field name="code">3</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+    <record id="sicred_240_boleto_protest_code_9" model="l10n_br_cnab.code">
+        <field name="name">Cancelamento protesto automático</field>
+        <field name="code">9</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+</odoo>

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_unicred_240_400_boleto_protest_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_unicred_240_400_boleto_protest_code.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright (C) 2025-Today - Akretion (<http://www.akretion.com>).
+  @author Magno Costa <magno.costa@akretion.com.br>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo noupdate="1">
+
+    <!-- Código de Protesto -->
+    <record id="unicred_240_400_boleto_protest_code_1" model="l10n_br_cnab.code">
+        <field name="name">Protestar Dias Corridos</field>
+        <field name="code">1</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+    <record id="unicred_240_400_boleto_protest_code_2" model="l10n_br_cnab.code">
+        <field name="name">Protestar Dias Úteis</field>
+        <field name="code">2</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+    <record id="unicred_240_400_boleto_protest_code_3" model="l10n_br_cnab.code">
+        <field name="name">Não Protestar</field>
+        <field name="code">3</field>
+        <field name="code_type">protest_code</field>
+        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="payment_method_ids"
+            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+        />
+    </record>
+
+</odoo>

--- a/l10n_br_account_payment_order/demo/l10n_br_cnab_config_demo.xml
+++ b/l10n_br_account_payment_order/demo/l10n_br_cnab_config_demo.xml
@@ -54,7 +54,9 @@
         <field name="boleto_wallet">3</field>
         <field name="wallet_code_id" ref="bradesco_240_boleto_wallet_code_1" />
         <field name="boleto_modality">DM</field>
-        <field name="boleto_variation">19</field>
+	<field name="boleto_variation">19</field>
+	<field name="boleto_protest_code_id" ref="bradesco_240_boleto_protest_code_1" />
+        <field name="boleto_days_protest">5</field>
         <field name="boleto_accept">S</field>
         <field
             name="boleto_discount_code_id"
@@ -125,7 +127,10 @@
         <field name="boleto_accept">N</field>
         <field name="cnab_sequence_id" ref="sequence_cnab_number_unicred_400" />
         <field name="own_number_sequence_id" ref="sequence_own_number_unicred_400" />
-        <field name="boleto_protest_code">2</field>
+        <field
+            name="boleto_protest_code_id"
+            ref="unicred_240_400_boleto_protest_code_2"
+        />
         <field name="boleto_days_protest">5</field>
         <field name="boleto_interest_code">2</field>
         <field name="boleto_interest_perc">2</field>
@@ -200,7 +205,7 @@
         <field name="boleto_discount_perc">1</field>
         <field name="cnab_sequence_id" ref="sequence_cnab_number_unicred_240" />
         <field name="own_number_sequence_id" ref="sequence_own_number_unicred_240" />
-        <field name="boleto_protest_code">2</field>
+	<field name="boleto_protest_code_id" ref="unicred_240_400_boleto_protest_code_2" />
         <field name="boleto_days_protest">5</field>
         <field name="cnab_company_bank_code">72234050</field>
         <field
@@ -258,7 +263,7 @@
         <field name="boleto_accept">N</field>
         <field name="cnab_sequence_id" ref="sequence_cnab_number_ailos_240" />
         <field name="own_number_sequence_id" ref="sequence_own_number_ailos_240" />
-        <field name="boleto_protest_code">3</field>
+	<field name="boleto_protest_code_id" ref="ailos_240_boleto_protest_code_2" />
         <field name="boleto_days_protest">5</field>
         <field name="boleto_discount_code_id" ref="ailos_240_boleto_discount_code_1" />
         <field name="boleto_discount_perc">1</field>
@@ -308,7 +313,9 @@
         <field name="boleto_modality">DM</field>
         <field name="boleto_variation">19</field>
         <field name="boleto_accept">S</field>
-        <field name="boleto_discount_perc">1</field>
+	<field name="boleto_discount_perc">1</field>
+	<field name="boleto_protest_code_id" ref="itau_240_boleto_protest_code_2" />
+	<field name="boleto_days_protest">5</field>
         <field name="cnab_sequence_id" ref="sequence_cnab_number_itau_240" />
         <field name="own_number_sequence_id" ref="sequence_own_number_itau_240" />
         <field
@@ -404,7 +411,9 @@
         <field name="boleto_variation">19</field>
         <field name="boleto_accept">S</field>
         <field name="boleto_discount_code_id" ref="cef_240_boleto_discount_code_2" />
-        <field name="boleto_discount_perc">1</field>
+	<field name="boleto_discount_perc">1</field>
+	<field name="boleto_protest_code_id" ref="cef_240_boleto_protest_code_1" />
+        <field name="boleto_days_protest">5</field>
         <field name="cnab_sequence_id" ref="sequence_cnab_number_cef_240" />
         <field name="own_number_sequence_id" ref="sequence_own_number_cef_240" />
         <field
@@ -499,7 +508,9 @@
         <field name="boleto_variation">19</field>
         <field name="boleto_accept">S</field>
         <field name="boleto_discount_code_id" ref="sicred_240_boleto_discount_code_3" />
-        <field name="boleto_discount_perc">1</field>
+	<field name="boleto_discount_perc">1</field>
+	<field name="boleto_protest_code_id" ref="sicred_240_boleto_protest_code_1" />
+	<field name="boleto_days_protest">5</field>
         <field name="cnab_sequence_id" ref="sequence_cnab_number_sicredi_240" />
         <field name="own_number_sequence_id" ref="sequence_own_number_sicredi_240" />
         <!-- Code de Convenio maximo 5 caracteres -->
@@ -779,7 +790,12 @@
         />
         <field name="write_off_devolution_number_of_days">0</field>
         <field name="boleto_fee_code">0</field>
-        <field name="boleto_fee_perc">0.00</field>
+	<field name="boleto_fee_perc">0.00</field>
+        <field
+            name="boleto_protest_code_id"
+            ref="santander_240_boleto_protest_code_2"
+        />
+        <field name="boleto_days_protest">5</field>
     </record>
 
     <!-- CNAB Manual Test -->

--- a/l10n_br_account_payment_order/migrations/16.0.6.0.0/post-migration.py
+++ b/l10n_br_account_payment_order/migrations/16.0.6.0.0/post-migration.py
@@ -1,0 +1,71 @@
+# Copyright (C) 2025-Today - Akretion (<http://www.akretion.com>).
+# @author Magno Costa <magno.costa@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+def update_cnab_config_protest_code(env):
+    """
+    Atualiza o Código de Protesto de CHAR para Objeto/l10n_br_cnab.code
+    """
+
+    env.cr.execute(
+        """
+        SELECT id, boleto_protest_code FROM l10n_br_cnab_config WHERE
+        boleto_protest_code IS NOT NULL;
+        """
+    )
+    for row in env.cr.fetchall():
+        cnab_config = env["l10n_br_cnab.config"].browse(row[0])
+        if row[1]:
+            protest_obj = env["l10n_br_cnab.code"].search(
+                [
+                    ("bank_ids", "in", cnab_config.bank_id.ids),
+                    ("payment_method_ids", "in", cnab_config.payment_method_id.ids),
+                    ("code_type", "=", "protest_code"),
+                    ("code", "=", row[1]),
+                ]
+            )
+            if protest_obj:
+                cnab_config.boleto_protest_code_id = protest_obj
+            else:
+                code_not_found = env["l10n_br_cnab.code"].create(
+                    {
+                        "code": row[1],
+                        "name": "CÓDIGO NÃO IDENTIFICADO, considere verificar esse"
+                        " problema, ver detalhes no Comentário do Código",
+                        "bank_ids": cnab_config.bank_id.ids,
+                        "payment_method_ids": cnab_config.payment_method_id.ids,
+                        "code_type": "protest_code",
+                        "comment": "Código Não Identificado, durante a atualização"
+                        "do campo de CHAR para o objeto l10n_br_cnab.code o "
+                        "conjunto de Códigos CNAB do Banco não existiam dentro do "
+                        " repositorio público https://github.com/OCA/l10n-brazil/"
+                        "tree/16.0/l10n_br_account_payment_order/data/cnab_codes "
+                        "por isso esse Código não foi incluído, para resolver esse "
+                        "problema você pode alterar o campo Nome para a descrição "
+                        "informada na Documentação desse CNAB específico e, se "
+                        "existirem, veja de criar as outras possibilidades de "
+                        "Código para que o Usuário/Empresa possam avaliar se esse "
+                        "Código está de acordo com o esperado. IMPORTANTE: por "
+                        "favor considere fazer um PR incluindo esse Código CNAB no "
+                        "projeto, se tiver erros veja de criar um ISSUE ou se "
+                        "precisar fazer alguma correção criar um PR corrigindo o "
+                        "problema, assim como você e a sua Empresa foram "
+                        "beneficiados e ajudados por esse trabalho o Projeto, como "
+                        "qualquer Projeto de Código Aberto, também espera que você,"
+                        " de acordo com as suas condições, busque contribuir com o "
+                        "Projeto para beneficiar e ajudar os outros, contribuindo "
+                        "para criar um circulo virtuoso de ajuda mutua que "
+                        "beneficia a todos os envolvidos.",
+                    }
+                )
+                cnab_config.boleto_protest_code_id = code_not_found
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if not version:
+        return
+    update_cnab_config_protest_code(env)

--- a/l10n_br_account_payment_order/models/l10n_br_cnab_boleto_fields.py
+++ b/l10n_br_account_payment_order/models/l10n_br_cnab_boleto_fields.py
@@ -105,23 +105,9 @@ class L10nBrCNABBoletoFields(models.AbstractModel):
         tracking=True,
     )
 
-    # Na configuração ou implementação de outros campos é
-    # melhor seguir a idéia abaixo pois os campos não são usados com
-    # frequencia e incluir um campo do tipo Char permitindo que seja
-    # informado o valor de acordo com a configuração do Boleto ao
-    # invês de diversos campos do Tipo Select para cada Banco parece
-    # ser melhor.
-    # [ Deixado manualmente, pois cada banco parece ter sua tabela.
-    # ('0', u'Sem instrução'),
-    # ('1', u'Protestar (Dias Corridos)'),
-    # ('2', u'Protestar (Dias Úteis)'),
-    # ('3', u'Não protestar'),
-    # ('7', u'Negativar (Dias Corridos)'),
-    # ('8', u'Não Negativar')
-    # ]
-    boleto_protest_code = fields.Char(
-        string="Código de Protesto",
-        default="0",
+    boleto_protest_code_id = fields.Many2one(
+        string="Protest Code",
+        comodel_name="l10n_br_cnab.code",
         help="Código adotado pela FEBRABAN para identificar o tipo "
         "de prazo a ser considerado para o protesto.",
         tracking=True,

--- a/l10n_br_account_payment_order/readme/HISTORY.md
+++ b/l10n_br_account_payment_order/readme/HISTORY.md
@@ -1,3 +1,7 @@
+## 16.0.6.0.0 (2024-03-06)
+
+- \[REF\] Alterado o Código de Protesto de Char para Objeto/l10n_br_cnab.code
+
 ## 16.0.5.0.0 (2024-12-16)
 
 - \[REM\] "Foward Port" Removendo Campos, Visões e Objetos obsoletos.

--- a/l10n_br_account_payment_order/static/description/index.html
+++ b/l10n_br_account_payment_order/static/description/index.html
@@ -373,7 +373,8 @@ ul.auto-toc {
 <p>O módulo implementa a parte comum da infra-estrutura necessária para o
 uso do CNAB implementando:</p>
 <ul class="simple">
-<li><strong>Códigos CNAB</strong> - códigos de Instrução, Retorno, Carteira e Desconto.</li>
+<li><strong>Códigos CNAB</strong> - códigos de Instrução, Retorno, Carteira e
+Desconto.</li>
 <li><strong>Configuração CNAB</strong> - onde serão salvas as informações específicas
 de cada caso como Convênio, Código do Beneficiário, Modalidade,
 Percentual de Multa, códigos de Instrução do Movimento de Liquidação
@@ -386,8 +387,8 @@ informar o Modo de Pagamento em um Pedido de Venda, Compras ou
 Faturamento o programa identifica como sendo um caso CNAB.</li>
 <li><strong>Ordem de Pagamento</strong> - localiza o módulo
 <a class="reference external" href="https://github.com/OCA/bank-payment/tree/16.0/account_payment_order">account_payment_order</a>
-que usa a <strong>Ordem de Pagamento</strong>, débito ou crédito, para registrar as
-<strong>Instruções de Movimento</strong> e onde será criado o <strong>Arquivo CNAB
+que usa a <strong>Ordem de Pagamento</strong>, débito ou crédito, para registrar
+as <strong>Instruções de Movimento</strong> e onde será criado o <strong>Arquivo CNAB
 Remessa</strong>.</li>
 <li><strong>Registro do LOG de Eventos</strong> - ao importar um arquivo de retorno
 CNAB.</li>
@@ -419,33 +420,34 @@ desconsidere esse aspecto.</p>
 <li><a class="reference internal" href="#usage" id="toc-entry-3">Usage</a></li>
 <li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-4">Known issues / Roadmap</a></li>
 <li><a class="reference internal" href="#changelog" id="toc-entry-5">Changelog</a><ul>
-<li><a class="reference internal" href="#section-1" id="toc-entry-6">16.0.5.0.0 (2024-12-16)</a></li>
-<li><a class="reference internal" href="#section-2" id="toc-entry-7">16.0.4.0.0 (2024-12-16)</a></li>
-<li><a class="reference internal" href="#section-3" id="toc-entry-8">16.0.3.0.0 (2024-12-16)</a></li>
-<li><a class="reference internal" href="#section-4" id="toc-entry-9">16.0.2.0.0 (2024-12-04)</a></li>
-<li><a class="reference internal" href="#section-5" id="toc-entry-10">16.0.1.0.0 (2024-09-10)</a></li>
-<li><a class="reference internal" href="#section-6" id="toc-entry-11">15.0.1.0.0 (2024-07-25)</a></li>
-<li><a class="reference internal" href="#section-7" id="toc-entry-12">14.0.9.0.0 (2024-09-19)</a></li>
-<li><a class="reference internal" href="#section-8" id="toc-entry-13">14.0.8.0.0 (2024-09-18)</a></li>
-<li><a class="reference internal" href="#section-9" id="toc-entry-14">14.0.7.0.0 (2024-09-13)</a></li>
-<li><a class="reference internal" href="#section-10" id="toc-entry-15">14.0.6.0.0 (2024-09-10)</a></li>
-<li><a class="reference internal" href="#section-11" id="toc-entry-16">14.0.1.0.0 (2022-04-29)</a></li>
-<li><a class="reference internal" href="#section-12" id="toc-entry-17">13.0.1.0.0 (2022-01-28)</a></li>
-<li><a class="reference internal" href="#section-13" id="toc-entry-18">12.0.3.0.0 (2021-05-13)</a></li>
-<li><a class="reference internal" href="#section-14" id="toc-entry-19">12.0.1.0.0 (2019-06-06)</a></li>
-<li><a class="reference internal" href="#section-15" id="toc-entry-20">10.0.2.0.0 (2018-05-17)</a></li>
-<li><a class="reference internal" href="#section-16" id="toc-entry-21">10.0.1.0.0 (2018-08-29)</a></li>
-<li><a class="reference internal" href="#section-17" id="toc-entry-22">8.0.1.0.1 (2017-07-14)</a></li>
-<li><a class="reference internal" href="#section-18" id="toc-entry-23">8.0.1.0.0 (2017-07-14)</a></li>
-<li><a class="reference internal" href="#section-19" id="toc-entry-24">8.0.0.0.0 (2016-01-18)</a></li>
+<li><a class="reference internal" href="#section-1" id="toc-entry-6">16.0.6.0.0 (2024-03-06)</a></li>
+<li><a class="reference internal" href="#section-2" id="toc-entry-7">16.0.5.0.0 (2024-12-16)</a></li>
+<li><a class="reference internal" href="#section-3" id="toc-entry-8">16.0.4.0.0 (2024-12-16)</a></li>
+<li><a class="reference internal" href="#section-4" id="toc-entry-9">16.0.3.0.0 (2024-12-16)</a></li>
+<li><a class="reference internal" href="#section-5" id="toc-entry-10">16.0.2.0.0 (2024-12-04)</a></li>
+<li><a class="reference internal" href="#section-6" id="toc-entry-11">16.0.1.0.0 (2024-09-10)</a></li>
+<li><a class="reference internal" href="#section-7" id="toc-entry-12">15.0.1.0.0 (2024-07-25)</a></li>
+<li><a class="reference internal" href="#section-8" id="toc-entry-13">14.0.9.0.0 (2024-09-19)</a></li>
+<li><a class="reference internal" href="#section-9" id="toc-entry-14">14.0.8.0.0 (2024-09-18)</a></li>
+<li><a class="reference internal" href="#section-10" id="toc-entry-15">14.0.7.0.0 (2024-09-13)</a></li>
+<li><a class="reference internal" href="#section-11" id="toc-entry-16">14.0.6.0.0 (2024-09-10)</a></li>
+<li><a class="reference internal" href="#section-12" id="toc-entry-17">14.0.1.0.0 (2022-04-29)</a></li>
+<li><a class="reference internal" href="#section-13" id="toc-entry-18">13.0.1.0.0 (2022-01-28)</a></li>
+<li><a class="reference internal" href="#section-14" id="toc-entry-19">12.0.3.0.0 (2021-05-13)</a></li>
+<li><a class="reference internal" href="#section-15" id="toc-entry-20">12.0.1.0.0 (2019-06-06)</a></li>
+<li><a class="reference internal" href="#section-16" id="toc-entry-21">10.0.2.0.0 (2018-05-17)</a></li>
+<li><a class="reference internal" href="#section-17" id="toc-entry-22">10.0.1.0.0 (2018-08-29)</a></li>
+<li><a class="reference internal" href="#section-18" id="toc-entry-23">8.0.1.0.1 (2017-07-14)</a></li>
+<li><a class="reference internal" href="#section-19" id="toc-entry-24">8.0.1.0.0 (2017-07-14)</a></li>
+<li><a class="reference internal" href="#section-20" id="toc-entry-25">8.0.0.0.0 (2016-01-18)</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-25">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-26">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-27">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-28">Contributors</a></li>
-<li><a class="reference internal" href="#other-credits" id="toc-entry-29">Other credits</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-30">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-26">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-27">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-28">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-29">Contributors</a></li>
+<li><a class="reference internal" href="#other-credits" id="toc-entry-30">Other credits</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-31">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -597,17 +599,18 @@ a ser utilizada.</p>
 <h1><a class="toc-backref" href="#toc-entry-4">Known issues / Roadmap</a></h1>
 <ul class="simple">
 <li>Verificar a questão do campos <strong>many2many</strong> que não estão sendo
-registrados pelo <strong>track_visibility</strong> e se será incluída a dependência
-do módulo
+registrados pelo <strong>track_visibility</strong> e se será incluída a
+dependência do módulo
 <a class="reference external" href="https://github.com/OCA/social/tree/16.0/mail_improved_tracking_value">mail_improved_tracking_value</a>.</li>
-<li>Processo de Alteração de Carteira, falta informações sobre o processo.</li>
+<li>Processo de Alteração de Carteira, falta informações sobre o
+processo.</li>
 <li>Mapear e incluir os Códigos dos Bancos CNAB 240/400, aqui devido a
 quantidade de possibilidades se trata de um “roadmap” constante onde
-contamos com PRs de outros contribuidores que irão implementar um caso
-que ainda não esteja cadastrado, apesar do código permitir que o
+contamos com PRs de outros contribuidores que irão implementar um
+caso que ainda não esteja cadastrado, apesar do código permitir que o
 cadastro seja feito na tela nesses casos.</li>
-<li>Processo de “Antecipação do Título junto ao Banco” ou “Venda do Título
-junto a Factoring” ver as alterações feitas na v14 em diante
+<li>Processo de “Antecipação do Título junto ao Banco” ou “Venda do
+Título junto a Factoring” ver as alterações feitas na v14 em diante
 <a class="reference external" href="https://www.odoo.com/pt_BR/forum/ajuda-1/v14-change-in-payment-behavior-how-do-the-suspense-and-outstanding-payment-accounts-change-the-journal-entries-posted-177592">https://www.odoo.com/pt_BR/forum/ajuda-1/v14-change-in-payment-behavior-how-do-the-suspense-and-outstanding-payment-accounts-change-the-journal-entries-posted-177592</a>.</li>
 <li>CNAB de Pagamento, verificar a integração com o PR
 <a class="reference external" href="https://github.com/OCA/l10n-brazil/pull/972">https://github.com/OCA/l10n-brazil/pull/972</a> e a possibilidade de
@@ -624,8 +627,8 @@ l10n_br_account_payment_order/models/account_payment_line.py#L130)</li>
 <li>Confirmar se existem Bancos que usam os mesmos conjuntos de Códigos
 CNAB de Instrução e Retorno para caso não existir remover o
 <strong>many2many</strong> do Banco e deixar apenas o <strong>many2one</strong>.</li>
-<li>Verificar a possibilidade de usar o objeto <strong>account.payment</strong> no caso
-CNAB e o módulo
+<li>Verificar a possibilidade de usar o objeto <strong>account.payment</strong> no
+caso CNAB e o módulo
 <a class="reference external" href="https://github.com/OCA/bank-payment/tree/16.0/account_payment_order_return">https://github.com/OCA/bank-payment/tree/16.0/account_payment_order_return</a>
 para tratar o <strong>LOG de Retorno do CNAB, RFC</strong>
 <a class="reference external" href="https://github.com/OCA/l10n-brazil/issues/2272">https://github.com/OCA/l10n-brazil/issues/2272</a>.</li>
@@ -634,85 +637,93 @@ para tratar o <strong>LOG de Retorno do CNAB, RFC</strong>
 <div class="section" id="changelog">
 <h1><a class="toc-backref" href="#toc-entry-5">Changelog</a></h1>
 <div class="section" id="section-1">
-<h2><a class="toc-backref" href="#toc-entry-6">16.0.5.0.0 (2024-12-16)</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">16.0.6.0.0 (2024-03-06)</a></h2>
+<ul class="simple">
+<li>[REF] Alterado o Código de Protesto de Char para
+Objeto/l10n_br_cnab.code</li>
+</ul>
+</div>
+<div class="section" id="section-2">
+<h2><a class="toc-backref" href="#toc-entry-7">16.0.5.0.0 (2024-12-16)</a></h2>
 <ul class="simple">
 <li>[REM] “Foward Port” Removendo Campos, Visões e Objetos obsoletos.</li>
 </ul>
 </div>
-<div class="section" id="section-2">
-<h2><a class="toc-backref" href="#toc-entry-7">16.0.4.0.0 (2024-12-16)</a></h2>
+<div class="section" id="section-3">
+<h2><a class="toc-backref" href="#toc-entry-8">16.0.4.0.0 (2024-12-16)</a></h2>
 <ul class="simple">
-<li>[IMP] “Foward Port” Possibilidade de informar Códigos de Desconto além
-do 0 e 1.</li>
+<li>[IMP] “Foward Port” Possibilidade de informar Códigos de Desconto
+além do 0 e 1.</li>
 </ul>
 </div>
-<div class="section" id="section-3">
-<h2><a class="toc-backref" href="#toc-entry-8">16.0.3.0.0 (2024-12-16)</a></h2>
+<div class="section" id="section-4">
+<h2><a class="toc-backref" href="#toc-entry-9">16.0.3.0.0 (2024-12-16)</a></h2>
 <ul class="simple">
 <li>[REF] “Foward-Port” Separando as Configurações do CNAB do Modo de
 Pagamento.</li>
 </ul>
 </div>
-<div class="section" id="section-4">
-<h2><a class="toc-backref" href="#toc-entry-9">16.0.2.0.0 (2024-12-04)</a></h2>
+<div class="section" id="section-5">
+<h2><a class="toc-backref" href="#toc-entry-10">16.0.2.0.0 (2024-12-04)</a></h2>
 <ul class="simple">
 <li>[REF] “Foward-Port” Unindo os Códigos CNAB em um mesmo objeto.</li>
 </ul>
 </div>
-<div class="section" id="section-5">
-<h2><a class="toc-backref" href="#toc-entry-10">16.0.1.0.0 (2024-09-10)</a></h2>
+<div class="section" id="section-6">
+<h2><a class="toc-backref" href="#toc-entry-11">16.0.1.0.0 (2024-09-10)</a></h2>
 <ul class="simple">
 <li>[MIG] Migração para a versão 16.0</li>
 </ul>
 </div>
-<div class="section" id="section-6">
-<h2><a class="toc-backref" href="#toc-entry-11">15.0.1.0.0 (2024-07-25)</a></h2>
+<div class="section" id="section-7">
+<h2><a class="toc-backref" href="#toc-entry-12">15.0.1.0.0 (2024-07-25)</a></h2>
 <ul class="simple">
 <li>[MIG] Migração para a versão 15.0</li>
 </ul>
 </div>
-<div class="section" id="section-7">
-<h2><a class="toc-backref" href="#toc-entry-12">14.0.9.0.0 (2024-09-19)</a></h2>
+<div class="section" id="section-8">
+<h2><a class="toc-backref" href="#toc-entry-13">14.0.9.0.0 (2024-09-19)</a></h2>
 <ul class="simple">
 <li>[REM] Removendo Campos, Visões e Objetos obsoletos.</li>
 </ul>
 </div>
-<div class="section" id="section-8">
-<h2><a class="toc-backref" href="#toc-entry-13">14.0.8.0.0 (2024-09-18)</a></h2>
+<div class="section" id="section-9">
+<h2><a class="toc-backref" href="#toc-entry-14">14.0.8.0.0 (2024-09-18)</a></h2>
 <ul class="simple">
 <li>[IMP] Possibilidade de informar Códigos de Desconto além do 0 e 1.</li>
 </ul>
 </div>
-<div class="section" id="section-9">
-<h2><a class="toc-backref" href="#toc-entry-14">14.0.7.0.0 (2024-09-13)</a></h2>
+<div class="section" id="section-10">
+<h2><a class="toc-backref" href="#toc-entry-15">14.0.7.0.0 (2024-09-13)</a></h2>
 <ul class="simple">
 <li>[REF] Separando as Configurações do CNAB do Modo de Pagamento.</li>
 </ul>
 </div>
-<div class="section" id="section-10">
-<h2><a class="toc-backref" href="#toc-entry-15">14.0.6.0.0 (2024-09-10)</a></h2>
+<div class="section" id="section-11">
+<h2><a class="toc-backref" href="#toc-entry-16">14.0.6.0.0 (2024-09-10)</a></h2>
 <ul class="simple">
 <li>[REF] Unindo os Códigos CNAB em um mesmo objeto.</li>
 </ul>
 </div>
-<div class="section" id="section-11">
-<h2><a class="toc-backref" href="#toc-entry-16">14.0.1.0.0 (2022-04-29)</a></h2>
+<div class="section" id="section-12">
+<h2><a class="toc-backref" href="#toc-entry-17">14.0.1.0.0 (2022-04-29)</a></h2>
 <ul class="simple">
 <li>[MIG] Migração para a versão 14.0.</li>
 </ul>
 </div>
-<div class="section" id="section-12">
-<h2><a class="toc-backref" href="#toc-entry-17">13.0.1.0.0 (2022-01-28)</a></h2>
+<div class="section" id="section-13">
+<h2><a class="toc-backref" href="#toc-entry-18">13.0.1.0.0 (2022-01-28)</a></h2>
 <ul class="simple">
 <li>[MIG] Migração para a versão 13.0.</li>
 </ul>
 </div>
-<div class="section" id="section-13">
-<h2><a class="toc-backref" href="#toc-entry-18">12.0.3.0.0 (2021-05-13)</a></h2>
+<div class="section" id="section-14">
+<h2><a class="toc-backref" href="#toc-entry-19">12.0.3.0.0 (2021-05-13)</a></h2>
 <ul class="simple">
 <li>[MIG] Migração para a versão 12.0.</li>
 <li>Incluído a possibilidade de parametrizar o CNAB 240 e 400, devido a
-falta de padrão cada Banco e CNAB podem ter e usar codigos diferentes.</li>
+falta de padrão cada Banco e CNAB podem ter e usar codigos
+diferentes.</li>
 <li>Incluído os metodos para fazer alterações em CNAB já enviados.</li>
 <li>Incluído dados de demo e testes.</li>
 <li>Separado o objeto que fazia o Retorno do arquivo e registrava as
@@ -721,48 +732,48 @@ os modulos que implementam a biblioteca escolhida podem ter um
 metodo/objeto especifico para essa função.</li>
 </ul>
 </div>
-<div class="section" id="section-14">
-<h2><a class="toc-backref" href="#toc-entry-19">12.0.1.0.0 (2019-06-06)</a></h2>
+<div class="section" id="section-15">
+<h2><a class="toc-backref" href="#toc-entry-20">12.0.1.0.0 (2019-06-06)</a></h2>
 <ul class="simple">
 <li>[MIG] Inicio da Migração para a versão 12.0.</li>
 </ul>
 </div>
-<div class="section" id="section-15">
-<h2><a class="toc-backref" href="#toc-entry-20">10.0.2.0.0 (2018-05-17)</a></h2>
+<div class="section" id="section-16">
+<h2><a class="toc-backref" href="#toc-entry-21">10.0.2.0.0 (2018-05-17)</a></h2>
 <ul class="simple">
-<li>[REF] Modulo unido com o l10n_br_account_payment_mode e renomeado para
-l10n_br_account_payment_order.</li>
+<li>[REF] Modulo unido com o l10n_br_account_payment_mode e renomeado
+para l10n_br_account_payment_order.</li>
 </ul>
 </div>
-<div class="section" id="section-16">
-<h2><a class="toc-backref" href="#toc-entry-21">10.0.1.0.0 (2018-08-29)</a></h2>
+<div class="section" id="section-17">
+<h2><a class="toc-backref" href="#toc-entry-22">10.0.1.0.0 (2018-08-29)</a></h2>
 <ul class="simple">
 <li>[MIG] Migração para a versão 10.</li>
 </ul>
 </div>
-<div class="section" id="section-17">
-<h2><a class="toc-backref" href="#toc-entry-22">8.0.1.0.1 (2017-07-14)</a></h2>
+<div class="section" id="section-18">
+<h2><a class="toc-backref" href="#toc-entry-23">8.0.1.0.1 (2017-07-14)</a></h2>
 <ul class="simple">
 <li>[NEW] Refatoração e melhorias para suportar a geração de boletos
 através do br-cobranca (ruby)</li>
 </ul>
 </div>
-<div class="section" id="section-18">
-<h2><a class="toc-backref" href="#toc-entry-23">8.0.1.0.0 (2017-07-14)</a></h2>
+<div class="section" id="section-19">
+<h2><a class="toc-backref" href="#toc-entry-24">8.0.1.0.0 (2017-07-14)</a></h2>
 <ul class="simple">
 <li>[NEW] Melhorias para suportar a geração de pagamento da folha de
 pagamento;</li>
 </ul>
 </div>
-<div class="section" id="section-19">
-<h2><a class="toc-backref" href="#toc-entry-24">8.0.0.0.0 (2016-01-18)</a></h2>
+<div class="section" id="section-20">
+<h2><a class="toc-backref" href="#toc-entry-25">8.0.0.0.0 (2016-01-18)</a></h2>
 <ul class="simple">
 <li>[NEW] Primeira versão</li>
 </ul>
 </div>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-25">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-26">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/l10n-brazil/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -770,16 +781,16 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-26">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-27">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-27">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-28">Authors</a></h2>
 <ul class="simple">
 <li>KMEE</li>
 <li>Akretion</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-28">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-29">Contributors</a></h2>
 <ul class="simple">
 <li><a class="reference external" href="https://www.kmee.com.br">KMEE</a>:<ul>
 <li>Luis Felipe Mileo &lt;<a class="reference external" href="mailto:mileo&#64;kmee.com.br">mileo&#64;kmee.com.br</a>&gt;</li>
@@ -802,7 +813,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="other-credits">
-<h2><a class="toc-backref" href="#toc-entry-29">Other credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-30">Other credits</a></h2>
 <p>The development of this module has been financially supported by:</p>
 <ul class="simple">
 <li>KMEE INFORMATICA LTDA - <a class="reference external" href="http://www.kmee.com.br">www.kmee.com.br</a></li>
@@ -810,7 +821,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-30">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-31">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/l10n_br_account_payment_order/views/l10n_br_cnab_config_view.xml
+++ b/l10n_br_account_payment_order/views/l10n_br_cnab_config_view.xml
@@ -133,7 +133,11 @@
                             </group>
 
                             <group name="protesto" string="Configuração do Protesto">
-                                <field name="boleto_protest_code" />
+                                <field
+                                        name="boleto_protest_code_id"
+                                        domain="['&amp;', ('payment_method_ids', 'in', payment_method_id),
+                                                ('bank_ids', 'in', bank_id), ('code_type', '=', 'protest_code')]"
+                                    />
                                 <field name="boleto_days_protest" />
                             </group>
                             <group


### PR DESCRIPTION
Change CNAB Protest Code from Char to Object 10n_br_cnab.code.

Alterando o 'Código de Protesto' de Char para Objeto l10n_br_cnab.code.

Eu já havia comentando essa questão na criação do objeto **l10n_br_cnab.code** e em outros PRs

* https://github.com/OCA/l10n-brazil/pull/3337
* https://github.com/OCA/l10n-brazil/pull/3360
* https://github.com/OCA/l10n-brazil/pull/3614

![image](https://github.com/user-attachments/assets/7676ef47-3a46-4602-9000-dc8b01147161)


Segue imagens:

Hoje na Configuração CNAB
![image](https://github.com/user-attachments/assets/c0e1aa8c-0e71-4c10-a66e-c82572a8d58d)

Com esse PR na Configuração CNAB

![image](https://github.com/user-attachments/assets/76b7727a-8ade-4b0e-ac51-74b7b9d5cddc)

Códigos CNAB
![image](https://github.com/user-attachments/assets/dd08967b-1119-4848-bd7b-d8890d774dc5)

**Importante 1:** Até onde vi apenas o Santander e Itaú 240 tem a opção "0" Zero

![image](https://github.com/user-attachments/assets/624980c0-520b-456c-933f-3754e6c596bd)

Portanto se você tem outro caso de uso que usava esse código veja de confirmar se vai ser necessário informa-lo no momento de Criar o Arquivo de Remessa em https://github.com/akretion/l10n-brazil/blob/16.0-REF-cnab_protest_code_from_char_to_obj/l10n_br_account_payment_brcobranca/models/account_payment_line.py#L133 veja que isso já ocorre em outros casos, se sim avise aqui no PR que eu posso incluir para evitar erros (idealmente isso deveria ser resolvido na lib BRCobranca).

Na Revisão, se você tiver uma caso CNAB implementado, veja de comparar os valores que existem na Documentação com o que está sendo incluído, isso ajuda a identificar algum erro de digitação ou algo que faltou, mas lembre-se estamos incluindo os textos de acordo com o que está na Documentação isso significa que vão ter casos com acentos, sem acentos, tudo em maiúsculo e erros de texto; isso é feito porque é importante que o Usuário veja no programa o mesmo texto que ele vê na Documentação, o que evita dúvidas e suporte desnecessário.

O PR tem um Script de Migração que vai buscar pelo novo **Código de Protesto** nos novos arquivos Data usando o valor do antigo **Char** se o seu Banco/CNAB não estiver aqui avise que podemos avaliar se faltou ou se realmente não existe, se tiver algum erro na Migração por favor inclua o LOG de erro aqui para poder ser avaliado, é possível simular a migração com os Dados de Demonstração criando o BD com a atual v16 e Confirmando algumas Faturas e criando os Arquivos de Remessa e depois atualizando o BD com esse PR.

**Importante 2:** Fazer o o merge com "nobump" por ter script de migração o **l10n_br_account_payment_order** já foi alterado para a versão **16.0.6.0.0** e o **l10n_br_account_payment_brcobranca** apesar de não ter script achei melhor alterar para **16.0.4.0.0** ( ou eu deveria apenas mudar para **16.0.3.3.0** por não ter script de migração?), outras alterações nos arquivos README foram feitas pelo pre-commit.

cc @OCA/local-brazil-maintainers 