### PR TITLE
[16.0][REF] l10n_br_fiscal: simplifica alguns campos name de cadastros.

### DIFF
--- a/l10n_br_fiscal/models/cest.py
+++ b/l10n_br_fiscal/models/cest.py
@@ -16,8 +16,6 @@ class Cest(models.Model):
 
     code_unmasked = fields.Char(size=7)
 
-    name = fields.Text(required=True, index=True)
-
     item = fields.Char(required=True)
 
     segment = fields.Selection(selection=CEST_SEGMENT, required=True)

--- a/l10n_br_fiscal/models/icms_regulation.py
+++ b/l10n_br_fiscal/models/icms_regulation.py
@@ -50,7 +50,7 @@ class ICMSRegulation(models.Model):
     _inherit = ["mail.thread", "mail.activity.mixin"]
     _description = "Tax ICMS Regulation"
 
-    name = fields.Text(required=True, index=True)
+    name = fields.Char(required=True, index=True)
 
     icms_imported_tax_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",

--- a/l10n_br_fiscal/models/nbm.py
+++ b/l10n_br_fiscal/models/nbm.py
@@ -15,8 +15,6 @@ class Nbm(models.Model):
 
     code_unmasked = fields.Char(size=10, unaccent=False)
 
-    name = fields.Text(required=True, index=True)
-
     product_tmpl_ids = fields.One2many(inverse_name="nbm_id")
 
     ncms = fields.Char(string="NCM")


### PR DESCRIPTION
PR de substituição de https://github.com/OCA/l10n-brazil/pull/3787

o Campo name é herdado do `l10n_br_fiscal.data.abstract `  nos arquivos onde eu tirei ele.

No icms_regulation.py ele não é herdado e da para converter ele para Char pois todos registros tem menos de 256 chars como pode ser visto num banco com o SELECT:

```
odoo14=> SELECT
    MAX(CHAR_LENGTH(name)) AS max_length,
    CASE
        WHEN MAX(CHAR_LENGTH(name)) <= 256 THEN 'Convertible to VARCHAR(256)'
        ELSE 'Cannot convert - exceeds 256 characters'
    END AS conversion_status
FROM l10n_br_fiscal_icms_regulation;
 max_length |      conversion_status
------------+-----------------------------
         19 | Convertible to VARCHAR(256)
(1 row)
```