### PR TITLE
[16.0][l10n_br_fiscal][l10n_br_hr] fields.Text -> fields.Char where possible

### DIFF
--- a/l10n_br_fiscal/models/cest.py
+++ b/l10n_br_fiscal/models/cest.py
@@ -16,7 +16,7 @@ class Cest(models.Model):
 
     code_unmasked = fields.Char(size=7)
 
-    name = fields.Text(required=True, index=True)
+    name = fields.Char(required=True, index=True)
 
     item = fields.Char(required=True)
 

--- a/l10n_br_fiscal/models/data_abstract.py
+++ b/l10n_br_fiscal/models/data_abstract.py
@@ -18,7 +18,7 @@ class DataAbstract(models.AbstractModel):
 
     code = fields.Char(required=True, index=True)
 
-    name = fields.Text(required=True, index=True)
+    name = fields.Char(required=True, index=True)
 
     code_unmasked = fields.Char(
         string="Unmasked Code", compute="_compute_code_unmasked", store=True, index=True

--- a/l10n_br_fiscal/models/icms_regulation.py
+++ b/l10n_br_fiscal/models/icms_regulation.py
@@ -50,7 +50,7 @@ class ICMSRegulation(models.Model):
     _inherit = ["mail.thread", "mail.activity.mixin"]
     _description = "Tax ICMS Regulation"
 
-    name = fields.Text(required=True, index=True)
+    name = fields.Char(required=True, index=True)
 
     icms_imported_tax_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",

--- a/l10n_br_fiscal/models/nbm.py
+++ b/l10n_br_fiscal/models/nbm.py
@@ -15,7 +15,7 @@ class Nbm(models.Model):
 
     code_unmasked = fields.Char(size=10, unaccent=False)
 
-    name = fields.Text(required=True, index=True)
+    name = fields.Char(required=True, index=True)
 
     product_tmpl_ids = fields.One2many(inverse_name="nbm_id")
 

--- a/l10n_br_fiscal/models/tax_pis_cofins.py
+++ b/l10n_br_fiscal/models/tax_pis_cofins.py
@@ -18,7 +18,7 @@ class TaxPisCofins(models.Model):
 
     code = fields.Char(required=True)
 
-    name = fields.Text(required=True, index=True)
+    name = fields.Char(required=True, index=True)
 
     piscofins_type = fields.Selection(
         selection=[

--- a/l10n_br_hr/models/data_abstract.py
+++ b/l10n_br_hr/models/data_abstract.py
@@ -12,7 +12,7 @@ class DataAbstract(models.AbstractModel):
 
     code = fields.Char(required=True, index=True)
 
-    name = fields.Text(required=True, index=True)
+    name = fields.Char(required=True, index=True)
 
     def name_get(self):
         return [(r.id, f"{r.code} - {r.name}") for r in self]


### PR DESCRIPTION
convert fields.Text to fields.Char where it makes sense.

| Feature               | `fields.Char`                          | `fields.Text`                          |
|-----------------------|----------------------------------------|----------------------------------------|
| **Max Length**        | 256 chars (configurable with `size`)   | Unlimited                              |
| **Database Type**     | `VARCHAR(size)`                        | `TEXT`                                 |
| **Use Case**          | Short strings (names, codes, emails)   | Long, multiline text (descriptions)    |
| **Supports Newlines** | ❌ No (single-line)                    | ✅ Yes (`\n` works)                    |
| **Performance**       | ✅ Slightly faster (fixed-size)        | ⚠️ Slightly slower (variable-size)     |
| **Example**           | `name = fields.Char(size=100)`         | `notes = fields.Text()`                |