### PR TITLE
[16.0][FIX] l10n_br_stock: Command.link fix

### DIFF
--- a/l10n_br_stock/demo/res_users_demo.xml
+++ b/l10n_br_stock/demo/res_users_demo.xml
@@ -4,14 +4,14 @@
     <record id="l10n_br_base.user_demo_simples" model="res.users">
         <field
             name="groups_id"
-            eval="[Command.link(ref('stock.group_stock_manager'), ref('stock.group_stock_multi_locations'), ref('stock.group_stock_multi_warehouses'))]"
+            eval="[Command.link(ref('stock.group_stock_manager')), Command.link(ref('stock.group_stock_multi_locations')), Command.link(ref('stock.group_stock_multi_warehouses'))]"
         />
     </record>
 
     <record id="l10n_br_base.user_demo_presumido" model="res.users">
         <field
             name="groups_id"
-            eval="[Command.link(ref('stock.group_stock_manager'), ref('stock.group_stock_multi_locations'), ref('stock.group_stock_multi_warehouses'))]"
+            eval="[Command.link(ref('stock.group_stock_manager')), Command.link(ref('stock.group_stock_multi_locations')), Command.link(ref('stock.group_stock_multi_warehouses'))]"
         />
     </record>
 


### PR DESCRIPTION
procurando resolver o problema em #3845 por dicotomia, eu fui desativando módulos e ai peguei um error no l10n_br_stock 

O erro passou a se manifestar depois que eu mudei pro  Command.link aqui:https://github.com/OCA/l10n-brazil/pull/3846/files#diff-8af6c54c6d92b5b098fd9deb701582a303538a62f11d8e327affb816b2fa34d2

Mas pelo jeito já tava errado antes:
https://github.com/odoo/odoo/blob/14.0/odoo/models.py#L3579
Pois o link so suportava um id e não uma lista, so tava passando batido pelo jeito.