### PR TITLE
[16.0][FIX] l10n_br_nfe: Check document date

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -853,7 +853,13 @@ class NFe(spec_models.StackedModel):
                 key_date_str = rec.document_key[2:6]
                 key_date = datetime.strptime(key_date_str, "%y%m")
 
-                document_date = fields.Datetime.from_string(rec.document_date)
+                # Converting the document_date to the user's timezone
+                # This is necessary because the NFe is printed
+                # using the user's local timezone
+                document_date = fields.Datetime.context_timestamp(
+                    rec, rec.document_date
+                )
+
                 if rec.state_edoc in ["a_enviar", "autorizada"] and (
                     key_date.year != document_date.year
                     or key_date.month != document_date.month


### PR DESCRIPTION
Evita falha de validação em NF-e emitidas das 21h às 23h59 (UTC–3) ajustando a `document_date` para UTC–3 antes de comparar com a data da chave, que já vem nesse fuso.
