### PR TITLE
[14.0][REM] l10n_br_fiscal: remove old _onchange_fiscal_operation_id

### DIFF
--- a/l10n_br_fiscal/models/document_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_mixin_methods.py
@@ -158,12 +158,6 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
                 # reload fiscal data, operation line, cfop, taxes, etc.
                 line._onchange_fiscal_operation_id()
 
-    @api.onchange("fiscal_operation_id")
-    def _onchange_fiscal_operation_id(self):
-        if self.fiscal_operation_id:
-            self.operation_name = self.fiscal_operation_id.name
-            self.comment_ids = self.fiscal_operation_id.comment_ids
-
     def _inverse_amount_landed_cost(self, field_name):
         """
         Set landed costs values to the document lines; rate by amount.


### PR DESCRIPTION
fazendo o port de #3700 na branch 15.0 com cherry-picks, eu fui alertado por esse erro de lint: https://github.com/OCA/l10n-brazil/actions/runs/14642411133/job/41087800175?pr=3733#step:7:95

Ou seja, na 15.0, já existia um método `_onchange_fiscal_operation_id` com 2 linhas (na 16.0 não existia https://github.com/OCA/l10n-brazil/pull/3695/commits/2fb8404803f03736a39d2c66a64c5fa9e9d1785d#diff-b4d70588f530c9b38382336e56e8de962636f292eeaa8808a089429ede9ebf75R31 ). 
Ai eu adicionei esse commit na 15.0 para remover e resolver.

Vi que na 14.0 existia tb esse mesmo método e aqui tou fazendo o backport do commit na 14.0

Esse metodo `_onchange_fiscal_operation_id` tinha sido introduzido na 12.0 aqui https://github.com/OCA/l10n-brazil/commit/1e5bfd9558ced976f475f3ccb2d724834cbc4c44

E eu tinha removido na 16.0 com esse `_onchange_fiscal_operation_id` refator recente: https://github.com/OCA/l10n-brazil/commit/21b0b9878fa43f9d18f2f977f91f2fd576c2f571