### PR TITLE
[16.0][FIX] l10n_br_nfe: Import Warning deprecated

### DIFF
--- a/l10n_br_nfe/wizards/l10n_br_account_nfe_export_invoice.py
+++ b/l10n_br_nfe/wizards/l10n_br_account_nfe_export_invoice.py
@@ -7,7 +7,7 @@ import time
 from datetime import datetime
 
 from odoo import _, fields, models
-from odoo.exceptions import Warning as UserError
+from odoo.exceptions import UserError
 
 
 class L10nBrAccountNfeExportInvoice(models.TransientModel):


### PR DESCRIPTION
Import Warning deprecated.

Basicamente parece que o **import Warning as** foi descontinuado, mas sem gerar nenhum erro diretamente, na v14 isso funcionava mas na v16 a mensagem de erro acaba sendo o LOG na tela, como pode ser visto no PR  https://github.com/OCA/l10n-brazil/pull/3847 nesse caso outro modulo, correção veio da Revisão do @antoniospneto nesse outro PR.

cc @OCA/local-brazil-maintainers 