### PR TITLE
[16.0][FIX] l10n_br_fiscal: script de migração uom_alias

### DIFF
--- a/l10n_br_fiscal/migrations/16.0.5.0.0/pre-migration.py
+++ b/l10n_br_fiscal/migrations/16.0.5.0.0/pre-migration.py
@@ -1,64 +1,33 @@
-# Copyright (C) 2025 - TODAY - Raphaël Valyi - Akretion <raphael.valyi@akretion.com.br>
+# Copyright (C) 2025 - Raphaël Valyi - Akretion <raphael.valyi@akretion.com.br>
+# Copyright (C) 2025 - Antônio S. Pereira Neto - Engenere <neto@engenere.one>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-
 from openupgradelib import openupgrade
-from psycopg2.extras import execute_values
-
-to_install = "uom_alias"
-
-
-def install_new_modules(cr):
-    sql = f"""
-    UPDATE ir_module_module
-    SET state='to install'
-    WHERE name = '{to_install}' AND state='uninstalled'
-    """
-    openupgrade.logged_query(cr, sql)
 
 
 @openupgrade.migrate()
 def migrate(env, version):
-    install_new_modules(env.cr)
-    openupgrade.logged_query(env.cr, "DELETE from ir_model WHERE model = 'uom.alias'")
+    # move data
     openupgrade.logged_query(
         env.cr,
-        "SELECT id, uom_id, code, write_uid, create_uid, "
-        "write_date, create_date FROM uom_uom_alternative",
+        """
+        INSERT INTO uom_alias (uom_id, code, write_uid, create_uid, write_date,
+         create_date)
+        SELECT uom_id, code, write_uid, create_uid, write_date, create_date
+        FROM uom_uom_alternative
+        """,
     )
-    alternatives = env.cr.fetchall()
-    openupgrade.rename_models(
-        env.cr,
-        [
-            (
-                "uom.uom.alternative",
-                "uom.alias",
-            ),
-        ],
-    )
-    execute_values(
-        env.cr,
-        """INSERT INTO uom_alias
-        (id, uom_id, code, write_uid, create_uid, write_date, create_date)
-        VALUES %s""",
-        alternatives,
-        template="(%s, %s, %s, %s, %s, %s, %s)",  # Ensures proper escaping
-    )
-
-    # avoid deleting uom.alias model, table and columns
-    # along with the old ir.model.data records:
+    # update xmlids
     openupgrade.logged_query(
         env.cr,
-        "DELETE FROM ir_model_data WHERE name = 'model_uom_alias' "
-        "and module = 'l10n_br_fiscal'",
-    )
-    openupgrade.logged_query(
-        env.cr,
-        "DELETE FROM ir_model_data where model='ir.model.fields' "
-        "and module = 'l10n_br_fiscal' and name ilike 'field_uom_uom__%'",
-    )
-    openupgrade.logged_query(
-        env.cr,
-        "DELETE FROM ir_model_data where model='ir.model.fields' "
-        "and module = 'l10n_br_fiscal' and name ilike 'field_uom_alias__%'",
+        """
+        UPDATE ir_model_data AS imd
+        SET model  = 'uom.alias',
+            res_id = new_alias.id
+        FROM uom_uom_alternative AS old_alias
+        JOIN uom_alias AS new_alias
+            ON new_alias.code = old_alias.code
+        WHERE imd.model = 'uom.uom.alternative'
+        AND imd.res_id = old_alias.id
+        """,
     )


### PR DESCRIPTION
Corrige erro de upgrade para l10n_br_fiscal 16.0.5.0.0: o script de migração da PR #3762 deixava IDs duplicados em uom_alias. Reescrevi o script para tratar os registros existentes e evitar a colisão. O upgrade agora finaliza sem exceções.

Antes estourava essa exceção:
```
Exception: Module loading l10n_br_fiscal failed: file l10n_br_fiscal/data/uom.alias.csv could not be processed:
 The value for the field 'id' already exists (this is probably 'ID' in the current model).
The value for the field 'id' already exists (this is probably 'ID' in the current model).
The value for the field 'id' already exists (this is probably 'ID' in the current model).
The value for the field 'id' already exists (this is probably 'ID' in the current model).
```

@rvalyi 
Não mantive a limpeza dos dados órfãos que você havia implementado antes. Penso que isso pode ser feito com o módulo database_cleanup. Conforme mencionado aqui: https://oca.github.io/OpenUpgrade/050_after_migration.html#after-migration. O que você acha? Qualquer coisa posso por de volta, é só me avisar.

Não é preciso incluir código extra para instalar o módulo; ele já é instalado antes da execução do pre-migration.py, graças à dependência declarada no manifesto.