### PR TITLE
[16.0][REF] l10n_br_account_payment_brcobranca: Verificar a variável de ambiente CI_NO_BRCOBRANCA

### DIFF
--- a/l10n_br_account_payment_brcobranca/models/account_move.py
+++ b/l10n_br_account_payment_brcobranca/models/account_move.py
@@ -5,6 +5,7 @@
 import base64
 import json
 import logging
+import os
 import tempfile
 
 import requests
@@ -21,7 +22,10 @@ class AccountMove(models.Model):
     _inherit = "account.move"
 
     def generate_boleto_pdf(self):
-        if self.payment_mode_id.cnab_config_id.cnab_processor != "brcobranca":
+        if (
+            self.payment_mode_id.cnab_config_id.cnab_processor != "brcobranca"
+            or os.environ.get("CI_NO_BRCOBRANCA")
+        ):
             return super().generate_boleto_pdf()
 
         file_pdf = self.file_boleto_pdf_id

--- a/l10n_br_account_payment_brcobranca/models/account_payment_order.py
+++ b/l10n_br_account_payment_brcobranca/models/account_payment_order.py
@@ -6,6 +6,7 @@
 
 import json
 import logging
+import os
 import tempfile
 
 import requests
@@ -97,7 +98,9 @@ class PaymentOrder(models.Model):
 
     def generate_payment_file(self):
         """Returns (payment file as string, filename)"""
-        self.ensure_one()
+        if os.environ.get("CI_NO_BRCOBRANCA"):
+            return (False, False)
+
         cnab_config = self.payment_mode_id.cnab_config_id
         self.file_number = cnab_config.cnab_sequence_id.next_by_id()
 


### PR DESCRIPTION
Check env variable to not make real calls for BRCobranca API to generate Boleto and Remessa File.

Necessário verificar se a variável de Ambiente **CI_NO_BRCOBRANCA** foi informada para não tentar fazer chamadas reais para tentar gerar o Boleto e o Arquivo Remessa, esse é o caso onde por algum motivo não tem um **boleto_cnab_api** rodando, e por isso não vai ser possível fazer chamadas reais para API, no PR https://github.com/OCA/l10n-brazil/pull/3794 eu estou removendo as **Respostas Simuladas / Mocked** porque aqui no CI do github foi incluído a possibilidade de fazer chamadas reais para API https://github.com/OCA/l10n-brazil/pull/3361 então eu busquei rever esse caso **CI_NO_BRCOBRANCA** para que nesses casos não retorne erros.

PR simples que é uma extração do https://github.com/OCA/l10n-brazil/pull/3794 com objetivo de reduzir o PR e facilitar a Revisão. 

cc @OCA/local-brazil-maintainers 