### PR TITLE
[16.0][REF] l10n_br_account_payment_order: Command.link

### DIFF
--- a/l10n_br_account_payment_order/data/cnab_codes/banco_ailos_240_boleto_discount_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_ailos_240_boleto_discount_code.xml
@@ -11,7 +11,10 @@
         <field name="name">Não assumirá Desconto</field>
         <field name="code">0</field>
         <field name="code_type">discount_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -22,7 +25,10 @@
         <field name="name">Valor Fixo Até a Data Informada</field>
         <field name="code">1</field>
         <field name="code_type">discount_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_ailos_240_boleto_discount_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_ailos_240_boleto_discount_code.xml
@@ -14,7 +14,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -25,7 +25,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="comment">Para o código '1' será obrigatório a informação da Data.
         </field>

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_ailos_240_boleto_protest_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_ailos_240_boleto_protest_code.xml
@@ -13,7 +13,10 @@
         >Protestar Dias Corridos (No Sistema Ailos o prazo para protesto é de 05 a 15).</field>
         <field name="code">1</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -29,7 +32,10 @@
         >Negativação de boletos via Serasa (No Sistema Ailos o prazo para protesto é de 05 a 15).</field>
         <field name="code">2</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -43,7 +49,10 @@
         <field name="name">Não Protestar / Não Negativar</field>
         <field name="code">3</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_ailos_240_boleto_protest_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_ailos_240_boleto_protest_code.xml
@@ -16,7 +16,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"
@@ -32,7 +32,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"
@@ -46,7 +46,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_ailos_cnab_240.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_ailos_cnab_240.xml
@@ -7,7 +7,10 @@
         <field name="name">Entrada Títulos</field>
         <field name="code">01</field>
         <field name="code_type">instruction_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -17,7 +20,10 @@
         <field name="name">Pedido de Baixa</field>
         <field name="code">02</field>
         <field name="code_type">instruction_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -27,7 +33,10 @@
         <field name="name">Concessão de Abatimento</field>
         <field name="code">04</field>
         <field name="code_type">instruction_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -37,7 +46,10 @@
         <field name="name">Cancelamento de Abatimento</field>
         <field name="code">05</field>
         <field name="code_type">instruction_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -47,7 +59,10 @@
         <field name="name">Alteração de Vencimento</field>
         <field name="code">06</field>
         <field name="code_type">instruction_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -57,7 +72,10 @@
         <field name="name">Concessão de Desconto</field>
         <field name="code">07</field>
         <field name="code_type">instruction_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -67,7 +85,10 @@
         <field name="name">Cancelamento de Desconto</field>
         <field name="code">08</field>
         <field name="code_type">instruction_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -77,7 +98,10 @@
         <field name="name">Protesto</field>
         <field name="code">09</field>
         <field name="code_type">instruction_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -87,7 +111,10 @@
         <field name="name">Sustar Protesto e Baixar Título</field>
         <field name="code">10</field>
         <field name="code_type">instruction_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -97,7 +124,10 @@
         <field name="name">Sustar Protesto e Manter em Carteira</field>
         <field name="code">11</field>
         <field name="code_type">instruction_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -109,7 +139,10 @@
         >Alteração de outros dados (Somente endereço do pagador)</field>
         <field name="code">31</field>
         <field name="code_type">instruction_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -119,7 +152,10 @@
         <field name="name">Cancelar instrução automática de protesto</field>
         <field name="code">41</field>
         <field name="code_type">instruction_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -129,7 +165,10 @@
         <field name="name">Alterar tipo de emissão - Cooperativa/EE</field>
         <field name="code">90</field>
         <field name="code_type">instruction_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -139,7 +178,10 @@
         <field name="name">Inclusão Negativação via Serasa</field>
         <field name="code">93</field>
         <field name="code_type">instruction_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -149,7 +191,10 @@
         <field name="name">Exclusão Negativação via Serasa</field>
         <field name="code">94</field>
         <field name="code_type">instruction_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -159,7 +204,10 @@
         <field name="name">Envio de SMS ao pagador</field>
         <field name="code">95</field>
         <field name="code_type">instruction_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -169,7 +217,10 @@
         <field name="name">Cancelamento Instrução de SMS</field>
         <field name="code">96</field>
         <field name="code_type">instruction_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -180,7 +231,10 @@
         <field name="name">Entrada Confirmada</field>
         <field name="code">02</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -190,7 +244,10 @@
         <field name="name">Entrada Rejeitada</field>
         <field name="code">03</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -200,7 +257,10 @@
         <field name="name">Liquidação</field>
         <field name="code">06</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -210,7 +270,10 @@
         <field name="name">Confirmação do Recebimento da Instrução de Desconto</field>
         <field name="code">07</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -222,7 +285,10 @@
         >Confirmação do Recebimento do Cancelamento do Desconto</field>
         <field name="code">08</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -232,7 +298,10 @@
         <field name="name">Baixa</field>
         <field name="code">09</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -242,7 +311,10 @@
         <field name="name">Confirmação Recebimento Instrução de Abatimento</field>
         <field name="code">12</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -254,7 +326,10 @@
         >Confirmação Recebimento Instrução de Cancelamento Abatimento</field>
         <field name="code">13</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -266,7 +341,10 @@
         >Confirmação Recebimento Instrução Alteração de Vencimento</field>
         <field name="code">14</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -278,7 +356,10 @@
         >Liquidação Após Baixa ou Liquidação Título Não Registrado</field>
         <field name="code">17</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -288,7 +369,10 @@
         <field name="name">Confirmação Recebimento Instrução de Protesto</field>
         <field name="code">19</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -300,7 +384,10 @@
         >Confirmação Recebimento Instrução de Sustação/Cancelamento de Protesto</field>
         <field name="code">20</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -310,7 +397,10 @@
         <field name="name">Título Enviado ao Cartório</field>
         <field name="code">22</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -320,7 +410,10 @@
         <field name="name">Remessa a Cartório (Aponte em Cartório)</field>
         <field name="code">23</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -330,7 +423,10 @@
         <field name="name">Retirada de Cartório e Manutenção em Carteira</field>
         <field name="code">24</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -340,7 +436,10 @@
         <field name="name">Protestado e Baixado (Baixa por Ter Sido Protestado)</field>
         <field name="code">25</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -350,7 +449,10 @@
         <field name="name">Instrução Rejeitada</field>
         <field name="code">26</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -360,7 +462,10 @@
         <field name="name">Confirmação do Pedido de Alteração de Outros Dados</field>
         <field name="code">27</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -370,7 +475,10 @@
         <field name="name">Débito de Tarifas/Custas</field>
         <field name="code">28</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -380,7 +488,10 @@
         <field name="name">Confirmação de Envio de SMS</field>
         <field name="code">36</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -390,7 +501,10 @@
         <field name="name">Envio de SMS rejeitado</field>
         <field name="code">37</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -400,7 +514,10 @@
         <field name="name">Confirmação da alteração dos dados do Sacado</field>
         <field name="code">42</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -410,7 +527,10 @@
         <field name="name">Instrução para cancelar protesto confirmada</field>
         <field name="code">46</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -420,7 +540,10 @@
         <field name="name">Cancelamento de SMS</field>
         <field name="code">64</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -430,7 +553,10 @@
         <field name="name">Liquidação de boleto cooperativa emite e expede</field>
         <field name="code">76</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -442,7 +568,10 @@
         >Liquidação de boleto após baixa ou não registrado cooperativa emite e expede</field>
         <field name="code">77</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -454,7 +583,10 @@
         >Rejeição cartorária (Visualizar motivo na última página deste manual)</field>
         <field name="code">89</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -464,7 +596,10 @@
         <field name="name">Título em aberto não enviado ao pagador</field>
         <field name="code">91</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -474,7 +609,10 @@
         <field name="name">Inconsistência Negativação Serasa</field>
         <field name="code">92</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -484,7 +622,10 @@
         <field name="name">Inclusão Negativação via Serasa</field>
         <field name="code">93</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -494,7 +635,10 @@
         <field name="name">Exclusão Negativação Serasa</field>
         <field name="code">94</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -504,7 +648,10 @@
         <field name="name">Excluir Protesto com carta de anuência</field>
         <field name="code">98</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_085'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_ailos_cnab_240.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_ailos_cnab_240.xml
@@ -10,7 +10,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_instruction_02" model="l10n_br_cnab.code">
@@ -20,7 +20,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_instruction_04" model="l10n_br_cnab.code">
@@ -30,7 +30,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_instruction_05" model="l10n_br_cnab.code">
@@ -40,7 +40,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_instruction_06" model="l10n_br_cnab.code">
@@ -50,7 +50,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_instruction_07" model="l10n_br_cnab.code">
@@ -60,7 +60,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_instruction_08" model="l10n_br_cnab.code">
@@ -70,7 +70,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_instruction_09" model="l10n_br_cnab.code">
@@ -80,7 +80,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_instruction_10" model="l10n_br_cnab.code">
@@ -90,7 +90,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_instruction_11" model="l10n_br_cnab.code">
@@ -100,7 +100,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_instruction_31" model="l10n_br_cnab.code">
@@ -112,7 +112,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_instruction_41" model="l10n_br_cnab.code">
@@ -122,7 +122,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_instruction_90" model="l10n_br_cnab.code">
@@ -132,7 +132,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_instruction_93" model="l10n_br_cnab.code">
@@ -142,7 +142,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_instruction_94" model="l10n_br_cnab.code">
@@ -152,7 +152,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_instruction_95" model="l10n_br_cnab.code">
@@ -162,7 +162,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_instruction_96" model="l10n_br_cnab.code">
@@ -172,7 +172,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <!-- CÓDIGOS DE RETORNO DE MOVIMENTO -->
@@ -183,7 +183,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_03" model="l10n_br_cnab.code">
@@ -193,7 +193,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_06" model="l10n_br_cnab.code">
@@ -203,7 +203,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_07" model="l10n_br_cnab.code">
@@ -213,7 +213,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_08" model="l10n_br_cnab.code">
@@ -225,7 +225,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_09" model="l10n_br_cnab.code">
@@ -235,7 +235,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_12" model="l10n_br_cnab.code">
@@ -245,7 +245,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_13" model="l10n_br_cnab.code">
@@ -257,7 +257,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_14" model="l10n_br_cnab.code">
@@ -269,7 +269,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_17" model="l10n_br_cnab.code">
@@ -281,7 +281,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_19" model="l10n_br_cnab.code">
@@ -291,7 +291,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_20" model="l10n_br_cnab.code">
@@ -303,7 +303,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_22" model="l10n_br_cnab.code">
@@ -313,7 +313,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_23" model="l10n_br_cnab.code">
@@ -323,7 +323,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_24" model="l10n_br_cnab.code">
@@ -333,7 +333,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_25" model="l10n_br_cnab.code">
@@ -343,7 +343,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_26" model="l10n_br_cnab.code">
@@ -353,7 +353,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_27" model="l10n_br_cnab.code">
@@ -363,7 +363,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_28" model="l10n_br_cnab.code">
@@ -373,7 +373,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_36" model="l10n_br_cnab.code">
@@ -383,7 +383,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_37" model="l10n_br_cnab.code">
@@ -393,7 +393,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_42" model="l10n_br_cnab.code">
@@ -403,7 +403,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_46" model="l10n_br_cnab.code">
@@ -413,7 +413,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_64" model="l10n_br_cnab.code">
@@ -423,7 +423,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_76" model="l10n_br_cnab.code">
@@ -433,7 +433,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_77" model="l10n_br_cnab.code">
@@ -445,7 +445,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_89" model="l10n_br_cnab.code">
@@ -457,7 +457,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_91" model="l10n_br_cnab.code">
@@ -467,7 +467,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_92" model="l10n_br_cnab.code">
@@ -477,7 +477,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_93" model="l10n_br_cnab.code">
@@ -487,7 +487,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_94" model="l10n_br_cnab.code">
@@ -497,7 +497,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
     <record id="ailos_240_return_98" model="l10n_br_cnab.code">
@@ -507,7 +507,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_085')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 </odoo>

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_bradesco_240_boleto_discount_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_bradesco_240_boleto_discount_code.xml
@@ -12,7 +12,10 @@
         <field name="name">Valor Fixo Até a Data Informada</field>
         <field name="code">1</field>
         <field name="code_type">discount_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -27,7 +30,10 @@
         <field name="name">Percentual Até a Data Informada</field>
         <field name="code">2</field>
         <field name="code_type">discount_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -42,7 +48,10 @@
         <field name="name">Valor por Antecipação Dia Corrido</field>
         <field name="code">3</field>
         <field name="code_type">discount_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -53,7 +62,10 @@
         <field name="name">Valor por Antecipação Dia Útil</field>
         <field name="code">4</field>
         <field name="code_type">discount_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -64,7 +76,10 @@
         <field name="name">Percentual Sobre o Valor Nominal Dia Corrido</field>
         <field name="code">5</field>
         <field name="code_type">discount_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -75,7 +90,10 @@
         <field name="name">Percentual Sobre o Valor Nominal Dia Útil</field>
         <field name="code">6</field>
         <field name="code_type">discount_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -86,7 +104,10 @@
         <field name="name">Cancelamento de Desconto</field>
         <field name="code">7</field>
         <field name="code_type">discount_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_bradesco_240_boleto_discount_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_bradesco_240_boleto_discount_code.xml
@@ -15,7 +15,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"
@@ -30,7 +30,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"
@@ -45,7 +45,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -56,7 +56,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -67,7 +67,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -78,7 +78,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -89,7 +89,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_bradesco_240_boleto_protest_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_bradesco_240_boleto_protest_code.xml
@@ -12,7 +12,10 @@
         <field name="name">Protestar Dias Corridos</field>
         <field name="code">1</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -23,7 +26,10 @@
         <field name="name">Protestar Dias Úteis</field>
         <field name="code">2</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -34,7 +40,10 @@
         <field name="name">Não Protestar</field>
         <field name="code">3</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -45,7 +54,10 @@
         <field name="name">Protestar Fim Falimentar - Dias Úteis</field>
         <field name="code">4</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -56,7 +68,10 @@
         <field name="name">Protestar Fim Falimentar - Dias Corridos</field>
         <field name="code">5</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -67,7 +82,10 @@
         <field name="name">Negativação sem Protesto (NÃO TRATADO PELO BANCO)</field>
         <field name="code">8</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -78,7 +96,10 @@
         <field name="name">Cancelamento Protesto Automático</field>
         <field name="code">9</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_bradesco_240_boleto_protest_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_bradesco_240_boleto_protest_code.xml
@@ -15,7 +15,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -26,7 +26,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -37,7 +37,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -48,7 +48,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -59,7 +59,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -70,7 +70,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -81,7 +81,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_bradesco_boleto_wallet_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_bradesco_boleto_wallet_code.xml
@@ -9,7 +9,10 @@
         <field name="name">Cobrança Simples</field>
         <field name="code">1</field>
         <field name="code_type">wallet_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -20,7 +23,10 @@
         <field name="name">Cobrança Vinculada</field>
         <field name="code">2</field>
         <field name="code_type">wallet_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -31,7 +37,10 @@
         <field name="name">Cobrança Caucionada</field>
         <field name="code">3</field>
         <field name="code_type">wallet_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -42,7 +51,10 @@
         <field name="name">Cobrança Descontada</field>
         <field name="code">4</field>
         <field name="code_type">wallet_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -53,7 +65,10 @@
         <field name="name">Cobrança Vendor</field>
         <field name="code">5</field>
         <field name="code_type">wallet_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_bradesco_boleto_wallet_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_bradesco_boleto_wallet_code.xml
@@ -12,7 +12,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -23,7 +23,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -34,7 +34,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -45,7 +45,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -56,7 +56,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_bradesco_cnab_240_400.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_bradesco_cnab_240_400.xml
@@ -13,7 +13,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_02" model="l10n_br_cnab.code">
@@ -24,7 +27,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_03" model="l10n_br_cnab.code">
@@ -35,7 +41,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_04" model="l10n_br_cnab.code">
@@ -46,7 +55,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_05" model="l10n_br_cnab.code">
@@ -57,7 +69,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_06" model="l10n_br_cnab.code">
@@ -68,7 +83,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_07" model="l10n_br_cnab.code">
@@ -79,7 +97,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_08" model="l10n_br_cnab.code">
@@ -90,7 +111,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_09" model="l10n_br_cnab.code">
@@ -101,7 +125,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_10" model="l10n_br_cnab.code">
@@ -112,7 +139,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_11" model="l10n_br_cnab.code">
@@ -123,7 +153,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_12" model="l10n_br_cnab.code">
@@ -134,7 +167,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_13" model="l10n_br_cnab.code">
@@ -145,7 +181,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_14" model="l10n_br_cnab.code">
@@ -156,7 +195,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_15" model="l10n_br_cnab.code">
@@ -167,7 +209,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_16" model="l10n_br_cnab.code">
@@ -178,7 +223,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_17" model="l10n_br_cnab.code">
@@ -189,7 +237,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_18" model="l10n_br_cnab.code">
@@ -200,7 +251,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_19" model="l10n_br_cnab.code">
@@ -211,7 +265,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_20" model="l10n_br_cnab.code">
@@ -222,7 +279,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_21" model="l10n_br_cnab.code">
@@ -233,7 +293,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_22" model="l10n_br_cnab.code">
@@ -244,7 +307,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_23" model="l10n_br_cnab.code">
@@ -255,7 +321,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_24" model="l10n_br_cnab.code">
@@ -266,7 +335,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_30" model="l10n_br_cnab.code">
@@ -277,7 +349,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_31" model="l10n_br_cnab.code">
@@ -288,7 +363,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_33" model="l10n_br_cnab.code">
@@ -299,7 +377,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_34" model="l10n_br_cnab.code">
@@ -310,7 +391,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_35" model="l10n_br_cnab.code">
@@ -321,7 +405,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_40" model="l10n_br_cnab.code">
@@ -332,7 +419,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_41" model="l10n_br_cnab.code">
@@ -343,7 +433,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_42" model="l10n_br_cnab.code">
@@ -354,7 +447,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_43" model="l10n_br_cnab.code">
@@ -365,7 +461,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_44" model="l10n_br_cnab.code">
@@ -376,7 +475,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_45" model="l10n_br_cnab.code">
@@ -387,7 +489,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_instruction_46" model="l10n_br_cnab.code">
@@ -400,7 +505,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <!-- Codigo de Retorno do Movimento -->
@@ -413,7 +521,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_03" model="l10n_br_cnab.code">
@@ -424,7 +535,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_04" model="l10n_br_cnab.code">
@@ -435,7 +549,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_05" model="l10n_br_cnab.code">
@@ -446,7 +563,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_06" model="l10n_br_cnab.code">
@@ -457,7 +577,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_07" model="l10n_br_cnab.code">
@@ -468,7 +591,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_08" model="l10n_br_cnab.code">
@@ -481,7 +607,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_09" model="l10n_br_cnab.code">
@@ -492,7 +621,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_11" model="l10n_br_cnab.code">
@@ -503,7 +635,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_12" model="l10n_br_cnab.code">
@@ -514,7 +649,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_13" model="l10n_br_cnab.code">
@@ -527,7 +665,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_14" model="l10n_br_cnab.code">
@@ -540,7 +681,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_15" model="l10n_br_cnab.code">
@@ -551,7 +695,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_17" model="l10n_br_cnab.code">
@@ -564,7 +711,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_19" model="l10n_br_cnab.code">
@@ -575,7 +725,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_20" model="l10n_br_cnab.code">
@@ -588,7 +741,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_23" model="l10n_br_cnab.code">
@@ -599,7 +755,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_24" model="l10n_br_cnab.code">
@@ -610,7 +769,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_25" model="l10n_br_cnab.code">
@@ -621,7 +783,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_26" model="l10n_br_cnab.code">
@@ -632,7 +797,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_27" model="l10n_br_cnab.code">
@@ -643,7 +811,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_28" model="l10n_br_cnab.code">
@@ -654,7 +825,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_29" model="l10n_br_cnab.code">
@@ -665,7 +839,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_30" model="l10n_br_cnab.code">
@@ -676,7 +853,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_33" model="l10n_br_cnab.code">
@@ -689,7 +869,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_34" model="l10n_br_cnab.code">
@@ -702,7 +885,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_35" model="l10n_br_cnab.code">
@@ -713,7 +899,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_36" model="l10n_br_cnab.code">
@@ -724,7 +913,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_37" model="l10n_br_cnab.code">
@@ -735,7 +927,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_38" model="l10n_br_cnab.code">
@@ -748,7 +943,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_39" model="l10n_br_cnab.code">
@@ -761,7 +959,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_40" model="l10n_br_cnab.code">
@@ -774,7 +975,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_41" model="l10n_br_cnab.code">
@@ -787,7 +991,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_42" model="l10n_br_cnab.code">
@@ -798,7 +1005,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_43" model="l10n_br_cnab.code">
@@ -811,7 +1021,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_44" model="l10n_br_cnab.code">
@@ -822,7 +1035,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_45" model="l10n_br_cnab.code">
@@ -833,7 +1049,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_46" model="l10n_br_cnab.code">
@@ -844,7 +1063,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_47" model="l10n_br_cnab.code">
@@ -857,7 +1079,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_48" model="l10n_br_cnab.code">
@@ -870,7 +1095,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_49" model="l10n_br_cnab.code">
@@ -881,7 +1109,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_50" model="l10n_br_cnab.code">
@@ -892,7 +1123,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_51" model="l10n_br_cnab.code">
@@ -903,7 +1137,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_52" model="l10n_br_cnab.code">
@@ -914,7 +1151,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_53" model="l10n_br_cnab.code">
@@ -925,7 +1165,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_54" model="l10n_br_cnab.code">
@@ -938,7 +1181,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_55" model="l10n_br_cnab.code">
@@ -949,7 +1195,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_56" model="l10n_br_cnab.code">
@@ -960,7 +1209,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_57" model="l10n_br_cnab.code">
@@ -973,7 +1225,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_58" model="l10n_br_cnab.code">
@@ -986,7 +1241,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_59" model="l10n_br_cnab.code">
@@ -999,7 +1257,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_240_return_60" model="l10n_br_cnab.code">
@@ -1010,7 +1271,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <!-- CNAB 400 -->
@@ -1025,7 +1289,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_400_instruction_02" model="l10n_br_cnab.code">
@@ -1036,7 +1303,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_400_instruction_03" model="l10n_br_cnab.code">
@@ -1047,7 +1317,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_400_instruction_04" model="l10n_br_cnab.code">
@@ -1058,7 +1331,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_400_instruction_05" model="l10n_br_cnab.code">
@@ -1069,7 +1345,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_400_instruction_06" model="l10n_br_cnab.code">
@@ -1080,7 +1359,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_400_instruction_07" model="l10n_br_cnab.code">
@@ -1091,7 +1373,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_400_instruction_08" model="l10n_br_cnab.code">
@@ -1102,7 +1387,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_400_instruction_09" model="l10n_br_cnab.code">
@@ -1113,7 +1401,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_400_instruction_12" model="l10n_br_cnab.code">
@@ -1124,7 +1415,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_400_instruction_13" model="l10n_br_cnab.code">
@@ -1135,7 +1429,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_400_instruction_14" model="l10n_br_cnab.code">
@@ -1146,7 +1443,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_400_instruction_18" model="l10n_br_cnab.code">
@@ -1157,7 +1457,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_400_instruction_19" model="l10n_br_cnab.code">
@@ -1168,7 +1471,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_400_instruction_20" model="l10n_br_cnab.code">
@@ -1179,7 +1485,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_400_instruction_22" model="l10n_br_cnab.code">
@@ -1190,7 +1499,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_400_instruction_23" model="l10n_br_cnab.code">
@@ -1201,7 +1513,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_400_instruction_24" model="l10n_br_cnab.code">
@@ -1212,7 +1527,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_400_instruction_31" model="l10n_br_cnab.code">
@@ -1223,7 +1541,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_400_instruction_32" model="l10n_br_cnab.code">
@@ -1234,7 +1555,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_400_instruction_45" model="l10n_br_cnab.code">
@@ -1245,7 +1569,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_400_instruction_46" model="l10n_br_cnab.code">
@@ -1256,7 +1583,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_400_instruction_47" model="l10n_br_cnab.code">
@@ -1267,7 +1597,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_400_instruction_68" model="l10n_br_cnab.code">
@@ -1278,7 +1611,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <record id="bradesco_400_instruction_69" model="l10n_br_cnab.code">
@@ -1289,7 +1625,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
     </record>
 
     <!-- Codigo de Retorno do Movimento -->
@@ -1297,7 +1636,10 @@
         <field name="name">Entrada Confirmada</field>
         <field name="code">02</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1308,7 +1650,10 @@
         <field name="name">Entrada Rejeitada</field>
         <field name="code">03</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1319,7 +1664,10 @@
         <field name="name">Liquidação Normal *</field>
         <field name="code">06</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1330,7 +1678,10 @@
         <field name="name">Conf. Exc. Cadastro Pagador Débito</field>
         <field name="code">07</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1341,7 +1692,10 @@
         <field name="name">Rej. Ped. Exc. Cadastro de Pagador Débito</field>
         <field name="code">08</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1352,7 +1706,10 @@
         <field name="name">Baixado Automat. via Arquivo</field>
         <field name="code">09</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1363,7 +1720,10 @@
         <field name="name">Baixado conforme instruções da Agência</field>
         <field name="code">10</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1374,7 +1734,10 @@
         <field name="name">Em Ser - Arquivo de Títulos pendentes</field>
         <field name="code">11</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1385,7 +1748,10 @@
         <field name="name">Abatimento Concedido</field>
         <field name="code">12</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1396,7 +1762,10 @@
         <field name="name">Abatimento Cancelado</field>
         <field name="code">13</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1407,7 +1776,10 @@
         <field name="name">Vencimento Alterado</field>
         <field name="code">14</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1418,7 +1790,10 @@
         <field name="name">Liquidação em Cartório</field>
         <field name="code">15</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1429,7 +1804,10 @@
         <field name="name">Título Pago em Cheque – Vinculado</field>
         <field name="code">16</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1440,7 +1818,10 @@
         <field name="name">Liquidação após baixa ou Título não registrado</field>
         <field name="code">17</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1451,7 +1832,10 @@
         <field name="name">Acerto de Depositária</field>
         <field name="code">18</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1462,7 +1846,10 @@
         <field name="name">Confirmação Receb. Inst. de Protesto</field>
         <field name="code">19</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1475,7 +1862,10 @@
         >Confirmação Recebimento Instrução Sustação de Protesto</field>
         <field name="code">20</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1486,7 +1876,10 @@
         <field name="name">Acerto do Controle do Participante (sem motivo)</field>
         <field name="code">21</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1497,7 +1890,10 @@
         <field name="name">Título Com Pagamento Cancelado</field>
         <field name="code">22</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1508,7 +1904,10 @@
         <field name="name">Entrada do Título em Cartório (sem motivo)</field>
         <field name="code">23</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1519,7 +1918,10 @@
         <field name="name">Entrada rejeitada por CEP Irregular</field>
         <field name="code">24</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1530,7 +1932,10 @@
         <field name="name">Confirmação Receb.Inst.de Protesto Falimentar</field>
         <field name="code">25</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1541,7 +1946,10 @@
         <field name="name">Baixa Rejeitada</field>
         <field name="code">27</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1552,7 +1960,10 @@
         <field name="name">Débito de tarifas/custas</field>
         <field name="code">28</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1563,7 +1974,10 @@
         <field name="name">Ocorrências do Pagador</field>
         <field name="code">29</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1574,7 +1988,10 @@
         <field name="name">Alteração de Outros Dados Rejeitados</field>
         <field name="code">30</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1585,7 +2002,10 @@
         <field name="name">Confirmado Inclusão Cadastro Pagador</field>
         <field name="code">31</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1596,7 +2016,10 @@
         <field name="name">Instrução Rejeitada</field>
         <field name="code">32</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1607,7 +2030,10 @@
         <field name="name">Confirmação Pedido Alteração Outros Dados</field>
         <field name="code">33</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1618,7 +2044,10 @@
         <field name="name">Retirado de Cartório e Manutenção Carteira</field>
         <field name="code">34</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1629,7 +2058,10 @@
         <field name="name">Desagendamento do débito automático</field>
         <field name="code">35</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1640,7 +2072,10 @@
         <field name="name">Rejeitado Inclusão Cadastro Pagador</field>
         <field name="code">37</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1651,7 +2086,10 @@
         <field name="name">Confirmado Alteração Pagador</field>
         <field name="code">38</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1662,7 +2100,10 @@
         <field name="name">Rejeitado Alteração Cadastro Pagador</field>
         <field name="code">39</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1673,7 +2114,10 @@
         <field name="name">Estorno de pagamento</field>
         <field name="code">40</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1684,7 +2128,10 @@
         <field name="name">Sustado judicial</field>
         <field name="code">55</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1695,7 +2142,10 @@
         <field name="name">Acerto dos dados do rateio de Crédito</field>
         <field name="code">68</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1706,7 +2156,10 @@
         <field name="name">Cancelamento de Rateio</field>
         <field name="code">69</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1717,7 +2170,10 @@
         <field name="name">Confirmação Receb. Pedido de Negativação</field>
         <field name="code">73</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1728,7 +2184,10 @@
         <field name="name">Confir Pedido de Excl de Negat (com ou sem baixa)</field>
         <field name="code">74</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1741,7 +2200,10 @@
         >Nota: Para as ocorrências sem motivos, as posições serão informadas com Zeros.</field>
         <field name="code">00</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_237'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_bradesco_cnab_240_400.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_bradesco_cnab_240_400.xml
@@ -11,7 +11,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -22,7 +22,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -33,7 +33,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -44,7 +44,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -55,7 +55,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -66,7 +66,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -77,7 +77,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -88,7 +88,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -99,7 +99,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -110,7 +110,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -121,7 +121,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -132,7 +132,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -143,7 +143,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -154,7 +154,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -165,7 +165,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -176,7 +176,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -187,7 +187,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -198,7 +198,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -209,7 +209,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -220,7 +220,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -231,7 +231,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -242,7 +242,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -253,7 +253,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -264,7 +264,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -275,7 +275,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -286,7 +286,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -297,7 +297,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -308,7 +308,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -319,7 +319,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -330,7 +330,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -341,7 +341,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -352,7 +352,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -363,7 +363,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -374,7 +374,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -385,7 +385,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -398,7 +398,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -411,7 +411,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -422,7 +422,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -433,7 +433,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -444,7 +444,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -455,7 +455,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -466,7 +466,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -479,7 +479,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -490,7 +490,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -501,7 +501,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -512,7 +512,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -525,7 +525,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -538,7 +538,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -549,7 +549,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -562,7 +562,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -573,7 +573,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -586,7 +586,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -597,7 +597,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -608,7 +608,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -619,7 +619,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -630,7 +630,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -641,7 +641,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -652,7 +652,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -663,7 +663,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -674,7 +674,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -687,7 +687,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -700,7 +700,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -711,7 +711,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -722,7 +722,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -733,7 +733,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -746,7 +746,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -759,7 +759,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -772,7 +772,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -785,7 +785,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -796,7 +796,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -809,7 +809,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -820,7 +820,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -831,7 +831,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -842,7 +842,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -855,7 +855,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -868,7 +868,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -879,7 +879,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -890,7 +890,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -901,7 +901,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -912,7 +912,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -923,7 +923,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -936,7 +936,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -947,7 +947,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -958,7 +958,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -971,7 +971,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -984,7 +984,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -997,7 +997,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -1008,7 +1008,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -1023,7 +1023,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -1034,7 +1034,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -1045,7 +1045,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -1056,7 +1056,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -1067,7 +1067,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -1078,7 +1078,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -1089,7 +1089,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -1100,7 +1100,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -1111,7 +1111,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -1122,7 +1122,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -1133,7 +1133,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -1144,7 +1144,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -1155,7 +1155,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -1166,7 +1166,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -1177,7 +1177,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -1188,7 +1188,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -1199,7 +1199,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -1210,7 +1210,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -1221,7 +1221,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -1232,7 +1232,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -1243,7 +1243,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -1254,7 +1254,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -1265,7 +1265,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -1276,7 +1276,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -1287,7 +1287,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
     </record>
@@ -1300,7 +1300,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1311,7 +1311,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1322,7 +1322,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1333,7 +1333,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1344,7 +1344,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1355,7 +1355,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1366,7 +1366,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1377,7 +1377,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1388,7 +1388,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1399,7 +1399,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1410,7 +1410,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1421,7 +1421,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1432,7 +1432,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1443,7 +1443,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1454,7 +1454,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1465,7 +1465,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1478,7 +1478,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1489,7 +1489,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1500,7 +1500,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1511,7 +1511,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1522,7 +1522,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1533,7 +1533,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1544,7 +1544,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1555,7 +1555,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1566,7 +1566,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1577,7 +1577,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1588,7 +1588,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1599,7 +1599,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1610,7 +1610,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1621,7 +1621,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1632,7 +1632,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1643,7 +1643,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1654,7 +1654,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1665,7 +1665,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1676,7 +1676,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1687,7 +1687,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1698,7 +1698,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1709,7 +1709,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1720,7 +1720,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1731,7 +1731,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1744,7 +1744,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_237')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_cef_240_boleto_discount_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_cef_240_boleto_discount_code.xml
@@ -11,7 +11,10 @@
         <field name="name">Sem Desconto</field>
         <field name="code">0</field>
         <field name="code_type">discount_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -22,7 +25,10 @@
         <field name="name">Valor Fixo até a data informada</field>
         <field name="code">1</field>
         <field name="code_type">discount_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -33,7 +39,10 @@
         <field name="name">Percentual até a data informada</field>
         <field name="code">2</field>
         <field name="code_type">discount_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_cef_240_boleto_discount_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_cef_240_boleto_discount_code.xml
@@ -14,7 +14,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -25,7 +25,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -36,7 +36,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_cef_240_boleto_protest_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_cef_240_boleto_protest_code.xml
@@ -11,7 +11,10 @@
         <field name="name">Protestar</field>
         <field name="code">1</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -28,7 +31,10 @@ cobrança), o título será registrado com instrução de devolução, sendo o P
         <field name="name">Não Protestar</field>
         <field name="code">3</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -41,7 +47,10 @@ cobrança), o título será registrado com instrução de devolução, sendo o P
         >Cancelamento Protesto Automático (Somente válido p/ Código Movimento Remessa = ‘31’ - Alteração de Outros Dados), vide nota C004.</field>
         <field name="code">2</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_cef_240_boleto_protest_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_cef_240_boleto_protest_code.xml
@@ -14,7 +14,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"
@@ -31,7 +31,7 @@ cobrança), o título será registrado com instrução de devolução, sendo o P
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -44,7 +44,7 @@ cobrança), o título será registrado com instrução de devolução, sendo o P
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_cef_cnab_240.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_cef_cnab_240.xml
@@ -14,7 +14,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_instruction_02" model="l10n_br_cnab.code">
@@ -25,7 +28,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_instruction_04" model="l10n_br_cnab.code">
@@ -36,7 +42,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_instruction_05" model="l10n_br_cnab.code">
@@ -47,7 +56,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_instruction_06" model="l10n_br_cnab.code">
@@ -58,7 +70,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_instruction_07" model="l10n_br_cnab.code">
@@ -69,7 +84,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_instruction_08" model="l10n_br_cnab.code">
@@ -80,7 +98,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_instruction_09" model="l10n_br_cnab.code">
@@ -91,7 +112,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_instruction_10" model="l10n_br_cnab.code">
@@ -102,7 +126,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_instruction_11" model="l10n_br_cnab.code">
@@ -113,7 +140,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_instruction_31" model="l10n_br_cnab.code">
@@ -124,7 +154,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_instruction_33" model="l10n_br_cnab.code">
@@ -135,7 +168,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_instruction_36" model="l10n_br_cnab.code">
@@ -146,7 +182,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_instruction_37" model="l10n_br_cnab.code">
@@ -157,7 +196,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_instruction_38" model="l10n_br_cnab.code">
@@ -168,7 +210,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_instruction_40" model="l10n_br_cnab.code">
@@ -179,7 +224,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_instruction_47" model="l10n_br_cnab.code">
@@ -190,7 +238,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_instruction_48" model="l10n_br_cnab.code">
@@ -201,7 +252,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <!-- Codigo de Retorno do Movimento -->
@@ -213,7 +267,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_02" model="l10n_br_cnab.code">
@@ -224,7 +281,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_03" model="l10n_br_cnab.code">
@@ -235,7 +295,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_04" model="l10n_br_cnab.code">
@@ -246,7 +309,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_05" model="l10n_br_cnab.code">
@@ -257,7 +323,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_06" model="l10n_br_cnab.code">
@@ -268,7 +337,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_07" model="l10n_br_cnab.code">
@@ -279,7 +351,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_08" model="l10n_br_cnab.code">
@@ -292,7 +367,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_09" model="l10n_br_cnab.code">
@@ -303,7 +381,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_12" model="l10n_br_cnab.code">
@@ -314,7 +395,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_13" model="l10n_br_cnab.code">
@@ -327,7 +411,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_14" model="l10n_br_cnab.code">
@@ -340,7 +427,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_19" model="l10n_br_cnab.code">
@@ -351,7 +441,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_20" model="l10n_br_cnab.code">
@@ -364,7 +457,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_23" model="l10n_br_cnab.code">
@@ -375,7 +471,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_24" model="l10n_br_cnab.code">
@@ -386,7 +485,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_25" model="l10n_br_cnab.code">
@@ -397,7 +499,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_26" model="l10n_br_cnab.code">
@@ -408,7 +513,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_27" model="l10n_br_cnab.code">
@@ -419,7 +527,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_28" model="l10n_br_cnab.code">
@@ -430,7 +541,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_30" model="l10n_br_cnab.code">
@@ -441,7 +555,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_35" model="l10n_br_cnab.code">
@@ -452,7 +569,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_36" model="l10n_br_cnab.code">
@@ -463,7 +583,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_37" model="l10n_br_cnab.code">
@@ -474,7 +597,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_38" model="l10n_br_cnab.code">
@@ -485,7 +611,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_39" model="l10n_br_cnab.code">
@@ -496,7 +625,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_40" model="l10n_br_cnab.code">
@@ -507,7 +639,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_41" model="l10n_br_cnab.code">
@@ -518,7 +653,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_44" model="l10n_br_cnab.code">
@@ -529,7 +667,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_45" model="l10n_br_cnab.code">
@@ -540,7 +681,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_46" model="l10n_br_cnab.code">
@@ -551,7 +695,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_47" model="l10n_br_cnab.code">
@@ -562,7 +709,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_51" model="l10n_br_cnab.code">
@@ -573,7 +723,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_52" model="l10n_br_cnab.code">
@@ -584,7 +737,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_53" model="l10n_br_cnab.code">
@@ -595,7 +751,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_61" model="l10n_br_cnab.code">
@@ -606,7 +765,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
     <record id="cef_240_return_62" model="l10n_br_cnab.code">
@@ -619,7 +781,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_104'))]"
+        />
     </record>
 
 </odoo>

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_cef_cnab_240.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_cef_cnab_240.xml
@@ -12,7 +12,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -23,7 +23,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -34,7 +34,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -45,7 +45,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -56,7 +56,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -67,7 +67,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -78,7 +78,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -89,7 +89,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -100,7 +100,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -111,7 +111,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -122,7 +122,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -133,7 +133,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -144,7 +144,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -155,7 +155,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -166,7 +166,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -177,7 +177,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -188,7 +188,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -199,7 +199,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -211,7 +211,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -222,7 +222,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -233,7 +233,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -244,7 +244,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -255,7 +255,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -266,7 +266,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -277,7 +277,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -290,7 +290,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -301,7 +301,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -312,7 +312,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -325,7 +325,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -338,7 +338,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -349,7 +349,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -362,7 +362,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -373,7 +373,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -384,7 +384,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -395,7 +395,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -406,7 +406,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -417,7 +417,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -428,7 +428,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -439,7 +439,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -450,7 +450,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -461,7 +461,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -472,7 +472,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -483,7 +483,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -494,7 +494,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -505,7 +505,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -516,7 +516,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -527,7 +527,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -538,7 +538,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -549,7 +549,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -560,7 +560,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -571,7 +571,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -582,7 +582,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -593,7 +593,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -604,7 +604,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>
@@ -617,7 +617,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_104')])]" />
     </record>

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_do_brasil_240_boleto_discount_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_do_brasil_240_boleto_discount_code.xml
@@ -18,7 +18,10 @@
         <field name="name">Valor Fixo Até a Data Informada</field>
         <field name="code">1</field>
         <field name="code_type">discount_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -33,7 +36,10 @@
         <field name="name">Percentual Até a Data Informada</field>
         <field name="code">2</field>
         <field name="code_type">discount_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -48,7 +54,10 @@
         <field name="name">Valor por Antecipação Dia Corrido</field>
         <field name="code">3</field>
         <field name="code_type">discount_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_do_brasil_240_boleto_discount_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_do_brasil_240_boleto_discount_code.xml
@@ -21,7 +21,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"
@@ -36,7 +36,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"
@@ -51,7 +51,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_do_brasil_240_boleto_protest_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_do_brasil_240_boleto_protest_code.xml
@@ -11,7 +11,10 @@
         <field name="name">Protestar dias corridos</field>
         <field name="code">1</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -26,7 +29,10 @@
         <field name="name">Protestar dias úteis</field>
         <field name="code">2</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -41,7 +47,10 @@
         <field name="name">Não protestar</field>
         <field name="code">3</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_do_brasil_240_boleto_protest_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_do_brasil_240_boleto_protest_code.xml
@@ -14,7 +14,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"
@@ -29,7 +29,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"
@@ -44,7 +44,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_do_brasil_cnab_240.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_do_brasil_cnab_240.xml
@@ -20,7 +20,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_240_instruction_02" model="l10n_br_cnab.code">
@@ -31,7 +34,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_240_instruction_04" model="l10n_br_cnab.code">
@@ -42,7 +48,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_240_instruction_05" model="l10n_br_cnab.code">
@@ -53,7 +62,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_240_instruction_06" model="l10n_br_cnab.code">
@@ -64,7 +76,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_240_instruction_07" model="l10n_br_cnab.code">
@@ -75,7 +90,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_240_instruction_08" model="l10n_br_cnab.code">
@@ -86,7 +104,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_240_instruction_09" model="l10n_br_cnab.code">
@@ -97,7 +118,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_240_instruction_10" model="l10n_br_cnab.code">
@@ -108,7 +132,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_240_instruction_12" model="l10n_br_cnab.code">
@@ -119,7 +146,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_240_instruction_13" model="l10n_br_cnab.code">
@@ -130,7 +160,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_240_instruction_14" model="l10n_br_cnab.code">
@@ -141,7 +174,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_240_instruction_15" model="l10n_br_cnab.code">
@@ -152,7 +188,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_240_instruction_16" model="l10n_br_cnab.code">
@@ -163,7 +202,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_240_instruction_19" model="l10n_br_cnab.code">
@@ -174,7 +216,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_240_instruction_20" model="l10n_br_cnab.code">
@@ -185,7 +230,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_240_instruction_21" model="l10n_br_cnab.code">
@@ -196,7 +244,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_240_instruction_22" model="l10n_br_cnab.code">
@@ -207,7 +258,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_240_instruction_23" model="l10n_br_cnab.code">
@@ -218,7 +272,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_240_instruction_30" model="l10n_br_cnab.code">
@@ -229,7 +286,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_240_instruction_31" model="l10n_br_cnab.code">
@@ -240,7 +300,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_240_instruction_34" model="l10n_br_cnab.code">
@@ -251,7 +314,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_240_instruction_40" model="l10n_br_cnab.code">
@@ -262,7 +328,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_240_instruction_45" model="l10n_br_cnab.code">
@@ -275,7 +344,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_240_instruction_46" model="l10n_br_cnab.code">
@@ -286,7 +358,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_240_instruction_47" model="l10n_br_cnab.code">
@@ -297,7 +372,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <!-- Códigos de movimento de retorno -->
@@ -305,7 +383,10 @@
         <field name="name">Entrada confirmada</field>
         <field name="code">02</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -316,7 +397,10 @@
         <field name="name">Entrada Rejeitada</field>
         <field name="code">03</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -327,7 +411,10 @@
         <field name="name">Transferência de Carteira/Entrada</field>
         <field name="code">04</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -338,7 +425,10 @@
         <field name="name">Transferência de Carteira/Baixa</field>
         <field name="code">05</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -349,7 +439,10 @@
         <field name="name">Liquidação</field>
         <field name="code">06</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -360,7 +453,10 @@
         <field name="name">Baixa</field>
         <field name="code">09</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -371,7 +467,10 @@
         <field name="name">Títulos em Carteira (em ser)</field>
         <field name="code">11</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -382,7 +481,10 @@
         <field name="name">Confirmação Recebimento Instrução de Abatimento</field>
         <field name="code">12</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -395,7 +497,10 @@
         >Confirmação Recebimento Instrução de Cancelamento Abatimento</field>
         <field name="code">13</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -408,7 +513,10 @@
         >Confirmação Recebimento Instrução Alteração de Vencimento</field>
         <field name="code">14</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -419,7 +527,10 @@
         <field name="name">Franco de Pagamento</field>
         <field name="code">15</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -430,7 +541,10 @@
         <field name="name">Confirmação do Pedido de Alteração de Juros</field>
         <field name="code">16</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -443,7 +557,10 @@
         >Liquidação Após Baixa ou Liquidação Título Não Registrado</field>
         <field name="code">17</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -454,7 +571,10 @@
         <field name="name">Confirmação Recebimento Instrução de Protesto</field>
         <field name="code">19</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -467,7 +587,10 @@
         >Confirmação Recebimento Instrução de Sustação/Cancelamento de Protesto</field>
         <field name="code">20</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -478,7 +601,10 @@
         <field name="name">Remessa a Cartório (Aponte em Cartório)</field>
         <field name="code">23</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -489,7 +615,10 @@
         <field name="name">Retirada de Cartório e Manutenção em Carteira</field>
         <field name="code">24</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -500,7 +629,10 @@
         <field name="name">Protestado e Baixado (Baixa por ter sido Protestado)</field>
         <field name="code">25</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -511,7 +643,10 @@
         <field name="name">Instrução Rejeitada</field>
         <field name="code">26</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -522,7 +657,10 @@
         <field name="name">Confirmação do Pedido de Alteração de Outros Dados</field>
         <field name="code">27</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -533,7 +671,10 @@
         <field name="name">Débito de Tarifas/Custas</field>
         <field name="code">28</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -544,7 +685,10 @@
         <field name="name">Ocorrências do Sacado</field>
         <field name="code">29</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -555,7 +699,10 @@
         <field name="name">Alteração de Dados Rejeitada</field>
         <field name="code">30</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -566,7 +713,10 @@
         <field name="name">Título pago com cheque devolvido</field>
         <field name="code">44</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -577,7 +727,10 @@
         <field name="name">Título pago com cheque pendente de Compensação</field>
         <field name="code">50</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -590,7 +743,10 @@
         >Confirmação do Pedido de Retificação do Valor de Desconto</field>
         <field name="code">58</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -603,7 +759,10 @@
         >Confirmação do Pedido de Alteração da Data do Desconto</field>
         <field name="code">59</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -614,7 +773,10 @@
         <field name="name">Confirmação do Pedido de Dispensa de Juros</field>
         <field name="code">60</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -625,7 +787,10 @@
         <field name="name">Confirmação de Alteração de Valor Nominal do Boleto</field>
         <field name="code">61</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -636,7 +801,10 @@
         <field name="name">Inclusão de Negativação</field>
         <field name="code">85</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -647,7 +815,10 @@
         <field name="name">Exclusão de Negativação</field>
         <field name="code">86</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -658,7 +829,10 @@
         <field name="name">Baixa Operacional</field>
         <field name="code">93</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_do_brasil_cnab_240.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_do_brasil_cnab_240.xml
@@ -18,7 +18,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -29,7 +29,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -40,7 +40,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -51,7 +51,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -62,7 +62,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -73,7 +73,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -84,7 +84,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -95,7 +95,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -106,7 +106,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -117,7 +117,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -128,7 +128,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -139,7 +139,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -150,7 +150,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -161,7 +161,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -172,7 +172,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -183,7 +183,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -194,7 +194,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -205,7 +205,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -216,7 +216,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -227,7 +227,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -238,7 +238,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -249,7 +249,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -260,7 +260,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -273,7 +273,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -284,7 +284,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -295,7 +295,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -308,7 +308,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -319,7 +319,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -330,7 +330,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -341,7 +341,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -352,7 +352,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -363,7 +363,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -374,7 +374,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -385,7 +385,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -398,7 +398,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -411,7 +411,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -422,7 +422,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -433,7 +433,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -446,7 +446,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -457,7 +457,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -470,7 +470,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -481,7 +481,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -492,7 +492,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -503,7 +503,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -514,7 +514,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -525,7 +525,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -536,7 +536,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -547,7 +547,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -558,7 +558,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -569,7 +569,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -580,7 +580,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -593,7 +593,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -606,7 +606,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -617,7 +617,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -628,7 +628,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -639,7 +639,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -650,7 +650,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -661,7 +661,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_do_brasil_cnab_400.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_do_brasil_cnab_400.xml
@@ -13,7 +13,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_400_instruction_02" model="l10n_br_cnab.code">
@@ -24,7 +27,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_400_instruction_03" model="l10n_br_cnab.code">
@@ -35,7 +41,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_400_instruction_04" model="l10n_br_cnab.code">
@@ -46,7 +55,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_400_instruction_05" model="l10n_br_cnab.code">
@@ -57,7 +69,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_400_instruction_06" model="l10n_br_cnab.code">
@@ -68,7 +83,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_400_instruction_07" model="l10n_br_cnab.code">
@@ -79,7 +97,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_400_instruction_08" model="l10n_br_cnab.code">
@@ -90,7 +111,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_400_instruction_09" model="l10n_br_cnab.code">
@@ -101,7 +125,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_400_instruction_10" model="l10n_br_cnab.code">
@@ -112,7 +139,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_400_instruction_11" model="l10n_br_cnab.code">
@@ -123,7 +153,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_400_instruction_12" model="l10n_br_cnab.code">
@@ -134,7 +167,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_400_instruction_16" model="l10n_br_cnab.code">
@@ -145,7 +181,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_400_instruction_31" model="l10n_br_cnab.code">
@@ -156,7 +195,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_400_instruction_32" model="l10n_br_cnab.code">
@@ -167,7 +209,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_400_instruction_33" model="l10n_br_cnab.code">
@@ -178,7 +223,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_400_instruction_34" model="l10n_br_cnab.code">
@@ -189,7 +237,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_400_instruction_35" model="l10n_br_cnab.code">
@@ -200,7 +251,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_400_instruction_36" model="l10n_br_cnab.code">
@@ -211,7 +265,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_400_instruction_37" model="l10n_br_cnab.code">
@@ -222,7 +279,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_400_instruction_38" model="l10n_br_cnab.code">
@@ -233,7 +293,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_400_instruction_39" model="l10n_br_cnab.code">
@@ -244,7 +307,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_400_instruction_40" model="l10n_br_cnab.code">
@@ -255,7 +321,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_400_instruction_47" model="l10n_br_cnab.code">
@@ -266,7 +335,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_400_instruction_85" model="l10n_br_cnab.code">
@@ -279,7 +351,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <record id="brasil_400_instruction_86" model="l10n_br_cnab.code">
@@ -290,7 +365,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
     </record>
 
     <!-- Codigo de Retorno do Movimento -->
@@ -298,7 +376,10 @@
         <field name="name">Confirmação de Entrada de Boleto</field>
         <field name="code">02</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -309,7 +390,10 @@
         <field name="name">Comando recusado (Motivo indicado na posição 087/088)</field>
         <field name="code">03</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -320,7 +404,10 @@
         <field name="name">Liquidado sem registro (carteira 17-tipo4)</field>
         <field name="code">05</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -331,7 +418,10 @@
         <field name="name">Liquidação Normal)</field>
         <field name="code">06</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -342,7 +432,10 @@
         <field name="name">Liquidação por Conta/Parcial</field>
         <field name="code">07</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -353,7 +446,10 @@
         <field name="name">Liquidação por Saldo</field>
         <field name="code">08</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -364,7 +460,10 @@
         <field name="name">Baixa de Titulo</field>
         <field name="code">09</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -375,7 +474,10 @@
         <field name="name">Baixa Solicitada</field>
         <field name="code">10</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -388,7 +490,10 @@
         >Boletos em Ser (constara somente do arquivo de existência de cobrança, fornecido mediante solicitação do cliente)</field>
         <field name="code">11</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -399,7 +504,10 @@
         <field name="name">Abatimento Concedido</field>
         <field name="code">12</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -410,7 +518,10 @@
         <field name="name">Abatimento Cancelado</field>
         <field name="code">13</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -421,7 +532,10 @@
         <field name="name">Alteração de Vencimento do boleto</field>
         <field name="code">14</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -432,7 +546,10 @@
         <field name="name">Liquidação em Cartório</field>
         <field name="code">15</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -443,7 +560,10 @@
         <field name="name">Confirmação de alteração de juros de mora</field>
         <field name="code">16</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -456,7 +576,10 @@
         >Confirmação de recebimento de instruções para protesto</field>
         <field name="code">19</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -467,7 +590,10 @@
         <field name="name">Débito em Conta</field>
         <field name="code">20</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -478,7 +604,10 @@
         <field name="name">Alteração do Nome do Sacado</field>
         <field name="code">21</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -489,7 +618,10 @@
         <field name="name">Alteração do Endereço do Sacado</field>
         <field name="code">22</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -500,7 +632,10 @@
         <field name="name">Indicação de encaminhamento a cartório</field>
         <field name="code">23</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -511,7 +646,10 @@
         <field name="name">Sustar Protesto</field>
         <field name="code">24</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -522,7 +660,10 @@
         <field name="name">Dispensar Juros de mora</field>
         <field name="code">25</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -535,7 +676,10 @@
         >Alteração do número do boleto dado pelo Cedente (Seu número) – 10 e 15 posições</field>
         <field name="code">26</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -546,7 +690,10 @@
         <field name="name">Manutenção de titulo vencido</field>
         <field name="code">28</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -557,7 +704,10 @@
         <field name="name">Conceder desconto</field>
         <field name="code">31</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -568,7 +718,10 @@
         <field name="name">Não conceder desconto</field>
         <field name="code">32</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -579,7 +732,10 @@
         <field name="name">Retificar desconto</field>
         <field name="code">33</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -590,7 +746,10 @@
         <field name="name">Cobrar Multa</field>
         <field name="code">35</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -601,7 +760,10 @@
         <field name="name">Dispensar Multa</field>
         <field name="code">36</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -612,7 +774,10 @@
         <field name="name">Dispensar Indexador</field>
         <field name="code">37</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -623,7 +788,10 @@
         <field name="name">Dispensar prazo limite para recebimento</field>
         <field name="code">38</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -634,7 +802,10 @@
         <field name="name">Alterar prazo limite para recebimento</field>
         <field name="code">39</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -647,7 +818,10 @@
         >Alteração do número do controle do participante (25 posições)</field>
         <field name="code">41</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -658,7 +832,10 @@
         <field name="name">Alteração do número do documento do sacado (CNPJ/CPF)</field>
         <field name="code">42</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -669,7 +846,10 @@
         <field name="name">Boleto pago com cheque devolvido)</field>
         <field name="code">44</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -680,7 +860,10 @@
         <field name="name">Boleto pago com cheque, aguardando compensação)</field>
         <field name="code">46</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -691,7 +874,10 @@
         <field name="name">Alteração de valor nominal do boleto</field>
         <field name="code">47</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -702,7 +888,10 @@
         <field name="name">Registrado QR Code Pix</field>
         <field name="code">61</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -715,7 +904,10 @@
         >Alteração de tipo de cobrança (específico para boletos das carteiras 11 e 17)</field>
         <field name="code">72</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -728,7 +920,10 @@
         >Confirmação de Instrução de Parâmetro de Pagamento Parcial</field>
         <field name="code">73</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -739,7 +934,10 @@
         <field name="name">Inclusão de Negativação</field>
         <field name="code">85</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -750,7 +948,10 @@
         <field name="name">Exclusão de Negativação</field>
         <field name="code">86</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -761,7 +962,10 @@
         <field name="name">Baixa Operacional</field>
         <field name="code">93</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -772,7 +976,10 @@
         <field name="name">Despesas de Protesto</field>
         <field name="code">96</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -783,7 +990,10 @@
         <field name="name">Despesas de Sustação de Protesto</field>
         <field name="code">97</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -794,7 +1004,10 @@
         <field name="name">Débito de Custas Antecipadas</field>
         <field name="code">98</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_001'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_do_brasil_cnab_400.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_do_brasil_cnab_400.xml
@@ -11,7 +11,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -22,7 +22,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -33,7 +33,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -44,7 +44,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -55,7 +55,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -66,7 +66,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -77,7 +77,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -88,7 +88,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -99,7 +99,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -110,7 +110,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -121,7 +121,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -132,7 +132,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -143,7 +143,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -154,7 +154,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -165,7 +165,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -176,7 +176,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -187,7 +187,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -198,7 +198,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -209,7 +209,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -220,7 +220,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -231,7 +231,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -242,7 +242,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -253,7 +253,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -264,7 +264,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -277,7 +277,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -288,7 +288,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
     </record>
@@ -301,7 +301,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -312,7 +312,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -323,7 +323,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -334,7 +334,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -345,7 +345,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -356,7 +356,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -367,7 +367,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -378,7 +378,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -391,7 +391,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -402,7 +402,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -413,7 +413,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -424,7 +424,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -435,7 +435,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -446,7 +446,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -459,7 +459,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -470,7 +470,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -481,7 +481,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -492,7 +492,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -503,7 +503,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -514,7 +514,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -525,7 +525,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -538,7 +538,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -549,7 +549,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -560,7 +560,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -571,7 +571,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -582,7 +582,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -593,7 +593,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -604,7 +604,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -615,7 +615,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -626,7 +626,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -637,7 +637,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -650,7 +650,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -661,7 +661,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -672,7 +672,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -683,7 +683,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -694,7 +694,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -705,7 +705,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -718,7 +718,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -731,7 +731,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -742,7 +742,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -753,7 +753,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -764,7 +764,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -775,7 +775,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -786,7 +786,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -797,7 +797,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_001')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_do_nordeste_cnab_400.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_do_nordeste_cnab_400.xml
@@ -18,7 +18,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
     </record>
 
     <record id="nordeste_400_instruction_02" model="l10n_br_cnab.code">
@@ -29,7 +32,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
     </record>
 
     <record id="nordeste_400_instruction_04" model="l10n_br_cnab.code">
@@ -40,7 +46,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
     </record>
 
     <record id="nordeste_400_instruction_06" model="l10n_br_cnab.code">
@@ -51,7 +60,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
     </record>
 
     <record id="nordeste_400_instruction_07" model="l10n_br_cnab.code">
@@ -62,7 +74,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
     </record>
 
     <record id="nordeste_400_instruction_08" model="l10n_br_cnab.code">
@@ -73,7 +88,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
     </record>
 
     <record id="nordeste_400_instruction_09" model="l10n_br_cnab.code">
@@ -84,7 +102,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
     </record>
 
     <record id="nordeste_400_instruction_10" model="l10n_br_cnab.code">
@@ -95,7 +116,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
     </record>
 
     <record id="nordeste_400_instruction_11" model="l10n_br_cnab.code">
@@ -106,7 +130,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
     </record>
 
     <record id="nordeste_400_instruction_12" model="l10n_br_cnab.code">
@@ -117,7 +144,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
     </record>
 
     <record id="nordeste_400_instruction_13" model="l10n_br_cnab.code">
@@ -128,7 +158,7 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-	<field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+	<field name="bank_ids" eval="[Command.link(ref('l10n_br_base.res_bank_004'))]" />
         <field
             name="comment"
         >- Quando utilizar o serviço 13, informar no campo vencimento a data da ocorrência a ser excluída.
@@ -145,7 +175,7 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-	<field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+	<field name="bank_ids" eval="[Command.link(ref('l10n_br_base.res_bank_004'))]" />
         <field
             name="comment"
         >OBS.: - Quando utilizar o serviço 31, informar a identificação do título e os campos que devem ser alterados. Os demais campos devem ficar com espaços.
@@ -160,7 +190,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
     </record>
 
     <record id="nordeste_400_instruction_33" model="l10n_br_cnab.code">
@@ -171,7 +204,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
     </record>
 
     <record id="nordeste_400_instruction_99" model="l10n_br_cnab.code">
@@ -182,7 +218,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
     </record>
 
     <!-- Codigo de Retorno do Movimento -->
@@ -190,7 +229,10 @@
         <field name="name">Entrada Confirmada.</field>
         <field name="code">02</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -201,7 +243,10 @@
         <field name="name">Alteração.</field>
         <field name="code">04</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -212,7 +257,10 @@
         <field name="name">Liquidação Normal.</field>
         <field name="code">06</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -223,7 +271,10 @@
         <field name="name">Pagamento por Conta.</field>
         <field name="code">07</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -234,7 +285,10 @@
         <field name="name">Pagamento por Cartório.</field>
         <field name="code">08</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -245,7 +299,10 @@
         <field name="name">Baixa Simples.</field>
         <field name="code">09</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -256,7 +313,10 @@
         <field name="name">Devolvido / Protestado</field>
         <field name="code">10</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -267,7 +327,10 @@
         <field name="name">Em ser.</field>
         <field name="code">11</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -278,7 +341,10 @@
         <field name="name">Abatimento Concedido.</field>
         <field name="code">12</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -289,7 +355,10 @@
         <field name="name">Abatimento Cancelado.</field>
         <field name="code">13</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -300,7 +369,10 @@
         <field name="name">Vencimento Alterado.</field>
         <field name="code">14</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -311,7 +383,10 @@
         <field name="name">Baixa Automática</field>
         <field name="code">15</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -322,7 +397,10 @@
         <field name="name">Alteração Depositária.</field>
         <field name="code">18</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -333,7 +411,10 @@
         <field name="name">Confirmação de Protesto.</field>
         <field name="code">19</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -344,7 +425,10 @@
         <field name="name">Confirmação de Sustar Protesto</field>
         <field name="code">20</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -355,7 +439,10 @@
         <field name="name">Alteração Informações de Controle da Empresa</field>
         <field name="code">21</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -366,7 +453,10 @@
         <field name="name">Alteração "Seu Número".</field>
         <field name="code">22</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -377,7 +467,10 @@
         <field name="name">Entrada Rejeitada.</field>
         <field name="code">51</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_004'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_do_nordeste_cnab_400.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_do_nordeste_cnab_400.xml
@@ -16,7 +16,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
     </record>
@@ -27,7 +27,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
     </record>
@@ -38,7 +38,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
     </record>
@@ -49,7 +49,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
     </record>
@@ -60,7 +60,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
     </record>
@@ -71,7 +71,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
     </record>
@@ -82,7 +82,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
     </record>
@@ -93,7 +93,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
     </record>
@@ -104,7 +104,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
     </record>
@@ -115,7 +115,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
     </record>
@@ -126,7 +126,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
 	<field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
         <field
@@ -143,7 +143,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
 	<field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
         <field
@@ -158,7 +158,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
     </record>
@@ -169,7 +169,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
     </record>
@@ -180,7 +180,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
     </record>
@@ -193,7 +193,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -204,7 +204,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -215,7 +215,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -226,7 +226,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -237,7 +237,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -248,7 +248,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -259,7 +259,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -270,7 +270,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -281,7 +281,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -292,7 +292,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -303,7 +303,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -314,7 +314,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -325,7 +325,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -336,7 +336,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -347,7 +347,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -358,7 +358,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -369,7 +369,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -380,7 +380,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_004')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_itau_240_boleto_protest_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_itau_240_boleto_protest_code.xml
@@ -11,7 +11,10 @@
         <field name="name">Sem instrução</field>
         <field name="code">0</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -22,7 +25,10 @@
         <field name="name">Protestar (Dias Corridos)</field>
         <field name="code">1</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -39,7 +45,10 @@ dias (corridos) após o vencimento, de acordo com a ocorrência.
         <field name="name">Protestar (Dias Úteis)</field>
         <field name="code">2</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -56,7 +65,10 @@ dias (corridos) após o vencimento, de acordo com a ocorrência.
         <field name="name">Não protestar</field>
         <field name="code">3</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -67,7 +79,10 @@ dias (corridos) após o vencimento, de acordo com a ocorrência.
         <field name="name">Negativar (Dias Corridos)</field>
         <field name="code">7</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -84,7 +99,10 @@ dias (corridos) após o vencimento, de acordo com a ocorrência.
         <field name="name">Não Negativar</field>
         <field name="code">8</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_itau_240_boleto_protest_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_itau_240_boleto_protest_code.xml
@@ -14,7 +14,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -25,7 +25,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"
@@ -42,7 +42,7 @@ dias (corridos) após o vencimento, de acordo com a ocorrência.
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"
@@ -59,7 +59,7 @@ dias (corridos) após o vencimento, de acordo com a ocorrência.
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -70,7 +70,7 @@ dias (corridos) após o vencimento, de acordo com a ocorrência.
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"
@@ -87,7 +87,7 @@ dias (corridos) após o vencimento, de acordo com a ocorrência.
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_itau_cnab_240_400.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_itau_cnab_240_400.xml
@@ -13,7 +13,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_instruction_02" model="l10n_br_cnab.code">
@@ -24,7 +27,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_instruction_04" model="l10n_br_cnab.code">
@@ -35,7 +41,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_instruction_05" model="l10n_br_cnab.code">
@@ -46,7 +55,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_instruction_06" model="l10n_br_cnab.code">
@@ -57,7 +69,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_instruction_09" model="l10n_br_cnab.code">
@@ -68,7 +83,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_instruction_10" model="l10n_br_cnab.code">
@@ -79,7 +97,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_instruction_18" model="l10n_br_cnab.code">
@@ -90,7 +111,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_instruction_31" model="l10n_br_cnab.code">
@@ -101,7 +125,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_instruction_38" model="l10n_br_cnab.code">
@@ -114,7 +141,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_instruction_41" model="l10n_br_cnab.code">
@@ -125,7 +155,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_instruction_49" model="l10n_br_cnab.code">
@@ -136,7 +169,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_instruction_66" model="l10n_br_cnab.code">
@@ -147,7 +183,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_instruction_67" model="l10n_br_cnab.code">
@@ -158,7 +197,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_instruction_68" model="l10n_br_cnab.code">
@@ -170,7 +212,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_instruction_69" model="l10n_br_cnab.code">
@@ -182,7 +227,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_instruction_93" model="l10n_br_cnab.code">
@@ -193,7 +241,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <!-- Codigo de Retorno do Movimento -->
@@ -207,7 +258,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_03" model="l10n_br_cnab.code">
@@ -218,7 +272,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_04" model="l10n_br_cnab.code">
@@ -231,7 +288,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_05" model="l10n_br_cnab.code">
@@ -242,7 +302,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_06" model="l10n_br_cnab.code">
@@ -253,7 +316,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_08" model="l10n_br_cnab.code">
@@ -264,7 +330,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_09" model="l10n_br_cnab.code">
@@ -275,7 +344,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_10" model="l10n_br_cnab.code">
@@ -286,7 +358,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_11" model="l10n_br_cnab.code">
@@ -297,7 +372,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_12" model="l10n_br_cnab.code">
@@ -308,7 +386,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_13" model="l10n_br_cnab.code">
@@ -319,7 +400,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_14" model="l10n_br_cnab.code">
@@ -330,7 +414,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_15" model="l10n_br_cnab.code">
@@ -341,7 +428,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_16" model="l10n_br_cnab.code">
@@ -352,7 +442,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_17" model="l10n_br_cnab.code">
@@ -365,7 +458,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_18" model="l10n_br_cnab.code">
@@ -378,7 +474,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_19" model="l10n_br_cnab.code">
@@ -389,7 +488,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_20" model="l10n_br_cnab.code">
@@ -402,7 +504,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_21" model="l10n_br_cnab.code">
@@ -413,7 +518,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_23" model="l10n_br_cnab.code">
@@ -424,7 +532,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_24" model="l10n_br_cnab.code">
@@ -435,7 +546,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_25" model="l10n_br_cnab.code">
@@ -446,7 +560,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_26" model="l10n_br_cnab.code">
@@ -457,7 +574,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_27" model="l10n_br_cnab.code">
@@ -468,7 +588,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_28" model="l10n_br_cnab.code">
@@ -479,7 +602,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_29" model="l10n_br_cnab.code">
@@ -490,7 +616,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_30" model="l10n_br_cnab.code">
@@ -501,7 +630,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_32" model="l10n_br_cnab.code">
@@ -512,7 +644,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_33" model="l10n_br_cnab.code">
@@ -523,7 +658,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_34" model="l10n_br_cnab.code">
@@ -534,7 +672,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_35" model="l10n_br_cnab.code">
@@ -545,7 +686,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_36" model="l10n_br_cnab.code">
@@ -556,7 +700,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_37" model="l10n_br_cnab.code">
@@ -569,7 +716,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_38" model="l10n_br_cnab.code">
@@ -580,7 +730,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_39" model="l10n_br_cnab.code">
@@ -591,7 +744,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_40" model="l10n_br_cnab.code">
@@ -604,7 +760,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_41" model="l10n_br_cnab.code">
@@ -617,7 +776,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_42" model="l10n_br_cnab.code">
@@ -628,7 +790,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_43" model="l10n_br_cnab.code">
@@ -641,7 +806,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_44" model="l10n_br_cnab.code">
@@ -652,7 +820,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_45" model="l10n_br_cnab.code">
@@ -663,7 +834,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_46" model="l10n_br_cnab.code">
@@ -674,7 +848,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_47" model="l10n_br_cnab.code">
@@ -685,7 +862,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_48" model="l10n_br_cnab.code">
@@ -696,7 +876,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_51" model="l10n_br_cnab.code">
@@ -709,7 +892,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_52" model="l10n_br_cnab.code">
@@ -720,7 +906,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_53" model="l10n_br_cnab.code">
@@ -733,7 +922,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_54" model="l10n_br_cnab.code">
@@ -744,7 +936,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_55" model="l10n_br_cnab.code">
@@ -757,7 +952,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_56" model="l10n_br_cnab.code">
@@ -768,7 +966,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_57" model="l10n_br_cnab.code">
@@ -779,7 +980,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_60" model="l10n_br_cnab.code">
@@ -790,7 +994,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_61" model="l10n_br_cnab.code">
@@ -803,7 +1010,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_62" model="l10n_br_cnab.code">
@@ -816,7 +1026,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_63" model="l10n_br_cnab.code">
@@ -827,7 +1040,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_74" model="l10n_br_cnab.code">
@@ -840,7 +1056,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_75" model="l10n_br_cnab.code">
@@ -853,7 +1072,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_77" model="l10n_br_cnab.code">
@@ -866,7 +1088,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_78" model="l10n_br_cnab.code">
@@ -879,7 +1104,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_79" model="l10n_br_cnab.code">
@@ -892,7 +1120,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_80" model="l10n_br_cnab.code">
@@ -905,7 +1136,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_82" model="l10n_br_cnab.code">
@@ -918,7 +1152,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_83" model="l10n_br_cnab.code">
@@ -931,7 +1168,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_85" model="l10n_br_cnab.code">
@@ -944,7 +1184,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_86" model="l10n_br_cnab.code">
@@ -955,7 +1198,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_87" model="l10n_br_cnab.code">
@@ -966,7 +1212,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_88" model="l10n_br_cnab.code">
@@ -979,7 +1228,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_89" model="l10n_br_cnab.code">
@@ -990,7 +1242,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_90" model="l10n_br_cnab.code">
@@ -1001,7 +1256,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_91" model="l10n_br_cnab.code">
@@ -1014,7 +1272,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_92" model="l10n_br_cnab.code">
@@ -1025,7 +1286,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_93" model="l10n_br_cnab.code">
@@ -1038,7 +1302,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_240_return_94" model="l10n_br_cnab.code">
@@ -1049,7 +1316,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <!-- CNAB 400 -->
@@ -1064,7 +1334,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_400_instruction_02" model="l10n_br_cnab.code">
@@ -1075,7 +1348,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_400_instruction_04" model="l10n_br_cnab.code">
@@ -1086,7 +1362,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_400_instruction_05" model="l10n_br_cnab.code">
@@ -1097,7 +1376,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_400_instruction_06" model="l10n_br_cnab.code">
@@ -1108,7 +1390,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_400_instruction_07" model="l10n_br_cnab.code">
@@ -1119,7 +1404,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_400_instruction_08" model="l10n_br_cnab.code">
@@ -1130,7 +1418,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_400_instruction_09" model="l10n_br_cnab.code">
@@ -1141,7 +1432,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_400_instruction_10" model="l10n_br_cnab.code">
@@ -1152,7 +1446,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_400_instruction_11" model="l10n_br_cnab.code">
@@ -1163,7 +1460,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_400_instruction_18" model="l10n_br_cnab.code">
@@ -1174,7 +1474,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_400_instruction_30" model="l10n_br_cnab.code">
@@ -1185,7 +1488,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_400_instruction_31" model="l10n_br_cnab.code">
@@ -1196,7 +1502,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_400_instruction_34" model="l10n_br_cnab.code">
@@ -1207,7 +1516,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_400_instruction_35" model="l10n_br_cnab.code">
@@ -1218,7 +1530,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_400_instruction_37" model="l10n_br_cnab.code">
@@ -1229,7 +1544,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_400_instruction_38" model="l10n_br_cnab.code">
@@ -1242,7 +1560,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_400_instruction_47" model="l10n_br_cnab.code">
@@ -1253,7 +1574,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_400_instruction_49" model="l10n_br_cnab.code">
@@ -1264,7 +1588,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_400_instruction_66" model="l10n_br_cnab.code">
@@ -1275,7 +1602,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_400_instruction_67" model="l10n_br_cnab.code">
@@ -1288,7 +1618,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_400_instruction_68" model="l10n_br_cnab.code">
@@ -1301,7 +1634,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_400_instruction_69" model="l10n_br_cnab.code">
@@ -1314,7 +1650,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <record id="itau_400_instruction_93" model="l10n_br_cnab.code">
@@ -1325,7 +1664,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
     </record>
 
     <!-- Codigo de Retorno do Movimento -->
@@ -1333,7 +1675,10 @@
         <field name="name">ENTRADA CONFIRMADA COM POSSIBILIDADE DE MENSAGEM</field>
         <field name="code">02</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1344,7 +1689,10 @@
         <field name="name">ENTRADA REJEITADA</field>
         <field name="code">03</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1357,7 +1705,10 @@
         >ALTERAÇÃO DE DADOS – NOVA ENTRADA OU ALTERAÇÃO/EXCLUSÃO DE DADOS ACATADA</field>
         <field name="code">04</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1368,7 +1719,10 @@
         <field name="name">ALTERAÇÃO DE DADOS – BAIXA</field>
         <field name="code">05</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1379,7 +1733,10 @@
         <field name="name">Liquidação Normal</field>
         <field name="code">06</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1390,7 +1747,10 @@
         <field name="name">LIQUIDAÇÃO PARCIAL – COBRANÇA INTELIGENTE (B2B)</field>
         <field name="code">07</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1401,7 +1761,10 @@
         <field name="name">LIQUIDAÇÃO EM CARTÓRIO</field>
         <field name="code">08</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1412,7 +1775,10 @@
         <field name="name">BAIXA SIMPLES</field>
         <field name="code">09</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1423,7 +1789,10 @@
         <field name="name">BAIXA POR TER SIDO LIQUIDADO</field>
         <field name="code">10</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1434,7 +1803,10 @@
         <field name="name">EM SER (SÓ NO RETORNO MENSAL)</field>
         <field name="code">11</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1445,7 +1817,10 @@
         <field name="name">ABATIMENTO CONCEDIDO</field>
         <field name="code">12</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1456,7 +1831,10 @@
         <field name="name">ABATIMENTO CANCELADO</field>
         <field name="code">13</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1467,7 +1845,10 @@
         <field name="name">VENCIMENTO ALTERADO</field>
         <field name="code">14</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1478,7 +1859,10 @@
         <field name="name">BAIXAS REJEITADAS (NOTA 20 – TABELA 4)</field>
         <field name="code">15</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1489,7 +1873,10 @@
         <field name="name">INSTRUÇÕES REJEITADAS (NOTA 20 – TABELA 3)</field>
         <field name="code">16</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1502,7 +1889,10 @@
         >ALTERAÇÃO/EXCLUSÃO DE DADOS REJEITADOS (NOTA 20 – TABELA 2)</field>
         <field name="code">17</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1515,7 +1905,10 @@
         >COBRANÇA CONTRATUAL – INSTRUÇÕES/ALTERAÇÕES REJEITADAS/PENDENTES (NOTA 20 – TABELA 5)</field>
         <field name="code">18</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1526,7 +1919,10 @@
         <field name="name">CONFIRMA RECEBIMENTO DE INSTRUÇÃO DE PROTESTO</field>
         <field name="code">19</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1539,7 +1935,10 @@
         >CONFIRMA RECEBIMENTO DE INSTRUÇÃO DE SUSTAÇÃO DE PROTESTO /TARIFA</field>
         <field name="code">20</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1550,7 +1949,10 @@
         <field name="name">CONFIRMA RECEBIMENTO DE INSTRUÇÃO DE NÃO PROTESTAR</field>
         <field name="code">21</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1561,7 +1963,10 @@
         <field name="name">TÍTULO ENVIADO A CARTÓRIO/TARIFA</field>
         <field name="code">23</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1574,7 +1979,10 @@
         >INSTRUÇÃO DE PROTESTO REJEITADA / SUSTADA / PENDENTE (NOTA 20 – TABELA 7)</field>
         <field name="code">24</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1585,7 +1993,10 @@
         <field name="name">ALEGAÇÕES DO PAGADOR (NOTA 20 – TABELA 6)</field>
         <field name="code">25</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1596,7 +2007,10 @@
         <field name="name">TARIFA DE AVISO DE COBRANÇA</field>
         <field name="code">26</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1607,7 +2021,10 @@
         <field name="name">TARIFA DE EXTRATO POSIÇÃO (B40X)</field>
         <field name="code">27</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1618,7 +2035,10 @@
         <field name="name">TARIFA DE RELAÇÃO DAS LIQUIDAÇÕES</field>
         <field name="code">28</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1629,7 +2049,10 @@
         <field name="name">TARIFA DE MANUTENÇÃO DE TÍTULOS VENCIDOS</field>
         <field name="code">29</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1640,7 +2063,10 @@
         <field name="name">DÉBITO MENSAL DE TARIFAS (PARA ENTRADAS E BAIXAS)</field>
         <field name="code">30</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1651,7 +2077,10 @@
         <field name="name">BAIXA POR TER SIDO PROTESTADO</field>
         <field name="code">32</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1662,7 +2091,10 @@
         <field name="name">CUSTAS DE PROTESTO</field>
         <field name="code">33</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1673,7 +2105,10 @@
         <field name="name">CUSTAS DE SUSTAÇÃO</field>
         <field name="code">34</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1684,7 +2119,10 @@
         <field name="name">CUSTAS DE CARTÓRIO DISTRIBUIDOR</field>
         <field name="code">35</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1695,7 +2133,10 @@
         <field name="name">CUSTAS DE EDITAL</field>
         <field name="code">36</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1708,7 +2149,10 @@
         >TARIFA DE EMISSÃO DE BOLETO/TARIFA DE ENVIO DE DUPLICATA</field>
         <field name="code">37</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1719,7 +2163,10 @@
         <field name="name">TARIFA DE INSTRUÇÃO</field>
         <field name="code">38</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1730,7 +2177,10 @@
         <field name="name">TARIFA DE OCORRÊNCIAS</field>
         <field name="code">39</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1743,7 +2193,10 @@
         >TARIFA MENSAL DE EMISSÃO DE BOLETO/TARIFA MENSAL DE ENVIO DE DUPLICATA</field>
         <field name="code">40</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1756,7 +2209,10 @@
         >DÉBITO MENSAL DE TARIFAS – EXTRATO DE POSIÇÃO (B4EP/B4OX)</field>
         <field name="code">41</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1767,7 +2223,10 @@
         <field name="name">DÉBITO MENSAL DE TARIFAS – OUTRAS INSTRUÇÕES</field>
         <field name="code">42</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1780,7 +2239,10 @@
         >DÉBITO MENSAL DE TARIFAS – MANUTENÇÃO DE TÍTULOS VENCIDOS</field>
         <field name="code">43</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1791,7 +2253,10 @@
         <field name="name">DÉBITO MENSAL DE TARIFAS – OUTRAS OCORRÊNCIAS</field>
         <field name="code">44</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1802,7 +2267,10 @@
         <field name="name">DÉBITO MENSAL DE TARIFAS – PROTESTO</field>
         <field name="code">45</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1813,7 +2281,10 @@
         <field name="name">DÉBITO MENSAL DE TARIFAS – SUSTAÇÃO DE PROTESTO</field>
         <field name="code">46</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1824,7 +2295,10 @@
         <field name="name">BAIXA COM TRANSFERÊNCIA PARA DESCONTO</field>
         <field name="code">47</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1835,7 +2309,10 @@
         <field name="name">CUSTAS DE SUSTAÇÃO JUDICIAL</field>
         <field name="code">48</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1848,7 +2325,10 @@
         >TARIFA MENSAL REF A ENTRADAS BANCOS CORRESPONDENTES NA CARTEIRA</field>
         <field name="code">51</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1859,7 +2339,10 @@
         <field name="name">TARIFA MENSAL BAIXAS NA CARTEIRA</field>
         <field name="code">52</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1872,7 +2355,10 @@
         >TARIFA MENSAL BAIXAS EM BANCOS CORRESPONDENTES NA CARTEIRA</field>
         <field name="code">53</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1883,7 +2369,10 @@
         <field name="name">TARIFA MENSAL DE LIQUIDAÇÕES NA CARTEIRA</field>
         <field name="code">54</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1896,7 +2385,10 @@
         >TARIFA MENSAL DE LIQUIDAÇÕES EM BANCOS CORRESPONDENTES NA CARTEIRA</field>
         <field name="code">55</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1907,7 +2399,10 @@
         <field name="name">CUSTAS DE IRREGULARIDADE</field>
         <field name="code">56</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1918,7 +2413,10 @@
         <field name="name">INSTRUÇÃO CANCELADA (NOTA 20 – TABELA 8)</field>
         <field name="code">57</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1929,7 +2427,10 @@
         <field name="name">BAIXA POR CRÉDITO EM C/C ATRAVÉS DO SISPAG</field>
         <field name="code">59</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1940,7 +2441,10 @@
         <field name="name">ENTRADA REJEITADA CARNÊ (NOTA 20 – TABELA 1)</field>
         <field name="code">60</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1953,7 +2457,10 @@
         >TARIFA EMISSÃO AVISO DE MOVIMENTAÇÃO DE TÍTULOS (2154)</field>
         <field name="code">61</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1966,7 +2473,10 @@
         >DÉBITO MENSAL DE TARIFA – AVISO DE MOVIMENTAÇÃO DE TÍTULOS (2154)</field>
         <field name="code">62</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1977,7 +2487,10 @@
         <field name="name">TÍTULO SUSTADO JUDICIALMENTE</field>
         <field name="code">63</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1988,7 +2501,10 @@
         <field name="name">ENTRADA CONFIRMADA COM RATEIO DE CRÉDITO</field>
         <field name="code">64</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -1999,7 +2515,10 @@
         <field name="name">PAGAMENTO COM CHEQUE – AGUARDANDO COMPENSAÇÃO</field>
         <field name="code">65</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -2010,7 +2529,10 @@
         <field name="name">CHEQUE DEVOLVIDO (NOTA 20 – TABELA 9)</field>
         <field name="code">69</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -2021,7 +2543,10 @@
         <field name="name">ENTRADA REGISTRADA, AGUARDANDO AVALIAÇÃO</field>
         <field name="code">71</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -2034,7 +2559,10 @@
         >BAIXA POR CRÉDITO EM C/C ATRAVÉS DO SISPAG SEM TÍTULO CORRESPONDENTE</field>
         <field name="code">72</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -2047,7 +2575,10 @@
         >CONFIRMAÇÃO DE ENTRADA NA COBRANÇA SIMPLES – ENTRADA NÃO ACEITA NA COBRANÇA CONTRATUAL</field>
         <field name="code">73</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -2060,7 +2591,10 @@
         >INSTRUÇÃO DE NEGATIVAÇÃO EXPRESSA REJEITADA (NOTA 20 – TABELA 11)</field>
         <field name="code">74</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -2073,7 +2607,10 @@
         >CONFIRMAÇÃO DE RECEBIMENTO DE INSTRUÇÃO DE ENTRADA EM NEGATIVAÇÃO EXPRESSA</field>
         <field name="code">75</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -2084,7 +2621,10 @@
         <field name="name">CHEQUE COMPENSADO</field>
         <field name="code">76</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -2097,7 +2637,10 @@
         >CONFIRMAÇÃO DE RECEBIMENTO DE INSTRUÇÃO DE EXCLUSÃO DE ENTRADA EM NEGATIVAÇÃO EXPRESSA</field>
         <field name="code">77</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -2110,7 +2653,10 @@
         >CONFIRMAÇÃO DE RECEBIMENTO DE INSTRUÇÃO DE CANCELAMENTO DE NEGATIVAÇÃO EXPRESSA</field>
         <field name="code">78</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -2123,7 +2669,10 @@
         >NEGATIVAÇÃO EXPRESSA INFORMACIONAL (NOTA 20 – TABELA 12)</field>
         <field name="code">79</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -2136,7 +2685,10 @@
         >CONFIRMAÇÃO DE ENTRADA EM NEGATIVAÇÃO EXPRESSA – TARIFA</field>
         <field name="code">80</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -2149,7 +2701,10 @@
         >CONFIRMAÇÃO DO CANCELAMENTO DE NEGATIVAÇÃO EXPRESSA – TARIFA</field>
         <field name="code">82</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -2162,7 +2717,10 @@
         >CONFIRMAÇÃO DE EXCLUSÃO DE ENTRADA EM NEGATIVAÇÃO EXPRESSA POR LIQUIDAÇÃO – TARIFA</field>
         <field name="code">83</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -2175,7 +2733,10 @@
         >TARIFA POR BOLETO (ATÉ 03 ENVIOS) COBRANÇA ATIVA ELETRÔNICA</field>
         <field name="code">85</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -2186,7 +2747,10 @@
         <field name="name">TARIFA EMAIL COBRANÇA ATIVA ELETRÔNICA</field>
         <field name="code">86</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -2197,7 +2761,10 @@
         <field name="name">TARIFA SMS COBRANÇA ATIVA ELETRÔNICA</field>
         <field name="code">87</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -2210,7 +2777,10 @@
         >TARIFA MENSAL POR BOLETO (ATÉ 03 ENVIOS) COBRANÇA ATIVA ELETRÔNICA</field>
         <field name="code">88</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -2221,7 +2791,10 @@
         <field name="name">TARIFA MENSAL EMAIL COBRANÇA ATIVA ELETRÔNICA</field>
         <field name="code">89</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -2232,7 +2805,10 @@
         <field name="name">TARIFA MENSAL SMS COBRANÇA ATIVA ELETRÔNICA</field>
         <field name="code">90</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -2245,7 +2821,10 @@
         >TARIFA MENSAL DE EXCLUSÃO DE ENTRADA DE NEGATIVAÇÃO EXPRESSA</field>
         <field name="code">91</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -2256,7 +2835,10 @@
         <field name="name">TARIFA MENSAL DE CANCELAMENTO DE NEGATIVAÇÃO EXPRESSA</field>
         <field name="code">92</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -2269,7 +2851,10 @@
         >TARIFA MENSAL DE EXCLUSÃO DE NEGATIVAÇÃO EXPRESSA POR LIQUIDAÇÃO</field>
         <field name="code">93</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_341'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_itau_cnab_240_400.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_itau_cnab_240_400.xml
@@ -11,7 +11,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -22,7 +22,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -33,7 +33,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -44,7 +44,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -55,7 +55,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -66,7 +66,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -77,7 +77,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -88,7 +88,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -99,7 +99,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -112,7 +112,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -123,7 +123,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -134,7 +134,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -145,7 +145,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -156,7 +156,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -168,7 +168,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -180,7 +180,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -191,7 +191,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -205,7 +205,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -216,7 +216,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -229,7 +229,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -240,7 +240,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -251,7 +251,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -262,7 +262,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -273,7 +273,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -284,7 +284,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -295,7 +295,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -306,7 +306,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -317,7 +317,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -328,7 +328,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -339,7 +339,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -350,7 +350,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -363,7 +363,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -376,7 +376,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -387,7 +387,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -400,7 +400,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -411,7 +411,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -422,7 +422,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -433,7 +433,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -444,7 +444,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -455,7 +455,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -466,7 +466,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -477,7 +477,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -488,7 +488,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -499,7 +499,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -510,7 +510,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -521,7 +521,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -532,7 +532,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -543,7 +543,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -554,7 +554,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -567,7 +567,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -578,7 +578,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -589,7 +589,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -602,7 +602,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -615,7 +615,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -626,7 +626,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -639,7 +639,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -650,7 +650,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -661,7 +661,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -672,7 +672,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -683,7 +683,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -694,7 +694,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -707,7 +707,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -718,7 +718,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -731,7 +731,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -742,7 +742,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -755,7 +755,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -766,7 +766,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -777,7 +777,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -788,7 +788,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -801,7 +801,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -814,7 +814,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -825,7 +825,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -838,7 +838,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -851,7 +851,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -864,7 +864,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -877,7 +877,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -890,7 +890,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -903,7 +903,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -916,7 +916,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -929,7 +929,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -942,7 +942,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -953,7 +953,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -964,7 +964,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -977,7 +977,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -988,7 +988,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -999,7 +999,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -1012,7 +1012,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -1023,7 +1023,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -1036,7 +1036,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -1047,7 +1047,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -1062,7 +1062,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -1073,7 +1073,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -1084,7 +1084,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -1095,7 +1095,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -1106,7 +1106,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -1117,7 +1117,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -1128,7 +1128,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -1139,7 +1139,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -1150,7 +1150,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -1161,7 +1161,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -1172,7 +1172,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -1183,7 +1183,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -1194,7 +1194,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -1205,7 +1205,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -1216,7 +1216,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -1227,7 +1227,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -1240,7 +1240,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -1251,7 +1251,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -1262,7 +1262,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -1273,7 +1273,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -1286,7 +1286,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -1299,7 +1299,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -1312,7 +1312,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -1323,7 +1323,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
     </record>
@@ -1336,7 +1336,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1347,7 +1347,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1360,7 +1360,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1371,7 +1371,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1382,7 +1382,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1393,7 +1393,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1404,7 +1404,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1415,7 +1415,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1426,7 +1426,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1437,7 +1437,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1448,7 +1448,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1459,7 +1459,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1470,7 +1470,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1481,7 +1481,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1492,7 +1492,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1505,7 +1505,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1518,7 +1518,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1529,7 +1529,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1542,7 +1542,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1553,7 +1553,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1564,7 +1564,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1577,7 +1577,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1588,7 +1588,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1599,7 +1599,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1610,7 +1610,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1621,7 +1621,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1632,7 +1632,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1643,7 +1643,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1654,7 +1654,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1665,7 +1665,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1676,7 +1676,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1687,7 +1687,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1698,7 +1698,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1711,7 +1711,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1722,7 +1722,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1733,7 +1733,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1746,7 +1746,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1759,7 +1759,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1770,7 +1770,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1783,7 +1783,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1794,7 +1794,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1805,7 +1805,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1816,7 +1816,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1827,7 +1827,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1838,7 +1838,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1851,7 +1851,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1862,7 +1862,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1875,7 +1875,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1886,7 +1886,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1899,7 +1899,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1910,7 +1910,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1921,7 +1921,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1932,7 +1932,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1943,7 +1943,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1956,7 +1956,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1969,7 +1969,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1980,7 +1980,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -1991,7 +1991,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -2002,7 +2002,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -2013,7 +2013,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -2024,7 +2024,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -2037,7 +2037,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -2050,7 +2050,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -2063,7 +2063,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -2076,7 +2076,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -2087,7 +2087,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -2100,7 +2100,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -2113,7 +2113,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -2126,7 +2126,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -2139,7 +2139,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -2152,7 +2152,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -2165,7 +2165,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -2178,7 +2178,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -2189,7 +2189,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -2200,7 +2200,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -2213,7 +2213,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -2224,7 +2224,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -2235,7 +2235,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -2248,7 +2248,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -2259,7 +2259,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -2272,7 +2272,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_341')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_santander_240_boleto_discount_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_santander_240_boleto_discount_code.xml
@@ -12,7 +12,10 @@
         <field name="name">ISENTO</field>
         <field name="code">0</field>
         <field name="code_type">discount_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -23,7 +26,10 @@
         <field name="name">Valor fixo ate a data informada</field>
         <field name="code">1</field>
         <field name="code_type">discount_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -38,7 +44,10 @@
         <field name="name">Percentual ate a data informada</field>
         <field name="code">2</field>
         <field name="code_type">discount_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -55,7 +64,10 @@
         >Valor por antecipação por dia corrido - Informar o valor no campo “valor de desconto a ser concedido”</field>
         <field name="code">3</field>
         <field name="code_type">discount_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -66,7 +78,10 @@
         <field name="name">Valor por antecipação dia útil</field>
         <field name="code">4</field>
         <field name="code_type">discount_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_santander_240_boleto_discount_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_santander_240_boleto_discount_code.xml
@@ -15,7 +15,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -26,7 +26,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"
@@ -41,7 +41,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"
@@ -58,7 +58,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -69,7 +69,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_santander_240_boleto_protest_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_santander_240_boleto_protest_code.xml
@@ -11,7 +11,10 @@
         <field name="name">NAO PROTESTAR</field>
         <field name="code">0</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -22,7 +25,10 @@
         <field name="name">PROTESTAR DIAS CORRIDOS</field>
         <field name="code">1</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -33,7 +39,10 @@
         <field name="name">PROTESTAR DIAS UTEIS</field>
         <field name="code">2</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -44,7 +53,10 @@
         <field name="name">UTILIZAR PERFIL BENEFICIÁRIO</field>
         <field name="code">3</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -55,7 +67,10 @@
         <field name="name">CANCELAMENTO DE PROTESTO AUTOMATICO</field>
         <field name="code">9</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_santander_240_boleto_protest_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_santander_240_boleto_protest_code.xml
@@ -14,7 +14,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -25,7 +25,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -36,7 +36,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -47,7 +47,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -58,7 +58,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_santander_240_boleto_write_off_devolution.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_santander_240_boleto_write_off_devolution.xml
@@ -7,7 +7,10 @@
         <field name="name">BAIXAR / DEVOLVER</field>
         <field name="code">1</field>
         <field name="code_type">boleto_write_off_devolution</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -18,7 +21,10 @@
         <field name="name">NAO BAIXAR / NAO DEVOLVER</field>
         <field name="code">2</field>
         <field name="code_type">boleto_write_off_devolution</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -29,7 +35,10 @@
         <field name="name">UTILIZAR PERFIL BENEFICIARIO</field>
         <field name="code">3</field>
         <field name="code_type">boleto_write_off_devolution</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_santander_240_boleto_write_off_devolution.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_santander_240_boleto_write_off_devolution.xml
@@ -10,7 +10,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -21,7 +21,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -32,7 +32,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_santander_boleto_wallet_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_santander_boleto_wallet_code.xml
@@ -7,7 +7,10 @@
         <field name="name">Cobrança Simples (Eletrônica com Registro)</field>
         <field name="code">1</field>
         <field name="code_type">wallet_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -18,7 +21,10 @@
         <field name="name">Cobrança Caucionada (Eletrônica com Registro)</field>
         <field name="code">3</field>
         <field name="code_type">wallet_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -29,7 +35,10 @@
         <field name="name">Cobrança Simples (Rápida com Registro)</field>
         <field name="code">5</field>
         <field name="code_type">wallet_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -40,7 +49,10 @@
         <field name="name">Cobrança Caucionada (Rápida com Registro)</field>
         <field name="code">6</field>
         <field name="code_type">wallet_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -51,7 +63,10 @@
         <field name="name">Cobrança Descontada (Eletrônica com Registro)</field>
         <field name="code">7</field>
         <field name="code_type">wallet_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -62,7 +77,10 @@
         <field name="name">Cobrança Cessão (Eletrônica com Registro)*</field>
         <field name="code">8</field>
         <field name="code_type">wallet_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
@@ -80,7 +98,10 @@
         >Cobrança Simples (Sem Registro e Eletrônica com Registro)</field>
         <field name="code">1</field>
         <field name="code_type">wallet_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -93,7 +114,10 @@
         >Cobrança Caucionada (Eletrônica com Registro e Convencional com Registro)</field>
         <field name="code">3</field>
         <field name="code_type">wallet_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -104,7 +128,10 @@
         <field name="name">Cobrança Descontada (Eletrônica com Registro)</field>
         <field name="code">4</field>
         <field name="code_type">wallet_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -115,7 +142,10 @@
         <field name="name">Cobrança Simples (Rápida com Registro)*</field>
         <field name="code">5</field>
         <field name="code_type">wallet_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -129,7 +159,10 @@
         <field name="name">Cobrança Caucionada (Rápida com Registro)</field>
         <field name="code">6</field>
         <field name="code_type">wallet_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -142,7 +175,10 @@
         >Transferência de Titularidade - Sem Devolução (Cobrança Simples - Eletrônica com Registro e Rápida com Registro)**</field>
         <field name="code">7</field>
         <field name="code_type">wallet_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -156,7 +192,10 @@
         <field name="name">Cobrança Cessão (Eletrônica com Registro)****</field>
         <field name="code">8</field>
         <field name="code_type">wallet_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -173,7 +212,10 @@
         >Transferência de Titularidade - Com Devolução (Cobrança Simples - Eletrônica com Registro e Rápida com Registro)</field>
         <field name="code">9</field>
         <field name="code_type">wallet_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -186,7 +228,10 @@
         >Cobrança Simples (Sem Registro sem pré-impresso e com pré-impresso)***</field>
         <field name="code">B</field>
         <field name="code_type">wallet_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_santander_boleto_wallet_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_santander_boleto_wallet_code.xml
@@ -10,7 +10,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -21,7 +21,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -32,7 +32,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -43,7 +43,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -54,7 +54,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
     </record>
 
@@ -65,7 +65,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field
             name="comment"
@@ -83,7 +83,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -96,7 +96,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -107,7 +107,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -118,7 +118,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"
@@ -132,7 +132,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -145,7 +145,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"
@@ -159,7 +159,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"
@@ -176,7 +176,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -189,7 +189,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_santander_cnab_240_400.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_santander_cnab_240_400.xml
@@ -15,7 +15,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_instruction_02" model="l10n_br_cnab.code">
@@ -26,7 +29,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_instruction_04" model="l10n_br_cnab.code">
@@ -37,7 +43,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_instruction_05" model="l10n_br_cnab.code">
@@ -48,7 +57,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_instruction_06" model="l10n_br_cnab.code">
@@ -59,7 +71,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_instruction_07" model="l10n_br_cnab.code">
@@ -72,7 +87,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_instruction_08" model="l10n_br_cnab.code">
@@ -83,7 +101,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_instruction_09" model="l10n_br_cnab.code">
@@ -94,7 +115,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_instruction_10" model="l10n_br_cnab.code">
@@ -105,7 +129,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_instruction_11" model="l10n_br_cnab.code">
@@ -116,7 +143,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_instruction_12" model="l10n_br_cnab.code">
@@ -127,7 +157,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_instruction_15" model="l10n_br_cnab.code">
@@ -140,7 +173,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="comment"
         >**O código movimento de remessa “15” é utilizado exclusivamente para transferência de boletos da carteira Simples para a carteira de Cessão, mediante a contratação do produto SX Integra que possibilita a cessão eletrônica de recebíveis.
@@ -155,7 +191,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="comment"
         >*** Os códigos de movimento de remessa “16” e “17” só podem ser utilizadas para boletos já registrados na carteira de Cessão, mediante regras pré-determinadas na contratação do produto SX Integra.
@@ -170,7 +209,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="comment"
         >*** Os códigos de movimento de remessa “16” e “17” só podem ser utilizadas para boletos já registrados na carteira de Cessão, mediante regras pré-determinadas na contratação do produto SX Integra.
@@ -185,7 +227,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_instruction_31" model="l10n_br_cnab.code">
@@ -196,7 +241,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="comment"
         >*O código movimento de remessa “31” – É utilizado para tratamento de Alterações de outros dados “Protesto”. Exemplo:  “31” – Alteração de outros dados, atende apenas alteração dos campos: - Segmento “P” (016 – 017) – Alteração de outros dados - Segmento “P” (221 – 221) – Tipo de prazo para protesto (ex.: De Dias Uteis para Dias Corridos) - Segmento “P” (222 – 223) – Número de dias para protesto (ex.: de 10 dias para 05 dias)
@@ -211,7 +259,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_instruction_48" model="l10n_br_cnab.code">
@@ -222,7 +273,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_instruction_49" model="l10n_br_cnab.code">
@@ -233,7 +287,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_instruction_98" model="l10n_br_cnab.code">
@@ -244,7 +301,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <!-- Codigos de Retorno do Movimento -->
@@ -257,7 +317,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_03" model="l10n_br_cnab.code">
@@ -268,7 +331,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_04" model="l10n_br_cnab.code">
@@ -279,7 +345,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_05" model="l10n_br_cnab.code">
@@ -292,7 +361,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_06" model="l10n_br_cnab.code">
@@ -303,7 +375,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_08" model="l10n_br_cnab.code">
@@ -316,7 +391,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_09" model="l10n_br_cnab.code">
@@ -327,7 +405,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_11" model="l10n_br_cnab.code">
@@ -338,7 +419,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_12" model="l10n_br_cnab.code">
@@ -349,7 +433,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_13" model="l10n_br_cnab.code">
@@ -362,7 +449,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_14" model="l10n_br_cnab.code">
@@ -375,7 +465,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_17" model="l10n_br_cnab.code">
@@ -388,7 +481,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_19" model="l10n_br_cnab.code">
@@ -399,7 +495,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_20" model="l10n_br_cnab.code">
@@ -412,7 +511,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_23" model="l10n_br_cnab.code">
@@ -423,7 +525,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_24" model="l10n_br_cnab.code">
@@ -434,7 +539,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_25" model="l10n_br_cnab.code">
@@ -445,7 +553,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_26" model="l10n_br_cnab.code">
@@ -456,7 +567,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_27" model="l10n_br_cnab.code">
@@ -467,7 +581,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_28" model="l10n_br_cnab.code">
@@ -478,7 +595,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_29" model="l10n_br_cnab.code">
@@ -489,7 +609,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_30" model="l10n_br_cnab.code">
@@ -500,7 +623,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_32" model="l10n_br_cnab.code">
@@ -511,7 +637,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_51" model="l10n_br_cnab.code">
@@ -522,7 +651,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_52" model="l10n_br_cnab.code">
@@ -533,7 +665,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_53" model="l10n_br_cnab.code">
@@ -544,7 +679,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_61" model="l10n_br_cnab.code">
@@ -555,7 +693,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_91" model="l10n_br_cnab.code">
@@ -568,7 +709,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_92" model="l10n_br_cnab.code">
@@ -581,7 +725,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_93" model="l10n_br_cnab.code">
@@ -592,7 +739,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_94" model="l10n_br_cnab.code">
@@ -603,7 +753,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_240_return_a4" model="l10n_br_cnab.code">
@@ -614,7 +767,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <!-- CNAB 400 -->
@@ -631,7 +787,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_instruction_02" model="l10n_br_cnab.code">
@@ -642,7 +801,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_instruction_04" model="l10n_br_cnab.code">
@@ -653,7 +815,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_instruction_05" model="l10n_br_cnab.code">
@@ -664,7 +829,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_instruction_06" model="l10n_br_cnab.code">
@@ -675,7 +843,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_instruction_07" model="l10n_br_cnab.code">
@@ -686,7 +857,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_instruction_08" model="l10n_br_cnab.code">
@@ -697,7 +871,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_instruction_09" model="l10n_br_cnab.code">
@@ -708,7 +885,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_instruction_15" model="l10n_br_cnab.code">
@@ -719,7 +899,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="comment"
         >*O código movimento de remessa “15” é utilizado exclusivamente para transferência de boletos da carteira Simples para a carteira de Cessão, mediante a contratação do produto SX Integra que possibilita a cessão eletrônica de recebíveis.
@@ -734,7 +917,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="comment"
         >**Os códigos de movimento de remessa “16” e “17” só podem ser utilizadas para boletos já registrados na carteira de Cessão, mediante regras pré-determinadas na contratação do produto SX Integra.
@@ -749,7 +935,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="comment"
         >**Os códigos de movimento de remessa “16” e “17” só podem ser utilizadas para boletos já registrados na carteira de Cessão, mediante regras pré-determinadas na contratação do produto SX Integra.
@@ -764,7 +953,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_instruction_47" model="l10n_br_cnab.code">
@@ -775,7 +967,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_instruction_48" model="l10n_br_cnab.code">
@@ -786,7 +981,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_instruction_49" model="l10n_br_cnab.code">
@@ -797,7 +995,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <!-- Codigos de Retorno do Movimento -->
@@ -810,7 +1011,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_02" model="l10n_br_cnab.code">
@@ -821,7 +1025,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_03" model="l10n_br_cnab.code">
@@ -832,7 +1039,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_04" model="l10n_br_cnab.code">
@@ -843,7 +1053,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_05" model="l10n_br_cnab.code">
@@ -854,7 +1067,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_06" model="l10n_br_cnab.code">
@@ -865,7 +1081,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_07" model="l10n_br_cnab.code">
@@ -876,7 +1095,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_08" model="l10n_br_cnab.code">
@@ -887,7 +1109,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_09" model="l10n_br_cnab.code">
@@ -898,7 +1123,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_10" model="l10n_br_cnab.code">
@@ -909,7 +1137,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_11" model="l10n_br_cnab.code">
@@ -920,7 +1151,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_12" model="l10n_br_cnab.code">
@@ -931,7 +1165,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_13" model="l10n_br_cnab.code">
@@ -942,7 +1179,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_14" model="l10n_br_cnab.code">
@@ -953,7 +1193,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_15" model="l10n_br_cnab.code">
@@ -964,7 +1207,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="comment"
         >O código 15 – Confirmação de Protesto, corresponde ao momento em que o tabelionato recebe o boleto para tratativa (intimação ao Pagador). O boleto ainda não está protestado neste cenário. Quando protestado, o código encaminhado é o 25 - Boleto Protestado.
@@ -979,7 +1225,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_17" model="l10n_br_cnab.code">
@@ -990,7 +1239,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_21" model="l10n_br_cnab.code">
@@ -1001,7 +1253,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_22" model="l10n_br_cnab.code">
@@ -1012,7 +1267,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_24" model="l10n_br_cnab.code">
@@ -1023,7 +1281,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_25" model="l10n_br_cnab.code">
@@ -1034,7 +1295,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_26" model="l10n_br_cnab.code">
@@ -1045,7 +1309,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
         <field
             name="comment"
         >O código 26 – Sustar Protesto, corresponde ao momento em que o boleto já está confirmado no tabelionato (código 15) e está em processo de intimação, mas não há desejo em prosseguir com o protesto. Diferente do código 38 - Não Protestar, utilizado para o cenário onde o boleto não iniciou o processo de cartório.
@@ -1060,7 +1327,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_35" model="l10n_br_cnab.code">
@@ -1071,7 +1341,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_36" model="l10n_br_cnab.code">
@@ -1082,7 +1355,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_37" model="l10n_br_cnab.code">
@@ -1093,7 +1369,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_38" model="l10n_br_cnab.code">
@@ -1104,7 +1383,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_39" model="l10n_br_cnab.code">
@@ -1115,7 +1397,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_61" model="l10n_br_cnab.code">
@@ -1126,7 +1411,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_62" model="l10n_br_cnab.code">
@@ -1139,7 +1427,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_63" model="l10n_br_cnab.code">
@@ -1152,7 +1443,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_93" model="l10n_br_cnab.code">
@@ -1163,7 +1457,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
     <record id="santander_400_return_94" model="l10n_br_cnab.code">
@@ -1174,7 +1471,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_033'))]"
+        />
     </record>
 
 </odoo>

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_santander_cnab_240_400.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_santander_cnab_240_400.xml
@@ -13,7 +13,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -24,7 +24,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -35,7 +35,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -46,7 +46,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -57,7 +57,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -70,7 +70,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -81,7 +81,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -92,7 +92,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -103,7 +103,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -114,7 +114,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -125,7 +125,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -138,7 +138,7 @@
        <field name="code_type">instruction_move_code</field>
        <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
@@ -153,7 +153,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
@@ -168,7 +168,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
@@ -183,7 +183,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -194,7 +194,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
@@ -209,7 +209,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -220,7 +220,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -231,7 +231,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -242,7 +242,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -255,7 +255,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -266,7 +266,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -277,7 +277,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -290,7 +290,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -301,7 +301,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -314,7 +314,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -325,7 +325,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -336,7 +336,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -347,7 +347,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -360,7 +360,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -373,7 +373,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -386,7 +386,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -397,7 +397,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -410,7 +410,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -421,7 +421,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -432,7 +432,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -443,7 +443,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -454,7 +454,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -465,7 +465,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -476,7 +476,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -487,7 +487,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -498,7 +498,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -509,7 +509,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -520,7 +520,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -531,7 +531,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -542,7 +542,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -553,7 +553,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -566,7 +566,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -579,7 +579,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -590,7 +590,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -601,7 +601,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -612,7 +612,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -629,7 +629,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -640,7 +640,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -651,7 +651,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -662,7 +662,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -673,7 +673,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -684,7 +684,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -695,7 +695,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -706,7 +706,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -717,7 +717,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
@@ -732,7 +732,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
@@ -747,7 +747,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
@@ -762,7 +762,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -773,7 +773,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -784,7 +784,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -795,7 +795,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -808,7 +808,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -819,7 +819,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -830,7 +830,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -841,7 +841,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -852,7 +852,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -863,7 +863,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -874,7 +874,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -885,7 +885,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -896,7 +896,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -907,7 +907,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -918,7 +918,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -929,7 +929,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -940,7 +940,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -951,7 +951,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -962,7 +962,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
@@ -977,7 +977,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -988,7 +988,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -999,7 +999,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -1010,7 +1010,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -1021,7 +1021,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -1032,7 +1032,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -1043,7 +1043,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
         <field
@@ -1058,7 +1058,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -1069,7 +1069,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -1080,7 +1080,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -1091,7 +1091,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -1102,7 +1102,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -1113,7 +1113,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -1124,7 +1124,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -1137,7 +1137,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -1150,7 +1150,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -1161,7 +1161,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>
@@ -1172,7 +1172,7 @@
         <field name="code_type">return_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_033')])]" />
     </record>

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_sicred_240_boleto_protest_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_sicred_240_boleto_protest_code.xml
@@ -11,7 +11,10 @@
         <field name="name">Protestar dias corridos</field>
         <field name="code">1</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -22,7 +25,10 @@
         <field name="name">Não protestar</field>
         <field name="code">3</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -33,7 +39,10 @@
         <field name="name">Cancelamento protesto automático</field>
         <field name="code">9</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_sicred_240_boleto_protest_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_sicred_240_boleto_protest_code.xml
@@ -14,7 +14,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -25,7 +25,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -36,7 +36,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_sicred_cnab_240.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_sicred_cnab_240.xml
@@ -12,7 +12,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
     </record>
 
     <record id="sicredi_240_instruction_02" model="l10n_br_cnab.code">
@@ -23,7 +26,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
     </record>
 
     <record id="sicredi_240_instruction_04" model="l10n_br_cnab.code">
@@ -34,7 +40,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
     </record>
 
     <record id="sicredi_240_instruction_05" model="l10n_br_cnab.code">
@@ -45,7 +54,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
     </record>
 
     <record id="sicredi_240_instruction_06" model="l10n_br_cnab.code">
@@ -56,7 +68,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
     </record>
 
     <record id="sicredi_240_instruction_07" model="l10n_br_cnab.code">
@@ -67,7 +82,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
     </record>
 
     <record id="sicredi_240_instruction_08" model="l10n_br_cnab.code">
@@ -78,7 +96,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
     </record>
 
     <record id="sicredi_240_instruction_09" model="l10n_br_cnab.code">
@@ -89,7 +110,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
     </record>
 
     <record id="sicredi_240_instruction_10" model="l10n_br_cnab.code">
@@ -100,7 +124,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
     </record>
 
     <record id="sicredi_240_instruction_11" model="l10n_br_cnab.code">
@@ -111,7 +138,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
     </record>
 
     <record id="sicredi_240_instruction_12" model="l10n_br_cnab.code">
@@ -122,7 +152,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
     </record>
 
     <record id="sicredi_240_instruction_13" model="l10n_br_cnab.code">
@@ -133,7 +166,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
     </record>
 
     <record id="sicredi_240_instruction_16" model="l10n_br_cnab.code">
@@ -144,7 +180,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
     </record>
 
     <record id="sicredi_240_instruction_17" model="l10n_br_cnab.code">
@@ -155,7 +194,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
     </record>
 
     <record id="sicredi_240_instruction_31" model="l10n_br_cnab.code">
@@ -166,7 +208,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
     </record>
 
     <record id="sicredi_240_instruction_45" model="l10n_br_cnab.code">
@@ -177,7 +222,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
     </record>
 
     <record id="sicredi_240_instruction_75" model="l10n_br_cnab.code">
@@ -188,7 +236,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
     </record>
 
     <record id="sicredi_240_instruction_76" model="l10n_br_cnab.code">
@@ -199,7 +250,10 @@
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
     </record>
 
     <!-- Codigo de Retorno do Movimento -->
@@ -207,7 +261,10 @@
         <field name="name">Entrada confirmada</field>
         <field name="code">02</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -218,7 +275,10 @@
         <field name="name">Entrada rejeitada</field>
         <field name="code">03</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -229,7 +289,10 @@
         <field name="name">Liquidação</field>
         <field name="code">06</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -240,7 +303,10 @@
         <field name="name">Confirmação do recebimento da instrução de desconto</field>
         <field name="code">07</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -253,7 +319,10 @@
         >Confirmação do recebimento do cancelamento do desconto</field>
         <field name="code">08</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -264,7 +333,10 @@
         <field name="name">Baixa</field>
         <field name="code">09</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -275,7 +347,10 @@
         <field name="name">Confirmação do recebimento instrução de abatimento</field>
         <field name="code">12</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -288,7 +363,10 @@
         >Confirmação do recebimento instrução de cancelamento abatimento</field>
         <field name="code">13</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -301,7 +379,10 @@
         >Confirmação do recebimento instrução alteração de vencimento</field>
         <field name="code">14</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -314,7 +395,10 @@
         >Liquidação após baixa ou liquidação título não registrado</field>
         <field name="code">17</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -325,7 +409,10 @@
         <field name="name">Confirmação do recebimento instrução de protesto</field>
         <field name="code">19</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -338,7 +425,10 @@
         >Confirmação do recebimento instrução de sustação/cancelamento de protesto</field>
         <field name="code">20</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -349,7 +439,10 @@
         <field name="name">Remessa a cartório (aponte em cartório)</field>
         <field name="code">23</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -360,7 +453,10 @@
         <field name="name">Retirada de cartório e manutenção em carteira</field>
         <field name="code">24</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -371,7 +467,10 @@
         <field name="name">Protestado e baixado (baixa por ter sido protestado)</field>
         <field name="code">25</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -382,7 +481,10 @@
         <field name="name">Instrução rejeitada</field>
         <field name="code">26</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -393,7 +495,10 @@
         <field name="name">Confirmação do pedido de alteração de outros dados</field>
         <field name="code">27</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -404,7 +509,10 @@
         <field name="name">Débito de tarifas custas</field>
         <field name="code">28</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -415,7 +523,10 @@
         <field name="name">Alteração de dados rejeitada</field>
         <field name="code">30</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -426,7 +537,10 @@
         <field name="name">Baixa rejeitada</field>
         <field name="code">36</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -437,7 +551,10 @@
         <field name="name">Título DDA reconhecido pelo pagador</field>
         <field name="code">51</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -448,7 +565,10 @@
         <field name="name">Título DDA não reconhecido pelo pagador</field>
         <field name="code">52</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -459,7 +579,10 @@
         <field name="name">Confirmação de recebimento de pedido de negativação</field>
         <field name="code">78</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -472,7 +595,10 @@
         >Confirmação de recebimento de pedido de exclusão de negativação</field>
         <field name="code">79</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -483,7 +609,10 @@
         <field name="name">Confirmação de entrada de negativação</field>
         <field name="code">80</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -494,7 +623,10 @@
         <field name="name">Entrada de negativação rejeitada</field>
         <field name="code">81</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -505,7 +637,10 @@
         <field name="name">Confirmação de exclusão de negativação</field>
         <field name="code">82</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -516,7 +651,10 @@
         <field name="name">Exclusão de Negativação rejeitada</field>
         <field name="code">83</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -527,7 +665,10 @@
         <field name="name">Exclusão de negativação por outros motivos</field>
         <field name="code">84</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -538,7 +679,10 @@
         <field name="name">Ocorrência informacional por outros motivos</field>
         <field name="code">85</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -549,7 +693,10 @@
         <field name="name">Intenção de pagamentos</field>
         <field name="code">91</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_sicred_cnab_240.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_sicred_cnab_240.xml
@@ -10,7 +10,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
     </record>
@@ -21,7 +21,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
     </record>
@@ -32,7 +32,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
     </record>
@@ -43,7 +43,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
     </record>
@@ -54,7 +54,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
     </record>
@@ -65,7 +65,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
     </record>
@@ -76,7 +76,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
     </record>
@@ -87,7 +87,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
     </record>
@@ -98,7 +98,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
     </record>
@@ -109,7 +109,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
     </record>
@@ -120,7 +120,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
     </record>
@@ -131,7 +131,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
     </record>
@@ -142,7 +142,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
     </record>
@@ -153,7 +153,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
     </record>
@@ -164,7 +164,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
     </record>
@@ -175,7 +175,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
     </record>
@@ -186,7 +186,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
     </record>
@@ -197,7 +197,7 @@
         <field name="code_type">instruction_move_code</field>
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
     </record>
@@ -210,7 +210,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -221,7 +221,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -232,7 +232,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -243,7 +243,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -256,7 +256,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -267,7 +267,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -278,7 +278,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -291,7 +291,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -304,7 +304,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -317,7 +317,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -328,7 +328,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -341,7 +341,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -352,7 +352,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -363,7 +363,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -374,7 +374,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -385,7 +385,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -396,7 +396,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -407,7 +407,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -418,7 +418,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -429,7 +429,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -440,7 +440,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -451,7 +451,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -462,7 +462,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -475,7 +475,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -486,7 +486,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -497,7 +497,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -508,7 +508,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -519,7 +519,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -530,7 +530,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -541,7 +541,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -552,7 +552,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_sicredi_240_boleto_discount_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_sicredi_240_boleto_discount_code.xml
@@ -12,7 +12,10 @@
         <field name="name">Valor fixo até a data informada</field>
         <field name="code">1</field>
         <field name="code_type">discount_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -27,7 +30,10 @@
         <field name="name">Percentual até a data informada</field>
         <field name="code">2</field>
         <field name="code_type">discount_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -42,7 +48,10 @@
         <field name="name">Valor por antecipação dia corrido</field>
         <field name="code">3</field>
         <field name="code_type">discount_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"
@@ -59,7 +68,10 @@
         <field name="name">Cancelamento de desconto</field>
         <field name="code">7</field>
         <field name="code_type">discount_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_748'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab240'))]"

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_sicredi_240_boleto_discount_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_sicredi_240_boleto_discount_code.xml
@@ -15,7 +15,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"
@@ -30,7 +30,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"
@@ -45,7 +45,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"
@@ -62,7 +62,7 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_748')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_unicred_240_400_boleto_discount_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_unicred_240_400_boleto_discount_code.xml
@@ -11,7 +11,11 @@
         <field name="name">Isento</field>
         <field name="code">0</field>
         <field name="code_type">discount_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_136'))]"
+        />
+
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400')),
@@ -23,7 +27,11 @@
         <field name="name">Valor Fixo</field>
         <field name="code">1</field>
         <field name="code_type">discount_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_136'))]"
+        />
+
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400')),

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_unicred_240_400_boleto_discount_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_unicred_240_400_boleto_discount_code.xml
@@ -14,7 +14,8 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400')),
+            Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -25,7 +26,8 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400')),
+            Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_unicred_240_400_boleto_protest_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_unicred_240_400_boleto_protest_code.xml
@@ -11,7 +11,10 @@
         <field name="name">Protestar Dias Corridos</field>
         <field name="code">1</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_136'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400')),
@@ -23,7 +26,10 @@
         <field name="name">Protestar Dias Úteis</field>
         <field name="code">2</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_136'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400')),
@@ -35,7 +41,10 @@
         <field name="name">Não Protestar</field>
         <field name="code">3</field>
         <field name="code_type">protest_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_136'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400')),

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_unicred_240_400_boleto_protest_code.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_unicred_240_400_boleto_protest_code.xml
@@ -14,7 +14,8 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400')),
+            Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -25,7 +26,8 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400')),
+            Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -36,7 +38,8 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400')),
+            Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_unicred_cnab_240_400.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_unicred_cnab_240_400.xml
@@ -8,7 +8,10 @@
         <field name="name">Remessa*</field>
         <field name="code">01</field>
         <field name="code_type">instruction_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_136'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400')),
@@ -27,7 +30,10 @@
         <field name="name">Pedido de Baixa</field>
         <field name="code">02</field>
         <field name="code_type">instruction_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_136'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400')),
@@ -39,7 +45,10 @@
         <field name="name">Concessão de Abatimento*</field>
         <field name="code">04</field>
         <field name="code_type">instruction_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_136'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400')),
@@ -54,7 +63,10 @@
         <field name="name">Cancelamento de Abatimento</field>
         <field name="code">05</field>
         <field name="code_type">instruction_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_136'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400')),
@@ -66,7 +78,10 @@
         <field name="name">Alteração de vencimento</field>
         <field name="code">06</field>
         <field name="code_type">instruction_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_136'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400')),
@@ -78,7 +93,10 @@
         <field name="name">Alteração de Seu Número</field>
         <field name="code">08</field>
         <field name="code_type">instruction_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_136'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400')),
@@ -90,7 +108,10 @@
         <field name="name">Protestar*</field>
         <field name="code">09</field>
         <field name="code_type">instruction_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_136'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400')),
@@ -115,7 +136,10 @@
         <field name="name">Sustar Protesto e Manter em Carteira</field>
         <field name="code">11</field>
         <field name="code_type">instruction_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_136'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400')),
@@ -127,7 +151,10 @@
         <field name="name">Sustar Protesto e Baixar Título</field>
         <field name="code">25</field>
         <field name="code_type">instruction_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_136'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400')),
@@ -139,7 +166,10 @@
         <field name="name">Protesto automático</field>
         <field name="code">26</field>
         <field name="code_type">instruction_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_136'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400')),
@@ -172,7 +202,10 @@
         >Alteração de outros dados (Alteração de dados do pagador)</field>
         <field name="code">31</field>
         <field name="code_type">instruction_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_136'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400')),
@@ -184,7 +217,10 @@
         <field name="name">Alteração de Carteira</field>
         <field name="code">40</field>
         <field name="code_type">instruction_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_136'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400')),
@@ -197,7 +233,10 @@
         <field name="name">Pago (Título protestado pago em cartório)</field>
         <field name="code">01</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_136'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400')),
@@ -209,7 +248,10 @@
         <field name="name">Instrução Confirmada*</field>
         <field name="code">02</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_136'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400')),
@@ -221,7 +263,10 @@
         <field name="name">Instrução Rejeitada*</field>
         <field name="code">03</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_136'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400')),
@@ -235,7 +280,10 @@
         >Sustado Judicial (Título protestado sustado judicialmente)</field>
         <field name="code">04</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_136'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400')),
@@ -247,7 +295,10 @@
         <field name="name">Liquidação Normal *</field>
         <field name="code">06</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_136'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400')),
@@ -261,7 +312,10 @@
         >Liquidação em Condicional (Título liquidado em cartório com cheque do próprio devedor)</field>
         <field name="code">07</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_136'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400')),
@@ -275,7 +329,10 @@
         >Sustado Definitivo (Título protestado sustado judicialmente)</field>
         <field name="code">08</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_136'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400')),
@@ -287,7 +344,10 @@
         <field name="name">Liquidação de Título Descontado</field>
         <field name="code">09</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_136'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400')),
@@ -299,7 +359,10 @@
         <field name="name">Protesto solicitado</field>
         <field name="code">10</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_136'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400')),
@@ -311,7 +374,10 @@
         <field name="name">Protesto Em cartório</field>
         <field name="code">11</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_136'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400')),
@@ -323,7 +389,10 @@
         <field name="name">Sustação solicitada</field>
         <field name="code">12</field>
         <field name="code_type">return_move_code</field>
-        <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
+        <field
+            name="bank_ids"
+            eval="[Command.link(ref('l10n_br_base.res_bank_136'))]"
+        />
         <field
             name="payment_method_ids"
             eval="[Command.link(ref('payment_mode_type_cnab400')),

--- a/l10n_br_account_payment_order/data/cnab_codes/banco_unicred_cnab_240_400.xml
+++ b/l10n_br_account_payment_order/data/cnab_codes/banco_unicred_cnab_240_400.xml
@@ -11,7 +11,8 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400')),
+            Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"
@@ -29,7 +30,8 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400')),
+            Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -40,7 +42,8 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400')),
+            Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"
@@ -54,7 +57,8 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400')),
+            Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -65,7 +69,8 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400')),
+            Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -76,7 +81,8 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400')),
+            Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -87,7 +93,8 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400')),
+            Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"
@@ -111,7 +118,8 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400')),
+            Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -122,7 +130,8 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400')),
+            Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -133,7 +142,8 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400')),
+            Command.link(ref('payment_mode_type_cnab240'))]"
         />
         <field
             name="comment"
@@ -165,7 +175,8 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400')),
+            Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -176,7 +187,8 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400')),
+            Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -188,7 +200,8 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400')),
+            Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -199,7 +212,8 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400')),
+            Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -210,7 +224,8 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400')),
+            Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -223,7 +238,8 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400')),
+            Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -234,7 +250,8 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400')),
+            Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -247,7 +264,8 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400')),
+            Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -260,7 +278,8 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400')),
+            Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -271,7 +290,8 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400')),
+            Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -282,7 +302,8 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400')),
+            Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -293,7 +314,8 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400')),
+            Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 
@@ -304,7 +326,8 @@
         <field name="bank_ids" eval="[(6,0,[ref('l10n_br_base.res_bank_136')])]" />
         <field
             name="payment_method_ids"
-            eval="[(6,0,[ref('payment_mode_type_cnab400'), ref('payment_mode_type_cnab240')])]"
+            eval="[Command.link(ref('payment_mode_type_cnab400')),
+            Command.link(ref('payment_mode_type_cnab240'))]"
         />
     </record>
 


### PR DESCRIPTION
Como comentando na PR #3957, usar o `Command.link` em vez do `eval="[(6,0,`.

**OBS:** Acabei seperando em dois commits um pro `payment_method_ids` outro para `bank_ids`


cc @rvalyi @mbcosta @antoniospneto @marcelsavegnago 