### PR TITLE
[16.0][IMP] l10n_br_fiscal: campos code e description na uom.uom

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -97,6 +97,7 @@
         "views/document_line_view.xml",
         "views/document_fiscal_line_mixin_view.xml",
         "views/res_config_settings_view.xml",
+        "views/uom_uom.xml",
         "views/invalidate_number_view.xml",
         "views/city_taxation_code.xml",
         "views/operation_dashboard_view.xml",

--- a/l10n_br_fiscal/data/uom_data.xml
+++ b/l10n_br_fiscal/data/uom_data.xml
@@ -5,28 +5,54 @@
         <field name="name">Area</field>
     </record>
 
+    <record id="uom.product_uom_km" model="uom.uom">
+        <field name="code">KM</field>
+        <field name="description">Quilômetro</field>
+    </record>
+
     <record id="uom.product_uom_hour" model="uom.uom">
-        <field name="name">hr</field>
+        <field name="code">HR</field>
+        <field name="description">Hora</field>
     </record>
 
     <record id="uom.product_uom_day" model="uom.uom">
-        <field name="name">dia</field>
+        <field name="code">DIA</field>
+        <field name="description">Dia</field>
+    </record>
+
+    <record id="uom.product_uom_lb" model="uom.uom">
+        <field name="code">LB</field>
+        <field name="description">Libra</field>
+    </record>
+
+    <record id="uom.product_uom_oz" model="uom.uom">
+        <field name="code">OZ</field>
+        <field name="description">Onça</field>
     </record>
 
     <record id="uom.product_uom_inch" model="uom.uom">
-        <field name="name">pol</field>
+        <field name="code">POL</field>
+        <field name="description">Polegada</field>
+    </record>
+
+    <record id="uom.product_uom_foot" model="uom.uom">
+        <field name="code">FT</field>
+        <field name="description">Pé</field>
     </record>
 
     <record id="uom.product_uom_mile" model="uom.uom">
-        <field name="name">mil</field>
+        <field name="code">MILHA</field>
+        <field name="description">Milha</field>
     </record>
 
     <record id="uom.product_uom_floz" model="uom.uom">
-        <field name="name">oz</field>
+        <field name="code">OZ FL</field>
+        <field name="description">Onça fluída</field>
     </record>
 
     <record id="uom.product_uom_qt" model="uom.uom">
-        <field name="name">qt</field>
+        <field name="code">QT(US)</field>
+        <field name="description">Quarto (US)</field>
     </record>
 
     <!-- Extracted from SEFAZ - Tabela_Unidades_de_Medida_Comercial_05072016.xls
@@ -38,27 +64,49 @@
      -->
 
     <record id="uom.product_uom_unit" model="uom.uom">
-        <field name="name">UN</field>
+        <field name="code">UN</field>
+        <field name="description">Unidade</field>
     </record>
 
     <record id="uom.product_uom_dozen" model="uom.uom">
-        <field name="name">DUZIA</field>
+        <field name="code">DUZIA</field>
+        <field name="description">Dúzia (12 unidades)</field>
     </record>
 
-    <record id="uom.product_uom_ton" model="uom.uom">
-        <field name="name">TON</field>
-    </record>
-
-    <record id="uom.product_uom_litre" model="uom.uom">
-        <field name="name">LITRO</field>
-    </record>
-
-    <record id="uom.product_uom_gal" model="uom.uom">
-        <field name="name">GALAO</field>
+    <record id="uom.product_uom_kgm" model="uom.uom">
+        <field name="code">KG</field>
+        <field name="name">KG</field>
+        <field name="description">Quilograma</field>
     </record>
 
     <record id="uom.product_uom_gram" model="uom.uom">
-        <field name="name">GRAMAS</field>
+        <field name="code">GRAMAS</field>
+        <field name="description">Grama</field>
+    </record>
+
+    <record id="uom.product_uom_meter" model="uom.uom">
+        <field name="code">M</field>
+        <field name="description">Metro</field>
+    </record>
+
+    <record id="uom.product_uom_ton" model="uom.uom">
+        <field name="code">TON</field>
+        <field name="description">Tonelada</field>
+    </record>
+
+    <record id="uom.product_uom_cm" model="uom.uom">
+        <field name="code">CM</field>
+        <field name="description">Centímetro</field>
+    </record>
+
+    <record id="uom.product_uom_litre" model="uom.uom">
+        <field name="code">L</field>
+        <field name="description">Litro</field>
+    </record>
+
+    <record id="uom.product_uom_gal" model="uom.uom">
+        <field name="code">GALAO</field>
+        <field name="description">Galão</field>
     </record>
 
     <!--
@@ -67,92 +115,117 @@
 
     <record id="UOM_AMPOLA" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
+        <field name="code">AMPOLA</field>
         <field name="name">AMPOLA</field>
+        <field name="description">Ampola</field>
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_BALDE" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
+        <field name="code">BALDE</field>
         <field name="name">BALDE</field>
+        <field name="description">Balde</field>
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
-
     <record id="UOM_BANDEJA" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
+        <field name="code">BANDEJ</field>
         <field name="name">BANDEJA</field>
+        <field name="description">Bandeja</field>
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_BARRA" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
+        <field name="code">BARRA</field>
         <field name="name">BARRA</field>
+        <field name="description">Barra</field>
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_BISNAGA" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
+        <field name="code">BISNAG</field>
         <field name="name">BISNAGA</field>
+        <field name="description">Bisnaga</field>
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_BLOCO" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
+        <field name="code">BLOCO</field>
         <field name="name">BLOCO</field>
+        <field name="description">Bloco</field>
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_BOBINA" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
+        <field name="code">BOBINA</field>
         <field name="name">BOBINA</field>
+        <field name="description">Bobina</field>
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_BOMBONA" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
+        <field name="code">BOMB</field>
         <field name="name">BOMBONA</field>
+        <field name="description">Bombona</field>
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_CAPSULA" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
+        <field name="code">CAPS</field>
         <field name="name">CAPSULA</field>
+        <field name="description">Cápsula</field>
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_CARTELA" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
+        <field name="code">CART</field>
         <field name="name">CARTELA</field>
+        <field name="description">Cartela</field>
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_CENTO" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
+        <field name="code">CENTO</field>
         <field name="name">CENTO</field>
+        <field name="description">Cento</field>
         <field name="factor_inv" eval="100" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_CONJUNTO" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
-        <field name="name">CONJUNTO</field>
+        <field name="code">CJ</field>
+        <field name="name">CJ</field>
+        <field name="description">Conjunto</field>
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_CX" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
+        <field name="code">CX</field>
         <field name="name">CX</field>
+        <field name="description">Caixa</field>
         <field name="factor" eval="1.0" />
         <field name="rounding" eval="0.001" />
         <field name="uom_type">bigger</field>
@@ -160,195 +233,251 @@
 
     <record id="UOM_CX2" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
-        <field name="name">CX2</field>
+        <field name="code">CX2</field>
+        <field name="name">CX 2UN</field>
+        <field name="description">Caixa com 2 unidades</field>
         <field name="factor_inv" eval="2" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_CX3" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
-        <field name="name">CX3</field>
+        <field name="code">CX3</field>
+        <field name="name">CX 3UN</field>
+        <field name="description">Caixa com 3 unidades</field>
         <field name="factor_inv" eval="3" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_CX5" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
-        <field name="name">CX5</field>
+        <field name="code">CX5</field>
+        <field name="name">CX 5UN</field>
+        <field name="description">Caixa com 5 unidades</field>
         <field name="factor_inv" eval="5" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_CX10" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
-        <field name="name">CX10</field>
-        <field name="factor_inv" eval="5" />
+        <field name="code">CX10</field>
+        <field name="name">CX 10UN</field>
+        <field name="description">Caixa com 10 unidades</field>
+        <field name="factor_inv" eval="10" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_CX15" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
-        <field name="name">CX15</field>
+        <field name="code">CX15</field>
+        <field name="name">CX 15UN</field>
+        <field name="description">Caixa com 15 unidades</field>
         <field name="factor_inv" eval="15" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_CX20" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
-        <field name="name">CX20</field>
+        <field name="code">CX20</field>
+        <field name="name">CX 20UN</field>
+        <field name="description">Caixa com 20 unidades</field>
         <field name="factor_inv" eval="20" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_CX25" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
-        <field name="name">CX25</field>
+        <field name="code">CX25</field>
+        <field name="name">CX 25UN</field>
+        <field name="description">Caixa com 25 unidades</field>
         <field name="factor_inv" eval="25" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_CX50" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
-        <field name="name">CX50</field>
+        <field name="code">CX50</field>
+        <field name="name">CX 50UN</field>
+        <field name="description">Caixa com 50 unidades</field>
         <field name="factor_inv" eval="50" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_CX100" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
-        <field name="name">CX100</field>
+        <field name="code">CX100</field>
+        <field name="name">CX 100UN</field>
+        <field name="description">Caixa com 100 unidades</field>
         <field name="factor_inv" eval="100" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_DISPLAY" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
+        <field name="code">DISP</field>
         <field name="name">DISPLAY</field>
+        <field name="description">Display</field>
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_EMBALAGEM" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
+        <field name="code">EMBAL</field>
         <field name="name">EMBALAGEM</field>
+        <field name="description">Embalagem</field>
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_FARDO" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
+        <field name="code">FARDO</field>
         <field name="name">FARDO</field>
+        <field name="description">Fardo</field>
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_FOLHA" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
+        <field name="code">FOLHA</field>
         <field name="name">FOLHA</field>
+        <field name="description">Folha</field>
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_FRASCO" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
+        <field name="code">FRASCO</field>
         <field name="name">FRASCO</field>
+        <field name="description">Frasco</field>
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_GARRAFA" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
-        <field name="name">GARRAFA</field>
+        <field name="code">GF</field>
+        <field name="name">GF</field>
+        <field name="description">Garrafa</field>
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_JOGO" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
+        <field name="code">JOGO</field>
         <field name="name">JOGO</field>
+        <field name="description">Jogo</field>
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_KIT" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
+        <field name="code">KIT</field>
         <field name="name">KIT</field>
+        <field name="description">Kit</field>
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_LATA" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
+        <field name="code">LATA</field>
         <field name="name">LATA</field>
+        <field name="description">Lata</field>
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_M2" model="uom.uom">
         <field name="category_id" ref="product_uom_categ_AREA" />
-        <field name="name">M2</field>
+        <field name="code">M2</field>
+        <field name="name">M²</field>
+        <field name="description">Metro quadrado</field>
         <field name="factor" eval="1.0" />
         <field name="rounding" eval="0.001" />
     </record>
 
     <record id="UOM_CM2" model="uom.uom">
         <field name="category_id" ref="product_uom_categ_AREA" />
-        <field name="name">CM2</field>
+        <field name="code">CM2</field>
+        <field name="name">CM²</field>
+        <field name="description">Centímetro quadrado</field>
         <field name="factor" eval="10000" />
         <field name="uom_type">smaller</field>
     </record>
 
     <record id="UOM_M3" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_vol" />
-        <field name="name">M3</field>
+        <field name="code">M3</field>
+        <field name="name">M³</field>
+        <field name="description">Metro cúbico</field>
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_MILHEIRO" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
+        <field name="code">MILHEI</field>
         <field name="name">MILHEIRO</field>
+        <field name="description">Milheiro (1000 unidades)</field>
         <field name="factor_inv" eval="1000" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_MILILITRO" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_vol" />
-        <field name="name">MILILITRO</field>
+        <field name="code">ML</field>
+        <field name="name">ML</field>
+        <field name="description">Mililitro</field>
         <field name="factor" eval="1000" />
         <field name="uom_type">smaller</field>
     </record>
 
     <record id="UOM_MWH" model="uom.uom">
         <field name="category_id" ref="uom.uom_categ_wtime" />
+        <field name="code">MWH</field>
         <field name="name">MWH</field>
+        <field name="description">Megawatt hora</field>
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_PACOTE" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
+        <field name="code">PCT</field>
         <field name="name">PACOTE</field>
+        <field name="description">Pacote</field>
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_PARES" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
+        <field name="code">PARES</field>
         <field name="name">PARES</field>
+        <field name="description">Par (2 unidades)</field>
         <field name="factor_inv" eval="2" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_PC" model="uom.uom">
-        <field name="name">PEÇA</field>
+        <field name="code">PÇ</field>
+        <field name="name">PÇ</field>
+        <field name="description">Peça</field>
         <field name="category_id" ref="uom.product_uom_categ_unit" />
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_POTE" model="uom.uom">
+        <field name="code">POTE</field>
         <field name="name">POTE</field>
+        <field name="description">Pote</field>
         <field name="category_id" ref="uom.product_uom_categ_unit" />
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
@@ -356,69 +485,89 @@
 
     <record id="UOM_QUILATE" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_kgm" />
+        <field name="code">K</field>
         <field name="name">QUILATE</field>
+        <field name="description">Quilate</field>
         <field name="factor" eval="5000" />
         <field name="uom_type">smaller</field>
     </record>
 
     <record id="UOM_RESMA" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
+        <field name="code">RESMA</field>
         <field name="name">RESMA</field>
+        <field name="description">Resma (500 folhas)</field>
         <field name="factor" eval="500" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_ROLO" model="uom.uom">
+        <field name="code">ROLO</field>
         <field name="name">ROLO</field>
+        <field name="description">Rolo</field>
         <field name="category_id" ref="uom.product_uom_categ_unit" />
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_SACO" model="uom.uom">
+        <field name="code">SACO</field>
         <field name="name">SACO</field>
+        <field name="description">Saco</field>
         <field name="category_id" ref="uom.product_uom_categ_unit" />
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_SACOLA" model="uom.uom">
+        <field name="code">SACOLA</field>
         <field name="name">SACOLA</field>
+        <field name="description">Sacola</field>
         <field name="category_id" ref="uom.product_uom_categ_unit" />
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_TAMBOR" model="uom.uom">
+        <field name="code">TAMBOR</field>
         <field name="name">TAMBOR</field>
+        <field name="description">Tambor</field>
         <field name="category_id" ref="uom.product_uom_categ_unit" />
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_TANQUE" model="uom.uom">
+        <field name="code">TANQUE</field>
         <field name="name">TANQUE</field>
+        <field name="description">Tanque</field>
         <field name="category_id" ref="uom.product_uom_categ_unit" />
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_TUBO" model="uom.uom">
+        <field name="code">TUBO</field>
         <field name="name">TUBO</field>
+        <field name="description">Tubo</field>
         <field name="category_id" ref="uom.product_uom_categ_unit" />
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_VASILHAME" model="uom.uom">
+        <field name="code">VASIL</field>
         <field name="name">VASILHAME</field>
+        <field name="description">Vasilhame</field>
         <field name="category_id" ref="uom.product_uom_categ_unit" />
         <field name="factor" eval="1.0" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_VIDRO" model="uom.uom">
+        <field name="code">VIDRO</field>
         <field name="name">VIDRO</field>
+        <field name="description">Vidro</field>
         <field name="category_id" ref="uom.product_uom_categ_unit" />
         <field name="factor" eval="1.0" />
         <field name="rounding" eval="0.001" />
@@ -427,14 +576,18 @@
 
     <record id="UOM_UN1000" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit" />
+        <field name="code">1000UN</field>
         <field name="name">1000UN</field>
+        <field name="description">1000 unidades</field>
         <field name="factor_inv" eval="1000" />
         <field name="uom_type">bigger</field>
     </record>
 
     <record id="UOM_MM" model="uom.uom">
         <field name="category_id" ref="uom.uom_categ_length" />
+        <field name="code">MM</field>
         <field name="name">MM</field>
+        <field name="description">Milímetro</field>
         <field name="factor" eval="1000" />
         <field name="uom_type">smaller</field>
     </record>

--- a/l10n_br_fiscal/models/__init__.py
+++ b/l10n_br_fiscal/models/__init__.py
@@ -50,6 +50,7 @@ from . import document_related
 from . import document_line
 from . import res_config_settings
 from . import res_country_state
+from . import uom_uom
 from . import operation_dashboard
 from . import city_taxation_code
 from . import document_supplement

--- a/l10n_br_fiscal/models/uom_uom.py
+++ b/l10n_br_fiscal/models/uom_uom.py
@@ -1,0 +1,24 @@
+# Copyright 2025 Engenere.one
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class Uom(models.Model):
+    _inherit = "uom.uom"
+
+    code = fields.Char(
+        size=6,
+        translate=False,
+        help="Abbreviated unit code used in electronic fiscal documents "
+        "(e.g. NF-e, NFC-e). Must have a maximum of 6 characters "
+        "by regulation. e.g. 'UN', 'KG', 'LITRO', 'CX12UN",
+    )
+
+    description = fields.Char(
+        help="Full unit description. e.g. 'Unit', 'Kilogram', 'Box of 12 Units'.",
+    )
+
+    _sql_constraints = [
+        ("unique_code", "UNIQUE(code)", "Unit of Measure code must be unique!")
+    ]

--- a/l10n_br_fiscal/views/uom_uom.xml
+++ b/l10n_br_fiscal/views/uom_uom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2025 Engenere
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record model="ir.ui.view" id="uom_uom_form_view">
+        <field name="name">uom.uom.form (in l10n_br_fiscal)</field>
+        <field name="model">uom.uom</field>
+        <field name="inherit_id" ref="uom.product_uom_form_view" />
+        <field name="arch" type="xml">
+            <field name="name" position="before">
+                <field name="code" required="1" />
+            </field>
+            <field name="name" position="after">
+                <field name="description" required="1" />
+            </field>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="uom_uom_tree_view">
+        <field name="name">uom.uom.tree (in l10n_br_fiscal)</field>
+        <field name="model">uom.uom</field>
+        <field name="inherit_id" ref="uom.product_uom_tree_view" />
+        <field name="arch" type="xml">
+            <field name="name" position="before">
+                <field name="code" required="1" />
+            </field>
+            <field name="name" position="after">
+                <field name="description" required="1" />
+            </field>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="uom_category_form_inherit_code_desc">
+        <field name="name">uom.category.form (in l10n_br_fiscal)</field>
+        <field name="model">uom.category</field>
+        <field name="inherit_id" ref="uom.product_uom_categ_form_view" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='uom_ids']/tree/field[@name='name']"
+                position="before"
+            >
+                <field name="code" />
+            </xpath>
+            <xpath
+                expr="//field[@name='uom_ids']/tree/field[@name='name']"
+                position="after"
+            >
+                <field name="description" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -158,7 +158,7 @@ class NFeLine(spec_models.StackedModel):
 
     nfe40_CFOP = fields.Char(related="cfop_id.code")
 
-    nfe40_uCom = fields.Char(related="uom_id.name")
+    nfe40_uCom = fields.Char(related="uom_id.code")
 
     nfe40_qCom = fields.Float(string="nfe40 qCom", related="quantity")
 
@@ -171,7 +171,7 @@ class NFeLine(spec_models.StackedModel):
 
     nfe40_cEANTrib = fields.Char(related="product_id.barcode")
 
-    nfe40_uTrib = fields.Char(related="uot_id.name")
+    nfe40_uTrib = fields.Char(related="uot_id.code")
 
     nfe40_qTrib = fields.Float(string="nfe40_qTrib", related="fiscal_quantity")
 

--- a/l10n_br_nfe/models/uom.py
+++ b/l10n_br_nfe/models/uom.py
@@ -11,8 +11,8 @@ class Uom(models.Model):
     def match_or_create_m2o(self, rec_dict, parent_dict, model=None):
         """If uom not found, break hard, don't create it"""
 
-        if rec_dict.get("name"):
-            domain = [("name", "=", rec_dict.get("name"))]
+        if rec_dict.get("code"):
+            domain = [("code", "=", rec_dict.get("code"))]
             match = self.search(domain, limit=1)
             if match:
                 return match.id

--- a/l10n_br_nfe/wizards/import_document.py
+++ b/l10n_br_nfe/wizards/import_document.py
@@ -250,8 +250,8 @@ class NfeImport(models.TransientModel):
                     xml_product.prod.xProd = internal_product.name
                     xml_product.prod.cEAN = internal_product.barcode or "SEM GTIN"
                     xml_product.prod.cEANTrib = internal_product.barcode or "SEM GTIN"
-                    xml_product.prod.uCom = product_line.uom_internal.name
-                    xml_product.prod.uTrib = product_line.uom_internal.name
+                    xml_product.prod.uCom = product_line.uom_internal.code
+                    xml_product.prod.uTrib = product_line.uom_internal.code
                     if product_line.new_cfop_id:
                         xml_product.prod.CFOP = product_line.new_cfop_id.code
         return parsed_xml


### PR DESCRIPTION
Pacote de correções e melhorias referente ao campo code do modelo uom.uom. Após a entrada da PR #3762, foi introduzido o modelo alias para unidades de medida e, junto com isso, ocorreu a remoção do campo code. A proposta trouxe avanços — o uso de alias tornou o sistema mais padronizado com o restante da OCA — mas, ao remover o code e tratar o campo name como seu substituto, surgiram algumas limitações importantes.

O alias tem seu valor e foi bem incorporado, mas não substitui completamente a necessidade de um campo code. O problema principal está em usar o name no lugar do code, o que gera os seguintes impactos:

1. Perda de tradução: como o name passa a ser usado como identificador, ele não pode mais ser traduzido, o que compromete aplicações multilíngues.
2. Perda do nome completo: em unidades menos comuns, o name muitas vezes precisa ser mais descritivo. Reduzi-lo para servir como identificador gera confusão para o usuário final.
3. Incompatibilidade com o SPED: o registro 0190 do SPED Fiscal exige código e descrição da unidade de medida, e isso não é atendido ao usar apenas o name.