### PR TITLE
[16.0][FIX] l10n_br_account: missing depends

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -285,6 +285,7 @@ class AccountMove(models.Model):
         "line_ids.full_reconcile_id",
         "state",
         "ind_final",
+        "line_ids.cfop_id",
     )
     def _compute_amount(self):
         for move in self.filtered(lambda m: m.fiscal_operation_id):
@@ -321,6 +322,8 @@ class AccountMove(models.Model):
         "currency_id",
         "amount_total_in_currency_signed",
         "invoice_date_due",
+        "invoice_line_ids.cfop_id",
+        "amount_financial_total",
     )
     def _compute_needed_terms(self):
         """

--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -291,7 +291,30 @@ class AccountMoveLine(models.Model):
         self.env.add_to_compute(self._fields["credit"], container["records"])
 
     @api.depends(
-        "quantity", "discount", "price_unit", "tax_ids", "currency_id", "discount"
+        "quantity",
+        "discount",
+        "price_unit",
+        "tax_ids",
+        "currency_id",
+        "discount",
+        "fiscal_tax_ids",
+        "fiscal_operation_line_id",
+        "cfop_id",
+        "ncm_id",
+        "nbs_id",
+        "nbm_id",
+        "cest_id",
+        "discount_value",
+        "insurance_value",
+        "other_value",
+        "ii_customhouse_charges",
+        "freight_value",
+        "fiscal_price",
+        "fiscal_quantity",
+        "uot_id",
+        "icmssn_range_id",
+        "icms_origin",
+        "ind_final",
     )
     def _compute_totals(self):
         """
@@ -367,6 +390,24 @@ class AccountMoveLine(models.Model):
         "partner_id",
         "move_id.partner_id",
         "price_unit",
+        "fiscal_tax_ids",
+        "fiscal_operation_line_id",
+        "cfop_id",
+        "ncm_id",
+        "nbm_id",
+        "nbs_id",
+        "cest_id",
+        "discount_value",
+        "insurance_value",
+        "other_value",
+        "ii_customhouse_charges",
+        "freight_value",
+        "fiscal_price",
+        "fiscal_quantity",
+        "uot_id",
+        "icmssn_range_id",
+        "icms_origin",
+        "ind_final",
     )
     def _compute_all_tax(self):
         """


### PR DESCRIPTION
esses campos são usados nos metodos e estavam faltando no @api.depends (apenas os campos do super método estavam lá)