### PR TITLE
[14.0][FIX] l10n_br_fiscal: remove freight, insurance and other value from ipi base

### DIFF
--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -603,7 +603,12 @@ class Tax(models.Model):
         operation_line = kwargs.get("operation_line")
         fiscal_operation_type = operation_line.fiscal_operation_type or FISCAL_OUT
 
-        # Se for entrada de importação o II entra na base de calculo do IPI
+        kwargs_ipi = kwargs.copy()
+
+        kwargs_ipi["freight_value"] = 0.00
+        kwargs_ipi["insurance_value"] = 0.00
+        kwargs_ipi["other_value"] = 0.00
+
         if (
             cfop
             and cfop.destination == CFOP_DESTINATION_EXPORT
@@ -612,7 +617,7 @@ class Tax(models.Model):
             tax_dict_ii = taxes_dict.get("ii", {})
             tax_dict["add_to_base"] += tax_dict_ii.get("tax_value", 0.00)
 
-        return self._compute_tax(tax, taxes_dict, **kwargs)
+        return self._compute_tax(tax, taxes_dict, **kwargs_ipi)
 
     @api.model
     def _compute_tax_sequence(self, taxes_dict, **kwargs):


### PR DESCRIPTION
Segundo o CTN (art. 47), a base do IPI deve ser só o valor da operação de industrialização, ou seja, frete, seguro e valores extras cobrados a parte não devem entra na conta

Com essa alteração, o cálculo do IPI fica mais preciso e evita cobrança indevida sobre valores que não fazem parte da base legal.