### PR TITLE
[16.0][FIX] l10n_br_account: fix move compute_amount sign

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -278,7 +278,7 @@ class AccountMove(models.Model):
 
         result = super()._compute_amount()
         for move in self.filtered(lambda m: m.fiscal_operation_id):
-            sign = move.direction_sign
+            sign = -move.direction_sign
             inv_line_ids = move.line_ids.filtered(
                 lambda line: line.display_type == "product"
                 and (not line.cfop_id or line.cfop_id.finance_move)


### PR DESCRIPTION
Ref https://github.com/OCA/l10n-brazil/pull/3954/files

<img width="711" height="369" alt="image" src="https://github.com/user-attachments/assets/ba29ee4a-e62a-4e6a-a601-81be4c90123d" />

<img width="822" height="155" alt="image" src="https://github.com/user-attachments/assets/a5d2da10-31e8-4f99-8c94-d22f5617dfe8" />
