### PR TITLE
[16.0][REF] l10n_br_coa: refactor tax repartion lines

### DIFF
--- a/l10n_br_coa/models/account_chart_template.py
+++ b/l10n_br_coa/models/account_chart_template.py
@@ -96,62 +96,10 @@ class AccountChartTemplate(models.Model):
                             acc_names.get(tax.type_tax_use, {}).get("refund_account_id")
                         ]
 
-                    if account:
-                        account_id = account_ref[account.id].id
-                    else:
-                        account_id = False
-
-                    if refund_account:
-                        refund_account_id = account_ref[refund_account.id].id
-                    else:
-                        refund_account_id = False
-
-                    tax.write(
-                        {
-                            "invoice_repartition_line_ids": [
-                                (5, 0, 0),
-                                (
-                                    0,
-                                    0,
-                                    {
-                                        "factor_percent": 100,
-                                        "repartition_type": "base",
-                                    },
-                                ),
-                                (
-                                    0,
-                                    0,
-                                    {
-                                        "factor_percent": -100
-                                        if tax.deductible or tax.withholdable
-                                        else 100,
-                                        "repartition_type": "tax",
-                                        "account_id": account_id,
-                                    },
-                                ),
-                            ],
-                            "refund_repartition_line_ids": [
-                                (5, 0, 0),
-                                (
-                                    0,
-                                    0,
-                                    {
-                                        "factor_percent": 100,
-                                        "repartition_type": "base",
-                                    },
-                                ),
-                                (
-                                    0,
-                                    0,
-                                    {
-                                        "factor_percent": -100
-                                        if tax.deductible or tax.withholdable
-                                        else 100,
-                                        "repartition_type": "tax",
-                                        "account_id": refund_account_id,
-                                    },
-                                ),
-                            ],
-                        }
+                    account_id = account_ref[account.id].id if account else False
+                    refund_account_id = (
+                        account_ref[refund_account.id].id if refund_account else False
                     )
+                    tax._update_repartition_lines(account_id, refund_account_id)
+
         return account_ref, taxes_ref

--- a/l10n_br_coa/models/account_tax.py
+++ b/l10n_br_coa/models/account_tax.py
@@ -7,3 +7,23 @@ from odoo import models
 class AccountTax(models.Model):
     _name = "account.tax"
     _inherit = ["account.tax.mixin", "account.tax"]
+
+    def _update_repartition_lines(self, account_id, refund_account_id):
+        for tax in self:
+            invoice_repartion_line = tax.invoice_repartition_line_ids.filtered(
+                lambda line: line.repartition_type == "tax"
+            )
+            if invoice_repartion_line:
+                invoice_repartion_line.account_id = account_id
+                invoice_repartion_line.factor_percent = (
+                    -100 if tax.deductible or tax.withholdable else 100
+                )
+
+            refund_repartition_line = tax.refund_repartition_line_ids.filtered(
+                lambda line: line.repartition_type == "tax"
+            )
+            if refund_account_id:
+                refund_repartition_line.account_id = refund_account_id
+                refund_repartition_line.factor_percent = (
+                    -100 if tax.deductible or tax.withholdable else 100
+                )


### PR DESCRIPTION
Esse PR foi extraído de #3804 
Ele permite de carregar os Charts of Account uns 20% mais rapidamente, em especial nos testes...
Pois elimina o unlink/create inútil e lento de centenas de account.tax.repartition.line (pois essas linhas já existem e ajustar o account_id delas é bem mais rápido) como tinha antes nos logs como:

```
025-05-26 05:28:51,031 448 INFO odoo odoo.addons.l10n_br_account.tests.test_account_taxes: Starting TestAccountTaxes.test_account_taxes ... 
2025-05-26 05:28:51,821 448 INFO odoo odoo.models.unlink: User #1 deleted account.tax.repartition.line records with IDs: [1505, 1506] 
2025-05-26 05:28:51,828 448 INFO odoo odoo.models.unlink: User #1 deleted account.tax.repartition.line records with IDs: [1625, 1626] 
2025-05-26 05:28:51,840 448 INFO odoo odoo.models.unlink: User #1 deleted account.tax.repartition.line records with IDs: [1507, 1508] 
2025-05-26 05:28:51,846 448 INFO odoo odoo.models.unlink: User #1 deleted account.tax.repartition.line records with IDs: [1627, 1628] 
2025-05-26 05:28:51,858 448 INFO odoo odoo.models.unlink: User #1 deleted account.tax.repartition.line records with IDs: [1509, 1510] 
2025-05-26 05:28:51,863 448 INFO odoo odoo.models.unlink: User #1 deleted account.tax.repartition.line records with IDs: [1629, 1630] 
2025-05-26 05:28:51,875 448 INFO odoo odoo.models.unlink: User #1 deleted account.tax.repartition.line records with IDs: [1511, 1512] 
2025-05-26 05:28:51,881 448 INFO odoo odoo.models.unlink: User #1 deleted account.tax.repartition.line records with IDs: [1631, 1632] 
[...]
```

l10n_br_account, antes:
Module l10n_br_account loaded in 27.65s (incl. 24.15s test), 2363 queries (+12552 test, +2363 other) 
depois:
Module l10n_br_account loaded in 26.04s (incl. 22.62s test), 2363 queries (+11032 test, +2363 other)

l10n_br_sale, antes:
Module l10n_br_sale loaded in 35.58s (incl. 30.25s test), 3077 queries (+15866 test, +3077 other) 
depois:
Module l10n_br_sale loaded in 33.60s (incl. 28.47s test), 3077 queries (+15866 test, +3077 other)

l10n_br_simple:
Module l10n_br_coa_simple loaded in 7.75s (incl. 3.77s test), 2778 queries (+3183 test, +2779 other) 
Module l10n_br_coa_simple loaded in 6.75s (incl. 3.43s test), 2044 queries (+2454 test, +2045 other)

l10n_br_coa_generic:
odule l10n_br_coa_generic loaded in 10.53s (incl. 4.93s test), 3975 queries (+3940 test, +3976 other)
Module l10n_br_coa_generic loaded in 8.88s (incl. 3.97s test), 2552 queries (+2530 test, +2553 other) 

Salva uns 7 segundos e milhares de queries apenas nestes 4 módulos.

Na partes dos testes todo salva até uns 35 segundos: 10m 21s  vs 9m 45s agora.

Tambem vai ajudar a migração para a s v17 e v18 onde isso mudou um pouco e que o diff sera menor.

cc @OCA/local-brazil-maintainers 