### PR TITLE
[16.0][WIP] Preço de custo nas entradas e custo médio

### DIFF
--- a/l10n_br_fiscal/constants/icms.py
+++ b/l10n_br_fiscal/constants/icms.py
@@ -54,6 +54,13 @@ ICMS_ORIGIN_TAX_IMPORTED = ["1", "2", "3", "8"]
 ICMS_CST = ["00", "10", "20", "30", "40", "41", "50", "51", "60", "70", "90"]
 
 
+ICMS_CST_IN_WITH_CREDIT = [
+    "00",  # Tributada integralmente
+    "10",  # Tributada e com cobrança do ICMS por substituição tributária
+    "20",  # Com redução de base de cálculo
+]
+
+
 ICMS_BASE_TYPE = [
     ("0", "Margem Valor Agregado (%)"),
     ("1", "Pauta (valor)"),

--- a/l10n_br_fiscal/constants/ipi.py
+++ b/l10n_br_fiscal/constants/ipi.py
@@ -25,6 +25,11 @@ CST_IPI_OUT_IN = {
     "99": "49",
 }
 
+IPI_CST_IN_WITH_CREDIT = [
+    "00",  # Tributada integralmente
+    "49",  # Outras
+]
+
 
 IPI_GUIDELINE_GROUP = [
     ("imunidade", "Imunidade"),

--- a/l10n_br_fiscal/constants/pis_cofins.py
+++ b/l10n_br_fiscal/constants/pis_cofins.py
@@ -27,12 +27,32 @@ CST_PIS_IN = [
     "99",
 ]
 
+PIS_CST_IN_WITH_CREDIT = [
+    "50",
+    "51",
+    "52",
+    "53",
+    "54",
+    "55",
+    "56",
+    "60",
+    "61",
+    "62",
+    "63",
+    "64",
+    "65",
+    "66",
+    "67",
+]
+
 CST_PIS_OUT = ["01", "02", "03", "04", "05", "06", "07", "08", "09", "49"]
 
 CST_PIS_NO_TAXED = ["04", "06", "07", "08", "09", "71", "72", "73", "74"]
 
 # Some CST for PIS and COFINS
 CST_COFINS_IN = CST_PIS_IN
+
+COFINS_CST_IN_WITH_CREDIT = PIS_CST_IN_WITH_CREDIT
 
 CST_COFINS_OUT = CST_PIS_OUT
 

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -192,6 +192,8 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         string="Fiscal Taxes",
     )
 
+    cost_unit = fields.Float(digits="Product Price")
+
     amount_fiscal = fields.Monetary(
         compute="_compute_fiscal_amounts",
     )

--- a/l10n_br_fiscal/models/document_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_line_mixin_methods.py
@@ -292,6 +292,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 ),
                 "amount_tax_withholding": compute_result.get("amount_withholding", 0.0),
                 "estimate_tax": compute_result.get("estimate_tax", 0.0),
+                "cost_unit": compute_result.get("cost_unit", 0.0),
             }
             to_update.update(line._prepare_tax_fields(compute_result))
 

--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -17,10 +17,13 @@ from ..constants.fiscal import (
     TAX_BASE_TYPE,
     TAX_BASE_TYPE_PERCENT,
     TAX_BASE_TYPE_VALUE,
+    TAX_FRAMEWORK_NORMAL,
+    TAX_FRAMEWORK_SIMPLES_ALL,
 )
 from ..constants.icms import (
     ICMS_BASE_TYPE,
     ICMS_BASE_TYPE_DEFAULT,
+    ICMS_CST_IN_WITH_CREDIT,
     ICMS_CST_RELIEF,
     ICMS_DIFAL_DOUBLE_BASE,
     ICMS_DIFAL_PARTITION,
@@ -30,6 +33,11 @@ from ..constants.icms import (
     ICMS_ST_BASE_TYPE,
     ICMS_ST_BASE_TYPE_DEFAULT,
     ICSM_CST_CSOSN_ST_BASE,
+)
+from ..constants.ipi import IPI_CST_IN_WITH_CREDIT
+from ..constants.pis_cofins import (
+    COFINS_CST_IN_WITH_CREDIT,
+    PIS_CST_IN_WITH_CREDIT,
 )
 
 TAX_DICT_VALUES = {
@@ -345,6 +353,75 @@ class Tax(models.Model):
                     )
 
         return amount_estimate_tax
+
+    @api.model
+    def _compute_cost_unit(self, taxes_dict, **kwargs):
+        """
+        Compute the cost unit based on the fiscal price and quantity.
+        """
+        company = kwargs.get("company")
+        product = kwargs.get("product")
+        fiscal_price = kwargs.get("fiscal_price")
+        fiscal_quantity = kwargs.get("fiscal_quantity")
+        op_line = kwargs.get("operation_line")
+        currency = kwargs.get("currency", company.currency_id)
+        discount_value = kwargs.get("discount_value", 0.00)
+        insurance_value = kwargs.get("insurance_value", 0.00)
+        freight_value = kwargs.get("freight_value", 0.00)
+        other_value = kwargs.get("other_value", 0.00)
+        ii_customhouse_charges = kwargs.get("ii_customhouse_charges", 0.00)
+        ii_iof_value = kwargs.get("ii_iof_value", 0.00)
+        cost_unit = 0.00
+        if not op_line:
+            fiscal_operation_type = FISCAL_OUT
+        else:
+            fiscal_operation_type = op_line.fiscal_operation_type
+
+        if fiscal_operation_type == FISCAL_OUT:
+            cost_unit = product.standard_price
+
+        if fiscal_operation_type == FISCAL_IN:
+            amount_subtotal = currency.round(fiscal_price * fiscal_quantity)
+            amount_subtotal += sum([freight_value, insurance_value, other_value])
+            amount_subtotal -= sum([discount_value])
+
+            if company.tax_framework == TAX_FRAMEWORK_NORMAL:
+                tax_dict_ii = taxes_dict.get("ii", {})
+                amount_subtotal += kwargs.get("ii_customhouse_charges", 0.00)
+                amount_subtotal += kwargs.get("ii_iof_value", 0.00)
+                amount_subtotal += tax_dict_ii.get("tax_value", 0.00)
+
+                tax_dict_pis = taxes_dict.get("pis", {})
+                if tax_dict_pis.get("cst_id"):
+                    if tax_dict_pis.get("cst_id").code in PIS_CST_IN_WITH_CREDIT:
+                        amount_subtotal -= tax_dict_pis.get("tax_value", 0.00)
+
+                tax_dict_cofins = taxes_dict.get("cofins", {})
+                if tax_dict_cofins.get("cst_id"):
+                    if tax_dict_cofins.get("cst_id").code in COFINS_CST_IN_WITH_CREDIT:
+                        amount_subtotal -= tax_dict_cofins.get("tax_value", 0.00)
+
+                tax_dict_icms = taxes_dict.get("icms", {})
+                if tax_dict_icms.get("cst_id"):
+                    if tax_dict_icms.get("cst_id").code in ICMS_CST_IN_WITH_CREDIT:
+                        amount_subtotal -= tax_dict_icms.get("tax_value", 0.00)
+
+                # caso não seja industria, o valor do IPI é adicionado ao custo unitário
+                if not company.is_industry:
+                    tax_dict_ipi = taxes_dict.get("ipi", {})
+                    if tax_dict_ipi.get("cst_id"):
+                        if tax_dict_ipi.get("cst_id").code in IPI_CST_IN_WITH_CREDIT:
+                            amount_subtotal += tax_dict_ipi.get("tax_value", 0.00)
+
+            if company.tax_framework in TAX_FRAMEWORK_SIMPLES_ALL:
+                tax_dict_icmssn = taxes_dict.get("icmssn", {})
+                if tax_dict_icmssn.get("cst_id"):
+                    if tax_dict_icmssn.get("cst_id").code in ICMS_SN_CST_WITH_CREDIT:
+                        amount_subtotal -= tax_dict_icmssn.get("tax_value", 0.00)
+
+            cost_unit = amount_subtotal / fiscal_quantity
+
+        return cost_unit
 
     @api.model
     def _compute_icms(self, tax, taxes_dict, **kwargs):
@@ -722,6 +799,7 @@ class Tax(models.Model):
 
         # Estimate taxes
         result_amounts["estimate_tax"] = self._compute_estimate_taxes(**kwargs)
+        result_amounts["cost_unit"] = self._compute_cost_unit(taxes, **kwargs)
         result_amounts["taxes"] = taxes
         return result_amounts
 

--- a/l10n_br_purchase_stock/models/stock_move.py
+++ b/l10n_br_purchase_stock/models/stock_move.py
@@ -18,3 +18,10 @@ class StockMove(models.Model):
                 result = self.purchase_line_id.price_unit
 
         return result
+
+    def _get_price_unit(self):
+        """Returns the unit price for the move"""
+        self.ensure_one()
+        price_unit = super()._get_price_unit()
+        price_unit = self.cost_unit
+        return price_unit

--- a/l10n_br_stock_account/models/stock_move.py
+++ b/l10n_br_stock_account/models/stock_move.py
@@ -298,3 +298,11 @@ class StockMove(models.Model):
             )
 
         return partner
+
+
+class StockValuationLayer(models.Model):
+    """Stock Valuation Layer"""
+
+    _inherit = "stock.valuation.layer"
+
+    unit_cost = fields.Float(digits="Product Price")


### PR DESCRIPTION
Olá pessoal,

Esse PR implementa o calculo de custos nas entradas de estoque para atualizar o valor de custo unitário de acordo com o pronunciamento técnico [CPC 16](https://www.cpc.org.br/CPC/Documentos-Emitidos/Pronunciamentos/Pronunciamento?Id=47) do [Comitê de Pronunciamento Técnico](https://www.cpc.org.br/) que é equivalente ao [IAS 2 IASB](https://www.ifrs.org/issued-standards/list-of-standards/ias-2-inventories/)

No objeto Fiscal Tax foi implementado o método _compute_cost_unit que retorna o valor do custo unitário e também foi criado o campo cost_unit do objeto Fiscal Document Line Mixin

# TODO

- [ ] Implementação de Testes
- [ ] Mover a mudança da precisão decimal do unit_cost do objeto stock.valuation.layer para o repositório genérico da OCA
- [ ] Mover a mudança no l10n_br_purchase_stock para o stock_account