### PR TITLE
[16.0] l10n_br_fiscal: dynamic @api.depends for compute_fiscal_amount

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -17,7 +17,6 @@ from odoo.addons.l10n_br_fiscal.constants.fiscal import (
     FISCAL_IN_OUT_ALL,
     FISCAL_OUT,
     MODELO_FISCAL_NFE,
-    SITUACAO_EDOC_AUTORIZADA,
     SITUACAO_EDOC_CANCELADA,
     SITUACAO_EDOC_EM_DIGITACAO,
 )
@@ -623,27 +622,6 @@ class AccountMove(models.Model):
                     )
 
         return new_moves
-
-    def _finalize_invoices(self, invoices):
-        for invoice in invoices:
-            invoice.compute_taxes()
-            for line in invoice.line_ids:
-                # Use additional field helper function (for account extensions)
-                line._set_additional_fields(invoice)
-            invoice._onchange_cash_rounding()
-
-    def post(self, invoice=False):
-        # TODO FIXME migrate: no more invoice keyword
-        result = super().post()
-        if invoice:
-            if (
-                invoice.document_type_id
-                and invoice.document_electronic
-                and invoice.issuer == DOCUMENT_ISSUER_COMPANY
-                and invoice.state_edoc != SITUACAO_EDOC_AUTORIZADA
-            ):
-                self.button_cancel()
-        return result
 
     def button_cancel(self):
         for doc in self.filtered(lambda d: d.document_type_id):

--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -200,9 +200,9 @@ class AccountMove(models.Model):
             else:
                 inv.fiscal_operation_type = MOVE_TO_OPERATION[inv.move_type]
 
-    def _get_amount_lines(self):
-        """Get object lines instances used to compute fields"""
-        return self.mapped("invoice_line_ids")
+    @api.model
+    def _get_fiscal_lines_field_name(self):
+        return "invoice_line_ids"
 
     def ensure_one_doc(self):
         self.ensure_one()
@@ -268,7 +268,7 @@ class AccountMove(models.Model):
     )
     def _compute_amount(self):
         for move in self.filtered(lambda m: m.fiscal_operation_id):
-            move._compute_fiscal_amount()
+            move._compute_fiscal_amount()  # breaks test_composite_move if removed
             for line in move.line_ids:
                 if (
                     move.is_invoice(include_receipts=True)

--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -333,21 +333,14 @@ class AccountMoveLine(models.Model):
 
             # Compute 'price_total'.
             if line.tax_ids:
-                # force_sign = (
-                #     -1
-                #     if line.move_type in ("out_invoice", "in_refund", "out_receipt")
-                #     else 1
-                # )
-                taxes_res = line.tax_ids._origin.with_context(
-                    #                    force_sign=force_sign
-                ).compute_all(
+                taxes_res = line.tax_ids._origin.with_context().compute_all(
                     line_discount_price_unit,
                     currency=line.currency_id,
                     quantity=line.quantity,
                     product=line.product_id,
                     partner=line.partner_id,
                     is_refund=line.move_type in ("out_refund", "in_refund"),
-                    handle_price_include=True,  # FIXME
+                    handle_price_include=True,  # sure?
                     fiscal_taxes=line.fiscal_tax_ids,
                     operation_line=line.fiscal_operation_line_id,
                     cfop=line.cfop_id or None,
@@ -412,8 +405,6 @@ class AccountMoveLine(models.Model):
         Overriden to pass all the extra Brazilian parameters we need
         to the account.tax#compute_all method.
         """
-        # TODO seems we should use sign in account_tax#compute_all
-        # so base and amount are negative if move is in.
         if not self.move_id.fiscal_operation_id:
             return super()._compute_all_tax()
 

--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -377,8 +377,6 @@ class AccountMoveLine(models.Model):
                 + line.freight_value
                 - line.icms_relief_value
             )
-            # TODO MIGRATE v16 (that is make icms_relief_value really work),
-            # for icms_relief_value see https://github.com/OCA/l10n-brazil/pull/3037
         return result
 
     @api.depends(

--- a/l10n_br_contract/models/contract_contract.py
+++ b/l10n_br_contract/models/contract_contract.py
@@ -78,13 +78,9 @@ class ContractContract(models.Model):
         copy=False,
     )
 
-    def _get_amount_lines(self):
-        """Get object lines instaces used to compute fields"""
-        return self.mapped("contract_line_ids")
-
-    @api.depends("contract_line_ids")
-    def _compute_amount(self):
-        return super()._compute_amount()
+    @api.model
+    def _get_fiscal_lines_field_name(self):
+        return "contract_line_ids"
 
     def _prepare_invoice(self, date_invoice, journal=None):
         self.ensure_one()

--- a/l10n_br_cte/tests/test_cte_serialize.py
+++ b/l10n_br_cte/tests/test_cte_serialize.py
@@ -39,7 +39,6 @@ class TestCTeSerialize(TransactionCase):
         cte.fiscal_line_ids.name = "Frete"
         cte.fiscal_line_ids._onchange_fiscal_operation_line_id()
         cte.fiscal_line_ids.cfop_id = cte.env.ref("l10n_br_fiscal.cfop_5352")
-        cte._compute_fiscal_amount()
 
         cte.action_document_confirm()
         cte.document_date = datetime.strptime(

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -546,22 +546,9 @@ class Document(models.Model):
         for r in self:
             r.name = r._compute_document_name()
 
-    @api.depends(
-        "fiscal_line_ids.estimate_tax",
-        "fiscal_line_ids.price_gross",
-        "fiscal_line_ids.amount_untaxed",
-        "fiscal_line_ids.amount_tax",
-        "fiscal_line_ids.amount_taxed",
-        "fiscal_line_ids.amount_total",
-        "fiscal_line_ids.financial_total",
-        "fiscal_line_ids.financial_total_gross",
-        "fiscal_line_ids.financial_discount_value",
-        "fiscal_line_ids.amount_tax_included",
-        "fiscal_line_ids.amount_tax_not_included",
-        "fiscal_line_ids.amount_tax_withholding",
-    )
-    def _compute_fiscal_amount(self):
-        return super()._compute_fiscal_amount()
+    @api.model
+    def _get_fiscal_lines_field_name(self):
+        return "fiscal_line_ids"
 
     def unlink(self):
         forbidden_states_unlink = [

--- a/l10n_br_fiscal/models/document_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_mixin_methods.py
@@ -66,20 +66,10 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
                 self.document_type_id = self.company_id.document_type_id
 
     def _get_amount_lines(self):
-        """
-        Hook method to retrieve the document lines used for amount calculations.
-
-        This method should be overridden by models that inherit this mixin
-        if their fiscal document lines are stored in a field other than
-        `fiscal_line_ids`. The returned recordset should contain line objects
-        that have the fiscal amount fields to be summed.
-
-        :return: A recordset of fiscal document line objects.
-        """
-        return self.mapped("fiscal_line_ids")
+        """Get object lines instances used to compute fiscal fields"""
+        return self.mapped(self._get_fiscal_lines_field_name())
 
     def _get_product_amount_lines(self):
-        """Get object lines instaces used to compute fields"""
         fiscal_line_ids = self._get_amount_lines()
         return fiscal_line_ids.filtered(lambda line: line.product_id.type != "service")
 
@@ -108,6 +98,30 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
             elif doc.document_serie_id is None:
                 doc.document_serie_id = False
 
+    @api.model
+    def _get_fiscal_lines_field_name(self):
+        return "fiscal_line_ids"
+
+    def _get_fiscal_amount_field_dependencies(self):
+        """
+        Dynamically get the list of field dependencies.
+        """
+        if self._abstract:
+            return []
+        o2m_field_name = self._get_fiscal_lines_field_name()
+        target_fields = []
+        for field in self._get_amount_fields():
+            if (
+                field.replace("amount_", "")
+                in getattr(self, o2m_field_name)._fields.keys()
+            ):
+                target_fields.append(field.replace("amount_", ""))
+
+        return [o2m_field_name] + [
+            f"{o2m_field_name}.{target_field}" for target_field in target_fields
+        ]
+
+    @api.depends(lambda self: self._get_fiscal_amount_field_dependencies())
     def _compute_fiscal_amount(self):
         """
         Compute and sum various fiscal amounts from the document lines.
@@ -121,7 +135,7 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
         """
 
         fields = self._get_amount_fields()
-        for doc in self:
+        for doc in self.filtered(lambda m: m.fiscal_operation_id):
             values = {key: 0.0 for key in fields}
             for line in doc._get_amount_lines():
                 for field in fields:
@@ -130,9 +144,9 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
                     if field.replace("amount_", "") in line._fields.keys():
                         # FIXME this field creates an error in invoice form
                         if field == "amount_financial_discount_value":
-                            values[
-                                "amount_financial_discount_value"
-                            ] += 0  # line.financial_discount_value
+                            values["amount_financial_discount_value"] += (
+                                0  # line.financial_discount_value
+                            )
                         else:
                             values[field] += line[field.replace("amount_", "")]
 

--- a/l10n_br_mdfe/tests/test_mdfe_serialize.py
+++ b/l10n_br_mdfe/tests/test_mdfe_serialize.py
@@ -37,7 +37,6 @@ class TestMDFeSerialize(TransactionCase):
         if mdfe.state != "em_digitacao":  # 2nd test run
             mdfe.action_document_back2draft()
 
-        mdfe._compute_fiscal_amount()
         mdfe.action_document_confirm()
         mdfe.document_date = datetime.strptime(
             "2020-01-01T11:00:00", "%Y-%m-%dT%H:%M:%S"

--- a/l10n_br_nfe/tests/test_nfe_serialize.py
+++ b/l10n_br_nfe/tests/test_nfe_serialize.py
@@ -41,7 +41,6 @@ class TestNFeExport(TransactionCase):
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
 
-        nfe._compute_fiscal_amount()
         nfe._register_hook()  # required in v16 for next statement
         nfe.nfe40_detPag = [
             Command.clear(),

--- a/l10n_br_purchase/models/purchase_order.py
+++ b/l10n_br_purchase/models/purchase_order.py
@@ -70,17 +70,9 @@ class PurchaseOrder(models.Model):
     def _onchange_fiscal_operation_id(self):
         self.fiscal_position_id = self.fiscal_operation_id.fiscal_position_id
 
-    def _get_amount_lines(self):
-        """Get object lines instaces used to compute fields"""
-        return self.mapped("order_line")
-
-    @api.depends("order_line")
-    def _compute_fiscal_amount(self):
-        return super()._compute_fiscal_amount()
-
-    @api.depends("order_line.price_total")
-    def _amount_all(self):
-        self._compute_fiscal_amount()
+    @api.model
+    def _get_fiscal_lines_field_name(self):
+        return "order_line"
 
     def _prepare_invoice(self):
         self.ensure_one()

--- a/l10n_br_purchase/tests/test_l10n_br_purchase.py
+++ b/l10n_br_purchase/tests/test_l10n_br_purchase.py
@@ -224,24 +224,23 @@ class L10nBrPurchaseBaseTest(TransactionCase):
             self.assertEqual(
                 order.amount_total,
                 invoice.amount_total,
-                "Error Amount Total in Invoice" " is different from Purchase Order.",
+                "Error Amount Total in Invoice is different from Purchase Order.",
             )
 
             self.assertEqual(
                 order.amount_tax,
                 invoice.amount_tax,
-                "Error Amount Tax in Invoice is" " different from Purchase Order.",
+                "Error Amount Tax in Invoice is different from Purchase Order.",
             )
             self.assertEqual(
                 order.amount_untaxed,
                 invoice.amount_untaxed,
-                "Error Amount Untaxed in Invoice" " is different from Purchase Order.",
+                "Error Amount Untaxed in Invoice is different from Purchase Order.",
             )
             self.assertEqual(
                 order.amount_price_gross,
                 invoice.amount_price_gross,
-                "Error Amount Price Gross in Invoice"
-                " is different from Purchase Order.",
+                "Error Amount Price Gross in Invoice is different from Purchase Order.",
             )
             self.assertEqual(
                 order.amount_financial_total,
@@ -274,7 +273,7 @@ class L10nBrPurchaseBaseTest(TransactionCase):
             for line in invoice.invoice_line_ids:
                 self.assertTrue(
                     line.fiscal_operation_line_id,
-                    "Error to included Operation " "Line from Purchase Order Line.",
+                    "Error to included Operation Line from Purchase Order Line.",
                 )
                 self.assertEqual(
                     line.price_total,
@@ -315,7 +314,7 @@ class L10nBrPurchaseBaseTest(TransactionCase):
 
             self.assertTrue(
                 line.fiscal_operation_line_id,
-                "Error to mapping Fiscal Operation" " Line on Purchase Order Line.",
+                "Error to mapping Fiscal Operation Line on Purchase Order Line.",
             )
 
             cfop = self.FISCAL_DEFS[line.cfop_id.destination][
@@ -463,7 +462,7 @@ class L10nBrPurchaseBaseTest(TransactionCase):
         arch, models = self.po_products._get_view()
         self.assertTrue(
             arch.findall(".//field[@name='fiscal_operation_id']"),
-            "Error to included Operation " "Line from Purchase Order Line.",
+            "Error to included Operation Line from Purchase Order Line.",
         )
 
     def test_fields_freight_insurance_other_costs(self):

--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -66,29 +66,9 @@ class SaleOrder(models.Model):
         store=True,
     )
 
-    amount_freight_value = fields.Monetary(
-        inverse="_inverse_amount_freight",
-    )
-
-    amount_insurance_value = fields.Monetary(
-        inverse="_inverse_amount_insurance",
-    )
-
-    amount_other_value = fields.Monetary(
-        inverse="_inverse_amount_other",
-    )
-
-    def _get_amount_lines(self):
-        """Get object lines instaces used to compute fields"""
-        return self.mapped("order_line")
-
-    @api.depends(
-        "order_line.price_subtotal", "order_line.price_tax", "order_line.price_total"
-    )
-    def _compute_amounts(self):
-        """Compute the total amounts of the SO."""
-        for order in self:
-            order._compute_fiscal_amount()
+    @api.model
+    def _get_fiscal_lines_field_name(self):
+        return "order_line"
 
     @api.model
     def _get_view(self, view_id=None, view_type="form", **options):

--- a/l10n_br_sale/tests/test_l10n_br_sale.py
+++ b/l10n_br_sale/tests/test_l10n_br_sale.py
@@ -173,7 +173,7 @@ class L10nBrSaleBaseTest(TransactionCase):
         for invoice in sale_order.invoice_ids:
             self.assertTrue(
                 invoice.fiscal_operation_id,
-                "Error to included Operation on invoice " "dictionary from Sale Order.",
+                "Error to included Operation on invoice dictionary from Sale Order.",
             )
 
             self.assertTrue(
@@ -186,18 +186,17 @@ class L10nBrSaleBaseTest(TransactionCase):
             self.assertEqual(
                 sale_order.amount_total,
                 invoice.amount_total,
-                "Error field Amount Total in Invoice" " are different from Sale Order.",
+                "Error field Amount Total in Invoice are different from Sale Order.",
             )
             self.assertEqual(
                 sale_order.amount_tax,
                 invoice.amount_tax,
-                "Error field Amount Tax in Invoice" " are different from Sale Order.",
+                "Error field Amount Tax in Invoice are different from Sale Order.",
             )
             self.assertEqual(
                 sale_order.amount_untaxed,
                 invoice.amount_untaxed,
-                "Error field Amount Untaxed in Invoice"
-                " are different from Sale Order.",
+                "Error field Amount Untaxed in Invoice are different from Sale Order.",
             )
             self.assertEqual(
                 sale_order.amount_price_gross,
@@ -220,8 +219,7 @@ class L10nBrSaleBaseTest(TransactionCase):
             self.assertEqual(
                 sale_order.amount_freight_value,
                 invoice.amount_freight_value,
-                "Error field Amount Freight in Invoice"
-                " are different from Sale Order.",
+                "Error field Amount Freight in Invoice are different from Sale Order.",
             )
             self.assertEqual(
                 sale_order.amount_insurance_value,
@@ -536,8 +534,6 @@ class L10nBrSaleBaseTest(TransactionCase):
             line.insurance_value = 10.0
             line.other_value = 10.0
 
-        self.so_products.action_confirm()
-
         self.assertEqual(
             self.so_products.amount_freight_value,
             20.0,
@@ -592,8 +588,6 @@ class L10nBrSaleBaseTest(TransactionCase):
         self.so_products.amount_freight_value = 20.0
         self.so_products.amount_insurance_value = 20.0
         self.so_products.amount_other_value = 20.0
-
-        self.so_products.action_confirm()
 
         for line in self.so_products.order_line:
             if line.price_total == 234.29:

--- a/l10n_br_stock_account/models/stock_picking.py
+++ b/l10n_br_stock_account/models/stock_picking.py
@@ -35,13 +35,9 @@ class StockPicking(models.Model):
         default=lambda self: self.env.company.currency_id,
     )
 
-    def _get_amount_lines(self):
-        """Get object lines instances used to compute fields"""
-        return self.mapped("move_ids")
-
-    @api.depends("move_ids")
-    def _compute_fiscal_amount(self):
-        return super()._compute_fiscal_amount()
+    @api.model
+    def _get_fiscal_lines_field_name(self):
+        return "move_ids"
 
     @api.depends("move_ids.price_unit")
     def _amount_all(self):


### PR DESCRIPTION
o compute_fiscal_amount no `l10n_br_fiscal.document.mixin` não tinha `@api.depends`. Eu imagino que é porque não era tão facil já que o mixin é injectado em varios objetos diferentes como sale.order, purchase.order, stock.picking e cada um deles tem linhas de mixin fiscais com um nome de campo One2many diferente.

Mas enfim neste PR eu bolei um sistema de @api.depends dinamico que usa o campo o2m certo do objeto onde on mixin é injectado com os override do `_get_fiscal_lines_field_name` . Nisso é possível tirar varias chamadas hardcode do `compute_fiscal_amount` e ficou possivel tirar os overrides dos métodos `compute_amount` que tinha como objetivo chamar o `compute_fiscal_amount`.

Esse PR resolve esse bug #3906. O problema era que ao salvar ou confirmar (action_confirm) um pedido de venda ou compra ele não recalculava o compute_fiscal_amount do pedido a menos que tiver o modulo l10n_br_sale_stock instalado com os dados demo botando suficientemente produtos no estoque para ele criar a entrega e ai recalcular o compute_fiscal_amount na hora de criar a entrega, com um self.env.flush_all() [aqui](https://github.com/odoo/odoo/blob/16.0/addons/stock/models/stock_move.py#L1528). Vejam como era precário sem @api.depends!! 

E no caso do pedido de compra não precisava de estoque mas era a validação do recebimento dos produtos que chamava esse  compute_fiscal_amount tb. Mas são apenas casos que foram detetados. Sem @api.depends a gente tinha que rezar para que alguém tivesse chamado o compute_fiscal_amount no botão ou método certo (esse tipicamente não era chamado na hora dos onchanges pois tinha que ser executado por ultimo). Então eu acho que ficou bem mais robusto assim.

ver tambem #3905 e #3704

obs: se alguém quiser fazer backport para a v14 deve ser possível...