### PR TITLE
[16.0][FIX] l10n_br_nfe, l10n_br_cte, l10n_br_mdfe: document supplement as a SpecModel

### DIFF
--- a/l10n_br_cte/models/document_supplement.py
+++ b/l10n_br_cte/models/document_supplement.py
@@ -6,13 +6,9 @@ from odoo import fields
 from odoo.addons.spec_driven_model.models import spec_models
 
 
-class CTeSupplement(spec_models.StackedModel):
+class CTeSupplement(spec_models.SpecModel):
     _name = "l10n_br_fiscal.document.supplement"
     _inherit = ["l10n_br_fiscal.document.supplement", "cte.40.tcte_infctesupl"]
-
-    _cte40_odoo_module = (
-        "odoo.addons.l10n_br_cte_spec.models.v4_0.cte_tipos_basico_v4_00"
-    )
-    _cte40_stacking_mixin = "cte.40.tcte_infctesupl"
+    _cte40_binding_type = "Tcte.InfCteSupl"  # avoid ambiguity with NFe and MDFe modules
 
     cte40_qrCodCTe = fields.Char(related="qrcode")

--- a/l10n_br_mdfe/models/document_supplement.py
+++ b/l10n_br_mdfe/models/document_supplement.py
@@ -6,12 +6,9 @@ from odoo import fields
 from odoo.addons.spec_driven_model.models import spec_models
 
 
-class MDFeSupplement(spec_models.StackedModel):
+class MDFeSupplement(spec_models.SpecModel):
     _name = "l10n_br_fiscal.document.supplement"
     _inherit = ["l10n_br_fiscal.document.supplement", "mdfe.30.infmdfesupl"]
-    _mdfe30_odoo_module = (
-        "odoo.addons.l10n_br_mdfe_spec.models.v3_0.mdfe_tipos_basico_v3_00"
-    )
-    _mdfe30_stacking_mixin = "mdfe.30.infmdfesupl"
+    _mdfe30_binding_type = "Tmdfe.InfMdfeSupl"  # avoid ambiguity with NFe and CTe
 
     mdfe30_qrCodMDFe = fields.Char(related="qrcode")

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -831,7 +831,7 @@ class NFe(spec_models.StackedModel):
 
     @api.constrains("document_type", "state_edoc", "fiscal_line_ids")
     def _check_product_default_code(self):
-        for rec in self:
+        for rec in self.filtered(filter_processador_edoc_nfe):
             if (
                 rec.document_type in PRODUCT_CODE_FISCAL_DOCUMENT_TYPES
                 and rec.state_edoc == "a_enviar"
@@ -841,26 +841,22 @@ class NFe(spec_models.StackedModel):
                         raise ValidationError(
                             _(
                                 f"The product {line.product_id.display_name} "
-                                f"must have a default code or the product code"
+                                f"must have a default code or the product code "
                                 f"line field (nfe40_cProd) should be filled."
                             )
                         )
 
     @api.constrains("document_date", "document_key", "state_edoc")
     def _check_document_date_key(self):
-        for rec in self:
+        for rec in self.filtered(filter_processador_edoc_nfe):
             if rec.document_key and rec.document_date:
                 key_date_str = rec.document_key[2:6]
                 key_date = datetime.strptime(key_date_str, "%y%m")
 
                 document_date = fields.Datetime.from_string(rec.document_date)
-                if (
-                    rec.document_type in ["55", "65"]
-                    and rec.state_edoc in ["a_enviar", "autorizada"]
-                    and (
-                        key_date.year != document_date.year
-                        or key_date.month != document_date.month
-                    )
+                if rec.state_edoc in ["a_enviar", "autorizada"] and (
+                    key_date.year != document_date.year
+                    or key_date.month != document_date.month
                 ):
                     raise ValidationError(
                         _(

--- a/l10n_br_nfe/models/document_supplement.py
+++ b/l10n_br_nfe/models/document_supplement.py
@@ -6,17 +6,10 @@ from odoo import fields
 from odoo.addons.spec_driven_model.models import spec_models
 
 
-class NFeSupplement(spec_models.StackedModel):
-    # FIXME: NFeSupplement should actually inherit from spec_models.SpecModel
-    # but it seems we had broken NFe or MDFe or CTe tests with SpecModel
-    # it's probably a spec_driven_model framework issue... So it has been reverted
-    # to StackedModel in https://github.com/OCA/l10n-brazil/pull/3445
+class NFeSupplement(spec_models.SpecModel):
     _name = "l10n_br_fiscal.document.supplement"
     _inherit = ["l10n_br_fiscal.document.supplement", "nfe.40.infnfesupl"]
-
-    _nfe40_odoo_module = "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00"
-    _nfe40_stacking_mixin = "nfe.40.infnfesupl"
+    _nfe40_binding_type = "Tnfe.InfNfeSupl"  # avoid ambiguity with CTe and MDFe modules
 
     nfe40_qrCode = fields.Char(related="qrcode")
-
     nfe40_urlChave = fields.Char(related="url_key")

--- a/spec_driven_model/models/spec_export.py
+++ b/spec_driven_model/models/spec_export.py
@@ -1,4 +1,5 @@
 # Copyright 2019 KMEE
+# Copyright 2021-TODAY Akretion - Raphael Valyi <raphael.valyi@akretion.com>
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
 
 import logging
@@ -11,12 +12,36 @@ _logger = logging.getLogger(__name__)
 
 class SpecMixinExport(models.AbstractModel):
     _name = "spec.mixin_export"
-    _description = "a mixin providing serialization features"
+    _description = "A mixin providing serialization features."
 
     @api.model
-    def _get_binding_class(self, class_obj):
+    def _get_binding_class(self, odoo_class) -> type:
+        """
+        Use (_spec_prefix)_binding_type of odoo_class and its binding_module to get
+        the Python binding type for export.
+        """
         binding_module = sys.modules[self._get_spec_property("binding_module")]
-        for attr in class_obj._binding_type.split("."):
+        binding_type = odoo_class._get_spec_property("binding_type")
+        if not binding_type:
+            binding_types = set(
+                map(
+                    lambda clazz: clazz._binding_type,
+                    list(
+                        filter(
+                            lambda clazz: hasattr(clazz, "_binding_type"),
+                            type(odoo_class).mro(),
+                        )
+                    ),
+                )
+            )
+            assert len(binding_types) == 1, (
+                f"Found several (or no) _binding_type attributes in {odoo_class} "
+                f"ancestors: {binding_types}. You can define a "
+                f"_{self._spec_prefix()}_binding_type in {odoo_class} "
+                "to avoid ambiguities."
+            )
+            binding_type = binding_types.pop()
+        for attr in binding_type.split("."):  # this will dive into nested classes
             binding_module = getattr(binding_module, attr)
         return binding_module
 
@@ -60,7 +85,7 @@ class SpecMixinExport(models.AbstractModel):
         binding_class_spec = binding_class.__dataclass_fields__
 
         class_name = class_obj._name.replace(".", "_")
-        export_method_name = "_export_fields_%s" % class_name
+        export_method_name = f"_export_fields_{class_name}"
         if hasattr(self, export_method_name):
             xsd_fields = [i for i in xsd_fields]
             export_method = getattr(self, export_method_name)
@@ -193,7 +218,7 @@ class SpecMixinExport(models.AbstractModel):
         """
         Iterate over an Odoo record and its m2o and o2m sub-records
         using a pre-order tree traversal and map the Odoo record values
-        to  a dict of Python binding values.
+        to a dict of Python binding values.
 
         These values will later be injected as **kwargs in the proper XML Python
         binding constructors. Hence the value can either be simple values or


### PR DESCRIPTION
Aqui eu resolvi um problema do modulo `spec_model_driven` com multiplos esquemas. Na 14, quando o @marcelsavegnago adicionou os modulos l10n_br_cte e l10n_br_mdfe ele teve que botar o `l10n_br_fiscal.document.supplement` como StackedModel para que os testes de serialização continuassem a funcionar.

Pois eu vi que o  `l10n_br_fiscal.document.supplement` passava a herdar mixins de NFe, CTe e MDFe com então _binding_type diferentes. Na serialização da NFe o framework tentava pegar o binding da CTe.

O que eu fiz foi de checar no get_binding_class se tivesse varios _binding_type diferente. Caso sim ai ele faz um raise agora (para evitar qualquer surpresa) e sugira de definir o atributo com o prefix direito na class considerada, o que eu fiz agora para NFe, MDfe e Cte:

```
   File "/__w/l10n-brazil/l10n-brazil/l10n_br_fiscal_edi/models/document.py", line 236, in serialize
    self._serialize(edocs)
  File "/__w/l10n-brazil/l10n-brazil/l10n_br_nfe/models/document.py", line 903, in _serialize
    inf_nfe_supl = record.nfe40_infNFeSupl._build_binding("nfe", "40")
  File "/__w/l10n-brazil/l10n-brazil/spec_driven_model/models/spec_export.py", line 244, in _build_binding
    binding_class = self._get_binding_class(class_obj)
  File "/__w/l10n-brazil/l10n-brazil/spec_driven_model/models/spec_export.py", line 37, in _get_binding_class
    assert len(binding_types) == 1, (
AssertionError: Found several (or no) _binding_type attributes in l10n_br_fiscal.document.supplement()ancestors: {binding_types}. You can define a {self._spec_prefix()}_binding_type in {odoo_class} to avoid ambiguities.
```

Assim eu pude botar essas classes como SpecModel de novo, tirando esse hack feio.

Finalmente eu adicionei meu copyright no arquivo. Pois em 2019, depois de prototipar  spec_driven_model, eu passei o pseudo code da serialização pro @mileo que depois passou pro @gabrielcardoso21 que na epoca não sabia fazer git squash/rebase e por isso fazia muitos commits de forma desnecessária. Depois eu fiz muita manutenção do arquivo e cheguei a re-rescrever ele quase tudo esses 4 ultimos anos.

Se analisar os logs do arquivo, ficou claro que cheguei até a fazer mais trabalho no arquivo:

| Author                              | Commits | Lines Added | Lines Removed |
|-------------------------------------|---------|-------------|---------------|
| Raphaël Valyi <rvalyi@akretion.com> | 20      | 402         | 310           |
| Gabriel Cardoso de Faria            | 18      | 151         | 150           |
| Luis Felipe Mileo <mileo@kmee.com.br> | 10      | 393         | 340           |
| Renato Lima <renato.lima@akretion.com> | 2       | 31          | 5             |
| Magno Costa <magno.costa@akretion.com.br> | 1       | 1           | 1             |
| Antônio Neto <neto@engenere.one>    | 1       | 3           | 3             |

Os principais commits e PRs meus desde 2021 foram:

- https://github.com/OCA/l10n-brazil/commit/a0b424a2d0627a47946e9fb03a06a03838bf15f1
- https://github.com/OCA/l10n-brazil/commit/dae9fa8ff749cb304cd7094aaaa00dbf839aefd5
- https://github.com/OCA/l10n-brazil/commit/f9fd8002927231a29f6fd8633ceab111378f98d6
- https://github.com/OCA/l10n-brazil/commit/77f48ea8211fd1e7733d01a0f25fc39d38ffc4be
- https://github.com/OCA/l10n-brazil/commit/936378ccbac6660af89594e19bea7fd6da56b4da
- https://github.com/OCA/l10n-brazil/commit/23053ac90931fd549c323d21a9ccec90f15c3bae
- https://github.com/OCA/l10n-brazil/commit/0748f85e08d4ee888cd9340c366d8bc7b77888c2
- https://github.com/OCA/l10n-brazil/pull/3720/commits/0c34ff4f2571509f4efa4a1fde76d80fb74605d2

Eu anexei o resultado do log com `git log --stat spec_driven_model/models/spec_export.py | grep Author -A7` se tiver duvida. [logs.txt](https://github.com/user-attachments/files/19814127/logs.txt)


cc @OCA/local-brazil-maintainers 

NOTE: é algo que seria seguro fazer backport para a v14...