### PR TITLE
[14.0][FIX] l10n_br_nfe, l10n_br_cte, l10n_br_mdfe: document supplement as a SpecModel - backport 3720

### DIFF
--- a/l10n_br_cte/models/document_supplement.py
+++ b/l10n_br_cte/models/document_supplement.py
@@ -6,13 +6,9 @@ from odoo import fields
 from odoo.addons.spec_driven_model.models import spec_models
 
 
-class CTeSupplement(spec_models.StackedModel):
+class CTeSupplement(spec_models.SpecModel):
     _name = "l10n_br_fiscal.document.supplement"
     _inherit = ["l10n_br_fiscal.document.supplement", "cte.40.tcte_infctesupl"]
-
-    _cte40_odoo_module = (
-        "odoo.addons.l10n_br_cte_spec.models.v4_0.cte_tipos_basico_v4_00"
-    )
-    _cte40_stacking_mixin = "cte.40.tcte_infctesupl"
+    _cte40_binding_type = "Tcte.InfCteSupl"  # avoid ambiguity with NFe and MDFe modules
 
     cte40_qrCodCTe = fields.Char(related="qrcode")

--- a/l10n_br_mdfe/models/document_supplement.py
+++ b/l10n_br_mdfe/models/document_supplement.py
@@ -6,12 +6,9 @@ from odoo import fields
 from odoo.addons.spec_driven_model.models import spec_models
 
 
-class MDFeSupplement(spec_models.StackedModel):
+class MDFeSupplement(spec_models.SpecModel):
     _name = "l10n_br_fiscal.document.supplement"
     _inherit = ["l10n_br_fiscal.document.supplement", "mdfe.30.infmdfesupl"]
-    _mdfe30_odoo_module = (
-        "odoo.addons.l10n_br_mdfe_spec.models.v3_0.mdfe_tipos_basico_v3_00"
-    )
-    _mdfe30_stacking_mixin = "mdfe.30.infmdfesupl"
+    _mdfe30_binding_type = "Tmdfe.InfMdfeSupl"  # avoid ambiguity with NFe and CTe
 
     mdfe30_qrCodMDFe = fields.Char(related="qrcode")

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -831,7 +831,7 @@ class NFe(spec_models.StackedModel):
 
     @api.constrains("document_type", "state_edoc", "fiscal_line_ids")
     def _check_product_default_code(self):
-        for rec in self:
+        for rec in self.filtered(filter_processador_edoc_nfe):
             if (
                 rec.document_type in PRODUCT_CODE_FISCAL_DOCUMENT_TYPES
                 and rec.state_edoc == "a_enviar"
@@ -841,14 +841,14 @@ class NFe(spec_models.StackedModel):
                         raise ValidationError(
                             _(
                                 f"The product {line.product_id.display_name} "
-                                f"must have a default code or the product code"
+                                f"must have a default code or the product code "
                                 f"line field (nfe40_cProd) should be filled."
                             )
                         )
 
     @api.constrains("document_date", "document_key", "state_edoc")
     def _check_document_date_key(self):
-        for rec in self:
+        for rec in self.filtered(filter_processador_edoc_nfe):
             if rec.document_key and rec.document_date:
                 key_date_str = rec.document_key[2:6]
                 key_date = datetime.strptime(key_date_str, "%y%m")
@@ -856,13 +856,9 @@ class NFe(spec_models.StackedModel):
                 document_date = fields.Datetime.context_timestamp(
                     rec, rec.document_date
                 )
-                if (
-                    rec.document_type in ["55", "65"]
-                    and rec.state_edoc in ["a_enviar", "autorizada"]
-                    and (
-                        key_date.year != document_date.year
-                        or key_date.month != document_date.month
-                    )
+                if rec.state_edoc in ["a_enviar", "autorizada"] and (
+                    key_date.year != document_date.year
+                    or key_date.month != document_date.month
                 ):
                     raise ValidationError(
                         _(

--- a/l10n_br_nfe/models/document_supplement.py
+++ b/l10n_br_nfe/models/document_supplement.py
@@ -7,13 +7,10 @@ from odoo import fields
 from odoo.addons.spec_driven_model.models import spec_models
 
 
-class NFeSupplement(spec_models.StackedModel):
+class NFeSupplement(spec_models.SpecModel):
     _name = "l10n_br_fiscal.document.supplement"
     _inherit = ["l10n_br_fiscal.document.supplement", "nfe.40.infnfesupl"]
-
-    _nfe40_odoo_module = "odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00"
-    _nfe40_stacking_mixin = "nfe.40.infnfesupl"
+    _nfe40_binding_type = "Tnfe.InfNfeSupl"  # avoid ambiguity with CTe and MDFe modules
 
     nfe40_qrCode = fields.Char(related="qrcode")
-
     nfe40_urlChave = fields.Char(related="url_key")

--- a/spec_driven_model/models/spec_export.py
+++ b/spec_driven_model/models/spec_export.py
@@ -1,4 +1,5 @@
 # Copyright 2019 KMEE
+# Copyright 2021-TODAY Akretion - Raphael Valyi <raphael.valyi@akretion.com>
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
 
 import logging
@@ -11,12 +12,36 @@ _logger = logging.getLogger(__name__)
 
 class SpecMixinExport(models.AbstractModel):
     _name = "spec.mixin_export"
-    _description = "a mixin providing serialization features"
+    _description = "A mixin providing serialization features."
 
     @api.model
-    def _get_binding_class(self, class_obj):
+    def _get_binding_class(self, odoo_class) -> type:
+        """
+        Use (_spec_prefix)_binding_type of odoo_class and its binding_module to get
+        the Python binding type for export.
+        """
         binding_module = sys.modules[self._get_spec_property("binding_module")]
-        for attr in class_obj._binding_type.split("."):
+        binding_type = odoo_class._get_spec_property("binding_type")
+        if not binding_type:
+            binding_types = set(
+                map(
+                    lambda clazz: clazz._binding_type,
+                    list(
+                        filter(
+                            lambda clazz: hasattr(clazz, "_binding_type"),
+                            type(odoo_class).mro(),
+                        )
+                    ),
+                )
+            )
+            assert len(binding_types) == 1, (
+                f"Found several (or no) _binding_type attributes in {odoo_class} "
+                f"ancestors: {binding_types}. You can define a "
+                f"_{self._spec_prefix()}_binding_type in {odoo_class} "
+                "to avoid ambiguities."
+            )
+            binding_type = binding_types.pop()
+        for attr in binding_type.split("."):  # this will dive into nested classes
             binding_module = getattr(binding_module, attr)
         return binding_module
 
@@ -60,7 +85,7 @@ class SpecMixinExport(models.AbstractModel):
         binding_class_spec = binding_class.__dataclass_fields__
 
         class_name = class_obj._name.replace(".", "_")
-        export_method_name = "_export_fields_%s" % class_name
+        export_method_name = f"_export_fields_{class_name}"
         if hasattr(self, export_method_name):
             xsd_fields = [i for i in xsd_fields]
             export_method = getattr(self, export_method_name)
@@ -193,7 +218,7 @@ class SpecMixinExport(models.AbstractModel):
         """
         Iterate over an Odoo record and its m2o and o2m sub-records
         using a pre-order tree traversal and map the Odoo record values
-        to  a dict of Python binding values.
+        to a dict of Python binding values.
 
         These values will later be injected as **kwargs in the proper XML Python
         binding constructors. Hence the value can either be simple values or


### PR DESCRIPTION
backport de #3720

Eu acho relativamente seguro fazer, simplifica o modelo de dados do document supplement da NFe, CTe e MDFe na 14.0 e deixa igual da 16.0, trazendo melhores garantias que código de importação ou exportação feito numa branch seja fácil de portar numa outra branch.

cc @marcelsavegnago @antoniospneto @mileo 