### PR TITLE
[16.0][REF] l10n_br_base: rename rg -> l10n_br_rg_code

### DIFF
--- a/l10n_br_base/migrations/16.0.5.0.0/pre-migration.py
+++ b/l10n_br_base/migrations/16.0.5.0.0/pre-migration.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2025 - TODAY Raphaël Valyi - Akretion
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if not openupgrade.column_exists(env.cr, "res_partner", "l10n_br_rg_code"):
+        openupgrade.rename_columns(
+            env.cr,
+            {
+                "res_partner": [
+                    (
+                        "rg",
+                        "l10n_br_rg_code",
+                    )
+                ]
+            },
+        )

--- a/l10n_br_base/models/party_mixin.py
+++ b/l10n_br_base/models/party_mixin.py
@@ -40,11 +40,6 @@ class PartyMixin(models.AbstractModel):
         related="l10n_br_ie_code", string="State Tax Number alias", readonly=False
     )
 
-    rg = fields.Char(
-        string="RG",
-        unaccent=False,
-    )
-
     state_tax_number_ids = fields.One2many(
         string="Others State Tax Number",
         comodel_name="state.tax.numbers",

--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -48,6 +48,8 @@ class Partner(models.Model):
 
     union_entity_code = fields.Char(string="Union Entity code", unaccent=False)
 
+    l10n_br_rg_code = fields.Char(string="RG", unaccent=False)
+
     pix_key_ids = fields.One2many(
         string="Pix Keys",
         comodel_name="res.partner.pix",

--- a/l10n_br_base/views/res_partner_view.xml
+++ b/l10n_br_base/views/res_partner_view.xml
@@ -81,13 +81,13 @@
                 <field name="vat" nolabel="1" />
                 <div>
                     <label
-                        for="rg"
+                        for="l10n_br_rg_code"
                         string="RG"
                         attrs="{'invisible': [('is_company','=', True)]}"
                     />
                 </div>
                 <field
-                    name="rg"
+                    name="l10n_br_rg_code"
                     nolabel="1"
                     attrs="{'invisible': [('is_company','=', True)]}"
                 />

--- a/l10n_br_crm/migrations/16.0.3.0.0/pre-migration.py
+++ b/l10n_br_crm/migrations/16.0.3.0.0/pre-migration.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2025 - TODAY Raphaël Valyi - Akretion
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if not openupgrade.column_exists(env.cr, "crm_lead", "l10n_br_rg_code"):
+        openupgrade.rename_columns(
+            env.cr,
+            {
+                "crm_lead": [
+                    (
+                        "rg",
+                        "l10n_br_rg_code",
+                    )
+                ]
+            },
+        )

--- a/l10n_br_crm/models/crm_lead.py
+++ b/l10n_br_crm/models/crm_lead.py
@@ -15,7 +15,11 @@ class Lead(models.Model):
     _name = "crm.lead"
     _inherit = [_name, "l10n_br_base.party.mixin"]
 
-    cnpj = fields.Char(string="CNPJ")
+    cnpj = fields.Char(string="CNPJ", unaccent=False)
+
+    cpf = fields.Char(string="CPF", unaccent=False)
+
+    l10n_br_rg_code = fields.Char(string="RG", unaccent=False)
 
     street_name = fields.Char()
 
@@ -24,8 +28,6 @@ class Lead(models.Model):
     name_surname = fields.Char(
         string="Name and Surname", help="Name used in fiscal documents"
     )
-
-    cpf = fields.Char(string="CPF")
 
     show_l10n_br = fields.Boolean(
         compute="_compute_show_l10n_br",
@@ -149,7 +151,7 @@ class Lead(models.Model):
                 )
                 result["website"] = self.partner_id.parent_id.website or False
                 result["cpf"] = self.partner_id.cnpj_cpf
-                result["rg"] = self.partner_id.rg
+                result["l10n_br_rg_code"] = self.partner_id.l10n_br_rg_code
                 result["name_surname"] = self.partner_id.legal_name
         self.update(result)
         return result
@@ -184,8 +186,8 @@ class Lead(models.Model):
             values.update(
                 {
                     "cnpj_cpf": self.cpf,
-                    "l10n_br_ie_code": self.rg,
-                    "rg": self.rg,
+                    "l10n_br_ie_code": self.l10n_br_rg_code,
+                    "l10n_br_rg_code": self.l10n_br_rg_code,
                 }
             )
         return values

--- a/l10n_br_crm/tests/test_crm_lead.py
+++ b/l10n_br_crm/tests/test_crm_lead.py
@@ -30,7 +30,7 @@ class CrmLeadTest(TransactionCase):
             {
                 "name": "Test Contact",
                 "cpf": "70531160505",
-                "rg": "99.888.777-1",
+                "l10n_br_rg_code": "99.888.777-1",
                 "stage_id": cls.env.ref("crm.stage_lead1").id,
                 "contact_name": "Test Contact",
             }

--- a/l10n_br_crm/views/crm_lead_view.xml
+++ b/l10n_br_crm/views/crm_lead_view.xml
@@ -21,7 +21,7 @@
                     attrs="{'invisible': [('show_l10n_br', '=', False)]}"
                 />
                 <field
-                    name="rg"
+                    name="l10n_br_rg_code"
                     attrs="{'invisible': [('show_l10n_br', '=', False)]}"
                 />
             </xpath>
@@ -98,7 +98,7 @@
                     attrs="{'invisible': [('show_l10n_br', '=', False)]}"
                 />
                 <field
-                    name="rg"
+                    name="l10n_br_rg_code"
                     attrs="{'invisible': [('show_l10n_br', '=', False)]}"
                 />
             </xpath>

--- a/l10n_br_crm/views/crm_quick_create_opportunity_form.xml
+++ b/l10n_br_crm/views/crm_quick_create_opportunity_form.xml
@@ -14,7 +14,7 @@
                 <field name="l10n_br_isuf_code" invisible="1" />
                 <field name="name_surname" invisible="1" />
                 <field name="cpf" invisible="1" />
-                <field name="rg" invisible="1" />
+                <field name="l10n_br_rg_code" invisible="1" />
             </xpath>
         </field>
     </record>

--- a/l10n_br_crm_cnpj_search/models/crm_lead.py
+++ b/l10n_br_crm_cnpj_search/models/crm_lead.py
@@ -42,8 +42,8 @@ class Lead(models.Model):
             values.update(
                 {
                     "cnpj_cpf": self.cpf,
-                    "l10n_br_ie_code": self.rg,
-                    "rg": self.rg,
+                    "l10n_br_ie_code": self.l10n_br_rg_code,
+                    "l10n_br_rg_code": self.l10n_br_rg_code,
                 }
             )
         return values

--- a/l10n_br_cte/models/res_partner.py
+++ b/l10n_br_cte/models/res_partner.py
@@ -514,7 +514,7 @@ class ResPartner(spec_models.SpecModel):
                 return "EX"
 
             if xsd_field == "cte40_idEstrangeiro":
-                return self.vat or self.cnpj_cpf or self.rg or "EXTERIOR"
+                return self.vat or self.cnpj_cpf or self.l10n_br_rg_code or "EXTERIOR"
 
         return super()._export_field(xsd_field, class_obj, member_spec, export_value)
 

--- a/l10n_br_hr/migrations/16.0.3.0.0/pre-migration.py
+++ b/l10n_br_hr/migrations/16.0.3.0.0/pre-migration.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2025 - TODAY Raphaël Valyi - Akretion
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if not openupgrade.column_exists(env.cr, "hr_employee", "l10n_br_rg_code"):
+        openupgrade.rename_columns(
+            env.cr,
+            {
+                "hr_employee": [
+                    (
+                        "rg",
+                        "l10n_br_rg_code",
+                    )
+                ]
+            },
+        )

--- a/l10n_br_hr/models/hr_employee.py
+++ b/l10n_br_hr/models/hr_employee.py
@@ -54,18 +54,15 @@ class HrEmployee(models.Model):
         groups="hr.group_hr_user",
     )
 
-    rg = fields.Char(
-        string="RG",
-        store=True,
-        related="address_home_id.l10n_br_ie_code",
+    l10n_br_rg_code = fields.Char(
+        related="address_home_id.l10n_br_rg_code",
         help="National ID number",
         groups="hr.group_hr_user",
     )
 
     cpf = fields.Char(
         string="CPF",
-        store=True,
-        related="address_home_id.cnpj_cpf",
+        related="address_home_id.vat",
         readonly=False,
         groups="hr.group_hr_user",
     )

--- a/l10n_br_hr/views/hr_employee_view.xml
+++ b/l10n_br_hr/views/hr_employee_view.xml
@@ -63,7 +63,7 @@
                             </group>
                             <group name="identidade" string="Identidade">
                                 <!-- <field name="identity_type_id"/> -->
-                                <field name="rg" string="Number" />
+                                <field name="l10n_br_rg_code" string="Number" />
                                 <field name="organ_exp" />
                                 <field name="rg_emission" />
                                 <field name="identity_validity" />

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -354,7 +354,7 @@ class ResPartner(spec_models.SpecModel):
                 return "EX"
 
             if xsd_field == "nfe40_idEstrangeiro":
-                return self.vat or self.cnpj_cpf or self.rg or "EXTERIOR"
+                return self.vat or self.cnpj_cpf or self.l10n_br_rg_code or "EXTERIOR"
 
         return super()._export_field(xsd_field, class_obj, member_spec, export_value)
 


### PR DESCRIPTION
1. o campo rg com apenas duas letras no res.partner era pedir para merda acontecer com os outros módulos (colisão de campos). Renoma l10n_br_rg_code para ficar future proof, adotando o tipo de padrão que a Odoo adotou pros campos das localizações.
2. não me parecia ok ter esse campo rg no party_mixin.py pois criava um campo rg na tabela res_company e a meu ver apenas o res.partner (e o hr.employee eventualmente no modulo l10n_br_hr) precisa ter. Como eu tirei do mixin eu tive que redefinir o campo no l10n_br_crm tb.