### PR TITLE
[16.0] l10n_br_nfe, l10n_br_mdfe: fix NFe and MDFe deprecated indent warning

### DIFF
--- a/l10n_br_mdfe/models/document.py
+++ b/l10n_br_mdfe/models/document.py
@@ -977,8 +977,14 @@ class MDFe(spec_models.StackedModel):
                 document_id=self,
             )
             record.authorization_event_id = event_id
-            xml_assinado = processador.assina_raiz(edoc, edoc.infMDFe.Id)
-            self._validate_xml(xml_assinado)
+            signed_xml = edoc.sign_xml(
+                xml_file,
+                self.company_id.certificate.file,
+                self.company_id.certificate.password,
+                edoc.infMDFe.Id,
+            )
+            self._validate_xml(signed_xml)
+
         return result
 
     def _validate_xml(self, xml_file):

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -956,10 +956,7 @@ class NFe(spec_models.StackedModel):
         result = super()._document_export()
         for record in self.filtered(filter_processador_edoc_nfe):
             edoc = record.serialize()[0]
-            processador = record._edoc_processor()
-            xml_file = processador.render_edoc_xsdata(edoc, pretty_print=pretty_print)[
-                0
-            ]
+            xml_file = edoc.to_xml()
             # Delete previous authorization events in draft
             if (
                 record.authorization_event_id
@@ -977,8 +974,13 @@ class NFe(spec_models.StackedModel):
                 document_id=self,
             )
             record.authorization_event_id = event_id
-            xml_assinado = processador.assina_raiz(edoc, edoc.infNFe.Id)
-            self._validate_xml(xml_assinado)
+            signed_xml = edoc.sign_xml(
+                xml_file,
+                self.company_id.certificate.file,
+                self.company_id.certificate.password,
+                edoc.infNFe.Id,
+            )
+            self._validate_xml(signed_xml)
         return result
 
     def _nfe_update_status_and_save_data(self, process):


### PR DESCRIPTION
tira os stack trace de warning como esse na hora de serializar as NFe e MDFe (já tava OK para a CTe):

```
2025-07-26 22:55:25,552 31602 INFO odoo16 odoo.models.unlink: User #1 deleted ir.attachment records with IDs: [440]
2025-07-26 22:55:25,630 31602 INFO odoo16 odoo.addons.l10n_br_nfe.tests.test_nfe_xml_validation: Starting TestXMLValidation.test_xml_nfe_taxes ...
2025-07-26 22:55:25,959 31602 WARNING odoo16 py.warnings: /home/rvalyi/DEV/odoo16/odoo/lib/python3.11/site-packages/xsdata/formats/dataclass/serializers/config.py:47: DeprecationWarning: Setting `pretty_prin
  File "/home/rvalyi/DEV/odoo16/odoo/bin/odoo", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/home/rvalyi/DEV/odoo16/odoo/src/setup/odoo", line 8, in <module>
    odoo.cli.main()
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/cli/command.py", line 66, in main
    o.run(args)
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/cli/server.py", line 187, in run
    main(args)
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/cli/server.py", line 180, in main
    rc = odoo.service.server.start(preload=preload, stop=stop)
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/service/server.py", line 1427, in start
    rc = server.run(preload, stop)
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/service/server.py", line 596, in run
    rc = preload_registries(preload)
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/service/server.py", line 1327, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/home/rvalyi/DEV/odoo16/odoo/lib/python3.11/site-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/modules/registry.py", line 87, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/modules/loading.py", line 489, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/modules/loading.py", line 374, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/modules/loading.py", line 292, in load_module_graph
    test_results = loader.run_suite(suite, module_name, global_report=report)
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/tests/loader.py", line 86, in run_suite
    suite(results)
  File "/usr/lib/python3.11/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/tests/suite.py", line 47, in run
    test(result)
  File "/usr/lib/python3.11/unittest/case.py", line 678, in __call__
    return self.run(*args, **kwds)
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/tests/common.py", line 275, in run
    super().run(result)
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/tests/case.py", line 216, in run
    self._callTestMethod(testMethod)
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/tests/case.py", line 184, in _callTestMethod
    method()
  File "/home/rvalyi/DEV/odoo16/odoo/external-src/l10n-brazil/l10n_br_nfe/tests/test_nfe_xml_validation.py", line 133, in test_xml_nfe_taxes
    document.action_document_confirm()
  File "/home/rvalyi/DEV/odoo16/odoo/external-src/l10n-brazil/l10n_br_fiscal_edi/models/document.py", line 172, in action_document_confirm
    return self._document_confirm_to_send()
  File "/home/rvalyi/DEV/odoo16/odoo/external-src/l10n-brazil/l10n_br_fiscal_edi/models/document_workflow.py", line 304, in _document_confirm_to_send
    to_confirm._document_confirm()
  File "/home/rvalyi/DEV/odoo16/odoo/external-src/l10n-brazil/l10n_br_fiscal_edi/models/document_workflow.py", line 297, in _document_confirm
    self._change_state(SITUACAO_EDOC_A_ENVIAR)
  File "/home/rvalyi/DEV/odoo16/odoo/external-src/l10n-brazil/l10n_br_fiscal_edi/models/document_workflow.py", line 216, in _change_state
    if record._before_change_state(old_state, new_state):
  File "/home/rvalyi/DEV/odoo16/odoo/external-src/l10n-brazil/l10n_br_fiscal_edi/models/document_workflow.py", line 112, in _before_change_state
    return self._exec_before_SITUACAO_EDOC_A_ENVIAR(old_state, new_state)
  File "/home/rvalyi/DEV/odoo16/odoo/external-src/l10n-brazil/l10n_br_fiscal_edi/models/document_workflow.py", line 77, in _exec_before_SITUACAO_EDOC_A_ENVIAR
    self._document_export()
  File "/home/rvalyi/DEV/odoo16/odoo/external-src/l10n-brazil/l10n_br_nfe/models/document.py", line 960, in _document_export
    xml_file = processador.render_edoc_xsdata(edoc, pretty_print=pretty_print)[
  File "/home/rvalyi/DEV/odoo16/odoo/lib/python3.11/site-packages/nfelib/nfe/ws/edoc_legacy.py", line 59, in render_edoc_xsdata
    serializer = XmlSerializer(config=SerializerConfig(pretty_print=pretty_print))
  File "<string>", line 11, in __init__
  File "/home/rvalyi/DEV/odoo16/odoo/lib/python3.11/site-packages/xsdata/formats/dataclass/serializers/config.py", line 40, in __post_init__
    self.__setattr__("pretty_print", pretty_print)
  File "/home/rvalyi/DEV/odoo16/odoo/lib/python3.11/site-packages/xsdata/formats/dataclass/serializers/config.py", line 47, in __setattr__
    warnings.warn(
```

Pois faz tempo que eu já tinha resolvido isso na nfelib para lidar com esse deprecate warning no xsdata: https://github.com/akretion/nfelib/blob/master/nfelib/__init__.py#L150

Eu também já aproveitei para usar o sign encapsulado na nfelib para aproximar da possibilidade de transmistir os documentos fiscais direitamente pela nfelib e o requests como pode ser visto neste POC #3671

Tudo isso funciona com a nfelib 2.0.7 que ainda é a versão usada no projeto. Mas assim isso é mais uma passo para poder usar facilmente uma versão mais atualizada sem o erpbrasil.edoc.