### PR TITLE
[16.0][FIX] l10n_br_fiscal: simply+fix onchanges

### DIFF
--- a/l10n_br_fiscal/models/document_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_line_mixin_methods.py
@@ -387,9 +387,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         self.ensure_one()
         return self.partner_id
 
-    @api.onchange(
-        "fiscal_operation_id", "ncm_id", "nbs_id", "cest_id", "service_type_id"
-    )
+    @api.onchange("fiscal_operation_id", "product_id", "company_id")
     def _onchange_fiscal_operation_id(self):
         if self.fiscal_operation_id:
             if not self.price_unit:
@@ -400,9 +398,15 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 partner=self._get_fiscal_partner(),
                 product=self.product_id,
             )
-            self._onchange_fiscal_operation_line_id()
 
-    @api.onchange("fiscal_operation_line_id")
+    @api.onchange(
+        "fiscal_operation_line_id",
+        "ncm_id",
+        "nbs_id",
+        "cest_id",
+        "service_type_id",
+        "ind_final",
+    )
     def _onchange_fiscal_operation_line_id(self):
         # Reset Taxes
         self._remove_all_fiscal_tax_ids()


### PR DESCRIPTION
- um metodo @api.onchange não deve chamar o onchange de algum campo que ele já muda. Pois isso é feito automaticamente pelo framework. Senão chama duas vezes de bobeira... Por isso removi o `self._onchange_fiscal_operation_line_id()` sendo que o self.fiscal_operation_line_id já tava sendo alterado umas 5 linhas antes.
- tinha métodos onchanges que claramente dependiam de campos que não tavam sendo listados no decorador... E foi preciso adicionar os campos para poder tirar o self._onchange_fiscal_operation_line_id() e continuar passando os testes. Eu imagino que alguém adicionou ele em vez de resolver o problema na raiz adicionando os campos que faltavam...

Sim a gente quer substituir o máximo desses onchanges por computes, mas isso vai ser progressivo. Enquanto isso tem que ser o mais limpo possível já...