### PR TITLE
[14.0][FIX] l10n_br_account_nfe: problem with payment_mode_id on reversal move

### DIFF
--- a/l10n_br_account_nfe/__init__.py
+++ b/l10n_br_account_nfe/__init__.py
@@ -2,3 +2,4 @@ from .hooks import post_init_hook
 
 from . import models
 from . import report
+from . import wizard

--- a/l10n_br_account_nfe/__manifest__.py
+++ b/l10n_br_account_nfe/__manifest__.py
@@ -23,6 +23,7 @@
     "data": [
         "views/account_payment_mode.xml",
         "report/danfe_report.xml",
+        "wizard/account_move_reversal_view.xml",
     ],
     "post_init_hook": "post_init_hook",
     "installable": True,

--- a/l10n_br_account_nfe/models/__init__.py
+++ b/l10n_br_account_nfe/models/__init__.py
@@ -1,3 +1,4 @@
 from . import account_payment_mode
 from . import document
 from . import leiauteNFe
+from . import account_move

--- a/l10n_br_account_nfe/models/account_move.py
+++ b/l10n_br_account_nfe/models/account_move.py
@@ -1,0 +1,27 @@
+# Copyright 2025 - Escodoo, Cristiano Mafra Junior <cristiano.mafra@escodoo.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl-3.0)
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _name = "account.move"
+    _inherit = [
+        _name,
+        "l10n_br_fiscal.document.mixin.methods",
+        "l10n_br_account.decorator.mixin",
+    ]
+
+    def _reverse_moves(self, default_values_list=None, cancel=False):
+        new_moves = super()._reverse_moves(
+            default_values_list=default_values_list, cancel=cancel
+        )
+
+        payment_mode_id = False
+        if self.env.context.get("payment_mode_id"):
+            payment_mode_id = self.env["account.payment.mode"].browse(
+                self.env.context.get("payment_mode_id")
+            )
+        for move in new_moves:
+            move.payment_mode_id = payment_mode_id
+
+        return new_moves

--- a/l10n_br_account_nfe/models/document.py
+++ b/l10n_br_account_nfe/models/document.py
@@ -144,6 +144,7 @@ class DocumentNfe(models.Model):
                 rec.state_edoc == "em_digitacao"
                 or not rec._need_compute_nfe_tags()
                 or rec._is_without_payment()
+                or rec.move_ids.move_type in ("out_refund", "in_refund")  # TODO TESTE
             ):
                 continue
 

--- a/l10n_br_account_nfe/static/description/index.html
+++ b/l10n_br_account_nfe/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -464,9 +463,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-10">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org">
-<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/l10n_br_account_nfe/tests/__init__.py
+++ b/l10n_br_account_nfe/tests/__init__.py
@@ -2,3 +2,4 @@ from . import test_nfe_generate_tags_cobr_dup_pag
 from . import test_nfce_contingency
 from . import test_nfe_with_ipi
 from . import test_nfe_danfe_account
+from . import test_invoice_refund

--- a/l10n_br_account_nfe/tests/test_invoice_refund.py
+++ b/l10n_br_account_nfe/tests/test_invoice_refund.py
@@ -1,0 +1,121 @@
+from odoo import fields
+from odoo.tests import SavepointCase
+
+
+class TestInvoiceRefund(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.sale_account = cls.env["account.account"].create(
+            dict(
+                code="X1020",
+                name="Product Refund Sales - (test)",
+                user_type_id=cls.env.ref("account.data_account_type_revenue").id,
+            )
+        )
+
+        cls.refund_journal = cls.env["account.journal"].create(
+            dict(
+                name="Refund Journal - (test)",
+                code="TREJ",
+                type="sale",
+                refund_sequence=True,
+                default_account_id=cls.sale_account.id,
+            )
+        )
+
+        cls.reverse_vals = {
+            "date": fields.Date.from_string("2019-02-01"),
+            "reason": "no reason",
+            "refund_method": "refund",
+            "journal_id": cls.refund_journal.id,
+        }
+
+        cls.invoice = cls.env["account.move"].create(
+            dict(
+                name="Test Refund Invoice 2",
+                move_type="out_invoice",
+                invoice_payment_term_id=cls.env.ref(
+                    "account.account_payment_term_advance"
+                ).id,
+                partner_id=cls.env.ref("l10n_br_base.res_partner_cliente1_sp").id,
+                journal_id=cls.refund_journal.id,
+                document_type_id=cls.env.ref("l10n_br_fiscal.document_55").id,
+                document_serie_id=cls.env.ref(
+                    "l10n_br_fiscal.empresa_lc_document_55_serie_1"
+                ).id,
+                invoice_line_ids=[
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": cls.env.ref("product.product_product_6").id,
+                            "quantity": 1.0,
+                            "price_unit": 100.0,
+                            "account_id": cls.env["account.account"]
+                            .search(
+                                [
+                                    (
+                                        "user_type_id",
+                                        "=",
+                                        cls.env.ref(
+                                            "account.data_account_type_revenue"
+                                        ).id,
+                                    ),
+                                    (
+                                        "company_id",
+                                        "=",
+                                        cls.env.company.id,
+                                    ),
+                                ],
+                                limit=1,
+                            )
+                            .id,
+                            "name": "Refund Test",
+                            "uom_id": cls.env.ref("uom.product_uom_unit").id,
+                        },
+                    )
+                ],
+            )
+        )
+
+    def test_refund_with_payment_mode(self):
+        payment_mode = self.env.ref("account_payment_mode.payment_mode_inbound_dd1")
+
+        invoice = self.invoice
+
+        invoice.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda").id
+        for line in invoice.invoice_line_ids:
+            line.fiscal_operation_id = invoice.fiscal_operation_id
+            line.fiscal_operation_line_id = self.env.ref(
+                "l10n_br_fiscal.fo_venda_venda"
+            ).id
+
+        invoice.action_post()
+
+        move_reversal = (
+            self.env["account.move.reversal"]
+            .with_context(active_model="account.move", active_ids=invoice.ids)
+            .create(
+                {
+                    "reason": "Estorno com boleto",
+                    "refund_method": "refund",
+                    "journal_id": self.refund_journal.id,
+                    "payment_mode_id": payment_mode.id,
+                }
+            )
+        )
+
+        self.assertEqual(
+            move_reversal.payment_mode_id.id,
+            payment_mode.id,
+        )
+
+        reversal_result = move_reversal.reverse_moves()
+        reverse_move = self.env["account.move"].browse(reversal_result["res_id"])
+
+        self.assertEqual(
+            reverse_move.payment_mode_id.id,
+            payment_mode.id,
+        )

--- a/l10n_br_account_nfe/wizard/__init__.py
+++ b/l10n_br_account_nfe/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import account_move_reversal

--- a/l10n_br_account_nfe/wizard/account_move_reversal.py
+++ b/l10n_br_account_nfe/wizard/account_move_reversal.py
@@ -1,0 +1,28 @@
+from odoo import fields, models
+
+
+class AccountMoveReversal(models.TransientModel):
+    _inherit = "account.move.reversal"
+
+    payment_mode_id = fields.Many2one(
+        comodel_name="account.payment.mode",
+        string="Payment Mode",
+    )
+
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+
+        active_ids = self.env.context.get("active_ids", [])
+        if active_ids:
+            invoice = self.env["account.move"].browse(active_ids[0])
+            if invoice.payment_mode_id:
+                res["payment_mode_id"] = invoice.payment_mode_id.id
+
+        return res
+
+    def reverse_moves(self):
+        self.ensure_one()
+        return super(
+            AccountMoveReversal,
+            self.with_context(payment_mode_id=self.payment_mode_id.id),
+        ).reverse_moves()

--- a/l10n_br_account_nfe/wizard/account_move_reversal_view.xml
+++ b/l10n_br_account_nfe/wizard/account_move_reversal_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="l10n_br_account_nfe_move_reversal_form" model="ir.ui.view">
+        <field name="name">account.move.reversal.form</field>
+        <field name="model">account.move.reversal</field>
+        <field name="inherit_id" ref="account.view_account_move_reversal" />
+        <field name="arch" type="xml">
+            <field name="journal_id" position="after">
+                <field name="payment_mode_id" />
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
## Objetivo da PR

Quando iremos criar uma Nota de Crédito vinculada ao um Documento Fiscal e selecionamos o método de Crédito: Reembolso Total ele lançar o UserError 
![image](https://github.com/user-attachments/assets/4833a083-7246-4387-a330-9f7474598677)

Agora quando abrir o Wizard vai trazer a informação de Modo de Pagamento e também carregando para Nota de Crédito para corrigir o UserError.
![print_23232323](https://github.com/user-attachments/assets/5f237f76-f2b0-4d57-b34b-3e03c5c05f8c)

Vou deixar em Rascunho por que ainda estou validando