### PR TITLE
[16.0][FIX] l10n_br_fiscal: tax_definition_state_to_rel

### DIFF
--- a/l10n_br_fiscal/models/res_country_state.py
+++ b/l10n_br_fiscal/models/res_country_state.py
@@ -9,7 +9,7 @@ class ResCountryState(models.Model):
     _inherit = "res.country.state"
 
     tax_definition_ids = fields.Many2many(
-        comodel_name="l10n_br_fiscal.tax.definition",
+        "l10n_br_fiscal.tax.definition",
         string="Tax Definitions",
         domain="['|', ('state_from_ids', '=', id), ('state_to_ids', '=', id)]",
     )

--- a/l10n_br_fiscal/models/tax_definition.py
+++ b/l10n_br_fiscal/models/tax_definition.py
@@ -127,10 +127,7 @@ class TaxDefinition(models.Model):
     )
 
     state_to_ids = fields.Many2many(
-        comodel_name="res.country.state",
-        relation="tax_definition_state_to_rel",
-        column1="tax_definition_id",
-        column2="state_id",
+        "res.country.state",
         string="To States",
         domain=[("country_id.code", "=", "BR")],
     )


### PR DESCRIPTION
quando instalamos o modulo l10n_br_fiscal, temos essas duas tabelas de relação entre l10n_br_fiscal.tax.definition e res.country.state:

odoo16=# \d tax_definition_state_to_rel;
          Table "public.tax_definition_state_to_rel"
      Column       |  Type   | Collation | Nullable | Default
-------------------+---------+-----------+----------+---------
 tax_definition_id | integer |           | not null |
 state_id          | integer |           | not null |
Indexes:
    "tax_definition_state_to_rel_pkey" PRIMARY KEY, btree (tax_definition_id, state_id)
    "tax_definition_state_to_rel_state_id_tax_definition_id_idx" btree (state_id, tax_definition_id)
Foreign-key constraints:
    "tax_definition_state_to_rel_state_id_fkey" FOREIGN KEY (state_id) REFERENCES res_country_state(id) ON DELETE CASCADE
    "tax_definition_state_to_rel_tax_definition_id_fkey" FOREIGN KEY (tax_definition_id) REFERENCES l10n_br_fiscal_tax_definition(id) ON DELETE CASCADE

odoo16=# \d l10n_br_fiscal_tax_definition_res_country_state_rel;
     Table "public.l10n_br_fiscal_tax_definition_res_country_state_rel"
              Column              |  Type   | Collation | Nullable | Default
----------------------------------+---------+-----------+----------+---------
 res_country_state_id             | integer |           | not null |
 l10n_br_fiscal_tax_definition_id | integer |           | not null |
Indexes:
    "l10n_br_fiscal_tax_definition_res_country_state_rel_pkey" PRIMARY KEY, btree (res_country_state_id, l10n_br_fiscal_tax_definition_id)
    "l10n_br_fiscal_tax_definition_l10n_br_fiscal_tax_definition_idx" btree (l10n_br_fiscal_tax_definition_id, res_country_state_id)
Foreign-key constraints:
    "l10n_br_fiscal_tax_definition_l10n_br_fiscal_tax_definitio_fkey" FOREIGN KEY (l10n_br_fiscal_tax_definition_id) REFERENCES l10n_br_fiscal_tax_definition(id) ON DELETE CASCADE
    "l10n_br_fiscal_tax_definition_res_cou_res_country_state_id_fkey" FOREIGN KEY (res_country_state_id) REFERENCES res_country_state(id) ON DELETE CASCADE

odoo16=# SELECT * from tax_definition_state_to_rel LIMIT 5;
 tax_definition_id | state_id
-------------------+----------
                23 |       71
                24 |       71
                25 |       71
                26 |       71
                27 |       71
(5 rows)

odoo16=# SELECT * from l10n_br_fiscal_tax_definition_res_country_state_rel LIMIT 5;
 res_country_state_id | l10n_br_fiscal_tax_definition_id
----------------------+----------------------------------
(0 rows)
