### PR TITLE
[16.0][FIX] l10n_br_fiscal: fix fiscal_operation_id domain

### DIFF
--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -91,9 +91,9 @@ class Document(models.Model):
     )
 
     fiscal_operation_id = fields.Many2one(
-        domain="[('state', '=', 'approved'), "
-        "'|', ('fiscal_operation_type', '=', fiscal_operation_type),"
-        " ('fiscal_operation_type', '=', 'all')]",
+        "l10n_br_fiscal.operation",
+        string="Fiscal Operation",
+        domain="[('state', '=', 'approved')]",
     )
 
     fiscal_operation_type = fields.Selection(
@@ -485,6 +485,19 @@ class Document(models.Model):
                         number=record.document_number,
                     )
                 )
+
+    @api.onchange("fiscal_operation_type")
+    def _onchange_fiscal_operation_type(self):
+        domain = [("state", "=", "approved")]
+        if self.fiscal_operation_type:
+            domain.append(("fiscal_operation_type", "=", self.fiscal_operation_type))
+        if (
+            self.fiscal_operation_id
+            and self.fiscal_operation_id.fiscal_operation_type
+            != self.fiscal_operation_type
+        ):
+            self.fiscal_operation_id = False
+        return {"domain": {"fiscal_operation_id": domain}}
 
     @api.depends("company_id")
     def _compute_currency_id(self):


### PR DESCRIPTION
Esse PR (extraído de #3704) visa a corrigir o domain da operação fiscal de quando vc vai cria um novo l10n_br_fiscal.document (sem ser pelo account.move) que ainda não tem um fiscal_operation_type imposto pelo menu/ação. Eh o caso se vc usa o menu fiscal "All low level fiscal documents" hoje por exemplo.

O domain padrão impede hoje de vc selecionar uma operação. Aqui tirei o fiscal_operation_type e preencho ele no onchange apenas se o usuário for definir um fiscal_operation_type.

O odoo da um warning que isso é deprecated mas não vi outra maneira de fazer e vi que varios modulos da OCA usam essa forma até na v18 ainda então talvez é um deprecated que não é mais deprecated depois. Se alguem tem uma alternativa melhor eu aceito.

@antoniospneto isso é um pouco ligado ao assunto que vc trouxe aqui #3924