### PR TITLE
[16.0][FIX] l10n_br_account: missing shadowed fields into move lines write

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -430,19 +430,6 @@ class AccountMove(models.Model):
                 }
             )
 
-    @api.model_create_multi
-    def create(self, vals_list):
-        self._inject_shadowed_fields(vals_list)
-        invoice = super(AccountMove, self.with_context(create_from_move=True)).create(
-            vals_list
-        )
-        return invoice
-
-    def write(self, values):
-        self._inject_shadowed_fields([values])
-        result = super().write(values)
-        return result
-
     def unlink(self):
         """Allow to delete draft or cancelled invoices"""
         unlink_moves = self.env["account.move"]

--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -131,8 +131,6 @@ class AccountMoveLine(models.Model):
             )
             values["document_id"] = fiscal_doc_id  # pass through the _inherits system
 
-        self._inject_shadowed_fields(vals_list)
-
         # This reordering bellow is crucial to ensure accurate linkage between
         # account.move.line (aml) and the fiscal document line. In the fiscal create a
         # fiscal document line, leaving only those that should be created. Proper
@@ -155,9 +153,7 @@ class AccountMoveLine(models.Model):
         vals_list = [val for _, val in sorted_indexed_vals_list]
 
         # Create the records
-        result = super(
-            AccountMoveLine, self.with_context(create_from_move_line=True)
-        ).create(vals_list)
+        result = super().create(vals_list)
 
         # Initialize the inverted index list with the same length as the original list
         inverted_index = [0] * len(original_indexes)

--- a/l10n_br_account/models/document.py
+++ b/l10n_br_account/models/document.py
@@ -148,7 +148,7 @@ class FiscalDocument(models.Model):
         fiscal_document_id despite the _inherits system:
         Odoo will write NULL as the value in this case.
         """
-        if self._context.get("create_from_move"):
+        if self._context.get("create_from_account"):
             filtered_vals_list = []
             for values in vals_list:
                 if values.get("document_type_id") or values.get("document_serie_id"):

--- a/l10n_br_account/models/document_line.py
+++ b/l10n_br_account/models/document_line.py
@@ -57,7 +57,7 @@ class FiscalDocumentLine(models.Model):
         necessary.
         """
 
-        if self._context.get("create_from_move_line"):
+        if self._context.get("create_from_account"):
             # Filter out the dictionaries that do not meet the conditions
             filtered_vals_list = [
                 vals

--- a/l10n_br_account/models/fiscal_decorator_mixin.py
+++ b/l10n_br_account/models/fiscal_decorator_mixin.py
@@ -82,3 +82,18 @@ class FiscalDecoratorMixin(models.AbstractModel):
             for field in self._shadowed_fields():
                 if field in vals:
                     vals[f"fiscal_proxy_{field}"] = vals[field]
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        self._inject_shadowed_fields(vals_list)
+        result = super(
+            FiscalDecoratorMixin, self.with_context(create_from_account=True)
+        ).create(vals_list)
+        return result
+
+    def write(self, values):
+        self._inject_shadowed_fields([values])
+        result = super(
+            FiscalDecoratorMixin, self.with_context(create_from_account=True)
+        ).write(values)
+        return result


### PR DESCRIPTION
Resolve o problema de incosistência em alguns valores da fatura com o documento fiscal, 
os campos que a gente chama de "shadowed fields" não estavam sendo injetados na linha do documento fiscal, quando eram alterados (write)

@rvalyi 

Estava faltando chamar o `_inject_shadowed_fields()` no `write()` do modelo `account_move_line`
Mas ao invés de acrescentar direto no modelos `account_move_line` e `account_move` apliquei no modelo que é herdado `fiscal_decorator_mixin` reduzindo um pouco o boilerplate.

Resolve o #3721 