### PR TITLE
[16.0][FIX] l10n_br_fiscal: avoid mass recomputation

### DIFF
--- a/l10n_br_cte/tests/test_cte_serialize.py
+++ b/l10n_br_cte/tests/test_cte_serialize.py
@@ -38,7 +38,7 @@ class TestCTeSerialize(TransactionCase):
 
         cte.fiscal_line_ids.name = "Frete"
         for line in cte.fiscal_line_ids:
-            line.product_id.list_price = 100
+            line.price_unit = 100
         cte.fiscal_line_ids.cfop_id = cte.env.ref("l10n_br_fiscal.cfop_5352")
 
         cte.action_document_confirm()

--- a/l10n_br_fiscal/models/document_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_line_mixin_methods.py
@@ -446,8 +446,6 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
     @api.depends(
         "product_id",
         "fiscal_operation_id",
-        "product_id.list_price",
-        "product_id.standard_price",
     )
     def _compute_price_unit_fiscal(self):  # OK when edited from aml?? c-> check
         for line in self:


### PR DESCRIPTION
Hoje na localização tem um bug que se você mudar o preço no cadastro de um produto, todas os documentos fiscais que tenham esse produto terão o preço unitário recomputado, outras informações que dependem do preço também são recomputados. 

Para resolver isso removi product_id.list_price e product_id.standard_price do @api.depends.

