### PR TITLE
[14.0][IMP] l10n_br_mdfe: demo mdfe30_vag

### DIFF
--- a/l10n_br_mdfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_mdfe/demo/fiscal_document_demo.xml
@@ -41,6 +41,29 @@
         />
         <field name="mdfe_route_state_ids" eval="[(6, 0, [ref('base.state_br_pb')])]" />
         <field name="mdfe_modal">4</field>
+        <field
+            name="mdfe30_vag"
+            eval="[
+            (0, 0, {
+                'mdfe30_pesoBC': 500,
+                'mdfe30_pesoR': 1,
+                'mdfe30_tpVag': '123',
+                'mdfe30_serie': '123',
+                'mdfe30_nVag': '123',
+                'mdfe30_nSeq': 123,
+                'mdfe30_TU': 1,
+            }),
+            (0, 0, {
+                'mdfe30_pesoBC': 500,
+                'mdfe30_pesoR': 1,
+                'mdfe30_tpVag': '321',
+                'mdfe30_serie': '321',
+                'mdfe30_nVag': '321',
+                'mdfe30_nSeq': 321,
+                'mdfe30_TU': 1,
+            })
+        ]"
+        />
     </record>
 
     <record


### PR DESCRIPTION
Conforme a documentação do DAMDFE Ferroviário a tag vag tem que ter pelo menos umas eu acabei adicionando essa informação mas para questão visual do DAMDFE. 
<img width="1118" height="425" alt="image" src="https://github.com/user-attachments/assets/a389349d-8958-4bba-b279-e6a6da707996" />

Hoje na localização DAMDFE Ferroviário fica assim: (Como a tag vag fica ausente desconfigura todo o PDF)
<img width="793" height="886" alt="image" src="https://github.com/user-attachments/assets/3e91a5cc-325e-4315-b4a5-aec1539e6f27" />

Com a introdução desses dados demos:
<img width="795" height="884" alt="image" src="https://github.com/user-attachments/assets/c90bcb24-dbfe-4967-bfce-c7a9c0386d2f" />

Isso é mais uma questão para alguém quiser testar via Runboat o DAMDFE Ferroviário não pegar o PDF todo desconfigurado, e achar que tem algum problema na geração do PDF.

cc @rvalyi @marcelsavegnago @antoniospneto


