### PR TITLE
[16.0][FIX] l10n_br_base: back-fill vat from cnpj_cpf

### DIFF
--- a/l10n_br_base/migrations/16.0.2.0.0/pre-migration.py
+++ b/l10n_br_base/migrations/16.0.2.0.0/pre-migration.py
@@ -1,0 +1,31 @@
+# Copyright (C) 2025 - Antônio S. Pereira Neto - Engenere <neto@engenere.one>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """
+    Safety net: copy the taxpayer ID from the custom `cnpj_cpf` column
+    into the official `vat` field **only** when `vat` is still empty.
+
+    In most databases both columns already match, but this prevents
+    accidental data loss on installs where the two got out of sync.
+    """
+
+    cr = env.cr
+    if not (
+        openupgrade.column_exists(cr, "res_partner", "vat")
+        and openupgrade.column_exists(cr, "res_partner", "cnpj_cpf")
+    ):
+        return  # nothing to do
+
+    openupgrade.logged_query(
+        cr,
+        """
+        UPDATE res_partner
+           SET vat = cnpj_cpf
+         WHERE vat IS NULL
+           AND cnpj_cpf IS NOT NULL;
+        """,
+    )


### PR DESCRIPTION
Ao atualizar uma instância do Odoo, percebi que perdi as informações de CNPJ em alguns contatos. Isso ocorreu porque havia registros inconsistentes: o campo `cnpj_cpf` estava preenchido, mas o `vat` não. Suspeito que tenha faltado algum script de migração no passado ou ocorrido outra falha antiga.

Até então isso não trazia grandes problemas, mas depois que a PR #3566 entrou perdi definitivamente o CNPJ desses contatos, pois o `cnpj_cpf` passou a ser calculado a partir do `vat`.

Para evitar novas perdas de dados, adicionei um script de migração que mantém `cnpj_cpf` e `vat` devidamente sincronizados.