### PR TITLE
[16.0][REF] l10n_br_base: string suframa

### DIFF
--- a/l10n_br_base/models/party_mixin.py
+++ b/l10n_br_base/models/party_mixin.py
@@ -58,6 +58,7 @@ class PartyMixin(models.AbstractModel):
     )
 
     l10n_br_isuf_code = fields.Char(
+        string="Suframa",
         size=18,
         unaccent=False,
     )


### PR DESCRIPTION
Faltou incluir na PR #3888 o Incluir `string="Suframa",` no campo l10n_br_isuf_code

Hoje esta ficando assim:
<img width="573" height="49" alt="image" src="https://github.com/user-attachments/assets/e60e6ebb-700d-4634-abd6-aa1b502fb550" />

Com a mudança:
<img width="548" height="34" alt="image" src="https://github.com/user-attachments/assets/78ad6d6c-73fc-4f85-a48e-51f667fcf9a9" />