### PR TITLE
[14.0][FIX] l10n_br_fiscal: fix DIFAL calculation for return operations

### DIFF
--- a/l10n_br_fiscal/models/icms_regulation.py
+++ b/l10n_br_fiscal/models/icms_regulation.py
@@ -2106,7 +2106,7 @@ class ICMSRegulation(models.Model):
             company.state_id != partner.state_id
             and partner.ind_ie_dest == NFE_IND_IE_DEST_9
             and operation_line.fiscal_operation_type == FISCAL_OUT
-            or operation_line.fiscal_operation_id.fiscal_type == "return_in"
+            or operation_line.fiscal_operation_id.fiscal_type != "return_in"
             and operation_line.fiscal_operation_type == FISCAL_IN
         ):
             domain = self._build_map_tax_def_domain(

--- a/l10n_br_fiscal/models/operation.py
+++ b/l10n_br_fiscal/models/operation.py
@@ -71,6 +71,12 @@ class Operation(models.Model):
         tracking=True,
     )
 
+    remove_difal = fields.Boolean(
+        string="Remover tag do DIFAL em operações de retorno",
+        readonly=True,
+        states={"draft": [("readonly", False)]},
+    )
+
     return_fiscal_operation_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.operation",
         string="Return Operation",

--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -393,7 +393,7 @@ class Tax(models.Model):
             and partner.ind_ie_dest == NFE_IND_IE_DEST_9
             and tax_dict.get("tax_value")
             and operation_line.fiscal_operation_type == FISCAL_OUT
-            and operation_line.fiscal_operation_type == FISCAL_OUT
+            and operation_line.fiscal_operation_type == FISCAL_IN
             and operation_line.fiscal_operation_id.fiscal_type != "return_in"
         ):
             icms_tax_difal, _ = company.icms_regulation_id.map_tax_def_icms_difal(

--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -393,8 +393,8 @@ class Tax(models.Model):
             and partner.ind_ie_dest == NFE_IND_IE_DEST_9
             and tax_dict.get("tax_value")
             and operation_line.fiscal_operation_type == FISCAL_OUT
-            or operation_line.fiscal_operation_id.fiscal_type == "return_in"
-            and operation_line.fiscal_operation_type == FISCAL_IN
+            and operation_line.fiscal_operation_type == FISCAL_OUT
+            and operation_line.fiscal_operation_id.fiscal_type != "return_in"
         ):
             icms_tax_difal, _ = company.icms_regulation_id.map_tax_def_icms_difal(
                 company, partner, product, ncm, nbm, cest, operation_line, ind_final

--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -392,9 +392,13 @@ class Tax(models.Model):
             and cfop.destination == CFOP_DESTINATION_EXTERNAL
             and partner.ind_ie_dest == NFE_IND_IE_DEST_9
             and tax_dict.get("tax_value")
-            and operation_line.fiscal_operation_type == FISCAL_OUT
-            and operation_line.fiscal_operation_type == FISCAL_IN
-            and operation_line.fiscal_operation_id.fiscal_type != "return_in"
+            and (
+                operation_line.fiscal_operation_type == FISCAL_OUT
+                or (
+                    operation_line.fiscal_operation_type == FISCAL_IN
+                    and operation_line.fiscal_operation_id.fiscal_type != "return_in"
+                )
+            )
         ):
             icms_tax_difal, _ = company.icms_regulation_id.map_tax_def_icms_difal(
                 company, partner, product, ncm, nbm, cest, operation_line, ind_final

--- a/l10n_br_fiscal/views/operation_view.xml
+++ b/l10n_br_fiscal/views/operation_view.xml
@@ -81,6 +81,10 @@
                         <group>
                             <field name="fiscal_operation_type" />
                             <field name="fiscal_type" />
+                            <field
+                                name="remove_difal"
+                                attrs="{'invisible': [('fiscal_type', '!=', 'return_in')]}"
+                            />
                             <field name="code" />
                             <field
                                 name="company_id"

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -333,6 +333,7 @@ class NFeLine(spec_models.StackedModel):
             or self.partner_id.ind_ie_dest != "9"
             or self.partner_id.state_id == self.company_id.state_id
             or self.partner_id.country_id != self.company_id.country_id
+            or self.fiscal_operation_id.remove_difal
         ):
             xsd_fields.remove("nfe40_ICMSUFDest")
 


### PR DESCRIPTION
Esta PR corrige o difal que está sendo calculado para operações de retorno quando o produto é importado e o destino do cfop é externo