### PR TITLE
[16.0][REF] l10n_br_account: robust company in tests/AGPL glitch

### DIFF
--- a/l10n_br_account/tests/test_account_move_lc.py
+++ b/l10n_br_account/tests/test_account_move_lc.py
@@ -162,7 +162,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "name": "COFINS",
             "product_id": False,
             "account_id": self.env["account.account"]
-            .search([("name", "=", "COFINS a Recolher")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "COFINS a Recolher"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
@@ -173,7 +179,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "COFINS Saida")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "COFINS Saida"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": -30.0,
@@ -186,7 +198,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "name": "ICMS",
             "product_id": False,
             "account_id": self.env["account.account"]
-            .search([("name", "=", "ICMS a Recolher")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "ICMS a Recolher"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
@@ -197,7 +215,14 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "ICMS Saida")], order="id desc", limit=1)
+            .search(
+                [
+                    ("name", "=", "ICMS Saida"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                order="id desc",
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": -120.0,
@@ -218,7 +243,7 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
                 order="id ASC",
                 limit=1,
             )
-            .id,  # TODO find our why this complex domain is required for IPI
+            .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
             "quantity": False,
@@ -241,7 +266,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "name": "PIS",
             "product_id": False,
             "account_id": self.env["account.account"]
-            .search([("name", "=", "PIS a Recolher")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "PIS a Recolher"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
@@ -331,7 +362,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "name": "COFINS",
             "product_id": False,
             "account_id": self.env["account.account"]
-            .search([("name", "=", "COFINS a Recolher")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "COFINS a Recolher"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
@@ -342,7 +379,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "COFINS Saida")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "COFINS Saida"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": -30.0,
@@ -355,7 +398,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "name": "ICMS",
             "product_id": False,
             "account_id": self.env["account.account"]
-            .search([("name", "=", "ICMS a Recolher")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "ICMS a Recolher"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
@@ -366,7 +415,14 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "ICMS Saida")], order="id desc", limit=1)
+            .search(
+                [
+                    ("name", "=", "ICMS Saida"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                order="id desc",
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": -88.12,
@@ -387,7 +443,7 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
                 order="id ASC",
                 limit=1,
             )
-            .id,  # TODO find our why this complex domain is required for IPI
+            .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
             "quantity": 0.0,
@@ -410,7 +466,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "name": "PIS",
             "product_id": False,
             "account_id": self.env["account.account"]
-            .search([("name", "=", "PIS a Recolher")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "PIS a Recolher"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
@@ -421,7 +483,14 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "PIS Saida")], order="id desc", limit=1)
+            .search(
+                [
+                    ("name", "=", "PIS Saida"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                order="id desc",
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": -6.5,
@@ -505,7 +574,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "name": "COFINS",
             "product_id": False,
             "account_id": self.env["account.account"]
-            .search([("name", "=", "COFINS a Recolher")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "COFINS a Recolher"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
@@ -516,7 +591,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "COFINS Saida")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "COFINS Saida"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": -30.0,
@@ -529,7 +610,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "name": "ICMS",
             "product_id": False,
             "account_id": self.env["account.account"]
-            .search([("name", "=", "ICMS a Recolher")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "ICMS a Recolher"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
@@ -540,7 +627,14 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "ICMS Saida")], order="id desc", limit=1)
+            .search(
+                [
+                    ("name", "=", "ICMS Saida"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                order="id desc",
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": -88.12,
@@ -561,7 +655,7 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
                 order="id ASC",
                 limit=1,
             )
-            .id,  # TODO find our why this complex domain is required for IPI
+            .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
             "quantity": 0.0,
@@ -571,7 +665,14 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "IPI Saída")], order="id desc", limit=1)
+            .search(
+                [
+                    ("name", "=", "IPI Saída"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                order="id desc",
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": -32.5,
@@ -584,7 +685,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "name": "PIS",
             "product_id": False,
             "account_id": self.env["account.account"]
-            .search([("name", "=", "PIS a Recolher")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "PIS a Recolher"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
@@ -595,7 +702,14 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "PIS Saida")], order="id desc", limit=1)
+            .search(
+                [
+                    ("name", "=", "PIS Saida"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                order="id desc",
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": -6.5,
@@ -676,7 +790,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "name": "COFINS",
             "product_id": False,
             "account_id": self.env["account.account"]
-            .search([("name", "=", "COFINS a Recolher")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "COFINS a Recolher"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
@@ -687,7 +807,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "COFINS Saida")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "COFINS Saida"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": -30.0,
@@ -700,7 +826,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "name": "ICMS",
             "product_id": False,
             "account_id": self.env["account.account"]
-            .search([("name", "=", "ICMS a Recolher")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "ICMS a Recolher"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
@@ -711,7 +843,14 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "ICMS Saida")], order="id desc", limit=1)
+            .search(
+                [
+                    ("name", "=", "ICMS Saida"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                order="id desc",
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": -120.0,
@@ -732,7 +871,7 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
                 order="id ASC",
                 limit=1,
             )
-            .id,  # TODO find our why this complex domain is required for IPI
+            .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
             "quantity": False,
@@ -742,7 +881,14 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "IPI Saída")], order="id desc", limit=1)
+            .search(
+                [
+                    ("name", "=", "IPI Saída"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                order="id desc",
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": -32.5,
@@ -755,7 +901,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "name": "PIS",
             "product_id": False,
             "account_id": self.env["account.account"]
-            .search([("name", "=", "PIS a Recolher")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "PIS a Recolher"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
@@ -766,7 +918,14 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "PIS Saida")], order="id desc", limit=1)
+            .search(
+                [
+                    ("name", "=", "PIS Saida"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                order="id desc",
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": -6.5,
@@ -850,7 +1009,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "name": "COFINS",
             "product_id": False,
             "account_id": self.env["account.account"]
-            .search([("name", "=", "COFINS a Compensar")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "COFINS a Compensar"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
@@ -861,7 +1026,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "COFINS Entrada")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "COFINS Entrada"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": 30.0,
@@ -874,7 +1045,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "name": "COFINS",
             "product_id": False,
             "account_id": self.env["account.account"]
-            .search([("name", "=", "COFINS s/ Vendas")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "COFINS s/ Vendas"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
@@ -886,7 +1063,12 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
             .search(
-                [("name", "=", "COFINS Entrada Dedutível")], order="id desc", limit=1
+                [
+                    ("name", "=", "COFINS Entrada Dedutível"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                order="id desc",
+                limit=1,
             )
             .id,
             "currency_id": self.company_data["currency"].id,
@@ -900,7 +1082,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "name": "ICMS",
             "product_id": False,
             "account_id": self.env["account.account"]
-            .search([("name", "=", "ICMS a Compensar")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "ICMS a Compensar"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
@@ -911,7 +1099,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "ICMS Entrada")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "ICMS Entrada"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": 120.0,
@@ -924,7 +1118,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "name": "ICMS",
             "product_id": False,
             "account_id": self.env["account.account"]
-            .search([("name", "=", "ICMS s/ Vendas")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "ICMS s/ Vendas"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
@@ -935,7 +1135,14 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "ICMS Entrada Dedutível")], order="id desc", limit=1)
+            .search(
+                [
+                    ("name", "=", "ICMS Entrada Dedutível"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                order="id desc",
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": -120.0,
@@ -948,7 +1155,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "name": "IPI",
             "product_id": False,
             "account_id": self.env["account.account"]
-            .search([("name", "=", "IPI a Compensar")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "IPI a Compensar"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
@@ -959,7 +1172,14 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "IPI Entrada")], order="id desc", limit=1)
+            .search(
+                [
+                    ("name", "=", "IPI Entrada"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                order="id desc",
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": 32.5,
@@ -972,7 +1192,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "name": "IPI",
             "product_id": False,
             "account_id": self.env["account.account"]
-            .search([("name", "=", "IPI s/ Vendas")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "IPI s/ Vendas"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
@@ -983,7 +1209,14 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "IPI Entrada Dedutível")], order="id desc", limit=1)
+            .search(
+                [
+                    ("name", "=", "IPI Entrada Dedutível"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                order="id desc",
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": -32.5,
@@ -996,7 +1229,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "name": "PIS",
             "product_id": False,
             "account_id": self.env["account.account"]
-            .search([("name", "=", "PIS a Compensar")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "PIS a Compensar"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
@@ -1007,7 +1246,14 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "PIS Entrada")], order="id desc", limit=1)
+            .search(
+                [
+                    ("name", "=", "PIS Entrada"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                order="id desc",
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": 6.5,
@@ -1020,7 +1266,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "name": "PIS",
             "product_id": False,
             "account_id": self.env["account.account"]
-            .search([("name", "=", "PIS s/ Vendas")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "PIS s/ Vendas"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
@@ -1031,7 +1283,14 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "PIS Entrada Dedutível")], order="id desc", limit=1)
+            .search(
+                [
+                    ("name", "=", "PIS Entrada Dedutível"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                order="id desc",
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": -6.5,
@@ -1135,7 +1394,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "COFINS WH Saida")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "COFINS WH Saida"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": 30.0,
@@ -1148,7 +1413,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "name": "ICMS",
             "product_id": False,
             "account_id": self.env["account.account"]
-            .search([("name", "=", "ICMS a Recolher")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "ICMS a Recolher"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
@@ -1159,7 +1430,14 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "ICMS Saida")], order="id desc", limit=1)
+            .search(
+                [
+                    ("name", "=", "ICMS Saida"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                order="id desc",
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": -120.0,
@@ -1180,7 +1458,7 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
                 order="id ASC",
                 limit=1,
             )
-            .id,  # TODO find our why this complex domain is required for IPI
+            .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
             "quantity": False,
@@ -1190,7 +1468,14 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "IPI Saída")], order="id desc", limit=1)
+            .search(
+                [
+                    ("name", "=", "IPI Saída"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                order="id desc",
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": -32.5,
@@ -1212,7 +1497,14 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "PIS WH Saida")], order="id desc", limit=1)
+            .search(
+                [
+                    ("name", "=", "PIS WH Saida"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                order="id desc",
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": 6.5,
@@ -1300,7 +1592,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "COFINS WH Saida")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "COFINS WH Saida"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": 30.0,
@@ -1313,7 +1611,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "name": "ICMS",
             "product_id": False,
             "account_id": self.env["account.account"]
-            .search([("name", "=", "ICMS a Recolher")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "ICMS a Recolher"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
@@ -1324,7 +1628,14 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "ICMS Saida")], order="id desc", limit=1)
+            .search(
+                [
+                    ("name", "=", "ICMS Saida"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                order="id desc",
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": -120.0,
@@ -1345,7 +1656,7 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
                 order="id ASC",
                 limit=1,
             )
-            .id,  # TODO find our why this complex domain is required for IPI
+            .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
             "quantity": False,
@@ -1355,7 +1666,14 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "IPI Saída")], order="id desc", limit=1)
+            .search(
+                [
+                    ("name", "=", "IPI Saída"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                order="id desc",
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": -32.5,
@@ -1377,7 +1695,14 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "PIS WH Saida")], order="id desc", limit=1)
+            .search(
+                [
+                    ("name", "=", "PIS WH Saida"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                order="id desc",
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": 6.5,
@@ -1459,7 +1784,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "name": "COFINS RET",
             "product_id": False,
             "account_id": self.env["account.account"]
-            .search([("name", "=", "COFINS a Recolher")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "COFINS a Recolher"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
@@ -1470,7 +1801,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "COFINS WH Entrada")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "COFINS WH Entrada"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": -30.0,
@@ -1483,7 +1820,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "name": "ICMS",
             "product_id": False,
             "account_id": self.env["account.account"]
-            .search([("name", "=", "ICMS a Compensar")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "ICMS a Compensar"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
@@ -1494,7 +1837,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "ICMS Entrada")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "ICMS Entrada"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": 120.0,
@@ -1507,7 +1856,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "name": "ICMS",
             "product_id": False,
             "account_id": self.env["account.account"]
-            .search([("name", "=", "ICMS s/ Vendas")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "ICMS s/ Vendas"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
@@ -1518,7 +1873,14 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "ICMS Entrada Dedutível")], order="id desc", limit=1)
+            .search(
+                [
+                    ("name", "=", "ICMS Entrada Dedutível"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                order="id desc",
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": -120.0,
@@ -1531,7 +1893,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "name": "IPI",
             "product_id": False,
             "account_id": self.env["account.account"]
-            .search([("name", "=", "IPI a Compensar")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "IPI a Compensar"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
@@ -1542,7 +1910,14 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "IPI Entrada")], order="id desc", limit=1)
+            .search(
+                [
+                    ("name", "=", "IPI Entrada"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                order="id desc",
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": 32.5,
@@ -1555,7 +1930,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "name": "IPI",
             "product_id": False,
             "account_id": self.env["account.account"]
-            .search([("name", "=", "IPI s/ Vendas")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "IPI s/ Vendas"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
@@ -1566,7 +1947,14 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "IPI Entrada Dedutível")], order="id desc", limit=1)
+            .search(
+                [
+                    ("name", "=", "IPI Entrada Dedutível"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                order="id desc",
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": -32.5,
@@ -1579,7 +1967,13 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "name": "PIS RET",
             "product_id": False,
             "account_id": self.env["account.account"]
-            .search([("name", "=", "PIS a Recolher")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "PIS a Recolher"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
@@ -1590,7 +1984,14 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "PIS WH Entrada")], order="id desc", limit=1)
+            .search(
+                [
+                    ("name", "=", "PIS WH Entrada"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                order="id desc",
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": -6.5,

--- a/l10n_br_account/tests/test_account_move_sn.py
+++ b/l10n_br_account/tests/test_account_move_sn.py
@@ -124,7 +124,13 @@ class AccountMoveSimpleNacional(AccountMoveBRCommon):
             "name": "ICMS - Simples Nacional",
             "product_id": False,
             "account_id": self.env["account.account"]
-            .search([("name", "=", "ICMS a Recolher")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "ICMS a Recolher"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "partner_id": self.partner_a.id,
             "product_uom_id": False,
@@ -135,7 +141,13 @@ class AccountMoveSimpleNacional(AccountMoveBRCommon):
             "price_total": 0.0,
             "tax_ids": [],
             "tax_line_id": self.env["account.tax"]
-            .search([("name", "=", "ICMS SN Saida")], order="id DESC", limit=1)
+            .search(
+                [
+                    ("name", "=", "ICMS SN Saida"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
             .id,
             "currency_id": self.company_data["currency"].id,
             "amount_currency": -27.0,

--- a/l10n_br_account/tests/test_move_edition.py
+++ b/l10n_br_account/tests/test_move_edition.py
@@ -1,5 +1,5 @@
 # Copyright 2025-TODAY Akretion - Raphael Valyi <raphael.valyi@akretion.com>
-# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
 
 import logging
 from unittest import mock


### PR DESCRIPTION
PR extraído de #3804 para facilitar o review depois e visando a ajudar na migração para a 17.0/18.0.

Acontece que no framework de tests do modulo account do qual herdamos 2 empresas de testes são criadas: company_1 e company2: https://github.com/odoo/odoo/blob/16.0/addons/account/tests/common.py#L62 . Um plano de conta é criado para cada uma delas. Por isso não podemos buscar uma conta apenas pelo nome porque porque poderia pegar a conta da outra empresa. Por sorte com o order="desc" tava funcionando na maioria dos casos. Porem não funcionava para a conta de IPI e eu já tinha colocado uma busca pela empresa também com um comentário TODO de procurar saber porque isso era necessário. 1 ano depois temos a explicação e a limpeza.

Eu tb ajustei a licença do novo teste test_move_edition.py onde eu tinha colocado LGPL por engano quando eu criei o teste umas 2 semanas atrás.

O diff é grande mas é apenas um ajuste simples nos testes.

cc @marcelsavegnago @renatonlima @antoniospneto 