### PR TITLE
[14.0] [FIX] l10n_br_account_withholding: corrigindo testes com falso positivo e tirando dependencia de dados demos

### DIFF
--- a/l10n_br_account_withholding/tests/test_account_wh_invoice.py
+++ b/l10n_br_account_withholding/tests/test_account_wh_invoice.py
@@ -76,7 +76,7 @@ class AccountMoveWithWhInvoice(AccountMoveBRCommon):
             document_type_id=cls.env.ref("l10n_br_fiscal.document_55").id,
             **kwargs,
         )
-        res["company"].partner_id.state_id = cls.env.ref("base.state_br_sp").id
+        res["company"].partner_id.state_id = cls.env.ref("base.state_br_sp")
         chart_template.load_fiscal_taxes()
         return res
 
@@ -343,14 +343,22 @@ class AccountMoveWithWhInvoice(AccountMoveBRCommon):
         for line_ids in move_issqn.invoice_line_ids:
             line_ids.issqn_tax_id = None
             line_ids.issqn_fg_city_id = self.env.ref("l10n_br_base.city_3550308")
-            line_ids.issqn_wh_tax_id = (
-                self.env["l10n_br_fiscal.tax"]
-                .search([("name", "=", "ISSQN RET 5%")], order="id DESC", limit=1)
-                .id
-            )
+            line_ids.issqn_wh_tax_id = self.env.ref("l10n_br_fiscal.tax_issqn_wh_5")
+
+        move_issqn.invoice_line_ids._onchange_fiscal_taxes()
+        move_issqn.invoice_line_ids._onchange_fiscal_tax_ids()
+        move_issqn.with_context(check_move_validity=False)._recompute_dynamic_lines(
+            recompute_all_taxes=True
+        )
 
         move_issqn.action_post()
         move_issqn._compute_wh_invoice_ids()
+
+        self.assertEqual(
+            move_issqn.wh_invoice_count,
+            1,
+            "The invoice should have 1 withholding invoice (ISSQN).",
+        )
 
         partner_wh = self.env["res.partner"].search(
             [
@@ -386,7 +394,7 @@ class AccountMoveWithWhInvoice(AccountMoveBRCommon):
         )
         tax_group = self.env.ref("l10n_br_fiscal.tax_group_issqn_wh")
         tax_group.generate_wh_invoice = True
-        tax_group.journal_id = self.company_data["default_journal_purchase"].id
+        tax_group.journal_id = self.company_data["default_journal_purchase"]
         partner_cityhall = self.env["res.partner"].create(
             {
                 "name": "Prefeitura de São Paulo",
@@ -410,18 +418,25 @@ class AccountMoveWithWhInvoice(AccountMoveBRCommon):
         for line_ids in move_issqn.invoice_line_ids:
             line_ids.issqn_tax_id = None
             line_ids.issqn_fg_city_id = self.env.ref("l10n_br_base.city_3550308")
-            line_ids.issqn_wh_tax_id = (
-                self.env["l10n_br_fiscal.tax"]
-                .search([("name", "=", "ISSQN RET 5%")], order="id DESC", limit=1)
-                .id
-            )
+            line_ids.issqn_wh_tax_id = self.env.ref("l10n_br_fiscal.tax_issqn_wh_5")
+
+        move_issqn.invoice_line_ids._onchange_fiscal_taxes()
+        move_issqn.invoice_line_ids._onchange_fiscal_tax_ids()
+        move_issqn.with_context(check_move_validity=False)._recompute_dynamic_lines(
+            recompute_all_taxes=True
+        )
 
         move_issqn.action_post()
         move_issqn._compute_wh_invoice_ids()
 
+        self.assertEqual(
+            move_issqn.wh_invoice_count,
+            1,
+            "The invoice should have 1 withholding invoice (ISSQN).",
+        )
         self.assertTrue(
             all(
-                wh_inv.partner_id == partner_cityhall.id
+                wh_inv.partner_id == partner_cityhall
                 for wh_inv in move_issqn.wh_invoice_ids
             )
         )

--- a/l10n_br_account_withholding/tests/test_account_wh_invoice.py
+++ b/l10n_br_account_withholding/tests/test_account_wh_invoice.py
@@ -55,6 +55,36 @@ class AccountMoveWithWhInvoice(AccountMoveBRCommon):
         cls.env.ref("l10n_br_fiscal.tax_group_pis_wh").generate_wh_invoice = True
         cls.env.ref("l10n_br_fiscal.tax_group_cofins_wh").generate_wh_invoice = True
 
+        cls.service_test = cls.env["product.product"].create(
+            {
+                "name": "Serviço de Testes",
+                "type": "service",
+                "standard_price": 1000.0,
+                "tax_icms_or_issqn": "issqn",
+                "ncm_id": cls.env.ref("l10n_br_fiscal.ncm_00000000").id,
+                "fiscal_type": "09",
+                "fiscal_genre_id": cls.env.ref("l10n_br_fiscal.product_genre_00").id,
+                "service_type_id": cls.env.ref("l10n_br_fiscal.service_type_1009").id,
+                "taxes_id": False,
+            }
+        )
+
+        cls.test_partner = cls.env["res.partner"].create(
+            {
+                "name": "Test Company Brasil",
+                "legal_name": "Test Company Brasil Ltda",
+                "cnpj_cpf": "32.680.221/0001-44",
+                "state_id": cls.env.ref("base.state_br_sp").id,
+                "city_id": cls.env.ref("l10n_br_base.city_3550308").id,
+                "zip": "04576-060",
+                "country_id": cls.env.ref("base.br").id,
+                "inscr_est": "621.240.850.633",
+                "is_company": True,
+                "active": True,
+            }
+        )
+        cls.test_partner._onchange_city_id()
+
     @classmethod
     def setup_company_data(cls, company_name, chart_template=None, **kwargs):
         if company_name == "company_1_data":
@@ -315,24 +345,14 @@ class AccountMoveWithWhInvoice(AccountMoveBRCommon):
         "Test move with Partner defined and no ISSQN City Partner"
         self.env.ref("l10n_br_fiscal.tax_group_pis_wh").generate_wh_invoice = False
         self.env.ref("l10n_br_fiscal.tax_group_cofins_wh").generate_wh_invoice = False
-        product = self.env.ref("l10n_br_sale_commission.service_commission")
-        product.write(
-            {
-                "standard_price": 1000.0,
-                "tax_icms_or_issqn": "issqn",
-                "ncm_id": self.env.ref("l10n_br_fiscal.ncm_00000000").id,
-                "fiscal_genre_id": self.env.ref("l10n_br_fiscal.product_genre_00").id,
-                "fiscal_type": "09",
-                "taxes_id": False,
-            }
-        )
+        product = self.service_test
         tax_group = self.env.ref("l10n_br_fiscal.tax_group_issqn_wh")
         tax_group.generate_wh_invoice = True
         tax_group.journal_id = self.company_data["default_journal_purchase"].id
         move_issqn = self.init_invoice(
             "in_invoice",
             products=[product],
-            partner=self.env.ref("l10n_br_base.res_partner_amd"),
+            partner=self.test_partner,
             document_type=self.env.ref("l10n_br_fiscal.document_55"),
             fiscal_operation=self.env.ref("l10n_br_fiscal.fo_compras"),
             fiscal_operation_lines=[self.env.ref("l10n_br_fiscal.fo_compras_servico")],
@@ -381,17 +401,7 @@ class AccountMoveWithWhInvoice(AccountMoveBRCommon):
         "Test move with Partner and ISSQN City Partner"
         self.env.ref("l10n_br_fiscal.tax_group_pis_wh").generate_wh_invoice = False
         self.env.ref("l10n_br_fiscal.tax_group_cofins_wh").generate_wh_invoice = False
-        product = self.env.ref("l10n_br_sale_commission.service_commission")
-        product.write(
-            {
-                "standard_price": 1000.0,
-                "tax_icms_or_issqn": "issqn",
-                "ncm_id": self.env.ref("l10n_br_fiscal.ncm_00000000").id,
-                "fiscal_genre_id": self.env.ref("l10n_br_fiscal.product_genre_00").id,
-                "fiscal_type": "09",
-                "taxes_id": False,
-            }
-        )
+        product = self.service_test
         tax_group = self.env.ref("l10n_br_fiscal.tax_group_issqn_wh")
         tax_group.generate_wh_invoice = True
         tax_group.journal_id = self.company_data["default_journal_purchase"]


### PR DESCRIPTION
Ao fazer os testes para a PR #3726, notei alguns problemas nos testes do módulo:

### Falso positivo nos testes
Os testes test_with_partner_issqn_with_city_partner e test_with_partner_issqn_without_city_partner apresentavam falso positivo porque o campo move_issqn.wh_invoice_ids estava vazio. Isso ocorria devido à ausência de chamadas de alguns onchanges responsáveis por gerar a linha do imposto ISSQN Retido, que é necessária para criar a fatura de retenção.
![image](https://github.com/user-attachments/assets/f46a549c-2a94-4e63-a456-98a45f22c732)

### Erro de comparação de ID
Mesmo se wh_invoice_ids não estivesse vazio nesses testes, haveria um erro ao comparar o parceiro correto, pois o código estava comparando um registro do Odoo diretamente com um ID (ex: partner.id vs partner).
![image](https://github.com/user-attachments/assets/50a08308-205f-427c-9c75-f2e83445a0a1)

### Problemas de dependência

- A dependência de dados demo dificultava a manutenção dos testes.

- O módulo dependia do produto l10n_br_sale_commission.service_commission, que pertence a um módulo sem dependência explícita no manifest. Isso gerava erros se último módulo não estivesse instalado.

### Melhorias implementadas:
Além de corrigir os problemas acima:

- Refatorei partes do código para remover outras dependências de dados demo.

- Adicionei validações extras nos testes citados para garantir que sempre exista exatamente uma fatura de retenção (o esperado).