### PR TITLE
[16.0][l10n_br_fiscal] fiscal quantity and fiscal price as compute

### DIFF
--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -122,16 +122,6 @@ class AccountMoveLine(models.Model):
             fiscal_doc_id = move_id.fiscal_document_id.id
             if not fiscal_doc_id:
                 continue
-
-            values.update(
-                self._update_fiscal_quantity(
-                    values.get("product_id"),
-                    values.get("price_unit"),
-                    values.get("quantity"),
-                    values.get("product_uom_id"),
-                    values.get("uot_id"),
-                )
-            )
             values["document_id"] = fiscal_doc_id  # pass through the _inherits system
 
         # This reordering bellow is crucial to ensure accurate linkage between

--- a/l10n_br_account/tests/test_move_edition.py
+++ b/l10n_br_account/tests/test_move_edition.py
@@ -378,3 +378,36 @@ class TestMoveEdition(TransactionCase):
         self.assertEqual(move.fiscal_line_ids[0].fiscal_price, 112)
         self.assertEqual(move.fiscal_line_ids[0].quantity, 10)
         self.assertEqual(move.fiscal_line_ids[0].fiscal_quantity, 5)
+
+    def test_product_fiscal_factor(self):
+        self.user.groups_id += self.env.ref("l10n_br_fiscal.group_user")
+        nfe_user_group = self.env.ref(
+            "l10n_br_nfe.group_user", raise_if_not_found=False
+        )
+        if nfe_user_group:
+            self.user.groups_id += nfe_user_group
+
+        move_form = Form(
+            self.env["account.move"].with_context(
+                default_move_type="out_invoice",
+            )
+        )
+        move_form.company_id = self.env.ref("l10n_br_base.empresa_lucro_presumido")
+        move_form.partner_id = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        move_form.document_type_id = self.env.ref("l10n_br_fiscal.document_55")
+        move_form.document_serie_id = self.env.ref(
+            "l10n_br_fiscal.empresa_lc_document_55_serie_1"
+        )
+        move_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
+        product_id = self.env.ref("product.product_product_6")
+        product_id.uot_factor = 2
+        with move_form.invoice_line_ids.new() as line_form:
+            line_form.product_id = product_id
+            line_form.price_unit = 100
+            line_form.quantity = 10
+
+        doc = move_form.save()
+        self.assertEqual(doc.fiscal_line_ids[0].price_unit, 100)
+        self.assertEqual(doc.fiscal_line_ids[0].fiscal_price, 50)
+        self.assertEqual(doc.fiscal_line_ids[0].quantity, 10)
+        self.assertEqual(doc.fiscal_line_ids[0].fiscal_quantity, 20)

--- a/l10n_br_account/tests/test_move_edition.py
+++ b/l10n_br_account/tests/test_move_edition.py
@@ -146,6 +146,8 @@ class TestMoveEdition(TransactionCase):
         if nfe_user_group:
             self.user.groups_id += nfe_user_group
 
+        self.product_id.list_price = 150  # we will later test price_unit can be changed
+
         move_form = Form(
             self.env["account.move"].with_context(
                 default_move_type="out_invoice",
@@ -221,6 +223,8 @@ class TestMoveEdition(TransactionCase):
         fisc_line = move.fiscal_line_ids[0]
         self.assertEqual(aml.product_id, fisc_line.product_id)
         self.assertEqual(aml.name, fisc_line.name)
+        self.assertEqual(aml.price_unit, 42)
+        self.assertEqual(aml.quantity, 42)
         self.assertEqual(aml.quantity, fisc_line.quantity)
         self.assertEqual(aml.price_unit, fisc_line.price_unit)
 
@@ -338,3 +342,39 @@ class TestMoveEdition(TransactionCase):
         self.assertEqual(move.state, "cancel")
         move.button_draft()
         self.assertEqual(move.state, "draft")
+
+    def test_product_fiscal_price_and_qty_edition(self):
+        self.user.groups_id += self.env.ref("l10n_br_fiscal.group_user")
+        nfe_user_group = self.env.ref(
+            "l10n_br_nfe.group_user", raise_if_not_found=False
+        )
+        if nfe_user_group:
+            self.user.groups_id += nfe_user_group
+
+        move_form = Form(
+            self.env["account.move"].with_context(
+                default_move_type="out_invoice",
+            )
+        )
+        move_form.company_id = self.env.ref("l10n_br_base.empresa_lucro_presumido")
+        move_form.partner_id = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        move_form.document_type_id = self.env.ref("l10n_br_fiscal.document_55")
+        move_form.document_serie_id = self.env.ref(
+            "l10n_br_fiscal.empresa_lc_document_55_serie_1"
+        )
+        move_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
+        move_form.ind_final = "1"
+        product_id = self.env.ref("product.product_product_6")
+        product_id.list_price = 100
+        with move_form.invoice_line_ids.new() as line_form:
+            line_form.product_id = self.product_id
+            line_form.price_unit = 110
+            line_form.quantity = 10
+            line_form.fiscal_price = 112
+            line_form.fiscal_quantity = 5
+
+        move = move_form.save()
+        self.assertEqual(move.fiscal_line_ids[0].price_unit, 110)
+        self.assertEqual(move.fiscal_line_ids[0].fiscal_price, 112)
+        self.assertEqual(move.fiscal_line_ids[0].quantity, 10)
+        self.assertEqual(move.fiscal_line_ids[0].fiscal_quantity, 5)

--- a/l10n_br_cte/demo/fiscal_document_demo.xml
+++ b/l10n_br_cte/demo/fiscal_document_demo.xml
@@ -86,7 +86,6 @@
         <field name="name">Frete</field>
         <field name="product_id" ref="product.product_product_9" />
         <field name="uom_id" ref="uom.product_uom_unit" />
-        <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -200,7 +199,6 @@
         <field name="name">Frete</field>
         <field name="product_id" ref="product.product_product_9" />
         <field name="uom_id" ref="uom.product_uom_unit" />
-        <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -314,7 +312,6 @@
         <field name="name">Frete</field>
         <field name="product_id" ref="product.product_product_9" />
         <field name="uom_id" ref="uom.product_uom_unit" />
-        <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -428,7 +425,6 @@
         <field name="name">Frete</field>
         <field name="product_id" ref="product.product_product_9" />
         <field name="uom_id" ref="uom.product_uom_unit" />
-        <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -542,7 +538,6 @@
         <field name="name">Frete</field>
         <field name="product_id" ref="product.product_product_9" />
         <field name="uom_id" ref="uom.product_uom_unit" />
-        <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -658,7 +653,6 @@
         <field name="name">Frete</field>
         <field name="product_id" ref="product.product_product_9" />
         <field name="uom_id" ref="uom.product_uom_unit" />
-        <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />

--- a/l10n_br_cte/tests/test_cte_serialize.py
+++ b/l10n_br_cte/tests/test_cte_serialize.py
@@ -37,6 +37,8 @@ class TestCTeSerialize(TransactionCase):
             cte.action_document_back2draft()
 
         cte.fiscal_line_ids.name = "Frete"
+        for line in cte.fiscal_line_ids:
+            line.product_id.list_price = 100
         cte.fiscal_line_ids._onchange_fiscal_operation_line_id()
         cte.fiscal_line_ids.cfop_id = cte.env.ref("l10n_br_fiscal.cfop_5352")
 

--- a/l10n_br_fiscal/demo/fiscal_document_demo.xml
+++ b/l10n_br_fiscal/demo/fiscal_document_demo.xml
@@ -30,7 +30,6 @@
         <field name="name">Teste</field>
         <field name="product_id" ref="product.product_product_6" />
         <field name="uom_id" ref="uom.product_uom_unit" />
-        <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -42,7 +41,6 @@
     </function>
 
     <record id="demo_nfe_line_same_state_1-1" model="l10n_br_fiscal.document.line">
-        <field name="price_unit">100</field>
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
@@ -61,7 +59,6 @@
         <field name="name">Teste</field>
         <field name="product_id" ref="product.product_product_27" />
         <field name="uom_id" ref="uom.product_uom_unit" />
-        <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -73,7 +70,6 @@
     </function>
 
     <record id="demo_nfe_line_same_state_1-2" model="l10n_br_fiscal.document.line">
-        <field name="price_unit">100</field>
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
@@ -107,7 +103,6 @@
         <field name="name">Teste</field>
         <field name="product_id" ref="product.product_product_6" />
         <field name="uom_id" ref="uom.product_uom_unit" />
-        <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -119,7 +114,6 @@
     </function>
 
     <record id="demo_nfe_line_other_state_1-3" model="l10n_br_fiscal.document.line">
-        <field name="price_unit">100</field>
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
@@ -138,7 +132,6 @@
         <field name="name">Teste</field>
         <field name="product_id" ref="product.product_product_27" />
         <field name="uom_id" ref="uom.product_uom_unit" />
-        <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -150,7 +143,6 @@
     </function>
 
     <record id="demo_nfe_line_other_state_2-3" model="l10n_br_fiscal.document.line">
-        <field name="price_unit">100</field>
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
@@ -181,7 +173,6 @@
     </function>
 
     <record id="demo_nfe_line_other_state_3-3" model="l10n_br_fiscal.document.line">
-        <field name="price_unit">100</field>
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
@@ -217,7 +208,6 @@
         <field name="name">Teste</field>
         <field name="product_id" ref="product.product_product_6" />
         <field name="uom_id" ref="uom.product_uom_unit" />
-        <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -229,7 +219,6 @@
     </function>
 
     <record id="demo_nfe_line_export_3-1" model="l10n_br_fiscal.document.line">
-        <field name="price_unit">100</field>
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
@@ -248,7 +237,6 @@
         <field name="name">Teste</field>
         <field name="product_id" ref="product.product_product_27" />
         <field name="uom_id" ref="uom.product_uom_unit" />
-        <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -260,7 +248,6 @@
     </function>
 
     <record id="demo_nfe_line_export_3-2" model="l10n_br_fiscal.document.line">
-        <field name="price_unit">100</field>
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
@@ -297,7 +284,6 @@
         <field name="name">Teste</field>
         <field name="product_id" ref="product.product_product_6" />
         <field name="uom_id" ref="uom.product_uom_unit" />
-        <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -320,7 +306,6 @@
         id="demo_nfe_line_nao_contribuinte_4-1"
         model="l10n_br_fiscal.document.line"
     >
-        <field name="price_unit">100</field>
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
@@ -342,7 +327,6 @@
         <field name="name">Teste</field>
         <field name="product_id" ref="product.product_product_27" />
         <field name="uom_id" ref="uom.product_uom_unit" />
-        <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -360,7 +344,6 @@
         id="demo_nfe_line_nao_contribuinte_4-2"
         model="l10n_br_fiscal.document.line"
     >
-        <field name="price_unit">100</field>
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
@@ -394,7 +377,6 @@
         <field name="name">Teste</field>
         <field name="product_id" ref="product.product_product_7" />
         <field name="uom_id" ref="uom.product_uom_unit" />
-        <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -414,7 +396,6 @@
     </function>
 
     <record id="demo_nfe_tax_benefit_4-1" model="l10n_br_fiscal.document.line">
-        <field name="price_unit">100</field>
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
@@ -448,7 +429,6 @@
         <field name="name">Teste</field>
         <field name="product_id" ref="product.product_product_6" />
         <field name="uom_id" ref="uom.product_uom_unit" />
-        <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -463,7 +443,6 @@
     </function>
 
     <record id="demo_nfe_nao_contribuinte_pf_1-2" model="l10n_br_fiscal.document.line">
-        <field name="price_unit">100</field>
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
@@ -482,7 +461,6 @@
         <field name="name">Teste</field>
         <field name="product_id" ref="product.product_product_27" />
         <field name="uom_id" ref="uom.product_uom_unit" />
-        <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -497,7 +475,6 @@
     </function>
 
     <record id="demo_nfe_nao_contribuinte_pf_2-2" model="l10n_br_fiscal.document.line">
-        <field name="price_unit">100</field>
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
@@ -531,7 +508,6 @@
         <field name="name">Teste</field>
         <field name="product_id" ref="product.product_product_6" />
         <field name="uom_id" ref="uom.product_uom_unit" />
-        <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -543,7 +519,6 @@
     </function>
 
     <record id="demo_nfe_line_sn_same_state_5-1" model="l10n_br_fiscal.document.line">
-        <field name="price_unit">100</field>
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
@@ -562,7 +537,6 @@
         <field name="name">Teste</field>
         <field name="product_id" ref="product.product_product_27" />
         <field name="uom_id" ref="uom.product_uom_unit" />
-        <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -574,7 +548,6 @@
     </function>
 
     <record id="demo_nfe_line_sn_same_state_5-2" model="l10n_br_fiscal.document.line">
-        <field name="price_unit">100</field>
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
@@ -608,7 +581,6 @@
         <field name="name">Teste</field>
         <field name="product_id" ref="product.product_product_6" />
         <field name="uom_id" ref="uom.product_uom_unit" />
-        <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -620,7 +592,6 @@
     </function>
 
     <record id="demo_nfe_line_sn_other_state_6-1" model="l10n_br_fiscal.document.line">
-        <field name="price_unit">100</field>
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
@@ -639,7 +610,6 @@
         <field name="name">Teste</field>
         <field name="product_id" ref="product.product_product_27" />
         <field name="uom_id" ref="uom.product_uom_unit" />
-        <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -651,7 +621,6 @@
     </function>
 
     <record id="demo_nfe_line_sn_other_state_6-2" model="l10n_br_fiscal.document.line">
-        <field name="price_unit">100</field>
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
@@ -685,7 +654,6 @@
         <field name="name">Teste</field>
         <field name="product_id" ref="product.product_product_6" />
         <field name="uom_id" ref="uom.product_uom_unit" />
-        <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -697,7 +665,6 @@
     </function>
 
     <record id="demo_nfe_line_sn_export_7-1" model="l10n_br_fiscal.document.line">
-        <field name="price_unit">100</field>
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
@@ -716,7 +683,6 @@
         <field name="name">Teste</field>
         <field name="product_id" ref="product.product_product_27" />
         <field name="uom_id" ref="uom.product_uom_unit" />
-        <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -728,7 +694,6 @@
     </function>
 
     <record id="demo_nfe_line_sn_export_7-2" model="l10n_br_fiscal.document.line">
-        <field name="price_unit">100</field>
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
@@ -765,7 +730,6 @@
         <field name="name">Teste</field>
         <field name="product_id" ref="product.product_product_6" />
         <field name="uom_id" ref="uom.product_uom_unit" />
-        <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -780,7 +744,6 @@
         id="demo_nfe_line_sn_nao_contribuinte_7-1"
         model="l10n_br_fiscal.document.line"
     >
-        <field name="price_unit">100</field>
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
@@ -802,7 +765,6 @@
         <field name="name">Teste</field>
         <field name="product_id" ref="product.product_product_27" />
         <field name="uom_id" ref="uom.product_uom_unit" />
-        <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -817,7 +779,6 @@
         id="demo_nfe_line_sn_nao_contribuinte_7-2"
         model="l10n_br_fiscal.document.line"
     >
-        <field name="price_unit">100</field>
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
@@ -855,7 +816,6 @@
         <field name="name">Teste</field>
         <field name="product_id" ref="product.product_product_6" />
         <field name="uom_id" ref="uom.product_uom_unit" />
-        <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_simples_faturamento" />
@@ -877,7 +837,6 @@
         id="demo_nfe_line_so_simples_faturamento_7-1"
         model="l10n_br_fiscal.document.line"
     >
-        <field name="price_unit">100</field>
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
@@ -912,7 +871,6 @@
         <field name="name">Purchase Test</field>
         <field name="product_id" ref="product.product_product_6" />
         <field name="uom_id" ref="uom.product_uom_unit" />
-        <field name="price_unit">100</field>
         <field name="quantity">1</field>
         <field name="fiscal_operation_type">in</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
@@ -930,7 +888,6 @@
         id="demo_nfe_purchase_line_same_state_1-1"
         model="l10n_br_fiscal.document.line"
     >
-        <field name="price_unit">100</field>
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">

--- a/l10n_br_fiscal/demo/fiscal_document_nfse_demo.xml
+++ b/l10n_br_fiscal/demo/fiscal_document_nfse_demo.xml
@@ -31,8 +31,5 @@
     <function model="l10n_br_fiscal.document.line" name="_onchange_product_id_fiscal">
         <value eval="[ref('l10n_br_fiscal.demo_nfse_line_same_state_1-1')]" />
     </function>
-    <function model="l10n_br_fiscal.document.line" name="_onchange_commercial_quantity">
-        <value eval="[ref('l10n_br_fiscal.demo_nfse_line_same_state_1-1')]" />
-    </function>
 
 </odoo>

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -127,7 +127,13 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         help="Indicates potential 'CSLL' and 'IRPJ' tax charges.",
     )
 
-    price_unit = fields.Float(digits="Product Price")
+    price_unit = fields.Float(
+        digits="Product Price",
+        compute="_compute_price_unit_fiscal",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     partner_id = fields.Many2one(comodel_name="res.partner", string="Partner")
 
@@ -198,11 +204,28 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         string="CFOP Destination",
     )
 
-    fiscal_price = fields.Float(digits="Product Price")
+    fiscal_price = fields.Float(
+        digits="Product Price",
+        compute="_compute_fiscal_price",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    uot_id = fields.Many2one(comodel_name="uom.uom", string="Tax UoM")
+    uot_id = fields.Many2one(
+        comodel_name="uom.uom",
+        string="Tax UoM",
+        compute="_compute_uot_id",
+        store=True,
+    )
 
-    fiscal_quantity = fields.Float(digits="Product Unit of Measure")
+    fiscal_quantity = fields.Float(
+        digits="Product Unit of Measure",
+        compute="_compute_fiscal_quantity",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     discount_value = fields.Monetary()
 
@@ -567,8 +590,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     ipi_cst_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.cst",
         string="CST IPI",
-        domain="[('cst_type', '=', fiscal_operation_type),"
-        "('tax_domain', '=', 'ipi')]",
+        domain="[('cst_type', '=', fiscal_operation_type),('tax_domain', '=', 'ipi')]",
     )
 
     ipi_cst_code = fields.Char(
@@ -590,8 +612,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     ipi_guideline_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax.ipi.guideline",
         string="IPI Guideline",
-        domain="['|', ('cst_in_id', '=', ipi_cst_id),"
-        "('cst_out_id', '=', ipi_cst_id)]",
+        domain="['|', ('cst_in_id', '=', ipi_cst_id),('cst_out_id', '=', ipi_cst_id)]",
     )
 
     # IPI Devolvido Fields

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -217,6 +217,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         string="Tax UoM",
         compute="_compute_uot_id",
         store=True,
+        readonly=False,
     )
 
     fiscal_quantity = fields.Float(

--- a/l10n_br_fiscal/models/document_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_line_mixin_methods.py
@@ -352,14 +352,12 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                         tax_values.update(prepared_fields)
         return tax_values
 
-    def _get_product_price(self):
-        self.ensure_one()
-        price = {
-            "sale_price": self.product_id.list_price,
-            "cost_price": self.product_id.standard_price,
-        }
-
-        self.price_unit = price.get(self.fiscal_operation_id.default_price_unit, 0.00)
+    def _compute_price_unit_fiscal(self):
+        for line in self:
+            line.price_unit = {
+                "sale_price": line.product_id.list_price,
+                "cost_price": line.product_id.standard_price,
+            }.get(line.fiscal_operation_id.default_price_unit, 0)
 
     def __document_comment_vals(self):
         self.ensure_one()
@@ -393,8 +391,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
     def _onchange_fiscal_operation_id(self):
         if self.fiscal_operation_id:
             if not self.price_unit:
-                self._get_product_price()
-            self._onchange_commercial_quantity()
+                self._compute_price_unit_fiscal()
             self.fiscal_operation_line_id = self.fiscal_operation_id.line_definition(
                 company=self.company_id,
                 partner=self._get_fiscal_partner(),
@@ -476,7 +473,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             self.city_taxation_code_id = False
             self.uot_id = False
 
-        self._get_product_price()
+        self._compute_price_unit_fiscal()
         self._onchange_fiscal_operation_id()
 
     def _prepare_fields_issqn(self, tax_dict):
@@ -755,28 +752,47 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         self._update_fiscal_tax_ids(self._get_all_tax_id_fields())
         self._update_fiscal_taxes()
 
-    @api.model
-    def _update_fiscal_quantity(self, product_id, price, quantity, uom_id, uot_id):
-        result = {"uot_id": uom_id, "fiscal_quantity": quantity, "fiscal_price": price}
-        if uot_id and uom_id != uot_id:
-            result["uot_id"] = uot_id
-            if product_id and price and quantity:
-                product = self.env["product.product"].browse(product_id)
-                result["fiscal_price"] = price / (product.uot_factor or 1.0)
-                result["fiscal_quantity"] = quantity * (product.uot_factor or 1.0)
+    @api.depends("uom_id")
+    def _compute_uot_id(self):
+        for line in self:
+            if not line.uot_id:
+                line.uot_id = line.uom_id
 
-        return result
+    @api.onchange("price_unit")
+    def _onchange_price_unit_fiscal(self):
+        self.fiscal_price = 0
+        self._compute_fiscal_price()
 
-    @api.onchange("uot_id", "uom_id", "price_unit", "quantity")
-    def _onchange_commercial_quantity(self):
-        product_id = False
-        if self.product_id:
-            product_id = self.product_id.id
-        self.update(
-            self._update_fiscal_quantity(
-                product_id, self.price_unit, self.quantity, self.uom_id, self.uot_id
-            )
-        )
+    @api.depends("price_unit")
+    def _compute_fiscal_price(self):
+        for line in self:
+            # this test and the onchange are required to avoid
+            # resetting manual changes in fiscal_price
+            if not line.fiscal_price:
+                if line.product_id and line.price_unit:
+                    line.fiscal_price = line.price_unit / (
+                        line.product_id.uot_factor or 1.0
+                    )
+                else:
+                    line.fiscal_price = line.price_unit
+
+    @api.onchange("quantity")
+    def _onchange_quantity_fiscal(self):
+        self.fiscal_quantity = 0
+        self._compute_fiscal_quantity()
+
+    @api.depends("quantity")
+    def _compute_fiscal_quantity(self):
+        for line in self:
+            # this test and the onchange are required to avoid
+            # resetting manual changes in fiscal_quantity
+            if not line.fiscal_quantity:
+                if line.product_id and line.quantity:
+                    line.fiscal_quantity = line.quantity * (
+                        line.product_id.uot_factor or 1.0
+                    )
+                else:
+                    line.fiscal_quantity = line.quantity
 
     @api.onchange("ii_customhouse_charges")
     def _onchange_ii_customhouse_charges(self):

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -6,6 +6,7 @@ from . import (
     test_fiscal_document_nfse,
     test_fiscal_tax,
     test_tax_benefit,
+    test_document_edition,
     test_ibpt_product,
     test_ibpt_service,
     test_icms_regulation,

--- a/l10n_br_fiscal/tests/test_document_edition.py
+++ b/l10n_br_fiscal/tests/test_document_edition.py
@@ -1,0 +1,117 @@
+# Copyright 2025-TODAY  Akretion - Raphaël Valyi
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from unittest import mock
+
+from odoo.tests import TransactionCase
+from odoo.tests.common import Form
+
+
+class TestDocumentEdition(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+
+    def test_basic_doc_edition(self):
+        doc_form = Form(
+            self.env["l10n_br_fiscal.document"].with_context(
+                default_fiscal_operation_type="out",
+            )
+        )
+        doc_form.company_id = self.env.ref("l10n_br_base.empresa_lucro_presumido")
+        doc_form.partner_id = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        doc_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
+        doc_form.ind_final = "1"
+        product_id = self.env.ref("product.product_product_6")
+        product_id.list_price = 150  # we will later check we can set priceunit to 100
+        with doc_form.fiscal_line_ids.new() as line_form:
+            original_method = type(
+                self.env["l10n_br_fiscal.operation.line"]
+            ).map_fiscal_taxes
+
+            def wrapped_method(self, *args, **kwargs):
+                return original_method(self, *args, **kwargs)
+
+            with mock.patch.object(
+                type(self.env["l10n_br_fiscal.operation.line"]),
+                "map_fiscal_taxes",
+                side_effect=wrapped_method,
+                autospec=True,
+            ) as mocked:
+                line_form.product_id = product_id
+
+            # ensure the tax engine is called with the proper
+            # parameters, especially ind_final
+            # as it is related=document_id.ind_final
+            # which is converted to move_id.ind_final to work live
+            mocked.assert_called_with(
+                self.env.ref("l10n_br_fiscal.fo_venda_revenda"),
+                company=doc_form.company_id,
+                partner=doc_form.partner_id,
+                product=product_id,
+                ncm=product_id.ncm_id,
+                nbm=self.env["l10n_br_fiscal.nbm"],
+                nbs=self.env["l10n_br_fiscal.nbs"],
+                cest=self.env["l10n_br_fiscal.cest"],
+                city_taxation_code=self.env["l10n_br_fiscal.city.taxation.code"],
+                service_type=self.env["l10n_br_fiscal.service.type"],
+                ind_final="1",
+            )
+
+            line_form.price_unit = 100
+            line_form.quantity = 2
+
+        doc = doc_form.save()
+        self.assertEqual(doc.fiscal_line_ids[0].price_unit, 100)
+        self.assertEqual(doc.fiscal_line_ids[0].fiscal_price, 100)
+        self.assertEqual(doc.fiscal_line_ids[0].quantity, 2)
+        self.assertEqual(doc.fiscal_line_ids[0].fiscal_quantity, 2)
+
+    def test_product_fiscal_factor(self):
+        doc_form = Form(
+            self.env["l10n_br_fiscal.document"].with_context(
+                default_fiscal_operation_type="out",
+            )
+        )
+        doc_form.company_id = self.env.ref("l10n_br_base.empresa_lucro_presumido")
+        doc_form.partner_id = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        doc_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
+        doc_form.ind_final = "1"
+        product_id = self.env.ref("product.product_product_6")
+        product_id.uot_factor = 2
+        with doc_form.fiscal_line_ids.new() as line_form:
+            line_form.product_id = product_id
+            line_form.price_unit = 100
+            line_form.quantity = 10
+
+        doc = doc_form.save()
+        self.assertEqual(doc.fiscal_line_ids[0].price_unit, 100)
+        self.assertEqual(doc.fiscal_line_ids[0].fiscal_price, 50)
+        self.assertEqual(doc.fiscal_line_ids[0].quantity, 10)
+        self.assertEqual(doc.fiscal_line_ids[0].fiscal_quantity, 20)
+
+    def test_product_fiscal_price_and_qty_edition(self):
+        doc_form = Form(
+            self.env["l10n_br_fiscal.document"].with_context(
+                default_fiscal_operation_type="out",
+            )
+        )
+        doc_form.company_id = self.env.ref("l10n_br_base.empresa_lucro_presumido")
+        doc_form.partner_id = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        doc_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
+        doc_form.ind_final = "1"
+        product_id = self.env.ref("product.product_product_6")
+        product_id.list_price = 100
+        with doc_form.fiscal_line_ids.new() as line_form:
+            line_form.product_id = product_id
+            line_form.price_unit = 110
+            line_form.quantity = 10
+            line_form.fiscal_price = 112
+            line_form.fiscal_quantity = 5
+
+        doc = doc_form.save()
+        self.assertEqual(doc.fiscal_line_ids[0].price_unit, 110)
+        self.assertEqual(doc.fiscal_line_ids[0].fiscal_price, 112)
+        self.assertEqual(doc.fiscal_line_ids[0].quantity, 10)
+        self.assertEqual(doc.fiscal_line_ids[0].fiscal_quantity, 5)

--- a/l10n_br_fiscal/tests/test_fiscal_document_generic.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_generic.py
@@ -2,7 +2,6 @@
 #   Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-
 from odoo.tests import TransactionCase
 
 from ..constants.icms import ICMS_ORIGIN_TAX_IMPORTED
@@ -44,17 +43,12 @@ class TestFiscalDocumentGeneric(TransactionCase):
         self.nfe_same_state._onchange_fiscal_operation_id()
 
         for line in self.nfe_same_state.fiscal_line_ids:
-            # Save the original price_unit value of the line as defined in
-            # the NFe demo data.
-            original_price_unit = line.price_unit
-
             line._onchange_product_id_fiscal()
 
             # Restore the original price_unit value,
             # as the product change might have altered it.
-            line.price_unit = original_price_unit
+            line.price_unit = 100
 
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_taxes()
 
@@ -175,7 +169,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         for line in self.nfe_other_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_taxes()
 
@@ -294,7 +287,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         for line in self.nfe_not_taxpayer.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_taxes()
 
@@ -400,7 +392,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         for line in self.nfe_not_taxpayer_pf.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_taxes()
 
@@ -506,7 +497,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         for line in self.nfe_export.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_taxes()
 
@@ -573,8 +563,7 @@ class TestFiscalDocumentGeneric(TransactionCase):
             self.assertEqual(
                 line.pis_tax_id.name,
                 "PIS 0,65%",
-                "Error to mapping PIS 0,65%"
-                " for Venda de Contribuinte p/ o Exterior.",
+                "Error to mapping PIS 0,65% for Venda de Contribuinte p/ o Exterior.",
             )
             self.assertEqual(
                 line.pis_cst_id.code,
@@ -588,8 +577,7 @@ class TestFiscalDocumentGeneric(TransactionCase):
             self.assertEqual(
                 line.cofins_tax_id.name,
                 "COFINS 3%",
-                "Error to mapping COFINS 3%"
-                " for Venda de Contribuinte p/ o Exterior.",
+                "Error to mapping COFINS 3% for Venda de Contribuinte p/ o Exterior.",
             )
             self.assertEqual(
                 line.cofins_cst_id.code,
@@ -606,7 +594,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         for line in self.nfe_sn_same_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
 
             # set fake estimate tax
             line.ncm_id.tax_estimate_ids.create(
@@ -723,7 +710,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         for line in self.nfe_sn_other_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_taxes()
 
@@ -825,7 +811,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         for line in self.nfe_sn_not_taxpayer.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_taxes()
 
@@ -868,8 +853,7 @@ class TestFiscalDocumentGeneric(TransactionCase):
             self.assertEqual(
                 line.ipi_tax_id.name,
                 "IPI 5%",
-                "Erro ao mapear IPI 5%"
-                " para Venda de Simples Nacional Fora do Estado.",
+                "Erro ao mapear IPI 5% para Venda de Simples Nacional Fora do Estado.",
             )
             self.assertEqual(
                 line.ipi_cst_id.code,
@@ -915,7 +899,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         for line in self.nfe_sn_export.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_taxes()
 
@@ -1038,6 +1021,7 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
         # Teste definindo os valores Por Linha
         for line in self.nfe_same_state.fiscal_line_ids:
+            line.price_unit = 100
             line.freight_value = 10.0
             line.insurance_value = 10.0
             line.other_value = 10.0
@@ -1045,19 +1029,17 @@ class TestFiscalDocumentGeneric(TransactionCase):
         self.assertEqual(
             self.nfe_same_state.amount_freight_value,
             20.0,
-            "Unexpected value for the field" " Amount Freight in Fiscal Document line",
+            "Unexpected value for the field Amount Freight in Fiscal Document line",
         )
         self.assertEqual(
             self.nfe_same_state.amount_insurance_value,
             20.0,
-            "Unexpected value for the field"
-            " Amount Insurance in Fiscal Document line",
+            "Unexpected value for the field Amount Insurance in Fiscal Document line",
         )
         self.assertEqual(
             self.nfe_same_state.amount_other_value,
             20.0,
-            "Unexpected value for the field"
-            " Amount Other Value in Fiscal Document line",
+            "Unexpected value for the field Amount Other Value in Fiscal Document line",
         )
 
         # Teste definindo os valores Por Total
@@ -1073,18 +1055,17 @@ class TestFiscalDocumentGeneric(TransactionCase):
             self.assertEqual(
                 line.freight_value,
                 5.0,
-                "Unexpected value for the field" " Freight in Fiscal Document line",
+                "Unexpected value for the field Freight in Fiscal Document line",
             )
             self.assertEqual(
                 line.insurance_value,
                 5.0,
-                "Unexpected value for the field" " Insurance in Fiscal Document line",
+                "Unexpected value for the field Insurance in Fiscal Document line",
             )
             self.assertEqual(
                 line.other_value,
                 5.0,
-                "Unexpected value for the field"
-                " Other Values in Fiscal Document line",
+                "Unexpected value for the field Other Values in Fiscal Document line",
             )
 
         # Caso que os Campos na Linha não tem valor
@@ -1101,16 +1082,15 @@ class TestFiscalDocumentGeneric(TransactionCase):
             self.assertEqual(
                 line.freight_value,
                 10.0,
-                "Unexpected value for the field" " Freight in Fiscal Document line",
+                "Unexpected value for the field Freight in Fiscal Document line",
             )
             self.assertEqual(
                 line.insurance_value,
                 10.0,
-                "Unexpected value for the field" " Insurance in Fiscal Document line",
+                "Unexpected value for the field Insurance in Fiscal Document line",
             )
             self.assertEqual(
                 line.other_value,
                 10.0,
-                "Unexpected value for the field"
-                " Other Values in Fiscal Document line",
+                "Unexpected value for the field Other Values in Fiscal Document line",
             )

--- a/l10n_br_fiscal/tests/test_fiscal_document_nfse.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_nfse.py
@@ -18,7 +18,6 @@ class TestFiscalDocumentNFSe(TransactionCase):
 
         for line in self.nfse_same_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_taxes()
 

--- a/l10n_br_fiscal/tests/test_tax_benefit.py
+++ b/l10n_br_fiscal/tests/test_tax_benefit.py
@@ -43,7 +43,6 @@ class TestTaxBenefit(TransactionCase):
 
         for line in self.nfe_tax_benefit.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_taxes()
 

--- a/l10n_br_nfse/demo/fiscal_document_demo.xml
+++ b/l10n_br_nfse/demo/fiscal_document_demo.xml
@@ -26,12 +26,6 @@
         >
             <value eval="[ref('l10n_br_fiscal.demo_nfse_line_same_state_1-1')]" />
         </function>
-        <function
-            model="l10n_br_fiscal.document.line"
-            name="_onchange_commercial_quantity"
-        >
-            <value eval="[ref('l10n_br_fiscal.demo_nfse_line_same_state_1-1')]" />
-        </function>
     </data>
 
 </odoo>

--- a/l10n_br_nfse/tests/test_fiscal_document_nfse_common.py
+++ b/l10n_br_nfse/tests/test_fiscal_document_nfse_common.py
@@ -128,7 +128,6 @@ class TestFiscalDocumentNFSeCommon(TransactionCase):
 
         for line in self.nfse_same_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_taxes()
 

--- a/l10n_br_purchase/models/purchase_order_line.py
+++ b/l10n_br_purchase/models/purchase_order_line.py
@@ -46,16 +46,24 @@ class PurchaseOrderLine(models.Model):
         string="Fiscal Taxes",
     )
 
+    # overriden to disable precompute as it depends on price_unit which is not
+    # precompute in the purchase module. We don't need precompute in purchase.
+    fiscal_price = fields.Float(
+        precompute=False,
+    )
+
+    price_unit = fields.Float(
+        precompute=False,
+    )
+
     quantity = fields.Float(
         string="Mixin Quantity",
         related="product_qty",
-        depends=["product_qty"],
     )
 
     uom_id = fields.Many2one(
         string="Mixin UOM",
         related="product_uom",
-        depends=["product_uom"],
     )
 
     tax_framework = fields.Selection(
@@ -108,12 +116,6 @@ class PurchaseOrderLine(models.Model):
                     }
                 )
         return result
-
-    @api.onchange("product_qty", "product_uom")
-    def _onchange_quantity(self):
-        """To call the method in the mixin to update
-        the price and fiscal quantity."""
-        return self._onchange_commercial_quantity()
 
     def _compute_tax_id(self):
         for line in self:

--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -48,7 +48,6 @@ class SaleOrderLine(models.Model):
     quantity = fields.Float(
         string="Product Uom Quantity",
         related="product_uom_qty",
-        depends=["product_uom_qty"],
     )
 
     fiscal_qty_delivered = fields.Float(
@@ -61,7 +60,6 @@ class SaleOrderLine(models.Model):
 
     uom_id = fields.Many2one(
         related="product_uom",
-        depends=["product_uom"],
     )
 
     tax_framework = fields.Selection(
@@ -209,11 +207,10 @@ class SaleOrderLine(models.Model):
         result.update(super()._prepare_invoice_line(**optional_values))
         return result
 
-    @api.onchange("product_uom", "product_uom_qty")
-    def _onchange_product_uom(self):
-        """To call the method in the mixin to update
-        the price and fiscal quantity."""
-        self._onchange_commercial_quantity()
+    @api.onchange("product_uom_qty")
+    def _onchange_quantity_fiscal(self):
+        self.fiscal_quantity = 0
+        self._compute_fiscal_quantity()
 
     @api.depends(
         "qty_delivered_method",
@@ -273,28 +270,28 @@ class SaleOrderLine(models.Model):
             res = None
         return res
 
-    def _get_product_price(self):
-        self.ensure_one()
-        if (
-            self.product_id
-            and self.fiscal_operation_id.default_price_unit == "sale_price"
-            and self.order_id.pricelist_id
-            and self.order_id.partner_id
-        ):
-            price = self.with_company(self.company_id)._get_display_price()
-            self.price_unit = self.product_id._get_tax_included_unit_price(
-                self.company_id,
-                self.order_id.currency_id,
-                self.order_id.date_order,
-                "sale",
-                fiscal_position=self.order_id.fiscal_position_id,
-                product_price_unit=price,
-                product_currency=self.currency_id,
-            )
-        elif self.fiscal_operation_id.default_price_unit == "cost_price":
-            self.price_unit = self.product_id.standard_price
-        else:
-            self.price_unit = 0.00
+    def _compute_price_unit_fiscal(self):
+        for line in self:
+            if (
+                line.product_id
+                and line.fiscal_operation_id.default_price_unit == "sale_price"
+                and line.order_id.pricelist_id
+                and line.order_id.partner_id
+            ):
+                price = line.with_company(line.company_id)._get_display_price()
+                line.price_unit = line.product_id._get_tax_included_unit_price(
+                    line.company_id,
+                    line.order_id.currency_id,
+                    line.order_id.date_order,
+                    "sale",
+                    fiscal_position=line.order_id.fiscal_position_id,
+                    product_price_unit=price,
+                    product_currency=line.currency_id,
+                )
+            elif line.fiscal_operation_id.default_price_unit == "cost_price":
+                line.price_unit = line.product_id.standard_price
+            else:
+                line.price_unit = 0
 
     def _get_fiscal_partner(self):
         """

--- a/l10n_br_sale_stock/demo/sale_order_demo.xml
+++ b/l10n_br_sale_stock/demo/sale_order_demo.xml
@@ -170,7 +170,6 @@
         <field name="product_id" ref="product.product_product_16" />
         <field name="product_uom_qty">2</field>
         <field name="product_uom" ref="uom.product_uom_unit" />
-        <field name="price_unit">500</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
         <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda" />
@@ -202,7 +201,6 @@
         <field name="product_id" ref="l10n_br_fiscal.customized_development_sale" />
         <field name="product_uom_qty">10</field>
         <field name="product_uom" ref="uom.product_uom_hour" />
-        <field name="price_unit">100</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
         <field

--- a/l10n_br_sale_stock/tests/test_sale_stock.py
+++ b/l10n_br_sale_stock/tests/test_sale_stock.py
@@ -61,7 +61,7 @@ class TestSaleStock(TestBrPickingInvoicingCommon):
         # set stock.picking to be invoiced
         self.assertTrue(
             len(self.so.picking_ids) == 1,
-            "More than one stock " "picking for sale.order",
+            "More than one stock picking for sale.order",
         )
         self.so.picking_ids.set_to_be_invoiced()
 
@@ -130,6 +130,12 @@ class TestSaleStock(TestBrPickingInvoicingCommon):
         Test Sale Order with product and service
         """
         sale_order_2 = self.env.ref("l10n_br_sale_stock.main_company-sale_order_2")
+        self.env.ref(
+            "l10n_br_sale_stock.main_company-sale_order_line_2_1"
+        ).product_id.list_price = 500
+        self.env.ref(
+            "l10n_br_sale_stock.main_company-sale_order_line_2_4"
+        ).product_id.list_price = 100
         sale_order_form = Form(sale_order_2)
         sale_order = sale_order_form.save()
         sale_order.action_confirm()

--- a/l10n_br_stock_account/models/stock_move.py
+++ b/l10n_br_stock_account/models/stock_move.py
@@ -116,15 +116,11 @@ class StockMove(models.Model):
                     if tax_ids:
                         record.tax_ids = tax_ids
 
-    @api.onchange("product_id", "product_uom", "product_uom_qty", "price_unit")
+    @api.onchange("product_id", "fiscal_operation_id", "price_unit")
     def _onchange_product_quantity(self):
-        """To call the method in the mixin to update
-        the price and fiscal quantity."""
-        result = self._onchange_commercial_quantity()
-
-        # No Brasil o caso de Ordens de Entrega com Operação Fiscal
-        # de Saída precisam informar o Preço de Custo e não o de Venda
-        # ex.: Simples Remessa, Remessa p/ Industrialiazação e etc.
+        """No Brasil o caso de Ordens de Entrega com Operação Fiscal
+        de Saída precisam informar o Preço de Custo e não o de Venda
+        ex.: Simples Remessa, Remessa p/ Industrialiazação e etc."""
         if (
             self.fiscal_operation_id.fiscal_operation_type == "out"
             and self.price_unit == 0.0
@@ -132,8 +128,6 @@ class StockMove(models.Model):
             self.price_unit = self.product_id.with_company(
                 self.company_id
             ).standard_price
-
-        return result
 
     def _get_new_picking_values(self):
         """Prepares a new picking for this move as it could not be assigned to
@@ -242,21 +236,9 @@ class StockMove(models.Model):
             # Caso Brasil se caracteriza por ter Operação Fiscal
             return new_moves_vals
 
-        self._onchange_commercial_quantity()
         self._onchange_fiscal_taxes()
 
         for new_move_vals in new_moves_vals:
-            product_id = new_move_vals.get("product_id")
-            price_unit = new_move_vals.get("price_unit")
-            quantity = new_move_vals.get("product_uom_qty")
-            uom_id = new_move_vals.get("uom_id")
-            uot_id = new_move_vals.get("uot_id")
-
-            new_move_vals.update(
-                self._update_fiscal_quantity(
-                    product_id, price_unit, quantity, uom_id, uot_id
-                )
-            )
             new_move_vals.update(self._prepare_br_fiscal_dict())
 
         return new_moves_vals

--- a/l10n_br_stock_account/tests/common.py
+++ b/l10n_br_stock_account/tests/common.py
@@ -12,8 +12,6 @@ class TestBrPickingInvoicingCommon(TestPickingInvoicingCommon):
 
     def _run_line_onchanges(self, record):
         result = super()._run_line_onchanges(record)
-        # Mixin Fiscal
-        record._onchange_commercial_quantity()
 
         # Stock Move
         record._onchange_product_id_fiscal()

--- a/l10n_br_stock_account/tests/test_invoicing_picking.py
+++ b/l10n_br_stock_account/tests/test_invoicing_picking.py
@@ -18,6 +18,9 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
         """Test Invoicing Picking"""
         self._change_user_company(self.env.ref("base.main_company"))
         picking = self.env.ref("l10n_br_stock_account.main_company-picking_1")
+        for line in picking.move_ids:
+            line.price_unit = 100
+
         # Testa os Impostos Dedutiveis
         picking.fiscal_operation_id.deductible_taxes = True
         nb_invoice_before = self.env["account.move"].search_count([])
@@ -627,6 +630,8 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
         for move in picking.move_ids_without_package:
             self._run_line_onchanges(move)
             move.quantity_done = move.product_uom_qty
+        for line in picking.move_ids:
+            line.price_unit = 100
 
         picking.action_put_in_pack()
         picking.button_validate()
@@ -685,6 +690,8 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
         picking.fiscal_operation_id.deductible_taxes = True
         nb_invoice_before = self.env["account.move"].search_count([])
         picking.picking_type_id.pre_generate_fiscal_document_number = "validate"
+        for line in picking.move_ids:
+            line.price_unit = 100
 
         self.picking_move_state(picking)
 
@@ -742,9 +749,10 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
         picking.fiscal_operation_id.deductible_taxes = True
         nb_invoice_before = self.env["account.move"].search_count([])
         picking.picking_type_id.pre_generate_fiscal_document_number = "validate"
+        for line in picking.move_ids:
+            line.price_unit = 100
 
         self.picking_move_state(picking)
-
         picking.set_to_be_invoiced()
         self.assertTrue(picking.document_number)
 


### PR DESCRIPTION
no `l10n_br_fiscal.document.line.mixin`, eu mudei os campos para compute com store=True:

- price_unit
- fiscal_price
- fiscal_qty
- uot_id

O objetivo é tirar o maximo os onchanges inseguros. Mas para que o compute se comporta como onchange, foi precisou botar precompute=True.

Para ter a possibilidade de edição manual, esses campos tem o readonly=False.

Para continuar com a possibilidade de alterar o fiscal_price e fiscal_quantity manualmente, foi preciso botar um teste se o campo era vazio no compute (para não sobreesvrever um valor manual) e ainda introduzir os _onchange_price_unit_fiscal e _onchange_quantity_fiscal para atualizar os valores dos fiscal_price e fiscal_quantity mesmo depois de preenchidos. Mesmo que tem esses onchanges ainda, o novo sistema é muito mais robusto, pois vai definir os valores para fiscal_price e fiscal_quantity automaticamente sem precisar chamar onchange manualmente.

Foi necessário adaptar alguna módulos (l10n_br_purchase) para respeitar o fato que campo precompute pode depender apenas de outro campo precompute. Limpei uns depends intuteis nesses módulos tb.

remove os métodos:

- _onchange_fiscal_quantity
- _update_fiscal_quantity
- _get_product_price (que virou _compute_price_unit_fiscal)


Agora que price_unit é compute, o Odoo joga lá o valor no produto (preço de venda ou custo) sem ter que chamar onchange. Nisso alguns testes que usavam dados de demo com price_unit=100 quebraram porque o preço do produto era diferente de 100. Eu removi esses price_unit=100 nos dados de demo e em vez disso eu forcei o preço do produto para 100 no início dos testes que precisavam desses valores.

resolve:

- #3896
- #3926