### PR TITLE
[16.0] spec_driven_model, l10n_br_account_nfe: ensure nfe.40.dup/nfe.40.pag are loaded as concrete models

### DIFF
--- a/l10n_br_account_nfe/models/document.py
+++ b/l10n_br_account_nfe/models/document.py
@@ -40,6 +40,8 @@ class DocumentNfe(models.Model):
 
     @api.depends("move_ids", "move_ids.due_line_ids")
     def _compute_nfe40_dup(self):
+        # 1st ensure nfe.40.dup model is already loaded as a concrete model:
+        self.with_context(schema_name="nfe")._register_remaining_schema_models_hook()
         for rec in self.filtered(lambda x: x._need_compute_nfe40_dup()):
             dups_vals = []
             for count, mov in enumerate(rec.move_ids.due_line_ids, 1):
@@ -78,6 +80,8 @@ class DocumentNfe(models.Model):
         "nfe40_tpNF",
     )
     def _compute_nfe40_detpag(self):
+        # 1st ensure nfe.40.pag model is already loaded as a concrete model:
+        self.with_context(schema_name="nfe")._register_remaining_schema_models_hook()
         for rec in self.filtered(lambda x: x._need_compute_nfe_tags()):
             if rec._is_without_payment():
                 det_pag_vals = {

--- a/spec_driven_model/models/spec_mixin.py
+++ b/spec_driven_model/models/spec_mixin.py
@@ -83,25 +83,24 @@ class SpecMixin(models.AbstractModel):
         return self._get_spec_property("stacking_points", {})
 
     def _register_hook(self):
+        res = super()._register_hook()
+        self._register_remaining_schema_models_hook()
+        return res
+
+    def _register_remaining_schema_models_hook(self):
         """
         Called once all modules are loaded.
         Here we take all spec models that were not injected into existing concrete
         Odoo models and we make them concrete automatically with
         their _auto_init method that will create their SQL DDL structure.
         """
-        res = super()._register_hook()
         spec_schema, spec_version = self._spec_prefix(split=True)
         if not spec_schema:
-            return res
+            return
 
-        spec_module = self._get_spec_property("odoo_module")
-        if "_spec." in spec_module:
-            odoo_module = spec_module.split("_spec.")[0].split(".")[-1]
-        else:  # for tests:
-            odoo_module = "spec_driven_model"
-        load_key = f"_{spec_module}_loaded"
-        if hasattr(self.env.registry, load_key):  # hook already done for registry
-            return res
+        load_key = f"_{spec_schema}_register_hook_loaded"
+        if hasattr(self.env.registry, load_key):  # hook already called for registry
+            return
         setattr(self.env.registry, load_key, True)
 
         access_data = []
@@ -120,6 +119,11 @@ class SpecMixin(models.AbstractModel):
             if self.env.registry.get(i[0])
             and not SPEC_MIXIN_MAPPINGS[self.env.cr.dbname].get(i[0])
         }
+        spec_module = self._get_spec_property("odoo_module")
+        if "_spec." in spec_module:
+            odoo_module = spec_module.split("_spec.")[0].split(".")[-1]
+        else:  # for tests:
+            odoo_module = "spec_driven_model"
         for name in remaining_models:
             spec_class = StackedModel._odoo_name_to_class(name, spec_module)
             if spec_class is None:
@@ -191,8 +195,6 @@ class SpecMixin(models.AbstractModel):
         )
         with mute_logger("odoo.models"):
             imd_recs.unlink()
-
-        return res
 
     @classmethod
     def _auto_fill_access_data(cls, env, module_name: str, access_data: list):


### PR DESCRIPTION
havia situações em que os campos calculados `nfe40_dup `e `nfe40_pag` pudessem ser calculados na instalação do modulo l10n_br_account_nfe ANTES que o _register_hook do do modulo l10n_br_nfe/spec_driven_model fosse chamado (_register_hook so é chamado depois que todos módulos são instalados e carregados no registro) para tornar esses modelos como concretos (no l10n_br_nfe_spec eles vem como modelos abstratos e como não são injetados em módulos Odoo existente, é o _register_hook do modulo spec_model_driven que torna eles concretos.

Em uso "normal" isso não acontecia, mas ao trabalhar no PR #3905 e em outras situações eu vi que acontecia bugs do tipo "nfe.30.pag has no attribute id" ou coisas do tipo pois a partir da v15 modelos abstratos não tem mais atributo id mesmo.

Para poder chamar facilmente a parte do _register_hook que cuida de tornar concretos os modelos "sobrando" como `nfe.40.dup` e `nfe.40.pag` sem ter que chamar o super()._register_hook eu optei por dividir o método _register_hook em 2.

Ao fazer essas coisas eu também vi que a chave que fica no registro para indicar se o hook já foi chamado ou não não tava legal. Para a nfe ficava como `"_odoo.addons.l10n_br_nfe_spec.models.v4_0.leiaute_nfe_v4_00_loaded"`. Definir um atributo comprido assim com pontos dentro era pedir para acontecer merda. Nisso agora essa mesma chave ficou apenas `_nfe_register_hook_loaded`.