### PR TITLE
[16.0][FIX] l10n_br_account: Necessário verificar se o método _document_reference existe

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -628,14 +628,17 @@ class AccountMove(models.Model):
                 )
                 line._onchange_fiscal_operation_id()
 
-            # Adds the related document to the NF-e.
-            # this is required for correct xml validation
-            if record.document_type_id and record.document_type_id.code in (
-                MODELO_FISCAL_NFE
-            ):
-                record.fiscal_document_id._document_reference(
-                    record.reversed_entry_id.fiscal_document_id
-                )
+            # This method is in l10n_br_fiscal_subsequent_document module, the IF
+            # is necessary to avoid a 'glue module' or direct dependence.
+            if hasattr(record.fiscal_document_id, "_document_reference"):
+                # Add the related document to the NF-e.
+                # this is required for correct xml validation
+                if record.document_type_id and record.document_type_id.code in (
+                    MODELO_FISCAL_NFE
+                ):
+                    record.fiscal_document_id._document_reference(
+                        record.reversed_entry_id.fiscal_document_id
+                    )
 
         return new_moves
 


### PR DESCRIPTION
fix move method _document_reference.

Movendo a chamada do método **_document_reference** do **l10n_br_account** para **l10n_br_fiscal_subsequent_document**.

Acredito que na recente extração do módulo  [l10n_br_fiscal_subsequent_document](https://github.com/OCA/l10n-brazil/pull/3853) acabou faltando mover a chamada do método _document_reference porque ao rodar os testes sem esse módulo instalado retorna o erro:

```bash
/l10n_br_account/models/account_move.py", line 636, in _reverse_moves
    record.fiscal_document_id._document_reference(
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'l10n_br_fiscal.document' object has no attribute '_document_reference'
```
Esse método passou para https://github.com/OCA/l10n-brazil/blob/16.0/l10n_br_fiscal_subsequent_document/models/document.py#L38

Mantive o mesmo cabeçalho de licença do arquivo original, deveria ser outro? Qual?

cc @OCA/local-brazil-maintainers 