### PR TITLE
[16.0] l10n_br_base: cnpj_cpf -> vat - complete replace

### DIFF
--- a/l10n_br_base/demo/l10n_br_base_demo.xml
+++ b/l10n_br_base/demo/l10n_br_base_demo.xml
@@ -13,7 +13,7 @@
     <record id="res_partner_intel" model="res.partner">
         <field name="name">Intel do Brasil</field>
         <field name="legal_name">Intel do Brasil</field>
-        <field name="cnpj_cpf">86.144.802/0001-90</field>
+        <field name="vat">86.144.802/0001-90</field>
         <field name="street_name">Avenida Doutor Chucri Zaidan</field>
         <field name="street_number">920</field>
         <field name="district">Vila Cordeiro</field>
@@ -36,7 +36,7 @@
     <record id="res_partner_amd" model="res.partner">
         <field name="name">AMD do Brasil</field>
         <field name="legal_name">AMD South America Ltda</field>
-        <field name="cnpj_cpf">62.228.384/0001-51</field>
+        <field name="vat">62.228.384/0001-51</field>
         <field name="street_name">Rua Samuel Morse</field>
         <field name="street_number">134</field>
         <field name="district">Brooklin</field>
@@ -59,7 +59,7 @@
     <record id="res_partner_lg" model="res.partner">
         <field name="name">LG do Brasil</field>
         <field name="legal_name">LG ELECTRONICS DA AMAZÔNIA LTDA</field>
-        <field name="cnpj_cpf">92.737.124/0001-72</field>
+        <field name="vat">92.737.124/0001-72</field>
         <field name="street_name">Avenida Javari</field>
         <field name="street_number">s/n</field>
         <field name="district">Distrito Industrial</field>
@@ -83,7 +83,7 @@
     <record id="res_partner_samsungpe" model="res.partner">
         <field name="name">Samsung Recife</field>
         <field name="legal_name">Samsung Recife LTDA</field>
-        <field name="cnpj_cpf">21.717.475/0001-73</field>
+        <field name="vat">21.717.475/0001-73</field>
         <field name="street_name">Av. República do Líbano</field>
         <field name="street_number">251</field>
         <field name="district">Centro</field>
@@ -107,7 +107,7 @@
     <record id="res_partner_positivo" model="res.partner">
         <field name="name">Positivo Informatica</field>
         <field name="legal_name">Positivo Informatica S/A</field>
-        <field name="cnpj_cpf">77.256.611/0001-20</field>
+        <field name="vat">77.256.611/0001-20</field>
         <field name="street_name">Rua Senador Accioly Filho</field>
         <field name="street_number">5200</field>
         <field name="district">Cidade Industrial</field>
@@ -131,7 +131,7 @@
     <record id="res_partner_dell" model="res.partner">
         <field name="name">Dell Computadores do Brasil</field>
         <field name="legal_name">Dell Computadores do Brasil LTDA</field>
-        <field name="cnpj_cpf">73.623.891/0001-06</field>
+        <field name="vat">73.623.891/0001-06</field>
         <field name="street_name">Avenida Ipiranga</field>
         <field name="street_number">6681</field>
         <field name="district">Partenon</field>
@@ -155,7 +155,7 @@
     <record id="res_partner_infobahia" model="res.partner">
         <field name="name">Info Bahia</field>
         <field name="legal_name">Informatica Bahia LTDA</field>
-        <field name="cnpj_cpf">14.685.381/0001-02</field>
+        <field name="vat">14.685.381/0001-02</field>
         <field name="street_name">Rua Francisco Muniz Barreto</field>
         <field name="street_number">2</field>
         <field name="district">Terreiro de Jesus</field>
@@ -179,7 +179,7 @@
     <record id="res_partner_infomanaus" model="res.partner">
         <field name="name">Informatica Manaus</field>
         <field name="legal_name">Informatica Manaus</field>
-        <field name="cnpj_cpf">38.633.837/0001-40</field>
+        <field name="vat">38.633.837/0001-40</field>
         <field name="street_name">Avenida Javari</field>
         <field name="street_number">s/n</field>
         <field name="district">Distrito Industrial</field>
@@ -203,7 +203,7 @@
     <record id="res_partner_cliente1_sp" model="res.partner">
         <field name="name">Cliente 1 SP Contribuinte</field>
         <field name="legal_name">Cliente 1 SP</field>
-        <field name="cnpj_cpf">81.493.979/0001-89</field>
+        <field name="vat">81.493.979/0001-89</field>
         <field name="street_name">Rua Samuel Morse</field>
         <field name="street_number">135</field>
         <field name="district">Brooklin</field>
@@ -226,7 +226,7 @@
     <record id="res_partner_cliente2_sp" model="res.partner">
         <field name="name">Cliente 2 -SP - Simples Nacional</field>
         <field name="legal_name">Cliente 2 - SP</field>
-        <field name="cnpj_cpf">12.046.835/0001-61</field>
+        <field name="vat">12.046.835/0001-61</field>
         <field name="street_name">Avenida Doutor Chucri Zaidan</field>
         <field name="street_number">950</field>
         <field name="district">Vila Cordeiro</field>
@@ -249,7 +249,7 @@
     <record id="res_partner_cliente2_sp_end_entrega" model="res.partner">
         <field name="name">Cliente 2 - SP - Endereço Entrega</field>
         <field name="legal_name">Cliente 2 - SP - Endereço Entrega</field>
-        <field name="cnpj_cpf">96.660.336/0001-50</field>
+        <field name="vat">96.660.336/0001-50</field>
         <field name="street_name">Rua Delfos</field>
         <field name="street_number">111</field>
         <field name="district">Vila Cordeiro</field>
@@ -281,7 +281,7 @@
     <record id="res_partner_cliente3_am" model="res.partner">
         <field name="name">Cliente 3 - Z/F Manaus - Contribuinte</field>
         <field name="legal_name">Cliente 3 - Manaus</field>
-        <field name="cnpj_cpf">46.081.676/0001-58</field>
+        <field name="vat">46.081.676/0001-58</field>
         <field name="street_name">Avenida Javari</field>
         <field name="street_number">s/n</field>
         <field name="district">Distrito Industrial</field>
@@ -305,7 +305,7 @@
     <record id="res_partner_cliente4_am" model="res.partner">
         <field name="name">Cliente 4 - Z/F Manaus - Simples Nacional</field>
         <field name="legal_name">Cliente 4 - Manaus</field>
-        <field name="cnpj_cpf">84.148.732/0001-13</field>
+        <field name="vat">84.148.732/0001-13</field>
         <field name="street_name">Avenida Javari</field>
         <field name="street_number">s/n</field>
         <field name="district">Distrito Industrial</field>
@@ -329,7 +329,7 @@
     <record id="res_partner_cliente5_pe" model="res.partner">
         <field name="name">Cliente 5 - Contribuinte - PE</field>
         <field name="legal_name">Cliente 5 PE</field>
-        <field name="cnpj_cpf">14.753.702/0001-50</field>
+        <field name="vat">14.753.702/0001-50</field>
         <field name="street_name">Av. República do Líbano</field>
         <field name="street_number">255</field>
         <field name="district">Centro</field>
@@ -353,7 +353,7 @@
     <record id="res_partner_cliente6_pe" model="res.partner">
         <field name="name">Cliente 6 - Simples Nacional- PE</field>
         <field name="legal_name">Cliente 6 Recife LTDA</field>
-        <field name="cnpj_cpf">97.449.840/0001-78</field>
+        <field name="vat">97.449.840/0001-78</field>
         <field name="street_name">Av. República do Líbano</field>
         <field name="street_number">275</field>
         <field name="district">Centro</field>
@@ -377,7 +377,7 @@
     <record id="res_partner_cliente7_rs" model="res.partner">
         <field name="name">Cliente 7 RS - Contribuinte</field>
         <field name="legal_name">Cliente 7 - RS</field>
-        <field name="cnpj_cpf">43.266.887/0001-77</field>
+        <field name="vat">43.266.887/0001-77</field>
         <field name="street_name">Avenida Ipiranga</field>
         <field name="street_number">6690</field>
         <field name="district">Partenon</field>
@@ -401,7 +401,7 @@
     <record id="res_partner_cliente7_rs_end_cobranca" model="res.partner">
         <field name="name">Cliente 7 - RS - Endereço Cobrança</field>
         <field name="legal_name">Cliente 7 - RS - Endereço Cobranca</field>
-        <field name="cnpj_cpf">13.691.522/0001-29</field>
+        <field name="vat">13.691.522/0001-29</field>
         <field name="street_name">Avenida Borges de Medeiros</field>
         <field name="street_number">123</field>
         <field name="district">Praia de Belas</field>
@@ -433,7 +433,7 @@
     <record id="res_partner_cliente8_rs" model="res.partner">
         <field name="name">Cliente 8 RS - Simples Nacional</field>
         <field name="legal_name">Cliente 7 - RS</field>
-        <field name="cnpj_cpf">32.406.080/0001-76</field>
+        <field name="vat">32.406.080/0001-76</field>
         <field name="street_name">Avenida Ipiranga</field>
         <field name="street_number">6600</field>
         <field name="district">Partenon</field>
@@ -456,7 +456,7 @@
 
     <record id="res_partner_akretion" model="res.partner">
         <field name="title" ref="res_partner_title_pvt_ltd" />
-        <field name="cnpj_cpf">11.034.414/0001-58</field>
+        <field name="vat">11.034.414/0001-58</field>
         <field eval="0" name="employee" />
         <field name="is_company" eval="1" />
         <field eval="1" name="active" />
@@ -512,7 +512,7 @@
 
     <record id="res_partner_address_ak3" model="res.partner">
         <field name="title" ref="res_partner_title_pvt_ltd" />
-        <field name="cnpj_cpf">11.034.414/0003-10</field>
+        <field name="vat">11.034.414/0003-10</field>
         <field name="inscr_mun">1448</field>
         <field eval="0" name="employee" />
         <field eval="1" name="active" />
@@ -543,7 +543,7 @@
     <record id="res_partner_cliente9_mg" model="res.partner">
         <field name="name">Cliente 9 MG - PJ Não Contribuinte</field>
         <field name="legal_name">Cliente 9 MG</field>
-        <field name="cnpj_cpf">26.355.289/0001-55</field>
+        <field name="vat">26.355.289/0001-55</field>
         <field name="street_name">R PRESIDENTE ROOSEVELT</field>
         <field name="street_number">63</field>
         <field name="district">Morro Chic</field>
@@ -566,7 +566,7 @@
     <record id="res_partner_cliente10_mg" model="res.partner">
         <field name="name">Cliente 10 MG - PF Não Contribuinte</field>
         <field name="legal_name">Cliente 10 PF</field>
-        <field name="cnpj_cpf">276.288.360-11</field>
+        <field name="vat">276.288.360-11</field>
         <field name="street_name">R PRESIDENTE ROOSEVELT</field>
         <field name="street_number">63</field>
         <field name="district">Morro Chic</field>
@@ -588,7 +588,7 @@
 
     <record id="res_partner_kmee" model="res.partner">
         <field name="title" ref="res_partner_title_pvt_ltd" />
-        <field name="cnpj_cpf">23.130.935/0001-98</field>
+        <field name="vat">23.130.935/0001-98</field>
         <field eval="0" name="employee" />
         <field name="is_company" eval="1" />
         <field eval="1" name="active" />
@@ -632,7 +632,7 @@
     <record id="res_partner_cliente11_sp" model="res.partner">
         <field name="name">Cliente 11 SP - PF Não Contribuinte</field>
         <field name="legal_name">Cliente 11 PF</field>
-        <field name="cnpj_cpf">765.865.078-12</field>
+        <field name="vat">765.865.078-12</field>
         <field name="street_name">Rua do Bosque</field>
         <field name="street_number">238</field>
         <field name="district">Barra Funda</field>

--- a/l10n_br_base/demo/res_company_demo.xml
+++ b/l10n_br_base/demo/res_company_demo.xml
@@ -15,7 +15,7 @@
         <field name="email">info@suaempresa.com.br</field>
         <field name="website">www.example.com</field>
         <field name="is_company" eval="True" />
-        <field name="cnpj_cpf">97.231.608/0001-69</field>
+        <field name="vat">97.231.608/0001-69</field>
         <field name="l10n_br_ie_code">454.504.604.553</field>
     </record>
     <function model="res.partner" name="_onchange_city_id">
@@ -43,7 +43,7 @@
         <field name="phone">+55 11 9999-9999</field>
         <field name="email">info@suaempresa.com.br</field>
         <field name="is_company" eval="True" />
-        <field name="cnpj_cpf">81.583.054/0001-29</field>
+        <field name="vat">81.583.054/0001-29</field>
         <field name="l10n_br_ie_code">078.016.350.838</field>
     </record>
     <function model="res.partner" name="_onchange_city_id">
@@ -72,7 +72,7 @@
         <field name="email">info@simplesnacional.example.com</field>
         <field name="website">www.example.com</field>
         <field name="is_company" eval="True" />
-        <field name="cnpj_cpf">59.594.315/0001-57</field>
+        <field name="vat">59.594.315/0001-57</field>
         <field name="l10n_br_ie_code">755.338.250.133</field>
     </record>
     <function model="res.partner" name="_onchange_city_id">

--- a/l10n_br_base/models/party_mixin.py
+++ b/l10n_br_base/models/party_mixin.py
@@ -131,19 +131,20 @@ class PartyMixin(models.AbstractModel):
         for partner in self:
             partner.cnpj_cpf = partner.vat
 
-    @api.depends("cnpj_cpf")
+    @api.depends("vat")
     def _compute_cnpj_cpf_stripped(self):
         for record in self:
-            if record.cnpj_cpf:
+            if record.vat:
                 record.cnpj_cpf_stripped = "".join(
-                    char for char in record.cnpj_cpf if char.isalnum()
+                    char for char in record.vat if char.isalnum()
                 )
             else:
                 record.cnpj_cpf_stripped = False
 
     @api.onchange("zip")
     def _onchange_zip(self):
-        self.zip = misc.format_zipcode(self.zip, self.country_id.code)
+        if self.country_id:
+            self.zip = misc.format_zipcode(self.zip, self.country_id.code)
 
     # TODO: O metodo tanto no res.partner quanto no res.company chamam
     #  _onchange_state e aqui também deveria, porém por algum motivo

--- a/l10n_br_base/models/res_company.py
+++ b/l10n_br_base/models/res_company.py
@@ -1,7 +1,5 @@
-#    Thinkopen - Brasil
-#    Copyright (C) Thinkopen Solutions (<http://www.thinkopensolutions.com.br>)
-#    Akretion
-#    Copyright (C) Akretion (<http://www.akretion.com>)
+# 2013 Copyright (C) Thinkopen Solutions (<http://www.thinkopensolutions.com.br>)
+# 2013 Copyright (C) Akretion (<http://www.akretion.com>)
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from odoo import api, fields, models
@@ -28,37 +26,30 @@ class Company(models.Model):
         ]
 
     def _inverse_legal_name(self):
-        """Write the l10n_br specific functional fields."""
         for company in self:
             company.partner_id.legal_name = company.legal_name
 
     def _inverse_district(self):
-        """Write the l10n_br specific functional fields."""
         for company in self:
             company.partner_id.district = company.district
 
     def _inverse_street_name(self):
-        """Write the l10n_br specific functional fields."""
         for company in self:
             company.partner_id.street_name = company.street_name
 
     def _inverse_street_number(self):
-        """Write the l10n_br specific functional fields."""
         for company in self:
             company.partner_id.street_number = company.street_number
 
     def _inverse_cnpj_cpf(self):
-        """Write the l10n_br specific functional fields."""
         for company in self:
             company.partner_id.cnpj_cpf = company.cnpj_cpf
 
     def _inverse_l10n_br_ie_code(self):
-        """Write the l10n_br specific functional fields."""
         for company in self:
             company.partner_id.l10n_br_ie_code = company.l10n_br_ie_code
 
     def _inverse_state(self):
-        """Write the l10n_br specific functional fields."""
         for company in self:
             company.partner_id.state_id = company.state_id
 

--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -113,7 +113,7 @@ class Partner(models.Model):
         for record in self:
             domain = []
 
-            if not record.cnpj_cpf:
+            if not record.vat:
                 return
 
             if self.env.context.get(
@@ -134,13 +134,16 @@ class Partner(models.Model):
                 ]
 
             if record.vat:
-                domain += [("vat", "=", record.vat), ("id", "!=", record.id)]
-            else:
+                domain += [
+                    ("vat", "=", record.vat),
+                    ("id", "!=", record.id),
+                    ("parent_id", "!=", record.id),
+                ]
                 return
 
             matches = record.env["res.partner"].search(domain)
             if matches:
-                if cnpj_cpf.validar_cnpj(record.cnpj_cpf):
+                if cnpj_cpf.validar_cnpj(record.vat):
                     if allow_cnpj_multi_ie == "True":
                         for partner in record.env["res.partner"].search(domain):
                             if (
@@ -183,7 +186,7 @@ class Partner(models.Model):
         for record in self:
             check_cnpj_cpf(
                 record.env,
-                record.cnpj_cpf,
+                record.vat,
                 record.country_id,
             )
 
@@ -259,7 +262,9 @@ class Partner(models.Model):
 
     def create_company(self):
         self.ensure_one()
-        res = super().create_company()
+        res = super(
+            Partner, self.with_context(allow_vat_duplicate=True)
+        ).create_company()
         if res and self.is_br_partner:
             parent = self.parent_id
             parent.legal_name = parent.name

--- a/l10n_br_base/tests/test_base_onchange.py
+++ b/l10n_br_base/tests/test_base_onchange.py
@@ -16,7 +16,7 @@ class L10nBrBaseOnchangeTest(TransactionCase):
             .create(
                 {
                     "name": "Company Test 1",
-                    "cnpj_cpf": "02.960.895/0001-31",
+                    "vat": "02.960.895/0001-31",
                     "city_id": cls.env.ref("l10n_br_base.city_3205002").id,
                     "zip": "29161-695",
                 }

--- a/l10n_br_base/tests/test_other_ie.py
+++ b/l10n_br_base/tests/test_other_ie.py
@@ -19,7 +19,7 @@ class OtherIETest(TransactionCase):
             {
                 "name": "Akretion Sao Paulo",
                 "legal_name": "Akretion Sao Paulo",
-                "cnpj_cpf": "26.905.703/0001-52",
+                "vat": "26.905.703/0001-52",
                 "l10n_br_ie_code": "932.446.119.086",
                 "street": "Rua Paulo Dias",
                 "street_number": "586",

--- a/l10n_br_base/tests/test_valid_createid.py
+++ b/l10n_br_base/tests/test_valid_createid.py
@@ -16,7 +16,7 @@ class ValidCreateIdTest(TransactionCase):
         cls.company_valid = {
             "name": "Company Test 1",
             "legal_name": "Company Testc 1 Ltda",
-            "cnpj_cpf": "02.960.895/0001-31",
+            "vat": "02.960.895/0001-31",
             "l10n_br_ie_code": "081.981.37-6",
             "street": "Rod BR-101 Norte Contorno",
             "street_number": "955",
@@ -35,7 +35,7 @@ class ValidCreateIdTest(TransactionCase):
         cls.company_invalid_cnpj = {
             "name": "Company Test 2",
             "legal_name": "Company Testc 2 Ltda",
-            "cnpj_cpf": "14.018.406/0001-93",
+            "vat": "14.018.406/0001-93",
             "l10n_br_ie_code": "385.611.86-2",
             "street": "Rod BR-101 Norte Contorno",
             "street_number": "955",
@@ -54,7 +54,7 @@ class ValidCreateIdTest(TransactionCase):
         cls.company_invalid_l10n_br_ie_code = {
             "name": "Company Test 3",
             "legal_name": "Company Testc 3 Ltda",
-            "cnpj_cpf": "31.295.101/0001-60",
+            "vat": "31.295.101/0001-60",
             "l10n_br_ie_code": "924.511.27-0",
             "street": "Rod BR-101 Norte Contorno",
             "street_number": "955",
@@ -73,7 +73,7 @@ class ValidCreateIdTest(TransactionCase):
         cls.partner_valid = {
             "name": "Partner Test 1",
             "legal_name": "Partner Testc 1 Ltda",
-            "cnpj_cpf": "734.419.622-06",
+            "vat": "734.419.622-06",
             "l10n_br_ie_code": "176.754.07-5",
             "street": "Rod BR-101 Norte Contorno",
             "street_number": "955",
@@ -92,7 +92,7 @@ class ValidCreateIdTest(TransactionCase):
         cls.partner_invalid_cpf = {
             "name": "Partner Test 2",
             "legal_name": "Partner Testc 2 Ltda",
-            "cnpj_cpf": "734.419.622-07",
+            "vat": "734.419.622-07",
             "l10n_br_ie_code": "538.759.92-5",
             "street": "Rod BR-101 Norte Contorno",
             "street_number": "955",
@@ -186,14 +186,14 @@ class ValidCreateIdTest(TransactionCase):
         )
         self.assertEqual(
             partner.vat,
-            self.partner_valid["cnpj_cpf"],
+            self.partner_valid["vat"],
             "vat should be equal to CPF for a br partner",
         )
 
     def test_vat_computation_without_cnpj(self):
         """Test VAT computation for a br partner without CNPJ"""
         partner_data = self.partner_valid.copy()
-        partner_data.pop("cnpj_cpf")
+        partner_data.pop("vat")
         partner = (
             self.env["res.partner"]
             .with_context(tracking_disable=True)
@@ -230,7 +230,7 @@ class ValidCreateIdTest(TransactionCase):
     def test_vat_computation_with_company_name_and_vat(self):
         """Test VAT computation for a br partner with company_name and vat"""
         partner_data = self.partner_valid.copy()
-        partner_data.pop("cnpj_cpf")
+        partner_data.pop("vat")
         partner_data.update(
             {
                 "company_name": "Company Partner",
@@ -271,7 +271,7 @@ class ValidCreateIdTest(TransactionCase):
             "The legal name must be the same as the company name",
         )
         self.assertEqual(
-            company.cnpj_cpf,
+            company.vat,
             partner.vat,
             "The company CNPJ_CPF must be the same as the partner VAT",
         )

--- a/l10n_br_base/views/res_company_view.xml
+++ b/l10n_br_base/views/res_company_view.xml
@@ -8,20 +8,10 @@
         <field name="model">res.company</field>
         <field name="inherit_id" ref="base.view_company_form" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='vat']" position="attributes">
-                <attribute
-                    name="attrs"
-                >{'invisible': [('country_id', '=', %(base.br)d)]}</attribute>
-            </xpath>
             <field name="company_registry" position="after">
                 <field
                     name="legal_name"
                     placeholder="Legal Name..."
-                    attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
-                />
-                <field
-                    name="cnpj_cpf"
-                    placeholder="CNPJ..."
                     attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
                 />
                 <field
@@ -79,7 +69,7 @@
         <field name="field_parent">child_ids</field>
         <field name="arch" type="xml">
             <field name="name" position="after">
-                <field name="cnpj_cpf" />
+                <field name="vat" />
             </field>
         </field>
     </record>

--- a/l10n_br_base/views/res_partner_view.xml
+++ b/l10n_br_base/views/res_partner_view.xml
@@ -12,7 +12,7 @@
             <field name="name" position="after">
                 <field name="legal_name" />
                 <field
-                    name="cnpj_cpf"
+                    name="vat"
                     filter_domain="['|', ('vat', 'ilike', self), ('cnpj_cpf_stripped', 'ilike', self)]"
                 />
             </field>
@@ -26,7 +26,7 @@
         <field name="arch" type="xml">
             <field name="display_name" position="after">
                 <field name="legal_name" />
-                <field name="cnpj_cpf" />
+                <field name="vat" />
                 <field name="l10n_br_ie_code" />
             </field>
         </field>
@@ -43,7 +43,7 @@
                     {
                         'readonly':
                             [
-                                '|', ('cnpj_cpf', 'not in', [False, ""]),
+                                '|', ('vat', 'not in', [False, ""]),
                                      ('parent_id', '!=', False),
 
                             ]
@@ -68,17 +68,17 @@
                 <field name="legal_name" nolabel="1" />
                 <div>
                     <label
-                        for="cnpj_cpf"
+                        for="vat"
                         string="CPF"
                         attrs="{'invisible': [('is_company','=', True)]}"
                     />
                     <label
-                        for="cnpj_cpf"
+                        for="vat"
                         string="CNPJ/Vat Number"
                         attrs="{'invisible': [('is_company','!=', True)]}"
                     />
                 </div>
-                <field name="cnpj_cpf" nolabel="1" />
+                <field name="vat" nolabel="1" />
                 <div>
                     <label
                         for="rg"

--- a/l10n_br_cnpj_search/views/res_company_view.xml
+++ b/l10n_br_cnpj_search/views/res_company_view.xml
@@ -9,10 +9,10 @@
             <field name="cnae_secondary_ids" position="after">
                 <field name="equity_capital" widget="monetary" />
             </field>
-            <field name="cnpj_cpf" position="replace">
-                <label for="cnpj_cpf" string="CNPJ" />
+            <field name="vat" position="replace">
+                <label for="vat" string="CNPJ" />
                      <div class="o_row" colspan="1">
-                        <field name="cnpj_cpf" />
+                        <field name="vat" />
                         <button
                         name="action_open_cnpj_search_wizard"
                         type="object"

--- a/l10n_br_cnpj_search/views/res_partner_view.xml
+++ b/l10n_br_cnpj_search/views/res_partner_view.xml
@@ -13,9 +13,9 @@
                 <field name="equity_capital" widget="monetary" />
             </field>
 
-            <field name="cnpj_cpf" position="replace">
+            <field name="vat" position="replace">
                      <div class="o_row" colspan="4">
-                        <field name="cnpj_cpf" nolabel="1" />
+                        <field name="vat" nolabel="1" />
                         <button
                         name="action_open_cnpj_search_wizard"
                         type="object"

--- a/l10n_br_fiscal/i18n/l10n_br_fiscal.pot
+++ b/l10n_br_fiscal/i18n/l10n_br_fiscal.pot
@@ -1218,9 +1218,9 @@ msgid "CNPJ"
 msgstr ""
 
 #. module: l10n_br_fiscal
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_related__cnpj_cpf
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_res_partner__cnpj_cpf
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_res_users__cnpj_cpf
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_related__vat
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_res_partner__vat
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_res_users__vat
 msgid "CNPJ/CPF"
 msgstr ""
 

--- a/l10n_br_fiscal/i18n/pt_BR.po
+++ b/l10n_br_fiscal/i18n/pt_BR.po
@@ -1300,9 +1300,9 @@ msgid "CNPJ"
 msgstr "CNPJ"
 
 #. module: l10n_br_fiscal
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_related__cnpj_cpf
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_res_partner__cnpj_cpf
-#: model:ir.model.fields,field_description:l10n_br_fiscal.field_res_users__cnpj_cpf
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_related__vat
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_res_partner__vat
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_res_users__vat
 msgid "CNPJ/CPF"
 msgstr "CNPJ/CPF"
 

--- a/l10n_br_fiscal/models/data_ncm_nbs_abstract.py
+++ b/l10n_br_fiscal/models/data_ncm_nbs_abstract.py
@@ -89,7 +89,7 @@ class DataNcmNbsAbstract(models.AbstractModel):
 
                 config = DeOlhoNoImposto(
                     company.ibpt_token,
-                    misc.punctuation_rm(company.cnpj_cpf),
+                    misc.punctuation_rm(company.vat),
                     company.state_id.code,
                     odooconfig.get("ibpt_request_timeout")
                     or self.env["ir.config_parameter"]

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -230,7 +230,7 @@ class Document(models.Model):
 
     partner_cnpj_cpf = fields.Char(
         string="CNPJ",
-        related="partner_id.cnpj_cpf",
+        related="partner_id.vat",
     )
 
     partner_l10n_br_ie_code = fields.Char(
@@ -334,7 +334,7 @@ class Document(models.Model):
 
     company_cnpj_cpf = fields.Char(
         string="Company CNPJ",
-        related="company_id.cnpj_cpf",
+        related="company_id.vat",
     )
 
     company_l10n_br_ie_code = fields.Char(

--- a/l10n_br_fiscal/models/document_related.py
+++ b/l10n_br_fiscal/models/document_related.py
@@ -128,7 +128,7 @@ class DocumentRelated(models.Model):
                 or False
             )
 
-            self.cnpj_cpf = related.partner_id and related.partner_id.cnpj_cpf or False
+            self.cnpj_cpf = related.partner_id and related.partner_id.vat or False
 
             if related.partner_id.is_company:
                 self.cpfcnpj_type = "cnpj"

--- a/l10n_br_fiscal/models/res_partner.py
+++ b/l10n_br_fiscal/models/res_partner.py
@@ -83,7 +83,7 @@ class ResPartner(models.Model):
         tracking=True,
     )
 
-    cnpj_cpf = fields.Char(
+    vat = fields.Char(
         tracking=True,
     )
 

--- a/l10n_br_fiscal/tests/test_ibpt.py
+++ b/l10n_br_fiscal/tests/test_ibpt.py
@@ -108,7 +108,7 @@ class TestIbpt(TransactionCase):
         try:
             config = DeOlhoNoImposto(
                 company.ibpt_token,
-                misc.punctuation_rm(company.cnpj_cpf),
+                misc.punctuation_rm(company.vat),
                 company.state_id.code,
                 odooconfig.get("ibpt_request_timeout")
                 or cls.env["ir.config_parameter"]
@@ -131,7 +131,7 @@ class TestIbpt(TransactionCase):
         company = cls.env["res.company"].create(
             {
                 "name": "Company Test Fiscal BR",
-                "cnpj_cpf": "02.960.895/0002-12",
+                "vat": "02.960.895/0002-12",
                 "country_id": cls.env.ref("base.br").id,
                 "state_id": cls.env.ref("base.state_br_es").id,
                 "ibpt_api": True,

--- a/l10n_br_fiscal/tools.py
+++ b/l10n_br_fiscal/tools.py
@@ -48,7 +48,7 @@ def domain_field_codes(
 def path_edoc_company(company_id):
     db_name = company_id._cr.dbname
     filestore = tools.config.filestore(db_name)
-    return "/".join([filestore, "edoc", punctuation_rm(company_id.cnpj_cpf)])
+    return "/".join([filestore, "edoc", punctuation_rm(company_id.vat)])
 
 
 def build_edoc_path(


### PR DESCRIPTION
aqui #3566 trocamos o campo cnpj_cpf no res.partner e no res.company pro vat para ter compatibilidade com os campos do modulo l10n_br que a Odoo acabou [padronizando](https://github.com/odoo/odoo/blob/16.0/addons/l10n_br/models/res_partner.py) e para ter uma maior compatibilidade com os outros modulos Odoo. Porem fizemos um replace minimalista mantendo o uso do alias no maximo possivel para facilitar os ports e backports com a v14.

Agora que estamos olhando mais para a v18, eu acho bom assumir o restante da mudança pelo menos nos modulos que vamos jogar em breve para a v18. Pois assim vai minimizar a fricção entre as branches 16.0 e 18.0.

Observem que aqui eu estou mantendo o alias cnpj_cpf. E nos modulos como l10n_br_nfe, l10n_br_cte, l10n_br_mdfe que talvez vai demorar um pouco mais para jogar para a v18 eu segurei a onda e não fiz o rename para continuar facilitando os ports entre a 14.0 e a 16.0 por enquanto.