### PR TITLE
[14.0][IMP] l10n_br_account_withholding: conta pagável para faturas de imposto retido

### DIFF
--- a/l10n_br_account_withholding/models/account_move.py
+++ b/l10n_br_account_withholding/models/account_move.py
@@ -142,6 +142,14 @@ class AccountMove(models.Model):
                         wh_invoice = self.env["account.move"].create(
                             self._prepare_wh_invoice(line, fiscal_group)
                         )
+                        if fiscal_group.wh_payable_account_id:
+                            payable_lines = wh_invoice.line_ids.filtered(
+                                lambda line: line.account_id.internal_type == "payable"
+                            )
+
+                            payable_lines.write(
+                                {"account_id": fiscal_group.wh_payable_account_id.id}
+                            )
                         wh_invoice.message_post_with_view(
                             "mail.message_origin_link",
                             values={"self": wh_invoice, "origin": move},

--- a/l10n_br_account_withholding/models/l10n_br_fiscal_tax_group.py
+++ b/l10n_br_account_withholding/models/l10n_br_fiscal_tax_group.py
@@ -19,3 +19,11 @@ class FiscalTaxGroup(models.Model):
         default=False,
         company_dependent=True,
     )
+
+    wh_payable_account_id = fields.Many2one(
+        comodel_name="account.account",
+        string="WH Payable Account",
+        help="Special account payable for withholding invoices",
+        domain="[('internal_type', '=', 'payable')]",
+        company_dependent=True,
+    )

--- a/l10n_br_account_withholding/readme/CONFIGURE.md
+++ b/l10n_br_account_withholding/readme/CONFIGURE.md
@@ -2,6 +2,6 @@ Configure a geração de faturas de retenção de impostos no Odoo seguindo este
 
 1. **Acesse Configurações Fiscais:** Vá até `Fiscal -> Configurações -> Grupos de Impostos`. Procure por impostos retidos do tipo entrada.
 
-2. **Configure os Impostos Retidos:** Para cada imposto que requer uma fatura de retenção, garanta que esteja corretamente configurado. Defina um fornecedor e o diário para a geração da fatura do imposto se necessário. Se um diário não for especificado, o módulo usará o diário da fatura de compra original.
+2. **Configure os Impostos Retidos:** Para cada imposto que requer uma fatura de retenção, garanta que esteja corretamente configurado. Defina um fornecedor, o diário e uma conta pagável para a geração da fatura do imposto se necessário. Se um diário não for especificado, o módulo usará o diário da fatura de compra original. A conta pagável é opicional, se não definida será utilizada a conta padrão do parceiro.
 
 3. **Definir uma Prefeitura para o ISSQN:** Crie ou edite um parceiro, vá até a aba "Fiscal" e marque a opção "É Prefeitura".

--- a/l10n_br_account_withholding/tests/test_account_wh_invoice.py
+++ b/l10n_br_account_withholding/tests/test_account_wh_invoice.py
@@ -76,7 +76,7 @@ class AccountMoveWithWhInvoice(AccountMoveBRCommon):
             document_type_id=cls.env.ref("l10n_br_fiscal.document_55").id,
             **kwargs,
         )
-        res["company"].partner_id.state_id = cls.env.ref("base.state_br_sp").id
+        res["company"].partner_id.state_id = cls.env.ref("base.state_br_sp")
         chart_template.load_fiscal_taxes()
         return res
 
@@ -343,14 +343,22 @@ class AccountMoveWithWhInvoice(AccountMoveBRCommon):
         for line_ids in move_issqn.invoice_line_ids:
             line_ids.issqn_tax_id = None
             line_ids.issqn_fg_city_id = self.env.ref("l10n_br_base.city_3550308")
-            line_ids.issqn_wh_tax_id = (
-                self.env["l10n_br_fiscal.tax"]
-                .search([("name", "=", "ISSQN RET 5%")], order="id DESC", limit=1)
-                .id
-            )
+            line_ids.issqn_wh_tax_id = self.env.ref("l10n_br_fiscal.tax_issqn_wh_5")
+
+        move_issqn.invoice_line_ids._onchange_fiscal_taxes()
+        move_issqn.invoice_line_ids._onchange_fiscal_tax_ids()
+        move_issqn.with_context(check_move_validity=False)._recompute_dynamic_lines(
+            recompute_all_taxes=True
+        )
 
         move_issqn.action_post()
         move_issqn._compute_wh_invoice_ids()
+
+        self.assertEqual(
+            move_issqn.wh_invoice_count,
+            1,
+            "The invoice should have 1 withholding invoice (ISSQN).",
+        )
 
         partner_wh = self.env["res.partner"].search(
             [
@@ -386,7 +394,7 @@ class AccountMoveWithWhInvoice(AccountMoveBRCommon):
         )
         tax_group = self.env.ref("l10n_br_fiscal.tax_group_issqn_wh")
         tax_group.generate_wh_invoice = True
-        tax_group.journal_id = self.company_data["default_journal_purchase"].id
+        tax_group.journal_id = self.company_data["default_journal_purchase"]
         partner_cityhall = self.env["res.partner"].create(
             {
                 "name": "Prefeitura de São Paulo",
@@ -410,18 +418,25 @@ class AccountMoveWithWhInvoice(AccountMoveBRCommon):
         for line_ids in move_issqn.invoice_line_ids:
             line_ids.issqn_tax_id = None
             line_ids.issqn_fg_city_id = self.env.ref("l10n_br_base.city_3550308")
-            line_ids.issqn_wh_tax_id = (
-                self.env["l10n_br_fiscal.tax"]
-                .search([("name", "=", "ISSQN RET 5%")], order="id DESC", limit=1)
-                .id
-            )
+            line_ids.issqn_wh_tax_id = self.env.ref("l10n_br_fiscal.tax_issqn_wh_5")
+
+        move_issqn.invoice_line_ids._onchange_fiscal_taxes()
+        move_issqn.invoice_line_ids._onchange_fiscal_tax_ids()
+        move_issqn.with_context(check_move_validity=False)._recompute_dynamic_lines(
+            recompute_all_taxes=True
+        )
 
         move_issqn.action_post()
         move_issqn._compute_wh_invoice_ids()
 
+        self.assertEqual(
+            move_issqn.wh_invoice_count,
+            1,
+            "The invoice should have 1 withholding invoice (ISSQN).",
+        )
         self.assertTrue(
             all(
-                wh_inv.partner_id == partner_cityhall.id
+                wh_inv.partner_id == partner_cityhall
                 for wh_inv in move_issqn.wh_invoice_ids
             )
         )

--- a/l10n_br_account_withholding/tests/test_account_wh_invoice.py
+++ b/l10n_br_account_withholding/tests/test_account_wh_invoice.py
@@ -402,9 +402,24 @@ class AccountMoveWithWhInvoice(AccountMoveBRCommon):
         self.env.ref("l10n_br_fiscal.tax_group_pis_wh").generate_wh_invoice = False
         self.env.ref("l10n_br_fiscal.tax_group_cofins_wh").generate_wh_invoice = False
         product = self.service_test
+        wh_payable_account = self.env["account.account"].create(
+            {
+                "name": "Withholding Payable",
+                "code": "WHT210",
+                "user_type_id": self.env.ref("account.data_account_type_payable").id,
+                "reconcile": True,
+                "company_id": self.company_data["company"].id,
+            }
+        )
+
         tax_group = self.env.ref("l10n_br_fiscal.tax_group_issqn_wh")
-        tax_group.generate_wh_invoice = True
-        tax_group.journal_id = self.company_data["default_journal_purchase"]
+        tax_group.write(
+            {
+                "generate_wh_invoice": True,
+                "journal_id": self.company_data["default_journal_purchase"].id,
+                "wh_payable_account_id": wh_payable_account.id,
+            }
+        )
         partner_cityhall = self.env["res.partner"].create(
             {
                 "name": "Prefeitura de São Paulo",
@@ -448,5 +463,14 @@ class AccountMoveWithWhInvoice(AccountMoveBRCommon):
             all(
                 wh_inv.partner_id == partner_cityhall
                 for wh_inv in move_issqn.wh_invoice_ids
+            )
+        )
+        payable_line_ids = move_issqn.wh_invoice_ids.line_ids.filtered(
+            lambda line: line.account_id.internal_type == "payable"
+        )
+        self.assertTrue(
+            all(
+                pay_line.account_id == wh_payable_account
+                for pay_line in payable_line_ids
             )
         )

--- a/l10n_br_account_withholding/tests/test_account_wh_invoice.py
+++ b/l10n_br_account_withholding/tests/test_account_wh_invoice.py
@@ -55,6 +55,36 @@ class AccountMoveWithWhInvoice(AccountMoveBRCommon):
         cls.env.ref("l10n_br_fiscal.tax_group_pis_wh").generate_wh_invoice = True
         cls.env.ref("l10n_br_fiscal.tax_group_cofins_wh").generate_wh_invoice = True
 
+        cls.service_test = cls.env["product.product"].create(
+            {
+                "name": "Serviço de Testes",
+                "type": "service",
+                "standard_price": 1000.0,
+                "tax_icms_or_issqn": "issqn",
+                "ncm_id": cls.env.ref("l10n_br_fiscal.ncm_00000000").id,
+                "fiscal_type": "09",
+                "fiscal_genre_id": cls.env.ref("l10n_br_fiscal.product_genre_00").id,
+                "service_type_id": cls.env.ref("l10n_br_fiscal.service_type_1009").id,
+                "taxes_id": False,
+            }
+        )
+
+        cls.test_partner = cls.env["res.partner"].create(
+            {
+                "name": "Test Company Brasil",
+                "legal_name": "Test Company Brasil Ltda",
+                "cnpj_cpf": "32.680.221/0001-44",
+                "state_id": cls.env.ref("base.state_br_sp").id,
+                "city_id": cls.env.ref("l10n_br_base.city_3550308").id,
+                "zip": "04576-060",
+                "country_id": cls.env.ref("base.br").id,
+                "inscr_est": "621.240.850.633",
+                "is_company": True,
+                "active": True,
+            }
+        )
+        cls.test_partner._onchange_city_id()
+
     @classmethod
     def setup_company_data(cls, company_name, chart_template=None, **kwargs):
         if company_name == "company_1_data":
@@ -315,24 +345,14 @@ class AccountMoveWithWhInvoice(AccountMoveBRCommon):
         "Test move with Partner defined and no ISSQN City Partner"
         self.env.ref("l10n_br_fiscal.tax_group_pis_wh").generate_wh_invoice = False
         self.env.ref("l10n_br_fiscal.tax_group_cofins_wh").generate_wh_invoice = False
-        product = self.env.ref("l10n_br_sale_commission.service_commission")
-        product.write(
-            {
-                "standard_price": 1000.0,
-                "tax_icms_or_issqn": "issqn",
-                "ncm_id": self.env.ref("l10n_br_fiscal.ncm_00000000").id,
-                "fiscal_genre_id": self.env.ref("l10n_br_fiscal.product_genre_00").id,
-                "fiscal_type": "09",
-                "taxes_id": False,
-            }
-        )
+        product = self.service_test
         tax_group = self.env.ref("l10n_br_fiscal.tax_group_issqn_wh")
         tax_group.generate_wh_invoice = True
         tax_group.journal_id = self.company_data["default_journal_purchase"].id
         move_issqn = self.init_invoice(
             "in_invoice",
             products=[product],
-            partner=self.env.ref("l10n_br_base.res_partner_amd"),
+            partner=self.test_partner,
             document_type=self.env.ref("l10n_br_fiscal.document_55"),
             fiscal_operation=self.env.ref("l10n_br_fiscal.fo_compras"),
             fiscal_operation_lines=[self.env.ref("l10n_br_fiscal.fo_compras_servico")],
@@ -381,17 +401,7 @@ class AccountMoveWithWhInvoice(AccountMoveBRCommon):
         "Test move with Partner and ISSQN City Partner"
         self.env.ref("l10n_br_fiscal.tax_group_pis_wh").generate_wh_invoice = False
         self.env.ref("l10n_br_fiscal.tax_group_cofins_wh").generate_wh_invoice = False
-        product = self.env.ref("l10n_br_sale_commission.service_commission")
-        product.write(
-            {
-                "standard_price": 1000.0,
-                "tax_icms_or_issqn": "issqn",
-                "ncm_id": self.env.ref("l10n_br_fiscal.ncm_00000000").id,
-                "fiscal_genre_id": self.env.ref("l10n_br_fiscal.product_genre_00").id,
-                "fiscal_type": "09",
-                "taxes_id": False,
-            }
-        )
+        product = self.service_test
         tax_group = self.env.ref("l10n_br_fiscal.tax_group_issqn_wh")
         tax_group.generate_wh_invoice = True
         tax_group.journal_id = self.company_data["default_journal_purchase"]

--- a/l10n_br_account_withholding/views/l10n_br_fiscal_tax_group.xml
+++ b/l10n_br_account_withholding/views/l10n_br_fiscal_tax_group.xml
@@ -10,6 +10,10 @@
             <field name='partner_id' position='before'>
                 <field name='generate_wh_invoice' />
                 <field name='journal_id' />
+                <field
+                    name="wh_payable_account_id"
+                    attrs="{'invisible': [('generate_wh_invoice', '=', False)]}"
+                />
             </field>
         </field>
     </record>


### PR DESCRIPTION
Esta PR introduz a possibilidade de colocar uma conta pagável especial para faturas de impostos retidos para um grupo de impostos fiscais, quando a operação de criar a fatura automática está ativa.

Exemplo:
A empresa tem uma nota de serviço que tem retenção de ISSQN e precisa que o ISSQN a pagar seja separado em uma conta específica para esse tipo de operação. Como a fatura de retenção tem a prefeitura como fornecedor, não seria possível definir o ISSQN a pagar como conta padrão para o parceiro, porque existem outras taxas a serem pagas, como IPTU, alvarás e etc. Por isso a necessidade dessa PR. 

No caso se a prefeitura tivesse como padrão Fornecedores a Pagar, para essa operação de retenção ficaria ISSQN a Pagar.

Depende da PR #3731, que já entrou.

@marcelsavegnago @douglascstd @rvalyi @antoniospneto 