### PR TITLE
[16.0][FIX] spec_driven_model: valid field parameter warning

### DIFF
--- a/spec_driven_model/models/spec_mixin.py
+++ b/spec_driven_model/models/spec_mixin.py
@@ -32,6 +32,7 @@ class SpecMixin(models.AbstractModel):
             "choice",
             "xsd_choice_required",
             "xsd_implicit",
+            "original_comodel_name",
         ):
             return True
         else:


### PR DESCRIPTION
Correção trivial para remover warnings como:

`Field res.partner.cte40_autXML_infCte_id: unknown parameter 'original_comodel_name', if this is an actual parameter you may want to override the method _valid_field_parameter on the relevant model in order to allow it `

![image](https://github.com/user-attachments/assets/95254830-809c-41b3-852d-9e2a8f8e0744)
