### PR TITLE
[16.0][several modules - trivial] related fields now default to readonly

### DIFF
--- a/l10n_br_account_payment_order/models/account_move.py
+++ b/l10n_br_account_payment_order/models/account_move.py
@@ -28,7 +28,6 @@ class AccountMove(models.Model):
     eval_payment_mode_instructions = fields.Text(
         string="Instruções de Cobrança do Modo de Pagamento",
         related="cnab_config_id.instructions",
-        readonly=True,
         help="Instruções Ordem de Pagamento configuradas na Configuração do CNAB",
     )
 

--- a/l10n_br_account_payment_order/models/account_move_line.py
+++ b/l10n_br_account_payment_order/models/account_move_line.py
@@ -119,7 +119,6 @@ class AccountMoveLine(models.Model):
 
     payment_method_code = fields.Char(
         related="payment_method_id.code",
-        readonly=True,
         store=True,
         string="Payment Method Code",
     )

--- a/l10n_br_account_payment_order/models/account_payment_line.py
+++ b/l10n_br_account_payment_order/models/account_payment_line.py
@@ -152,7 +152,6 @@ class AccountPaymentLine(models.Model):
 
     payment_method_code = fields.Char(
         related="payment_method_id.code",
-        readonly=True,
         store=True,
         string="Payment Method Code",
     )

--- a/l10n_br_cnab_structure/wizard/cnab_import_wizard.py
+++ b/l10n_br_cnab_structure/wizard/cnab_import_wizard.py
@@ -20,7 +20,6 @@ class CNABImportWizard(models.TransientModel):
     bank_account_cnab_id = fields.Many2one(
         comodel_name="account.account",
         related="journal_id.default_account_id",
-        readonly=True,
     )
     return_file = fields.Binary()
     filename = fields.Char()

--- a/l10n_br_fiscal/models/cst.py
+++ b/l10n_br_fiscal/models/cst.py
@@ -27,7 +27,6 @@ class CST(models.Model):
     tax_domain = fields.Selection(
         related="tax_group_id.tax_domain",
         string="Tax Domain",
-        readonly=True,
         store=True,
     )
 

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -148,12 +148,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     fiscal_operation_type = fields.Selection(
         string="Operation Type",
         related="fiscal_operation_id.fiscal_operation_type",
-        readonly=True,
     )
 
     operation_fiscal_type = fields.Selection(
         related="fiscal_operation_id.fiscal_type",
-        readonly=True,
         string="Operation Fiscal Type",
     )
 

--- a/l10n_br_fiscal/models/document_mixin_fields.py
+++ b/l10n_br_fiscal/models/document_mixin_fields.py
@@ -61,7 +61,6 @@ class FiscalDocumentMixinFields(models.AbstractModel):
 
     fiscal_operation_type = fields.Selection(
         related="fiscal_operation_id.fiscal_operation_type",
-        readonly=True,
     )
 
     ind_pres = fields.Selection(

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -65,14 +65,12 @@ class OperationLine(models.Model):
         related="fiscal_operation_id.fiscal_operation_type",
         string="Fiscal Operation Type",
         store=True,
-        readonly=True,
     )
 
     fiscal_type = fields.Selection(
         related="fiscal_operation_id.fiscal_type",
         string="Fiscal Type",
         store=True,
-        readonly=True,
     )
 
     tax_icms_or_issqn = fields.Selection(

--- a/l10n_br_fiscal/models/tax_definition.py
+++ b/l10n_br_fiscal/models/tax_definition.py
@@ -92,14 +92,12 @@ class TaxDefinition(models.Model):
     cst_code = fields.Char(
         string="CST Code",
         related="cst_id.code",
-        readonly=True,
     )
 
     tax_domain = fields.Selection(
         related="tax_group_id.tax_domain",
         store=True,
         string="Tax Domain",
-        readonly=True,
         states={"draft": [("readonly", False)]},
     )
 

--- a/l10n_br_fiscal_edi/models/invalidate_number.py
+++ b/l10n_br_fiscal_edi/models/invalidate_number.py
@@ -26,14 +26,12 @@ class InvalidateNumber(models.Model):
 
     authorization_date = fields.Datetime(
         string="Authorization Date",
-        readonly=True,
         related="authorization_event_id.protocol_date",
     )
 
     authorization_protocol = fields.Char(
         string="Authorization Protocol",
         related="authorization_event_id.protocol_number",
-        readonly=True,
     )
 
     send_file_id = fields.Many2one(
@@ -41,7 +39,6 @@ class InvalidateNumber(models.Model):
         related="authorization_event_id.file_request_id",
         string="Send Document File XML",
         ondelete="restrict",
-        readonly=True,
     )
 
     authorization_file_id = fields.Many2one(
@@ -49,5 +46,4 @@ class InvalidateNumber(models.Model):
         related="authorization_event_id.file_response_id",
         string="Authorization File XML",
         ondelete="restrict",
-        readonly=True,
     )

--- a/l10n_br_resource/models/resource_calendar_leaves.py
+++ b/l10n_br_resource/models/resource_calendar_leaves.py
@@ -35,14 +35,12 @@ class ResourceCalendarLeave(models.Model):
         "Estado",
         related="calendar_id.state_id",
         domain="[('country_id','=',country_id)]",
-        readonly=True,
     )
     l10n_br_city_id = fields.Many2one(
         "res.city",
         "Municipio",
         related="calendar_id.l10n_br_city_id",
         domain="[('state_id','=',state_id)]",
-        readonly=True,
     )
     leave_type = fields.Selection(
         string="Tipo",


### PR DESCRIPTION
A partir da versão 12.0, os campos related vem com readonly=True por padrão, não precisa repetir.

Usei esse comando para dar um scan: `grep -r "readonly=True" . -B 5 -A3` e depois conferi se tinha algum campo related.

Então na real isso já faz um tempo que é assim então mas pelo jeito tem código legacy que a gente não limpou ainda ou que os desenvolvedores não mudaram os hábitos. Mas enfim esse PR é trivial, é apenas para limpar o código.

v11: https://github.com/odoo/odoo/blob/11.0/odoo/fields.py#L414
v12+: https://github.com/odoo/odoo/blob/12.0/odoo/fields.py#L463