### PR TITLE
[14.0][IMP] l10n_br_nfse/l10n_br_nfse_focus: informações adicionais do Contribuinte e Fiscal

### DIFF
--- a/l10n_br_nfse/models/document.py
+++ b/l10n_br_nfse/models/document.py
@@ -270,6 +270,8 @@ class Document(models.Model):
             "carga_tributaria": self.amount_tax,
             "total_recebido": self.amount_price_gross,
             "carga_tributaria_estimada": self.amount_estimate_tax,
+            "customer_additional_data": self.customer_additional_data,
+            "fiscal_additional_data": self.fiscal_additional_data,
         }
 
     def convert_type_nfselib(self, class_object, object_filed, value):

--- a/l10n_br_nfse_focus/models/document.py
+++ b/l10n_br_nfse_focus/models/document.py
@@ -146,6 +146,9 @@ class FocusnfeNfse(models.AbstractModel):
             "natureza_operacao": rps_info.get("natureza_operacao"),
             "optante_simples_nacional": rps_info.get("optante_simples_nacional", False),
             "status": rps_info.get("status"),
+            "informacoes_adicionais_contribuinte": rps_info.get(
+                "customer_additional_data", False
+            ),
         }
         codigo_obra = rps_info.get("codigo_obra", False)
         art = rps_info.get("art", False)


### PR DESCRIPTION
cc @marcelsavegnago @WesleyOliveira98 

Esta alteração introduz o uso do campo `customer_additional_data` conforme orientações da Focus NFe, com o objetivo de viabilizar a emissão correta de NFS-e para o município de Caxias do Sul (RS).

A implementação segue a documentação oficial da Focus NFe: [Como emitir NFS-e em Caxias do Sul - API Focus NFe](https://focusnfe.com.br/blog/como-emitir-nfs-e-em-caxias-sul-rs-api-focus-nfe/), garantindo conformidade com os requisitos específicos dessa prefeitura.