### PR TITLE
[16.0][FIX] l10n_br_account_nfe: permitido informar a tag pag com o tpag = 90

### DIFF
--- a/l10n_br_account_nfe/models/document.py
+++ b/l10n_br_account_nfe/models/document.py
@@ -40,7 +40,9 @@ class DocumentNfe(models.Model):
 
     @api.depends("move_ids", "move_ids.due_line_ids")
     def _compute_nfe40_dup(self):
-        for rec in self.filtered(lambda x: x._need_compute_nfe40_dup()):
+        for rec in self.filtered(
+            lambda x: x._need_compute_nfe40_dup() and x._is_installment()
+        ):
             dups_vals = []
             for count, mov in enumerate(rec.move_ids.due_line_ids, 1):
                 dups_vals.append(
@@ -81,7 +83,7 @@ class DocumentNfe(models.Model):
         for rec in self.filtered(lambda x: x._need_compute_nfe_tags()):
             if rec._is_without_payment():
                 det_pag_vals = {
-                    "nfe40_indPag": A_VISTA,
+                    "nfe40_indPag": False,
                     "nfe40_tPag": SEM_PAGAMENTO,
                     "nfe40_vPag": 0.00,
                 }
@@ -136,6 +138,10 @@ class DocumentNfe(models.Model):
         if not self.amount_financial_total:
             return True
         if self.nfe40_tpNF == NFE_IN:
+            return True
+        if not self.move_ids.payment_mode_id:
+            return True
+        if self.move_ids.payment_mode_id.fiscal_payment_mode == "90":
             return True
         else:
             return False


### PR DESCRIPTION
Permitir a emissão de NFe considerando alguns fluxos:

- Dados de cobrança não deve ser informado quando o pagamento é a vista
- Permitir não informar as informações de pagamento

Eu alterei para permitir informar ou não as informações de pagamento, isso é necessário para os casos onde é emitida uma NF-e com operações de venda e bonificação/remessa para ser rejeitada: **Rejeição 865: Total dos pagamentos menor que o total da nota**

Caso o campo payment_mode_id não for preenchido ou se for preenchido mas o campo fiscal_payment_mode no modo de pagamento seja definido como "90" não vai ser informada as informações de pagamento da NFe