### PR TITLE
[16.0] l10n_br_base fixes

### DIFF
--- a/l10n_br_base/models/party_mixin.py
+++ b/l10n_br_base/models/party_mixin.py
@@ -66,13 +66,23 @@ class PartyMixin(models.AbstractModel):
     )
 
     country_id = fields.Many2one(
-        comodel_name="res.country.state",
-        default=lambda self: self.env.ref("base.br"),
+        comodel_name="res.country",
+        default=lambda self: self._default_country_id(),
     )
 
     district = fields.Char(
         size=32,
     )
+
+    def _default_country_id(self):
+        """Default country set to Brazil if the current company is Brazilian.
+        Can be overridden in other modules if needed.
+        """
+        return (
+            self.env.ref("base.br")
+            if self.env.company.country_id.code == "BR"
+            else False
+        )
 
     @api.depends("cnpj_cpf")
     def _compute_cnpj_cpf_stripped(self):

--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -169,10 +169,11 @@ class Partner(models.Model):
                             " number per state for each partner!"
                         )
                     )
-                duplicate_ie = record.search(
+                duplicate_ie = self.env["res.partner"].search(
                     [
                         ("state_id", "=", inscr_est_line.state_id.id),
                         ("inscr_est", "=", inscr_est_line.inscr_est),
+                        ("id", "!=", record.id),
                     ]
                 )
                 if duplicate_ie:

--- a/l10n_br_base/models/res_partner_bank.py
+++ b/l10n_br_base/models/res_partner_bank.py
@@ -87,7 +87,7 @@ class ResPartnerBank(models.Model):
         for b in self:
             if b.bank_id.code_bc:
                 if len(b.bra_number) > 4:
-                    raise UserError(_("Bank branch code must be four caracteres."))
+                    raise UserError(_("Bank branch code must be four characters."))
 
     @api.constrains(
         "transactional_acc_type",

--- a/l10n_br_base/views/res_partner_view.xml
+++ b/l10n_br_base/views/res_partner_view.xml
@@ -94,7 +94,6 @@
                 <div name="inscr_est">
                          <label
                         for="inscr_est"
-                        name="inscr_est"
                         string="IE"
                         attrs="{'invisible': [('is_company','=', False), ('parent_id', '!=', False)]}"
                     />


### PR DESCRIPTION
já que queremos migrar o modulo l10n_br_base para a 17.0 e para a 18.0 é importante resolver os bugs nele quanto antes para não ter que administrar isso em varias branches depois...


o comodel do country_id no l10n_br_base/models/party_mixin.py tava zoado. Mas aproveitei para ajustar para que os res.partner sejam no Brazil por padrão apenas se o usuário for de uma empresa brasileira.