### PR TITLE
[16.0][FIX] spec_driven_model: proper export if field is False

### DIFF
--- a/spec_driven_model/models/spec_export.py
+++ b/spec_driven_model/models/spec_export.py
@@ -246,6 +246,6 @@ class SpecMixinExport(models.AbstractModel):
         sliced_kwargs = {
             key: kwargs.get(key)
             for key in binding_class.__dataclass_fields__.keys()
-            if kwargs.get(key)
+            if kwargs.get(key) is not None
         }
         return binding_class(**sliced_kwargs)

--- a/spec_driven_model/models/spec_models.py
+++ b/spec_driven_model/models/spec_models.py
@@ -281,10 +281,6 @@ class StackedModel(SpecModel):
         2. It is also useful to generate an automatic view of the spec fields.
         3. Finally it is used when exporting as XML.
         """
-        # We are removing the description of the node
-        # to avoid translations error
-        # https://github.com/OCA/l10n-brazil/pull/1272#issuecomment-821806603
-        node._description = None
         if path is None:
             path = stacking_settings["stacking_mixin"].split(".")[-1]
         cls._map_concrete(env.cr.dbname, node._name, cls._name, quiet=True)

--- a/spec_driven_model/tests/fake_odoo_purchase.py
+++ b/spec_driven_model/tests/fake_odoo_purchase.py
@@ -53,7 +53,6 @@ class PurchaseOrder(models.Model):
         index=True,
         copy=False,
         default="draft",
-        tracking=True,
     )
 
     order_line = fields.One2many(

--- a/spec_driven_model/tests/spec_purchase.py
+++ b/spec_driven_model/tests/spec_purchase.py
@@ -49,7 +49,7 @@ class PurchaseOrder(spec_models.StackedModel):
     poxsd10_confirmDate = fields.Date(related="date_approve", string="POXSD Approval Date")
     poxsd10_shipTo = fields.Many2one(related="dest_address_id", readonly=False)
     poxsd10_billTo = fields.Many2one(related="partner_id", readonly=False)
-    poxsd10_item = fields.One2many(related="order_line", relation_field="order_id")
+    poxsd10_item = fields.One2many(related="order_line")
 
     def _compute_date(self):
         """


### PR DESCRIPTION
No momento se um attributo de um elemento XML é False, parece que não seria exportado. Aqui eu exporto mesmo se for False. Mas tem que ver se isso não for trazer regressão.

EDIT: na verdade nos módulos "spec_*" da  localização nunca é usado campos fields.Boolean. Geralmente a Fazenda usa campos Char/string "indicadores" com valores 0 ou 1 para Boolean.
Isso pode ser visto procurando por fields.Boolean aqui: https://github.com/OCA/l10n-brazil/blob/16.0/l10n_br_nfe_spec/models/v4_0/leiaute_nfe_v4_00.py  (não tem)

Nisso é seguro fazer essa mudança e é desejável para tornar o spec_driven_model mais robusto.


no segundo commits eu removi os ultimos warnings no modulo spec_driven_model como:

```
2025-05-18 05:27:18,445 14679 WARNING odoo16 odoo.models: The model poxsd.10.items has no _description
2025-05-18 05:27:18,445 14679 WARNING odoo16 odoo.models: The model poxsd.10.purchaseordertype has no _description
[...]
2025-05-18 05:32:48,941 19742 WARNING odoo16 odoo.fields: Field fake.purchase.order.state: unknown parameter 'tracking', if this is an actual parameter you may want to override the method _valid_field_parameter on the relevant model in order to allow it
2025-05-18 05:32:48,941 19742 WARNING odoo16 odoo.fields: Field fake.purchase.order.poxsd10_item: unknown parameter 'relation_field', if this is an actual parameter you may want to override the method _valid_field_parameter on the relevant model in order to allow it
2025-05-18 05:32:48,947 19742 INFO odoo16 odoo.modules.registry: module spec_driven_model: creating or updating database tables
2025-05-18 05:32:49,004 19742 WARNING odoo16 odoo.fields: Field fake.purchase.order.state: unknown parameter 'tracking', if this is an actual parameter you may want to override the method _valid_field_parameter on the relevant model in order to allow it
2025-05-18 05:32:49,004 19742 WARNING odoo16 odoo.fields: Field fake.purchase.order.poxsd10_item: unknown parameter 'relation_field', if this is an actual parameter you may want to override the method _valid_field_parameter on the relevant model in order to allow it
```