### PR TITLE
[16.0][DEL] l10n_br_nfe: don't depend on erpbrasil.edoc.pdf anymore

### DIFF
--- a/l10n_br_account_nfe/tests/test_nfe_danfe_account.py
+++ b/l10n_br_account_nfe/tests/test_nfe_danfe_account.py
@@ -2,6 +2,8 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from unittest.mock import patch
 
+from erpbrasil import edoc
+
 from odoo.tests import TransactionCase, tagged
 
 
@@ -26,6 +28,8 @@ class TestDanfe(TransactionCase):
     def test_generate_danfe_erpbrasil_edoc(self):
         nfe = self.env.ref("l10n_br_account_nfe.demo_nfe_dados_de_cobranca")
         nfe.company_id.danfe_library = "erpbrasil.edoc.pdf"
+        if not hasattr(edoc, "pdf"):
+            return  # skip test if erpbrasil.edoc.pdf is not installed
 
         with patch("erpbrasil.edoc.pdf.base.ImprimirXml.imprimir") as mock_make_pdf:
             mock_make_pdf.return_value = b"Mock PDF"

--- a/l10n_br_nfe/__manifest__.py
+++ b/l10n_br_nfe/__manifest__.py
@@ -57,7 +57,6 @@
             "erpbrasil.assinatura>=1.7.0",
             "erpbrasil.transmissao>=1.1.0",
             "erpbrasil.edoc>=2.5.2",
-            "erpbrasil.edoc.pdf",
             "erpbrasil.base>=2.3.0",
             "brazilfiscalreport",
         ],

--- a/l10n_br_nfe/report/ir_actions_report.py
+++ b/l10n_br_nfe/report/ir_actions_report.py
@@ -5,13 +5,17 @@ import logging
 from io import BytesIO
 
 from brazilfiscalreport.danfe import Danfe, DanfeConfig, InvoiceDisplay, Margins
-from erpbrasil.edoc.pdf import base
 from lxml import etree
 
 from odoo import _, api, models
 from odoo.exceptions import UserError
 
 _logger = logging.getLogger(__name__)
+
+try:
+    from erpbrasil.edoc.pdf import edoc_pdf_base
+except ImportError:
+    _logger.debug(_("erpbrasil.edoc.pdf lib not installed!"))
 
 
 class IrActionsReport(models.Model):
@@ -112,7 +116,7 @@ class IrActionsReport(models.Model):
         return DanfeConfig(**danfe_config)
 
     def render_danfe_erpbrasil(self, nfe_xml):
-        pdf = base.ImprimirXml.imprimir(
+        pdf = edoc_pdf_base.ImprimirXml.imprimir(
             string_xml=nfe_xml,
         )
         return pdf, "pdf"

--- a/l10n_br_nfe/tests/test_nfe_danfe.py
+++ b/l10n_br_nfe/tests/test_nfe_danfe.py
@@ -2,6 +2,8 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from unittest.mock import patch
 
+from erpbrasil import edoc
+
 from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
 
@@ -20,6 +22,8 @@ class TestDanfeGeneration(TransactionCase):
     def test_generate_danfe_erpbrasil_edoc(self):
         nfe = self.env.ref("l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11")
         nfe.company_id.danfe_library = "erpbrasil.edoc.pdf"
+        if not hasattr(edoc, "pdf"):
+            return  # skip test if erpbrasil.edoc.pdf is not installed
 
         with patch("erpbrasil.edoc.pdf.base.ImprimirXml.imprimir") as mock_make_pdf:
             mock_make_pdf.return_value = b"Mock PDF"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ brazilfiscalreport
 email-validator
 erpbrasil.assinatura>=1.7.0
 erpbrasil.base>=2.3.0
-erpbrasil.edoc.pdf
 erpbrasil.edoc>=2.5.2
 erpbrasil.transmissao>=1.1.0
 nfelib<=2.0.7


### PR DESCRIPTION
Na v14, permitimos a opção de imprimir o DANFE com a nova lib [BrazilFiscalReport](https://github.com/Engenere/BrazilFiscalReport) da Engenere https://github.com/OCA/l10n-brazil/pull/3068
Enquanto isso a gente deixou a opção de poder imprimir o DANFE usando a lib legacy da KMEE [erpbrasil.edoc.pdf](https://github.com/erpbrasil/erpbrasil.edoc.pdf).

Na CI da OCA, a opção com erpbrasil.edoc.pdf já tava sem teste para não ter que matar 3 focas baixando e instalando o Libreoffice a cada push.

Até então, deixamos o erpbrasil.edoc.pdf como dependência do modulo l10n_br_nfe. Mas então que tal continuar mantendo essa opção de impressão mas tirando a dependencia a partir da v16?

A ideia é abaixar a barreira de entrada e tornar o projeto mais profissional, então eu acho que a gente tem que fazer o trabalho de limpar a casa: se 99% do pessoal não tem porque usar essa lib a partir da v16, não me parece bom deixar a dependência e fazer  que o iniciante tenha que se perguntar que diabo é essa lib, como instala e levar um susto ainda se o cara for bom... Ai o 1% que realmente quer essa opção e que vai se garantir baixa a dependência e beleza; a gente mantém o código para usar se tiver instalado...

Parece que até o pessoal da KMEE pulou do barco da lib erpbrasil.edoc.pdf:  não teve mais manutenção da parte da KMEE desde que eu fiz essa observação o ano passado https://github.com/OCA/l10n-brazil/pull/3068#issuecomment-2109009100
enquanto isso geral foi contribuir na nova lib top da Engenere, até o pessoal da KMEE... https://github.com/Engenere/BrazilFiscalReport/pulls?q=is%3Apr+is%3Amerged+