### PR TITLE
[14.0][IMP] l10n_br_cnpj_search: treats null values

### DIFF
--- a/l10n_br_cnpj_search/models/cnpj_webservice.py
+++ b/l10n_br_cnpj_search/models/cnpj_webservice.py
@@ -94,8 +94,9 @@ class CNPJWebservice(models.AbstractModel):
     @api.model
     def get_data(self, data, name, title=False, lower=False):
         value = False
-        if data.get(name) != "":
-            value = data[name]
+        name_str = data.get(name)
+        if name_str:
+            value = name_str
             if lower:
                 value = value.lower()
             elif title:


### PR DESCRIPTION
Diferentemente da https://receitaws.com.br/, algumas apis privadas ou públicas (como a https://docs.minhareceita.org/) podem retornar um valor nulo para uma string.
<img width="291" height="179" alt="image" src="https://github.com/user-attachments/assets/133ecf0f-1604-4905-8b88-ce01e1a4435c" />

A alteração trata valores nulos dentro da função get_data.

OBS: Esse erro pode acontecer no contexto em que o `l10n_br_cnpj_search` esteja sendo extendido em um outro módulo que adiciona um outro _provider_.