### PR TITLE
[14.0][FIX] l10n_br_account_payment_order safe guard mig

### DIFF
--- a/l10n_br_account_payment_order/migrations/14.0.6.0.0/post-migration.py
+++ b/l10n_br_account_payment_order/migrations/14.0.6.0.0/post-migration.py
@@ -2,7 +2,11 @@
 # @author Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import logging
+
 from openupgradelib import openupgrade
+
+_logger = logging.getLogger(__name__)
 
 
 def unifying_cnab_codes(env):
@@ -104,8 +108,8 @@ def unifying_cnab_codes(env):
 
         # Relação payment_method_ids x return_move_code
         payment_method_id_colunm = (
-            "l10n_br_cnab_mov_instruction_code_id"
-        )  # nome tava errado
+            "l10n_br_cnab_mov_instruction_code_id"  # nome tava errado
+        )
         return_move_code_id_colunm = "payment_method_id"
         env.cr.execute(
             f"""
@@ -117,17 +121,24 @@ def unifying_cnab_codes(env):
         payment_method_ids = [
             payment_method_id[0] for payment_method_id in env.cr.fetchall()
         ]
-        env["l10n_br_cnab.code"].create(
-            {
-                "name": row[1],
-                "code": row[2],
-                "code_type": "return_move_code",
-                "bank_ids": [(6, 0, bank_ids)],
-                "payment_method_ids": [(6, 0, payment_method_ids)],
-            }
-        )
+        try:
+            env["l10n_br_cnab.code"].create(
+                {
+                    "name": row[1],
+                    "code": row[2],
+                    "code_type": "return_move_code",
+                    "bank_ids": [(6, 0, bank_ids)],
+                    "payment_method_ids": [(6, 0, payment_method_ids)],
+                }
+            )
+        except Exception as e:
+            _logger.warning(f"Could not create CNAB code {e}")
 
     # Codigo da Carteira
+    if not openupgrade.table_exists(env.cr, "l10n_br_cnab_boleto_wallet_code"):
+        _logger.warning("No table l10n_br_cnab_boleto_wallet_code; exiting... ")
+        return
+
     env.cr.execute(
         """
     SELECT lcmic.id, lcmic.name, lcmic.code, lcmic.bank_id, lcmic.payment_method_id

--- a/l10n_br_account_payment_order/migrations/14.0.7.0.0/post-migration.py
+++ b/l10n_br_account_payment_order/migrations/14.0.7.0.0/post-migration.py
@@ -2,7 +2,11 @@
 # @author Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import logging
+
 from openupgradelib import openupgrade
+
+_logger = logging.getLogger(__name__)
 
 
 def update_payment_mode_inbound(env):
@@ -110,45 +114,48 @@ def update_payment_mode_inbound(env):
             cnab_config.liq_return_move_code_ids = [(6, 0, liq_code_ids)]
 
         # Codigos ainda Char
-        cnab_config.write(
-            {
-                "invoice_print": row[13],
-                "instructions": row[14],
-                "cnab_company_bank_code": row[15],
-                "convention_code": row[16],
-                "condition_issuing_paper": row[17],
-                "communication_2": row[18],
-                "boleto_wallet": row[19],
-                "boleto_modality": row[20],
-                "boleto_variation": row[21],
-                "boleto_accept": row[22],
-                "boleto_species": row[23],
-                "boleto_protest_code": row[24],
-                "boleto_days_protest": row[25],
-                "generate_own_number": row[26],
-                "own_number_sequence_id": row[27],
-                "cnab_sequence_id": row[28],
-                "boleto_interest_code": row[29],
-                "boleto_interest_perc": row[30],
-                "boleto_fee_code": row[31],
-                "boleto_fee_perc": row[32],
-                "boleto_discount_perc": row[33],
-                "boleto_byte_idt": row[34],
-                "boleto_post": row[35],
-            }
-        )
+        try:
+            cnab_config.write(
+                {
+                    "invoice_print": row[13],
+                    "instructions": row[14],
+                    "cnab_company_bank_code": row[15],
+                    "convention_code": row[16],
+                    "condition_issuing_paper": row[17],
+                    "communication_2": row[18],
+                    "boleto_wallet": row[19],
+                    "boleto_modality": row[20],
+                    "boleto_variation": row[21],
+                    "boleto_accept": row[22],
+                    "boleto_species": row[23],
+                    "boleto_protest_code": row[24],
+                    "boleto_days_protest": row[25],
+                    "generate_own_number": row[26],
+                    "own_number_sequence_id": row[27],
+                    "cnab_sequence_id": row[28],
+                    "boleto_interest_code": row[29],
+                    "boleto_interest_perc": row[30],
+                    "boleto_fee_code": row[31],
+                    "boleto_fee_perc": row[32],
+                    "boleto_discount_perc": row[33],
+                    "boleto_byte_idt": row[34],
+                    "boleto_post": row[35],
+                }
+            )
 
-        # Contas Contabeis
-        account_fields = {
-            36: "interest_fee_account_id",
-            37: "discount_account_id",
-            38: "rebate_account_id",
-            39: "tariff_charge_account_id",
-            40: "not_payment_account_id",
-        }
-        for index, field in account_fields.items():
-            if row[index]:
-                setattr(cnab_config, field, row[index])
+            # Contas Contabeis
+            account_fields = {
+                36: "interest_fee_account_id",
+                37: "discount_account_id",
+                38: "rebate_account_id",
+                39: "tariff_charge_account_id",
+                40: "not_payment_account_id",
+            }
+            for index, field in account_fields.items():
+                if row[index]:
+                    setattr(cnab_config, field, row[index])
+        except Exception as e:
+            _logger.warning(f"Could not write CNAB config: {e}")
 
 
 def update_payment_mode_outbound(env):


### PR DESCRIPTION
safe guard migration se a tabela l10n_br_cnab_boleto_wallet_code não existe, por exemplo porque o banco é migrado a partir da 12.0.

o l10n_br_cnab.code pode tb não ser possível de criar caso já existe um código com a mesma restrição de unicidade. Por isso eu botei um try.

O segundo commit evita blocar em casos como:

```
  File "/odoo/external-src/l10n-brazil/l10n_br_account_payment_order/migrations/14.0.7.0.0/post-migration.py", line 113, in update_payment_mode_inbound
    cnab_config.write(
  File "/odoo/src/addons/mail/models/mail_thread.py", line 322, in write
    result = super(MailThread, self).write(values)
  File "/odoo/external-src/connector/component_event/models/base.py", line 109, in write
    result = super(Base, self).write(vals)
  File "/odoo/src/odoo/models.py", line 3716, in write
    real_recs._validate_fields(vals, inverse_fields)
  File "/odoo/src/odoo/models.py", line 1277, in _validate_fields
    check(self)
  File "/odoo/external-src/l10n-brazil/l10n_br_account_payment_order/models/l10n_br_cnab_config.py", line 139, in _check_sequences
    raise ValidationError(
odoo.exceptions.ValidationError: Sequence Own Number already in use by Cooperativa Central de Crédito - Ailos - CNAB 240 (inbound)!
```