### PR TITLE
[16.0][FIX] l10n_br_account: Ignore compute fields with missing methods

### DIFF
--- a/l10n_br_account/models/fiscal_decorator_mixin.py
+++ b/l10n_br_account/models/fiscal_decorator_mixin.py
@@ -63,6 +63,10 @@ class FiscalDecoratorMixin(models.AbstractModel):
                         f"it in {self._name}."
                     )
                     continue
+                if isinstance(field.compute, str) and not hasattr(
+                    self.__class__, field.compute
+                ):
+                    continue
 
                 attrs = {
                     "related": field.related,


### PR DESCRIPTION
Como foi Reportado na Issue #3835 estamos com erro no compute ao Módulo Fiscal -> Documentos -> NF-e -> Lança o Error.

Para contornar esse problema, foi adicionada uma verificação que ignora dinamicamente qualquer campo cujo atributo compute seja definido como string, mas cujo método correspondente não exista na classe. Isso evita que o sistema tente acessar métodos inválidos durante o carregamento de modelos.

OBS: Eu acredito que não é a melhor forma de fazer isso, mas não consegui pegar qual motivo ainda estou analisando melhor.

@OCA/local-brazil-maintainers Queria saber opinião de vocês como a gente pode fazer a correcção desse erro.