### PR TITLE
[14.0][FIX] l10n_br_account_withholding: chamada errada do super

### DIFF
--- a/l10n_br_account_withholding/models/account_move_line.py
+++ b/l10n_br_account_withholding/models/account_move_line.py
@@ -4,10 +4,6 @@
 from odoo import _, fields, models
 from odoo.exceptions import UserError
 
-from odoo.addons.l10n_br_account.models.account_move_line import (
-    AccountMoveLine as AccountMoveLineBR,
-)
-
 
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
@@ -19,7 +15,7 @@ class AccountMoveLine(models.Model):
     )
 
     def write(self, values):
-        res = super(AccountMoveLineBR, self).write(values)
+        res = super().write(values)
         for line in self:
             if line.wh_move_line_id and (
                 "quantity" in values or "price_unit" in values


### PR DESCRIPTION
No Odoo 14.0, o módulo `l10n_br_account_withholding` rompeu a sincronização de preço unitário e quantidade nas linhas de fatura devido a uma chamada incorreta de super().write(). Ajustei essa chamada para respeitar o fluxo de herança e a sincronização voltou a funcionar corretamente.