### PR TITLE
[16.0] l10n_br_fiscal: _compute_tax_fields compute attrs, no precompute

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -466,10 +466,15 @@ class AccountMove(models.Model):
         self.clear_caches()
         return result
 
-    @api.onchange("fiscal_operation_id")
-    def _onchange_fiscal_operation_id(self):
-        if self.fiscal_operation_id and self.fiscal_operation_id.journal_id:
-            self.journal_id = self.fiscal_operation_id.journal_id
+    @api.depends("move_type", "fiscal_operation_id")
+    def _compute_journal_id(self):
+        fisc_operation_driven = self.filtered(
+            lambda move: move.fiscal_operation_id
+            and move.fiscal_operation_id.journal_id
+        )
+        for move in fisc_operation_driven:
+            move.journal_id = self.fiscal_operation_id.journal_id
+        return super(AccountMove, self - fisc_operation_driven)._compute_journal_id()
 
     def open_fiscal_document(self):
         """
@@ -593,7 +598,6 @@ class AccountMove(models.Model):
                 force_fiscal_operation_id
                 or record.fiscal_operation_id.return_fiscal_operation_id
             )
-            record._onchange_fiscal_operation_id()
 
             for line in record.invoice_line_ids:
                 if (

--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -274,7 +274,7 @@ class AccountMove(models.Model):
                     move.is_invoice(include_receipts=True)
                     and line.display_type == "product"
                 ):
-                    line._update_fiscal_taxes()
+                    line._compute_tax_fields()
 
         result = super()._compute_amount()
         for move in self.filtered(lambda m: m.fiscal_operation_id):

--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -468,10 +468,8 @@ class AccountMove(models.Model):
 
     @api.onchange("fiscal_operation_id")
     def _onchange_fiscal_operation_id(self):
-        result = super()._onchange_fiscal_operation_id()
         if self.fiscal_operation_id and self.fiscal_operation_id.journal_id:
             self.journal_id = self.fiscal_operation_id.journal_id
-        return result
 
     def open_fiscal_document(self):
         """

--- a/l10n_br_account/models/document_line.py
+++ b/l10n_br_account/models/document_line.py
@@ -16,10 +16,11 @@ class FiscalDocumentLine(models.Model):
     )
 
     uom_id = fields.Many2one(
-        comodel_name="uom.uom",
-        related="account_line_ids.product_uom_id",
+        compute="_compute_product_uom_id",
         store=True,
-        string="UOM",
+        readonly=False,
+        precompute=True,
+        ondelete="restrict",
     )
 
     # -------------------------------------------------------------------------
@@ -70,6 +71,15 @@ class FiscalDocumentLine(models.Model):
                     != 0
                 ):
                     aml.price_unit = line.price_unit
+
+    @api.depends("product_id")
+    def _compute_product_uom_id(self):
+        for line in self:
+            # vendor bills should have the product purchase UOM
+            if line.fiscal_operation_type == "in":
+                line.uom_id = line.product_id.uom_po_id
+            else:
+                line.uom_id = line.product_id.uom_id
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/l10n_br_account/models/document_line.py
+++ b/l10n_br_account/models/document_line.py
@@ -81,6 +81,32 @@ class FiscalDocumentLine(models.Model):
             else:
                 line.uom_id = line.product_id.uom_id
 
+    def _get_fiscal_partner(self):
+        """
+        Get the partner from the aml to avoid an _inherits/ORM limitation.
+        partner_id can be None on a NewID fiscal document line behind an aml.
+        In this case we can retrieve it using the related amls.
+        """
+        self.ensure_one()
+        if self.partner_id:
+            return self.partner_id
+        elif self.account_line_ids:
+            return self.account_line_ids[0].partner_id
+        return self.partner_id
+
+    def _get_fiscal_company(self):
+        """
+        Get the company from the aml to avoid an _inherits/ORM limitation.
+        company_id can be None on a NewID fiscal document line behind an aml.
+        In this case we can retrieve it using the related amls.
+        """
+        self.ensure_one()
+        if self.company_id:
+            return self.company_id
+        elif self.account_line_ids:
+            return self.account_line_ids[0].company_id
+        return self.company_id
+
     @api.model_create_multi
     def create(self, vals_list):
         """

--- a/l10n_br_account_nfe/models/document.py
+++ b/l10n_br_account_nfe/models/document.py
@@ -40,6 +40,8 @@ class DocumentNfe(models.Model):
 
     @api.depends("move_ids", "move_ids.due_line_ids")
     def _compute_nfe40_dup(self):
+        # 1st ensure nfe.40.dup model is already loaded as a concrete model:
+        self.with_context(schema_name="nfe")._register_remaining_schema_models_hook()
         for rec in self.filtered(lambda x: x._need_compute_nfe40_dup()):
             dups_vals = []
             for count, mov in enumerate(rec.move_ids.due_line_ids, 1):
@@ -78,6 +80,8 @@ class DocumentNfe(models.Model):
         "nfe40_tpNF",
     )
     def _compute_nfe40_detpag(self):
+        # 1st ensure nfe.40.pag model is already loaded as a concrete model:
+        self.with_context(schema_name="nfe")._register_remaining_schema_models_hook()
         for rec in self.filtered(lambda x: x._need_compute_nfe_tags()):
             if rec._is_without_payment():
                 det_pag_vals = {

--- a/l10n_br_fiscal/demo/fiscal_document_demo.xml
+++ b/l10n_br_fiscal/demo/fiscal_document_demo.xml
@@ -47,13 +47,6 @@
         <value eval="[ref('demo_nfe_line_same_state_1-1')]" />
     </function>
 
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('demo_nfe_line_same_state_1-1')]" />
-    </function>
-
     <record id="demo_nfe_line_same_state_1-2" model="l10n_br_fiscal.document.line">
         <field name="document_id" ref="demo_nfe_same_state" />
         <field name="name">Teste</field>
@@ -73,13 +66,6 @@
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('demo_nfe_line_same_state_1-2')]" />
-    </function>
-
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
         <value eval="[ref('demo_nfe_line_same_state_1-2')]" />
     </function>
 
@@ -120,13 +106,6 @@
         <value eval="[ref('demo_nfe_line_other_state_1-3')]" />
     </function>
 
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('demo_nfe_line_other_state_1-3')]" />
-    </function>
-
     <record id="demo_nfe_line_other_state_2-3" model="l10n_br_fiscal.document.line">
         <field name="document_id" ref="demo_nfe_other_state" />
         <field name="name">Teste</field>
@@ -146,13 +125,6 @@
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('demo_nfe_line_other_state_2-3')]" />
-    </function>
-
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
         <value eval="[ref('demo_nfe_line_other_state_2-3')]" />
     </function>
 
@@ -176,13 +148,6 @@
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('demo_nfe_line_other_state_3-3')]" />
-    </function>
-
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
         <value eval="[ref('demo_nfe_line_other_state_3-3')]" />
     </function>
 
@@ -225,13 +190,6 @@
         <value eval="[ref('demo_nfe_line_export_3-1')]" />
     </function>
 
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('demo_nfe_line_export_3-1')]" />
-    </function>
-
     <record id="demo_nfe_line_export_3-2" model="l10n_br_fiscal.document.line">
         <field name="document_id" ref="demo_nfe_export" />
         <field name="name">Teste</field>
@@ -251,13 +209,6 @@
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('demo_nfe_line_export_3-2')]" />
-    </function>
-
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
         <value eval="[ref('demo_nfe_line_export_3-2')]" />
     </function>
 
@@ -312,13 +263,6 @@
         <value eval="[ref('demo_nfe_line_nao_contribuinte_4-1')]" />
     </function>
 
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('demo_nfe_line_nao_contribuinte_4-1')]" />
-    </function>
-
     <record
         id="demo_nfe_line_nao_contribuinte_4-2"
         model="l10n_br_fiscal.document.line"
@@ -347,13 +291,6 @@
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('demo_nfe_line_nao_contribuinte_4-2')]" />
-    </function>
-
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
         <value eval="[ref('demo_nfe_line_nao_contribuinte_4-2')]" />
     </function>
 
@@ -402,13 +339,6 @@
         <value eval="[ref('demo_nfe_tax_benefit_4-1')]" />
     </function>
 
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('demo_nfe_tax_benefit_4-1')]" />
-    </function>
-
     <!-- NFe Test - Empresa Contribuinte - Nao Contribuinte PF -->
     <record id="demo_nfe_nao_contribuinte_pf" model="l10n_br_fiscal.document">
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
@@ -449,13 +379,6 @@
         <value eval="[ref('demo_nfe_nao_contribuinte_pf_1-2')]" />
     </function>
 
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('demo_nfe_nao_contribuinte_pf_1-2')]" />
-    </function>
-
     <record id="demo_nfe_nao_contribuinte_pf_2-2" model="l10n_br_fiscal.document.line">
         <field name="document_id" ref="demo_nfe_nao_contribuinte_pf" />
         <field name="name">Teste</field>
@@ -478,13 +401,6 @@
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('demo_nfe_nao_contribuinte_pf_2-2')]" />
-    </function>
-
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
         <value eval="[ref('demo_nfe_nao_contribuinte_pf_2-2')]" />
     </function>
 
@@ -525,13 +441,6 @@
         <value eval="[ref('demo_nfe_line_sn_same_state_5-1')]" />
     </function>
 
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('demo_nfe_line_sn_same_state_5-1')]" />
-    </function>
-
     <record id="demo_nfe_line_sn_same_state_5-2" model="l10n_br_fiscal.document.line">
         <field name="document_id" ref="demo_nfe_sn_same_state" />
         <field name="name">Teste</field>
@@ -551,13 +460,6 @@
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('demo_nfe_line_sn_same_state_5-2')]" />
-    </function>
-
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
         <value eval="[ref('demo_nfe_line_sn_same_state_5-2')]" />
     </function>
 
@@ -598,13 +500,6 @@
         <value eval="[ref('demo_nfe_line_sn_other_state_6-1')]" />
     </function>
 
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('demo_nfe_line_sn_other_state_6-1')]" />
-    </function>
-
     <record id="demo_nfe_line_sn_other_state_6-2" model="l10n_br_fiscal.document.line">
         <field name="document_id" ref="demo_nfe_sn_other_state" />
         <field name="name">Teste</field>
@@ -624,13 +519,6 @@
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('demo_nfe_line_sn_other_state_6-2')]" />
-    </function>
-
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
         <value eval="[ref('demo_nfe_line_sn_other_state_6-2')]" />
     </function>
 
@@ -671,13 +559,6 @@
         <value eval="[ref('demo_nfe_line_sn_export_7-1')]" />
     </function>
 
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('demo_nfe_line_sn_export_7-1')]" />
-    </function>
-
     <record id="demo_nfe_line_sn_export_7-2" model="l10n_br_fiscal.document.line">
         <field name="document_id" ref="demo_nfe_sn_export" />
         <field name="name">Teste</field>
@@ -697,13 +578,6 @@
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('demo_nfe_line_sn_export_7-2')]" />
-    </function>
-
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
         <value eval="[ref('demo_nfe_line_sn_export_7-2')]" />
     </function>
 
@@ -750,13 +624,6 @@
         <value eval="[ref('demo_nfe_line_sn_nao_contribuinte_7-1')]" />
     </function>
 
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('demo_nfe_line_sn_nao_contribuinte_7-1')]" />
-    </function>
-
     <record
         id="demo_nfe_line_sn_nao_contribuinte_7-2"
         model="l10n_br_fiscal.document.line"
@@ -782,13 +649,6 @@
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('demo_nfe_line_sn_nao_contribuinte_7-2')]" />
-    </function>
-
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
         <value eval="[ref('demo_nfe_line_sn_nao_contribuinte_7-2')]" />
     </function>
 
@@ -843,13 +703,6 @@
         <value eval="[ref('demo_nfe_line_so_simples_faturamento_7-1')]" />
     </function>
 
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('demo_nfe_line_so_simples_faturamento_7-1')]" />
-    </function>
-
     <!-- NFe Compras Test - Empresa Contribuinte - Mesmo Estado -->
     <record id="demo_nfe_purchase_same_state" model="l10n_br_fiscal.document">
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
@@ -893,13 +746,5 @@
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
         <value eval="[ref('demo_nfe_purchase_line_same_state_1-1')]" />
     </function>
-
-    <function
-        model="l10n_br_fiscal.document.line"
-        name="_onchange_fiscal_operation_line_id"
-    >
-        <value eval="[ref('demo_nfe_purchase_line_same_state_1-1')]" />
-    </function>
-
 
 </odoo>

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -596,7 +596,6 @@ class Document(models.Model):
 
             new_doc = record.copy()
             new_doc.fiscal_operation_id = fsc_op
-            new_doc._onchange_fiscal_operation_id()
 
             for line in new_doc.fiscal_line_ids:
                 fsc_op_line = line.fiscal_operation_id.return_fiscal_operation_id
@@ -658,14 +657,3 @@ class Document(models.Model):
     def _compute_edoc_purpose(self):
         for record in self:
             record.edoc_purpose = record.fiscal_operation_id.edoc_purpose
-
-    @api.onchange("fiscal_operation_id")
-    def _onchange_fiscal_operation_id(self):
-        result = super()._onchange_fiscal_operation_id()
-        if self.fiscal_operation_id:
-            self.fiscal_operation_type = self.fiscal_operation_id.fiscal_operation_type
-
-        if self.issuer == DOCUMENT_ISSUER_COMPANY and not self.document_type_id:
-            self.document_type_id = self.company_id.document_type_id
-
-        return result

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -36,6 +36,7 @@ class DocumentLine(models.Model):
         comodel_name="res.company",
         related="document_id.company_id",
         store=True,
+        precompute=True,
         string="Company",
     )
 
@@ -46,6 +47,7 @@ class DocumentLine(models.Model):
     partner_id = fields.Many2one(
         related="document_id.partner_id",
         store=True,
+        precompute=True,
     )
 
     quantity = fields.Float(default=1.0)

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -239,6 +239,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     fiscal_tax_ids = fields.Many2many(
         comodel_name="l10n_br_fiscal.tax",
         string="Fiscal Taxes",
+        compute="_compute_fiscal_tax_ids",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     amount_fiscal = fields.Monetary(

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -218,6 +218,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         compute="_compute_uot_id",
         store=True,
         readonly=False,
+        precompute=True,
     )
 
     fiscal_quantity = fields.Float(
@@ -322,6 +323,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         comodel_name="l10n_br_fiscal.tax",
         string="Tax ISSQN",
         domain=[("tax_domain", "=", TAX_DOMAIN_ISSQN)],
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
     issqn_fg_city_id = fields.Many2one(
@@ -355,33 +360,89 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         default=ISSQN_INCENTIVE_DEFAULT,
     )
 
-    issqn_base = fields.Monetary(string="ISSQN Base")
+    issqn_base = fields.Monetary(
+        string="ISSQN Base",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    issqn_percent = fields.Float(string="ISSQN %")
+    issqn_percent = fields.Float(
+        string="ISSQN %",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    issqn_reduction = fields.Float(string="ISSQN % Reduction")
+    issqn_reduction = fields.Float(
+        string="ISSQN % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    issqn_value = fields.Monetary(string="ISSQN Value")
+    issqn_value = fields.Monetary(
+        string="ISSQN Value",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     issqn_wh_tax_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",
         string="Tax ISSQN RET",
         domain=[("tax_domain", "=", TAX_DOMAIN_ISSQN_WH)],
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
-    issqn_wh_base = fields.Monetary(string="ISSQN RET Base")
+    issqn_wh_base = fields.Monetary(
+        string="ISSQN RET Base",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    issqn_wh_percent = fields.Float(string="ISSQN RET %")
+    issqn_wh_percent = fields.Float(
+        string="ISSQN RET %",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    issqn_wh_reduction = fields.Float(string="ISSQN RET % Reduction")
+    issqn_wh_reduction = fields.Float(
+        string="ISSQN RET % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    issqn_wh_value = fields.Monetary(string="ISSQN RET Value")
+    issqn_wh_value = fields.Monetary(
+        string="ISSQN RET Value",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     # ICMS Fields
     icms_tax_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",
         string="Tax ICMS",
         domain=[("tax_domain", "=", TAX_DOMAIN_ICMS)],
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
     icms_cst_id = fields.Many2one(
@@ -389,6 +450,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         string="CST ICMS",
         domain="[('tax_domain', '=', {'1': 'icmssn', '2': 'icmssn', "
         "'3': 'icms'}.get(tax_framework))]",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
     icms_cst_code = fields.Char(
@@ -412,6 +477,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         selection=ICMS_BASE_TYPE,
         string="ICMS Base Type",
         default=ICMS_BASE_TYPE_DEFAULT,
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
     icms_origin = fields.Selection(
@@ -419,16 +488,40 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     )
 
     # vBC - Valor da base de cálculo do ICMS
-    icms_base = fields.Monetary(string="ICMS Base")
+    icms_base = fields.Monetary(
+        string="ICMS Base",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     # pICMS - Alíquota do IMCS
-    icms_percent = fields.Float(string="ICMS %")
+    icms_percent = fields.Float(
+        string="ICMS %",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     # pRedBC - Percentual de redução do ICMS
-    icms_reduction = fields.Float(string="ICMS % Reduction")
+    icms_reduction = fields.Float(
+        string="ICMS % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     # vICMS - Valor do ICMS
-    icms_value = fields.Monetary(string="ICMS Value")
+    icms_value = fields.Monetary(
+        string="ICMS Value",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     # vICMSSubstituto - Valor do ICMS cobrado em operação anterior
     icms_substitute = fields.Monetary(
@@ -442,13 +535,23 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     )
 
     # vICMSDeson - Valor do ICMS desonerado
-    icms_relief_value = fields.Monetary(string="ICMS Relief Value")
+    icms_relief_value = fields.Monetary(
+        string="ICMS Relief Value",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     # ICMS ST Fields
     icmsst_tax_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",
         string="Tax ICMS ST",
         domain=[("tax_domain", "=", TAX_DOMAIN_ICMS_ST)],
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
     # modBCST - Modalidade de determinação da BC do ICMS ST
@@ -456,22 +559,56 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         selection=ICMS_ST_BASE_TYPE,
         string="ICMS ST Base Type",
         default=ICMS_ST_BASE_TYPE_DEFAULT,
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
     # pMVAST - Percentual da margem de valor Adicionado do ICMS ST
-    icmsst_mva_percent = fields.Float(string="ICMS ST MVA %")
+    icmsst_mva_percent = fields.Float(
+        string="ICMS ST MVA %",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     # pRedBCST - Percentual da Redução de BC do ICMS ST
-    icmsst_reduction = fields.Float(string="ICMS ST % Reduction")
+    icmsst_reduction = fields.Float(
+        string="ICMS ST % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     # vBCST - Valor da BC do ICMS ST
-    icmsst_base = fields.Monetary(string="ICMS ST Base")
+    icmsst_base = fields.Monetary(
+        string="ICMS ST Base",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     # pICMSST - Alíquota do imposto do ICMS ST
-    icmsst_percent = fields.Float(string="ICMS ST %")
+    icmsst_percent = fields.Float(
+        string="ICMS ST %",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     # vICMSST - Valor do ICMS ST
-    icmsst_value = fields.Monetary(string="ICMS ST Value")
+    icmsst_value = fields.Monetary(
+        string="ICMS ST Value",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     # vBCSTRet - Valor da base de cálculo do ICMS ST retido
     icmsst_wh_base = fields.Monetary(string="ICMS ST WH Base")
@@ -487,58 +624,134 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         comodel_name="l10n_br_fiscal.tax",
         string="Tax ICMS FCP",
         domain=[("tax_domain", "=", TAX_DOMAIN_ICMS_FCP)],
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
     # vBCFCPUFDest
     icmsfcp_base = fields.Monetary(
         string="ICMS FCP Base",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
     # pFCPUFDest - Percentual do ICMS relativo ao Fundo de
     # Combate à Pobreza (FCP) na UF de destino
-    icmsfcp_percent = fields.Float(string="ICMS FCP %")
+    icmsfcp_percent = fields.Float(
+        string="ICMS FCP %",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     # vFCPUFDest - Valor do ICMS relativo ao Fundo
     # de Combate à Pobreza (FCP) da UF de destino
-    icmsfcp_value = fields.Monetary(string="ICMS FCP Value")
+    icmsfcp_value = fields.Monetary(
+        string="ICMS FCP Value",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     # ICMS FCP ST Fields
     icmsfcpst_tax_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",
         string="Tax ICMS FCP ST",
         domain=[("tax_domain", "=", TAX_DOMAIN_ICMS_FCP_ST)],
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
     # vBCFCPST
     icmsfcpst_base = fields.Monetary(
         string="ICMS FCP ST Base",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
     # pFCPST - Percentual do FCP ST
-    icmsfcpst_percent = fields.Float(string="ICMS FCP ST %")
+    icmsfcpst_percent = fields.Float(
+        string="ICMS FCP ST %",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     # vFCPST - Valor do ICMS relativo ao
     # Fundo de Combate à Pobreza (FCP) por Substituição Tributária
-    icmsfcpst_value = fields.Monetary(string="ICMS FCP ST Value")
+    icmsfcpst_value = fields.Monetary(
+        string="ICMS FCP ST Value",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     # ICMS DIFAL Fields
     # vBCUFDest - Valor da BC do ICMS na UF de destino
-    icms_destination_base = fields.Monetary(string="ICMS Destination Base")
+    icms_destination_base = fields.Monetary(
+        string="ICMS Destination Base",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     # pICMSUFDest - Alíquota interna da UF de destino
-    icms_origin_percent = fields.Float(string="ICMS Internal %")
+    icms_origin_percent = fields.Float(
+        string="ICMS Internal %",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     # pICMSInter - Alíquota interestadual das UF envolvidas
-    icms_destination_percent = fields.Float(string="ICMS External %")
+    icms_destination_percent = fields.Float(
+        string="ICMS External %",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     # pICMSInterPart - Percentual provisório de partilha do ICMS Interestadual
-    icms_sharing_percent = fields.Float(string="ICMS Sharing %")
+    icms_sharing_percent = fields.Float(
+        string="ICMS Sharing %",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     # vICMSUFRemet - Valor do ICMS Interestadual para a UF do remetente
-    icms_origin_value = fields.Monetary(string="ICMS Origin Value")
+    icms_origin_value = fields.Monetary(
+        string="ICMS Origin Value",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     # vICMSUFDest - Valor do ICMS Interestadual para a UF de destino
-    icms_destination_value = fields.Monetary(string="ICMS Dest. Value")
+    icms_destination_value = fields.Monetary(
+        string="ICMS Dest. Value",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     # ICMS Simples Nacional Fields
     icmssn_range_id = fields.Many2one(
@@ -551,17 +764,45 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         comodel_name="l10n_br_fiscal.tax",
         string="Tax ICMS SN",
         domain=[("tax_domain", "=", TAX_DOMAIN_ICMS_SN)],
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
-    icmssn_base = fields.Monetary(string="ICMS SN Base")
+    icmssn_base = fields.Monetary(
+        string="ICMS SN Base",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    icmssn_reduction = fields.Monetary(string="ICMS SN Reduction")
+    icmssn_reduction = fields.Monetary(
+        string="ICMS SN Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     # pCredICMSSN - Alíquota aplicável de cálculo do crédito (Simples Nacional)
-    icmssn_percent = fields.Float(string="ICMS SN %")
+    icmssn_percent = fields.Float(
+        string="ICMS SN %",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     # vCredICMSSN - Valor do crédito do ICMS que pode ser aproveitado
-    icmssn_credit_value = fields.Monetary(string="ICMS SN Credit")
+    icmssn_credit_value = fields.Monetary(
+        string="ICMS SN Credit",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     # ICMS COBRADO ANTERIORMENTE POR ST
     # vBCFCPSTRet - Valor da base de cálculo do FCP retido anteriormente
@@ -590,12 +831,20 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         comodel_name="l10n_br_fiscal.tax",
         string="Tax IPI",
         domain=[("tax_domain", "=", TAX_DOMAIN_IPI)],
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
     ipi_cst_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.cst",
         string="CST IPI",
         domain="[('cst_type', '=', fiscal_operation_type),('tax_domain', '=', 'ipi')]",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
     ipi_cst_code = fields.Char(
@@ -603,16 +852,46 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     )
 
     ipi_base_type = fields.Selection(
-        selection=TAX_BASE_TYPE, string="IPI Base Type", default=TAX_BASE_TYPE_PERCENT
+        selection=TAX_BASE_TYPE,
+        string="IPI Base Type",
+        default=TAX_BASE_TYPE_PERCENT,
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
-    ipi_base = fields.Monetary(string="IPI Base")
+    ipi_base = fields.Monetary(
+        string="IPI Base",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    ipi_percent = fields.Float(string="IPI %")
+    ipi_percent = fields.Float(
+        string="IPI %",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    ipi_reduction = fields.Float(string="IPI % Reduction")
+    ipi_reduction = fields.Float(
+        string="IPI % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    ipi_value = fields.Monetary(string="IPI Value")
+    ipi_value = fields.Monetary(
+        string="IPI Value",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     ipi_guideline_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax.ipi.guideline",
@@ -630,13 +909,35 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         comodel_name="l10n_br_fiscal.tax",
         string="Tax II",
         domain=[("tax_domain", "=", TAX_DOMAIN_II)],
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
-    ii_base = fields.Monetary(string="II Base")
+    ii_base = fields.Monetary(
+        string="II Base",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    ii_percent = fields.Float(string="II %")
+    ii_percent = fields.Float(
+        string="II %",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    ii_value = fields.Monetary(string="II Value")
+    ii_value = fields.Monetary(
+        string="II Value",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     ii_iof_value = fields.Monetary(string="IOF Value")
 
@@ -648,6 +949,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         comodel_name="l10n_br_fiscal.tax",
         string="Tax COFINS",
         domain=[("tax_domain", "=", TAX_DOMAIN_COFINS)],
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
     cofins_cst_id = fields.Many2one(
@@ -656,6 +961,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         domain="['|', ('cst_type', '=', fiscal_operation_type),"
         "('cst_type', '=', 'all'),"
         "('tax_domain', '=', 'cofins')]",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
     cofins_cst_code = fields.Char(
@@ -666,15 +975,43 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         selection=TAX_BASE_TYPE,
         string="COFINS Base Type",
         default=TAX_BASE_TYPE_PERCENT,
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
-    cofins_base = fields.Monetary(string="COFINS Base")
+    cofins_base = fields.Monetary(
+        string="COFINS Base",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    cofins_percent = fields.Float(string="COFINS %")
+    cofins_percent = fields.Float(
+        string="COFINS %",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    cofins_reduction = fields.Float(string="COFINS % Reduction")
+    cofins_reduction = fields.Float(
+        string="COFINS % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    cofins_value = fields.Monetary(string="COFINS Value")
+    cofins_value = fields.Monetary(
+        string="COFINS Value",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     cofins_base_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax.pis.cofins.base", string="COFINS Base Code"
@@ -689,6 +1026,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         comodel_name="l10n_br_fiscal.tax",
         string="Tax COFINS ST",
         domain=[("tax_domain", "=", TAX_DOMAIN_COFINS_ST)],
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
     cofinsst_cst_id = fields.Many2one(
@@ -697,6 +1038,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         domain="['|', ('cst_type', '=', fiscal_operation_type),"
         "('cst_type', '=', 'all'),"
         "('tax_domain', '=', 'cofinsst')]",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
     cofinsst_cst_code = fields.Char(
@@ -707,41 +1052,105 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         selection=TAX_BASE_TYPE,
         string="COFINS ST Base Type",
         default=TAX_BASE_TYPE_PERCENT,
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
-    cofinsst_base = fields.Monetary(string="COFINS ST Base")
+    cofinsst_base = fields.Monetary(
+        string="COFINS ST Base",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    cofinsst_percent = fields.Float(string="COFINS ST %")
+    cofinsst_percent = fields.Float(
+        string="COFINS ST %",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    cofinsst_reduction = fields.Float(string="COFINS ST % Reduction")
+    cofinsst_reduction = fields.Float(
+        string="COFINS ST % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    cofinsst_value = fields.Monetary(string="COFINS ST Value")
+    cofinsst_value = fields.Monetary(
+        string="COFINS ST Value",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     cofins_wh_tax_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",
         string="Tax COFINS RET",
         domain=[("tax_domain", "=", TAX_DOMAIN_COFINS_WH)],
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
     cofins_wh_base_type = fields.Selection(
         selection=TAX_BASE_TYPE,
         string="COFINS WH Base Type",
         default=TAX_BASE_TYPE_PERCENT,
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
-    cofins_wh_base = fields.Monetary(string="COFINS RET Base")
+    cofins_wh_base = fields.Monetary(
+        string="COFINS RET Base",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    cofins_wh_percent = fields.Float(string="COFINS RET %")
+    cofins_wh_percent = fields.Float(
+        string="COFINS RET %",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    cofins_wh_reduction = fields.Float(string="COFINS RET % Reduction")
+    cofins_wh_reduction = fields.Float(
+        string="COFINS RET % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    cofins_wh_value = fields.Monetary(string="COFINS RET Value")
+    cofins_wh_value = fields.Monetary(
+        string="COFINS RET Value",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     # PIS
     pis_tax_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",
         string="Tax PIS",
         domain=[("tax_domain", "=", TAX_DOMAIN_PIS)],
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
     pis_cst_id = fields.Many2one(
@@ -750,6 +1159,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         domain="['|', ('cst_type', '=', fiscal_operation_type),"
         "('cst_type', '=', 'all'),"
         "('tax_domain', '=', 'pis')]",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
     pis_cst_code = fields.Char(
@@ -757,16 +1170,46 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     )
 
     pis_base_type = fields.Selection(
-        selection=TAX_BASE_TYPE, string="PIS Base Type", default=TAX_BASE_TYPE_PERCENT
+        selection=TAX_BASE_TYPE,
+        string="PIS Base Type",
+        default=TAX_BASE_TYPE_PERCENT,
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
-    pis_base = fields.Monetary(string="PIS Base")
+    pis_base = fields.Monetary(
+        string="PIS Base",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    pis_percent = fields.Float(string="PIS %")
+    pis_percent = fields.Float(
+        string="PIS %",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    pis_reduction = fields.Float(string="PIS % Reduction")
+    pis_reduction = fields.Float(
+        string="PIS % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    pis_value = fields.Monetary(string="PIS Value")
+    pis_value = fields.Monetary(
+        string="PIS Value",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     pis_base_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax.pis.cofins.base", string="PIS Base Code"
@@ -781,6 +1224,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         comodel_name="l10n_br_fiscal.tax",
         string="Tax PIS ST",
         domain=[("tax_domain", "=", TAX_DOMAIN_PIS_ST)],
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
     pisst_cst_id = fields.Many2one(
@@ -789,6 +1236,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         domain="['|', ('cst_type', '=', fiscal_operation_type),"
         "('cst_type', '=', 'all'),"
         "('tax_domain', '=', 'pisst')]",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
     pisst_cst_code = fields.Char(
@@ -799,125 +1250,363 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         selection=TAX_BASE_TYPE,
         string="PIS ST Base Type",
         default=TAX_BASE_TYPE_PERCENT,
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
-    pisst_base = fields.Monetary(string="PIS ST Base")
+    pisst_base = fields.Monetary(
+        string="PIS ST Base",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    pisst_percent = fields.Float(string="PIS ST %")
+    pisst_percent = fields.Float(
+        string="PIS ST %",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    pisst_reduction = fields.Float(string="PIS ST % Reduction")
+    pisst_reduction = fields.Float(
+        string="PIS ST % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    pisst_value = fields.Monetary(string="PIS ST Value")
+    pisst_value = fields.Monetary(
+        string="PIS ST Value",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     pis_wh_tax_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",
         string="Tax PIS RET",
         domain=[("tax_domain", "=", TAX_DOMAIN_PIS_WH)],
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
     pis_wh_base_type = fields.Selection(
         selection=TAX_BASE_TYPE,
         string="PIS WH Base Type",
         default=TAX_BASE_TYPE_PERCENT,
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
-    pis_wh_base = fields.Monetary(string="PIS RET Base")
+    pis_wh_base = fields.Monetary(
+        string="PIS RET Base",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    pis_wh_percent = fields.Float(string="PIS RET %")
+    pis_wh_percent = fields.Float(
+        string="PIS RET %",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    pis_wh_reduction = fields.Float(string="PIS RET % Reduction")
+    pis_wh_reduction = fields.Float(
+        string="PIS RET % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    pis_wh_value = fields.Monetary(string="PIS RET Value")
+    pis_wh_value = fields.Monetary(
+        string="PIS RET Value",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     # CSLL Fields
     csll_tax_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",
         string="Tax CSLL",
         domain=[("tax_domain", "=", TAX_DOMAIN_CSLL)],
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
-    csll_base = fields.Monetary(string="CSLL Base")
+    csll_base = fields.Monetary(
+        string="CSLL Base",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    csll_percent = fields.Float(string="CSLL %")
+    csll_percent = fields.Float(
+        string="CSLL %",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    csll_reduction = fields.Float(string="CSLL % Reduction")
+    csll_reduction = fields.Float(
+        string="CSLL % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    csll_value = fields.Monetary(string="CSLL Value")
+    csll_value = fields.Monetary(
+        string="CSLL Value",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     csll_wh_tax_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",
         string="Tax CSLL RET",
         domain=[("tax_domain", "=", TAX_DOMAIN_CSLL_WH)],
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
-    csll_wh_base = fields.Monetary(string="CSLL RET Base")
+    csll_wh_base = fields.Monetary(
+        string="CSLL RET Base",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    csll_wh_percent = fields.Float(string="CSLL RET %")
+    csll_wh_percent = fields.Float(
+        string="CSLL RET %",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    csll_wh_reduction = fields.Float(string="CSLL RET % Reduction")
+    csll_wh_reduction = fields.Float(
+        string="CSLL RET % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    csll_wh_value = fields.Monetary(string="CSLL RET Value")
+    csll_wh_value = fields.Monetary(
+        string="CSLL RET Value",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     irpj_tax_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",
         string="Tax IRPJ",
         domain=[("tax_domain", "=", TAX_DOMAIN_IRPJ)],
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
-    irpj_base = fields.Monetary(string="IRPJ Base")
+    irpj_base = fields.Monetary(
+        string="IRPJ Base",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    irpj_percent = fields.Float(string="IRPJ %")
+    irpj_percent = fields.Float(
+        string="IRPJ %",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    irpj_reduction = fields.Float(string="IRPJ % Reduction")
+    irpj_reduction = fields.Float(
+        string="IRPJ % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    irpj_value = fields.Monetary(string="IRPJ Value")
+    irpj_value = fields.Monetary(
+        string="IRPJ Value",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     irpj_wh_tax_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",
         string="Tax IRPJ RET",
         domain=[("tax_domain", "=", TAX_DOMAIN_IRPJ_WH)],
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
-    irpj_wh_base = fields.Monetary(string="IRPJ RET Base")
+    irpj_wh_base = fields.Monetary(
+        string="IRPJ RET Base",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    irpj_wh_percent = fields.Float(string="IRPJ RET %")
+    irpj_wh_percent = fields.Float(
+        string="IRPJ RET %",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    irpj_wh_reduction = fields.Float(string="IRPJ RET % Reduction")
+    irpj_wh_reduction = fields.Float(
+        string="IRPJ RET % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    irpj_wh_value = fields.Monetary(string="IRPJ RET Value")
+    irpj_wh_value = fields.Monetary(
+        string="IRPJ RET Value",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     inss_tax_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",
         string="Tax INSS",
         domain=[("tax_domain", "=", TAX_DOMAIN_INSS)],
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
-    inss_base = fields.Monetary(string="INSS Base")
+    inss_base = fields.Monetary(
+        string="INSS Base",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    inss_percent = fields.Float(string="INSS %")
+    inss_percent = fields.Float(
+        string="INSS %",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    inss_reduction = fields.Float(string="INSS % Reduction")
+    inss_reduction = fields.Float(
+        string="INSS % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    inss_value = fields.Monetary(string="INSS Value")
+    inss_value = fields.Monetary(
+        string="INSS Value",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     inss_wh_tax_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",
         string="Tax INSS RET",
         domain=[("tax_domain", "=", TAX_DOMAIN_INSS_WH)],
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
-    inss_wh_base = fields.Monetary(string="INSS RET Base")
+    inss_wh_base = fields.Monetary(
+        string="INSS RET Base",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    inss_wh_percent = fields.Float(string="INSS RET %")
+    inss_wh_percent = fields.Float(
+        string="INSS RET %",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    inss_wh_reduction = fields.Float(string="INSS RET % Reduction")
+    inss_wh_reduction = fields.Float(
+        string="INSS RET % Reduction",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    inss_wh_value = fields.Monetary(string="INSS RET Value")
+    inss_wh_value = fields.Monetary(
+        string="INSS RET Value",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
-    simple_value = fields.Monetary(string="National Simple Taxes")
+    simple_value = fields.Monetary(
+        string="National Simple Taxes",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
+    )
 
     simple_without_icms_value = fields.Monetary(
-        string="National Simple Taxes without ICMS"
+        string="National Simple Taxes without ICMS",
+        compute="_compute_tax_fields",
+        store=True,
+        # precompute=True,
+        readonly=False,
     )
 
     comment_ids = fields.Many2many(

--- a/l10n_br_fiscal/models/document_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_line_mixin_methods.py
@@ -342,7 +342,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
 
     def _update_fiscal_taxes(self):
         pass  # replaced by _compute_tax_fields, kept for backward compat; TODO remove
-        # self._compute_tax_fields()  # TODO remove
+        self._compute_tax_fields()  # TODO remove
 
     def _prepare_tax_fields(self, compute_result):
         self.ensure_one()

--- a/l10n_br_fiscal/models/document_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_line_mixin_methods.py
@@ -210,7 +210,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
     def _compute_taxes(self, taxes, cst=None):
         self.ensure_one()
         return taxes.compute_taxes(
-            company=self.company_id,
+            company=self._get_fiscal_company(),
             partner=self._get_fiscal_partner(),
             product=self.product_id,
             price_unit=self.price_unit,
@@ -321,7 +321,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
 
     def _update_fiscal_taxes(self):
         for line in self:
-            compute_result = self._compute_taxes(line.fiscal_tax_ids)
+            compute_result = line._compute_taxes(line.fiscal_tax_ids)
             to_update = {
                 "amount_tax_included": compute_result.get("amount_included", 0.0),
                 "amount_tax_not_included": compute_result.get(
@@ -332,7 +332,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             }
             to_update.update(line._prepare_tax_fields(compute_result))
 
-            in_draft_mode = self != self._origin
+            in_draft_mode = line != line._origin
             if in_draft_mode:
                 line.update(to_update)
             else:
@@ -410,43 +410,73 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 partner=self._get_fiscal_partner(),
                 product=self.product_id,
             )
-            self._onchange_fiscal_operation_line_id()
+            self._compute_fiscal_tax_ids()  # sadly seems required for composite move
 
-    @api.onchange("fiscal_operation_line_id")
     def _onchange_fiscal_operation_line_id(self):
-        # Reset Taxes
-        self._remove_all_fiscal_tax_ids()
-        if self.fiscal_operation_line_id:
-            mapping_result = self.fiscal_operation_line_id.map_fiscal_taxes(
-                company=self.company_id,
-                partner=self._get_fiscal_partner(),
-                product=self.product_id,
-                ncm=self.ncm_id,
-                nbm=self.nbm_id,
-                nbs=self.nbs_id,
-                cest=self.cest_id,
-                city_taxation_code=self.city_taxation_code_id,
-                service_type=self.service_type_id,
-                ind_final=self.ind_final,
-            )
+        pass  # for backward compat, TODO remove later
 
-            self.cfop_id = mapping_result["cfop"]
-            if self._is_imported():
-                return
-            self._process_fiscal_mapping(mapping_result)
+    def _get_fiscal_tax_ids_dependencies(self):
+        """
+        Dynamically get the list of fields dependencies, overriden in l10n_br_purchase.
+        """
+        return [
+            "company_id",
+            "partner_id",
+            "fiscal_operation_line_id",
+            "product_id",
+            "ncm_id",
+            "nbs_id",
+            "nbm_id",
+            "cest_id",
+            "city_taxation_code_id",
+            "service_type_id",
+            "ind_final",
+        ]
 
-        if not self.fiscal_operation_line_id:
-            self.cfop_id = False
+    @api.depends(lambda self: self._get_fiscal_tax_ids_dependencies())
+    def _compute_fiscal_tax_ids(self):
+        """
+        Among the dependencies, company_id, partner_id and ind_final are related
+        to the fiscal document/line container. When called from account.move.line
+        via _inherits on newID records, we read these values from the related aml
+        to work around and _inherits/precompute limitation.
+        """
+        for line in self:
+            # Reset Taxes
+            line._remove_all_fiscal_tax_ids()
+            if line.ind_final:
+                ind_final = line.ind_final
+            elif hasattr(line, "account_line_ids") and line.account_line_ids:
+                ind_final = line.account_line_ids[0].ind_final
+            else:
+                ind_final = None
+            if line.fiscal_operation_line_id:
+                mapping_result = line.fiscal_operation_line_id.map_fiscal_taxes(
+                    company=line._get_fiscal_company(),
+                    partner=line._get_fiscal_partner(),
+                    product=line.product_id,
+                    ncm=line.ncm_id,
+                    nbm=line.nbm_id,
+                    nbs=line.nbs_id,
+                    cest=line.cest_id,
+                    city_taxation_code=line.city_taxation_code_id,
+                    service_type=line.service_type_id,
+                    ind_final=ind_final,
+                )
 
-    def _process_fiscal_mapping(self, mapping_result):
-        self.ipi_guideline_id = mapping_result["ipi_guideline"]
-        self.icms_tax_benefit_id = mapping_result["icms_tax_benefit_id"]
-        taxes = self.env["l10n_br_fiscal.tax"]
-        for tax in mapping_result["taxes"].values():
-            taxes |= tax
-        self.fiscal_tax_ids = taxes
-        self._update_fiscal_taxes()
-        self.comment_ids = self.fiscal_operation_line_id.comment_ids
+                line.cfop_id = mapping_result["cfop"]
+                if line._is_imported():
+                    return
+                line.ipi_guideline_id = mapping_result["ipi_guideline"]
+                line.icms_tax_benefit_id = mapping_result["icms_tax_benefit_id"]
+                taxes = line.env["l10n_br_fiscal.tax"]
+                for tax in mapping_result["taxes"].values():
+                    taxes |= tax
+                line.fiscal_tax_ids = taxes
+                line._update_fiscal_taxes()
+                line.comment_ids = line.fiscal_operation_line_id.comment_ids
+            else:
+                line.cfop_id = False
 
     @api.onchange("product_id")
     def _onchange_product_id_fiscal(self):

--- a/l10n_br_fiscal/models/document_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_line_mixin_methods.py
@@ -389,6 +389,15 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         self.ensure_one()
         return self.partner_id
 
+    def _get_fiscal_company(self):
+        """
+        Meant to be overriden in account.move.line.
+        Indeed when using this mixin in a NewID fiscal document line behind an aml,
+        self.company_id is None but it can be retrived from the aml.
+        """
+        self.ensure_one()
+        return self.company_id
+
     @api.onchange(
         "fiscal_operation_id", "ncm_id", "nbs_id", "cest_id", "service_type_id"
     )

--- a/l10n_br_fiscal/models/document_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_line_mixin_methods.py
@@ -207,37 +207,6 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 record.financial_total_gross = record.financial_total = 0.0
                 record.financial_discount_value = 0.0
 
-    def _compute_taxes(self, taxes, cst=None):
-        self.ensure_one()
-        return taxes.compute_taxes(
-            company=self._get_fiscal_company(),
-            partner=self._get_fiscal_partner(),
-            product=self.product_id,
-            price_unit=self.price_unit,
-            quantity=self.quantity,
-            uom_id=self.uom_id,
-            fiscal_price=self.fiscal_price,
-            fiscal_quantity=self.fiscal_quantity,
-            uot_id=self.uot_id,
-            discount_value=self.discount_value,
-            insurance_value=self.insurance_value,
-            ii_customhouse_charges=self.ii_customhouse_charges,
-            ii_iof_value=self.ii_iof_value,
-            other_value=self.other_value,
-            freight_value=self.freight_value,
-            ncm=self.ncm_id,
-            nbs=self.nbs_id,
-            nbm=self.nbm_id,
-            cest=self.cest_id,
-            operation_line=self.fiscal_operation_line_id,
-            cfop=self.cfop_id,
-            icmssn_range=self.icmssn_range_id,
-            icms_origin=self.icms_origin,
-            icms_cst_id=self.icms_cst_id,
-            ind_final=self.ind_final,
-            icms_relief_id=self.icms_relief_id,
-        )
-
     @api.depends("tax_icms_or_issqn", "partner_is_public_entity")
     def _compute_allow_csll_irpj(self):
         """Calculates the possibility of 'CSLL' and 'IRPJ' tax charges."""
@@ -319,9 +288,42 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             )
             line.fiscal_tax_ids = fiscal_taxes + taxes
 
-    def _update_fiscal_taxes(self):
+    # TODO: depends and removal of meth calls will come next
+    def _compute_tax_fields(self):
+        """
+        Compute base, percent, value... tax fields for ICMS, IPI, PIS, COFINS... taxes.
+        """
         for line in self:
-            compute_result = line._compute_taxes(line.fiscal_tax_ids)
+            if line._is_imported() or not line.fiscal_tax_ids:
+                continue
+            compute_result = line.fiscal_tax_ids.compute_taxes(
+                company=line._get_fiscal_company(),
+                partner=line._get_fiscal_partner(),
+                product=line.product_id,
+                price_unit=line.price_unit,
+                quantity=line.quantity,
+                uom_id=line.uom_id,
+                fiscal_price=line.fiscal_price,
+                fiscal_quantity=line.fiscal_quantity,
+                uot_id=line.uot_id,
+                discount_value=line.discount_value,
+                insurance_value=line.insurance_value,
+                ii_customhouse_charges=line.ii_customhouse_charges,
+                ii_iof_value=line.ii_iof_value,
+                other_value=line.other_value,
+                freight_value=line.freight_value,
+                ncm=line.ncm_id,
+                nbs=line.nbs_id,
+                nbm=line.nbm_id,
+                cest=line.cest_id,
+                operation_line=line.fiscal_operation_line_id,
+                cfop=line.cfop_id,
+                icmssn_range=line.icmssn_range_id,
+                icms_origin=line.icms_origin,
+                icms_cst_id=line.icms_cst_id,
+                ind_final=line._get_ind_final(),
+                icms_relief_id=line.icms_relief_id,
+            )
             to_update = {
                 "amount_tax_included": compute_result.get("amount_included", 0.0),
                 "amount_tax_not_included": compute_result.get(
@@ -331,12 +333,16 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 "estimate_tax": compute_result.get("estimate_tax", 0.0),
             }
             to_update.update(line._prepare_tax_fields(compute_result))
-
+            # line.update(to_update)
             in_draft_mode = line != line._origin
             if in_draft_mode:
                 line.update(to_update)
             else:
                 line.write(to_update)
+
+    def _update_fiscal_taxes(self):
+        pass  # replaced by _compute_tax_fields, kept for backward compat; TODO remove
+        # self._compute_tax_fields()  # TODO remove
 
     def _prepare_tax_fields(self, compute_result):
         self.ensure_one()
@@ -398,6 +404,16 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         self.ensure_one()
         return self.company_id
 
+    def _get_ind_final(self):
+        self.ensure_one()
+        if self.ind_final:
+            return self.ind_final
+        elif hasattr(self, "account_line_ids") and self.account_line_ids:
+            # TODO override in l10n_br_account
+            return self.account_line_ids[0].ind_final
+        else:
+            return self.ind_final
+
     @api.onchange(
         "fiscal_operation_id", "ncm_id", "nbs_id", "cest_id", "service_type_id"
     )
@@ -444,12 +460,6 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         for line in self:
             # Reset Taxes
             line._remove_all_fiscal_tax_ids()
-            if line.ind_final:
-                ind_final = line.ind_final
-            elif hasattr(line, "account_line_ids") and line.account_line_ids:
-                ind_final = line.account_line_ids[0].ind_final
-            else:
-                ind_final = None
             if line.fiscal_operation_line_id:
                 mapping_result = line.fiscal_operation_line_id.map_fiscal_taxes(
                     company=line._get_fiscal_company(),
@@ -461,7 +471,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                     cest=line.cest_id,
                     city_taxation_code=line.city_taxation_code_id,
                     service_type=line.service_type_id,
-                    ind_final=ind_final,
+                    ind_final=line._get_ind_final(),
                 )
 
                 line.cfop_id = mapping_result["cfop"]
@@ -473,7 +483,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 for tax in mapping_result["taxes"].values():
                     taxes |= tax
                 line.fiscal_tax_ids = taxes
-                line._update_fiscal_taxes()
+                line._compute_tax_fields()
                 line.comment_ids = line.fiscal_operation_line_id.comment_ids
             else:
                 line.cfop_id = False
@@ -795,7 +805,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
     )
     def _onchange_fiscal_taxes(self):
         self._update_fiscal_tax_ids(self._get_all_tax_id_fields())
-        self._update_fiscal_taxes()
+        self._compute_tax_fields()
 
     @api.depends("uom_id")
     def _compute_uot_id(self):
@@ -842,11 +852,11 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
     @api.onchange("ii_customhouse_charges")
     def _onchange_ii_customhouse_charges(self):
         if self.ii_customhouse_charges:
-            self._update_fiscal_taxes()
+            self._compute_tax_fields()
 
     @api.onchange("fiscal_tax_ids")
     def _onchange_fiscal_tax_ids(self):
-        self._update_fiscal_taxes()
+        self._compute_tax_fields()
 
     @api.onchange("city_taxation_code_id")
     def _onchange_city_taxation_code_id(self):

--- a/l10n_br_fiscal/models/document_mixin.py
+++ b/l10n_br_fiscal/models/document_mixin.py
@@ -33,7 +33,6 @@ class FiscalDocumentMixin(models.AbstractModel):
     - Inverse methods for distributing header-level costs (freight, insurance)
       to lines.
     - Hooks for customizing data retrieval (e.g., lines, fiscal partner).
-    - Onchange helpers for common fiscal fields.
 
     Models using this mixin are often expected to also include fields defined
     in `l10n_br_fiscal.document.mixin` for methods like
@@ -90,7 +89,6 @@ class FiscalDocumentMixin(models.AbstractModel):
 
     fiscal_operation_type = fields.Selection(
         related="fiscal_operation_id.fiscal_operation_type",
-        readonly=True,
     )
 
     ind_pres = fields.Selection(
@@ -481,6 +479,10 @@ class FiscalDocumentMixin(models.AbstractModel):
 
     document_type_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.document.type",
+        compute="_compute_document_type_id",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     document_serie_id = fields.Many2one(

--- a/l10n_br_fiscal/models/document_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_mixin_methods.py
@@ -57,13 +57,11 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
                 self.company_id, self.fiscal_operation_id
             )
 
-    @api.onchange("fiscal_operation_id")
-    def _onchange_fiscal_operation_id(self):
-        if self.fiscal_operation_id:
-            self.fiscal_operation_type = self.fiscal_operation_id.fiscal_operation_type
-
-            if self.issuer == DOCUMENT_ISSUER_COMPANY and not self.document_type_id:
-                self.document_type_id = self.company_id.document_type_id
+    @api.depends("fiscal_operation_id")
+    def _compute_document_type_id(self):
+        for doc in self.filtered(lambda doc: doc.fiscal_operation_id):
+            if doc.issuer == DOCUMENT_ISSUER_COMPANY and not doc.document_type_id:
+                doc.document_type_id = doc.company_id.document_type_id
 
     def _get_amount_lines(self):
         """Get object lines instances used to compute fiscal fields"""

--- a/l10n_br_fiscal/tests/test_fiscal_document_generic.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_generic.py
@@ -39,9 +39,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
     def test_nfe_same_state(self):
         """Test NFe same state."""
-
-        self.nfe_same_state._onchange_fiscal_operation_id()
-
         for line in self.nfe_same_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
 
@@ -164,9 +161,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
     def test_nfe_other_state(self):
         """Test NFe other state."""
-
-        self.nfe_other_state._onchange_fiscal_operation_id()
-
         for line in self.nfe_other_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_fiscal_operation_id()
@@ -282,9 +276,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
     def test_nfe_not_taxpayer(self):
         """Test NFe not taxpayer."""
-
-        self.nfe_not_taxpayer._onchange_fiscal_operation_id()
-
         for line in self.nfe_not_taxpayer.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_fiscal_operation_id()
@@ -387,9 +378,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
     def test_nfe_not_taxpayer_not_company(self):
         """Test NFe not taxpayer not Company."""
-
-        self.nfe_not_taxpayer_pf._onchange_fiscal_operation_id()
-
         for line in self.nfe_not_taxpayer_pf.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_fiscal_operation_id()
@@ -492,9 +480,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
     def test_nfe_export(self):
         """Test NFe export."""
-
-        self.nfe_export._onchange_fiscal_operation_id()
-
         for line in self.nfe_export.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_fiscal_operation_id()
@@ -589,9 +574,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
     def test_nfe_sn_same_state(self):
         """Test NFe Simples Nacional same state."""
-
-        self.nfe_sn_same_state._onchange_fiscal_operation_id()
-
         for line in self.nfe_sn_same_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
 
@@ -705,9 +687,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
     def test_nfe_sn_other_state(self):
         """Test NFe SN other state."""
-
-        self.nfe_sn_other_state._onchange_fiscal_operation_id()
-
         for line in self.nfe_sn_other_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_fiscal_operation_id()
@@ -806,9 +785,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
     def test_nfe_sn_not_taxpayer(self):
         """Test NFe SN not taxpayer."""
-
-        self.nfe_sn_not_taxpayer._onchange_fiscal_operation_id()
-
         for line in self.nfe_sn_not_taxpayer.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_fiscal_operation_id()
@@ -894,9 +870,6 @@ class TestFiscalDocumentGeneric(TransactionCase):
 
     def test_nfe_sn_export(self):
         """Test NFe SN export."""
-
-        self.nfe_sn_export._onchange_fiscal_operation_id()
-
         for line in self.nfe_sn_export.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_fiscal_operation_id()

--- a/l10n_br_fiscal/tests/test_fiscal_document_nfse.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_nfse.py
@@ -14,8 +14,6 @@ class TestFiscalDocumentNFSe(TransactionCase):
     def test_nfse_same_state(self):
         """Test NFSe same state."""
 
-        self.nfse_same_state._onchange_fiscal_operation_id()
-
         for line in self.nfse_same_state.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_fiscal_operation_id()

--- a/l10n_br_fiscal/tests/test_tax_benefit.py
+++ b/l10n_br_fiscal/tests/test_tax_benefit.py
@@ -39,8 +39,6 @@ class TestTaxBenefit(TransactionCase):
     def test_nfe_tax_benefit(self):
         """Test NFe with tax benefit."""
 
-        self.nfe_tax_benefit._onchange_fiscal_operation_id()
-
         for line in self.nfe_tax_benefit.fiscal_line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_fiscal_operation_id()

--- a/l10n_br_fiscal_subsequent_document/tests/test_subsequent_operation.py
+++ b/l10n_br_fiscal_subsequent_document/tests/test_subsequent_operation.py
@@ -21,7 +21,11 @@ class TestSubsequentOperation(TransactionCase):
     def test_subsequent_operation_simple_faturamento(self):
         """Test Fiscal Subsequent Operation Simples Faturamento"""
 
-        self.nfe_simples_faturamento._onchange_fiscal_operation_id()
+        # TODO this legacy onchange was overriden in this module
+        # but the code went broken and it it was commented out.
+        # later the onchange in the l10n_br_fiscal module was converted
+        # to a compute so this onchange might need rework here:
+        # self.nfe_simples_faturamento._onchange_fiscal_operation_id()
 
         for line in self.nfe_simples_faturamento.fiscal_line_ids:
             line._onchange_product_id_fiscal()

--- a/l10n_br_nfe/tests/test_nfce.py
+++ b/l10n_br_nfe/tests/test_nfce.py
@@ -121,8 +121,6 @@ class TestNFCe(TestNFeExport):
         self.assertEqual(self.document_id.state_edoc, SITUACAO_EDOC_INUTILIZADA)
 
     def test_atualiza_status_nfce(self):
-        self.document_id._onchange_fiscal_operation_id()
-
         self.document_id._compute_nfe40_dhSaiEnt()
         self.assertFalse(self.document_id.nfe40_dhSaiEnt)
 

--- a/l10n_br_nfe/tests/test_nfe_xml_validation.py
+++ b/l10n_br_nfe/tests/test_nfe_xml_validation.py
@@ -27,7 +27,6 @@ class TestXMLValidation(TransactionCase):
                 "fiscal_operation_id": self.env.ref("l10n_br_fiscal.fo_venda").id,
             }
         )
-        document._onchange_fiscal_operation_id()
         line = document_line_model.create(
             {
                 "document_id": document.id,
@@ -66,7 +65,6 @@ class TestXMLValidation(TransactionCase):
                 "fiscal_operation_id": self.env.ref("l10n_br_fiscal.fo_venda").id,
             }
         )
-        document._onchange_fiscal_operation_id()
 
         # Line 1
         line = document_line_model.create(

--- a/l10n_br_nfse/tests/test_fiscal_document_nfse_common.py
+++ b/l10n_br_nfse/tests/test_fiscal_document_nfse_common.py
@@ -36,9 +36,6 @@ class TestFiscalDocumentNFSeCommon(TransactionCase):
 
     def test_certified_nfse_same_state_(self):
         """Test Certified NFSe same state."""
-
-        self.nfse_same_state._onchange_fiscal_operation_id()
-
         # RPS Number
         self.assertEqual(
             self.nfse_same_state.rps_number,

--- a/l10n_br_purchase/demo/l10n_br_purchase.xml
+++ b/l10n_br_purchase/demo/l10n_br_purchase.xml
@@ -12,10 +12,6 @@
         <field name="company_id" ref="base.main_company" />
     </record>
 
-    <function model="purchase.order" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_po_only_products')]" />
-    </function>
-
     <record id="main_pl_only_products_1_2" model="purchase.order.line">
         <field name="order_id" ref="main_po_only_products" />
         <field name="name">Office Chair Black</field>
@@ -70,10 +66,6 @@
         <field name="company_id" ref="base.main_company" />
     </record>
 
-    <function model="purchase.order" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_company-purchase_2')]" />
-    </function>
-
     <record id="main_company-purchase_line_2_1" model="purchase.order.line">
         <field name="order_id" ref="main_company-purchase_2" />
         <field name="name">Office Chair Black</field>
@@ -127,10 +119,6 @@
         <field name="user_id" ref="base.user_admin" />
         <field name="company_id" ref="base.main_company" />
     </record>
-
-    <function model="purchase.order" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_company-purchase_3')]" />
-    </function>
 
     <record id="main_company-purchase_line_3_1" model="purchase.order.line">
         <field name="order_id" ref="main_company-purchase_3" />
@@ -188,10 +176,6 @@
         <field name="company_id" ref="base.main_company" />
     </record>
 
-    <function model="purchase.order" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_company-purchase_4')]" />
-    </function>
-
     <record id="main_company-purchase_line_4_1" model="purchase.order.line">
         <field name="order_id" ref="main_company-purchase_4" />
         <field name="name">Office Chair Black</field>
@@ -244,10 +228,6 @@
         <field name="company_id" ref="base.main_company" />
     </record>
 
-    <function model="purchase.order" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_company-purchase_5')]" />
-    </function>
-
     <record id="main_company-purchase_line_5_1" model="purchase.order.line">
         <field name="order_id" ref="main_company-purchase_5" />
         <field name="name">Office Chair Black</field>
@@ -298,10 +278,6 @@
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
 
-    <function model="purchase.order" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('lp_po_only_products')]" />
-    </function>
-
     <record id="lp_pl_only_products_1_2" model="purchase.order.line">
         <field name="order_id" ref="lp_po_only_products" />
         <field name="name">Office Chair Black</field>
@@ -350,10 +326,6 @@
         <field name="user_id" ref="base.user_admin" />
         <field name="company_id" ref="l10n_br_base.empresa_simples_nacional" />
     </record>
-
-    <function model="purchase.order" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('sn_po_only_products')]" />
-    </function>
 
     <record id="sn_pl_only_products_1_2" model="purchase.order.line">
         <field name="order_id" ref="sn_po_only_products" />
@@ -404,10 +376,6 @@
         <field name="company_id" ref="base.main_company" />
     </record>
 
-    <function model="purchase.order" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_po_only_service')]" />
-    </function>
-
     <record id="main_pl_only_service_1_1" model="purchase.order.line">
         <field name="order_id" ref="main_po_only_service" />
         <field name="name">Desenvolvimento Odoo</field>
@@ -439,10 +407,6 @@
         <field name="user_id" ref="base.user_admin" />
         <field name="company_id" ref="base.main_company" />
     </record>
-
-    <function model="purchase.order" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_po_service_product')]" />
-    </function>
 
     <record id="main_pl_service_product_1_1" model="purchase.order.line">
         <field name="order_id" ref="main_po_service_product" />

--- a/l10n_br_purchase/models/purchase_order_line.py
+++ b/l10n_br_purchase/models/purchase_order_line.py
@@ -38,14 +38,6 @@ class PurchaseOrderLine(models.Model):
         "('state', '=', 'approved')]",
     )
 
-    fiscal_tax_ids = fields.Many2many(
-        comodel_name="l10n_br_fiscal.tax",
-        relation="fiscal_purchase_line_tax_rel",
-        column1="document_id",
-        column2="fiscal_tax_id",
-        string="Fiscal Taxes",
-    )
-
     # overriden to disable precompute as it depends on price_unit which is not
     # precompute in the purchase module. We don't need precompute in purchase.
     fiscal_price = fields.Float(
@@ -86,6 +78,21 @@ class PurchaseOrderLine(models.Model):
     delivery_costs = fields.Selection(
         related="company_id.delivery_costs",
     )
+
+    def _get_fiscal_tax_ids_dependencies(self):
+        return [
+            # "company_id",  # not precompute in purchase
+            # "partner_id",  # not precompute in purchase
+            "fiscal_operation_line_id",
+            "product_id",
+            "ncm_id",
+            "nbs_id",
+            "nbm_id",
+            "cest_id",
+            "city_taxation_code_id",
+            "service_type_id",
+            "ind_final",
+        ]
 
     @api.depends(
         "product_uom_qty",

--- a/l10n_br_purchase_stock/demo/purchase_order.xml
+++ b/l10n_br_purchase_stock/demo/purchase_order.xml
@@ -43,10 +43,6 @@
         <field name="ind_final">0</field>
     </record>
 
-    <function model="purchase.order" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_po_only_products_1')]" />
-    </function>
-
     <record id="main_pl_only_products_1_1" model="purchase.order.line">
         <field name="order_id" ref="main_po_only_products_1" />
         <field name="name">Office Chair Black</field>
@@ -155,10 +151,6 @@
         >TESTE - FISCAL ADDITIONAL DATA</field>
         <field name="ind_final">0</field>
     </record>
-
-    <function model="purchase.order" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_po_only_products_2')]" />
-    </function>
 
     <record id="main_pl_only_products_2_1" model="purchase.order.line">
         <field name="order_id" ref="main_po_only_products_2" />
@@ -270,10 +262,6 @@
         <field name="ind_final">0</field>
     </record>
 
-    <function model="purchase.order" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('lucro_presumido_po_only_products_1')]" />
-    </function>
-
     <record id="lucro_presumido_pol_only_products_1_1" model="purchase.order.line">
         <field name="order_id" ref="lucro_presumido_po_only_products_1" />
         <field name="name">Office Chair Black</field>
@@ -343,10 +331,6 @@
         <field name="ind_final">0</field>
     </record>
 
-    <function model="purchase.order" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_po_only_service_stock')]" />
-    </function>
-
     <record id="main_pl_only_service_stock_1_1" model="purchase.order.line">
         <field name="order_id" ref="main_po_only_service_stock" />
         <field name="name">Desenvolvimento Odoo</field>
@@ -379,10 +363,6 @@
         <field name="company_id" ref="base.main_company" />
         <field name="ind_final">0</field>
     </record>
-
-    <function model="purchase.order" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('main_po_service_product_stock')]" />
-    </function>
 
     <record id="main_pl_service_product_stock_1_1" model="purchase.order.line">
         <field name="order_id" ref="main_po_service_product_stock" />

--- a/spec_driven_model/models/spec_mixin.py
+++ b/spec_driven_model/models/spec_mixin.py
@@ -83,25 +83,24 @@ class SpecMixin(models.AbstractModel):
         return self._get_spec_property("stacking_points", {})
 
     def _register_hook(self):
+        res = super()._register_hook()
+        self._register_remaining_schema_models_hook()
+        return res
+
+    def _register_remaining_schema_models_hook(self):
         """
         Called once all modules are loaded.
         Here we take all spec models that were not injected into existing concrete
         Odoo models and we make them concrete automatically with
         their _auto_init method that will create their SQL DDL structure.
         """
-        res = super()._register_hook()
         spec_schema, spec_version = self._spec_prefix(split=True)
         if not spec_schema:
-            return res
+            return
 
-        spec_module = self._get_spec_property("odoo_module")
-        if "_spec." in spec_module:
-            odoo_module = spec_module.split("_spec.")[0].split(".")[-1]
-        else:  # for tests:
-            odoo_module = "spec_driven_model"
-        load_key = f"_{spec_module}_loaded"
-        if hasattr(self.env.registry, load_key):  # hook already done for registry
-            return res
+        load_key = f"_{spec_schema}_register_hook_loaded"
+        if hasattr(self.env.registry, load_key):  # hook already called for registry
+            return
         setattr(self.env.registry, load_key, True)
 
         access_data = []
@@ -120,6 +119,11 @@ class SpecMixin(models.AbstractModel):
             if self.env.registry.get(i[0])
             and not SPEC_MIXIN_MAPPINGS[self.env.cr.dbname].get(i[0])
         }
+        spec_module = self._get_spec_property("odoo_module")
+        if "_spec." in spec_module:
+            odoo_module = spec_module.split("_spec.")[0].split(".")[-1]
+        else:  # for tests:
+            odoo_module = "spec_driven_model"
         for name in remaining_models:
             spec_class = StackedModel._odoo_name_to_class(name, spec_module)
             if spec_class is None:
@@ -191,8 +195,6 @@ class SpecMixin(models.AbstractModel):
         )
         with mute_logger("odoo.models"):
             imd_recs.unlink()
-
-        return res
 
     @classmethod
     def _auto_fill_access_data(cls, env, module_name: str, access_data: list):


### PR DESCRIPTION
e sem @api.depends ainda

Alternativa a #3943 para ver como fica a performance botando compute=True nos ~200 campos fiscais mas  sem precompute e ainda sem @api.depends. Se a gente fosse seguir esse caminho teriamos que manter os onchange em paralelo dos compute, pelo menos na 16.0

EDIT: sem precompute (e nem depends), apenas com os atributos compute=, a CI já foi para 18 minutos. Isso mostra que fica complicado essa tentativa de botar qualquer compute nos ~200 campos de taxas na v16...