### PR TITLE
[16.0][REF] l10n_br_account: stronger _compute_taxes_for_single_line

### DIFF
--- a/l10n_br_account/models/account_tax.py
+++ b/l10n_br_account/models/account_tax.py
@@ -205,13 +205,23 @@ class AccountTax(models.Model):
         Similar to the _compute_taxes_for_single_line super method in the account module
         but overriden to pass extra parameters to the account.tax compule_all method
         to compute taxes properly in Brazil.
-        WARNING: it seems we might not be able to call the super method here...
         """
+        taxes = base_line["taxes"]._origin
+        line = base_line.get("record")
+        if not taxes or not line or not line.fiscal_tax_ids:
+            return super()._compute_taxes_for_single_line(
+                base_line,
+                handle_price_include=True,
+                include_caba_tags=False,
+                early_pay_discount_computation=None,
+                early_pay_discount_percentage=None,
+            )
+
         orig_price_unit_after_discount = base_line["price_unit"] * (
             1 - (base_line["discount"] / 100.0)
         )
         price_unit_after_discount = orig_price_unit_after_discount
-        taxes = base_line["taxes"]._origin
+        # taxes = base_line["taxes"]._origin
         currency = base_line["currency"] or self.env.company.currency_id
         rate = base_line["rate"]
 
@@ -222,7 +232,7 @@ class AccountTax(models.Model):
             )
 
         if taxes:
-            line = base_line["record"]
+            # line = base_line["record"]
             taxes_res = taxes.with_context(**base_line["extra_context"]).compute_all(
                 price_unit_after_discount,
                 currency=currency,


### PR DESCRIPTION
No método _compute_taxes_for_single_line a gente não chamava o super e botamos um WARNING. 

Mas na verdade é possivel chamar o super do modulo account quando o _compute_taxes_for_single_line náo é chamado para um account.move.line ou quando esse account.move.line não tem fiscal_tax_ids do Brasil.

Assim fica mais robusto e melhora a compatibilidade multi-pais