### PR TITLE
[16.0][l10n_br_fiscal] _compute_document_type_id instead of onchange

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -466,10 +466,15 @@ class AccountMove(models.Model):
         self.clear_caches()
         return result
 
-    @api.onchange("fiscal_operation_id")
-    def _onchange_fiscal_operation_id(self):
-        if self.fiscal_operation_id and self.fiscal_operation_id.journal_id:
-            self.journal_id = self.fiscal_operation_id.journal_id
+    @api.depends("move_type", "fiscal_operation_id")
+    def _compute_journal_id(self):
+        fisc_operation_driven = self.filtered(
+            lambda move: move.fiscal_operation_id
+            and move.fiscal_operation_id.journal_id
+        )
+        for move in fisc_operation_driven:
+            move.journal_id = self.fiscal_operation_id.journal_id
+        return super(AccountMove, self - fisc_operation_driven)._compute_journal_id()
 
     def open_fiscal_document(self):
         """
@@ -593,7 +598,6 @@ class AccountMove(models.Model):
                 force_fiscal_operation_id
                 or record.fiscal_operation_id.return_fiscal_operation_id
             )
-            record._onchange_fiscal_operation_id()
 
             for line in record.invoice_line_ids:
                 if (

--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -468,10 +468,8 @@ class AccountMove(models.Model):
 
     @api.onchange("fiscal_operation_id")
     def _onchange_fiscal_operation_id(self):
-        result = super()._onchange_fiscal_operation_id()
         if self.fiscal_operation_id and self.fiscal_operation_id.journal_id:
             self.journal_id = self.fiscal_operation_id.journal_id
-        return result
 
     def open_fiscal_document(self):
         """

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -596,7 +596,6 @@ class Document(models.Model):
 
             new_doc = record.copy()
             new_doc.fiscal_operation_id = fsc_op
-            new_doc._onchange_fiscal_operation_id()
 
             for line in new_doc.fiscal_line_ids:
                 fsc_op_line = line.fiscal_operation_id.return_fiscal_operation_id
@@ -658,14 +657,3 @@ class Document(models.Model):
     def _compute_edoc_purpose(self):
         for record in self:
             record.edoc_purpose = record.fiscal_operation_id.edoc_purpose
-
-    @api.onchange("fiscal_operation_id")
-    def _onchange_fiscal_operation_id(self):
-        result = super()._onchange_fiscal_operation_id()
-        if self.fiscal_operation_id:
-            self.fiscal_operation_type = self.fiscal_operation_id.fiscal_operation_type
-
-        if self.issuer == DOCUMENT_ISSUER_COMPANY and not self.document_type_id:
-            self.document_type_id = self.company_id.document_type_id
-
-        return result

--- a/l10n_br_fiscal/models/document_mixin.py
+++ b/l10n_br_fiscal/models/document_mixin.py
@@ -33,7 +33,6 @@ class FiscalDocumentMixin(models.AbstractModel):
     - Inverse methods for distributing header-level costs (freight, insurance)
       to lines.
     - Hooks for customizing data retrieval (e.g., lines, fiscal partner).
-    - Onchange helpers for common fiscal fields.
 
     Models using this mixin are often expected to also include fields defined
     in `l10n_br_fiscal.document.mixin` for methods like
@@ -90,7 +89,6 @@ class FiscalDocumentMixin(models.AbstractModel):
 
     fiscal_operation_type = fields.Selection(
         related="fiscal_operation_id.fiscal_operation_type",
-        readonly=True,
     )
 
     ind_pres = fields.Selection(
@@ -481,6 +479,10 @@ class FiscalDocumentMixin(models.AbstractModel):
 
     document_type_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.document.type",
+        compute="_compute_document_type_id",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     document_serie_id = fields.Many2one(

--- a/l10n_br_fiscal/models/document_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_mixin_methods.py
@@ -57,13 +57,11 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
                 self.company_id, self.fiscal_operation_id
             )
 
-    @api.onchange("fiscal_operation_id")
-    def _onchange_fiscal_operation_id(self):
-        if self.fiscal_operation_id:
-            self.fiscal_operation_type = self.fiscal_operation_id.fiscal_operation_type
-
-            if self.issuer == DOCUMENT_ISSUER_COMPANY and not self.document_type_id:
-                self.document_type_id = self.company_id.document_type_id
+    @api.depends("fiscal_operation_id")
+    def _compute_document_type_id(self):
+        for doc in self.filtered(lambda doc: doc.fiscal_operation_id):
+            if doc.issuer == DOCUMENT_ISSUER_COMPANY and not doc.document_type_id:
+                doc.document_type_id = doc.company_id.document_type_id
 
     def _get_amount_lines(self):
         """Get object lines instances used to compute fiscal fields"""

--- a/l10n_br_fiscal/tests/test_fiscal_document_generic.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_generic.py
@@ -39,9 +39,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
     def test_nfe_same_state(self):
         """Test NFe same state."""
-
-        self.nfe_same_state._onchange_fiscal_operation_id()
-
         for line in self.nfe_same_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
 
@@ -164,9 +161,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
     def test_nfe_other_state(self):
         """Test NFe other state."""
-
-        self.nfe_other_state._onchange_fiscal_operation_id()
-
         for line in self.nfe_other_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_fiscal_operation_id()
@@ -282,9 +276,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
     def test_nfe_not_taxpayer(self):
         """Test NFe not taxpayer."""
-
-        self.nfe_not_taxpayer._onchange_fiscal_operation_id()
-
         for line in self.nfe_not_taxpayer.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_fiscal_operation_id()
@@ -387,9 +378,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
     def test_nfe_not_taxpayer_not_company(self):
         """Test NFe not taxpayer not Company."""
-
-        self.nfe_not_taxpayer_pf._onchange_fiscal_operation_id()
-
         for line in self.nfe_not_taxpayer_pf.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_fiscal_operation_id()
@@ -492,9 +480,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
     def test_nfe_export(self):
         """Test NFe export."""
-
-        self.nfe_export._onchange_fiscal_operation_id()
-
         for line in self.nfe_export.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_fiscal_operation_id()
@@ -589,9 +574,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
     def test_nfe_sn_same_state(self):
         """Test NFe Simples Nacional same state."""
-
-        self.nfe_sn_same_state._onchange_fiscal_operation_id()
-
         for line in self.nfe_sn_same_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
 
@@ -705,9 +687,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
     def test_nfe_sn_other_state(self):
         """Test NFe SN other state."""
-
-        self.nfe_sn_other_state._onchange_fiscal_operation_id()
-
         for line in self.nfe_sn_other_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_fiscal_operation_id()
@@ -806,9 +785,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
     def test_nfe_sn_not_taxpayer(self):
         """Test NFe SN not taxpayer."""
-
-        self.nfe_sn_not_taxpayer._onchange_fiscal_operation_id()
-
         for line in self.nfe_sn_not_taxpayer.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_fiscal_operation_id()
@@ -894,9 +870,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
     def test_nfe_sn_export(self):
         """Test NFe SN export."""
-
-        self.nfe_sn_export._onchange_fiscal_operation_id()
-
         for line in self.nfe_sn_export.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_fiscal_operation_id()

--- a/l10n_br_fiscal/tests/test_fiscal_document_nfse.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_nfse.py
@@ -14,8 +14,6 @@ class TestFiscalDocumentNFSe(TransactionCase):
     def test_nfse_same_state(self):
         """Test NFSe same state."""
 
-        self.nfse_same_state._onchange_fiscal_operation_id()
-
         for line in self.nfse_same_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_fiscal_operation_id()

--- a/l10n_br_fiscal/tests/test_tax_benefit.py
+++ b/l10n_br_fiscal/tests/test_tax_benefit.py
@@ -39,8 +39,6 @@ class TestTaxBenefit(TransactionCase):
     def test_nfe_tax_benefit(self):
         """Test NFe with tax benefit."""
 
-        self.nfe_tax_benefit._onchange_fiscal_operation_id()
-
         for line in self.nfe_tax_benefit.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_fiscal_operation_id()

--- a/l10n_br_fiscal_subsequent_document/tests/test_subsequent_operation.py
+++ b/l10n_br_fiscal_subsequent_document/tests/test_subsequent_operation.py
@@ -21,7 +21,11 @@ class TestSubsequentOperation(TransactionCase):
     def test_subsequent_operation_simple_faturamento(self):
         """Test Fiscal Subsequent Operation Simples Faturamento"""
 
-        self.nfe_simples_faturamento._onchange_fiscal_operation_id()
+        # TODO this legacy onchange was overriden in this module
+        # but the code went broken and it it was commented out.
+        # later the onchange in the l10n_br_fiscal module was converted
+        # to a compute so this onchange might need rework here:
+        # self.nfe_simples_faturamento._onchange_fiscal_operation_id()
 
         for line in self.nfe_simples_faturamento.fiscal_line_ids:
             line._onchange_product_id_fiscal()

--- a/l10n_br_nfe/tests/test_nfce.py
+++ b/l10n_br_nfe/tests/test_nfce.py
@@ -121,8 +121,6 @@ class TestNFCe(TestNFeExport):
         self.assertEqual(self.document_id.state_edoc, SITUACAO_EDOC_INUTILIZADA)
 
     def test_atualiza_status_nfce(self):
-        self.document_id._onchange_fiscal_operation_id()
-
         self.document_id._compute_nfe40_dhSaiEnt()
         self.assertFalse(self.document_id.nfe40_dhSaiEnt)
 

--- a/l10n_br_nfe/tests/test_nfe_xml_validation.py
+++ b/l10n_br_nfe/tests/test_nfe_xml_validation.py
@@ -27,7 +27,6 @@ class TestXMLValidation(TransactionCase):
                 "fiscal_operation_id": self.env.ref("l10n_br_fiscal.fo_venda").id,
             }
         )
-        document._onchange_fiscal_operation_id()
         line = document_line_model.create(
             {
                 "document_id": document.id,
@@ -66,7 +65,6 @@ class TestXMLValidation(TransactionCase):
                 "fiscal_operation_id": self.env.ref("l10n_br_fiscal.fo_venda").id,
             }
         )
-        document._onchange_fiscal_operation_id()
 
         # Line 1
         line = document_line_model.create(

--- a/l10n_br_nfse/tests/test_fiscal_document_nfse_common.py
+++ b/l10n_br_nfse/tests/test_fiscal_document_nfse_common.py
@@ -36,9 +36,6 @@ class TestFiscalDocumentNFSeCommon(TransactionCase):
 
     def test_certified_nfse_same_state_(self):
         """Test Certified NFSe same state."""
-
-        self.nfse_same_state._onchange_fiscal_operation_id()
-
         # RPS Number
         self.assertEqual(
             self.nfse_same_state.rps_number,

--- a/l10n_br_purchase/demo/l10n_br_purchase.xml
+++ b/l10n_br_purchase/demo/l10n_br_purchase.xml
@@ -12,10 +12,6 @@
         <field name="company_id" ref="base.main_company" />
     </record>
 
-    <function model="purchase.order" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_po_only_products')]" />
-    </function>
-
     <record id="main_pl_only_products_1_2" model="purchase.order.line">
         <field name="order_id" ref="main_po_only_products" />
         <field name="name">Office Chair Black</field>
@@ -70,10 +66,6 @@
         <field name="company_id" ref="base.main_company" />
     </record>
 
-    <function model="purchase.order" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_company-purchase_2')]" />
-    </function>
-
     <record id="main_company-purchase_line_2_1" model="purchase.order.line">
         <field name="order_id" ref="main_company-purchase_2" />
         <field name="name">Office Chair Black</field>
@@ -127,10 +119,6 @@
         <field name="user_id" ref="base.user_admin" />
         <field name="company_id" ref="base.main_company" />
     </record>
-
-    <function model="purchase.order" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_company-purchase_3')]" />
-    </function>
 
     <record id="main_company-purchase_line_3_1" model="purchase.order.line">
         <field name="order_id" ref="main_company-purchase_3" />
@@ -188,10 +176,6 @@
         <field name="company_id" ref="base.main_company" />
     </record>
 
-    <function model="purchase.order" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_company-purchase_4')]" />
-    </function>
-
     <record id="main_company-purchase_line_4_1" model="purchase.order.line">
         <field name="order_id" ref="main_company-purchase_4" />
         <field name="name">Office Chair Black</field>
@@ -244,10 +228,6 @@
         <field name="company_id" ref="base.main_company" />
     </record>
 
-    <function model="purchase.order" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_company-purchase_5')]" />
-    </function>
-
     <record id="main_company-purchase_line_5_1" model="purchase.order.line">
         <field name="order_id" ref="main_company-purchase_5" />
         <field name="name">Office Chair Black</field>
@@ -298,10 +278,6 @@
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
 
-    <function model="purchase.order" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('lp_po_only_products')]" />
-    </function>
-
     <record id="lp_pl_only_products_1_2" model="purchase.order.line">
         <field name="order_id" ref="lp_po_only_products" />
         <field name="name">Office Chair Black</field>
@@ -350,10 +326,6 @@
         <field name="user_id" ref="base.user_admin" />
         <field name="company_id" ref="l10n_br_base.empresa_simples_nacional" />
     </record>
-
-    <function model="purchase.order" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('sn_po_only_products')]" />
-    </function>
 
     <record id="sn_pl_only_products_1_2" model="purchase.order.line">
         <field name="order_id" ref="sn_po_only_products" />
@@ -404,10 +376,6 @@
         <field name="company_id" ref="base.main_company" />
     </record>
 
-    <function model="purchase.order" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_po_only_service')]" />
-    </function>
-
     <record id="main_pl_only_service_1_1" model="purchase.order.line">
         <field name="order_id" ref="main_po_only_service" />
         <field name="name">Desenvolvimento Odoo</field>
@@ -439,10 +407,6 @@
         <field name="user_id" ref="base.user_admin" />
         <field name="company_id" ref="base.main_company" />
     </record>
-
-    <function model="purchase.order" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_po_service_product')]" />
-    </function>
 
     <record id="main_pl_service_product_1_1" model="purchase.order.line">
         <field name="order_id" ref="main_po_service_product" />

--- a/l10n_br_purchase_stock/demo/purchase_order.xml
+++ b/l10n_br_purchase_stock/demo/purchase_order.xml
@@ -43,10 +43,6 @@
         <field name="ind_final">0</field>
     </record>
 
-    <function model="purchase.order" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_po_only_products_1')]" />
-    </function>
-
     <record id="main_pl_only_products_1_1" model="purchase.order.line">
         <field name="order_id" ref="main_po_only_products_1" />
         <field name="name">Office Chair Black</field>
@@ -155,10 +151,6 @@
         >TESTE - FISCAL ADDITIONAL DATA</field>
         <field name="ind_final">0</field>
     </record>
-
-    <function model="purchase.order" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_po_only_products_2')]" />
-    </function>
 
     <record id="main_pl_only_products_2_1" model="purchase.order.line">
         <field name="order_id" ref="main_po_only_products_2" />
@@ -270,10 +262,6 @@
         <field name="ind_final">0</field>
     </record>
 
-    <function model="purchase.order" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('lucro_presumido_po_only_products_1')]" />
-    </function>
-
     <record id="lucro_presumido_pol_only_products_1_1" model="purchase.order.line">
         <field name="order_id" ref="lucro_presumido_po_only_products_1" />
         <field name="name">Office Chair Black</field>
@@ -343,10 +331,6 @@
         <field name="ind_final">0</field>
     </record>
 
-    <function model="purchase.order" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_po_only_service_stock')]" />
-    </function>
-
     <record id="main_pl_only_service_stock_1_1" model="purchase.order.line">
         <field name="order_id" ref="main_po_only_service_stock" />
         <field name="name">Desenvolvimento Odoo</field>
@@ -379,10 +363,6 @@
         <field name="company_id" ref="base.main_company" />
         <field name="ind_final">0</field>
     </record>
-
-    <function model="purchase.order" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_po_service_product_stock')]" />
-    </function>
 
     <record id="main_pl_service_product_stock_1_1" model="purchase.order.line">
         <field name="order_id" ref="main_po_service_product_stock" />


### PR DESCRIPTION
_onchange_fiscal_operation_id servia para nada no l10n_br_fiscal.document porque era o mesmo do que no l10n_br_fiscal.document.mixin (agora que fizemos a extração do modulo l10n_br_fiscal_subsequent_document).

e no l10n_br_fiscal.document.mixin eu troquei o onchange _onchange_fiscal_operation_id por um _compute_document_type_id. O campo fiscal_operation_type ja era um related e não precisava de tratamento.

Adaptei a simplificação nos outros módulos.