### PR TITLE
[16.0][FIX] Permitir editar o campo Incoterm nos documentos fiscais

### DIFF
--- a/l10n_br_account/models/document.py
+++ b/l10n_br_account/models/document.py
@@ -90,7 +90,8 @@ class FiscalDocument(models.Model):
     # the related directly in the account.move does not work correctly.
     incoterm_id = fields.Many2one(
         string="Fiscal Inconterm",
-        related="move_ids.invoice_incoterm_id",
+        compute="_compute_incoterm_id",
+        inverse="_inverse_incoterm_id",
     )
 
     document_date = fields.Datetime(
@@ -143,6 +144,20 @@ class FiscalDocument(models.Model):
                 move_id = record.move_ids[0]
                 if record.date_in_out:
                     move_id.date = record.date_in_out.date()
+
+    @api.depends("move_ids.invoice_incoterm_id")
+    def _compute_incoterm_id(self):
+        for record in self:
+            for move in record.move_ids:
+                if move.invoice_incoterm_id:
+                    record.incoterm_id = move.invoice_incoterm_id
+                else:
+                    record.incoterm_id = False
+
+    def _inverse_incoterm_id(self):
+        for record in self:
+            if record.move_ids:
+                record.move_ids.invoice_incoterm_id = record.incoterm_id
 
     @api.depends("move_ids")
     def _compute_move_count(self):


### PR DESCRIPTION
Atualmente o campo inconterm_id no documento fiscal é um campo related do move_ids.invoice_inconterm_id o que não permite editar o campo a partir do documento fiscal, esse PR tem o objetivo torna-lo editável, para isso foi removido o atributo related e adicionado os atributos compute e inverse.