### PR TITLE
[16.0][FIX] l10n_br_fiscal: tax_definition update

### DIFF
--- a/l10n_br_fiscal/migrations/16.0.5.2.0/pre-migration.py
+++ b/l10n_br_fiscal/migrations/16.0.5.2.0/pre-migration.py
@@ -1,0 +1,21 @@
+# Copyright (C) 2025 - Engenere (<https://engenere.one>).
+# @author Antônio S. Pereira Neto <neto@engenere.one>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    # Migration script that was missing in the related PR:
+    # https://github.com/OCA/l10n-brazil/pull/3768
+    xmlids_renames = [
+        (
+            "l10n_br_fiscal.tax_icmsfcp_2_regulation_pb_pb",
+            "l10n_br_fiscal.tax_icmsfcp_2_regulation_pr_pr",
+        ),
+        (
+            "l10n_br_fiscal.tax_icmsfcp_nt_regulation_pb_pb",
+            "l10n_br_fiscal.tax_icmsfcp_2_regulation_pb_pb",
+        ),
+    ]
+    openupgrade.rename_xmlids(env.cr, xmlids_renames)


### PR DESCRIPTION
Ao atualizar um banco em produção após o merge da PR #3768, o processo falhou com o erro:

```
odoo.tools.convert.ParseError: while parsing /opt/odoo/auto/addons/l10n_br_fiscal/data/l10n_br_fiscal_icms_tax_definition_data.xml:4222
Definição Tributária já existe para este ICMS e Grupo Tributário !
```
O mesmo problema foi relatado por @marcos-mendez neste comentário: https://github.com/OCA/l10n-brazil/pull/3786#issuecomment-2910377270

Essa PR adiciona um script de migração para renomear os XMLIDs conflitantes alterados na #3768.