### PR TITLE
[16.0][REF] l10n_br_stock_account: clean up test class

### DIFF
--- a/l10n_br_stock_account/tests/common.py
+++ b/l10n_br_stock_account/tests/common.py
@@ -6,17 +6,9 @@ from odoo.addons.stock_picking_invoicing.tests.common import TestPickingInvoicin
 
 
 class TestBrPickingInvoicingCommon(TestPickingInvoicingCommon):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-
     def _change_user_company(self, company):
         self.env.user.company_ids += company
         self.env.user.company_id = company
-
-    def _run_picking_onchanges(self, record):
-        result = super()._run_picking_onchanges(record)
-        return result
 
     def _run_line_onchanges(self, record):
         result = super()._run_line_onchanges(record)


### PR DESCRIPTION
assim como o @mbcosta observou, depois de https://github.com/OCA/l10n-brazil/commit/4e0dc4e10b9494d464405ddd6b8e47708f8b2b93 da para tirar o override do _run_picking_onchanges. Tb removi o override do setupClass.