### PR TITLE
[16.0][l10n_br_fiscal] document_serie(_id): onchange -> compute

### DIFF
--- a/l10n_br_account/tests/test_document_date.py
+++ b/l10n_br_account/tests/test_document_date.py
@@ -60,6 +60,9 @@ class TestInvoiceDiscount(TransactionCase):
                 0,
                 0,
                 {
+                    "fiscal_operation_line_id": cls.env.ref(
+                        "l10n_br_fiscal.fo_venda_revenda"
+                    ).id,
                     "account_id": cls.invoice_line_account_id.id,
                     "product_id": product_id.id,
                     "quantity": 1,
@@ -75,6 +78,8 @@ class TestInvoiceDiscount(TransactionCase):
             .create(
                 {
                     "company_id": cls.company.id,
+                    "partner_id": cls.env.ref("base.res_partner_3").id,
+                    "document_type_id": cls.env.ref("l10n_br_fiscal.document_55").id,
                     "document_serie_id": cls.env.ref(
                         "l10n_br_fiscal.empresa_lc_document_55_serie_1"
                     ).id,

--- a/l10n_br_account/tests/test_move_edition.py
+++ b/l10n_br_account/tests/test_move_edition.py
@@ -1,4 +1,4 @@
-# Copyright 2019-TODAY Akretion - Raphael Valyi <raphael.valyi@akretion.com>
+# Copyright 2025-TODAY Akretion - Raphael Valyi <raphael.valyi@akretion.com>
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
 
 import logging
@@ -164,10 +164,6 @@ class TestMoveEdition(TransactionCase):
         move_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
         with move_form.invoice_line_ids.new() as line_form:
             line_form.product_id = self.product_id
-            # it seems the Form framework won't fill it so we fill it:
-            line_form.fiscal_operation_line_id = self.env.ref(
-                "l10n_br_fiscal.fo_venda_revenda"
-            )
             line_form.price_unit = 42
             line_form.quantity = 42
         move = move_form.save()

--- a/l10n_br_account_nfe/tests/test_nfe_generate_tags_cobr_dup_pag.py
+++ b/l10n_br_account_nfe/tests/test_nfe_generate_tags_cobr_dup_pag.py
@@ -87,6 +87,10 @@ class TestGeneratePaymentInfo(TransactionCase):
         move_form.partner_id = cls.env.ref("l10n_br_base.res_partner_cliente1_sp")
         move_form.document_type_id = cls.env.ref("l10n_br_fiscal.document_55")
         move_form.fiscal_operation_id = cls.fiscal_operation_id
+        move_form.document_type_id = cls.env.ref("l10n_br_fiscal.document_55")
+        move_form.document_serie_id = cls.env.ref(
+            "l10n_br_fiscal.empresa_lc_document_55_serie_1"
+        )
         move_form.payment_mode_id = cls.payment_mode
         move_form.invoice_payment_term_id = cls.payment_term
         with move_form.invoice_line_ids.new() as line_form:

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -10,7 +10,6 @@ from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 
 from ..constants.fiscal import (
-    DOCUMENT_ISSUER,
     DOCUMENT_ISSUER_COMPANY,
     DOCUMENT_ISSUER_DICT,
     DOCUMENT_ISSUER_PARTNER,
@@ -182,11 +181,6 @@ class Document(models.Model):
     # while state_edoc avoids colliding with the state field
     # of objects where the fiscal mixin might be injected.
     state = fields.Selection(related="state_edoc", string="State")
-
-    issuer = fields.Selection(
-        selection=DOCUMENT_ISSUER,
-        default=DOCUMENT_ISSUER_COMPANY,
-    )
 
     document_subsequent_ids = fields.One2many(
         comodel_name="l10n_br_fiscal.subsequent.document",

--- a/l10n_br_fiscal/models/document_mixin.py
+++ b/l10n_br_fiscal/models/document_mixin.py
@@ -5,6 +5,8 @@ from odoo import api, fields, models
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
 
 from ..constants.fiscal import (
+    DOCUMENT_ISSUER,
+    DOCUMENT_ISSUER_COMPANY,
     FINAL_CUSTOMER,
     FINAL_CUSTOMER_YES,
     FISCAL_COMMENT_DOCUMENT,
@@ -447,6 +449,11 @@ class FiscalDocumentMixin(models.AbstractModel):
 
     force_compute_delivery_costs_by_total = fields.Boolean(default=False)
 
+    issuer = fields.Selection(
+        selection=DOCUMENT_ISSUER,
+        default=DOCUMENT_ISSUER_COMPANY,
+    )
+
     document_type_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.document.type",
     )
@@ -454,6 +461,8 @@ class FiscalDocumentMixin(models.AbstractModel):
     document_serie_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.document.serie",
         domain="[('active', '=', True)," "('document_type_id', '=', document_type_id)]",
+        compute="_compute_document_serie_id",
+        store=True,
     )
 
     document_serie = fields.Char(

--- a/l10n_br_fiscal/models/document_mixin.py
+++ b/l10n_br_fiscal/models/document_mixin.py
@@ -458,6 +458,8 @@ class FiscalDocumentMixin(models.AbstractModel):
 
     document_serie = fields.Char(
         string="Serie Number",
+        compute="_compute_document_serie",
+        store=True,
     )
 
     document_number = fields.Char(

--- a/l10n_br_fiscal/models/document_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_mixin_methods.py
@@ -35,11 +35,6 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
                 self.company_id, self.fiscal_operation_id
             )
 
-    @api.onchange("document_serie_id")
-    def _onchange_document_serie_id(self):
-        if self.document_serie_id and self.issuer == DOCUMENT_ISSUER_COMPANY:
-            self.document_serie = self.document_serie_id.code
-
     @api.onchange("fiscal_operation_id")
     def _onchange_fiscal_operation_id(self):
         if self.fiscal_operation_id:

--- a/l10n_br_fiscal/models/document_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_mixin_methods.py
@@ -79,6 +79,24 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
         amount_fields = [f for f in fields if f.startswith("amount_")]
         return amount_fields
 
+    @api.depends("document_serie_id", "issuer")
+    def _compute_document_serie(self):
+        for doc in self:
+            if doc.document_serie_id and doc.issuer == DOCUMENT_ISSUER_COMPANY:
+                doc.document_serie = doc.document_serie_id.code
+            elif doc.document_serie is None:
+                doc.document_serie = False
+
+    @api.depends("document_type_id", "issuer")
+    def _compute_document_serie_id(self):
+        for doc in self:
+            if doc.document_type_id and doc.issuer == DOCUMENT_ISSUER_COMPANY:
+                doc.document_serie_id = doc.document_type_id.get_document_serie(
+                    doc.company_id, doc.fiscal_operation_id
+                )
+            elif doc.document_serie_id is None:
+                doc.document_serie_id = False
+
     def _compute_fiscal_amount(self):
         fields = self._get_amount_fields()
         for doc in self:

--- a/l10n_br_fiscal/tests/test_fiscal_document_generic.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_generic.py
@@ -39,7 +39,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
     def test_nfe_same_state(self):
         """Test NFe same state."""
 
-        self.nfe_same_state._onchange_document_serie_id()
         self.nfe_same_state._onchange_fiscal_operation_id()
 
         for line in self.nfe_same_state.fiscal_line_ids:
@@ -171,7 +170,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
     def test_nfe_other_state(self):
         """Test NFe other state."""
 
-        self.nfe_other_state._onchange_document_serie_id()
         self.nfe_other_state._onchange_fiscal_operation_id()
 
         for line in self.nfe_other_state.fiscal_line_ids:
@@ -292,7 +290,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
     def test_nfe_not_taxpayer(self):
         """Test NFe not taxpayer."""
 
-        self.nfe_not_taxpayer._onchange_document_serie_id()
         self.nfe_not_taxpayer._onchange_fiscal_operation_id()
 
         for line in self.nfe_not_taxpayer.fiscal_line_ids:
@@ -400,7 +397,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
     def test_nfe_not_taxpayer_not_company(self):
         """Test NFe not taxpayer not Company."""
 
-        self.nfe_not_taxpayer_pf._onchange_document_serie_id()
         self.nfe_not_taxpayer_pf._onchange_fiscal_operation_id()
 
         for line in self.nfe_not_taxpayer_pf.fiscal_line_ids:
@@ -508,7 +504,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
     def test_nfe_export(self):
         """Test NFe export."""
 
-        self.nfe_export._onchange_document_serie_id()
         self.nfe_export._onchange_fiscal_operation_id()
 
         for line in self.nfe_export.fiscal_line_ids:
@@ -610,7 +605,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
     def test_nfe_sn_same_state(self):
         """Test NFe Simples Nacional same state."""
 
-        self.nfe_sn_same_state._onchange_document_serie_id()
         self.nfe_sn_same_state._onchange_fiscal_operation_id()
 
         for line in self.nfe_sn_same_state.fiscal_line_ids:
@@ -729,7 +723,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
     def test_nfe_sn_other_state(self):
         """Test NFe SN other state."""
 
-        self.nfe_sn_other_state._onchange_document_serie_id()
         self.nfe_sn_other_state._onchange_fiscal_operation_id()
 
         for line in self.nfe_sn_other_state.fiscal_line_ids:
@@ -833,7 +826,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
     def test_nfe_sn_not_taxpayer(self):
         """Test NFe SN not taxpayer."""
 
-        self.nfe_sn_not_taxpayer._onchange_document_serie_id()
         self.nfe_sn_not_taxpayer._onchange_fiscal_operation_id()
 
         for line in self.nfe_sn_not_taxpayer.fiscal_line_ids:
@@ -925,7 +917,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
     def test_nfe_sn_export(self):
         """Test NFe SN export."""
 
-        self.nfe_sn_export._onchange_document_serie_id()
         self.nfe_sn_export._onchange_fiscal_operation_id()
 
         for line in self.nfe_sn_export.fiscal_line_ids:

--- a/l10n_br_fiscal/tests/test_fiscal_document_nfse.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_nfse.py
@@ -13,7 +13,6 @@ class TestFiscalDocumentNFSe(TransactionCase):
     def test_nfse_same_state(self):
         """Test NFSe same state."""
 
-        self.nfse_same_state._onchange_document_serie_id()
         self.nfse_same_state._onchange_fiscal_operation_id()
 
         for line in self.nfse_same_state.fiscal_line_ids:

--- a/l10n_br_fiscal/tests/test_subsequent_operation.py
+++ b/l10n_br_fiscal/tests/test_subsequent_operation.py
@@ -26,7 +26,6 @@ class TestSubsequentOperation(TransactionCase):
         """Test Fiscal Subsequent Operation Simples Faturamento"""
 
         self.nfe_simples_faturamento._onchange_fiscal_operation_id()
-        self.nfe_simples_faturamento._onchange_document_serie_id()
 
         for line in self.nfe_simples_faturamento.fiscal_line_ids:
             line._onchange_product_id_fiscal()

--- a/l10n_br_fiscal/tests/test_tax_benefit.py
+++ b/l10n_br_fiscal/tests/test_tax_benefit.py
@@ -35,7 +35,6 @@ class TestTaxBenefit(TransactionCase):
     def test_nfe_tax_benefit(self):
         """Test NFe with tax benefit."""
 
-        self.nfe_tax_benefit._onchange_document_serie_id()
         self.nfe_tax_benefit._onchange_fiscal_operation_id()
 
         for line in self.nfe_tax_benefit.fiscal_line_ids:

--- a/l10n_br_fiscal_edi/tests/test_fiscal_document_generic.py
+++ b/l10n_br_fiscal_edi/tests/test_fiscal_document_generic.py
@@ -45,7 +45,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
     def test_nfe_same_state(self):
         """Test NFe same state."""
 
-        self.nfe_same_state._onchange_document_serie_id()
         self.nfe_same_state._onchange_fiscal_operation_id()
 
         for line in self.nfe_same_state.fiscal_line_ids:
@@ -194,7 +193,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
     def test_nfe_other_state(self):
         """Test NFe other state."""
 
-        self.nfe_other_state._onchange_document_serie_id()
         self.nfe_other_state._onchange_fiscal_operation_id()
 
         for line in self.nfe_other_state.fiscal_line_ids:
@@ -315,7 +313,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
     def test_nfe_not_taxpayer(self):
         """Test NFe not taxpayer."""
 
-        self.nfe_not_taxpayer._onchange_document_serie_id()
         self.nfe_not_taxpayer._onchange_fiscal_operation_id()
 
         for line in self.nfe_not_taxpayer.fiscal_line_ids:
@@ -423,7 +420,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
     def test_nfe_not_taxpayer_not_company(self):
         """Test NFe not taxpayer not Company."""
 
-        self.nfe_not_taxpayer_pf._onchange_document_serie_id()
         self.nfe_not_taxpayer_pf._onchange_fiscal_operation_id()
 
         for line in self.nfe_not_taxpayer_pf.fiscal_line_ids:
@@ -531,7 +527,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
     def test_nfe_export(self):
         """Test NFe export."""
 
-        self.nfe_export._onchange_document_serie_id()
         self.nfe_export._onchange_fiscal_operation_id()
 
         for line in self.nfe_export.fiscal_line_ids:
@@ -633,7 +628,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
     def test_nfe_sn_same_state(self):
         """Test NFe Simples Nacional same state."""
 
-        self.nfe_sn_same_state._onchange_document_serie_id()
         self.nfe_sn_same_state._onchange_fiscal_operation_id()
 
         for line in self.nfe_sn_same_state.fiscal_line_ids:
@@ -752,7 +746,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
     def test_nfe_sn_other_state(self):
         """Test NFe SN other state."""
 
-        self.nfe_sn_other_state._onchange_document_serie_id()
         self.nfe_sn_other_state._onchange_fiscal_operation_id()
 
         for line in self.nfe_sn_other_state.fiscal_line_ids:
@@ -856,7 +849,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
     def test_nfe_sn_not_taxpayer(self):
         """Test NFe SN not taxpayer."""
 
-        self.nfe_sn_not_taxpayer._onchange_document_serie_id()
         self.nfe_sn_not_taxpayer._onchange_fiscal_operation_id()
 
         for line in self.nfe_sn_not_taxpayer.fiscal_line_ids:
@@ -948,7 +940,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
     def test_nfe_sn_export(self):
         """Test NFe SN export."""
 
-        self.nfe_sn_export._onchange_document_serie_id()
         self.nfe_sn_export._onchange_fiscal_operation_id()
 
         for line in self.nfe_sn_export.fiscal_line_ids:

--- a/l10n_br_fiscal_edi/tests/test_tax_benefit.py
+++ b/l10n_br_fiscal_edi/tests/test_tax_benefit.py
@@ -37,7 +37,6 @@ class TestTaxBenefit(TransactionCase):
     def test_nfe_tax_benefit(self):
         """Test NFe with tax benefit."""
 
-        self.nfe_tax_benefit._onchange_document_serie_id()
         self.nfe_tax_benefit._onchange_fiscal_operation_id()
 
         for line in self.nfe_tax_benefit.fiscal_line_ids:

--- a/l10n_br_nfe/tests/test_nfce.py
+++ b/l10n_br_nfe/tests/test_nfce.py
@@ -120,7 +120,6 @@ class TestNFCe(TestNFeExport):
 
     def test_atualiza_status_nfce(self):
         self.document_id._onchange_fiscal_operation_id()
-        self.document_id._onchange_document_type_id()
 
         self.document_id._compute_nfe40_dhSaiEnt()
         self.assertFalse(self.document_id.nfe40_dhSaiEnt)

--- a/l10n_br_nfe/tests/test_nfe_xml_validation.py
+++ b/l10n_br_nfe/tests/test_nfe_xml_validation.py
@@ -28,7 +28,6 @@ class TestXMLValidation(TransactionCase):
             }
         )
         document._onchange_fiscal_operation_id()
-        document._onchange_document_type_id()
         line = document_line_model.create(
             {
                 "document_id": document.id,
@@ -68,7 +67,6 @@ class TestXMLValidation(TransactionCase):
             }
         )
         document._onchange_fiscal_operation_id()
-        document._onchange_document_type_id()
 
         # Line 1
         line = document_line_model.create(

--- a/l10n_br_nfe/tests/test_nfe_xml_validation.py
+++ b/l10n_br_nfe/tests/test_nfe_xml_validation.py
@@ -29,7 +29,6 @@ class TestXMLValidation(TransactionCase):
         )
         document._onchange_fiscal_operation_id()
         document._onchange_document_type_id()
-        document._onchange_document_serie_id()
         line = document_line_model.create(
             {
                 "document_id": document.id,
@@ -70,7 +69,6 @@ class TestXMLValidation(TransactionCase):
         )
         document._onchange_fiscal_operation_id()
         document._onchange_document_type_id()
-        document._onchange_document_serie_id()
 
         # Line 1
         line = document_line_model.create(

--- a/l10n_br_nfse/tests/test_fiscal_document_nfse_common.py
+++ b/l10n_br_nfse/tests/test_fiscal_document_nfse_common.py
@@ -36,7 +36,6 @@ class TestFiscalDocumentNFSeCommon(TransactionCase):
     def test_certified_nfse_same_state_(self):
         """Test Certified NFSe same state."""
 
-        self.nfse_same_state._onchange_document_serie_id()
         self.nfse_same_state._onchange_fiscal_operation_id()
 
         # RPS Number


### PR DESCRIPTION
o mesmo PR do que #3654 mas com rebase em cima de #3695 (que agora entrou na 16.0)

Nota: como o _compute_document_serie_id depende do issuer, eu tive que mudar o campo issuer do l10n_br_fiscal.document pro l10n_br_fiscal.document.mixin.field. Então sale.order ou purchase.order passam a herdar esse campo enquanto ele é inútil nesses objetos. Mas eu acho que tb não faz mal, não encontrei uma forma mais simples...

@antoniospneto @felipemotter eu tive que acrescentar alguns parâmetros no teste l10n_br_account/tests/test_document_date.py porque senão o move não tinha documento fiscal. Era uma furada dos testes passar antes...
Mesma coisa no l10n_br_account_nfe/tests/test_nfe_generate_tags_cobr_dup_pag.py

Eu tb tive que fazer um ajuste no l10n_br_account.fiscal.decorator.mixin https://github.com/OCA/l10n-brazil/pull/3709/commits/f9adfa652a7da093bd910b6e83e2d200b306afdd  Eu vou até separar isso num outro PR, pois eh algo simples que deveria ter sido feito quando eu introduzi esse mixin. O problema eh que existem campos com compute e store=True. E nestes casos, a gente quer fazer o que faz o _add_inherited_fields nativo, que é de tornar o campo um related. Pois da forma como tava no  l10n_br_account.fiscal.decorator.mixin ele transformava tais campos em campos compute sem related e ai eles ficavam com readonly=True e sem ler o valor do (linha de) documento fiscal.