### PR TITLE
[16.0][FIX] l10n_br_base: vat readonly

### DIFF
--- a/l10n_br_base/views/res_partner_view.xml
+++ b/l10n_br_base/views/res_partner_view.xml
@@ -39,6 +39,7 @@
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="arch" type="xml">
             <field name="vat" position="attributes">
+                <attribute name="force_save">1</attribute>
                 <attribute name="attrs">
                     {
                         'readonly':


### PR DESCRIPTION
Correção da Issue #3949 

Código anterior

```
'readonly': [
  '|',
  ('vat', 'not in', [False, ""]),
  ('parent_id', '!=', False),
]
```

No codigo anterior acontecia que travava o campo vat assim que era preenchido (porque vat not in [False, ""] já disparava) assim valor ficava readonly ainda em modo de edição.

Código novo

```
'readonly': [
  '|',
  '&amp;',
  ('id', '!=', False),
  ('vat', '!=', False),
  ('parent_id', '!=', False),
]
```
Só trava o campo depois que o registro já existe e tem CNPJ ou se for contato-filho.

cc @marioolofo @viniciusilveira