### PR TITLE
[16.0][FIX] l10n_br_account: fix _get_view

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -232,33 +232,12 @@ class AccountMove(models.Model):
         arch, view = super()._get_view(view_id, view_type, **options)
         if self.env.company.country_id.code != "BR" or view_type != "form":
             return arch, view
+        arch = self.env["account.move.line"].inject_fiscal_fields(arch)
 
         for tax_totals_node in arch.xpath(
             "//field[@name='tax_totals'][@widget='account-tax-totals-field']"
         ):
             tax_totals_node.set("attrs", "{'invisible': True}")
-
-        if view_id == self.env.ref("l10n_br_account.fiscal_invoice_form").id:
-            invoice_line_form_id = self.env.ref(
-                "l10n_br_account.fiscal_invoice_line_form"
-            ).id
-            sub_form_node, _sub_view = self.env["account.move.line"]._get_view(
-                view_id=invoice_line_form_id, view_type="form"
-            )
-            self.env["account.move.line"].inject_fiscal_fields(sub_form_node)
-
-            for original_sub_form_node in arch.xpath(
-                "//field[@name='invoice_line_ids']/form"
-            ):
-                parent = original_sub_form_node.parent
-                parent.remove(original_sub_form_node)
-                parent.append(sub_form_node)
-
-        else:
-            for sub_form_node in arch.xpath("//field[@name='invoice_line_ids']/form"):
-                self.env["account.move.line"].inject_fiscal_fields(sub_form_node)
-            for sub_form_node in arch.xpath("//field[@name='line_ids']/tree"):
-                self.env["account.move.line"].inject_fiscal_fields(sub_form_node)
 
         if view_type == "form" and (
             self.user_has_groups("l10n_br_account.group_line_fiscal_detail")

--- a/l10n_br_account/tests/test_account_move_lc.py
+++ b/l10n_br_account/tests/test_account_move_lc.py
@@ -732,8 +732,8 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "tax_ids": [],
             "tax_line_id": False,
             "currency_id": self.company_data["currency"].id,
-            "amount_currency": 1013.77,
-            "debit": 1013.77,
+            "amount_currency": 996.27,
+            "debit": 996.27,
             "credit": 0.0,
             "date_maturity": fields.Date.from_string("2019-01-01"),
         }
@@ -746,25 +746,23 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "fiscal_position_id": False,
             "payment_reference": "",
             "invoice_payment_term_id": self.pay_terms_a.id,
-            "amount_untaxed": 1000.0,
-            "amount_tax": 50.0,
-            "amount_total": 1013.77,
+            "amount_untaxed": 963.77,
+            "amount_tax": 32.5,
+            "amount_total": 996.27,
         }
 
-        # TODO MIGRATE to v16: strangely this test works
-        # on my PC and not in the CI. We may fix it after merging...
-        # self.assertInvoiceValues(
-        #     self.move_out_venda_with_icms_reduction,
-        #     [
-        #         product_line_vals_1,
-        #         tax_line_vals_cofins,
-        #         tax_line_vals_icms,
-        #         tax_line_vals_ipi,
-        #         tax_line_vals_pis,
-        #         term_line_vals_1,
-        #     ],
-        #     move_vals,
-        # )
+        self.assertInvoiceValues(
+            self.move_out_venda_with_icms_reduction,
+            [
+                product_line_vals_1,
+                tax_line_vals_cofins,
+                tax_line_vals_icms,
+                tax_line_vals_ipi,
+                tax_line_vals_pis,
+                term_line_vals_1,
+            ],
+            move_vals,
+        )
 
     def test_simples_remessa(self):
         product_line_vals_1 = {

--- a/l10n_br_account/tests/test_account_move_sn.py
+++ b/l10n_br_account/tests/test_account_move_sn.py
@@ -38,11 +38,6 @@ class AccountMoveSimpleNacional(AccountMoveBRCommon):
                 "active": True,
             }
         )
-        # for some reason this invoice should be created with the popup mode.
-        # it seems like a test framework glitch because in the browser it works fine
-        cls.env.user.groups_id |= cls.env.ref(
-            "l10n_br_account.group_line_fiscal_detail"
-        )
         cls.move_out_revenda = cls.init_invoice(
             "out_invoice",
             products=[cls.product_a],

--- a/l10n_br_account/views/account_move_view.xml
+++ b/l10n_br_account/views/account_move_view.xml
@@ -168,14 +168,10 @@
                     domain here that is checked before the dynamic fiscal
                     placeholders kick in.
                 -->
-                <field name="tax_framework" invisible="1" />
                 <field name="fiscal_operation_id" invisible="1" />
-                <field name="freight_value" invisible="1" />
-                <field name="insurance_value" invisible="1" />
-                <field name="other_value" invisible="1" />
+                <field name="document_type_id" invisible="1" />
                 <field name="fiscal_operation_type" invisible="1" />
-                <field name="ipi_cst_id" invisible="1" />
-                <field name="ipi_guideline_id" invisible="1" />
+                <field name="tax_icms_or_issqn" invisible="1" />
 
                 <field
                     name="tax_ids"
@@ -186,21 +182,9 @@
                 />
                 <field name="fiscal_document_line_id" invisible="1" />
                 <field name="document_type_id" invisible="1" />
-                <field name="amount_tax_withholding" optional="hide" />
-                <field name="amount_tax_included" optional="hide" />
-                <field name="amount_tax_not_included" optional="hide" />
                 <field name="fiscal_operation_id" optional="hide" />
-                <field name="fiscal_operation_line_id" optional="show" />
                 <field name="cfop_id" optional="hide" />
                 <field name="city_taxation_code_id" optional="hide" />
-                <field name="service_type_id" optional="hide" />
-                <field name="cnae_id" optional="hide" />
-                <field name="ncm_id" optional="hide" />
-                <field name="nbs_id" optional="hide" />
-                <field name="nbm_id" optional="hide" />
-                <field name="cest_id" optional="hide" />
-                <field name="product_uom_id" optional="hide" />
-                <field name="fiscal_genre_id" optional="hide" />
                 <field
                     name="fiscal_operation_line_id"
                     attrs="{'column_invisible': [('parent.fiscal_operation_id', '=', False)]}"
@@ -211,14 +195,6 @@
                     widget="many2many_tags"
                     options="{'no_create': True}"
                 />
-                <field name="icms_value" optional="hide" />
-                <field name="ipi_value" optional="hide" />
-                <field name="pis_value" optional="hide" />
-                <field name="cofins_value" optional="hide" />
-                <field name="freight_value" optional="hide" />
-                <field name="insurance_value" optional="hide" />
-                <field name="other_value" optional="hide" />
-                <field name="estimate_tax" optional="hide" />
             </xpath>
 
 
@@ -249,32 +225,34 @@
                 expr="//field[@name='line_ids']/tree/field[@name='tax_ids']"
                 position="replace"
             >
+                <control
+                    name="fiscal_fields"
+                    invisible="1"
+                /><!-- this is a dynamic fiscal fields placeholder-->
+                <control
+                    name="fiscal_taxes_fields"
+                    string="Taxes"
+                    invisible="1"
+                /><!-- this is a dynamic fiscal fields placeholder-->
+
+                <!-- the fields below would be injected by the placeholders
+                    above, but we need to repeat them here to please the
+                    Form test framework or because they are used in some
+                    domain here that is checked before the dynamic fiscal
+                    placeholders kick in.
+                -->
+                <field name="fiscal_operation_id" invisible="1" />
+                <field name="document_type_id" invisible="1" />
+                <field name="fiscal_operation_type" invisible="1" />
+                <field name="tax_icms_or_issqn" invisible="1" />
+
                 <field
                     name="tax_ids"
                     optional="hide"
                     widget="many2many_tags"
                     options="{'no_create': True}"
                 />
-                <field name="fiscal_document_line_id" invisible="1" />
-                <field name="document_type_id" invisible="1" />
-                <field name="amount_tax_withholding" invisible="1" />
-                <field name="amount_tax_included" invisible="1" />
-                <field name="amount_tax_not_included" invisible="1" />
-                <field name="fiscal_operation_id" invisible="1" />
-                <field name="fiscal_operation_line_id" optional="hide" />
-                <field name="cfop_id" optional="hide" />
                 <field name="product_id" optional="hide" />
-                <field name="city_taxation_code_id" optional="hide" />
-                <field name="service_type_id" optional="hide" />
-                <field name="cnae_id" optional="hide" />
-                <field name="ncm_id" optional="hide" />
-                <field name="nbs_id" optional="hide" />
-                <field name="nbm_id" optional="hide" />
-                <field name="cest_id" optional="hide" />
-                <field name="uom_id" optional="hide" />
-                <field name="fiscal_genre_id" optional="hide" />
-                <field name="partner_company_type" invisible="1" />
-                <field name="fiscal_operation_type" invisible="1" />
                 <field
                     name="fiscal_tax_ids"
                     invisible="1"
@@ -287,16 +265,8 @@
                             <field name="fiscal_price" invisible="1" />
                             <field name="discount_value" invisible="1" />
 
-                    <!--group name="fiscal_fields" invisible="1" /-->
-
-                    <field name="freight_value" invisible="1" />
-                    <field name="insurance_value" invisible="1" />
-                    <field name="other_value" invisible="1" />
-                    <field name="estimate_tax" invisible="1" />
-
                   <!-- TODO adapt these placeholders for tree view for fiscal_form_view -->
                     <control name="fiscal_taxes_fields" string="Taxes" invisible="1" />
-                    <field name="tax_icms_or_issqn" invisible="1" />
                     <control
                     name="fiscal_line_extra_info_fields"
                     string="Extra Info"


### PR DESCRIPTION
1. Resolve o _view_get do account.move. O _inject_fiscal_fields não tava efetivo e isso era o motivo dos bugs com a nova edição "inline", pois sempre faltava algum campo para ser passado em algum onchange fiscal. O ponto é que em algum momento na 14.0 o form das linhas do account.move precisam ser tratada nos subforms ligados aos campos. Isso não é mais assim na v16 e passou quase batido até agora que os campos fiscais não tavam sendo injetados. Apenas sobravam alguns campos que a gente tinha botatod nos trees (do invoice_line_ids e do move_line_ids) antes de bolar o _inject_fiscal_fields ou depois como paliativo na 16.0 para resolver os bugs mais obvious.
2. No _view_get ainda, não precisa mais do bloco if view_id == self.env.ref("l10n_br_account.fiscal_invoice_form").id. Pois no inicio na v12 com o botão "fiscal detail" a gente abria a tela form fiscal mas mantinha o objeto account.move. Em algum momento da v14 mudamos isso e agora na tela do detalhe fiscal, usamos o l10n_br_fiscal.document mesmo. Isso facilita quando tem vários documentos fiscais ligados ao mesmo account.move. Mas enfim a questão é que não precisa mais desse bloco mesmo. Pode ser visto no coverage tb que era código morto mesmo: https://app.codecov.io/gh/OCA/l10n-brazil/blob/16.0/l10n_br_account%2Fmodels%2Faccount_move.py#L241
3. Com o _inject_fiscal_fields funcionando de volta no account.move eu pude tirar os campos gambiarras que a gente tinha acumulados manualmente nos tree dos invoice_line_ids e do move_line_ids. O _inject_fiscal_fields injeta TODOS campos que ele encontra na tela do documento fiscal. Isso pode ser verificando clicando no botão para adicionar algum campo opcional para mostrar no invoice_line_ids ou move_line_ids. Da para selecionar todos campos fiscais, assim como já era o caso nos sale.order, purchase.order e stock.picking.
4. Com isso  eu dei um a geral nos testes: o teste do simples não precisava mais do grupo da ediçao pelo form para passar. E no teste do lucro presumido eu pude verificar que o teste da reduçao de ICMS que tava comentado apenas precisava de atualizar alguns valores pois tinha mudado o valor do ICMS aplicado na v16 no refator dos NCM de demo que agora usam um subset dos NCMs de prod.

Enfim nisso ficou pronto e foi uma limpeza bem importante pro uso da v16 em prod.

cc @OCA/local-brazil-maintainers 