### PR TITLE
[16.0][MIG] l10n_br_cte, l10n_br_mdfe: _render_qweb_* methods migration

### DIFF
--- a/l10n_br_cte/models/document.py
+++ b/l10n_br_cte/models/document.py
@@ -1750,8 +1750,10 @@ class CTe(spec_models.StackedModel):
             "mimetype": "application/pdf",
             "type": "binary",
         }
-        report = self.env.ref("l10n_br_cte.report_dacte")
-        pdf_data = report._render_qweb_pdf(self.fiscal_line_ids.document_id.ids)
+        report = self.env.ref("l10n_br_cte.main_template_dacte")
+        pdf_data = report._render_qweb_pdf(
+            "main_template_dacte", self.fiscal_line_ids.document_id.ids
+        )
         attachment_data["datas"] = base64.b64encode(pdf_data[0])
         file_pdf = self.file_report_id
         self.file_report_id = False

--- a/l10n_br_cte/report/dacte_report.xml
+++ b/l10n_br_cte/report/dacte_report.xml
@@ -1,5 +1,5 @@
 <odoo>
-        <record id="report_dacte" model="ir.actions.report">
+        <record id="main_template_dacte" model="ir.actions.report">
             <field name="name">DACTE</field>
             <field name="model">l10n_br_fiscal.document</field>
             <field name="report_type">qweb-pdf</field>

--- a/l10n_br_cte/report/ir_actions_report.py
+++ b/l10n_br_cte/report/ir_actions_report.py
@@ -13,15 +13,14 @@ from odoo.exceptions import UserError
 class IrActionsReport(models.Model):
     _inherit = "ir.actions.report"
 
-    def _render_qweb_html(self, res_ids, data=None):
-        if self.report_name == "main_template_dacte":
+    def _render_qweb_html(self, report_ref, res_ids, data=None):
+        if report_ref == "main_template_dacte":
             return
+        return super()._render_qweb_html(report_ref, res_ids, data=data)
 
-        return super()._render_qweb_html(res_ids, data=data)
-
-    def _render_qweb_pdf(self, res_ids, data=None):
-        if self.report_name not in ["main_template_dacte"]:
-            return super()._render_qweb_pdf(res_ids, data=data)
+    def _render_qweb_pdf(self, report_ref, res_ids, data=None):
+        if report_ref not in ["main_template_dacte"]:
+            return super()._render_qweb_pdf(report_ref, res_ids, data=data)
 
         cte = self.env["l10n_br_fiscal.document"].search([("id", "in", res_ids)])
 

--- a/l10n_br_cte/tests/test_cte_dacte.py
+++ b/l10n_br_cte/tests/test_cte_dacte.py
@@ -24,7 +24,7 @@ class TestDacteGeneration(TransactionCase):
         cte.document_type_id = self.env.ref("l10n_br_fiscal.document_01")
         cte.action_document_confirm()
         with self.assertRaises(UserError) as captured_exception:
-            dacte_report._render_qweb_pdf([cte.id])
+            dacte_report._render_qweb_pdf("main_template_dacte", [cte.id])
         self.assertEqual(
             captured_exception.exception.args[0],
             "You can only print a DACTE of a CTe(57).",

--- a/l10n_br_mdfe/models/document.py
+++ b/l10n_br_mdfe/models/document.py
@@ -1001,8 +1001,10 @@ class MDFe(spec_models.StackedModel):
             "mimetype": "application/pdf",
             "type": "binary",
         }
-        report = self.env.ref("l10n_br_mdfe.report_damdfe")
-        pdf_data = report._render_qweb_pdf(self.fiscal_line_ids.document_id.ids)
+        report = self.env.ref("l10n_br_mdfe.main_template_damdfe")
+        pdf_data = report._render_qweb_pdf(
+            "main_template_damdfe", self.fiscal_line_ids.document_id.ids
+        )
         attachment_data["datas"] = base64.b64encode(pdf_data[0])
         file_pdf = self.file_report_id
         self.file_report_id = False

--- a/l10n_br_mdfe/report/damdfe_report.xml
+++ b/l10n_br_mdfe/report/damdfe_report.xml
@@ -1,5 +1,5 @@
 <odoo>
-        <record id="report_damdfe" model="ir.actions.report">
+        <record id="main_template_damdfe" model="ir.actions.report">
             <field name="name">DAMDFE</field>
             <field name="model">l10n_br_fiscal.document</field>
             <field name="report_type">qweb-pdf</field>

--- a/l10n_br_mdfe/report/ir_actions_report.py
+++ b/l10n_br_mdfe/report/ir_actions_report.py
@@ -13,15 +13,14 @@ from odoo.exceptions import UserError
 class IrActionsReport(models.Model):
     _inherit = "ir.actions.report"
 
-    def _render_qweb_html(self, res_ids, data=None):
-        if self.report_name == "main_template_damdfe":
+    def _render_qweb_html(self, report_ref, res_ids, data=None):
+        if report_ref == "main_template_damdfe":
             return
+        return super()._render_qweb_html(report_ref, res_ids, data=data)
 
-        return super()._render_qweb_html(res_ids, data=data)
-
-    def _render_qweb_pdf(self, res_ids, data=None):
-        if self.report_name not in ["main_template_damdfe"]:
-            return super()._render_qweb_pdf(res_ids, data=data)
+    def _render_qweb_pdf(self, report_ref, res_ids, data=None):
+        if report_ref not in ["main_template_damdfe"]:
+            return super()._render_qweb_pdf(report_ref, res_ids, data=data)
 
         mdfe = self.env["l10n_br_fiscal.document"].search([("id", "in", res_ids)])
 

--- a/l10n_br_mdfe/tests/test_mdfe_damdfe.py
+++ b/l10n_br_mdfe/tests/test_mdfe_damdfe.py
@@ -24,7 +24,7 @@ class TestDamdfeGeneration(TransactionCase):
         mdfe.document_type_id = self.env.ref("l10n_br_fiscal.document_01")
         mdfe.action_document_confirm()
         with self.assertRaises(UserError) as captured_exception:
-            damdfe_report._render_qweb_pdf([mdfe.id])
+            damdfe_report._render_qweb_pdf("main_template_damdfe", [mdfe.id])
         self.assertEqual(
             captured_exception.exception.args[0],
             "You can only print a DAMDFE of a MDFe(58).",


### PR DESCRIPTION
Essa PR é parecida com a #3255 nessa PR tem uma explicação do que foi mudado da v14 pra v16

Eu estava fazendo teste através do Runboat e acabei pegando esse erro aqui ao gerar o PDF do DAMDFE

Erro ao clicar no botão Visualizar PDF:
![image](https://github.com/user-attachments/assets/87d6c0c7-8362-407a-b0bb-b1a08b91db91)

Erro ao clicar na opção Imprimir -> DAMDFE:
![image](https://github.com/user-attachments/assets/3f73ec2c-c2b6-49b0-841a-3aefc166fe37)

Essa PR faz a correção desses erros

cc @rvalyi @marcelsavegnago @antoniospneto
Se conseguirem fazer o teste funcional no Runboat pra vê se não tem nenhum erro agradeço 