### PR TITLE
[16.0][FIX] CFOP não carregava em tree views

### DIFF
--- a/l10n_br_purchase/views/purchase_view.xml
+++ b/l10n_br_purchase/views/purchase_view.xml
@@ -47,6 +47,8 @@
                     domain here that is checked before the dynamic fiscal
                     placeholders kick in.
                 -->
+                <field name="fiscal_operation_type" invisible="1" />
+                <field name="cfop_id" invisible="1" />
                 <field name="tax_framework" invisible="1" />
                 <field name="fiscal_operation_id" invisible="1" />
                 <field name="freight_value" invisible="1" />

--- a/l10n_br_sale/views/sale_view.xml
+++ b/l10n_br_sale/views/sale_view.xml
@@ -134,6 +134,8 @@
                     domain here that is checked before the dynamic fiscal
                     placeholders kick in.
                 -->
+                <field name="fiscal_operation_type" invisible="1" />
+                <field name="cfop_id" invisible="1" />
                 <field name="tax_framework" invisible="1" />
                 <field name="fiscal_operation_id" invisible="1" />
                 <field name="freight_value" invisible="1" />

--- a/l10n_br_stock_account/views/stock_picking.xml
+++ b/l10n_br_stock_account/views/stock_picking.xml
@@ -74,6 +74,8 @@
                     domain here that is checked before the dynamic fiscal
                     placeholders kick in.
                 -->
+                <field name="fiscal_operation_type" invisible="1" />
+                <field name="cfop_id" invisible="1" />
                 <field name="tax_framework" invisible="1" />
                 <field name="fiscal_operation_id" invisible="1" />
                 <field name="freight_value" invisible="1" />


### PR DESCRIPTION
Ao adicionar uma nova linha no modo lista (tree view), o campo CFOP não era carregado. O problema ocorria em vendas, compras e separações de estoque. Esta PR inclui o campo `cfop_id` nas respectivas tree views e corrige o erro.