### PR TITLE
[16.0][l10n_br_fiscal] l10n_br_fiscal.document.mixin.methods: convert _onchange_fiscal_operation_id to compute

### DIFF
--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -112,10 +112,6 @@ class Document(models.Model):
         default=lambda self: self.env.user,
     )
 
-    operation_name = fields.Char(
-        copy=False,
-    )
-
     document_electronic = fields.Boolean(
         related="document_type_id.electronic",
         string="Electronic?",

--- a/l10n_br_fiscal/models/document_mixin_fields.py
+++ b/l10n_br_fiscal/models/document_mixin_fields.py
@@ -41,6 +41,11 @@ class FiscalDocumentMixinFields(models.AbstractModel):
         default=_default_operation,
     )
 
+    operation_name = fields.Char(
+        copy=False,
+        compute="_compute_operation_name",
+    )
+
     #
     # Company and Partner are defined here to avoid warnings on runbot
     #
@@ -72,6 +77,8 @@ class FiscalDocumentMixinFields(models.AbstractModel):
         column2="comment_id",
         string="Comments",
         domain=[("object", "=", FISCAL_COMMENT_DOCUMENT)],
+        compute="_compute_comment_ids",
+        store=True,
     )
 
     fiscal_additional_data = fields.Text()

--- a/l10n_br_fiscal/models/document_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_mixin_methods.py
@@ -112,11 +112,21 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
                 # reload fiscal data, operation line, cfop, taxes, etc.
                 line._onchange_fiscal_operation_id()
 
-    @api.onchange("fiscal_operation_id")
-    def _onchange_fiscal_operation_id(self):
-        if self.fiscal_operation_id:
-            self.operation_name = self.fiscal_operation_id.name
-            self.comment_ids = self.fiscal_operation_id.comment_ids
+    @api.depends("fiscal_operation_id")
+    def _compute_operation_name(self):
+        for doc in self:
+            if doc.fiscal_operation_id:
+                doc.operation_name = doc.fiscal_operation_id.name
+            else:
+                doc.operation_name = False
+
+    @api.depends("fiscal_operation_id")
+    def _compute_comment_ids(self):
+        for doc in self:
+            if doc.fiscal_operation_id:
+                doc.comment_ids = doc.fiscal_operation_id.comment_ids
+            elif doc.comment_ids is None:
+                doc.comment_ids = []
 
     def _inverse_amount_freight(self):
         for record in self.filtered(lambda doc: doc._get_product_amount_lines()):

--- a/l10n_br_fiscal/models/document_move_mixin.py
+++ b/l10n_br_fiscal/models/document_move_mixin.py
@@ -232,7 +232,6 @@ class DocumentMoveMixin(models.AbstractModel):
 
     @api.onchange("fiscal_operation_id")
     def _onchange_fiscal_operation_id(self):
-        result = super()._onchange_fiscal_operation_id()
         if self.fiscal_operation_id:
             self.fiscal_operation_type = self.fiscal_operation_id.fiscal_operation_type
             self.edoc_purpose = self.fiscal_operation_id.edoc_purpose
@@ -258,4 +257,3 @@ class DocumentMoveMixin(models.AbstractModel):
                     )
                 )
             self.document_subsequent_ids = subsequent_documents
-        return result

--- a/l10n_br_purchase/models/purchase_order.py
+++ b/l10n_br_purchase/models/purchase_order.py
@@ -57,10 +57,8 @@ class PurchaseOrder(models.Model):
         column1="purchase_id",
         column2="comment_id",
         string="Comments",
-    )
-
-    operation_name = fields.Char(
-        copy=False,
+        compute="_compute_comment_ids",
+        store=True,
     )
 
     @api.model
@@ -71,9 +69,7 @@ class PurchaseOrder(models.Model):
 
     @api.onchange("fiscal_operation_id")
     def _onchange_fiscal_operation_id(self):
-        result = super()._onchange_fiscal_operation_id()
         self.fiscal_position_id = self.fiscal_operation_id.fiscal_position_id
-        return result
 
     def _get_amount_lines(self):
         """Get object lines instaces used to compute fields"""

--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -73,6 +73,8 @@ class SaleOrder(models.Model):
         column1="sale_id",
         column2="comment_id",
         string="Comments",
+        compute="_compute_comment_ids",
+        store=True,
     )
 
     amount_freight_value = fields.Monetary(
@@ -85,10 +87,6 @@ class SaleOrder(models.Model):
 
     amount_other_value = fields.Monetary(
         inverse="_inverse_amount_other",
-    )
-
-    operation_name = fields.Char(
-        copy=False,
     )
 
     def _get_amount_lines(self):
@@ -113,7 +111,6 @@ class SaleOrder(models.Model):
 
     @api.onchange("fiscal_operation_id")
     def _onchange_fiscal_operation_id(self):
-        result = super()._onchange_fiscal_operation_id()
         if self.fiscal_operation_id:
             self.fiscal_position_id = self.fiscal_operation_id.fiscal_position_id
         else:
@@ -127,8 +124,6 @@ class SaleOrder(models.Model):
             # visivel ele é requirido.
             for line in self.order_line:
                 line.fiscal_operation_id = False
-
-        return result
 
     def _get_invoiceable_lines(self, final=False):
         lines = super()._get_invoiceable_lines(final=final)

--- a/l10n_br_stock_account/models/stock_picking.py
+++ b/l10n_br_stock_account/models/stock_picking.py
@@ -21,16 +21,14 @@ class StockPicking(models.Model):
         domain=lambda self: self._fiscal_operation_domain(),
     )
 
-    operation_name = fields.Char(
-        copy=False,
-    )
-
     comment_ids = fields.Many2many(
         comodel_name="l10n_br_fiscal.comment",
         relation="stock_picking_comment_rel",
         column1="picking_id",
         column2="comment_id",
         string="Comments",
+        compute="_compute_comment_ids",
+        store=True,
     )
 
     def _get_amount_lines(self):

--- a/l10n_br_stock_account/tests/common.py
+++ b/l10n_br_stock_account/tests/common.py
@@ -16,7 +16,6 @@ class TestBrPickingInvoicingCommon(TestPickingInvoicingCommon):
 
     def _run_picking_onchanges(self, record):
         result = super()._run_picking_onchanges(record)
-        record._onchange_fiscal_operation_id()
         return result
 
     def _run_line_onchanges(self, record):


### PR DESCRIPTION
como o modulo l10n_br_fiscal nasceu antes de existir o sistema dos campos compute do Odoo, o modulo ainda esta repleto de onchange. Isso não esta muito legal,  seria melhor ter campos compute.

Aqui eu matei o _onchange_fiscal_position_id nas camadas mais baixas. Tem outros objetos de mais alto nivel onde tem um onchange _onchange_fiscal_position_id, como o sale.order, purchase.order e l10n_br_fiscal.document. Aqui deixei de chamar o super (o onchange que eu removei) mas não procurei eliminar esses outros onchanges. Poderia ser feito depois, mas sera um um pouco mais complexo.

Fazendo esse refator, eu tb vi que o campo operation_name tava definido nos sale.order, purchase.order e stock.picking. Não precisava: eu joguei no l10n_br_fiscal.document.mixin.fields onde ele fica herdado então. (O campo operation_name não precisa ser ser store=True).

Converter tudo iria tomar bastante esforço/tempo, temos que balancear isso com outras prioridades...
Aqui eu comecei convertando _onchange_fiscal_operation_id do l10n_br_fiscal.document.mixin.methods porque era  relativamente facil...