### PR TITLE
[16.0] l10n_br_fiscal: _compute_fiscal_tax_ids instead of onchange

### DIFF
--- a/l10n_br_account/models/document_line.py
+++ b/l10n_br_account/models/document_line.py
@@ -16,10 +16,11 @@ class FiscalDocumentLine(models.Model):
     )
 
     uom_id = fields.Many2one(
-        comodel_name="uom.uom",
-        related="account_line_ids.product_uom_id",
+        compute="_compute_product_uom_id",
         store=True,
-        string="UOM",
+        readonly=False,
+        precompute=True,
+        ondelete="restrict",
     )
 
     # -------------------------------------------------------------------------
@@ -70,6 +71,15 @@ class FiscalDocumentLine(models.Model):
                     != 0
                 ):
                     aml.price_unit = line.price_unit
+
+    @api.depends("product_id")
+    def _compute_product_uom_id(self):
+        for line in self:
+            # vendor bills should have the product purchase UOM
+            if line.fiscal_operation_type == "in":
+                line.uom_id = line.product_id.uom_po_id
+            else:
+                line.uom_id = line.product_id.uom_id
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/l10n_br_account/models/document_line.py
+++ b/l10n_br_account/models/document_line.py
@@ -81,6 +81,45 @@ class FiscalDocumentLine(models.Model):
             else:
                 line.uom_id = line.product_id.uom_id
 
+    def _get_fiscal_partner(self):
+        """
+        Get the partner from the aml to avoid an _inherits/ORM limitation.
+        partner_id can be None on a NewID fiscal document line behind an aml.
+        In this case we can retrieve it using the related amls.
+        """
+        self.ensure_one()
+        if self.partner_id:
+            return self.partner_id
+        elif self.account_line_ids:
+            return self.account_line_ids[0].partner_id
+        return self.partner_id
+
+    def _get_fiscal_company(self):
+        """
+        Get the company from the aml to avoid an _inherits/ORM limitation.
+        company_id can be None on a NewID fiscal document line behind an aml.
+        In this case we can retrieve it using the related amls.
+        """
+        self.ensure_one()
+        if self.company_id:
+            return self.company_id
+        elif self.account_line_ids:
+            return self.account_line_ids[0].company_id
+        return self.company_id
+
+    def _get_ind_final(self):
+        """
+        Get ind_final from the aml to avoid an _inherits/ORM limitation.
+        ind_final can be None on a NewID fiscal document line behind an aml.
+        In this case we can retrieve it using the related amls.
+        """
+        self.ensure_one()
+        if self.ind_final:
+            return self.ind_final
+        elif self.account_line_ids:
+            return self.account_line_ids[0].ind_final
+        return self.ind_final
+
     @api.model_create_multi
     def create(self, vals_list):
         """

--- a/l10n_br_account_nfe/hooks.py
+++ b/l10n_br_account_nfe/hooks.py
@@ -36,20 +36,6 @@ def load_simples_nacional_demo(env, registry):
             kind="demo",
         )
 
-        # É necessário rodar os onchanges fiscais para
-        # preencher os campos referentes aos Impostos
-        invoice_tag_cobranca = env.ref("l10n_br_account_nfe.demo_nfe_dados_de_cobranca")
-        for line in invoice_tag_cobranca.invoice_line_ids:
-            line._onchange_fiscal_operation_line_id()
-            line._onchange_fiscal_tax_ids()
-
-        invoice_sem_tag_cobranca = env.ref(
-            "l10n_br_account_nfe.demo_nfe_sem_dados_de_cobranca"
-        )
-        for line in invoice_sem_tag_cobranca.invoice_line_ids:
-            line._onchange_fiscal_operation_line_id()
-            line._onchange_fiscal_tax_ids()
-
     # back to the main company as the next modules to be installed
     # expect this to be the default company.
     env.user.company_id = env.ref("base.main_company")

--- a/l10n_br_account_nfe/tests/test_nfe_generate_tags_cobr_dup_pag.py
+++ b/l10n_br_account_nfe/tests/test_nfe_generate_tags_cobr_dup_pag.py
@@ -111,11 +111,6 @@ class TestGeneratePaymentInfo(TransactionCase):
             "l10n_br_account_nfe.demo_nfe_dados_de_cobranca"
         )
         cls.env.user.company_id = cls.invoice_demo_data.company_id
-        for line in cls.invoice_demo_data.invoice_line_ids:
-            line.with_context(
-                check_move_validity=False
-            )._onchange_fiscal_operation_line_id()
-            line.with_context(check_move_validity=False)._onchange_fiscal_tax_ids()
 
     def test_nfe_generate_tag_pag(self):
         """Test NFe generate TAG PAG."""

--- a/l10n_br_cte/demo/fiscal_document_demo.xml
+++ b/l10n_br_cte/demo/fiscal_document_demo.xml
@@ -108,14 +108,6 @@
         <value eval="[ref('l10n_br_cte.demo_cte_lc_modal_rodoviario_1-1')]" />
     </function>
 
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('l10n_br_cte.demo_cte_lc_modal_rodoviario_1-1')]" />
-    </function>
-
-
     <!-- CTe Test - Modal Aereo - LC -->
     <record id="demo_cte_lc_modal_aereo" model="l10n_br_fiscal.document">
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -220,14 +212,6 @@
     <function model="l10n_br_fiscal.document.line" name="_onchange_product_id_fiscal">
         <value eval="[ref('l10n_br_cte.demo_cte_lc_modal_aereo_1-1')]" />
     </function>
-
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('l10n_br_cte.demo_cte_lc_modal_aereo_1-1')]" />
-    </function>
-
 
     <!-- CTe Test - Modal Aquaviario - LC -->
     <record id="demo_cte_lc_modal_aquaviario" model="l10n_br_fiscal.document">
@@ -334,14 +318,6 @@
         <value eval="[ref('l10n_br_cte.demo_cte_lc_modal_aquaviario_1-1')]" />
     </function>
 
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('l10n_br_cte.demo_cte_lc_modal_aquaviario_1-1')]" />
-    </function>
-
-
     <!-- CTe Test - Modal Ferroviario - LC -->
     <record id="demo_cte_lc_modal_ferroviario" model="l10n_br_fiscal.document">
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -447,14 +423,6 @@
         <value eval="[ref('l10n_br_cte.demo_cte_lc_modal_ferroviario_1-1')]" />
     </function>
 
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('l10n_br_cte.demo_cte_lc_modal_ferroviario_1-1')]" />
-    </function>
-
-
     <!-- CTe Test - Modal Dutoviario - LC -->
     <record id="demo_cte_lc_modal_dutoviario" model="l10n_br_fiscal.document">
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -559,14 +527,6 @@
     <function model="l10n_br_fiscal.document.line" name="_onchange_product_id_fiscal">
         <value eval="[ref('l10n_br_cte.demo_cte_lc_modal_dutoviario_1-1')]" />
     </function>
-
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('l10n_br_cte.demo_cte_lc_modal_dutoviario_1-1')]" />
-    </function>
-
 
     <!-- Empresa Simples Nacional -->
 
@@ -674,14 +634,5 @@
     <function model="l10n_br_fiscal.document.line" name="_onchange_product_id_fiscal">
         <value eval="[ref('l10n_br_cte.demo_cte_sn_modal_rodoviario_1-1')]" />
     </function>
-
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('l10n_br_cte.demo_cte_sn_modal_rodoviario_1-1')]" />
-    </function>
-
-
 
 </odoo>

--- a/l10n_br_cte/tests/test_cte_serialize.py
+++ b/l10n_br_cte/tests/test_cte_serialize.py
@@ -39,7 +39,6 @@ class TestCTeSerialize(TransactionCase):
         cte.fiscal_line_ids.name = "Frete"
         for line in cte.fiscal_line_ids:
             line.product_id.list_price = 100
-        cte.fiscal_line_ids._onchange_fiscal_operation_line_id()
         cte.fiscal_line_ids.cfop_id = cte.env.ref("l10n_br_fiscal.cfop_5352")
 
         cte.action_document_confirm()

--- a/l10n_br_delivery/demo/sale_order_demo.xml
+++ b/l10n_br_delivery/demo/sale_order_demo.xml
@@ -41,10 +41,6 @@
         <value eval="[ref('main_sl_delivery_1_2')]" />
     </function>
 
-    <function model="sale.order.line" name="_onchange_fiscal_operation_line_id">
-        <value eval="[ref('main_sl_delivery_1_2')]" />
-    </function>
-
     <record id="main_sl_delivery_2_2" model="sale.order.line">
         <field name="order_id" ref="main_so_delivery_1" />
         <field name="name">Office Lamp</field>
@@ -65,10 +61,6 @@
     </function>
 
     <function model="sale.order.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_sl_delivery_2_2')]" />
-    </function>
-
-    <function model="sale.order.line" name="_onchange_fiscal_operation_line_id">
         <value eval="[ref('main_sl_delivery_2_2')]" />
     </function>
 

--- a/l10n_br_fiscal/demo/fiscal_document_demo.xml
+++ b/l10n_br_fiscal/demo/fiscal_document_demo.xml
@@ -47,13 +47,6 @@
         <value eval="[ref('demo_nfe_line_same_state_1-1')]" />
     </function>
 
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('demo_nfe_line_same_state_1-1')]" />
-    </function>
-
     <record id="demo_nfe_line_same_state_1-2" model="l10n_br_fiscal.document.line">
         <field name="document_id" ref="demo_nfe_same_state" />
         <field name="name">Teste</field>
@@ -73,13 +66,6 @@
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('demo_nfe_line_same_state_1-2')]" />
-    </function>
-
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
         <value eval="[ref('demo_nfe_line_same_state_1-2')]" />
     </function>
 
@@ -120,13 +106,6 @@
         <value eval="[ref('demo_nfe_line_other_state_1-3')]" />
     </function>
 
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('demo_nfe_line_other_state_1-3')]" />
-    </function>
-
     <record id="demo_nfe_line_other_state_2-3" model="l10n_br_fiscal.document.line">
         <field name="document_id" ref="demo_nfe_other_state" />
         <field name="name">Teste</field>
@@ -146,13 +125,6 @@
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('demo_nfe_line_other_state_2-3')]" />
-    </function>
-
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
         <value eval="[ref('demo_nfe_line_other_state_2-3')]" />
     </function>
 
@@ -176,13 +148,6 @@
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('demo_nfe_line_other_state_3-3')]" />
-    </function>
-
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
         <value eval="[ref('demo_nfe_line_other_state_3-3')]" />
     </function>
 
@@ -225,13 +190,6 @@
         <value eval="[ref('demo_nfe_line_export_3-1')]" />
     </function>
 
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('demo_nfe_line_export_3-1')]" />
-    </function>
-
     <record id="demo_nfe_line_export_3-2" model="l10n_br_fiscal.document.line">
         <field name="document_id" ref="demo_nfe_export" />
         <field name="name">Teste</field>
@@ -251,13 +209,6 @@
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('demo_nfe_line_export_3-2')]" />
-    </function>
-
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
         <value eval="[ref('demo_nfe_line_export_3-2')]" />
     </function>
 
@@ -312,13 +263,6 @@
         <value eval="[ref('demo_nfe_line_nao_contribuinte_4-1')]" />
     </function>
 
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('demo_nfe_line_nao_contribuinte_4-1')]" />
-    </function>
-
     <record
         id="demo_nfe_line_nao_contribuinte_4-2"
         model="l10n_br_fiscal.document.line"
@@ -347,13 +291,6 @@
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('demo_nfe_line_nao_contribuinte_4-2')]" />
-    </function>
-
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
         <value eval="[ref('demo_nfe_line_nao_contribuinte_4-2')]" />
     </function>
 
@@ -402,13 +339,6 @@
         <value eval="[ref('demo_nfe_tax_benefit_4-1')]" />
     </function>
 
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('demo_nfe_tax_benefit_4-1')]" />
-    </function>
-
     <!-- NFe Test - Empresa Contribuinte - Nao Contribuinte PF -->
     <record id="demo_nfe_nao_contribuinte_pf" model="l10n_br_fiscal.document">
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -449,13 +379,6 @@
         <value eval="[ref('demo_nfe_nao_contribuinte_pf_1-2')]" />
     </function>
 
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('demo_nfe_nao_contribuinte_pf_1-2')]" />
-    </function>
-
     <record id="demo_nfe_nao_contribuinte_pf_2-2" model="l10n_br_fiscal.document.line">
         <field name="document_id" ref="demo_nfe_nao_contribuinte_pf" />
         <field name="name">Teste</field>
@@ -478,13 +401,6 @@
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('demo_nfe_nao_contribuinte_pf_2-2')]" />
-    </function>
-
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
         <value eval="[ref('demo_nfe_nao_contribuinte_pf_2-2')]" />
     </function>
 
@@ -525,13 +441,6 @@
         <value eval="[ref('demo_nfe_line_sn_same_state_5-1')]" />
     </function>
 
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('demo_nfe_line_sn_same_state_5-1')]" />
-    </function>
-
     <record id="demo_nfe_line_sn_same_state_5-2" model="l10n_br_fiscal.document.line">
         <field name="document_id" ref="demo_nfe_sn_same_state" />
         <field name="name">Teste</field>
@@ -551,13 +460,6 @@
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('demo_nfe_line_sn_same_state_5-2')]" />
-    </function>
-
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
         <value eval="[ref('demo_nfe_line_sn_same_state_5-2')]" />
     </function>
 
@@ -598,13 +500,6 @@
         <value eval="[ref('demo_nfe_line_sn_other_state_6-1')]" />
     </function>
 
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('demo_nfe_line_sn_other_state_6-1')]" />
-    </function>
-
     <record id="demo_nfe_line_sn_other_state_6-2" model="l10n_br_fiscal.document.line">
         <field name="document_id" ref="demo_nfe_sn_other_state" />
         <field name="name">Teste</field>
@@ -624,13 +519,6 @@
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('demo_nfe_line_sn_other_state_6-2')]" />
-    </function>
-
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
         <value eval="[ref('demo_nfe_line_sn_other_state_6-2')]" />
     </function>
 
@@ -671,13 +559,6 @@
         <value eval="[ref('demo_nfe_line_sn_export_7-1')]" />
     </function>
 
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('demo_nfe_line_sn_export_7-1')]" />
-    </function>
-
     <record id="demo_nfe_line_sn_export_7-2" model="l10n_br_fiscal.document.line">
         <field name="document_id" ref="demo_nfe_sn_export" />
         <field name="name">Teste</field>
@@ -697,13 +578,6 @@
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('demo_nfe_line_sn_export_7-2')]" />
-    </function>
-
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
         <value eval="[ref('demo_nfe_line_sn_export_7-2')]" />
     </function>
 
@@ -750,13 +624,6 @@
         <value eval="[ref('demo_nfe_line_sn_nao_contribuinte_7-1')]" />
     </function>
 
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('demo_nfe_line_sn_nao_contribuinte_7-1')]" />
-    </function>
-
     <record
         id="demo_nfe_line_sn_nao_contribuinte_7-2"
         model="l10n_br_fiscal.document.line"
@@ -782,13 +649,6 @@
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('demo_nfe_line_sn_nao_contribuinte_7-2')]" />
-    </function>
-
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
         <value eval="[ref('demo_nfe_line_sn_nao_contribuinte_7-2')]" />
     </function>
 
@@ -843,13 +703,6 @@
         <value eval="[ref('demo_nfe_line_so_simples_faturamento_7-1')]" />
     </function>
 
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('demo_nfe_line_so_simples_faturamento_7-1')]" />
-    </function>
-
     <!-- NFe Compras Test - Empresa Contribuinte - Mesmo Estado -->
     <record id="demo_nfe_purchase_same_state" model="l10n_br_fiscal.document">
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
@@ -893,13 +746,5 @@
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('demo_nfe_purchase_line_same_state_1-1')]" />
     </function>
-
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('demo_nfe_purchase_line_same_state_1-1')]" />
-    </function>
-
 
 </odoo>

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -36,6 +36,7 @@ class DocumentLine(models.Model):
         comodel_name="res.company",
         related="document_id.company_id",
         store=True,
+        precompute=True,
         string="Company",
     )
 
@@ -46,6 +47,7 @@ class DocumentLine(models.Model):
     partner_id = fields.Many2one(
         related="document_id.partner_id",
         store=True,
+        precompute=True,
     )
 
     quantity = fields.Float(default=1.0)

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -197,6 +197,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         comodel_name="l10n_br_fiscal.cfop",
         string="CFOP",
         domain="[('type_in_out', '=', fiscal_operation_type)]",
+        compute="_compute_fiscal_tax_ids",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     cfop_destination = fields.Selection(
@@ -402,6 +406,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
             ("is_benefit", "=", True),
             ("tax_domain", "=", TAX_DOMAIN_ICMS),
         ],
+        compute="_compute_fiscal_tax_ids",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     icms_tax_benefit_code = fields.Char(
@@ -618,6 +626,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         comodel_name="l10n_br_fiscal.tax.ipi.guideline",
         string="IPI Guideline",
         domain="['|', ('cst_in_id', '=', ipi_cst_id),('cst_out_id', '=', ipi_cst_id)]",
+        compute="_compute_fiscal_tax_ids",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     # IPI Devolvido Fields
@@ -924,6 +936,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         comodel_name="l10n_br_fiscal.comment",
         string="Comments",
         domain=[("object", "=", FISCAL_COMMENT_LINE)],
+        compute="_compute_fiscal_tax_ids",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     additional_data = fields.Text()

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -239,6 +239,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     fiscal_tax_ids = fields.Many2many(
         comodel_name="l10n_br_fiscal.tax",
         string="Fiscal Taxes",
+        compute="_compute_fiscal_tax_ids",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     amount_fiscal = fields.Monetary(

--- a/l10n_br_fiscal/models/document_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_line_mixin_methods.py
@@ -210,7 +210,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
     def _compute_taxes(self, taxes, cst=None):
         self.ensure_one()
         return taxes.compute_taxes(
-            company=self.company_id,
+            company=self._get_fiscal_company(),
             partner=self._get_fiscal_partner(),
             product=self.product_id,
             price_unit=self.price_unit,
@@ -234,7 +234,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             icmssn_range=self.icmssn_range_id,
             icms_origin=self.icms_origin,
             icms_cst_id=self.icms_cst_id,
-            ind_final=self.ind_final,
+            ind_final=self._get_ind_final(),
             icms_relief_id=self.icms_relief_id,
         )
 
@@ -321,7 +321,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
 
     def _update_fiscal_taxes(self):
         for line in self:
-            compute_result = self._compute_taxes(line.fiscal_tax_ids)
+            compute_result = line._compute_taxes(line.fiscal_tax_ids)
             to_update = {
                 "amount_tax_included": compute_result.get("amount_included", 0.0),
                 "amount_tax_not_included": compute_result.get(
@@ -332,7 +332,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             }
             to_update.update(line._prepare_tax_fields(compute_result))
 
-            in_draft_mode = self != self._origin
+            in_draft_mode = line != line._origin
             if in_draft_mode:
                 line.update(to_update)
             else:
@@ -389,6 +389,24 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         self.ensure_one()
         return self.partner_id
 
+    def _get_fiscal_company(self):
+        """
+        Meant to be overriden in account.move.line.
+        Indeed when using this mixin in a NewID fiscal document line behind an aml,
+        self.company_id is None but it can be retrived from the aml.
+        """
+        self.ensure_one()
+        return self.company_id
+
+    def _get_ind_final(self):
+        """
+        Meant to be overriden in account.move.line.
+        Indeed when using this mixin in a NewID fiscal document line behind an aml,
+        self.ind_final is None but it can be retrived from the aml.
+        """
+        self.ensure_one()
+        return self.ind_final
+
     @api.onchange(
         "fiscal_operation_id", "ncm_id", "nbs_id", "cest_id", "service_type_id"
     )
@@ -401,43 +419,62 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 partner=self._get_fiscal_partner(),
                 product=self.product_id,
             )
-            self._onchange_fiscal_operation_line_id()
+            self._compute_fiscal_tax_ids()  # sadly seems required for composite move
 
-    @api.onchange("fiscal_operation_line_id")
-    def _onchange_fiscal_operation_line_id(self):
-        # Reset Taxes
-        self._remove_all_fiscal_tax_ids()
-        if self.fiscal_operation_line_id:
-            mapping_result = self.fiscal_operation_line_id.map_fiscal_taxes(
-                company=self.company_id,
-                partner=self._get_fiscal_partner(),
-                product=self.product_id,
-                ncm=self.ncm_id,
-                nbm=self.nbm_id,
-                nbs=self.nbs_id,
-                cest=self.cest_id,
-                city_taxation_code=self.city_taxation_code_id,
-                service_type=self.service_type_id,
-                ind_final=self.ind_final,
-            )
+    def _get_fiscal_tax_ids_dependencies(self):
+        """
+        Dynamically get the list of fields dependencies, overriden in l10n_br_purchase.
+        """
+        return [
+            "company_id",
+            "partner_id",
+            "fiscal_operation_line_id",
+            "product_id",
+            "ncm_id",
+            "nbs_id",
+            "nbm_id",
+            "cest_id",
+            "city_taxation_code_id",
+            "service_type_id",
+            "ind_final",
+        ]
 
-            self.cfop_id = mapping_result["cfop"]
-            if self._is_imported():
-                return
-            self._process_fiscal_mapping(mapping_result)
-
-        if not self.fiscal_operation_line_id:
-            self.cfop_id = False
-
-    def _process_fiscal_mapping(self, mapping_result):
-        self.ipi_guideline_id = mapping_result["ipi_guideline"]
-        self.icms_tax_benefit_id = mapping_result["icms_tax_benefit_id"]
-        taxes = self.env["l10n_br_fiscal.tax"]
-        for tax in mapping_result["taxes"].values():
-            taxes |= tax
-        self.fiscal_tax_ids = taxes
-        self._update_fiscal_taxes()
-        self.comment_ids = self.fiscal_operation_line_id.comment_ids
+    @api.depends(lambda self: self._get_fiscal_tax_ids_dependencies())
+    def _compute_fiscal_tax_ids(self):
+        """
+        Among the dependencies, company_id, partner_id and ind_final are related
+        to the fiscal document/line container. When called from account.move.line
+        via _inherits on newID records, we read these values from the related aml
+        to work around and _inherits/precompute limitation.
+        """
+        for line in self:
+            line._remove_all_fiscal_tax_ids()
+            if line.fiscal_operation_line_id:
+                mapping_result = line.fiscal_operation_line_id.map_fiscal_taxes(
+                    company=line._get_fiscal_company(),
+                    partner=line._get_fiscal_partner(),
+                    product=line.product_id,
+                    ncm=line.ncm_id,
+                    nbm=line.nbm_id,
+                    nbs=line.nbs_id,
+                    cest=line.cest_id,
+                    city_taxation_code=line.city_taxation_code_id,
+                    service_type=line.service_type_id,
+                    ind_final=line._get_ind_final(),
+                )
+                line.cfop_id = mapping_result["cfop"]
+                if line._is_imported():
+                    return
+                line.ipi_guideline_id = mapping_result["ipi_guideline"]
+                line.icms_tax_benefit_id = mapping_result["icms_tax_benefit_id"]
+                taxes = line.env["l10n_br_fiscal.tax"]
+                for tax in mapping_result["taxes"].values():
+                    taxes |= tax
+                line.fiscal_tax_ids = taxes
+                line._update_fiscal_taxes()
+                line.comment_ids = line.fiscal_operation_line_id.comment_ids
+            else:
+                line.cfop_id = False
 
     @api.onchange("product_id")
     def _onchange_product_id_fiscal(self):

--- a/l10n_br_nfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_nfe/demo/fiscal_document_demo.xml
@@ -35,13 +35,6 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
     </function>
 
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-1')]" />
-    </function>
-
     <record id="demo_nfe_line_same_state_1-2" model="l10n_br_fiscal.document.line">
         <field name="document_id" ref="demo_nfe_same_state" />
         <field name="name">Teste</field>
@@ -55,13 +48,6 @@
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_product_id_fiscal">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
-    </function>
-
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
         <value eval="[ref('l10n_br_nfe.demo_nfe_line_same_state_1-2')]" />
     </function>
 
@@ -104,13 +90,6 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]" />
     </function>
 
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]" />
-    </function>
-
     <!-- NFe Test - Pessoa Física - ICMS 18% with a reduction of 51.11% -->
     <record id="demo_nfe_natural_icms_18_red_51_11" model="l10n_br_fiscal.document">
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -150,13 +129,6 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]" />
     </function>
 
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]" />
-    </function>
-
     <!-- NFe Test - Pessoa Física - ICMS 4% Imported for Resale -->
     <record id="demo_nfe_natural_icms_7_resale" model="l10n_br_fiscal.document">
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -190,13 +162,6 @@
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_product_id_fiscal">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
-    </function>
-
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]" />
     </function>
 
@@ -235,13 +200,6 @@
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_product_id_fiscal">
-        <value eval="[ref('l10n_br_nfe.demo_nfce_line_same_state_1-1')]" />
-    </function>
-
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
         <value eval="[ref('l10n_br_nfe.demo_nfce_line_same_state_1-1')]" />
     </function>
 

--- a/l10n_br_nfe/tests/test_nfe_xml_validation.py
+++ b/l10n_br_nfe/tests/test_nfe_xml_validation.py
@@ -38,7 +38,6 @@ class TestXMLValidation(TransactionCase):
             }
         )
         line._onchange_product_id_fiscal()
-        line._onchange_fiscal_operation_line_id()
         document.action_document_confirm()
         document.action_document_send()
         _logger.info(
@@ -78,7 +77,6 @@ class TestXMLValidation(TransactionCase):
             }
         )
         line._onchange_product_id_fiscal()
-        line._onchange_fiscal_operation_line_id()
 
         # Force taxes
         line.update(
@@ -109,7 +107,6 @@ class TestXMLValidation(TransactionCase):
             }
         )
         line2._onchange_product_id_fiscal()
-        line2._onchange_fiscal_operation_line_id()
 
         # Force taxes
         line2.update(

--- a/l10n_br_product_contract/demo/sale_order.xml
+++ b/l10n_br_product_contract/demo/sale_order.xml
@@ -40,8 +40,4 @@
         <value eval="[ref('main_sl_recurrency_service_1_1')]" />
     </function>
 
-    <function model="sale.order.line" name="_onchange_fiscal_operation_line_id">
-        <value eval="[ref('main_sl_recurrency_service_1_1')]" />
-    </function>
-
 </odoo>

--- a/l10n_br_purchase/models/purchase_order_line.py
+++ b/l10n_br_purchase/models/purchase_order_line.py
@@ -38,14 +38,6 @@ class PurchaseOrderLine(models.Model):
         "('state', '=', 'approved')]",
     )
 
-    fiscal_tax_ids = fields.Many2many(
-        comodel_name="l10n_br_fiscal.tax",
-        relation="fiscal_purchase_line_tax_rel",
-        column1="document_id",
-        column2="fiscal_tax_id",
-        string="Fiscal Taxes",
-    )
-
     # overriden to disable precompute as it depends on price_unit which is not
     # precompute in the purchase module. We don't need precompute in purchase.
     fiscal_price = fields.Float(
@@ -86,6 +78,21 @@ class PurchaseOrderLine(models.Model):
     delivery_costs = fields.Selection(
         related="company_id.delivery_costs",
     )
+
+    def _get_fiscal_tax_ids_dependencies(self):
+        return [
+            # "company_id",  # not precompute in purchase
+            # "partner_id",  # not precompute in purchase
+            "fiscal_operation_line_id",
+            "product_id",
+            "ncm_id",
+            "nbs_id",
+            "nbm_id",
+            "cest_id",
+            "city_taxation_code_id",
+            "service_type_id",
+            "ind_final",
+        ]
 
     @api.depends(
         "product_uom_qty",

--- a/l10n_br_purchase_stock/tests/test_stock_rule.py
+++ b/l10n_br_purchase_stock/tests/test_stock_rule.py
@@ -38,7 +38,6 @@ class StockRuleTest(TransactionCase):
         )
         self.assertTrue(po_line.fiscal_operation_id, "Missing Fiscal Operation.")
         po_line._onchange_fiscal_operation_id()
-        po_line._onchange_fiscal_operation_line_id()
         self.assertTrue(
             po_line.fiscal_operation_line_id,
             "Missing Fiscal Operation Line in Purchase Order.",

--- a/l10n_br_sale_invoice_plan/demo/sale_order_demo.xml
+++ b/l10n_br_sale_invoice_plan/demo/sale_order_demo.xml
@@ -37,10 +37,6 @@
         <value eval="[ref('lc_sl_invoice_plan_service_br_1_1')]" />
     </function>
 
-    <function model="sale.order.line" name="_onchange_fiscal_operation_line_id">
-        <value eval="[ref('lc_sl_invoice_plan_service_br_1_1')]" />
-    </function>
-
     <function
         model="sale.order.line"
         name="_onchange_fiscal_tax_ids"


### PR DESCRIPTION
troca _onchange_fiscal_operation_line_id por _compute_fiscal_tax_ids, com precompute e readonly=False.

Vale a pena notar que na hora do precompute quando a linha de documento fiscal é um NewID, parece que tem um bug no ORM para acessar a um campo related do "container" da linha (o documento fiscal por exemplo) quando é feito atraves do _inherits (quando é chamado pelo account.move.line). Neste caso a forma que eu consegui accessar é usando o account_line_ids que aponto pros account.move.line (normalmente apenas 1).

Para calcular o campo fiscal_tax_ids, apenas os campos company_id, partner_id e ind_final vinham do "container" e não da linha diretamente.

Nisso eu introduzi os métodos _get_fiscal_company e _get_ind_final no mesmo molde que a gente tinha com o _get_fiscal_partner e fiz os 3 override no modulo l10n_br_account.