### PR TITLE
[16.0][IMP] l10n_br_sale: Melhorias na visão do pedido de venda

### DIFF
--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -23,7 +23,11 @@ class SaleOrder(models.Model):
 
     @api.model
     def _fiscal_operation_domain(self):
-        domain = [("state", "=", "approved")]
+        domain = [
+            ("fiscal_operation_type", "=", "out"),
+            ("state", "=", "approved"),
+            ("fiscal_type", "not ilike", "%refund%"),
+        ]
         return domain
 
     company_country_id = fields.Many2one(related="company_id.country_id")

--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -15,7 +15,11 @@ class SaleOrderLine(models.Model):
 
     @api.model
     def _fiscal_operation_domain(self):
-        domain = [("state", "=", "approved")]
+        domain = [
+            ("fiscal_operation_type", "=", "out"),
+            ("state", "=", "approved"),
+            ("fiscal_type", "not ilike", "%refund%"),
+        ]
         return domain
 
     fiscal_operation_id = fields.Many2one(

--- a/l10n_br_sale/views/sale_view.xml
+++ b/l10n_br_sale/views/sale_view.xml
@@ -20,6 +20,30 @@
         </field>
     </record>
 
+    <record id="l10n_br_sale_quotation_tree" model="ir.ui.view">
+        <field name="name">l10n_br_sale.quotation.form</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_quotation_tree" />
+        <field name="priority">99</field>
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+                <field name="fiscal_operation_id" readonly="1" optional="show" />
+            </field>
+        </field>
+    </record>
+
+    <record id="l10n_br_sale_order_tree" model="ir.ui.view">
+        <field name="name">l10n_br_sale.order.form</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_tree" />
+        <field name="priority">99</field>
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+                <field name="fiscal_operation_id" readonly="1" optional="show" />
+            </field>
+        </field>
+    </record>
+
     <record id="l10n_br_sale_order_form" model="ir.ui.view">
         <field name="name">l10n_br_sale.order.form</field>
         <field name="model">sale.order</field>
@@ -83,7 +107,7 @@
             <group name="sale_shipping" position="inside">
                 <field name="force_compute_delivery_costs_by_total" />
             </group>
-            <field name="validity_date" position="after">
+            <field name="show_update_fpos" position="before">
                 <field name="company_country_id" invisible="True" />
                 <field
                     name="fiscal_operation_id"
@@ -166,6 +190,11 @@
                 expr="//field[@name='order_line']/tree/field[@name='price_unit']"
                 position="after"
             >
+                <field
+                    name="fiscal_operation_id"
+                    options="{'no_create': True}"
+                    attrs="{'readonly': [('state', 'in', ('sale', 'done', 'cancel'))], 'required': [('parent.fiscal_operation_id', '!=', False)], 'invisible': [('parent.fiscal_operation_id', '=', False)]}"
+                />
                 <field
                     name="discount"
                     groups="!l10n_br_sale.group_discount_per_value"


### PR DESCRIPTION
Hoje os campos de operação fiscal, consumidor final e indicador de presença ficam na parte superior na tela, esses campos foram movidos para a aba Outras Informações no grupo de Faturamentos e Pagamentos, também foi alterado o Domain para trazer somente as operações de saída

![image](https://github.com/user-attachments/assets/cb07c580-1e26-4c64-93b0-a8a64027fdd3)

E nas linhas do pedido de venda foi adicionado o campo Operação Fiscal:

![image](https://github.com/user-attachments/assets/63a82d66-ccd7-40db-a662-cbaa33a46490)


Também foi adicionado o campo Operação Fiscal na visão lista da cotação e pedido de venda:

![image](https://github.com/user-attachments/assets/628db11f-63aa-43b9-a0d3-1bd6384b7f57)

