### PR TITLE
[16.0][FIX] l10n_br_account: _add_inherited_fields fix (indFinal...)

### DIFF
--- a/l10n_br_account/models/fiscal_decorator_mixin.py
+++ b/l10n_br_account/models/fiscal_decorator_mixin.py
@@ -1,8 +1,12 @@
 # Copyright (C) 2025 - TODAY Raphaël Valyi - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+import logging
+
 from odoo import api, fields, models
 from odoo.tools import mute_logger
+
+_logger = logging.getLogger(__name__)
 
 
 class InheritsCheckMuteLogger(mute_logger):
@@ -40,25 +44,42 @@ class FiscalDecoratorMixin(models.AbstractModel):
         """
         if self._fiscal_decorator_model is not None:
             for name, field in self.env.registry[
-                f"{self._fiscal_decorator_model}.mixin"
+                self._fiscal_decorator_model
             ]._fields.items():
                 field_cls = type(field)
                 if (
                     name in self._fields
                     or field_cls in [fields.One2many, fields.Many2many]
                     or not (field.compute or field.related)
-                    or (field.compute and field.store)
                     or field.compute in self._fiscal_decorator_compute_blacklist
-                ):
+                ):  # not a problematic case, or expected for o2m and m2m or blacklist
                     continue
+                if field.compute and field.store:
+                    _logger.debug(
+                        f"field {name} is a compute with store=True in "
+                        f"{self._fiscal_decorator_model} with store=True. "
+                        "It may not be refreshed 'live' before saving in "
+                        f"{self._name}. For that, you may want to override "
+                        f"it in {self._name}."
+                    )
+                    continue
+
+                attrs = {
+                    "related": field.related,
+                    "compute": field.compute,
+                    "inverse": field.inverse,
+                    "comodel_name": field.comodel_name,
+                }
+
+                if field.related and field.related.startswith("document_id."):
+                    attrs["related"] = field.related.replace("document_id.", "move_id.")
+
+                if field_cls == fields.Selection:  # required for some NFe/CTe fields
+                    attrs["selection"] = field.selection
+
                 self._add_field(
                     name,
-                    field_cls(
-                        related=field.related,
-                        compute=field.compute,
-                        inverse=field.inverse,
-                        comodel_name=field.comodel_name,
-                    ),
+                    field_cls(**attrs),
                 )
         return super()._add_inherited_fields()
 

--- a/l10n_br_account/tests/test_move_edition.py
+++ b/l10n_br_account/tests/test_move_edition.py
@@ -2,6 +2,7 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
 
 import logging
+from unittest import mock
 
 from odoo import fields
 from odoo.exceptions import UserError
@@ -162,10 +163,44 @@ class TestMoveEdition(TransactionCase):
             move_form.save()
 
         move_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
+        move_form.ind_final = "1"
         with move_form.invoice_line_ids.new() as line_form:
-            line_form.product_id = self.product_id
+            original_method = type(
+                self.env["l10n_br_fiscal.operation.line"]
+            ).map_fiscal_taxes
+
+            def wrapped_method(self, *args, **kwargs):
+                return original_method(self, *args, **kwargs)
+
+            with mock.patch.object(
+                type(self.env["l10n_br_fiscal.operation.line"]),
+                "map_fiscal_taxes",
+                side_effect=wrapped_method,
+                autospec=True,
+            ) as mocked:
+                line_form.product_id = self.product_id
+
+            # ensure the tax engine is called with the proper
+            # parameters, especially ind_final
+            # as it is related=document_id.ind_final
+            # which is converted to move_id.ind_final to work live
+            mocked.assert_called_with(
+                self.env.ref("l10n_br_fiscal.fo_venda_revenda"),
+                company=move_form.company_id,
+                partner=move_form.partner_id,
+                product=self.product_id,
+                ncm=self.product_id.ncm_id,
+                nbm=self.env["l10n_br_fiscal.nbm"],
+                nbs=self.env["l10n_br_fiscal.nbs"],
+                cest=self.env["l10n_br_fiscal.cest"],
+                city_taxation_code=self.env["l10n_br_fiscal.city.taxation.code"],
+                service_type=self.env["l10n_br_fiscal.service.type"],
+                ind_final="1",
+            )
+
             line_form.price_unit = 42
             line_form.quantity = 42
+
         move = move_form.save()
 
         self.assertEqual(move.state, "draft")


### PR DESCRIPTION
alternativa para https://github.com/OCA/l10n-brazil/pull/3779

como o @antoniospneto detetou em #3776, o problema dos campos related dos objetos decorados pelos _inherits não serem atualizados nos account.move(.line) antes do save/write no banco não se limita apenas aos campos dos l10n_br_br_fiscal.document(.line).mixin. Mas na verdade em vez de adicionar apenas os campos dos l10n_br_br_fiscal.document(.line) como o @antoniospneto  fez em #3779, podemos pegar todos os campos de todos objetos herdados  simplesmente substituindo l10n_br_br_fiscal.document(.line).mixin por l10n_br_br_fiscal.document(.line).

Ao fazer isso percebemos que alguns campos related Selection do modulo l10n_br_nfe criam erros. Pois campo selection related precisa repetir o atributo selection, o que eu fiz aqui neste PR para resolver.