### PR TITLE
[16.0][FIX] l10n_br_base: add hidden attributte to a duplicate vat

### DIFF
--- a/l10n_br_base/views/res_partner_view.xml
+++ b/l10n_br_base/views/res_partner_view.xml
@@ -39,17 +39,7 @@
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="arch" type="xml">
             <field name="vat" position="attributes">
-                <attribute name="force_save">1</attribute>
-                <attribute name="attrs">
-                    {
-                        'readonly':
-                            [
-                                '|', ('vat', 'not in', [False, ""]),
-                                     ('parent_id', '!=', False),
-
-                            ]
-                    }
-                </attribute>
+                <attribute name="invisible">1</attribute>
             </field>
             <xpath expr="//h1" position="after">
                 <field name="city_id" invisible="1" />


### PR DESCRIPTION
O campo vat está aparecendo duplicado no formulário de contatos. 
Esse PR adiciona o attributo invisible e oculta o campo duplicado

https://github.com/OCA/l10n-brazil/issues/3961

@antoniospneto @CristianoMafraJunior 