### PR TITLE
[16.0][REF] l10n_br_coa_simple: remove brittle without_demo

### DIFF
--- a/l10n_br_base/models/res_company.py
+++ b/l10n_br_base/models/res_company.py
@@ -1,5 +1,3 @@
-#    OpenERP, Open Source Management Solution
-#    Copyright (C) 2004-2010 Tiny SPRL (<http://tiny.be>).
 #    Thinkopen - Brasil
 #    Copyright (C) Thinkopen Solutions (<http://www.thinkopensolutions.com.br>)
 #    Akretion
@@ -7,7 +5,7 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from odoo import api, fields, models
-from odoo.tools import config
+from odoo.exceptions import UserError
 
 
 class Company(models.Model):
@@ -153,11 +151,22 @@ class Company(models.Model):
         return res
 
     def write(self, values):
+        """
+        Overriden so we can change the currency_id of base.main_company
+        in l10n_br_base/demo/res_company_demo.xml (demo data)
+        """
         try:
             result = super().write(values)
-        except Exception as e:
-            if not config["without_demo"] and values.get("currency_id"):
-                # required for demo installation
+        except UserError as e:
+            demo_main_company = self.env.ref(
+                "base.main_company", raise_if_not_found=False
+            )
+            brl_currency = self.env.ref("base.BRL")
+            if (
+                demo_main_company
+                and self.ids == [demo_main_company.id]
+                and values.get("currency_id") == brl_currency.id
+            ):
                 result = models.Model.write(self, values)
             else:
                 raise e

--- a/l10n_br_coa_simple/hooks.py
+++ b/l10n_br_coa_simple/hooks.py
@@ -6,21 +6,22 @@ from odoo import SUPERUSER_ID, api, tools
 
 def post_init_hook(cr, registry):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    coa_simple_tmpl = env.ref("l10n_br_coa_simple.l10n_br_coa_simple_chart_template")
 
-    # Load COA to Demo Company
-    if not tools.config.get("without_demo"):
-        company = env.ref(
-            "l10n_br_base.empresa_simples_nacional", raise_if_not_found=False
+    # Load COA for demo Company
+    company_sn = env.ref(
+        "l10n_br_base.empresa_simples_nacional", raise_if_not_found=False
+    )
+    if company_sn:
+        coa_simple_tmpl = env.ref(
+            "l10n_br_coa_simple.l10n_br_coa_simple_chart_template"
         )
-        if company:
-            coa_simple_tmpl.try_loading(company=company)
-            tools.convert_file(
-                cr,
-                "l10n_br_coa_simple",
-                "demo/account_journal.xml",
-                None,
-                mode="init",
-                noupdate=True,
-                kind="init",
-            )
+        coa_simple_tmpl.try_loading(company=company_sn)
+        tools.convert_file(
+            cr,
+            "l10n_br_coa_simple",
+            "demo/account_journal.xml",
+            None,
+            mode="init",
+            noupdate=True,
+            kind="init",
+        )


### PR DESCRIPTION
sobre o segundo commit, continua permitindo de botar BRL para a empresa de demo base.main_company, so que de forma mais robusta (sem tentar o hack para qualquer exceção apenas se tiver UserError e que tentar botar BRL como currency_id para base.main_company.

Depois do commit continua funcionando (ou senão verificar no Runboat):

```
odoo16=# select name, id, currency_id from res_company;
           name           | id | currency_id
--------------------------+----+-------------
 Sua Empresa              |  1 |           6
 Empresa Lucro Presumido  |  2 |           6
 Empresa Simples Nacional |  3 |           6
(3 rows)

odoo16=# select name from res_currency where id=6;
 name
------
 BRL
(1 row)
```