### PR TITLE
[16.0][FIX] l10n_br_fiscal: _onchange_fiscal_operation_id

### DIFF
--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -163,6 +163,9 @@ class Document(models.Model):
         selection=EDOC_PURPOSE,
         string="Finalidade",
         default=EDOC_PURPOSE_NORMAL,
+        compute="_compute_edoc_purpose",
+        store=True,
+        precompute=True,
     )
 
     document_type = fields.Char(
@@ -665,13 +668,14 @@ class Document(models.Model):
         # see https://github.com/OCA/l10n-brazil/pull/3272
         pass
 
+    @api.depends("fiscal_operation_id")
+    def _compute_edoc_purpose(self):
+        for record in self:
+            record.edoc_purpose = record.fiscal_operation_id.edoc_purpose
+
     @api.onchange("fiscal_operation_id")
     def _onchange_fiscal_operation_id(self):
         result = super()._onchange_fiscal_operation_id()
-        if self.fiscal_operation_id:
-            self.fiscal_operation_type = self.fiscal_operation_id.fiscal_operation_type
-            self.edoc_purpose = self.fiscal_operation_id.edoc_purpose
-
         if self.issuer == DOCUMENT_ISSUER_COMPANY and not self.document_type_id:
             self.document_type_id = self.company_id.document_type_id
 

--- a/l10n_br_fiscal/models/document_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_mixin_methods.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2019  Renato Lima - Akretion <renato.lima@akretion.com.br>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import Command, api, models
+from odoo import api, models
 
 from ..constants.fiscal import (
     COMMENT_TYPE_COMMERCIAL,
@@ -61,29 +61,9 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
     def _onchange_fiscal_operation_id(self):
         if self.fiscal_operation_id:
             self.fiscal_operation_type = self.fiscal_operation_id.fiscal_operation_type
-            self.edoc_purpose = self.fiscal_operation_id.edoc_purpose
 
             if self.issuer == DOCUMENT_ISSUER_COMPANY and not self.document_type_id:
                 self.document_type_id = self.company_id.document_type_id
-
-            subsequent_documents = [Command.set({})]
-            for subsequent_id in self.fiscal_operation_id.mapped(
-                "operation_subsequent_ids"
-            ):
-                subsequent_documents.append(
-                    (
-                        0,
-                        0,
-                        {
-                            "source_document_id": self.id,
-                            "subsequent_operation_id": subsequent_id.id,
-                            "fiscal_operation_id": (
-                                subsequent_id.subsequent_operation_id.id
-                            ),
-                        },
-                    )
-                )
-            self.document_subsequent_ids = subsequent_documents
 
     def _get_amount_lines(self):
         """


### PR DESCRIPTION
Ao executar o onchange do campo Operação Fiscal no objeto stock.picking está sendo gerado um erro:

```
Traceback (most recent call last):
  File "/odoo/src/odoo/http.py", line 1658, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/odoo/src/odoo/service/model.py", line 152, in retrying
    result = func()
  File "/odoo/src/odoo/http.py", line 1686, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/odoo/src/odoo/http.py", line 1890, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/odoo/src/odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "/odoo/src/odoo/http.py", line 734, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/odoo/src/addons/web/controllers/dataset.py", line 43, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/odoo/src/addons/web/controllers/dataset.py", line 34, in _call_kw
    return call_kw(Model, method, args, kwargs)
  File "/odoo/src/odoo/api.py", line 484, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/odoo/src/odoo/api.py", line 469, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/odoo/src/odoo/models.py", line 6667, in onchange
    record._onchange_eval(name, field_onchange[name], result)
  File "/odoo/src/odoo/models.py", line 6378, in _onchange_eval
    method_res = method(self)
  File "/odoo/external-src/l10n-brazil/l10n_br_fiscal/models/document_mixin_methods.py", line 64, in _onchange_fiscal_operation_id
    self.edoc_purpose = self.fiscal_operation_id.edoc_purpose
AttributeError: 'stock.picking' object has no attribute 'edoc_purpose'

The above server error caused the following client error:
null
```

Isso acontece porque o objeto stock.picking invoca o método _onchange_fiscal_operation_id do l10n_br_fiscal.document.mixin.methods, porém os campos edoc_purpose e operation_subsequent_ids não estão presentes no l10n_br_fiscal.document_mixin só no l10n_br_fiscal.document

Esse PR edita o método _onchange_fiscal_operation_id removendo os campos não presentes no mixin.

Eu olhei os módulos l10n_br_sale e l10n_br_purchase, nesses módulos o erro não acontece porque eles editam o método _onchange_fiscal_operation_id sem chama o super.