### PR TITLE
[16.0][REF] l10n_br_fiscal: Duplicate label conflict in Fiscal Type

### DIFF
--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -154,6 +154,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     operation_fiscal_type = fields.Selection(
         related="fiscal_operation_id.fiscal_type",
         readonly=True,
+        string="Operation Fiscal Type",
     )
 
     fiscal_operation_line_id = fields.Many2one(


### PR DESCRIPTION
## Objetivo da PR

Corrige conflito de rótulos duplicados nos campos 'Fiscal Type', ter mais clareza no rótulos dos campos

Se conferir o LOG do teste aparece esse warning 
![image](https://github.com/user-attachments/assets/3a2ee7cd-c880-4485-9013-6a77389e5b88)

