### PR TITLE
[16.0][IMP] l10n_br_mdfe: limits for aquaviario, rodoviario and condutor

### DIFF
--- a/l10n_br_mdfe/models/document.py
+++ b/l10n_br_mdfe/models/document.py
@@ -409,19 +409,16 @@ class MDFe(spec_models.StackedModel):
     mdfe30_infTermCarreg = fields.One2many(
         comodel_name="l10n_br_mdfe.modal.aquaviario.carregamento",
         inverse_name="document_id",
-        size=5,
     )
 
     mdfe30_infTermDescarreg = fields.One2many(
         comodel_name="l10n_br_mdfe.modal.aquaviario.descarregamento",
         inverse_name="document_id",
-        size=5,
     )
 
     mdfe30_infEmbComb = fields.One2many(
         comodel_name="l10n_br_mdfe.modal.aquaviario.comboio",
         inverse_name="document_id",
-        size=30,
     )
 
     mdfe30_infUnidCargaVazia = fields.One2many(
@@ -492,7 +489,6 @@ class MDFe(spec_models.StackedModel):
     mdfe30_condutor = fields.One2many(
         comodel_name="l10n_br_mdfe.modal.rodoviario.veiculo.condutor",
         inverse_name="document_id",
-        size=10,
     )
 
     mdfe30_cInt = fields.Char(size=10, string="Código do Veículo")
@@ -516,13 +512,11 @@ class MDFe(spec_models.StackedModel):
     mdfe30_veicReboque = fields.One2many(
         comodel_name="l10n_br_mdfe.modal.rodoviario.reboque",
         inverse_name="document_id",
-        size=3,
     )
 
     mdfe30_lacRodo = fields.One2many(
         comodel_name="l10n_br_mdfe.modal.rodoviario.lacre",
         inverse_name="document_id",
-        size=3,
     )
 
     mdfe30_UF = fields.Selection(selection=TUF, compute="_compute_mdfe30_rodo_uf")

--- a/l10n_br_mdfe/models/modal_aquaviario.py
+++ b/l10n_br_mdfe/models/modal_aquaviario.py
@@ -1,7 +1,8 @@
 # Copyright 2023 KMEE
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields
+from odoo import _, api, fields
+from odoo.exceptions import UserError
 
 from odoo.addons.spec_driven_model.models import spec_models
 
@@ -90,6 +91,19 @@ class MDFeModalAquaviarioCarregamento(spec_models.SpecModel):
                 self._fields["loading_harbor"].selection
             ).get(record.loading_harbor)
 
+    @api.constrains("document_id")
+    def _check_maximum_carregamento(self):
+        for record in self:
+            if record.document_id:
+                count = self.search_count([("document_id", "=", record.document_id.id)])
+                if count > 5:
+                    raise UserError(
+                        _(
+                            "You can only add up to 5 loading terminals "
+                            "for the same MDF-e."
+                        )
+                    )
+
 
 class MDFeModalAquaviarioDescarregamento(spec_models.SpecModel):
     _name = "l10n_br_mdfe.modal.aquaviario.descarregamento"
@@ -112,6 +126,19 @@ class MDFeModalAquaviarioDescarregamento(spec_models.SpecModel):
             record.mdfe30_xTermDescarreg = dict(
                 self._fields["unloading_harbor"].selection
             ).get(record.unloading_harbor)
+
+    @api.constrains("document_id")
+    def _check_maximum_descarregamento(self):
+        for record in self:
+            if record.document_id:
+                count = self.search_count([("document_id", "=", record.document_id.id)])
+                if count > 5:
+                    raise UserError(
+                        _(
+                            "You can only add up to 5 unloading terminals "
+                            "for the same MDF-e."
+                        )
+                    )
 
 
 class MDFeModalAquaviarioComboio(spec_models.SpecModel):

--- a/l10n_br_mdfe/tests/test_mdfe_structure.py
+++ b/l10n_br_mdfe/tests/test_mdfe_structure.py
@@ -3,6 +3,7 @@
 
 from io import StringIO
 
+from odoo.exceptions import UserError
 from odoo.tests import TransactionCase
 
 from odoo.addons.spec_driven_model.models.spec_models import SpecModel
@@ -162,3 +163,25 @@ class MDFeStructure(TransactionCase):
 
     def test_doc_visit_stack(self):
         pass
+
+    def test_check_aquaviario(self):
+        mdfe = self.env.ref("l10n_br_mdfe.demo_mdfe_sn_modal_aquaviario")
+        with self.assertRaises(UserError):
+            mdfe.mdfe30_infTermCarreg = [
+                (0, 0, {"loading_harbor": "BRADR"}),
+                (0, 0, {"loading_harbor": "BRAFU"}),
+                (0, 0, {"loading_harbor": "BRAJU"}),
+                (0, 0, {"loading_harbor": "BRALT"}),
+                (0, 0, {"loading_harbor": "BRAMM"}),
+                (0, 0, {"loading_harbor": "BRAMW"}),
+            ]
+
+        with self.assertRaises(UserError):
+            mdfe.mdfe30_infTermDescarreg = [
+                (0, 0, {"unloading_harbor": "BRAFU"}),
+                (0, 0, {"unloading_harbor": "BRBZC"}),
+                (0, 0, {"unloading_harbor": "BRAJU"}),
+                (0, 0, {"unloading_harbor": "BRALT"}),
+                (0, 0, {"unloading_harbor": "BRAMM"}),
+                (0, 0, {"unloading_harbor": "BRAMW"}),
+            ]


### PR DESCRIPTION
## Objetivo da PR

Remoção dos atributos size que não estava sendo usado e assim corigindo os warnings do teste.

![image](https://github.com/user-attachments/assets/e1580222-f4ae-4814-95bc-300f213b2099)

Antes estava podendo adicionar mais de Portos de Carregamento e Descarregamento quando o Modelo de Transporte era Aquaviário.
**Exemplo:**
Adicionando 6 portos de carregamento:
![WhatsApp Image 2025-04-22 at 16 05 47](https://github.com/user-attachments/assets/f1784123-36ed-465d-a948-baac0fbfd6bc)

XML Gerado:
![WhatsApp Image 2025-04-22 at 16 05 47 (1)](https://github.com/user-attachments/assets/ebbca8ed-2731-4536-b86c-977b75833117)

Eu fiz alguns checks para limitar isso conforme a documentação do MDF-e

![image](https://github.com/user-attachments/assets/eca89304-b4d8-4d07-a006-0f597a449902)

