### PR TITLE
[14.0][FIX] l10n_br_cte: ensure XML is correctly saved in cteRecepcao

### DIFF
--- a/l10n_br_cte/models/document.py
+++ b/l10n_br_cte/models/document.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 import base64
+import gzip
 import logging
 import re
 import string
@@ -1485,10 +1486,11 @@ class CTe(spec_models.StackedModel):
                 process = None
                 for p in processador.processar_documento(edoc):
                     process = p
-                    if process.webservice == "cteRecepcaoLote":
-                        record.authorization_event_id._save_event_file(
-                            process.envio_xml, "xml"
-                        )
+                    if process.webservice in ["cteRecepcaoLote", "cteRecepcao"]:
+                        send_xml = gzip.decompress(
+                            base64.b64decode(process.envio_xml)
+                        ).decode("utf-8")
+                        record.authorization_event_id._save_event_file(send_xml, "xml")
 
             if process.resposta.cStat in LOTE_PROCESSADO + ["100"]:
                 record.update_status_cte(process)


### PR DESCRIPTION
This pull request introduces support for handling compressed XML data in the `_eletronic_document_send` method of the `l10n_br_cte` module. The most notable changes include importing the `gzip` library and adding logic to decompress XML data before saving it.

### Enhancements to XML processing:

* [`l10n_br_cte/models/document.py`](diffhunk://#diff-1829c5b205a5d8924ee13e415a82af38b8a84d7e36615d7a0680a66ce4c9cbc3R6): Added the `gzip` library to handle compressed data.
* [`l10n_br_cte/models/document.py`](diffhunk://#diff-1829c5b205a5d8924ee13e415a82af38b8a84d7e36615d7a0680a66ce4c9cbc3L1488-R1493): Updated the `_eletronic_document_send` method to check for an additional web service type (`cteRecepcao`) and added logic to decompress the base64-encoded XML data using `gzip` before saving it.