### PR TITLE
[16.0][l10n_br_fiscal] fiscal quantity and fiscal price as compute

### DIFF
--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -99,6 +99,22 @@ class AccountMoveLine(models.Model):
         compute="_compute_allow_csll_irpj",
     )
 
+    fiscal_price = fields.Float(
+        digits="Product Price",
+        compute="_compute_fiscal_quantity_and_price",
+    )
+
+    uot_id = fields.Many2one(
+        comodel_name="uom.uom",
+        string="Tax UoM",
+        compute="_compute_fiscal_quantity_and_price",
+    )
+
+    fiscal_quantity = fields.Float(
+        digits="Product Unit of Measure",
+        compute="_compute_fiscal_quantity_and_price",
+    )
+
     discount = fields.Float(
         compute="_compute_discounts",
         store=True,
@@ -191,16 +207,6 @@ class AccountMoveLine(models.Model):
 
             if not fiscal_doc_id:
                 continue
-
-            values.update(
-                self._update_fiscal_quantity(
-                    values.get("product_id"),
-                    values.get("price_unit"),
-                    values.get("quantity"),
-                    values.get("product_uom_id"),
-                    values.get("uot_id"),
-                )
-            )
             values["document_id"] = fiscal_doc_id  # pass through the _inherits system
 
         self._inject_shadowed_fields(vals_list)

--- a/l10n_br_account_nfe/tests/test_nfe_generate_tags_cobr_dup_pag.py
+++ b/l10n_br_account_nfe/tests/test_nfe_generate_tags_cobr_dup_pag.py
@@ -190,4 +190,8 @@ class TestGeneratePaymentInfo(TransactionCase):
         """
         invoice = self.invoice
         invoice.fiscal_document_id._document_export()
-        self.assertEqual(invoice.fiscal_document_id.xml_error_message, False)
+        self.assertEqual(
+            invoice.fiscal_document_id.xml_error_message,
+            False,
+            invoice.fiscal_document_id.xml_error_message,
+        )

--- a/l10n_br_fiscal/demo/fiscal_document_nfse_demo.xml
+++ b/l10n_br_fiscal/demo/fiscal_document_nfse_demo.xml
@@ -31,8 +31,5 @@
     <function model="l10n_br_fiscal.document.line" name="_onchange_product_id_fiscal">
         <value eval="[ref('l10n_br_fiscal.demo_nfse_line_same_state_1-1')]" />
     </function>
-    <function model="l10n_br_fiscal.document.line" name="_onchange_commercial_quantity">
-        <value eval="[ref('l10n_br_fiscal.demo_nfse_line_same_state_1-1')]" />
-    </function>
 
 </odoo>

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -175,11 +175,24 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         string="CFOP Destination",
     )
 
-    fiscal_price = fields.Float(digits="Product Price")
+    fiscal_price = fields.Float(
+        digits="Product Price",
+        compute="_compute_fiscal_quantity_and_price",
+        store=True,
+    )
 
-    uot_id = fields.Many2one(comodel_name="uom.uom", string="Tax UoM")
+    uot_id = fields.Many2one(
+        comodel_name="uom.uom",
+        string="Tax UoM",
+        compute="_compute_fiscal_quantity_and_price",
+        store=True,
+    )
 
-    fiscal_quantity = fields.Float(digits="Product Unit of Measure")
+    fiscal_quantity = fields.Float(
+        digits="Product Unit of Measure",
+        compute="_compute_fiscal_quantity_and_price",
+        store=True,
+    )
 
     discount_value = fields.Monetary()
 

--- a/l10n_br_fiscal/models/document_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_line_mixin_methods.py
@@ -359,7 +359,6 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         if self.fiscal_operation_id:
             if not self.price_unit:
                 self._get_product_price()
-            self._onchange_commercial_quantity()
             self.fiscal_operation_line_id = self.fiscal_operation_id.line_definition(
                 company=self.company_id,
                 partner=self._get_fiscal_partner(),
@@ -720,28 +719,20 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         self._update_fiscal_tax_ids(self._get_all_tax_id_fields())
         self._update_fiscal_taxes()
 
-    @api.model
-    def _update_fiscal_quantity(self, product_id, price, quantity, uom_id, uot_id):
-        result = {"uot_id": uom_id, "fiscal_quantity": quantity, "fiscal_price": price}
-        if uot_id and uom_id != uot_id:
-            result["uot_id"] = uot_id
-            if product_id and price and quantity:
-                product = self.env["product.product"].browse(product_id)
-                result["fiscal_price"] = price / (product.uot_factor or 1.0)
-                result["fiscal_quantity"] = quantity * (product.uot_factor or 1.0)
+    @api.depends("uot_id", "uom_id", "price_unit", "quantity")
+    def _compute_fiscal_quantity_and_price(self):
+        for line in self:
+            if not line.uot_id:
+                line.uot_id = line.uom_id
 
-        return result
-
-    @api.onchange("uot_id", "uom_id", "price_unit", "quantity")
-    def _onchange_commercial_quantity(self):
-        product_id = False
-        if self.product_id:
-            product_id = self.product_id.id
-        self.update(
-            self._update_fiscal_quantity(
-                product_id, self.price_unit, self.quantity, self.uom_id, self.uot_id
-            )
-        )
+            fiscal_quantity = line.quantity
+            fiscal_price = line.price_unit
+            if line.product_id and line.price_unit:
+                fiscal_price = line.price_unit / (line.product_id.uot_factor or 1.0)
+            if line.product_id and line.quantity:
+                fiscal_quantity = line.quantity * (line.product_id.uot_factor or 1.0)
+            line.fiscal_quantity = fiscal_quantity
+            line.fiscal_price = fiscal_price
 
     @api.onchange("ii_customhouse_charges")
     def _onchange_ii_customhouse_charges(self):

--- a/l10n_br_fiscal/tests/test_fiscal_document_generic.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_generic.py
@@ -53,7 +53,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
             # as the product change might have altered it.
             line.price_unit = original_price_unit
 
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -176,7 +175,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         for line in self.nfe_other_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -297,7 +295,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         for line in self.nfe_not_taxpayer.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -405,7 +402,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         for line in self.nfe_not_taxpayer_pf.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -513,7 +509,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         for line in self.nfe_export.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -615,7 +610,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         for line in self.nfe_sn_same_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
 
             # set fake estimate tax
             line.ncm_id.tax_estimate_ids.create(
@@ -734,7 +728,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         for line in self.nfe_sn_other_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -838,7 +831,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         for line in self.nfe_sn_not_taxpayer.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -930,7 +922,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         for line in self.nfe_sn_export.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()

--- a/l10n_br_fiscal/tests/test_fiscal_document_nfse.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_nfse.py
@@ -18,7 +18,6 @@ class TestFiscalDocumentNFSe(TransactionCase):
 
         for line in self.nfse_same_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()

--- a/l10n_br_fiscal/tests/test_tax_benefit.py
+++ b/l10n_br_fiscal/tests/test_tax_benefit.py
@@ -40,7 +40,6 @@ class TestTaxBenefit(TransactionCase):
 
         for line in self.nfe_tax_benefit.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()

--- a/l10n_br_fiscal_edi/tests/test_fiscal_document_generic.py
+++ b/l10n_br_fiscal_edi/tests/test_fiscal_document_generic.py
@@ -59,7 +59,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
             # as the product change might have altered it.
             line.price_unit = original_price_unit
 
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -199,7 +198,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         for line in self.nfe_other_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -320,7 +318,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         for line in self.nfe_not_taxpayer.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -428,7 +425,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         for line in self.nfe_not_taxpayer_pf.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -536,7 +532,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         for line in self.nfe_export.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -638,7 +633,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         for line in self.nfe_sn_same_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
 
             # set fake estimate tax
             line.ncm_id.tax_estimate_ids.create(
@@ -757,7 +751,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         for line in self.nfe_sn_other_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -861,7 +854,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         for line in self.nfe_sn_not_taxpayer.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -953,7 +945,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         for line in self.nfe_sn_export.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()

--- a/l10n_br_fiscal_edi/tests/test_tax_benefit.py
+++ b/l10n_br_fiscal_edi/tests/test_tax_benefit.py
@@ -42,7 +42,6 @@ class TestTaxBenefit(TransactionCase):
 
         for line in self.nfe_tax_benefit.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()

--- a/l10n_br_nfse/demo/fiscal_document_demo.xml
+++ b/l10n_br_nfse/demo/fiscal_document_demo.xml
@@ -26,12 +26,6 @@
         >
             <value eval="[ref('l10n_br_fiscal.demo_nfse_line_same_state_1-1')]" />
         </function>
-        <function
-            model="l10n_br_fiscal.document.line"
-            name="_onchange_commercial_quantity"
-        >
-            <value eval="[ref('l10n_br_fiscal.demo_nfse_line_same_state_1-1')]" />
-        </function>
     </data>
 
 </odoo>

--- a/l10n_br_nfse/tests/test_fiscal_document_nfse_common.py
+++ b/l10n_br_nfse/tests/test_fiscal_document_nfse_common.py
@@ -128,7 +128,6 @@ class TestFiscalDocumentNFSeCommon(TransactionCase):
 
         for line in self.nfse_same_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()

--- a/l10n_br_purchase/models/purchase_order_line.py
+++ b/l10n_br_purchase/models/purchase_order_line.py
@@ -109,12 +109,6 @@ class PurchaseOrderLine(models.Model):
                 )
         return result
 
-    @api.onchange("product_qty", "product_uom")
-    def _onchange_quantity(self):
-        """To call the method in the mixin to update
-        the price and fiscal quantity."""
-        return self._onchange_commercial_quantity()
-
     def _compute_tax_id(self):
         for line in self:
             if line.fiscal_operation_line_id:

--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -205,12 +205,6 @@ class SaleOrderLine(models.Model):
         result.update(super()._prepare_invoice_line(**optional_values))
         return result
 
-    @api.onchange("product_uom", "product_uom_qty")
-    def _onchange_product_uom(self):
-        """To call the method in the mixin to update
-        the price and fiscal quantity."""
-        self._onchange_commercial_quantity()
-
     @api.depends(
         "qty_delivered_method",
         "analytic_line_ids.so_line",

--- a/l10n_br_stock_account/models/stock_move.py
+++ b/l10n_br_stock_account/models/stock_move.py
@@ -116,15 +116,11 @@ class StockMove(models.Model):
                     if tax_ids:
                         record.tax_ids = tax_ids
 
-    @api.onchange("product_id", "product_uom", "product_uom_qty", "price_unit")
+    @api.onchange("product_id", "fiscal_operation_id", "price_unit")
     def _onchange_product_quantity(self):
-        """To call the method in the mixin to update
-        the price and fiscal quantity."""
-        result = self._onchange_commercial_quantity()
-
-        # No Brasil o caso de Ordens de Entrega com Operação Fiscal
-        # de Saída precisam informar o Preço de Custo e não o de Venda
-        # ex.: Simples Remessa, Remessa p/ Industrialiazação e etc.
+        """No Brasil o caso de Ordens de Entrega com Operação Fiscal
+        de Saída precisam informar o Preço de Custo e não o de Venda
+        ex.: Simples Remessa, Remessa p/ Industrialiazação e etc."""
         if (
             self.fiscal_operation_id.fiscal_operation_type == "out"
             and self.price_unit == 0.0
@@ -132,8 +128,6 @@ class StockMove(models.Model):
             self.price_unit = self.product_id.with_company(
                 self.company_id
             ).standard_price
-
-        return result
 
     def _get_new_picking_values(self):
         """Prepares a new picking for this move as it could not be assigned to
@@ -242,21 +236,9 @@ class StockMove(models.Model):
             # Caso Brasil se caracteriza por ter Operação Fiscal
             return new_moves_vals
 
-        self._onchange_commercial_quantity()
         self._onchange_fiscal_taxes()
 
         for new_move_vals in new_moves_vals:
-            product_id = new_move_vals.get("product_id")
-            price_unit = new_move_vals.get("price_unit")
-            quantity = new_move_vals.get("product_uom_qty")
-            uom_id = new_move_vals.get("uom_id")
-            uot_id = new_move_vals.get("uot_id")
-
-            new_move_vals.update(
-                self._update_fiscal_quantity(
-                    product_id, price_unit, quantity, uom_id, uot_id
-                )
-            )
             new_move_vals.update(self._prepare_br_fiscal_dict())
 
         return new_moves_vals

--- a/l10n_br_stock_account/tests/common.py
+++ b/l10n_br_stock_account/tests/common.py
@@ -12,8 +12,6 @@ class TestBrPickingInvoicingCommon(TestPickingInvoicingCommon):
 
     def _run_line_onchanges(self, record):
         result = super()._run_line_onchanges(record)
-        # Mixin Fiscal
-        record._onchange_commercial_quantity()
 
         # Stock Move
         record._onchange_product_id_fiscal()


### PR DESCRIPTION
mudei os campos `fiscal_price`, `fiscal_qty` e `uot_id` para compute/store=True. Tirei o onchange `_onchange_commercial_quantity` e implementei o metodo compute `_compute_fiscal_quantity_and_price`.

Uma coisa importante: no account.move.line (modulo l10n_br_account) esses campos são herdados pelo _inherits. Porem, assim como para alguns outros campos, os métodos compute (our related) precisam ser redefinidos no próprio objeto account.move.line para ser chamados nas telas (como se fosse onchange) então eu tive que repetir esses campos (sem store=True! aqui!) assim  como ja fizemos para alguns outros campos na mesma situação.

Depois ajustei nos testes e dados de demo dos varios módulos para tirar as antigas chamadas ao método onchange removido. Pude remover o método _update_fiscal_quantity também.