### PR TITLE
[16.0][FIX] l10n_br_account: Chamar o método super _inverse_company_id correto

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -121,7 +121,7 @@ class AccountMove(models.Model):
         for move in self:
             for doc in move.fiscal_document_ids:
                 doc.company_id = move.company_id
-        return super()._inverse_partner_id()
+        return super()._inverse_company_id()
 
     @api.onchange("currency_id")
     def _inverse_currency_id(self):


### PR DESCRIPTION
PR para corrigir a chamada do método super _inverse_company_id