### PR TITLE
[16.0][ADD] l10n_br_fiscal: editable data mixin

### DIFF
--- a/l10n_br_fiscal/__init__.py
+++ b/l10n_br_fiscal/__init__.py
@@ -3,6 +3,7 @@
 
 from . import models
 from . import wizards
+from .hooks import post_init_hook
 
 import csv
 from io import StringIO

--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -133,6 +133,7 @@
     "installable": True,
     "application": True,
     "auto_install": False,
+    "post_init_hook": "post_init_hook",
     "external_dependencies": {
         "python": [
             "erpbrasil.base",

--- a/l10n_br_fiscal/hooks.py
+++ b/l10n_br_fiscal/hooks.py
@@ -1,0 +1,33 @@
+# Copyright 2025-TODAY Akretion - Raphael Valyi <raphael.valyi@akretion.com>
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
+
+from odoo import SUPERUSER_ID, api
+
+
+def fill_missing_xml_ids(env):
+    """
+    Backfill missing ir.model.data (XML IDs) for manually created records
+    in every model that inherits l10n_br_fiscal.data.editable.mixin and
+    implements _get_xml_id_name(). This ensures that manual records are
+    tracked and can be properly updated or preserved during future module
+    updates.
+
+    This helper can also be called from a migration script when deploying
+    the mixin on an existing database (post_init_hook only runs at install).
+    """
+    mixin = env["l10n_br_fiscal.data.editable.mixin"]
+    for model_name in env.registry:
+        model = env[model_name]
+        if (
+            model._auto
+            and not model._abstract
+            and isinstance(model, type(mixin))
+            # skip models that don't implement their own naming convention:
+            and type(model)._get_xml_id_name is not type(mixin)._get_xml_id_name
+        ):
+            model.fill_missing_xml_ids()
+
+
+def post_init_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    fill_missing_xml_ids(env)

--- a/l10n_br_fiscal/models/__init__.py
+++ b/l10n_br_fiscal/models/__init__.py
@@ -1,5 +1,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from . import data_editable_mixin
 from . import data_abstract
 from . import data_product_abstract
 from . import data_ncm_nbs_abstract

--- a/l10n_br_fiscal/models/cest.py
+++ b/l10n_br_fiscal/models/cest.py
@@ -55,3 +55,7 @@ class Cest(models.Model):
             if r.ncms:
                 domain = tools.domain_field_codes(field_codes=r.ncms)
                 r.ncm_ids = ncm.search(domain)
+
+    def _get_xml_id_name(self):
+        self.ensure_one()
+        return f"cest_{self.code.replace('.', '')}"

--- a/l10n_br_fiscal/models/cfop.py
+++ b/l10n_br_fiscal/models/cfop.py
@@ -198,3 +198,7 @@ class Cfop(models.Model):
             "CFOP already exists with this code !",
         )
     ]
+
+    def _get_xml_id_name(self):
+        self.ensure_one()
+        return f"cfop_{self.code}"

--- a/l10n_br_fiscal/models/cnae.py
+++ b/l10n_br_fiscal/models/cnae.py
@@ -37,3 +37,7 @@ class Cnae(models.Model):
             _("CNAE already exists with this code !"),
         )
     ]
+
+    def _get_xml_id_name(self):
+        self.ensure_one()
+        return f"cnae_{self.code.replace('.', '').replace('/', '').replace('-', '')}"

--- a/l10n_br_fiscal/models/cst.py
+++ b/l10n_br_fiscal/models/cst.py
@@ -37,3 +37,7 @@ class CST(models.Model):
             _("CST already exists with this code !"),
         )
     ]
+
+    def _get_xml_id_name(self):
+        self.ensure_one()
+        return f"cst_{self.tax_domain}_{self.code}"

--- a/l10n_br_fiscal/models/data_abstract.py
+++ b/l10n_br_fiscal/models/data_abstract.py
@@ -6,8 +6,7 @@ import json
 from erpbrasil.base import misc
 from lxml import etree
 
-from odoo import _, api, fields, models
-from odoo.exceptions import AccessError
+from odoo import api, fields, models
 from odoo.osv import expression
 
 
@@ -31,6 +30,8 @@ class DataAbstract(models.AbstractModel):
 
     _name = "l10n_br_fiscal.data.abstract"
     _description = "Fiscal Data Abstract"
+    _inherit = "l10n_br_fiscal.data.editable.mixin"
+
     _order = "code"
 
     code = fields.Char(required=True, index=True)
@@ -40,8 +41,6 @@ class DataAbstract(models.AbstractModel):
     code_unmasked = fields.Char(
         string="Unmasked Code", compute="_compute_code_unmasked", store=True, index=True
     )
-
-    active = fields.Boolean(default=True)
 
     date_start = fields.Date(string="Start Date")
 
@@ -54,16 +53,6 @@ class DataAbstract(models.AbstractModel):
             "The end date must be greater than or equal to the start date.",
         )
     ]
-
-    def action_archive(self):
-        if not self.env.user.has_group("l10n_br_fiscal.group_manager"):
-            raise AccessError(_("You don't have permission to archive records."))
-        return super().action_archive()
-
-    def action_unarchive(self):
-        if not self.env.user.has_group("l10n_br_fiscal.group_manager"):
-            raise AccessError(_("You don't have permission to unarchive records."))
-        return super().action_unarchive()
 
     @api.depends("code")
     def _compute_code_unmasked(self):

--- a/l10n_br_fiscal/models/data_editable_mixin.py
+++ b/l10n_br_fiscal/models/data_editable_mixin.py
@@ -1,0 +1,336 @@
+# Copyright 2025-TODAY Akretion - Raphael Valyi <raphael.valyi@akretion.com>
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
+
+import logging
+
+from odoo import _, api, fields, models
+from odoo.exceptions import AccessError, UserError
+
+_logger = logging.getLogger(__name__)
+
+
+class EditableDataMixin(models.AbstractModel):
+    """
+    Mixin to automatically manage ir.model.data entries for records.
+
+    Features:
+    - Automatically creates ir.model.data entries for manually created records.
+    - Skips creation if an entry already exists (e.g., from XML/CSV import).
+    - Inheriting models can override `_get_xml_id_name()` to specify the
+      naming pattern (the default implementation returns None and disables
+      the mixin behavior for the record).
+    - Provides `get_records_without_xmlid()` to find records lacking an XML ID.
+    - Provides `fill_missing_xml_ids()` to backfill missing XML IDs for
+      existing records.
+    - Prevent writing values inconsistent with record xml_id.
+    - Allow to toggle update/noupdate mode.
+    """
+
+    _name = "l10n_br_fiscal.data.editable.mixin"
+    _description = "Mixin for Automatic ir.model.data Management"
+
+    # To be defined in the inheriting model
+    _xml_id_module = "l10n_br_fiscal"
+
+    active = fields.Boolean(default=True)
+
+    def _get_xml_id_name(self):
+        """
+        Calculate the specific 'name' for the ir.model.data entry.
+
+        Inheriting models can override this method to specify their
+        naming pattern. The default implementation returns None, meaning
+        the record is not tracked by the mixin: no ir.model.data entry
+        is generated on create and the write() consistency check is
+        skipped. This is the desired behavior for purely user managed
+        records (e.g. l10n_br_fiscal.document.serie,
+        l10n_br_fiscal.document.type) and for data models for which no
+        convention has been defined yet.
+
+        :param self: A singleton recordset of the inheriting model.
+        :return: The string to be used as the 'name' field in ir.model.data.
+                 Return None or False if an XML ID cannot/should not be generated
+                 for this specific record based on its current state.
+        :rtype: str | None
+        """
+        return None
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        if self.env.context.get("install_mode") or self.env.context.get("module"):
+            self = self.with_context(tracking_disable=True)  # faster creation
+            return super().create(vals_list)
+
+        records = super().create(vals_list)
+        if not records:
+            return records
+
+        # Check which records already have an XML ID
+        new_ids = records.ids
+        DataModel = self.env["ir.model.data"]
+        _logger.debug(
+            "Mixin Create: Searching ir.model.data for model '%s' and res_ids %s",
+            self._name,
+            new_ids,
+        )
+        existing_data = DataModel.search(
+            [("model", "=", self._name), ("res_id", "in", new_ids)]
+        )
+        ids_with_xmlid = set(existing_data.mapped("res_id"))
+
+        # Filter records needing an XML ID
+        records_to_process = records.filtered(lambda r: r.id not in ids_with_xmlid)
+
+        # Process records needing an XML ID
+        if records_to_process:
+            DataModelSudo = DataModel.sudo()
+            for record in records_to_process:
+                try:
+                    # Call the helper method for the specific record
+                    self._create_missing_xml_id(record, DataModelSudo)
+                except Exception as e:
+                    # Log error but continue with other records
+                    _logger.error(
+                        "Mixin Create: Error calling _create_missing_xml_id for "
+                        "%s (%s): %s",
+                        record._name,
+                        record.id,
+                        e,
+                        exc_info=True,
+                    )
+
+        return records
+
+    def write(self, vals):
+        """Prevent writing values inconsistent with the record xml_id."""
+
+        if self.env.context.get("install_mode") or self.env.context.get("module"):
+            # self = self.with_context(tracking_disable=True)  # faster write; risky?
+            return super().write(vals)
+
+        existing_data = (
+            self.env["ir.model.data"]
+            .sudo()
+            .search([("model", "=", self._name), ("res_id", "in", self.ids)])
+        )
+        original_ids = {}
+        names_before = {}
+        for record in self:
+            original_ids[record.id] = tuple(
+                map(
+                    lambda imd: imd.name,
+                    filter(lambda imd: imd.res_id == record.id, existing_data),
+                )
+            )
+            try:
+                names_before[record.id] = record._get_xml_id_name()
+            except Exception:
+                # if the convention cannot be computed from the current
+                # values, we cannot enforce it either.
+                names_before[record.id] = None
+
+        res = super().write(vals)
+
+        for record in self:
+            original = original_ids[record.id]
+            if not original:
+                continue
+            name_before = names_before[record.id]
+            # Only enforce the consistency check for records whose xml_id
+            # actually followed the naming convention before the write.
+            # Legacy data records with exceptional xml_ids (e.g.
+            # tax_cofins_seminc, tax_icms_regulation_ac_ac_icms_suspencao,
+            # tax_piscofins_4310_001) don't match their computed name and
+            # should not be blocked by false positives.
+            if name_before is None or name_before != original[0]:
+                continue
+            name_after = record._get_xml_id_name()
+            if name_after is not None and name_after != original[0]:
+                raise UserError(
+                    _(
+                        "Writing these values %(vals)s is forbidden in this record "
+                        "because this record is tracked by the xml_id "
+                        "%(module)s.%(xml_id_name)s and these values would "
+                        "mean an xml_id like %(module)s.%(new_xml_id_name)s "
+                        "instead! So if you need a record with these values you "
+                        "can archive this record and create a new one instead. "
+                        "(The proper xml_id will be created by the %(module)s "
+                        "module).",
+                        vals=vals,
+                        module=record._xml_id_module,
+                        xml_id_name=original[0],
+                        new_xml_id_name=name_after,
+                    )
+                )
+        return res
+
+    def action_archive(self):
+        if not self.env.user.has_group("l10n_br_fiscal.group_manager"):
+            raise AccessError(_("You don't have permission to archive records."))
+        return super().action_archive()
+
+    def action_unarchive(self):
+        if not self.env.user.has_group("l10n_br_fiscal.group_manager"):
+            raise AccessError(_("You don't have permission to unarchive records."))
+        return super().action_unarchive()
+
+    def button_set_update(self):
+        if (
+            not self.env.user.has_group("l10n_br_fiscal.group_manager")
+            and not self.env.user._is_superuser()
+            and not self.env.user._is_system()
+        ):
+            raise AccessError(_("You don't have permission to set records for update!"))
+
+        imds = (
+            self.env["ir.model.data"]
+            .sudo()
+            .search(
+                [
+                    ("model", "=", self._name),
+                    ("res_id", "in", self.ids),
+                    ("noupdate", "=", True),
+                ]
+            )
+        )
+        _logger.warning(
+            "Toggled noupdate = False for %s records %s",
+            self._name,
+            imds.mapped("res_id"),
+        )
+        return imds.sudo().write({"noupdate": False})
+
+    def button_set_noupdate(self):
+        if (
+            not self.env.user.has_group("l10n_br_fiscal.group_manager")
+            and not self.env.user._is_superuser()
+            and not self.env.user._is_system()
+        ):
+            raise AccessError(_("You don't have permission to disable records update!"))
+
+        imds = (
+            self.env["ir.model.data"]
+            .sudo()
+            .search(
+                [
+                    ("model", "=", self._name),
+                    ("res_id", "in", self.ids),
+                    ("noupdate", "=", False),
+                ]
+            )
+        )
+        _logger.warning(
+            "Toggled noupdate = True for %s records %s",
+            self._name,
+            imds.mapped("res_id"),
+        )
+        return imds.sudo().write({"noupdate": True})
+
+    def _create_missing_xml_id(self, record, DataModel):
+        """Internal helper to create the ir.model.data record."""
+        record.ensure_one()
+
+        xml_id_name = record._get_xml_id_name()
+        if xml_id_name:
+            # Check if the specific name already exists
+            if DataModel.search_count(
+                [("module", "=", self._xml_id_module), ("name", "=", xml_id_name)]
+            ):
+                return
+
+            DataModel.create(
+                {
+                    "module": self._xml_id_module,
+                    "name": xml_id_name,
+                    "model": record._name,
+                    "res_id": record.id,
+                    "noupdate": True,
+                }
+            )
+
+    # --- Utility Methods ---
+
+    def get_records_without_xmlid(self):
+        """
+        Returns a recordset containing only the records from self
+        that do not have a corresponding ir.model.data entry.
+
+        :param self: The input recordset.
+        :return: A recordset of the same model.
+        :rtype: odoo.models.Model
+        """
+        if not self:
+            return self.browse()
+
+        record_ids = self.ids
+        if not record_ids:
+            return self.browse()
+
+        data_model = self.env["ir.model.data"]
+        existing_data = data_model.search(
+            [("model", "=", self._name), ("res_id", "in", record_ids)]
+        )
+        ids_with_xmlid = set(existing_data.mapped("res_id"))
+
+        ids_without_xmlid = [rid for rid in record_ids if rid not in ids_with_xmlid]
+
+        # Return as recordset for easier chaining/operations
+        return self.browse(ids_without_xmlid)
+
+    def fill_missing_xml_ids(self):
+        """
+        Efficiently finds records without an XML ID via SQL and creates them.
+
+        If called on an empty recordset (e.g. `env['my.model'].fill_missing_xml_ids()`),
+        it scans the entire table.
+        If called on specific records, it filters only those.
+        """
+
+        if self:
+            # Filter based on IDs in self
+            query = f"""
+                SELECT m.id
+                FROM "{self._table}" m
+                LEFT JOIN ir_model_data d ON (
+                    d.res_id = m.id AND
+                    d.model = %s
+                )
+                WHERE d.id IS NULL AND m.id IN %s
+            """
+            params = (self._name, tuple(self.ids))
+        else:
+            # Scan whole table (Optimization for hooks)
+            query = f"""
+                SELECT m.id
+                FROM "{self._table}" m
+                LEFT JOIN ir_model_data d ON (
+                    d.res_id = m.id AND
+                    d.model = %s
+                )
+                WHERE d.id IS NULL
+            """
+            params = (self._name,)
+
+        self.env.cr.execute(query, params)
+        missing_ids = [row[0] for row in self.env.cr.fetchall()]
+
+        if not missing_ids:
+            return
+
+        _logger.info(
+            "L10n Br Fiscal: Found %s orphan records in %s. Generating XML IDs...",
+            len(missing_ids),
+            self._name,
+        )
+
+        DataModelSudo = self.env["ir.model.data"].sudo()
+        for record in self.browse(missing_ids):
+            try:
+                self._create_missing_xml_id(record, DataModelSudo)
+            except Exception as e:
+                _logger.error(
+                    "Failed to generate XML ID for %s ID %s: %s",
+                    self._name,
+                    record.id,
+                    e,
+                )

--- a/l10n_br_fiscal/models/nbm.py
+++ b/l10n_br_fiscal/models/nbm.py
@@ -50,3 +50,7 @@ class Nbm(models.Model):
             if r.ncms:
                 domain = tools.domain_field_codes(field_codes=r.ncms)
                 r.ncm_ids = ncm.search(domain)
+
+    def _get_xml_id_name(self):
+        self.ensure_one()
+        return f"nbm_{self.code.replace('.', '')}"

--- a/l10n_br_fiscal/models/nbs.py
+++ b/l10n_br_fiscal/models/nbs.py
@@ -33,3 +33,7 @@ class Nbs(models.Model):
 
     def _get_ibpt(self, config, code_unmasked):
         return get_ibpt_service(config, code_unmasked)
+
+    def _get_xml_id_name(self):
+        self.ensure_one()
+        return f"nbs_{self.code.replace('.', '')}"

--- a/l10n_br_fiscal/models/ncm.py
+++ b/l10n_br_fiscal/models/ncm.py
@@ -76,3 +76,10 @@ class Ncm(models.Model):
 
     def _get_ibpt(self, config, code_unmasked):
         return get_ibpt_product(config, code_unmasked)
+
+    def _get_xml_id_name(self):
+        self.ensure_one()
+        return (
+            f"ncm_{self.code.replace('.', '')}"
+            f"{self.exception and '_' + self.exception or ''}"
+        )

--- a/l10n_br_fiscal/models/service_type.py
+++ b/l10n_br_fiscal/models/service_type.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2014  KMEE - www.kmee.com.br
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import fields, models
+from odoo import _, fields, models
 
 
 class ServiceType(models.Model):
@@ -43,3 +43,15 @@ class ServiceType(models.Model):
     )
 
     withholding_possible = fields.Boolean(string="Subject to withholding tax")
+
+    _sql_constraints = [
+        (
+            "fiscal_service_type_code_uniq",
+            "unique (code)",
+            _("service_type already exists with this code!"),
+        )
+    ]
+
+    def _get_xml_id_name(self):
+        self.ensure_one()
+        return f"service_type_{self.code.replace('.', '')}"

--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -116,6 +116,7 @@ class Tax(models.Model):
     """
 
     _name = "l10n_br_fiscal.tax"
+    _inherit = "l10n_br_fiscal.data.editable.mixin"
     _order = "sequence, tax_domain, name"
     _description = "Fiscal Tax"
 
@@ -864,3 +865,53 @@ class Tax(models.Model):
                 tax.tax_base_type = ICMS_ST_BASE_TYPE_REL.get(tax.icmsst_base_type)
             elif tax.tax_base_type is None:
                 tax.tax_base_type = False
+
+    def _get_xml_id_name(self):
+        """
+        Generate XML ID name like: tax_pis_value_0_0211.
+        It works for 98% of the cases, the common
+        cases for which the user may create a missing tax record.
+        Some other cases like tax_icms_isento or tax_csll_nt don't
+        follow a common pattern, but they are rare exception the user is
+        not expect to create manually.
+        """
+
+        def fmt(val):
+            return (
+                str(int(val))
+                if float_is_zero(val - int(val), precision_digits=4)
+                else str(val).replace(".", "_")
+            )
+
+        self.ensure_one()
+        if not self.tax_domain:
+            return None
+
+        name_lower = self.name.lower()
+
+        # PIS / COFINS
+        if self.tax_domain in ("pis", "cofins"):
+            # Monofasico
+            if (
+                "monofásico" in name_lower
+                or "monofasico" in name_lower
+                or "sico" in name_lower
+            ):
+                if self.value_amount:
+                    return f"tax_{self.tax_domain}_value_{fmt(self.value_amount)}"
+                return f"tax_{self.tax_domain}_monofasico_{fmt(self.percent_amount)}"
+
+            # Aliq Dif
+            if "aliq" in name_lower and "dif" in name_lower:
+                # Using fields assuming they are populated correctly for these taxes
+                return (
+                    f"tax_{self.tax_domain}_aliqdif_"
+                    f"{fmt(self.percent_debit_credit)}_cred_{fmt(self.percent_amount)}"
+                )
+
+        # Standard format
+        res = f"tax_{self.tax_domain}_{fmt(self.percent_amount)}"
+        if self.percent_reduction:
+            res += f"_red_{fmt(self.percent_reduction)}"
+
+        return res

--- a/l10n_br_fiscal/models/tax_definition.py
+++ b/l10n_br_fiscal/models/tax_definition.py
@@ -52,7 +52,11 @@ class TaxDefinition(models.Model):
     """
 
     _name = "l10n_br_fiscal.tax.definition"
-    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _inherit = [
+        "l10n_br_fiscal.data.editable.mixin",
+        "mail.thread",
+        "mail.activity.mixin",
+    ]
     _description = "Tax Definition"
 
     def _get_complete_name(self):
@@ -609,10 +613,7 @@ class TaxDefinition(models.Model):
                 domain = self._get_search_domain(record)
                 if record.env["l10n_br_fiscal.tax.definition"].search_count(domain):
                     raise ValidationError(
-                        _(
-                            "Tax Definition already exists "
-                            "for this ICMS and Tax Group !"
-                        )
+                        _("Tax Definition already exists for this ICMS and Tax Group !")
                     )
 
     @api.constrains("company_id")
@@ -647,10 +648,7 @@ class TaxDefinition(models.Model):
 
                 if record.env["l10n_br_fiscal.tax.definition"].search_count(domain):
                     raise ValidationError(
-                        _(
-                            "Tax Definition already exists "
-                            "for this CFOP and Tax Group !"
-                        )
+                        _("Tax Definition already exists for this CFOP and Tax Group !")
                     )
 
     @api.constrains("is_benefit", "code", "benefit_type", "state_from_id")
@@ -667,3 +665,101 @@ class TaxDefinition(models.Model):
                         raise ValidationError(
                             _("Tax benefit code must be start with state code!")
                         )
+
+    def _get_xml_id_name(self):
+        self.ensure_one()
+        # This method is used by l10n_br_fiscal.data.editable.mixin to enforce
+        # the xml_id name for manually created records.
+        # It tries to match the patterns found in
+        # l10n_br_fiscal/data/l10n_br_fiscal_icms_tax_definition_data.xml
+
+        if not self.tax_id:
+            return None
+
+        # 1. Try to find existing XML ID for the linked tax
+        # This is important because standard taxes (loaded via data files) have specific
+        # naming conventions (e.g. tax_icms_nt, tax_icmsst_47) that might differ
+        # from the mixin's calculated name based purely on values.
+        domain = [("model", "=", "l10n_br_fiscal.tax"), ("res_id", "=", self.tax_id.id)]
+        # Prefer module 'l10n_br_fiscal'
+        imd = self.env["ir.model.data"].search(
+            domain + [("module", "=", "l10n_br_fiscal")], limit=1
+        )
+        if not imd:
+            imd = self.env["ir.model.data"].search(domain, limit=1)
+
+        if imd:
+            tax_xml_id = imd.name
+        else:
+            # 2. Fallback to mixin calculation or name normalization
+            tax_xml_id = self.tax_id._get_xml_id_name()
+            if not tax_xml_id:
+                tax_xml_id = "tax_" + self.tax_id.name.lower().replace(" ", "_")
+
+        # Remove module prefix if present in tax_xml_id
+        # (e.g. l10n_br_fiscal.tax_icms_12)
+        if "." in tax_xml_id:
+            tax_xml_id = tax_xml_id.split(".")[-1]
+
+        state_from = self.state_from_id.code.lower() if self.state_from_id else "br"
+
+        # Check if Internal Operation (Single destination state same as origin)
+        is_internal = False
+        state_to_suffix = ""
+        if (
+            len(self.state_to_ids) == 1
+            and self.state_to_ids.id == self.state_from_id.id
+        ):
+            state_to_suffix = self.state_to_ids.code.lower()
+            is_internal = True
+
+        # 1. ICMS Normal (Tax Domain 'icms')
+        if self.tax_domain == "icms":
+            if is_internal:
+                # Pattern: tax_icms_regulation_{from}_{from}_{suffix}
+                # Suffix heuristics based on existing data:
+                # tax_icms_12 ->12
+                # tax_icms_nt ->nt
+                # tax_icms_suspensao ->icms_suspensao (Exception keeps icms_ prefix)
+                # tax_icms_diferimento ->icms_diferimento (Exception keeps icms_ prefix)
+
+                suffix = tax_xml_id.replace("tax_icms_", "")
+
+                # Handle exceptions where icms_ prefix is kept in data file
+                if "suspensao" in tax_xml_id or "diferimento" in tax_xml_id:
+                    suffix = tax_xml_id.replace("tax_", "")
+
+                # Handle the "_default" case for approved/numeric taxes
+                # Logic: if state is approved and it looks like a standard numeric rate
+                if self.state == "approved" and suffix.replace("_", "").isdigit():
+                    suffix += "_default"
+
+                return f"tax_icms_regulation_{state_from}_{state_from}_{suffix}"
+
+            else:
+                # Interstate Operation
+                # Pattern: tax_icms_regulation_{from}_{suffix}
+                # Suffix: tax_icms_12 -> icms_12 (strips 'tax_')
+                suffix = tax_xml_id.replace("tax_", "")
+                return f"tax_icms_regulation_{state_from}_{suffix}"
+
+        # 2. FCP (Tax Domain 'icmsfcp')
+        elif self.tax_domain == "icmsfcp":
+            # Pattern: {tax_xml_id}_regulation_{from}_{to}
+            # Note: FCP definitions seem to follow tax_xml_id prefix
+            if not state_to_suffix:
+                # Fallback if multiple destinations or none (though usually specific)
+                # Trying to match patterns like tax_icmsfcp_nt_regulation_pa_pa
+                state_to_suffix = state_from  # assumption based on data
+
+            return f"{tax_xml_id}_regulation_{state_from}_{state_to_suffix}"
+
+        # 3. ICMS ST (Tax Domain 'icmsst')
+        elif self.tax_domain == "icmsst":
+            # Pattern: tax_icmsst_definition_{from}_mva_{suffix}
+            # tax_icmsst_47 -> 47
+            suffix = tax_xml_id.replace("tax_icmsst_", "")
+            return f"tax_icmsst_definition_{state_from}_mva_{suffix}"
+
+        # Fallback for other domains/unmatched patterns
+        return None

--- a/l10n_br_fiscal/models/tax_pis_cofins.py
+++ b/l10n_br_fiscal/models/tax_pis_cofins.py
@@ -14,8 +14,12 @@ from ..constants.fiscal import (
 
 class TaxPisCofins(models.Model):
     _name = "l10n_br_fiscal.tax.pis.cofins"
-    _inherit = "l10n_br_fiscal.data.abstract"
     _description = "Tax PIS/COFINS"
+    # NOTE: l10n_br_fiscal.data.abstract now inherits
+    # l10n_br_fiscal.data.editable.mixin, so we get the mixin
+    # behavior through it while keeping code_unmasked,
+    # date_start/date_end and sped_table.
+    _inherit = "l10n_br_fiscal.data.abstract"
 
     code = fields.Char(required=True)
 
@@ -96,3 +100,50 @@ class TaxPisCofins(models.Model):
 
             if domain:
                 r.ncm_ids = ncm.search(domain)
+
+    def _get_xml_id_name(self):
+        self.ensure_one()
+
+        clean_code = self.code.strip()
+        name_lower = self.name.lower()
+
+        if "monofásico" in name_lower or "monofasico" in name_lower:
+            return f"tax_piscofins_monofasico_{clean_code}"
+
+        if "substituição tributária" in name_lower or " st " in name_lower:
+            return f"tax_pis_cofins_st_{clean_code}"
+
+        if "isenção" in name_lower or "isento" in name_lower:
+            return f"tax_pis_cofins_isento_{clean_code}"
+
+        if "suspensão" in name_lower:
+            return f"tax_pis_cofins_susp_{clean_code}"
+
+        if "sem incidência" in name_lower:
+            return f"tax_pis_cofins_seminc_{clean_code}"
+
+        is_zero = False
+        if (
+            self.tax_pis_id
+            and self.tax_pis_id.percent_amount == 0
+            and self.tax_cofins_id
+            and self.tax_cofins_id.percent_amount == 0
+        ):
+            is_zero = True
+
+        if is_zero and "monofásico" not in name_lower:
+            return f"tax_pis_cofins_0_{clean_code}"
+
+        if "r$" in name_lower:
+            return f"tax_pis_cofins_value_{clean_code}"
+
+        if "cumulativo" in name_lower and "não" not in name_lower:
+            return "tax_pis_cofins_columativo"
+        if "não cumulativo" in name_lower:
+            return "tax_pis_cofins_nao_columativo"
+        if "simples nacional" in name_lower:
+            return "tax_pis_cofins_simples_nacional"
+        if "diferenciada" in name_lower:
+            return "tax_pis_cofins_diferenciado"
+
+        return f"tax_pis_cofins_{clean_code}"

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -1,6 +1,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import (
+    test_data_editable_mixin,
     test_cnae,
     test_fiscal_document_serie,
     test_fiscal_document_generic,
@@ -16,4 +17,5 @@ from . import (
     test_partner_profile,
     test_service_type,
     test_operation,
+    test_tax_definition_mixin,
 )

--- a/l10n_br_fiscal/tests/test_data_editable_mixin.py
+++ b/l10n_br_fiscal/tests/test_data_editable_mixin.py
@@ -1,0 +1,455 @@
+# Copyright 2025-TODAY Akretion - Raphael Valyi <raphael.valyi@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
+
+import logging
+
+from odoo.exceptions import AccessError, UserError
+from odoo.tests.common import TransactionCase
+from odoo.tools import mute_logger
+
+_logger = logging.getLogger(__name__)
+
+
+class TestIrModelDataEditableMixinOnNcm(TransactionCase):
+    """
+    Tests for the l10n_br_fiscal.data.editable.mixin integrated
+    with the l10n_br_fiscal.ncm model.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(
+            context=dict(
+                cls.env.context,
+                tracking_disable=True,
+            )
+        )
+        cls.Ncm = cls.env["l10n_br_fiscal.ncm"]
+        cls.ncm_model_name = "l10n_br_fiscal.ncm"
+        cls.ncm_module_name = "l10n_br_fiscal"
+        cls.IrModelData = cls.env["ir.model.data"].sudo()
+
+    def _create_ncm(self, code_suffix, name_suffix=None, **kwargs):
+        code = f"9999.99.{code_suffix:02d}"
+        name = f"Test NCM {name_suffix or code_suffix}"
+        vals = {"code": code, "name": name, **kwargs}
+        return self.Ncm.create(vals)
+
+    def _get_xml_id(self, record):
+        return self.IrModelData.search(
+            [
+                ("module", "=", self.ncm_module_name),
+                ("model", "=", self.ncm_model_name),
+                ("res_id", "=", record.id),
+            ]
+        )
+
+    # --- Test Methods Adjusted Below ---
+
+    def test_01_create_generates_xmlid(self):
+        """Test that creating an NCM record generates an ir.model.data entry."""
+        # This test should now pass after fixing the mixin's create method
+        record_code_suffix = 1
+        record = self._create_ncm(record_code_suffix)
+        expected_xml_id_name = f"ncm_{record.code.replace('.', '')}"
+
+        self.assertTrue(record, "NCM Record should be created")
+        xml_id_record = self._get_xml_id(record)
+        self.assertEqual(
+            len(xml_id_record), 1, "Exactly one XML ID should be created for NCM"
+        )
+        self.assertEqual(
+            xml_id_record.name,
+            expected_xml_id_name,
+            "NCM XML ID name should match the pattern",
+        )
+        self.assertTrue(xml_id_record.noupdate, "XML ID noupdate flag should be True")
+
+    def test_02_create_skips_existing_xmlid(self):
+        """
+        Test that create does not create a duplicate if XML ID
+        already exists for NCM.
+        """
+        record_code_suffix = 2
+        manual_xml_id_name = f"manual_ncm_{record_code_suffix}"
+
+        # Create NCM first
+        record = self._create_ncm(record_code_suffix)
+        # Manually remove the auto-generated one (if any) to simulate import
+        self._get_xml_id(record).unlink()
+
+        # Manually create an ir.model.data
+        manual_xml_id = self.IrModelData.create(
+            {
+                "module": self.ncm_module_name,
+                "name": manual_xml_id_name,
+                "model": self.ncm_model_name,
+                "res_id": record.id,
+                "noupdate": True,
+            }
+        )
+        self.assertTrue(manual_xml_id, "Manual XML ID should be created")
+
+        # Verify no duplicate was made and manual one remains
+        xml_id_records = self._get_xml_id(record)
+        self.assertEqual(
+            len(xml_id_records), 1, "Still exactly one XML ID should exist for NCM"
+        )
+        self.assertEqual(
+            xml_id_records.name,
+            manual_xml_id_name,
+            "XML ID name should be the manually created one",
+        )
+        self.assertTrue(
+            xml_id_records.noupdate,
+            "XML ID noupdate flag should be the manually set one (True)",
+        )
+
+    def test_03_create_skips_in_test_mode(self):
+        """Test that create *does not* skip just for test_enable=True."""
+        # This test's premise changes: test_enable should NOT prevent creation.
+        # The skipping happens for install_mode=True or module=True in context.
+        # We can rename or repurpose this test to ensure normal creation works.
+        # Or simply trust test_01 covers normal creation. Let's keep it simple:
+        # Test that default test creation *does* create an ID.
+        record = self._create_ncm(3)
+        self.assertTrue(record)
+        xml_id_record = self._get_xml_id(record)
+        # ASSERTION IS NOW assertTrue
+        self.assertTrue(xml_id_record, "XML ID *should* be created in normal test mode")
+
+    def test_04_create_skips_in_install_mode(self):
+        """
+        Test that create *does* skip XML ID gen when
+        context indicates install mode.
+        """
+        # This test remains valid as it checks the context key
+        record = self.Ncm.with_context(install_mode=True).create(
+            {"code": "9999.99.04", "name": "Test NCM 04 Install"}
+        )
+        self.assertTrue(record)
+        xml_id_record = self._get_xml_id(record)
+        self.assertFalse(
+            xml_id_record, "No XML ID should be created for NCM in install mode"
+        )
+
+    def test_05_get_records_without_xmlid(self):
+        """Test the get_records_without_xmlid method on NCM."""
+        # Record 1: Gets XML ID automatically
+        rec1 = self._create_ncm(61)
+        # Record 2: Create WITH code, but manually remove its XML ID
+        rec2 = self._create_ncm(62)
+        rec2_xml_id = self._get_xml_id(rec2)
+        self.assertTrue(rec2_xml_id, "Rec2 should initially get an XML ID")
+        rec2_xml_id.unlink()  # Remove it for the test
+
+        # Record 3: Manually add XML ID (after removing auto-one)
+        rec3 = self._create_ncm(63)
+        self._get_xml_id(rec3).unlink()  # Remove auto-one first
+        self.IrModelData.create(
+            {
+                "module": self.ncm_module_name,
+                "name": "manual_ncm_63",
+                "model": self.ncm_model_name,
+                "res_id": rec3.id,
+            }
+        )
+
+        all_records = rec1 | rec2 | rec3
+
+        # Verify state before calling the method
+        self.assertTrue(self._get_xml_id(rec1), "Rec1 should have XML ID")
+        self.assertFalse(
+            self._get_xml_id(rec2), "Rec2 should NOT have XML ID (manually removed)"
+        )
+        self.assertTrue(self._get_xml_id(rec3), "Rec3 should have manual XML ID")
+
+        # Call the method
+        records_without_id = all_records.get_records_without_xmlid()
+
+        # Assertions
+        self.assertEqual(
+            len(records_without_id), 1, "Should find exactly one record without XML ID"
+        )
+        self.assertEqual(
+            records_without_id.id, rec2.id, "The record found should be rec2"
+        )
+
+    def test_06_fill_missing_xml_ids(self):
+        """Test the fill_missing_xml_ids utility method on NCM."""
+        # Record 1: Create WITH code, manually remove XML ID. This one should be filled.
+        rec1 = self._create_ncm(71)
+        rec1_xml_id = self._get_xml_id(rec1)
+        self.assertTrue(rec1_xml_id, "Rec1 should initially get an XML ID")
+        rec1_xml_id.unlink()  # Remove it
+        expected_xml_id_name_rec1 = f"ncm_{rec1.code.replace('.', '')}"
+
+        # Record 2: Create WITH code, keep its XML ID. This one should NOT be touched.
+        rec2 = self._create_ncm(72)
+        self.assertTrue(self._get_xml_id(rec2), "Rec2 should have XML ID and keep it")
+
+        # Record 3: Will test skipping if pattern returns None (if possible)
+        # For NCM, this is hard to test as code is required. Let's omit for now.
+
+        records_to_check = rec1 | rec2
+
+        # Call the fill method
+        records_to_check.fill_missing_xml_ids()
+
+        # Check XML IDs after filling
+        xml_id_rec1_after = self._get_xml_id(rec1)
+        self.assertTrue(xml_id_rec1_after, "Rec1 should now have an XML ID after fill")
+        self.assertEqual(
+            xml_id_rec1_after.name,
+            expected_xml_id_name_rec1,
+            "Rec1 XML ID name should be correct",
+        )
+        self.assertTrue(xml_id_rec1_after.noupdate, "Rec1 noupdate should be True")
+
+        self.assertTrue(
+            self._get_xml_id(rec2), "Rec2 should still have its original XML ID"
+        )
+
+    def test_07_write_does_not_create_xmlid(self):
+        """Test that write() itself does not trigger XML ID creation on NCM."""
+        # Setup: Create record WITH code, remove its XML ID
+        record = self._create_ncm(81)
+        initial_xml_id = self._get_xml_id(record)
+        self.assertTrue(initial_xml_id, "Record should have XML ID initially")
+        initial_xml_id.unlink()
+        self.assertFalse(
+            self._get_xml_id(record),
+            "Record should not have XML ID after manual removal",
+        )
+
+        # Write some other field (e.g., name)
+        record.write({"name": "Updated NCM Name 81"})
+
+        # Verify that write did NOT create the ID
+        self.assertFalse(
+            self._get_xml_id(record), "Record should still not have XML ID after write"
+        )
+
+        # Verify fill *does* work now
+        record.fill_missing_xml_ids()
+        self.assertTrue(
+            self._get_xml_id(record), "Record should have XML ID after fill"
+        )
+
+    def test_08_write_does_allow_conflicting_values(self):
+        """
+        Test that write() will not allow writing values
+        inconsistent with the xml_id
+        """
+        record = self._create_ncm(81)
+        initial_xml_id = self._get_xml_id(record)
+        self.assertTrue(initial_xml_id, "Record should have XML ID initially")
+        with self.assertRaises(UserError):
+            record.write({"code": "badcode"})
+
+    @mute_logger("odoo.addons.l10n_br_fiscal.models.data_editable_mixin")
+    def test_09_update_noupdate(self):
+        """Test update / nopupdate toggle"""
+        record = self._create_ncm(81)
+
+        user = self.env["res.users"].create(
+            {
+                "name": "Fiscal User",
+                "login": "test_editable_data_user",
+                "password": "admin",
+                "groups_id": [
+                    (4, self.env.ref("l10n_br_fiscal.group_user").id),
+                ],
+            }
+        )
+        with self.assertRaises(AccessError):
+            record.with_user(user).button_set_update()
+        with self.assertRaises(AccessError):
+            record.with_user(user).button_set_noupdate()
+
+        manager = self.env["res.users"].create(
+            {
+                "name": "Fiscal Manager",
+                "login": "test_editable_data_manager",
+                "password": "admin",
+                "groups_id": [
+                    (4, self.env.ref("l10n_br_fiscal.group_manager").id),
+                ],
+            }
+        )
+        record.with_user(manager).button_set_update()
+        self.assertFalse(self._get_xml_id(record).noupdate)
+        record.with_user(manager).button_set_noupdate()
+        self.assertTrue(self._get_xml_id(record).noupdate)
+
+    def test_10_archive_unarchive(self):
+        """Test update / nopupdate toggle"""
+        record = self._create_ncm(81)
+
+        user = self.env["res.users"].create(
+            {
+                "name": "Fiscal User",
+                "login": "test_editable_data_user",
+                "password": "admin",
+                "groups_id": [
+                    (4, self.env.ref("l10n_br_fiscal.group_user").id),
+                ],
+            }
+        )
+        with self.assertRaises(AccessError):
+            record.with_user(user).action_archive()
+
+        manager = self.env["res.users"].create(
+            {
+                "name": "Fiscal Manager",
+                "login": "test_editable_data_manager",
+                "password": "admin",
+                "groups_id": [
+                    (4, self.env.ref("l10n_br_fiscal.group_manager").id),
+                ],
+            }
+        )
+        record.with_user(manager).action_archive()
+        self.assertFalse(record.active)
+        record.with_user(manager).action_unarchive()
+        self.assertTrue(record.active)
+
+    def test_11_various_xml_id_names(self):
+        """Test the xml ids of some classes were the mixin is injected"""
+        self.assertEqual(
+            self.env.ref("l10n_br_fiscal.tax_icms_16")._get_xml_id_name(), "tax_icms_16"
+        )
+        self.assertEqual(
+            self.env.ref("l10n_br_fiscal.tax_icms_12_red_26_57")._get_xml_id_name(),
+            "tax_icms_12_red_26_57",
+        )
+        self.assertEqual(
+            self.env.ref("l10n_br_fiscal.tax_pis_value_26_36")._get_xml_id_name(),
+            "tax_pis_value_26_36",
+        )
+        self.assertEqual(
+            self.env.ref("l10n_br_fiscal.tax_pis_monofasico_1_67")._get_xml_id_name(),
+            "tax_pis_monofasico_1_67",
+        )
+        self.assertEqual(
+            self.env.ref("l10n_br_fiscal.tax_pis_value_0_0211")._get_xml_id_name(),
+            "tax_pis_value_0_0211",
+        )
+        self.assertEqual(
+            self.env.ref("l10n_br_fiscal.tax_ipi_33_86")._get_xml_id_name(),
+            "tax_ipi_33_86",
+        )
+
+        self.assertEqual(
+            self.env.ref("l10n_br_fiscal.service_type_404")._get_xml_id_name(),
+            "service_type_404",
+        )
+        self.assertEqual(
+            self.env.ref("l10n_br_fiscal.cst_icmssn_300")._get_xml_id_name(),
+            "cst_icmssn_300",
+        )
+        self.assertEqual(
+            self.env.ref("l10n_br_fiscal.cnae_0116402")._get_xml_id_name(),
+            "cnae_0116402",
+        )
+        self.assertEqual(
+            self.env.ref("l10n_br_fiscal.cfop_1120")._get_xml_id_name(), "cfop_1120"
+        )
+        self.assertEqual(
+            self.env.ref("l10n_br_fiscal.nbs_114021100")._get_xml_id_name(),
+            "nbs_114021100",
+        )
+
+        # PIS/COFINS Tests
+        # 1. Monofásico
+        pc_mono = self.env["l10n_br_fiscal.tax.pis.cofins"].create(
+            {
+                "code": "101",
+                "name": "Gasolina Monofásico",  # Keyword 'Monofásico'
+                "piscofins_type": "product",
+            }
+        )
+        self.assertEqual(pc_mono._get_xml_id_name(), "tax_piscofins_monofasico_101")
+
+        # 2. Simples Nacional
+        pc_simples = self.env["l10n_br_fiscal.tax.pis.cofins"].create(
+            {
+                "code": "000",
+                "name": "Regime Simples Nacional",
+                "piscofins_type": "company",
+            }
+        )
+        self.assertEqual(
+            pc_simples._get_xml_id_name(), "tax_pis_cofins_simples_nacional"
+        )
+
+        # 3. Generic Fallback
+        pc_generic = self.env["l10n_br_fiscal.tax.pis.cofins"].create(
+            {"code": "999", "name": "Operação Genérica", "piscofins_type": "product"}
+        )
+        self.assertEqual(pc_generic._get_xml_id_name(), "tax_pis_cofins_999")
+
+    def test_12_write_allowed_when_xmlid_does_not_follow_convention(self):
+        """
+        Records whose existing xml_id does NOT match the naming convention
+        (legacy data exceptions) should not be blocked by the write guard.
+        Example: tax_cofins_seminc computes as tax_cofins_0.
+        """
+        tax_seminc = self.env.ref("l10n_br_fiscal.tax_cofins_seminc")
+        self.assertNotEqual(tax_seminc._get_xml_id_name(), "tax_cofins_seminc")
+        # should not raise UserError:
+        tax_seminc.write({"name": "COFINS Sem Incidência"})
+        self.assertEqual(tax_seminc.name, "COFINS Sem Incidência")
+
+    def test_13_untracked_model_does_not_crash(self):
+        """
+        Models inheriting the mixin through l10n_br_fiscal.data.abstract
+        but not implementing _get_xml_id_name (e.g. legal.nature) should
+        be creatable/writable without crash and stay untracked.
+        """
+        legal_nature = self.env["l10n_br_fiscal.legal.nature"].create(
+            {"code": "9999", "name": "Test Legal Nature"}
+        )
+        self.assertTrue(legal_nature)
+        self.assertIsNone(legal_nature._get_xml_id_name())
+        xml_id_record = self.IrModelData.search(
+            [
+                ("model", "=", "l10n_br_fiscal.legal.nature"),
+                ("res_id", "=", legal_nature.id),
+            ]
+        )
+        self.assertFalse(xml_id_record, "No XML ID should be created")
+        # write should not crash either:
+        legal_nature.write({"name": "Test Legal Nature 2"})
+
+    def test_14_cest_nbm_xml_id_names(self):
+        """Test the xml id naming convention for CEST and NBM records."""
+        cest = self.env["l10n_br_fiscal.cest"].create(
+            {
+                "code": "01.002.00",
+                "item": "2.0",
+                "segment": "01",
+                "name": "Test CEST",
+            }
+        )
+        cest_xml_id = self.IrModelData.search(
+            [
+                ("module", "=", "l10n_br_fiscal"),
+                ("model", "=", "l10n_br_fiscal.cest"),
+                ("res_id", "=", cest.id),
+            ]
+        )
+        self.assertEqual(cest_xml_id.name, "cest_0100200")
+
+        nbm = self.env["l10n_br_fiscal.nbm"].create(
+            {"code": "0000.10.0001", "name": "Test NBM"}
+        )
+        nbm_xml_id = self.IrModelData.search(
+            [
+                ("module", "=", "l10n_br_fiscal"),
+                ("model", "=", "l10n_br_fiscal.nbm"),
+                ("res_id", "=", nbm.id),
+            ]
+        )
+        self.assertEqual(nbm_xml_id.name, "nbm_0000100001")

--- a/l10n_br_fiscal/tests/test_tax_definition_mixin.py
+++ b/l10n_br_fiscal/tests/test_tax_definition_mixin.py
@@ -1,0 +1,156 @@
+# Copyright 2025-TODAY Akretion - Raphael Valyi <raphael.valyi@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestTaxDefinitionMixin(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.TaxDefinition = cls.env["l10n_br_fiscal.tax.definition"]
+        cls.Tax = cls.env["l10n_br_fiscal.tax"]
+        cls.State = cls.env["res.country.state"]
+        cls.TaxGroup = cls.env["l10n_br_fiscal.tax.group"]
+
+        # Get necessary records
+        cls.state_ac = cls.env.ref("base.state_br_ac")
+        cls.state_al = cls.env.ref("base.state_br_al")
+        cls.tax_group_icms = cls.env.ref("l10n_br_fiscal.tax_group_icms")
+        cls.tax_group_icmsfcp = cls.env.ref("l10n_br_fiscal.tax_group_icmsfcp")
+        cls.tax_group_icmsst = cls.env.ref("l10n_br_fiscal.tax_group_icmsst")
+
+        # Mock Taxes (simulating existing ones)
+        cls.tax_icms_12 = cls.env.ref("l10n_br_fiscal.tax_icms_12")
+        cls.tax_icms_nt = cls.env.ref("l10n_br_fiscal.tax_icms_nt")
+        cls.tax_icms_suspensao = cls.env.ref("l10n_br_fiscal.tax_icms_suspensao")
+        cls.tax_icmsfcp_2 = cls.env.ref("l10n_br_fiscal.tax_icmsfcp_2")
+        cls.tax_icmsst_47 = cls.env.ref("l10n_br_fiscal.tax_icmsst_47")
+
+    def test_01_xml_id_icms_internal_numeric_approved(self):
+        """Test XML ID generation for Internal ICMS (Approved, Numeric Rate)"""
+        # Mimic: tax_icms_regulation_ac_ac_19_default
+        # We use tax_icms_12 for test to vary slightly or 19 if available
+
+        # Create a transient definition
+        # Using tax_icms_12, state AC->AC, Approved
+
+        tax_def = self.TaxDefinition.create(
+            {
+                "tax_group_id": self.tax_group_icms.id,
+                "state_from_id": self.state_ac.id,
+                "state_to_ids": [(6, 0, [self.state_ac.id])],
+                "tax_id": self.tax_icms_12.id,
+                "state": "approved",
+                "custom_tax": True,
+                "is_taxed": True,
+            }
+        )
+
+        expected_xml_id = "tax_icms_regulation_ac_ac_12_default"
+        generated_xml_id = tax_def._get_xml_id_name()
+        self.assertEqual(generated_xml_id, expected_xml_id)
+
+    def test_02_xml_id_icms_internal_nt(self):
+        """Test XML ID generation for Internal ICMS (NT - Non Taxed)"""
+        # Mimic: tax_icms_regulation_ac_ac_nt
+
+        tax_def = self.TaxDefinition.create(
+            {
+                "tax_group_id": self.tax_group_icms.id,
+                "state_from_id": self.state_ac.id,
+                "state_to_ids": [(6, 0, [self.state_ac.id])],
+                "tax_id": self.tax_icms_nt.id,
+                "state": "draft",
+                "custom_tax": True,
+                "is_taxed": False,
+            }
+        )
+
+        expected_xml_id = "tax_icms_regulation_ac_ac_nt"
+        generated_xml_id = tax_def._get_xml_id_name()
+        self.assertEqual(generated_xml_id, expected_xml_id)
+
+    def test_03_xml_id_icms_internal_suspensao(self):
+        """Test XML ID generation for Internal ICMS (Suspensao - Special case)"""
+        # Mimic: tax_icms_regulation_ac_ac_icms_suspencao
+        # Note: tax xml id is tax_icms_suspensao
+
+        tax_def = self.TaxDefinition.create(
+            {
+                "tax_group_id": self.tax_group_icms.id,
+                "state_from_id": self.state_ac.id,
+                "state_to_ids": [(6, 0, [self.state_ac.id])],
+                "tax_id": self.tax_icms_suspensao.id,
+                "state": "draft",
+                "custom_tax": True,
+                "is_taxed": False,
+            }
+        )
+
+        # Logic enforces 'icms_suspensao' suffix based on tax id
+        expected_xml_id = "tax_icms_regulation_ac_ac_icms_suspensao"
+        generated_xml_id = tax_def._get_xml_id_name()
+        self.assertEqual(generated_xml_id, expected_xml_id)
+
+    def test_04_xml_id_icms_interstate(self):
+        """Test XML ID generation for Interstate ICMS"""
+        # Mimic: tax_icms_regulation_ac_icms_12
+
+        tax_def = self.TaxDefinition.create(
+            {
+                "tax_group_id": self.tax_group_icms.id,
+                "state_from_id": self.state_ac.id,
+                "state_to_ids": [(6, 0, [self.state_al.id])],  # Different state
+                "tax_id": self.tax_icms_12.id,
+                "state": "approved",
+                "custom_tax": True,
+                "is_taxed": True,
+            }
+        )
+
+        expected_xml_id = "tax_icms_regulation_ac_icms_12"
+        generated_xml_id = tax_def._get_xml_id_name()
+        self.assertEqual(generated_xml_id, expected_xml_id)
+
+    def test_05_xml_id_icmsfcp(self):
+        """Test XML ID generation for FCP"""
+        # Mimic: tax_icmsfcp_2_regulation_al_al
+
+        tax_def = self.TaxDefinition.create(
+            {
+                "tax_group_id": self.tax_group_icmsfcp.id,
+                "state_from_id": self.state_al.id,
+                "state_to_ids": [(6, 0, [self.state_al.id])],
+                "tax_id": self.tax_icmsfcp_2.id,
+                "state": "approved",
+                "custom_tax": True,
+                "is_taxed": True,
+            }
+        )
+
+        expected_xml_id = "tax_icmsfcp_2_regulation_al_al"
+        generated_xml_id = tax_def._get_xml_id_name()
+        self.assertEqual(generated_xml_id, expected_xml_id)
+
+    def test_06_xml_id_icmsst(self):
+        """Test XML ID generation for ICMS ST"""
+        # Mimic: tax_icmsst_definition_sp_mva_47
+        # Note: state_from SP.
+        sp_state = self.env.ref("base.state_br_sp")
+
+        tax_def = self.TaxDefinition.create(
+            {
+                "tax_group_id": self.tax_group_icmsst.id,
+                "state_from_id": sp_state.id,
+                "state_to_ids": [(6, 0, [self.state_al.id])],
+                "tax_id": self.tax_icmsst_47.id,
+                "state": "approved",
+                "custom_tax": True,
+                "is_taxed": True,
+            }
+        )
+
+        expected_xml_id = "tax_icmsst_definition_sp_mva_47"
+        generated_xml_id = tax_def._get_xml_id_name()
+        self.assertEqual(generated_xml_id, expected_xml_id)


### PR DESCRIPTION
Rationale:

As for today many very large fiscal data are loaded via CSV or XML. Examples:

- ncm
- cnae
- cfop
- cest
- nbs
- tax.pis.cofins
- fiscal.tax
- cst
- tax.definition

Because these files can be so huge, we often load them with noupdate=True (we even monkey_patched convert_csv_import for this) to avoid long minutes of updates in production.

Also historically these files were poorly maintained. So when Akretion had a big customer, we would maintain their data for their specific operations, but don't really bother maintaining these files up to date. This is now changing with more serious projects in production and more serious contributors participating.

A problem with these data is when a user wants to update some value manually or create a new record (like a new NCM that was missing). These records will have no xml_id or ir.model.data entry. And later when we try to update or migrate the database, the new records that would eventually be inserted in the source csv or XML files would clash with these manually entered records in the database making the whole upgrade process cumbersome.

So I introduced a new mixin here that will fix this by providing these features:

- Automatically creates ir.model.data entries for manually created records.
- Provides `get_records_without_xmlid()` to find records lacking an XML ID.
- Provides `fill_missing_xml_ids()` to backfill missing XML IDs for existing records.
- Prevent writing values inconsistent with record xml_id.
- Allow to toggle update/noupdate mode.

NOTE: some of the mixin code has been proposed by the Gemini AI (I'm still adjusting it) and most of the tests were written by the AI. This worked because this code is quite independent from the localization code.