### PR TITLE
[16.0] l10n_br_fiscal: _compute_tax_fields: dynamic depends - WIP

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -274,7 +274,7 @@ class AccountMove(models.Model):
                     move.is_invoice(include_receipts=True)
                     and line.display_type == "product"
                 ):
-                    line._update_fiscal_taxes()
+                    line._compute_tax_fields()
 
         result = super()._compute_amount()
         for move in self.filtered(lambda m: m.fiscal_operation_id):

--- a/l10n_br_account/tests/test_account_move_lc.py
+++ b/l10n_br_account/tests/test_account_move_lc.py
@@ -2084,6 +2084,7 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             }
         )
         fiscal_doc_line_to_import._onchange_product_id_fiscal()
+        fiscal_doc_line_to_import._compute_tax_fields()
 
         # let's import it:
         self.move_in_compra_para_revenda.fiscal_document_id = fiscal_doc_to_import

--- a/l10n_br_account_withholding/tests/test_account_wh_invoice.py
+++ b/l10n_br_account_withholding/tests/test_account_wh_invoice.py
@@ -430,7 +430,6 @@ class AccountMoveWithWhInvoice(AccountMoveBRCommon):
             line_ids.issqn_wh_tax_id = self.env.ref("l10n_br_fiscal.tax_issqn_wh_5")
 
         move_issqn.invoice_line_ids._onchange_fiscal_taxes()
-        move_issqn.invoice_line_ids._onchange_fiscal_tax_ids()
         move_issqn.action_post()
         move_issqn._compute_wh_invoice_ids()
 
@@ -506,7 +505,6 @@ class AccountMoveWithWhInvoice(AccountMoveBRCommon):
             line_ids.issqn_wh_tax_id = self.env.ref("l10n_br_fiscal.tax_issqn_wh_5")
 
         move_issqn.invoice_line_ids._onchange_fiscal_taxes()
-        move_issqn.invoice_line_ids._onchange_fiscal_tax_ids()
         move_issqn.action_post()
         move_issqn._compute_wh_invoice_ids()
 

--- a/l10n_br_contract/models/contract_line.py
+++ b/l10n_br_contract/models/contract_line.py
@@ -60,7 +60,6 @@ class ContractLine(models.Model):
             {"company_currency_id": contract.company_id.currency_id.id}
         )
 
-        self._onchange_fiscal_tax_ids()
         quantity = invoice_line_vals.get("quantity")
 
         tax_ids = self.fiscal_tax_ids.account_taxes(

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -222,6 +222,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         compute="_compute_uot_id",
         store=True,
         readonly=False,
+        precompute=True,
     )
 
     fiscal_quantity = fields.Float(
@@ -326,6 +327,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         comodel_name="l10n_br_fiscal.tax",
         string="Tax ISSQN",
         domain=[("tax_domain", "=", TAX_DOMAIN_ISSQN)],
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     issqn_fg_city_id = fields.Many2one(
@@ -359,33 +364,89 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         default=ISSQN_INCENTIVE_DEFAULT,
     )
 
-    issqn_base = fields.Monetary(string="ISSQN Base")
+    issqn_base = fields.Monetary(
+        string="ISSQN Base",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    issqn_percent = fields.Float(string="ISSQN %")
+    issqn_percent = fields.Float(
+        string="ISSQN %",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    issqn_reduction = fields.Float(string="ISSQN % Reduction")
+    issqn_reduction = fields.Float(
+        string="ISSQN % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    issqn_value = fields.Monetary(string="ISSQN Value")
+    issqn_value = fields.Monetary(
+        string="ISSQN Value",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     issqn_wh_tax_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",
         string="Tax ISSQN RET",
         domain=[("tax_domain", "=", TAX_DOMAIN_ISSQN_WH)],
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
-    issqn_wh_base = fields.Monetary(string="ISSQN RET Base")
+    issqn_wh_base = fields.Monetary(
+        string="ISSQN RET Base",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    issqn_wh_percent = fields.Float(string="ISSQN RET %")
+    issqn_wh_percent = fields.Float(
+        string="ISSQN RET %",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    issqn_wh_reduction = fields.Float(string="ISSQN RET % Reduction")
+    issqn_wh_reduction = fields.Float(
+        string="ISSQN RET % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    issqn_wh_value = fields.Monetary(string="ISSQN RET Value")
+    issqn_wh_value = fields.Monetary(
+        string="ISSQN RET Value",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     # ICMS Fields
     icms_tax_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",
         string="Tax ICMS",
         domain=[("tax_domain", "=", TAX_DOMAIN_ICMS)],
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     icms_cst_id = fields.Many2one(
@@ -393,6 +454,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         string="CST ICMS",
         domain="[('tax_domain', '=', {'1': 'icmssn', '2': 'icmssn', "
         "'3': 'icms'}.get(tax_framework))]",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     icms_cst_code = fields.Char(
@@ -420,6 +485,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         selection=ICMS_BASE_TYPE,
         string="ICMS Base Type",
         default=ICMS_BASE_TYPE_DEFAULT,
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     icms_origin = fields.Selection(
@@ -427,16 +496,40 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     )
 
     # vBC - Valor da base de cálculo do ICMS
-    icms_base = fields.Monetary(string="ICMS Base")
+    icms_base = fields.Monetary(
+        string="ICMS Base",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     # pICMS - Alíquota do IMCS
-    icms_percent = fields.Float(string="ICMS %")
+    icms_percent = fields.Float(
+        string="ICMS %",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     # pRedBC - Percentual de redução do ICMS
-    icms_reduction = fields.Float(string="ICMS % Reduction")
+    icms_reduction = fields.Float(
+        string="ICMS % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     # vICMS - Valor do ICMS
-    icms_value = fields.Monetary(string="ICMS Value")
+    icms_value = fields.Monetary(
+        string="ICMS Value",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     # vICMSSubstituto - Valor do ICMS cobrado em operação anterior
     icms_substitute = fields.Monetary(
@@ -450,13 +543,23 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     )
 
     # vICMSDeson - Valor do ICMS desonerado
-    icms_relief_value = fields.Monetary(string="ICMS Relief Value")
+    icms_relief_value = fields.Monetary(
+        string="ICMS Relief Value",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     # ICMS ST Fields
     icmsst_tax_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",
         string="Tax ICMS ST",
         domain=[("tax_domain", "=", TAX_DOMAIN_ICMS_ST)],
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     # modBCST - Modalidade de determinação da BC do ICMS ST
@@ -464,22 +567,56 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         selection=ICMS_ST_BASE_TYPE,
         string="ICMS ST Base Type",
         default=ICMS_ST_BASE_TYPE_DEFAULT,
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     # pMVAST - Percentual da margem de valor Adicionado do ICMS ST
-    icmsst_mva_percent = fields.Float(string="ICMS ST MVA %")
+    icmsst_mva_percent = fields.Float(
+        string="ICMS ST MVA %",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     # pRedBCST - Percentual da Redução de BC do ICMS ST
-    icmsst_reduction = fields.Float(string="ICMS ST % Reduction")
+    icmsst_reduction = fields.Float(
+        string="ICMS ST % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     # vBCST - Valor da BC do ICMS ST
-    icmsst_base = fields.Monetary(string="ICMS ST Base")
+    icmsst_base = fields.Monetary(
+        string="ICMS ST Base",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     # pICMSST - Alíquota do imposto do ICMS ST
-    icmsst_percent = fields.Float(string="ICMS ST %")
+    icmsst_percent = fields.Float(
+        string="ICMS ST %",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     # vICMSST - Valor do ICMS ST
-    icmsst_value = fields.Monetary(string="ICMS ST Value")
+    icmsst_value = fields.Monetary(
+        string="ICMS ST Value",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     # vBCSTRet - Valor da base de cálculo do ICMS ST retido
     icmsst_wh_base = fields.Monetary(string="ICMS ST WH Base")
@@ -495,58 +632,134 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         comodel_name="l10n_br_fiscal.tax",
         string="Tax ICMS FCP",
         domain=[("tax_domain", "=", TAX_DOMAIN_ICMS_FCP)],
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     # vBCFCPUFDest
     icmsfcp_base = fields.Monetary(
         string="ICMS FCP Base",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     # pFCPUFDest - Percentual do ICMS relativo ao Fundo de
     # Combate à Pobreza (FCP) na UF de destino
-    icmsfcp_percent = fields.Float(string="ICMS FCP %")
+    icmsfcp_percent = fields.Float(
+        string="ICMS FCP %",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     # vFCPUFDest - Valor do ICMS relativo ao Fundo
     # de Combate à Pobreza (FCP) da UF de destino
-    icmsfcp_value = fields.Monetary(string="ICMS FCP Value")
+    icmsfcp_value = fields.Monetary(
+        string="ICMS FCP Value",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     # ICMS FCP ST Fields
     icmsfcpst_tax_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",
         string="Tax ICMS FCP ST",
         domain=[("tax_domain", "=", TAX_DOMAIN_ICMS_FCP_ST)],
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     # vBCFCPST
     icmsfcpst_base = fields.Monetary(
         string="ICMS FCP ST Base",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     # pFCPST - Percentual do FCP ST
-    icmsfcpst_percent = fields.Float(string="ICMS FCP ST %")
+    icmsfcpst_percent = fields.Float(
+        string="ICMS FCP ST %",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     # vFCPST - Valor do ICMS relativo ao
     # Fundo de Combate à Pobreza (FCP) por Substituição Tributária
-    icmsfcpst_value = fields.Monetary(string="ICMS FCP ST Value")
+    icmsfcpst_value = fields.Monetary(
+        string="ICMS FCP ST Value",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     # ICMS DIFAL Fields
     # vBCUFDest - Valor da BC do ICMS na UF de destino
-    icms_destination_base = fields.Monetary(string="ICMS Destination Base")
+    icms_destination_base = fields.Monetary(
+        string="ICMS Destination Base",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     # pICMSUFDest - Alíquota interna da UF de destino
-    icms_origin_percent = fields.Float(string="ICMS Internal %")
+    icms_origin_percent = fields.Float(
+        string="ICMS Internal %",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     # pICMSInter - Alíquota interestadual das UF envolvidas
-    icms_destination_percent = fields.Float(string="ICMS External %")
+    icms_destination_percent = fields.Float(
+        string="ICMS External %",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     # pICMSInterPart - Percentual provisório de partilha do ICMS Interestadual
-    icms_sharing_percent = fields.Float(string="ICMS Sharing %")
+    icms_sharing_percent = fields.Float(
+        string="ICMS Sharing %",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     # vICMSUFRemet - Valor do ICMS Interestadual para a UF do remetente
-    icms_origin_value = fields.Monetary(string="ICMS Origin Value")
+    icms_origin_value = fields.Monetary(
+        string="ICMS Origin Value",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     # vICMSUFDest - Valor do ICMS Interestadual para a UF de destino
-    icms_destination_value = fields.Monetary(string="ICMS Dest. Value")
+    icms_destination_value = fields.Monetary(
+        string="ICMS Dest. Value",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     # ICMS Simples Nacional Fields
     icmssn_range_id = fields.Many2one(
@@ -559,17 +772,45 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         comodel_name="l10n_br_fiscal.tax",
         string="Tax ICMS SN",
         domain=[("tax_domain", "=", TAX_DOMAIN_ICMS_SN)],
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
-    icmssn_base = fields.Monetary(string="ICMS SN Base")
+    icmssn_base = fields.Monetary(
+        string="ICMS SN Base",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    icmssn_reduction = fields.Monetary(string="ICMS SN Reduction")
+    icmssn_reduction = fields.Monetary(
+        string="ICMS SN Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     # pCredICMSSN - Alíquota aplicável de cálculo do crédito (Simples Nacional)
-    icmssn_percent = fields.Float(string="ICMS SN %")
+    icmssn_percent = fields.Float(
+        string="ICMS SN %",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     # vCredICMSSN - Valor do crédito do ICMS que pode ser aproveitado
-    icmssn_credit_value = fields.Monetary(string="ICMS SN Credit")
+    icmssn_credit_value = fields.Monetary(
+        string="ICMS SN Credit",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     # ICMS COBRADO ANTERIORMENTE POR ST
     # vBCFCPSTRet - Valor da base de cálculo do FCP retido anteriormente
@@ -598,12 +839,20 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         comodel_name="l10n_br_fiscal.tax",
         string="Tax IPI",
         domain=[("tax_domain", "=", TAX_DOMAIN_IPI)],
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     ipi_cst_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.cst",
         string="CST IPI",
         domain="[('cst_type', '=', fiscal_operation_type),('tax_domain', '=', 'ipi')]",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     ipi_cst_code = fields.Char(
@@ -611,16 +860,46 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     )
 
     ipi_base_type = fields.Selection(
-        selection=TAX_BASE_TYPE, string="IPI Base Type", default=TAX_BASE_TYPE_PERCENT
+        selection=TAX_BASE_TYPE,
+        string="IPI Base Type",
+        default=TAX_BASE_TYPE_PERCENT,
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
-    ipi_base = fields.Monetary(string="IPI Base")
+    ipi_base = fields.Monetary(
+        string="IPI Base",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    ipi_percent = fields.Float(string="IPI %")
+    ipi_percent = fields.Float(
+        string="IPI %",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    ipi_reduction = fields.Float(string="IPI % Reduction")
+    ipi_reduction = fields.Float(
+        string="IPI % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    ipi_value = fields.Monetary(string="IPI Value")
+    ipi_value = fields.Monetary(
+        string="IPI Value",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     ipi_guideline_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax.ipi.guideline",
@@ -642,13 +921,35 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         comodel_name="l10n_br_fiscal.tax",
         string="Tax II",
         domain=[("tax_domain", "=", TAX_DOMAIN_II)],
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
-    ii_base = fields.Monetary(string="II Base")
+    ii_base = fields.Monetary(
+        string="II Base",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    ii_percent = fields.Float(string="II %")
+    ii_percent = fields.Float(
+        string="II %",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    ii_value = fields.Monetary(string="II Value")
+    ii_value = fields.Monetary(
+        string="II Value",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     ii_iof_value = fields.Monetary(string="IOF Value")
 
@@ -660,6 +961,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         comodel_name="l10n_br_fiscal.tax",
         string="Tax COFINS",
         domain=[("tax_domain", "=", TAX_DOMAIN_COFINS)],
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     cofins_cst_id = fields.Many2one(
@@ -668,6 +973,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         domain="['|', ('cst_type', '=', fiscal_operation_type),"
         "('cst_type', '=', 'all'),"
         "('tax_domain', '=', 'cofins')]",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     cofins_cst_code = fields.Char(
@@ -678,15 +987,43 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         selection=TAX_BASE_TYPE,
         string="COFINS Base Type",
         default=TAX_BASE_TYPE_PERCENT,
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
-    cofins_base = fields.Monetary(string="COFINS Base")
+    cofins_base = fields.Monetary(
+        string="COFINS Base",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    cofins_percent = fields.Float(string="COFINS %")
+    cofins_percent = fields.Float(
+        string="COFINS %",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    cofins_reduction = fields.Float(string="COFINS % Reduction")
+    cofins_reduction = fields.Float(
+        string="COFINS % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    cofins_value = fields.Monetary(string="COFINS Value")
+    cofins_value = fields.Monetary(
+        string="COFINS Value",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     cofins_base_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax.pis.cofins.base", string="COFINS Base Code"
@@ -701,6 +1038,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         comodel_name="l10n_br_fiscal.tax",
         string="Tax COFINS ST",
         domain=[("tax_domain", "=", TAX_DOMAIN_COFINS_ST)],
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     cofinsst_cst_id = fields.Many2one(
@@ -709,6 +1050,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         domain="['|', ('cst_type', '=', fiscal_operation_type),"
         "('cst_type', '=', 'all'),"
         "('tax_domain', '=', 'cofinsst')]",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     cofinsst_cst_code = fields.Char(
@@ -719,41 +1064,105 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         selection=TAX_BASE_TYPE,
         string="COFINS ST Base Type",
         default=TAX_BASE_TYPE_PERCENT,
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
-    cofinsst_base = fields.Monetary(string="COFINS ST Base")
+    cofinsst_base = fields.Monetary(
+        string="COFINS ST Base",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    cofinsst_percent = fields.Float(string="COFINS ST %")
+    cofinsst_percent = fields.Float(
+        string="COFINS ST %",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    cofinsst_reduction = fields.Float(string="COFINS ST % Reduction")
+    cofinsst_reduction = fields.Float(
+        string="COFINS ST % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    cofinsst_value = fields.Monetary(string="COFINS ST Value")
+    cofinsst_value = fields.Monetary(
+        string="COFINS ST Value",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     cofins_wh_tax_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",
         string="Tax COFINS RET",
         domain=[("tax_domain", "=", TAX_DOMAIN_COFINS_WH)],
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     cofins_wh_base_type = fields.Selection(
         selection=TAX_BASE_TYPE,
         string="COFINS WH Base Type",
         default=TAX_BASE_TYPE_PERCENT,
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
-    cofins_wh_base = fields.Monetary(string="COFINS RET Base")
+    cofins_wh_base = fields.Monetary(
+        string="COFINS RET Base",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    cofins_wh_percent = fields.Float(string="COFINS RET %")
+    cofins_wh_percent = fields.Float(
+        string="COFINS RET %",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    cofins_wh_reduction = fields.Float(string="COFINS RET % Reduction")
+    cofins_wh_reduction = fields.Float(
+        string="COFINS RET % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    cofins_wh_value = fields.Monetary(string="COFINS RET Value")
+    cofins_wh_value = fields.Monetary(
+        string="COFINS RET Value",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     # PIS
     pis_tax_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",
         string="Tax PIS",
         domain=[("tax_domain", "=", TAX_DOMAIN_PIS)],
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     pis_cst_id = fields.Many2one(
@@ -762,6 +1171,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         domain="['|', ('cst_type', '=', fiscal_operation_type),"
         "('cst_type', '=', 'all'),"
         "('tax_domain', '=', 'pis')]",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     pis_cst_code = fields.Char(
@@ -769,16 +1182,46 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     )
 
     pis_base_type = fields.Selection(
-        selection=TAX_BASE_TYPE, string="PIS Base Type", default=TAX_BASE_TYPE_PERCENT
+        selection=TAX_BASE_TYPE,
+        string="PIS Base Type",
+        default=TAX_BASE_TYPE_PERCENT,
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
-    pis_base = fields.Monetary(string="PIS Base")
+    pis_base = fields.Monetary(
+        string="PIS Base",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    pis_percent = fields.Float(string="PIS %")
+    pis_percent = fields.Float(
+        string="PIS %",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    pis_reduction = fields.Float(string="PIS % Reduction")
+    pis_reduction = fields.Float(
+        string="PIS % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    pis_value = fields.Monetary(string="PIS Value")
+    pis_value = fields.Monetary(
+        string="PIS Value",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     pis_base_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax.pis.cofins.base", string="PIS Base Code"
@@ -793,6 +1236,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         comodel_name="l10n_br_fiscal.tax",
         string="Tax PIS ST",
         domain=[("tax_domain", "=", TAX_DOMAIN_PIS_ST)],
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     pisst_cst_id = fields.Many2one(
@@ -801,6 +1248,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         domain="['|', ('cst_type', '=', fiscal_operation_type),"
         "('cst_type', '=', 'all'),"
         "('tax_domain', '=', 'pisst')]",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     pisst_cst_code = fields.Char(
@@ -811,125 +1262,363 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         selection=TAX_BASE_TYPE,
         string="PIS ST Base Type",
         default=TAX_BASE_TYPE_PERCENT,
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
-    pisst_base = fields.Monetary(string="PIS ST Base")
+    pisst_base = fields.Monetary(
+        string="PIS ST Base",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    pisst_percent = fields.Float(string="PIS ST %")
+    pisst_percent = fields.Float(
+        string="PIS ST %",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    pisst_reduction = fields.Float(string="PIS ST % Reduction")
+    pisst_reduction = fields.Float(
+        string="PIS ST % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    pisst_value = fields.Monetary(string="PIS ST Value")
+    pisst_value = fields.Monetary(
+        string="PIS ST Value",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     pis_wh_tax_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",
         string="Tax PIS RET",
         domain=[("tax_domain", "=", TAX_DOMAIN_PIS_WH)],
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     pis_wh_base_type = fields.Selection(
         selection=TAX_BASE_TYPE,
         string="PIS WH Base Type",
         default=TAX_BASE_TYPE_PERCENT,
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
-    pis_wh_base = fields.Monetary(string="PIS RET Base")
+    pis_wh_base = fields.Monetary(
+        string="PIS RET Base",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    pis_wh_percent = fields.Float(string="PIS RET %")
+    pis_wh_percent = fields.Float(
+        string="PIS RET %",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    pis_wh_reduction = fields.Float(string="PIS RET % Reduction")
+    pis_wh_reduction = fields.Float(
+        string="PIS RET % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    pis_wh_value = fields.Monetary(string="PIS RET Value")
+    pis_wh_value = fields.Monetary(
+        string="PIS RET Value",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     # CSLL Fields
     csll_tax_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",
         string="Tax CSLL",
         domain=[("tax_domain", "=", TAX_DOMAIN_CSLL)],
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
-    csll_base = fields.Monetary(string="CSLL Base")
+    csll_base = fields.Monetary(
+        string="CSLL Base",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    csll_percent = fields.Float(string="CSLL %")
+    csll_percent = fields.Float(
+        string="CSLL %",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    csll_reduction = fields.Float(string="CSLL % Reduction")
+    csll_reduction = fields.Float(
+        string="CSLL % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    csll_value = fields.Monetary(string="CSLL Value")
+    csll_value = fields.Monetary(
+        string="CSLL Value",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     csll_wh_tax_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",
         string="Tax CSLL RET",
         domain=[("tax_domain", "=", TAX_DOMAIN_CSLL_WH)],
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
-    csll_wh_base = fields.Monetary(string="CSLL RET Base")
+    csll_wh_base = fields.Monetary(
+        string="CSLL RET Base",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    csll_wh_percent = fields.Float(string="CSLL RET %")
+    csll_wh_percent = fields.Float(
+        string="CSLL RET %",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    csll_wh_reduction = fields.Float(string="CSLL RET % Reduction")
+    csll_wh_reduction = fields.Float(
+        string="CSLL RET % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    csll_wh_value = fields.Monetary(string="CSLL RET Value")
+    csll_wh_value = fields.Monetary(
+        string="CSLL RET Value",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     irpj_tax_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",
         string="Tax IRPJ",
         domain=[("tax_domain", "=", TAX_DOMAIN_IRPJ)],
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
-    irpj_base = fields.Monetary(string="IRPJ Base")
+    irpj_base = fields.Monetary(
+        string="IRPJ Base",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    irpj_percent = fields.Float(string="IRPJ %")
+    irpj_percent = fields.Float(
+        string="IRPJ %",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    irpj_reduction = fields.Float(string="IRPJ % Reduction")
+    irpj_reduction = fields.Float(
+        string="IRPJ % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    irpj_value = fields.Monetary(string="IRPJ Value")
+    irpj_value = fields.Monetary(
+        string="IRPJ Value",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     irpj_wh_tax_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",
         string="Tax IRPJ RET",
         domain=[("tax_domain", "=", TAX_DOMAIN_IRPJ_WH)],
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
-    irpj_wh_base = fields.Monetary(string="IRPJ RET Base")
+    irpj_wh_base = fields.Monetary(
+        string="IRPJ RET Base",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    irpj_wh_percent = fields.Float(string="IRPJ RET %")
+    irpj_wh_percent = fields.Float(
+        string="IRPJ RET %",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    irpj_wh_reduction = fields.Float(string="IRPJ RET % Reduction")
+    irpj_wh_reduction = fields.Float(
+        string="IRPJ RET % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    irpj_wh_value = fields.Monetary(string="IRPJ RET Value")
+    irpj_wh_value = fields.Monetary(
+        string="IRPJ RET Value",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     inss_tax_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",
         string="Tax INSS",
         domain=[("tax_domain", "=", TAX_DOMAIN_INSS)],
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
-    inss_base = fields.Monetary(string="INSS Base")
+    inss_base = fields.Monetary(
+        string="INSS Base",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    inss_percent = fields.Float(string="INSS %")
+    inss_percent = fields.Float(
+        string="INSS %",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    inss_reduction = fields.Float(string="INSS % Reduction")
+    inss_reduction = fields.Float(
+        string="INSS % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    inss_value = fields.Monetary(string="INSS Value")
+    inss_value = fields.Monetary(
+        string="INSS Value",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     inss_wh_tax_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",
         string="Tax INSS RET",
         domain=[("tax_domain", "=", TAX_DOMAIN_INSS_WH)],
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
-    inss_wh_base = fields.Monetary(string="INSS RET Base")
+    inss_wh_base = fields.Monetary(
+        string="INSS RET Base",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    inss_wh_percent = fields.Float(string="INSS RET %")
+    inss_wh_percent = fields.Float(
+        string="INSS RET %",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    inss_wh_reduction = fields.Float(string="INSS RET % Reduction")
+    inss_wh_reduction = fields.Float(
+        string="INSS RET % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    inss_wh_value = fields.Monetary(string="INSS RET Value")
+    inss_wh_value = fields.Monetary(
+        string="INSS RET Value",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
-    simple_value = fields.Monetary(string="National Simple Taxes")
+    simple_value = fields.Monetary(
+        string="National Simple Taxes",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     simple_without_icms_value = fields.Monetary(
-        string="National Simple Taxes without ICMS"
+        string="National Simple Taxes without ICMS",
+        compute="_compute_tax_fields",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     comment_ids = fields.Many2many(

--- a/l10n_br_fiscal/models/document_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_line_mixin_methods.py
@@ -288,7 +288,41 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             )
             line.fiscal_tax_ids = fiscal_taxes + taxes
 
-    # TODO: depends and removal of meth calls will come next
+    def _get_tax_fields_dependencies(self):
+        """
+        Dynamically get the list of fields dependencies, overriden in l10n_br_purchase.
+        """
+        return [
+            "company_id",
+            "partner_id",
+            "ind_final",
+            "fiscal_tax_ids",
+            "product_id",
+            "price_unit",
+            "quantity",
+            "uom_id",
+            "fiscal_price",
+            "fiscal_quantity",
+            "uot_id",
+            "discount_value",
+            "insurance_value",
+            "ii_customhouse_charges",
+            "ii_iof_value",
+            "other_value",
+            "freight_value",
+            "ncm_id",
+            "nbs_id",
+            "nbm_id",
+            "cest_id",
+            "fiscal_operation_line_id",
+            "cfop_id",
+            "icmssn_range_id",
+            "icms_origin",
+            "icms_cst_id",
+            "icms_relief_id",
+        ]
+
+    @api.depends(lambda self: self._get_tax_fields_dependencies())
     def _compute_tax_fields(self):
         """
         Compute base, percent, value... tax fields for ICMS, IPI, PIS, COFINS... taxes.

--- a/l10n_br_fiscal/models/document_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_line_mixin_methods.py
@@ -207,37 +207,6 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 record.financial_total_gross = record.financial_total = 0.0
                 record.financial_discount_value = 0.0
 
-    def _compute_taxes(self, taxes, cst=None):
-        self.ensure_one()
-        return taxes.compute_taxes(
-            company=self._get_fiscal_company(),
-            partner=self._get_fiscal_partner(),
-            product=self.product_id,
-            price_unit=self.price_unit,
-            quantity=self.quantity,
-            uom_id=self.uom_id,
-            fiscal_price=self.fiscal_price,
-            fiscal_quantity=self.fiscal_quantity,
-            uot_id=self.uot_id,
-            discount_value=self.discount_value,
-            insurance_value=self.insurance_value,
-            ii_customhouse_charges=self.ii_customhouse_charges,
-            ii_iof_value=self.ii_iof_value,
-            other_value=self.other_value,
-            freight_value=self.freight_value,
-            ncm=self.ncm_id,
-            nbs=self.nbs_id,
-            nbm=self.nbm_id,
-            cest=self.cest_id,
-            operation_line=self.fiscal_operation_line_id,
-            cfop=self.cfop_id,
-            icmssn_range=self.icmssn_range_id,
-            icms_origin=self.icms_origin,
-            icms_cst_id=self.icms_cst_id,
-            ind_final=self._get_ind_final(),
-            icms_relief_id=self.icms_relief_id,
-        )
-
     @api.depends("tax_icms_or_issqn", "partner_is_public_entity")
     def _compute_allow_csll_irpj(self):
         """Calculates the possibility of 'CSLL' and 'IRPJ' tax charges."""
@@ -319,9 +288,42 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             )
             line.fiscal_tax_ids = fiscal_taxes + taxes
 
-    def _update_fiscal_taxes(self):
+    # TODO: depends and removal of meth calls will come next
+    def _compute_tax_fields(self):
+        """
+        Compute base, percent, value... tax fields for ICMS, IPI, PIS, COFINS... taxes.
+        """
         for line in self:
-            compute_result = line._compute_taxes(line.fiscal_tax_ids)
+            if line._is_imported() or not line.fiscal_tax_ids:
+                continue
+            compute_result = line.fiscal_tax_ids.compute_taxes(
+                company=line._get_fiscal_company(),
+                partner=line._get_fiscal_partner(),
+                product=line.product_id,
+                price_unit=line.price_unit,
+                quantity=line.quantity,
+                uom_id=line.uom_id,
+                fiscal_price=line.fiscal_price,
+                fiscal_quantity=line.fiscal_quantity,
+                uot_id=line.uot_id,
+                discount_value=line.discount_value,
+                insurance_value=line.insurance_value,
+                ii_customhouse_charges=line.ii_customhouse_charges,
+                ii_iof_value=line.ii_iof_value,
+                other_value=line.other_value,
+                freight_value=line.freight_value,
+                ncm=line.ncm_id,
+                nbs=line.nbs_id,
+                nbm=line.nbm_id,
+                cest=line.cest_id,
+                operation_line=line.fiscal_operation_line_id,
+                cfop=line.cfop_id,
+                icmssn_range=line.icmssn_range_id,
+                icms_origin=line.icms_origin,
+                icms_cst_id=line.icms_cst_id,
+                ind_final=line._get_ind_final(),
+                icms_relief_id=line.icms_relief_id,
+            )
             to_update = {
                 "amount_tax_included": compute_result.get("amount_included", 0.0),
                 "amount_tax_not_included": compute_result.get(
@@ -331,12 +333,16 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 "estimate_tax": compute_result.get("estimate_tax", 0.0),
             }
             to_update.update(line._prepare_tax_fields(compute_result))
-
+            # line.update(to_update)
             in_draft_mode = line != line._origin
             if in_draft_mode:
                 line.update(to_update)
             else:
                 line.write(to_update)
+
+    def _update_fiscal_taxes(self):
+        pass  # replaced by _compute_tax_fields, kept for backward compat; TODO remove
+        # self._compute_tax_fields()  # TODO remove
 
     def _prepare_tax_fields(self, compute_result):
         self.ensure_one()
@@ -471,7 +477,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 for tax in mapping_result["taxes"].values():
                     taxes |= tax
                 line.fiscal_tax_ids = taxes
-                line._update_fiscal_taxes()
+                line._compute_tax_fields()
                 line.comment_ids = line.fiscal_operation_line_id.comment_ids
             else:
                 line.cfop_id = False
@@ -793,7 +799,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
     )
     def _onchange_fiscal_taxes(self):
         self._update_fiscal_tax_ids(self._get_all_tax_id_fields())
-        self._update_fiscal_taxes()
+        self._compute_tax_fields()
 
     @api.depends("uom_id")
     def _compute_uot_id(self):
@@ -840,11 +846,11 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
     @api.onchange("ii_customhouse_charges")
     def _onchange_ii_customhouse_charges(self):
         if self.ii_customhouse_charges:
-            self._update_fiscal_taxes()
+            self._compute_tax_fields()
 
     @api.onchange("fiscal_tax_ids")
     def _onchange_fiscal_tax_ids(self):
-        self._update_fiscal_taxes()
+        self._compute_tax_fields()
 
     @api.onchange("city_taxation_code_id")
     def _onchange_city_taxation_code_id(self):

--- a/l10n_br_fiscal/models/document_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_line_mixin_methods.py
@@ -293,11 +293,11 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         Dynamically get the list of fields dependencies, overriden in l10n_br_purchase.
         """
         return [
-            "company_id",
-            "partner_id",
-            "ind_final",
-            "fiscal_tax_ids",
-            "product_id",
+            # "company_id",
+            # "partner_id",
+            # "ind_final",
+            # "fiscal_tax_ids",
+            # "product_id",
             "price_unit",
             "quantity",
             "uom_id",
@@ -310,16 +310,17 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             "ii_iof_value",
             "other_value",
             "freight_value",
-            "ncm_id",
-            "nbs_id",
-            "nbm_id",
-            "cest_id",
-            "fiscal_operation_line_id",
+            # "ncm_id",
+            # "nbs_id",
+            # "nbm_id",
+            # "cest_id",
+            # "fiscal_operation_line_id",
             "cfop_id",
             "icmssn_range_id",
             "icms_origin",
             "icms_cst_id",
             "icms_relief_id",
+            # "fiscal_tax_ids"  TODO: is it OK for performance?
         ]
 
     @api.depends(lambda self: self._get_tax_fields_dependencies())
@@ -358,14 +359,49 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 ind_final=line._get_ind_final(),
                 icms_relief_id=line.icms_relief_id,
             )
-            to_update = {
-                "amount_tax_included": compute_result.get("amount_included", 0.0),
-                "amount_tax_not_included": compute_result.get(
-                    "amount_not_included", 0.0
-                ),
-                "amount_tax_withholding": compute_result.get("amount_withholding", 0.0),
-                "estimate_tax": compute_result.get("estimate_tax", 0.0),
-            }
+            to_update = {}
+            for fiscal_tax_field in FISCAL_TAX_ID_FIELDS:
+                to_update[fiscal_tax_field] = False
+            tax_methods = [
+                line._prepare_fields_issqn,
+                line._prepare_fields_csll,
+                line._prepare_fields_irpj,
+                line._prepare_fields_inss,
+                line._prepare_fields_icms,
+                line._prepare_fields_icmsfcp,
+                line._prepare_fields_icmsfcpst,
+                line._prepare_fields_icmsst,
+                line._prepare_fields_icmssn,
+                line._prepare_fields_ipi,
+                line._prepare_fields_ii,
+                line._prepare_fields_pis,
+                line._prepare_fields_pisst,
+                line._prepare_fields_cofins,
+                line._prepare_fields_cofinsst,
+                line._prepare_fields_issqn_wh,
+                line._prepare_fields_pis_wh,
+                line._prepare_fields_cofins_wh,
+                line._prepare_fields_csll_wh,
+                line._prepare_fields_irpj_wh,
+                line._prepare_fields_inss_wh,
+            ]
+            for method in tax_methods:
+                prepared_fields = method(TAX_DICT_VALUES)
+                if prepared_fields:
+                    to_update.update(prepared_fields)
+
+            to_update.update(
+                {
+                    "amount_tax_included": compute_result.get("amount_included", 0.0),
+                    "amount_tax_not_included": compute_result.get(
+                        "amount_not_included", 0.0
+                    ),
+                    "amount_tax_withholding": compute_result.get(
+                        "amount_withholding", 0.0
+                    ),
+                    "estimate_tax": compute_result.get("estimate_tax", 0.0),
+                }
+            )
             to_update.update(line._prepare_tax_fields(compute_result))
             # line.update(to_update)
             in_draft_mode = line != line._origin
@@ -373,10 +409,6 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 line.update(to_update)
             else:
                 line.write(to_update)
-
-    def _update_fiscal_taxes(self):
-        pass  # replaced by _compute_tax_fields, kept for backward compat; TODO remove
-        # self._compute_tax_fields()  # TODO remove
 
     def _prepare_tax_fields(self, compute_result):
         self.ensure_one()
@@ -459,7 +491,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 partner=self._get_fiscal_partner(),
                 product=self.product_id,
             )
-            self._compute_fiscal_tax_ids()  # sadly seems required for composite move
+            # self._compute_fiscal_tax_ids()  # sadly seems required for composite move
 
     def _get_fiscal_tax_ids_dependencies(self):
         """
@@ -488,7 +520,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         to work around and _inherits/precompute limitation.
         """
         for line in self:
-            line._remove_all_fiscal_tax_ids()
+            # line._remove_all_fiscal_tax_ids()
             if line.fiscal_operation_line_id:
                 mapping_result = line.fiscal_operation_line_id.map_fiscal_taxes(
                     company=line._get_fiscal_company(),
@@ -514,6 +546,10 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 line._compute_tax_fields()
                 line.comment_ids = line.fiscal_operation_line_id.comment_ids
             else:
+                # TODO
+                # if line._origin.fiscal_operation_line_id
+                #                              != line.fiscal_operation_line_id:
+                #    line._remove_all_fiscal_tax_ids()
                 line.cfop_id = False
 
     @api.onchange("product_id")
@@ -800,37 +836,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             "cofinsst_value": tax_dict.get("tax_value", 0.00),
         }
 
-    @api.onchange(
-        "csll_tax_id",
-        "csll_wh_tax_id",
-        "irpj_tax_id",
-        "irpj_wh_tax_id",
-        "inss_tax_id",
-        "inss_wh_tax_id",
-        "issqn_tax_id",
-        "issqn_wh_tax_id",
-        "icms_tax_id",
-        "icmssn_tax_id",
-        "icmsst_tax_id",
-        "icmsfcp_tax_id",
-        "icmsfcpst_tax_id",
-        "icms_relief_id",
-        "icms_relief_value",
-        "ipi_tax_id",
-        "ii_tax_id",
-        "pis_tax_id",
-        "pis_wh_tax_id",
-        "pisst_tax_id",
-        "cofins_tax_id",
-        "cofins_wh_tax_id",
-        "cofinsst_tax_id",
-        "fiscal_price",
-        "fiscal_quantity",
-        "discount_value",
-        "insurance_value",
-        "other_value",
-        "freight_value",
-    )
+    @api.onchange(*FISCAL_TAX_ID_FIELDS)
     def _onchange_fiscal_taxes(self):
         self._update_fiscal_tax_ids(self._get_all_tax_id_fields())
         self._compute_tax_fields()
@@ -876,15 +882,6 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                     )
                 else:
                     line.fiscal_quantity = line.quantity
-
-    @api.onchange("ii_customhouse_charges")
-    def _onchange_ii_customhouse_charges(self):
-        if self.ii_customhouse_charges:
-            self._compute_tax_fields()
-
-    @api.onchange("fiscal_tax_ids")
-    def _onchange_fiscal_tax_ids(self):
-        self._compute_tax_fields()
 
     @api.onchange("city_taxation_code_id")
     def _onchange_city_taxation_code_id(self):

--- a/l10n_br_purchase/models/purchase_order_line.py
+++ b/l10n_br_purchase/models/purchase_order_line.py
@@ -107,11 +107,7 @@ class PurchaseOrderLine(models.Model):
         result = super()._compute_amount()
         for line in self:
             if line.fiscal_operation_id:
-                # Update taxes fields
-                line._update_fiscal_taxes()
-                # Call mixin compute method
-                line._compute_fiscal_amounts()
-                # Update record
+                line._compute_tax_fields()  # TODO is it required?
                 line.update(
                     {
                         "price_subtotal": line.amount_untaxed,
@@ -137,15 +133,11 @@ class PurchaseOrderLine(models.Model):
     @api.onchange("fiscal_tax_ids")
     def _onchange_fiscal_tax_ids(self):
         if self.fiscal_operation_line_id:
-            res = super()._onchange_fiscal_tax_ids()
             self.taxes_id = self.fiscal_tax_ids.account_taxes(
                 user_type="purchase",
                 fiscal_operation=self.fiscal_operation_id,
                 company=self.company_id,
             )
-        else:
-            res = None
-        return res
 
     def _prepare_account_move_line(self, move=False):
         values = super()._prepare_account_move_line(move)

--- a/l10n_br_purchase/models/purchase_order_line.py
+++ b/l10n_br_purchase/models/purchase_order_line.py
@@ -80,19 +80,16 @@ class PurchaseOrderLine(models.Model):
     )
 
     def _get_fiscal_tax_ids_dependencies(self):
-        return [
-            # "company_id",  # not precompute in purchase
-            # "partner_id",  # not precompute in purchase
-            "fiscal_operation_line_id",
-            "product_id",
-            "ncm_id",
-            "nbs_id",
-            "nbm_id",
-            "cest_id",
-            "city_taxation_code_id",
-            "service_type_id",
-            "ind_final",
-        ]
+        fields = super()._get_fiscal_tax_ids_dependencies()
+        fields.remove("company_id")
+        fields.remove("partner_id")
+        return fields
+
+    def _get_tax_fields_dependencies(self):
+        fields = super()._get_tax_fields_dependencies()
+        fields.remove("price_unit")
+        fields.remove("fiscal_price")
+        return fields
 
     @api.depends(
         "product_uom_qty",

--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -183,11 +183,7 @@ class SaleOrderLine(models.Model):
         """Compute the amounts of the SO line."""
         result = super()._compute_amount()
         for line in self:
-            # Update taxes fields
-            line._update_fiscal_taxes()
-            # Call mixin compute method
-            line._compute_fiscal_amounts()
-            # Update record
+            line._compute_tax_fields()  # TODO is it required?
             line.update(
                 {
                     "price_tax": line.amount_tax,
@@ -262,15 +258,11 @@ class SaleOrderLine(models.Model):
     @api.onchange("fiscal_tax_ids")
     def _onchange_fiscal_tax_ids(self):
         if self.product_id and self.fiscal_operation_line_id:
-            res = super()._onchange_fiscal_tax_ids()
             self.tax_id = self.fiscal_tax_ids.account_taxes(
                 user_type="sale",
                 fiscal_operation=self.fiscal_operation_id,
                 company=self.company_id,
             )
-        else:
-            res = None
-        return res
 
     def _compute_price_unit_fiscal(self):
         for line in self:

--- a/l10n_br_sale_invoice_plan/demo/sale_order_demo.xml
+++ b/l10n_br_sale_invoice_plan/demo/sale_order_demo.xml
@@ -37,14 +37,6 @@
         <value eval="[ref('lc_sl_invoice_plan_service_br_1_1')]" />
     </function>
 
-    <function
-        model="sale.order.line"
-        name="_onchange_fiscal_tax_ids"
-        context="{'default_company_id': ref('l10n_br_base.empresa_lucro_presumido')}"
-    >
-        <value eval="[ref('lc_sl_invoice_plan_service_br_1_1')]" />
-    </function>
-
     <function model="sale.order" name="create_invoice_plan">
         <value eval="[ref('lc_so_invoice_plan_service_br')]" />
         <value eval="3" />

--- a/l10n_br_sale_invoice_plan/models/sale_invoice_plan.py
+++ b/l10n_br_sale_invoice_plan/models/sale_invoice_plan.py
@@ -13,5 +13,4 @@ class SaleInvoicePlan(models.Model):
         if invoice_move:
             for line in invoice_move.invoice_line_ids:
                 line.write({"fiscal_quantity": line.quantity})
-                line._onchange_fiscal_tax_ids()
         return result

--- a/l10n_br_sale_stock/tests/test_sale_stock.py
+++ b/l10n_br_sale_stock/tests/test_sale_stock.py
@@ -138,6 +138,8 @@ class TestSaleStock(TestBrPickingInvoicingCommon):
         ).product_id.list_price = 100
         sale_order_form = Form(sale_order_2)
         sale_order = sale_order_form.save()
+        for line in sale_order.order_line:
+            line._compute_tax_fields()
         sale_order.action_confirm()
         # Metodo de criação da fatura a partir do sale.order
         # deve gerar apenas a linha de serviço
@@ -407,6 +409,8 @@ class TestSaleStock(TestBrPickingInvoicingCommon):
         sale_order_1 = self.env.ref("l10n_br_sale_stock.lucro_presumido-sale_order_1")
         sale_order_form = Form(sale_order_1)
         sale_order = sale_order_form.save()
+        for line in sale_order.order_line:
+            line._compute_tax_fields()
         sale_order.incoterm = self.env.ref("account.incoterm_FOB")
 
         sale_order.action_confirm()


### PR DESCRIPTION
Work in Progess
continuação de #3943 num PR separado para monitorar a performance e verificar que cada passo fica OK na CI.

Esse é o primeiro passo do @api.depends dinamico. Depois de OK podemos ver de remover os method calls e ganhar um pouco de performance de volta... Porem é provavel que usar precompute+depends nos ~200 campos fiscais vai degradar um pouco a performance. Vamos ver como fica. Se fica ruim demais a gente pode desativar o precompute (e deixar os onchanges) e fazer a mudança apenas na 18.0 onde o ORM tem um desempenho melhor.

EDIT 1: a CI passou mas levou 21 minutos (em vez de 15), a parte dos testes levou 18 minutos em vez de 13. Ou seja uns 50% de degradação de performance. Tudo bem que deve ser possível ganhar alguns pontos de volta tirando os method calls. Mas ainda assim é muito provável que ficaria uns 25% mais lento...  cc @OCA/local-brazil-maintainers 

EDIT 2: eu consegui voltar abaixo de 17 minutos! Vamos que vamos!

