### PR TITLE
[16.0][FIX] l10n_br_fiscal: fix redundant default currency warning

### DIFF
--- a/l10n_br_fiscal/models/document_mixin.py
+++ b/l10n_br_fiscal/models/document_mixin.py
@@ -128,7 +128,6 @@ class FiscalDocumentMixin(models.AbstractModel):
     currency_id = fields.Many2one(
         comodel_name="res.currency",
         string="Currency",
-        default=lambda self: self.env.company.currency_id,
     )
 
     amount_price_gross = fields.Monetary(

--- a/l10n_br_stock_account/models/stock_picking.py
+++ b/l10n_br_stock_account/models/stock_picking.py
@@ -31,6 +31,10 @@ class StockPicking(models.Model):
         store=True,
     )
 
+    currency_id = fields.Many2one(
+        default=lambda self: self.env.company.currency_id,
+    )
+
     def _get_amount_lines(self):
         """Get object lines instances used to compute fields"""
         return self.mapped("move_ids")
@@ -50,6 +54,7 @@ class StockPicking(models.Model):
         arch, view = super()._get_view(view_id, view_type, **options)
         if self.env.company.country_id.code == "BR":
             arch = self.env["stock.move"].inject_fiscal_fields(arch)
+
         return arch, view
 
     def _put_in_pack(self, move_line_ids, create_package_level=True):


### PR DESCRIPTION
o ORM dava warning porque os objetos sale.order, purchase.order e stock.picking já tinham um currency_id padrão então não podia re-definir um padrão no document_mixin. Pro stock.picking porem eu tive que botar um currency_id padrão para não dar bug nos testes.