### PR TITLE
[14.0][FIX] l10n_br_mdfe: fix mdfe view attrs

### DIFF
--- a/l10n_br_mdfe/views/document.xml
+++ b/l10n_br_mdfe/views/document.xml
@@ -196,16 +196,16 @@
                                         <field name="mdfe30_cInt" />
                                         <field
                                             name="mdfe30_placa"
-                                            attrs="{'required': [('mdfe_modal', '=', '1'), ('document_type', '=', ['58'])]}"
+                                            attrs="{'required': [('mdfe_modal', '=', '1'), ('document_type', '=', '58')]}"
                                         />
                                         <field name="mdfe30_RENAVAM" />
                                         <field
                                             name="mdfe30_tpCar"
-                                            attrs="{'required': [('mdfe_modal', '=', '1'), ('document_type', '=', ['58'])]}"
+                                            attrs="{'required': [('mdfe_modal', '=', '1'), ('document_type', '=', '58')]}"
                                         />
                                         <field
                                             name="mdfe30_tpRod"
-                                            attrs="{'required': [('mdfe_modal', '=', '1'), ('document_type', '=', ['58'])]}"
+                                            attrs="{'required': [('mdfe_modal', '=', '1'), ('document_type', '=', '58')]}"
                                         />
                                         <field name="rodo_vehicle_state_id" />
                                         <field
@@ -222,7 +222,7 @@
                                     <group>
                                         <field
                                             name="mdfe30_tara"
-                                            attrs="{'required': [('mdfe_modal', '=', '1'), ('document_type', '=', ['58'])]}"
+                                            attrs="{'required': [('mdfe_modal', '=', '1'), ('document_type', '=', '58')]}"
                                         />
                                         <field name="mdfe30_capKG" />
                                         <field name="mdfe30_capM3" />


### PR DESCRIPTION
Fix required domains in mdfe views by changing from `('document_type', '=', ['58'])` to `('document_type', '=', '58')`