### PR TITLE
[16.0][FIX] l10n_br_account, l10n_br_contract, l10n_br_purchase, l10n_br_sale, l10n_br_stock_account: conflito de empresa no account.tax

### DIFF
--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -516,7 +516,9 @@ class AccountMoveLine(models.Model):
             user_type = "purchase"
 
         return self.fiscal_tax_ids.account_taxes(
-            user_type=user_type, fiscal_operation=self.fiscal_operation_id
+            user_type=user_type,
+            fiscal_operation=self.fiscal_operation_id,
+            company=self.company_id,
         )
 
     @api.constrains("product_uom_id")

--- a/l10n_br_account/models/fiscal_tax.py
+++ b/l10n_br_account/models/fiscal_tax.py
@@ -7,10 +7,10 @@ from odoo import Command, api, fields, models
 class FiscalTax(models.Model):
     _inherit = "l10n_br_fiscal.tax"
 
-    def account_taxes(self, user_type="sale", fiscal_operation=False):
+    def account_taxes(self, user_type="sale", fiscal_operation=False, company=False):
         account_taxes = self.env["account.tax"]
         for fiscal_tax in self:
-            taxes = fiscal_tax._account_taxes()
+            taxes = fiscal_tax._account_taxes(company)
             # Atualiza os impostos contábeis relacionados aos impostos fiscais
             account_taxes |= taxes.filtered(
                 lambda t: t.type_tax_use == user_type and t.active and not t.deductible
@@ -25,17 +25,18 @@ class FiscalTax(models.Model):
 
         return account_taxes
 
-    def _account_taxes(self):
+    def _account_taxes(self, company=False):
         self.ensure_one()
         account_tax_group = self.tax_group_id.account_tax_group()
-        company = self.env.company
-        if self.env.context.get("default_company_id") or self.env.context.get(
-            "allowed_company_ids"
-        ):
-            company = self.env["res.company"].browse(
-                self.env.context.get("default_company_id")
-                or self.env.context.get("allowed_company_ids")[0]
-            )
+        if not company:
+            company = self.env.company
+            if self.env.context.get("default_company_id") or self.env.context.get(
+                "allowed_company_ids"
+            ):
+                company = self.env["res.company"].browse(
+                    self.env.context.get("default_company_id")
+                    or self.env.context.get("allowed_company_ids")[0]
+                )
         return self.env["account.tax"].search(
             [
                 ("tax_group_id", "=", account_tax_group.id),

--- a/l10n_br_contract/models/contract_line.py
+++ b/l10n_br_contract/models/contract_line.py
@@ -66,6 +66,7 @@ class ContractLine(models.Model):
         tax_ids = self.fiscal_tax_ids.account_taxes(
             user_type=contract.contract_type,
             fiscal_operation=contract.fiscal_operation_id,
+            company=contract.company_id,
         )
 
         if invoice_line_vals:

--- a/l10n_br_purchase/models/purchase_order_line.py
+++ b/l10n_br_purchase/models/purchase_order_line.py
@@ -129,7 +129,9 @@ class PurchaseOrderLine(models.Model):
             if line.fiscal_operation_line_id:
                 res = super()._compute_tax_id()
                 line.taxes_id = line.fiscal_tax_ids.account_taxes(
-                    user_type="purchase", fiscal_operation=line.fiscal_operation_id
+                    user_type="purchase",
+                    fiscal_operation=line.fiscal_operation_id,
+                    company=line.company_id,
                 )
             else:
                 res = None
@@ -140,7 +142,9 @@ class PurchaseOrderLine(models.Model):
         if self.fiscal_operation_line_id:
             res = super()._onchange_fiscal_tax_ids()
             self.taxes_id = self.fiscal_tax_ids.account_taxes(
-                user_type="purchase", fiscal_operation=self.fiscal_operation_id
+                user_type="purchase",
+                fiscal_operation=self.fiscal_operation_id,
+                company=self.company_id,
             )
         else:
             res = None

--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -264,7 +264,9 @@ class SaleOrderLine(models.Model):
         if self.product_id and self.fiscal_operation_line_id:
             res = super()._onchange_fiscal_tax_ids()
             self.tax_id = self.fiscal_tax_ids.account_taxes(
-                user_type="sale", fiscal_operation=self.fiscal_operation_id
+                user_type="sale",
+                fiscal_operation=self.fiscal_operation_id,
+                company=self.company_id,
             )
         else:
             res = None
@@ -316,7 +318,9 @@ class SaleOrderLine(models.Model):
 
         for line in lines_with_fiscal_operation:
             line.tax_id = line.fiscal_tax_ids.account_taxes(
-                user_type="sale", fiscal_operation=line.fiscal_operation_id
+                user_type="sale",
+                fiscal_operation=line.fiscal_operation_id,
+                company=line.company_id,
             )
 
         if lines_without_fiscal_operation:

--- a/l10n_br_stock_account/models/stock_move.py
+++ b/l10n_br_stock_account/models/stock_move.py
@@ -111,6 +111,7 @@ class StockMove(models.Model):
                     ).account_taxes(
                         user_type=user_type[0],
                         fiscal_operation=record.fiscal_operation_id,
+                        company=record.company_id,
                     )
 
                     if tax_ids:


### PR DESCRIPTION
Após a entrada da PR #3939, passou a ocorrer um conflito nos dados de demonstração da localização, o que pode impedir a instalação inicial do módulo l10n_br_sale, dependendo da ordem de instalação dos módulos.

No repositório da Engenere, os testes que antes rodavam sem qualquer problema com o comando:

`odoo -i l10n_br_account,l10n_br_account_payment_order,l10n_br_base,l10n_br_coa_generic,l10n_br_coa_simple,l10n_br_delivery,l10n_br_fiscal,l10n_br_nfe,l10n_br_purchase,l10n_br_purchase_stock,l10n_br_sale,l10n_br_sale_stock --stop-after-init`

Passaram a apresentar o erro mostrado nas imagens a seguir:
<img width="1187" height="713" alt="image" src="https://github.com/user-attachments/assets/2618dbe9-ef32-4179-aed5-d3fa8603b408" />
<img width="1346" height="774" alt="image" src="https://github.com/user-attachments/assets/256819f4-10d3-444e-a3c3-4584aafc6cfd" />
<img width="1269" height="773" alt="image" src="https://github.com/user-attachments/assets/3b27c8f7-59dc-4342-a6c6-151c26674567" />
<img width="1311" height="793" alt="image" src="https://github.com/user-attachments/assets/e8a56de4-fc70-4b6b-8d7d-963a9284e05d" />
<img width="1233" height="777" alt="image" src="https://github.com/user-attachments/assets/6a089ffe-22af-4015-a513-dab92458f1b9" />
<img width="1275" height="274" alt="image" src="https://github.com/user-attachments/assets/b58d2b7c-9bb4-4395-849d-173a29fc29d8" />

O mesmo erro também ocorre ao instalar apenas os módulos:

`docker compose run --rm odoo -i l10n_br_coa_generic,l10n_br_coa_simple,l10n_br_sale --stop-after-init`

Não investiguei exatamente onde o company no env entra em conflito, mas optei por uma abordagem que permite definir a empresa diretamente. Essa alteração não apenas resolve o problema, como também torna o comportamento em multiempresa mais robusto.

Cenário de exemplo:
Um usuário está ativo na empresa X, mas altera um pedido de venda da empresa Y. Embora não seja recomendado editar registros de empresas diferentes (especialmente quando a empresa não está ativa), é prudente prever que isso possa acontecer. Na forma atual, isso gera conflito; com a alteração proposta, o sistema lida melhor com esses casos, garantindo maior compatibilidade no multiempresa.