### PR TITLE
[16.0][FIX+REF] l10n_br_account_payment_brcobranca: Mensagem de Erro da biblioteca BRCobranca

### DIFF
--- a/l10n_br_account_payment_brcobranca/models/account_move.py
+++ b/l10n_br_account_payment_brcobranca/models/account_move.py
@@ -10,7 +10,7 @@ import tempfile
 import requests
 
 from odoo import _, models
-from odoo.exceptions import UserError
+from odoo.exceptions import ValidationError
 
 from ..constants.br_cobranca import TIMEOUT, get_brcobranca_api_url
 
@@ -32,7 +32,7 @@ class AccountMove(models.Model):
 
         boletos = receivable_ids.send_payment()
         if not boletos:
-            raise UserError(
+            raise ValidationError(
                 _(
                     "It is not possible generated boletos\n"
                     "Make sure the Invoice are in Confirm state and "
@@ -81,7 +81,20 @@ class AccountMove(models.Model):
         if str(res.status_code)[0] == "2":
             pdf_string = res.content
         else:
-            raise UserError(res.text.encode("utf-8"))
+            # Retornando apenas as 2 primeiras Linhas do LOG porque é onde estão as
+            # estão as principais informações, por exemplo:
+            # 1 - 'Puma caught this error: Tipo de convênio não implementado.
+            #     (Brcobranca::NaoImplementado)',
+            # 2 - "/usr/.../brcobranca/boleto/banco_brasil.rb:110:in `nosso_numero'",
+            # 3 - "/usr/.../brcobranca/validations.rb:98:in `block (2 levels) in
+            #     check_presences'",
+            # Se necessário é possível ver o LOG completo pelo container
+            # ou com a linha abaixo:
+            # raise ValidationError(res.text.encode("utf-8"))
+
+            raise ValidationError(
+                "\n".join([str(item) for item in res.text.splitlines()[0:2]])
+            )
 
         return pdf_string
 
@@ -111,7 +124,7 @@ class AccountMove(models.Model):
                 # Conciliação Automatica entre a Linha da Fatura e a Linha criada
                 if self.journal_id.return_auto_reconcile:
                     if line_to_reconcile.reconciled:
-                        raise UserError(
+                        raise ValidationError(
                             _(
                                 "The invoice line %(name)s is already reconciled.\n\n"
                                 "Invoice: %(invoice)s\n"

--- a/l10n_br_account_payment_brcobranca/models/account_payment_order.py
+++ b/l10n_br_account_payment_brcobranca/models/account_payment_order.py
@@ -12,7 +12,7 @@ import requests
 from erpbrasil.base import misc
 
 from odoo import _, models
-from odoo.exceptions import Warning as ValidationError
+from odoo.exceptions import ValidationError
 
 from ..constants.br_cobranca import (
     DICT_BRCOBRANCA_CNAB_TYPE,

--- a/l10n_br_account_payment_brcobranca/parser/cnab_file_parser.py
+++ b/l10n_br_account_payment_brcobranca/parser/cnab_file_parser.py
@@ -9,7 +9,7 @@ import logging
 
 import requests
 
-from odoo.exceptions import UserError
+from odoo.exceptions import ValidationError
 
 from odoo.addons.account_move_base_import.parser.file_parser import FileParser
 
@@ -95,7 +95,14 @@ class CNABFileParser(FileParser):
         )
 
         if res.status_code != 201:
-            raise UserError(res.text)
+            # Retornando apenas as 8 primeiras Linhas do LOG porque é onde estão as
+            # estão as principais informações. Se necessário é possível ver o LOG
+            # completo pelo container ou com a Linha Abaixo:
+            # raise ValidationError(res.text)
+
+            raise ValidationError(
+                "\n".join([str(item) for item in res.text.splitlines()[0:8]])
+            )
 
         string_result = res.json()
         data = json.loads(string_result)


### PR DESCRIPTION
Fix error mensage for generate Remessa File and reduce the error mensage for generate Boleto and Import CNAB File.

Na v16 a mensagem de erro da biblioteca **BRCobranca** para **Gerar o Arquivo Remessa do CNAB** passou a não ser mostrada de uma forma clara

![image](https://github.com/user-attachments/assets/2040298c-164f-4f73-89b8-3a14e8b71afe)

![image](https://github.com/user-attachments/assets/49e12d02-d945-4248-b0cb-fb96aa1c436e)

Isso acontece devido a forma que o **import** era feito, algo simples, com esse PR a mensagem volta a ser mostrada como na v14 de uma forma mais clara

![image](https://github.com/user-attachments/assets/6c59fc1e-2528-40cc-b3ca-e93f02112879)

Olhando as mensagens de erro para **Gerar o Boleto e Importar o Arquivo de Retorno** eu decidi fazer um segundo commit com o objetivo de reduzir a mensagem, boa parte do que é mostrado são apenas referencias de onde o código passou mas não tem nada que ajude a solucionar o problema, a primeira linha é importante por mostrar a mensagem de erro e as outras linhas até onde o LOG mostra a Linha especifica do caso com erro, o resto até onde vi é desnecessário.

Hoje no caso do Boleto a mensagem completa aparece assim

![image](https://github.com/user-attachments/assets/8c7e9496-91c6-43f2-94f6-7ede2c375def)


Pelos testes apenas as 3 primeiras linhas já trazem a informação necessária, então com esse PR a mensagem passa para

![image](https://github.com/user-attachments/assets/3895199a-872d-40b3-af80-2349bdde2f22)

No caso da Importação do Arquivo de Retorno a mensagem hoje aparece assim

![image](https://github.com/user-attachments/assets/138654b2-7bd4-46aa-ad21-88e48d808ba5)

E pelos testes apenas as 8 primeiras linhas já trazem a informação necessária, então com esse PR a mensagem passa para 

![image](https://github.com/user-attachments/assets/2fffbe48-5d71-4074-aa0c-e98543238ab0)

Os commits estão em separado porque o primeiro é uma Correção/FIX, já que a mensagem aparece corretamente na v14, e o segundo é uma Refatoração, por não ser um um erro, e para facilitar a remoção caso essa segunda alteração seja rejeitada.

Deixei comentários no Código sobre a redução do LOG de Erro e como exibir a mensagem completa, talvez exista algum erro que precise da mensagem completa, eu ainda não encontrei, teria? Fiz a alteração porque acredito que isso deve ajudar no suporte por mostrar apenas o necessário. 

cc @OCA/local-brazil-maintainers  