### PR TITLE
[14.0][FIX] l10n_br_account: adjust fiscal decorator fields - backport de 3743

### DIFF
--- a/l10n_br_account/models/fiscal_decorator_mixin.py
+++ b/l10n_br_account/models/fiscal_decorator_mixin.py
@@ -46,8 +46,9 @@ class FiscalDecoratorMixin(models.AbstractModel):
                 if (
                     name in self._fields
                     or name.startswith("fiscal_proxy_")
-                    or (not field.compute and not field.related)
                     or field_cls in [fields.One2many, fields.Many2many]
+                    or not (field.compute or field.related)
+                    or (field.compute and field.store)
                     or field.compute in self._fiscal_decorator_compute_blacklist
                 ):
                     continue


### PR DESCRIPTION
backport de #3743

Isso deveria ter sido feito quando eu introduzi esse mixin. O problema eh que existem campos com compute e store=True. E nestes casos, a gente quer fazer o que faz o _add_inherited_fields nativo, que é de tornar o campo um related. Pois da forma como tava no l10n_br_account.fiscal.decorator.mixin ele transformava tais campos em campos compute sem related e ai eles ficavam com readonly=True e sem ler o valor do (linha de) documento fiscal.
