### PR TITLE
[16.0][FIX] l10n_br_fiscal: tax_definition_product_rel

### DIFF
--- a/l10n_br_fiscal/models/product_template.py
+++ b/l10n_br_fiscal/models/product_template.py
@@ -125,12 +125,3 @@ class ProductTemplate(models.Model):
     uot_id = fields.Many2one(comodel_name="uom.uom", string="Tax UoM")
 
     uot_factor = fields.Float(string="Tax UoM Factor")
-
-    tax_definition_ids = fields.Many2many(
-        comodel_name="l10n_br_fiscal.tax.definition",
-        relation="tax_definition_product_rel",
-        column1="product_id",
-        column2="tax_definition_id",
-        readonly=True,
-        string="Tax Definition",
-    )


### PR DESCRIPTION
quando instala o modulo `l10n_br_fiscal`, temos a tabela de relação `tax_definition_product_rel`:

```
odoo16=# \d tax_definition_product_rel
          Table "public.tax_definition_product_rel"
      Column       |  Type   | Collation | Nullable | Default
-------------------+---------+-----------+----------+---------
 tax_definition_id | integer |           | not null |
 product_id        | integer |           | not null |
Indexes:
    "tax_definition_product_rel_pkey" PRIMARY KEY, btree (tax_definition_id, product_id)
    "tax_definition_product_rel_product_id_tax_definition_id_idx" btree (product_id, tax_definition_id)
Foreign-key constraints:
    "tax_definition_product_rel_product_id_fkey" FOREIGN KEY (product_id) REFERENCES product_product(id) ON DELETE CASCADE
    "tax_definition_product_rel_tax_definition_id_fkey" FOREIGN KEY (tax_definition_id) REFERENCES l10n_br_fiscal_tax_definition(id) ON DELETE CASCADE
```

Ou seja a coluna `product_id` aponta na variante de produto `product.product`.

Porem dentro do `product_template.py `tinha essa tentativa de relação usando a mesma tabela de relação `tax_definition_product_rel`:

```
    tax_definition_ids = fields.Many2many(
        comodel_name="l10n_br_fiscal.tax.definition",
        relation="tax_definition_product_rel",
        column1="product_id",
        column2="tax_definition_id",
        readonly=True,
        string="Tax Definition",
    )
```

@renatonlima eu imagino que vc ficou com a duvida se era melhor ligar o `l10n_br_fiscal.tax.definition` ao `product.template` ou o` product.product.` No fim é o` product.product` que esta sendo usado pelo código no tax_definition.py:

```
    product_ids = fields.Many2many(
        comodel_name="product.product",
        relation="tax_definition_product_rel",
        column1="tax_definition_id",
        column2="product_id",
        string="Products",
    )
```

Eu acho tudo bem a gente usar a variante product.product para definir as possíveis exceções fiscais. Tivemos que usar isso num projeto na França onde por exemplo a instalação de paneis solares de potencia X para particulares tinha uma taxa A, mas a instalação para uma potencia Y de B2B tinha uma taxa B.

Mas enfim então tem que remover esse código no `product_template.py`, e é isso que eu fiz neste PR.

NOTE: depois de fazer --update=l10n_br_fiscal com essa modificação, a definição da tabela permanece igual se fizer \d tax_definition_product_rel no psql.

Foi trabalhando em #3745 que eu me dei conta desse problema.
