### PR TITLE
[14.0][FIX] l10n_br_account: safe guard mig 14.0.1.0.0

### DIFF
--- a/l10n_br_account/migrations/14.0.1.0.0/post-migration.py
+++ b/l10n_br_account/migrations/14.0.1.0.0/post-migration.py
@@ -15,16 +15,21 @@ def migrate(env, version):
         WHERE ai.id = am.old_invoice_id AND ai.fiscal_document_id IS NOT NULL
         """,
     )
-    openupgrade.logged_query(
-        env.cr,
-        """
-        UPDATE account_move_line aml
-        SET fiscal_document_line_id = COALESCE(
-            ail.fiscal_document_line_id, aml.fiscal_document_line_id),
-            wh_move_line_id = COALESCE(ail.wh_move_line_id, aml.wh_move_line_id)
-        FROM account_invoice_line ail
-        WHERE aml.old_invoice_line_id = ail.id AND
-            (ail.fiscal_document_line_id IS NOT NULL
-            OR ail.wh_move_line_id IS NOT NULL)
-        """,
-    )
+    if (
+        openupgrade.table_exists(env.cr, "account_invoice_line")
+        and openupgrade.column_exists(env.cr, "account_move_line", "wh_move_line_id")
+        and openupgrade.column_exists(env.cr, "account_invoice_line", "wh_move_line_id")
+    ):
+        openupgrade.logged_query(
+            env.cr,
+            """
+            UPDATE account_move_line aml
+            SET fiscal_document_line_id = COALESCE(
+                ail.fiscal_document_line_id, aml.fiscal_document_line_id),
+                wh_move_line_id = COALESCE(ail.wh_move_line_id, aml.wh_move_line_id)
+            FROM account_invoice_line ail
+            WHERE aml.old_invoice_line_id = ail.id AND
+                (ail.fiscal_document_line_id IS NOT NULL
+                OR ail.wh_move_line_id IS NOT NULL)
+            """,
+        )


### PR DESCRIPTION
ao migrar um cliente da 13.0 (vindo da 12.0) para 14.0 eu tive esse erro:

```
2025-05-09 13:39:49,024 72 INFO odoo14 odoo.modules.migration: module l10n_br_account: Running migration [14.0.1.0.0>] post-migration
2025-05-09 13:39:49,035 72 INFO odoo14 OpenUpgrade: l10n_br_account: post-migration script called with version 12.0.16.3.0
2025-05-09 13:40:07,113 72 DEBUG odoo14 OpenUpgrade: 88011 rows affected after 0:00:18.077322 running
        UPDATE account_move am
        SET fiscal_document_id = ai.fiscal_document_id
        FROM account_invoice ai
        WHERE ai.id = am.old_invoice_id AND ai.fiscal_document_id IS NOT NULL

2025-05-09 13:40:07,131 72 ERROR odoo14 odoo.sql_db: bad query:
        UPDATE account_move_line aml
        SET fiscal_document_line_id = COALESCE(
            ail.fiscal_document_line_id, aml.fiscal_document_line_id),
            wh_move_line_id = COALESCE(ail.wh_move_line_id, aml.wh_move_line_id)
        FROM account_invoice_line ail
        WHERE aml.old_invoice_line_id = ail.id AND
            (ail.fiscal_document_line_id IS NOT NULL
            OR ail.wh_move_line_id IS NOT NULL)

ERROR: column aml.wh_move_line_id does not exist
LINE 5: ...  wh_move_line_id = COALESCE(ail.wh_move_line_id, aml.wh_mov...
                                                             ^
HINT:  Perhaps you meant to reference the column "ail.wh_move_line_id".

2025-05-09 13:40:07,131 72 ERROR odoo14 OpenUpgrade: Error after 0:00:00.018143 running
        UPDATE account_move_line aml
        SET fiscal_document_line_id = COALESCE(
            ail.fiscal_document_line_id, aml.fiscal_document_line_id),
            wh_move_line_id = COALESCE(ail.wh_move_line_id, aml.wh_move_line_id)
        FROM account_invoice_line ail
        WHERE aml.old_invoice_line_id = ail.id AND
            (ail.fiscal_document_line_id IS NOT NULL
            OR ail.wh_move_line_id IS NOT NULL)

2025-05-09 13:40:07,131 72 ERROR odoo14 OpenUpgrade: l10n_br_account: error in migration script /odoo/external-src/l10n-brazil/l10n_br_account/migrations/14.0.1.0.0/post-migration.py: column aml.wh_move_line
_id does not exist
LINE 5: ...  wh_move_line_id = COALESCE(ail.wh_move_line_id, aml.wh_mov...
                                                             ^
HINT:  Perhaps you meant to reference the column "ail.wh_move_line_id".
```

Com esse PR que apenas checa table_exists e column_exists  os scripts rodaram. Obs: não tinha modulo de retenção instalado neste banco.