### PR TITLE
[16.0][IMP] spec_driven_model: faster/cleaner update

### DIFF
--- a/spec_driven_model/models/spec_mixin.py
+++ b/spec_driven_model/models/spec_mixin.py
@@ -4,6 +4,7 @@
 from importlib import import_module
 
 from odoo import api, models
+from odoo.tools import mute_logger
 
 from .spec_models import SPEC_MIXIN_MAPPINGS, SpecModel, StackedModel
 
@@ -170,6 +171,24 @@ class SpecMixin(models.AbstractModel):
         self.env.registry.init_models(
             self.env.cr, remaining_models, {"module": odoo_module}
         )
+
+        # init_models just created ir.model.data records for the "MAGIC FIELDS"
+        # of the remaining_models. If we let these fields, next Odoo update
+        # will decide that these MAGIC FIELDS do not match the fields of the
+        # abstract schema mixins and would take a long time to delete these records
+        # and the fields. This is not what we want, so we just remove these records:
+        imd_magic_field_names = []
+        for model in remaining_models:
+            for field in models.MAGIC_COLUMNS + ["display_name", "__last_update"]:
+                imd_magic_field_names.append(
+                    f"field_{model.replace('.', '_')}__{field}"
+                )
+        imd_recs = self.env["ir.model.data"].search(
+            [("name", "in", imd_magic_field_names)]
+        )
+        with mute_logger("odoo.models"):
+            imd_recs.unlink()
+
         return res
 
     @classmethod

--- a/spec_driven_model/models/spec_models.py
+++ b/spec_driven_model/models/spec_models.py
@@ -270,6 +270,10 @@ class StackedModel(SpecModel):
                             "_stacking_points"
                         ):
                             if name in getattr(cls, attr).keys():
+                                # TODO it seems Odoo would still generate ir.model.data
+                                # records for these fields we skip. They are deleted
+                                # in IrModelData#_process_end. Eventually we could
+                                # avoid creating these records or delete them.
                                 return
         return super()._add_field(name, field)
 


### PR DESCRIPTION
Antes disso, se vc inicia o Odoo com --update=l10n_br_nfe por exemplo, demora e tem um monte de logs assim:

```
2025-05-27 05:58:59,317 1131 INFO odoo16 odoo.addons.base.models.ir_model: Deleting 15117@ir.model.fields (l10n_br_nfe.field_nfe_40_adi__id)
2025-05-27 05:58:59,370 1131 INFO odoo16 odoo.models.unlink: User #1 deleted ir.model.data records with IDs: [144267]
2025-05-27 05:58:59,370 1131 INFO odoo16 odoo.models.unlink: User #1 deleted ir.model.fields records with IDs: [15117]
2025-05-27 05:58:59,371 1131 INFO odoo16 odoo.addons.base.models.ir_model: Deleting 15116@ir.model.fields (l10n_br_nfe.field_nfe_40_ipi__display_name)
2025-05-27 05:58:59,434 1131 INFO odoo16 odoo.models.unlink: User #1 deleted ir.model.data records with IDs: [144266]
2025-05-27 05:58:59,434 1131 INFO odoo16 odoo.models.unlink: User #1 deleted ir.model.fields records with IDs: [15116]
2025-05-27 05:58:59,434 1131 INFO odoo16 odoo.addons.base.models.ir_model: Deleting 15115@ir.model.fields (l10n_br_nfe.field_nfe_40_ipi____last_update)
2025-05-27 05:58:59,543 1131 INFO odoo16 odoo.models.unlink: User #1 deleted ir.model.data records with IDs: [144265]
2025-05-27 05:58:59,543 1131 INFO odoo16 odoo.models.unlink: User #1 deleted ir.model.fields records with IDs: [15115]
2025-05-27 05:58:59,544 1131 INFO odoo16 odoo.addons.base.models.ir_model: Deleting 15114@ir.model.fields (l10n_br_nfe.field_nfe_40_ipi__id)
2025-05-27 05:58:59,577 1131 INFO odoo16 odoo.models.unlink: User #1 deleted ir.model.data records with IDs: [144264]
2025-05-27 05:58:59,577 1131 INFO odoo16 odoo.models.unlink: User #1 deleted ir.model.fields records with IDs: [15114]
2025-05-27 05:58:59,578 1131 INFO odoo16 odoo.addons.base.models.ir_model: Deleting 15101@ir.model.fields (l10n_br_nfe.field_nfe_40_det_obsfisco__write_date)
2025-05-27 05:58:59,614 1131 INFO odoo16 odoo.models.unlink: User #1 deleted ir.model.data records with IDs: [144261]
2025-05-27 05:58:59,614 1131 INFO odoo16 odoo.models.unlink: User #1 deleted ir.model.fields records with IDs: [15101]
2025-05-27 05:58:59,615 1131 INFO odoo16 odoo.addons.base.models.ir_model: Deleting 15100@ir.model.fields (l10n_br_nfe.field_nfe_40_det_obsfisco__write_uid)
2025-05-27 05:58:59,652 1131 INFO odoo16 odoo.models.unlink: User #1 deleted ir.model.data records with IDs: [144260]
2025-05-27 05:58:59,652 1131 INFO odoo16 odoo.models.unlink: User #1 deleted ir.model.fields records with IDs: [15100]
2025-05-27 05:58:59,653 1131 INFO odoo16 odoo.addons.base.models.ir_model: Deleting 15099@ir.model.fields (l10n_br_nfe.field_nfe_40_det_obsfisco__create_date)
2025-05-27 05:58:59,688 1131 INFO odoo16 odoo.models.unlink: User #1 deleted ir.model.data records with IDs: [144259]
2025-05-27 05:58:59,688 1131 INFO odoo16 odoo.models.unlink: User #1 deleted ir.model.fields records with IDs: [15099]
2025-05-27 05:58:59,689 1131 INFO odoo16 odoo.addons.base.models.ir_model: Deleting 15098@ir.model.fields (l10n_br_nfe.field_nfe_40_det_obsfisco__create_uid)
2025-05-27 05:58:59,735 1131 INFO odoo16 odoo.models.unlink: User #1 deleted ir.model.data records with IDs: [144257]
2025-05-27 05:58:59,735 1131 INFO odoo16 odoo.models.unlink: User #1 deleted ir.model.fields records with IDs: [15098]
2025-05-27 05:58:59,736 1131 INFO odoo16 odoo.addons.base.models.ir_model: Deleting 15094@ir.model.fields (l10n_br_nfe.field_nfe_40_infadic_obsfisco__write_date)
2025-05-27 05:58:59,853 1131 INFO odoo16 odoo.models.unlink: User #1 deleted ir.model.data records with IDs: [144256]
2025-05-27 05:58:59,853 1131 INFO odoo16 odoo.models.unlink: User #1 deleted ir.model.fields records with IDs: [15094]
2025-05-27 05:58:59,854 1131 INFO odoo16 odoo.addons.base.models.ir_model: Deleting 15093@ir.model.fields (l10n_br_nfe.field_nfe_40_infadic_obsfisco__write_uid)
2025-05-27 05:58:59,903 1131 INFO odoo16 odoo.models.unlink: User #1 deleted ir.model.data records with IDs: [144255]
2025-05-27 05:58:59,903 1131 INFO odoo16 odoo.models.unlink: User #1 deleted ir.model.fields records with IDs: [15093]
2025-05-27 05:58:59,904 1131 INFO odoo16 odoo.addons.base.models.ir_model: Deleting 15092@ir.model.fields (l10n_br_nfe.field_nfe_40_infadic_obsfisco__create_date)
2025-05-27 05:58:59,949 1131 INFO odoo16 odoo.models.unlink: User #1 deleted ir.model.data records with IDs: [144254]
2025-05-27 05:58:59,949 1131 INFO odoo16 odoo.models.unlink: User #1 deleted ir.model.fields records with IDs: [15092]
2025-05-27 05:58:59,950 1131 INFO odoo16 odoo.addons.base.models.ir_model: Deleting 15091@ir.model.fields (l10n_br_nfe.field_nfe_40_infadic_obsfisco__create_uid)
2025-05-27 05:58:59,985 1131 INFO odoo16 odoo.models.unlink: User #1 deleted ir.model.data records with IDs: [144253]
2025-05-27 05:58:59,986 1131 INFO odoo16 odoo.models.unlink: User #1 deleted ir.model.fields records with IDs: [15091]
2025-05-27 05:58:59,987 1131 INFO odoo16 odoo.addons.base.models.ir_model: Deleting 15087@ir.model.fields (l10n_br_nfe.field_nfe_40_detexport__write_date)
2025-05-27 05:59:00,045 1131 INFO odoo16 odoo.models.unlink: User #1 deleted ir.model.data records with IDs: [144252]
2025-05-27 05:59:00,045 1131 INFO odoo16 odoo.models.unlink: User #1 deleted ir.model.fields records with IDs: [15087]
2025-05-27 05:59:00,046 1131 INFO odoo16 odoo.addons.base.models.ir_model: Deleting 15086@ir.model.fields (l10n_br_nfe.field_nfe_40_detexport__write_uid)
2025-05-27 05:59:00,092 1131 INFO odoo16 odoo.models.unlink: User #1 deleted ir.model.data records with IDs: [144251]
2025-05-27 05:59:00,093 1131 INFO odoo16 odoo.models.unlink: User #1 deleted ir.model.fields records with IDs: [15086]
2025-05-27 05:59:00,093 1131 INFO odoo16 odoo.addons.base.models.ir_model: Deleting 15085@ir.model.fields (l10n_br_nfe.field_nfe_40_detexport__create_date)
2025-05-27 05:59:00,219 1131 INFO odoo16 odoo.models.unlink: User #1 deleted ir.model.data records with IDs: [144250]
```

Isso é porque os framework spec_driven_model tornou concreto alguns mixins abstractos do esquema da NFe que não foram injectados dentro de modelos concretos existentes. So que no init_models do Odoo, o Odoo criou registros ir.model.data pros "MAGIC FIELDS", esses campos do framework. Mas no proximo update, o Odoo vai estranhar que esses registros ir.model.data não batem com modelos que parecem apenas abstratos (até o _register_hook do spec.mixin que so vai acontecer depois) e começa a detonar os registros ir.model.data e os campos relacionados antes de re-cria-los. Isso demora tempo e polui os logs, não ta legal. O que eu fiz agora é simplesmente remover os registros ir.model.data que o init_models criou (já que parece difícil impedir que sejam criados). E assim os updates seguintes são suave sem essa dança dos delete toda.