### PR TITLE
[16.0][REF] l10n_br_account: Usando o campo direction_sign para definir o Sinal

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -278,10 +278,7 @@ class AccountMove(models.Model):
 
         result = super()._compute_amount()
         for move in self.filtered(lambda m: m.fiscal_operation_id):
-            if move.move_type == "entry" or move.is_outbound():
-                sign = -1
-            else:
-                sign = 1
+            sign = move.direction_sign
             inv_line_ids = move.line_ids.filtered(
                 lambda line: line.display_type == "product"
                 and (not line.cfop_id or line.cfop_id.finance_move)


### PR DESCRIPTION
Use compute field for Sign.

PR simples, existe um campo [direction_sign](https://github.com/OCA/OCB/blob/16.0/addons/account/models/account_move.py#L398) que é do tipo compute usado para definir o Sinal, se positivo ou negativo, outras partes do código da Localização já usam esse campo mas acabei encontrando essa parte que na verdade é igual ao código executado pelo método compute

https://github.com/OCA/OCB/blob/16.0/addons/account/models/account_move.py#L838
```bash
    @api.depends('move_type')
    def _compute_direction_sign(self):
        for invoice in self:
            if invoice.move_type == 'entry' or invoice.is_outbound():
                invoice.direction_sign = 1
            else:
                invoice.direction_sign = -1
```

Portanto essa alteração não deve ter nenhum efeito colateral, apenas reduz 3 linhas removendo algo desnecessário.

cc @OCA/local-brazil-maintainers 