### PR TITLE
[15.0][l10n_br_fiscal] remove onchange_ncm_id

### DIFF
--- a/l10n_br_fiscal/models/document_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_line_mixin_methods.py
@@ -363,7 +363,9 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         self.ensure_one()
         return self.partner_id
 
-    @api.onchange("fiscal_operation_id")
+    @api.onchange(
+        "fiscal_operation_id", "ncm_id", "nbs_id", "cest_id", "service_type_id"
+    )
     def _onchange_fiscal_operation_id(self):
         if self.fiscal_operation_id:
             if not self.price_unit:
@@ -755,10 +757,6 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         if self.ii_customhouse_charges:
             self._update_fiscal_taxes()
 
-    @api.onchange("ncm_id", "nbs_id", "cest_id")
-    def _onchange_ncm_id(self):
-        self._onchange_fiscal_operation_id()
-
     @api.onchange("fiscal_tax_ids")
     def _onchange_fiscal_tax_ids(self):
         self._update_fiscal_taxes()
@@ -770,11 +768,6 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             self._onchange_fiscal_operation_id()
             if self.city_taxation_code_id.city_id:
                 self.update({"issqn_fg_city_id": self.city_taxation_code_id.city_id})
-
-    @api.onchange("service_type_id")
-    def _onchange_service_type_id(self):
-        if self.service_type_id:
-            self._onchange_fiscal_operation_id()
 
     @api.model
     def _add_fields_to_amount(self):

--- a/l10n_br_fiscal/tests/test_fiscal_document_generic.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_generic.py
@@ -54,7 +54,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
             line.price_unit = original_price_unit
 
             line._onchange_commercial_quantity()
-            line._onchange_ncm_id()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -178,7 +177,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
         for line in self.nfe_other_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
-            line._onchange_ncm_id()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -300,7 +298,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
         for line in self.nfe_not_taxpayer.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
-            line._onchange_ncm_id()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -409,7 +406,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
         for line in self.nfe_not_taxpayer_pf.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
-            line._onchange_ncm_id()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -518,7 +514,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
         for line in self.nfe_export.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
-            line._onchange_ncm_id()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -633,7 +628,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
                 }
             )
 
-            line._onchange_ncm_id()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -741,7 +735,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
         for line in self.nfe_sn_other_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
-            line._onchange_ncm_id()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -846,7 +839,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
         for line in self.nfe_sn_not_taxpayer.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
-            line._onchange_ncm_id()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -939,7 +931,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
         for line in self.nfe_sn_export.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
-            line._onchange_ncm_id()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()

--- a/l10n_br_fiscal/tests/test_fiscal_document_nfse.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_nfse.py
@@ -19,7 +19,6 @@ class TestFiscalDocumentNFSe(TransactionCase):
         for line in self.nfse_same_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
-            line._onchange_ncm_id()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()

--- a/l10n_br_fiscal/tests/test_tax_benefit.py
+++ b/l10n_br_fiscal/tests/test_tax_benefit.py
@@ -41,7 +41,6 @@ class TestTaxBenefit(TransactionCase):
         for line in self.nfe_tax_benefit.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
-            line._onchange_ncm_id()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()

--- a/l10n_br_fiscal_edi/tests/test_fiscal_document_generic.py
+++ b/l10n_br_fiscal_edi/tests/test_fiscal_document_generic.py
@@ -60,7 +60,6 @@ class TestFiscalDocumentGeneric(SavepointCase):
             line.price_unit = original_price_unit
 
             line._onchange_commercial_quantity()
-            line._onchange_ncm_id()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -201,7 +200,6 @@ class TestFiscalDocumentGeneric(SavepointCase):
         for line in self.nfe_other_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
-            line._onchange_ncm_id()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -323,7 +321,6 @@ class TestFiscalDocumentGeneric(SavepointCase):
         for line in self.nfe_not_taxpayer.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
-            line._onchange_ncm_id()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -432,7 +429,6 @@ class TestFiscalDocumentGeneric(SavepointCase):
         for line in self.nfe_not_taxpayer_pf.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
-            line._onchange_ncm_id()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -541,7 +537,6 @@ class TestFiscalDocumentGeneric(SavepointCase):
         for line in self.nfe_export.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
-            line._onchange_ncm_id()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -656,7 +651,6 @@ class TestFiscalDocumentGeneric(SavepointCase):
                 }
             )
 
-            line._onchange_ncm_id()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -764,7 +758,6 @@ class TestFiscalDocumentGeneric(SavepointCase):
         for line in self.nfe_sn_other_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
-            line._onchange_ncm_id()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -869,7 +862,6 @@ class TestFiscalDocumentGeneric(SavepointCase):
         for line in self.nfe_sn_not_taxpayer.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
-            line._onchange_ncm_id()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
@@ -962,7 +954,6 @@ class TestFiscalDocumentGeneric(SavepointCase):
         for line in self.nfe_sn_export.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
-            line._onchange_ncm_id()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()

--- a/l10n_br_fiscal_edi/tests/test_tax_benefit.py
+++ b/l10n_br_fiscal_edi/tests/test_tax_benefit.py
@@ -43,7 +43,6 @@ class TestTaxBenefit(SavepointCase):
         for line in self.nfe_tax_benefit.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
-            line._onchange_ncm_id()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()

--- a/l10n_br_nfse/tests/test_fiscal_document_nfse_common.py
+++ b/l10n_br_nfse/tests/test_fiscal_document_nfse_common.py
@@ -129,7 +129,6 @@ class TestFiscalDocumentNFSeCommon(TransactionCase):
         for line in self.nfse_same_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_commercial_quantity()
-            line._onchange_ncm_id()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()


### PR DESCRIPTION
backport de https://github.com/OCA/l10n-brazil/pull/3685 que ja entrou na 14.0 tb.