### PR TITLE
[16.0][REF] l10n_br_account: account_line_ids->move_line_ids

### DIFF
--- a/l10n_br_account/models/document_line.py
+++ b/l10n_br_account/models/document_line.py
@@ -9,7 +9,7 @@ from odoo.tools import float_compare
 class FiscalDocumentLine(models.Model):
     _inherit = "l10n_br_fiscal.document.line"
 
-    account_line_ids = fields.One2many(
+    move_line_ids = fields.One2many(
         comodel_name="account.move.line",
         inverse_name="fiscal_document_line_id",
         string="Invoice Lines",
@@ -17,7 +17,7 @@ class FiscalDocumentLine(models.Model):
 
     uom_id = fields.Many2one(
         comodel_name="uom.uom",
-        related="account_line_ids.product_uom_id",
+        related="move_line_ids.product_uom_id",
         store=True,
         string="UOM",
     )
@@ -34,21 +34,21 @@ class FiscalDocumentLine(models.Model):
     @api.onchange("product_id")
     def _inverse_product_id(self):
         for line in self:
-            for aml in line.account_line_ids:
+            for aml in line.move_line_ids:
                 if aml.product_id != line.product_id:
                     aml.product_id = line.product_id.id
 
     @api.onchange("name")
     def _inverse_name(self):
         for line in self:
-            for aml in line.account_line_ids:
+            for aml in line.move_line_ids:
                 if aml.name != line.name:
                     aml.name = line.name
 
     @api.onchange("quantity")
     def _inverse_quantity(self):
         for line in self:
-            for aml in line.account_line_ids:
+            for aml in line.move_line_ids:
                 if (
                     float_compare(
                         aml.quantity,
@@ -64,7 +64,7 @@ class FiscalDocumentLine(models.Model):
     @api.onchange("price_unit")
     def _inverse_price_unit(self):
         for line in self:
-            for aml in line.account_line_ids:
+            for aml in line.move_line_ids:
                 if (
                     aml.currency_id.compare_amounts(aml.price_unit, line.price_unit)
                     != 0

--- a/l10n_br_account/models/document_line.py
+++ b/l10n_br_account/models/document_line.py
@@ -16,10 +16,11 @@ class FiscalDocumentLine(models.Model):
     )
 
     uom_id = fields.Many2one(
-        comodel_name="uom.uom",
-        related="move_line_ids.product_uom_id",
+        compute="_compute_product_uom_id",
         store=True,
-        string="UOM",
+        readonly=False,
+        precompute=True,
+        ondelete="restrict",
     )
 
     # -------------------------------------------------------------------------
@@ -70,6 +71,15 @@ class FiscalDocumentLine(models.Model):
                     != 0
                 ):
                     aml.price_unit = line.price_unit
+
+    @api.depends("product_id")
+    def _compute_product_uom_id(self):
+        for line in self:
+            # vendor bills should have the product purchase UOM
+            if line.fiscal_operation_type == "in":
+                line.uom_id = line.product_id.uom_po_id
+            else:
+                line.uom_id = line.product_id.uom_id
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/l10n_br_account/views/document_line_view.xml
+++ b/l10n_br_account/views/document_line_view.xml
@@ -11,7 +11,7 @@
         <field name="inherit_id" ref="l10n_br_fiscal.document_line_form" />
         <field name="arch" type="xml">
             <field name="name" position="after">
-                <field name="account_line_ids" invisible="1" />
+                <field name="move_line_ids" invisible="1" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
Em 2021, o Gabriel Cardoso criou esse campo account_line_ids mas esse nome não é muito bom pois faz pensar em contas contabeis enquanto se trata de account.move.line. Proponho renomar o campo para move_line_ids enquanto ainda esta pouco usado.