### PR TITLE
[16.0][IMP] l10n_br_fiscal: debug fiscal line

### DIFF
--- a/l10n_br_account/views/account_move_view.xml
+++ b/l10n_br_account/views/account_move_view.xml
@@ -427,6 +427,7 @@
                         </group>
                     </page>
                     <page name="fiscal_line_extra_info" string="Extra Info" />
+                    <page name="fiscal_line_debug" string="Debug" />
                     <page name="accounting" string="Accounting">
                         <group>
                             <field name="fiscal_document_line_id" />

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -1688,6 +1688,8 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         string="CNAE Code",
     )
 
+    debug_message = fields.Text()
+
     @api.depends("company_id")
     def _compute_currency_id(self):
         for doc_line in self:

--- a/l10n_br_fiscal/models/document_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_line_mixin_methods.py
@@ -119,6 +119,10 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                     ".//page[@name='fiscal_line_extra_info']",
                     "//page[@name='fiscal_line_extra_info']",
                 ),
+                (
+                    ".//page[@name='fiscal_line_debug']",
+                    "//page[@name='fiscal_line_debug']",
+                ),
                 # these will only collect (invisible) fields for onchanges:
                 (
                     ".//control[@name='fiscal_fields']...",
@@ -138,6 +142,16 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             if not placeholder_nodes:
                 continue
             fiscal_nodes = fsc_doc.xpath(fiscal_xpath)
+            if "fiscal_line_debug" in fiscal_xpath:
+                debug_fiscal_line = (
+                    self.env["ir.config_parameter"]
+                    .sudo()
+                    .get_param("l10n_br_fiscal.debug_fiscal_line")
+                )
+                if not debug_fiscal_line:
+                    for target_node in doc.findall(placeholder_xpath):
+                        target_node.getparent().remove(target_node)
+                    continue
             for target_node in placeholder_nodes:
                 if len(fiscal_nodes) == 1:
                     # replace unique placeholder
@@ -315,17 +329,19 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 wrapped_line = line
 
             if wrapped_line.fiscal_operation_line_id:
-                mapping_result = wrapped_line.fiscal_operation_line_id.map_fiscal_taxes(
-                    company=wrapped_line.company_id,
-                    partner=wrapped_line._get_fiscal_partner(),
-                    product=wrapped_line.product_id,
-                    ncm=wrapped_line.ncm_id,
-                    nbm=wrapped_line.nbm_id,
-                    nbs=wrapped_line.nbs_id,
-                    cest=wrapped_line.cest_id,
-                    city_taxation_code=wrapped_line.city_taxation_code_id,
-                    service_type=wrapped_line.service_type_id,
-                    ind_final=wrapped_line.ind_final,
+                mapping_result, debug_message = (
+                    wrapped_line.fiscal_operation_line_id.map_fiscal_taxes(
+                        company=wrapped_line.company_id,
+                        partner=wrapped_line._get_fiscal_partner(),
+                        product=wrapped_line.product_id,
+                        ncm=wrapped_line.ncm_id,
+                        nbm=wrapped_line.nbm_id,
+                        nbs=wrapped_line.nbs_id,
+                        cest=wrapped_line.cest_id,
+                        city_taxation_code=wrapped_line.city_taxation_code_id,
+                        service_type=wrapped_line.service_type_id,
+                        ind_final=wrapped_line.ind_final,
+                    )
                 )
                 line.cfop_id = mapping_result["cfop"]
                 line.ipi_guideline_id = mapping_result["ipi_guideline"]
@@ -337,6 +353,9 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 for tax in mapping_result["taxes"].values():
                     taxes |= tax
                 line.fiscal_tax_ids = taxes
+                if debug_message:
+                    line.debug_message = debug_message
+
             else:
                 line.fiscal_tax_ids = [Command.clear()]
 

--- a/l10n_br_fiscal/models/operation.py
+++ b/l10n_br_fiscal/models/operation.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2013  Renato Lima - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+import logging
+
 from odoo import _, fields, models
 from odoo.exceptions import UserError
 
@@ -14,6 +16,8 @@ from ..constants.fiscal import (
     OPERATION_STATE,
     OPERATION_STATE_DEFAULT,
 )
+
+_logger = logging.getLogger(__name__)
 
 
 class Operation(models.Model):
@@ -278,13 +282,31 @@ class Operation(models.Model):
         return domain
 
     def line_definition(self, company, partner, product):
+        """
+        Match the best operation line for company, partner and product settings.
+        """
+
         self.ensure_one()
         if not company:
             company = self.env.company
-
-        lines = self.line_ids.search(self._line_domain(company, partner, product))
-
-        return self._select_best_line(lines)
+        line_domain = self._line_domain(company, partner, product)
+        lines = self.line_ids.search(line_domain)
+        best_line = self._select_best_line(lines)
+        _logger.debug(
+            _(
+                "Operation %(op_name)s (%(op_id)s): searching among lines "
+                "%(line_names)s with domain %(domain)s -> found %(op_line_names)s; "
+                "best %(best_name)s (%(best_id)s)",
+                op_name=self.name,
+                op_id=self.id,
+                line_names=self.line_ids.mapped("name"),
+                domain=line_domain,
+                op_line_names=lines.mapped("name"),
+                best_name=best_line.name,
+                best_id=best_line.id,
+            )
+        )
+        return best_line
 
     def _select_best_line(self, lines):
         if not lines:

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -1,6 +1,9 @@
 # Copyright (C) 2019  Renato Lima - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+import logging
+from io import StringIO
+
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
@@ -12,13 +15,14 @@ from ..constants.fiscal import (
     OPERATION_STATE_DEFAULT,
     PRODUCT_FISCAL_TYPE,
     TAX_DOMAIN_ICMS,
-    TAX_DOMAIN_IPI,
     TAX_DOMAIN_ISSQN,
     TAX_FRAMEWORK,
     TAX_FRAMEWORK_NORMAL,
     TAX_ICMS_OR_ISSQN,
 )
 from ..constants.icms import ICMS_ORIGIN
+
+_logger = logging.getLogger(__name__)
 
 
 class OperationLine(models.Model):
@@ -167,25 +171,6 @@ class OperationLine(models.Model):
             cfop = self.cfop_export_id
         return cfop
 
-    def _build_mapping_result_ipi(self, mapping_result, tax_definition):
-        if tax_definition and tax_definition.ipi_guideline_id:
-            mapping_result["ipi_guideline"] = tax_definition.ipi_guideline_id
-
-    def _build_mapping_result_icms(self, mapping_result, tax_definition):
-        if tax_definition and tax_definition.is_benefit:
-            mapping_result["icms_tax_benefit_id"] = tax_definition.id
-
-    def _build_mapping_result(self, mapping_result, tax_definition):
-        mapping_result["taxes"][tax_definition.tax_domain] = tax_definition.tax_id
-        self._build_mapping_result_icms(
-            mapping_result,
-            tax_definition.filtered(lambda t: t.tax_domain == TAX_DOMAIN_ICMS),
-        )
-        self._build_mapping_result_ipi(
-            mapping_result,
-            tax_definition.filtered(lambda t: t.tax_domain == TAX_DOMAIN_IPI),
-        )
-
     def map_fiscal_taxes(
         self,
         company,
@@ -247,20 +232,53 @@ class OperationLine(models.Model):
             - 'icms_tax_benefit_id': The determined ICMS tax benefit record
               ID (l10n_br_fiscal.tax.definition) or False.
         """
+
+        self.ensure_one()
+        if not company.state_id:
+            raise UserError(
+                _(
+                    "Company %(company_name)s should have a Federal State defined!",
+                    company_name=company.name,
+                )
+            )
+        if not company.tax_framework:
+            raise UserError(
+                _(
+                    "Company %(company_name)s should have a Tax Framework defined!",
+                    company_name=company.name,
+                )
+            )
+
+        if partner.is_company:
+            if not partner.state_id:
+                raise UserError(
+                    _(
+                        "Partner %(partner_name)s should have a Federal State defined!",
+                        partner_name=partner.name,
+                    )
+                )
+            if not partner.tax_framework:
+                raise UserError(
+                    _(
+                        "Partner %(partner_name)s should have a Tax Framework defined!",
+                        partner_name=partner.name,
+                    )
+                )
+
         mapping_result = {
             "taxes": {},
             "cfop": False,
             "ipi_guideline": self.env.ref("l10n_br_fiscal.tax_guideline_999"),
             "icms_tax_benefit_id": False,
         }
-
-        self.ensure_one()
+        debug_message = StringIO()
+        debug_message.write(f"selected operation: {self.name} ID: {self.id}")
 
         # Define CFOP
         mapping_result["cfop"] = self._get_cfop(company, partner)
 
         # 1 Get Tax Defs from Company
-        for tax_definition in company.tax_definition_ids.map_tax_definition(
+        company.tax_definition_ids.map_tax_definition(
             company,
             partner,
             product,
@@ -270,8 +288,10 @@ class OperationLine(models.Model):
             cest=cest,
             city_taxation_code=city_taxation_code,
             service_type=service_type,
-        ):
-            self._build_mapping_result(mapping_result, tax_definition)
+            mapping_result=mapping_result,
+            debug_label="COMPANY",
+            debug_message=debug_message,
+        )
 
         # 2 From NCM
         if not ncm and product:
@@ -284,6 +304,11 @@ class OperationLine(models.Model):
 
             if mapping_result["cfop"].destination == CFOP_DESTINATION_EXPORT:
                 mapping_result["taxes"][tax_ii.tax_domain] = tax_ii
+
+            debug_message.write(
+                f"\n\napplying NCM for IPI: {tax_ipi.name} ID: {tax_ipi.id}"
+                f"\napplying NCM for II: {tax_ii.name} ID: {tax_ii.id}"
+            )
 
             # 3 From ICMS Regulation
             if company.icms_regulation_id:
@@ -298,14 +323,24 @@ class OperationLine(models.Model):
                     ind_final=ind_final,
                 )
 
-                for tax_def in icms_tax_defs:
-                    self._build_mapping_result_icms(mapping_result, tax_def)
+                for tax_definition in icms_tax_defs:
+                    if tax_definition.is_benefit:
+                        mapping_result["icms_tax_benefit_id"] = tax_definition.id
+                        debug_message.write(
+                            f"\n\napplying ICMS regulation Tax Benefit: "
+                            f"{tax_definition.name or ''} ID: {tax_definition.id}"
+                        )
 
                 for tax in icms_taxes:
                     mapping_result["taxes"][tax.tax_domain] = tax
+                if icms_taxes:
+                    debug_message.write(
+                        f"\n\nadding IMCS TAXES from ICMS REGULATION: "
+                        f"{[(tax.tax_domain, tax.id) for tax in icms_taxes]}"
+                    )
 
         # 4 From Operation Line
-        for tax_definition in self.tax_definition_ids.map_tax_definition(
+        self.tax_definition_ids.map_tax_definition(
             company,
             partner,
             product,
@@ -315,13 +350,13 @@ class OperationLine(models.Model):
             cest=cest,
             city_taxation_code=city_taxation_code,
             service_type=service_type,
-        ):
-            self._build_mapping_result(mapping_result, tax_definition)
+            mapping_result=mapping_result,
+            debug_label="OPERATION_LINE",
+            debug_message=debug_message,
+        )
 
         # 5 From CFOP
-        for tax_definition in mapping_result[
-            "cfop"
-        ].tax_definition_ids.map_tax_definition(
+        mapping_result["cfop"].tax_definition_ids.map_tax_definition(
             company,
             partner,
             product,
@@ -331,13 +366,13 @@ class OperationLine(models.Model):
             cest=cest,
             city_taxation_code=city_taxation_code,
             service_type=service_type,
-        ):
-            self._build_mapping_result(mapping_result, tax_definition)
+            mapping_result=mapping_result,
+            debug_label="CFOP",
+            debug_message=debug_message,
+        )
 
         # 6 From Partner Profile
-        for (
-            tax_definition
-        ) in partner.fiscal_profile_id.tax_definition_ids.map_tax_definition(
+        partner.fiscal_profile_id.tax_definition_ids.map_tax_definition(
             company,
             partner,
             product,
@@ -347,8 +382,10 @@ class OperationLine(models.Model):
             cest=cest,
             city_taxation_code=city_taxation_code,
             service_type=service_type,
-        ):
-            self._build_mapping_result(mapping_result, tax_definition)
+            mapping_result=mapping_result,
+            debug_label="PARTNER PROFILE",
+            debug_message=debug_message,
+        )
 
         if product.tax_icms_or_issqn == TAX_DOMAIN_ICMS:
             mapping_result["taxes"].pop(TAX_DOMAIN_ISSQN, None)
@@ -358,7 +395,9 @@ class OperationLine(models.Model):
             mapping_result["taxes"].pop(TAX_DOMAIN_ICMS, None)
             mapping_result["taxes"].pop(TAX_DOMAIN_ISSQN, None)
 
-        return mapping_result
+        debug_str = debug_message.getvalue()
+        _logger.debug("\n" + debug_str)
+        return mapping_result, debug_str
 
     def action_review(self):
         self.write({"state": "review"})

--- a/l10n_br_fiscal/models/res_config_settings.py
+++ b/l10n_br_fiscal/models/res_config_settings.py
@@ -51,3 +51,10 @@ class ResConfigSettings(models.TransientModel):
     delivery_costs = fields.Selection(
         related="company_id.delivery_costs", readonly=False
     )
+
+    debug_fiscal_line = fields.Boolean(
+        string="Debug Tax Mapping in Fiscal Document lines?",
+        help="Enable the Debug tab in the Fiscal Document Line popup form. Note that"
+        "the debug_message in document lines will consume additional disk space.",
+        config_parameter="l10n_br_fiscal.debug_fiscal_line",
+    )

--- a/l10n_br_fiscal/models/tax_definition.py
+++ b/l10n_br_fiscal/models/tax_definition.py
@@ -1,6 +1,9 @@
 # Copyright (C) 2013  Renato Lima - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+import logging
+from pprint import pformat
+
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 
@@ -11,8 +14,12 @@ from ..constants.fiscal import (
     FISCAL_OUT,
     OPERATION_STATE,
     OPERATION_STATE_DEFAULT,
+    TAX_DOMAIN_ICMS,
+    TAX_DOMAIN_IPI,
 )
 from ..constants.icms import ICMS_TAX_BENEFIT_TYPE
+
+_logger = logging.getLogger(__name__)
 
 
 class TaxDefinition(models.Model):
@@ -445,6 +452,9 @@ class TaxDefinition(models.Model):
         cest=None,
         city_taxation_code=None,
         service_type=None,
+        mapping_result=None,
+        debug_label="",
+        debug_message=None,
     ):
         """
         Filter and return tax definitions that match the given criteria.
@@ -482,14 +492,21 @@ class TaxDefinition(models.Model):
             l10n_br_fiscal.tax.definition.
         """
 
-        if not ncm:
-            ncm = product.ncm_id
+        if product:
+            if not ncm:
+                ncm = product.ncm_id
+                if not ncm and product.tax_icms_or_issqn == "icms":
+                    raise UserError(
+                        _(
+                            "Product %(product_name)s has no NCM!",
+                            product_name=product.name,
+                        )
+                    )
 
-        if not nbm:
-            nbm = product.nbm_id
-
-        if not cest:
-            cest = product.cest_id
+            if not nbm:
+                nbm = product.nbm_id
+            if not cest:
+                cest = product.cest_id
 
         domain = [
             ("state", "!=", "expired"),
@@ -517,7 +534,86 @@ class TaxDefinition(models.Model):
             ("product_ids", "=", product.id),
         ]
 
-        return self.search(domain)
+        matches = self.search(domain)
+        debug_args = [
+            company,
+            partner,
+            product,
+            ncm,
+            nbm,
+            ncm,
+            cest,
+            city_taxation_code,
+            service_type,
+        ]
+        for tax_definition in matches:
+            self._build_mapping_result(
+                mapping_result, tax_definition, debug_label, debug_message, debug_args
+            )
+        return matches
+
+    def _build_mapping_result_ipi(self, mapping_result, tax_definition):
+        if tax_definition and tax_definition.ipi_guideline_id:
+            mapping_result["ipi_guideline"] = tax_definition.ipi_guideline_id
+
+    def _build_mapping_result_icms(self, mapping_result, tax_definition):
+        if tax_definition and tax_definition.is_benefit:
+            mapping_result["icms_tax_benefit_id"] = tax_definition.id
+
+    def _build_mapping_result(
+        self, mapping_result, tax_definition, debug_label, debug_message, debug_args
+    ):
+        def convert_odoo_records_to_tuples(data):
+            if isinstance(data, dict):
+                return {
+                    key: convert_odoo_records_to_tuples(value)
+                    for key, value in data.items()
+                }
+            elif isinstance(data, list | tuple | set):
+                return type(data)(convert_odoo_records_to_tuples(item) for item in data)
+            elif hasattr(data, "_name"):  # Check if it's an Odoo record
+                return (
+                    data._name,
+                    getattr(data, "name", ""),
+                    f"ID: {data.id}",
+                )
+            return data
+
+        def debug_tax_definition(message, label, args, definition, mapping_result):
+            args_str = []
+            for arg in args:
+                if isinstance(arg, models.BaseModel):
+                    args_str.append(
+                        f"{arg._name}: {arg.name[:64] if arg.name else ''} ({arg.id})"
+                    )
+                else:
+                    args_str.append(str(arg))
+            args_str = "\n    ".join(args_str)
+            formatted_mapping_result = "\n".join(
+                f"    {line}"
+                for line in pformat(
+                    convert_odoo_records_to_tuples(mapping_result)
+                ).splitlines()
+            )
+            message.write(
+                f"\n\nadding tax_definition for {label}:\n    {args_str}"
+                f"\n->{definition}\nMAPPING RESULT:\n"
+                f"{formatted_mapping_result}"
+            )
+            return message
+
+        mapping_result["taxes"][tax_definition.tax_domain] = tax_definition.tax_id
+        self._build_mapping_result_icms(
+            mapping_result,
+            tax_definition.filtered(lambda t: t.tax_domain == TAX_DOMAIN_ICMS),
+        )
+        self._build_mapping_result_ipi(
+            mapping_result,
+            tax_definition.filtered(lambda t: t.tax_domain == TAX_DOMAIN_IPI),
+        )
+        debug_tax_definition(
+            debug_message, debug_label, debug_args, tax_definition, mapping_result
+        )
 
     @api.onchange("is_taxed")
     def _onchange_tribute(self):

--- a/l10n_br_fiscal/views/document_line_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_line_mixin_view.xml
@@ -1053,6 +1053,11 @@
                             <field name="manual_additional_data" />
                         </group>
                     </page>
+                    <page name="fiscal_line_debug" string="Debug">
+                        <group>
+                            <field name="debug_message" />
+                        </group>
+                    </page>
                 </notebook>
             </form>
         </field>

--- a/l10n_br_fiscal/views/document_line_view.xml
+++ b/l10n_br_fiscal/views/document_line_view.xml
@@ -114,6 +114,7 @@
                             </group>
                         </group>
                     </page>
+                    <page name="fiscal_line_debug" string="Debug" />
                     <page name="fiscal_line_extra_info" string="Extra Info">
                         <field name="additional_data" readonly="1" />
                     </page>

--- a/l10n_br_fiscal/views/res_config_settings_view.xml
+++ b/l10n_br_fiscal/views/res_config_settings_view.xml
@@ -81,6 +81,23 @@
                                 </div>
                             </div>
                         </div>
+
+                        <div
+                            class="col-12 col-lg-6 o_setting_box"
+                            id="settings_debug_fiscal_line"
+                        >
+                            <div class="o_setting_left_pane">
+                                <field name="debug_fiscal_line" />
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <label for="debug_fiscal_line" />
+                                <div class="text-muted">
+                                    Enable the Debug tab in the Fiscal Document Line popup form. Note that
+                                    the debug_message in document lines will consume additional disk space."
+                                </div>
+                            </div>
+                        </div>
+
                     </div>
                     <h2>Fiscal Documents</h2>
                     <div class="row mt16 o_settings_container">

--- a/l10n_br_sale/tests/test_l10n_br_sale_pricelist.py
+++ b/l10n_br_sale/tests/test_l10n_br_sale_pricelist.py
@@ -13,10 +13,15 @@ class TestSaleOrderPriceList(TestSaleCommon):
         super().setUpClass(chart_template_ref=chart_template_ref)
 
         cls.env.user.groups_id |= cls.env.ref("l10n_br_fiscal.group_manager")
+        cls.company_data["product_order_no"].ncm_id = cls.env.ref(
+            "l10n_br_fiscal.ncm_48191000"
+        ).id
 
         Pricelist = cls.env["product.pricelist"]
         PricelistItem = cls.env["product.pricelist.item"]
         SaleOrder = cls.env["sale.order"].with_context(tracking_disable=True)
+
+        cls.company_data["company"].state_id = cls.env.ref("base.state_br_sp").id
 
         # Create a pricelist with especial price for partner_a
         cls.pricelist_partner_a = Pricelist.create(

--- a/l10n_br_sale/tests/test_sale_order_report.py
+++ b/l10n_br_sale/tests/test_sale_order_report.py
@@ -12,6 +12,10 @@ class TestSaleReport(TestSaleCommon):
     @classmethod
     def setUpClass(cls, chart_template_ref=None):
         super().setUpClass(chart_template_ref=chart_template_ref)
+        cls.company_data["company"].state_id = cls.env.ref("base.state_br_sp").id
+        cls.company_data["product_order_no"].ncm_id = cls.env.ref(
+            "l10n_br_fiscal.ncm_48191000"
+        ).id
 
         sale_form = Form(cls.env["sale.order"])
         sale_form.partner_id = cls.partner_a


### PR DESCRIPTION
O tax engine no l10n_br_fiscal é muito complexo para lidar com as maluquices do regime fiscal normal do Brasil. Mas até então ele era bem opaque e chato de debugar (tinha que botar uns breakpoints e gastar muito tempo), em especial numa instancia de produção...

Agora se iniciar o servidor com --log-level=debug, tem um log detalhado do processo de mapping das taxas brasileiras.

Se ativar o novo setting `debug_fiscal_line`, esse log detalhado tb aparece no popup form das linhas de documento fiscal, vendas, compras... numa nova aba Debug.

Além disso eu adicionei algumas asserções para verificar os dados fiscais do partner ou do produto.

Para deixar o código mais fatorizado, eu mudei a chamada do `_build_mapping_result` para dentro do método `map_tax_definition` e nisso eu mudei todos métodos `_build_mapping`* para dentro do `l10n_br_fiscal/models/tax_definition.py`


![2025-05-26_15-49](https://github.com/user-attachments/assets/32792568-3e01-45fe-bdbe-786cdba7630e)
![2025-05-26_15-56](https://github.com/user-attachments/assets/9e7bb2a6-d5d4-4c2c-b362-201d740f55ca)
![2025-05-26_15-56_1](https://github.com/user-attachments/assets/8f2fce88-07cb-4edf-8a02-7dab033d72bf)

cc @OCA/local-brazil-maintainers 
