### PR TITLE
[14.0][IMP] l10n_br_fiscal: fiscal doc VAT specification

### DIFF
--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -234,7 +234,16 @@ class Document(models.Model):
 
     partner_cnpj_cpf = fields.Char(
         string="CNPJ",
-        related="partner_id.cnpj_cpf",
+        compute="_compute_partner_cnpj_cpf",
+        store=True,
+    )
+
+    has_vat_specification = fields.Boolean(
+        string="Has VAT Specification",
+        default=False,
+        help="Indicates whether this fiscal document includes a specific "
+        "VAT (CNPJ/CPF) identification that must be preserved — "
+        "commonly known in Brazil as 'CPF na nota'.",
     )
 
     partner_inscr_est = fields.Char(
@@ -561,6 +570,16 @@ class Document(models.Model):
     )
     def _compute_amount(self):
         return super()._compute_amount()
+
+    @api.depends("partner_id", "has_vat_specification")
+    def _compute_partner_cnpj_cpf(self):
+        for record in self:
+            if record.partner_id and not record.has_vat_specification:
+                record.partner_cnpj_cpf = record.partner_id.cnpj_cpf
+            elif not record.partner_id:
+                record.partner_cnpj_cpf = False
+            # if record.has_vat_specification is True, keep current value
+            # (no assignment needed as the field retains its current value)
 
     def unlink(self):
         forbidden_states_unlink = [

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -335,12 +335,16 @@
             <page name="partners" string="Partners">
               <group name="partner">
                 <field name="partner_id" />
+                <field name="has_vat_specification" />
               </group>
               <group>
                 <group name="partner_left">
                   <field name="partner_legal_name" readonly="1" />
                   <field name="partner_name" readonly="1" />
-                  <field name="partner_cnpj_cpf" readonly="1" />
+                  <field
+                                        name="partner_cnpj_cpf"
+                                        attrs="{'readonly': [('has_vat_specification', '=', False)]}"
+                                    />
                   <field name="partner_inscr_est" readonly="1" />
                   <field name="partner_ind_ie_dest" readonly="1" />
                   <field name="partner_street" readonly="1" />


### PR DESCRIPTION
## Objetivo

Permitir a configuração manual do campo partner_cnpj_cpf no documento fiscal, visando eventualmente cobrir todo o fluxo de "CPF na nota?".

### Notas

os booleans `has_vat_specification` e `is_anonymous_consumer` passariam a descrever os seguintes casos respectivamente: consumidor não identificado mas com CPF na nota; consumidor anônimo com omissão da tag `<dest>`

Vou abrir um segundo PR pra manipular a NFe e o condicionamento dessa tag `<dest>`

### Utilização

Ao marcar o bool `has_vat_specification`, é possível alterar manualmente o valor do `partner_cnpj_cpf`:
![image](https://github.com/user-attachments/assets/eb751bb8-e926-4530-a6da-600c8fa8494b)
