### PR TITLE
[16.0][FIX] l10n_br_account_payment_brcobranca: Mensagem de Erro do BRCobranca na Geração do Arquivo CNAB

### DIFF
--- a/l10n_br_account_payment_brcobranca/models/account_payment_order.py
+++ b/l10n_br_account_payment_brcobranca/models/account_payment_order.py
@@ -12,7 +12,7 @@ import requests
 from erpbrasil.base import misc
 
 from odoo import _, models
-from odoo.exceptions import Warning as ValidationError
+from odoo.exceptions import ValidationError
 
 from ..constants.br_cobranca import (
     DICT_BRCOBRANCA_CNAB_TYPE,


### PR DESCRIPTION
Fix error mensage for generate Remessa File.

Na v16 a mensagem de erro da biblioteca BRCobranca para Gerar o Arquivo Remessa do CNAB passou a não ser mostrada de uma forma clara

![image](https://github.com/user-attachments/assets/0f11a4f4-41f3-4443-93e1-e5b8758d59ed)

![image](https://github.com/user-attachments/assets/ed796b1d-fe50-4e94-98c3-2e0460c6df59)

Isso acontece devido a forma que o import era feito, algo simples, com esse PR a mensagem volta a ser mostrada como na v14 de uma forma mais clara

![image](https://github.com/user-attachments/assets/1935d90e-705d-4a7c-a64e-411770762ee1)


Esse PR é uma extração do PR https://github.com/OCA/l10n-brazil/pull/3793 com objetivo de facilitar a Revisão.

Importante notar que hoje isso é um **ERRO** simples de ser resolvido, esse PR tem uma linha de alteração e resolve esse erro.

cc @OCA/local-brazil-maintainers 