### PR TITLE
[16.0][REF] l10n_br_fiscal: cleanup relateds fields

### DIFF
--- a/l10n_br_cte/models/document.py
+++ b/l10n_br_cte/models/document.py
@@ -516,7 +516,7 @@ class CTe(spec_models.StackedModel):
     )
 
     cte40_CRT = fields.Selection(
-        related="company_tax_framework",
+        related="company_id.tax_framework",
         string="Código de Regime Tributário (CTe)",
     )
 

--- a/l10n_br_fiscal/demo/fiscal_document_nfse_demo.xml
+++ b/l10n_br_fiscal/demo/fiscal_document_nfse_demo.xml
@@ -9,11 +9,6 @@
         <field name="document_serie">001</field>
         <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
         <field name="user_id" ref="base.user_demo" />
-        <field name="partner_legal_name">Cliente 1 SP</field>
-        <field name="partner_name">Cliente 1 SP Contribuinte</field>
-        <field name="partner_cnpj_cpf">81.493.979/0001-89</field>
-        <field name="partner_l10n_br_ie_code">454.504.604.553</field>
-        <field name="partner_tax_framework">3</field>
         <field name="fiscal_operation_type">out</field>
     </record>
 

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -215,204 +215,24 @@ class Document(models.Model):
         ],
         string="Tomador do Serviço",
     )
-
-    # ----- Now some handy related fields:
-
     partner_legal_name = fields.Char(
         string="Legal Name",
         related="partner_id.legal_name",
     )
-
-    partner_name = fields.Char(
-        string="Partner Name",
-        related="partner_id.name",
-    )
-
     partner_cnpj_cpf = fields.Char(
         string="CNPJ",
         related="partner_id.vat",
     )
-
     partner_l10n_br_ie_code = fields.Char(
         string="State Tax Number",
         related="partner_id.l10n_br_ie_code",
     )
 
-    partner_ind_ie_dest = fields.Selection(
-        string="Contribuinte do ICMS",
-        related="partner_id.ind_ie_dest",
-    )
-
-    partner_l10n_br_im_code = fields.Char(
-        string="Municipal Tax Number",
-        related="partner_id.l10n_br_im_code",
-    )
-
-    partner_l10n_br_isuf_code = fields.Char(
-        string="Suframa",
-        related="partner_id.l10n_br_isuf_code",
-    )
-
-    partner_cnae_main_id = fields.Many2one(
-        comodel_name="l10n_br_fiscal.cnae",
-        string="Main CNAE",
-        related="partner_id.cnae_main_id",
-    )
-
-    partner_tax_framework = fields.Selection(
-        string="Tax Framework",
-        related="partner_id.tax_framework",
-    )
-
-    partner_street = fields.Char(
-        string="Partner Street",
-        related="partner_id.street",
-    )
-
-    partner_number = fields.Char(
-        string="Partner Number",
-        related="partner_id.street_number",
-    )
-
-    partner_street2 = fields.Char(
-        string="Partner Street2",
-        related="partner_id.street2",
-    )
-
-    partner_district = fields.Char(
-        string="Partner District",
-        related="partner_id.district",
-    )
-
-    partner_country_id = fields.Many2one(
-        comodel_name="res.country",
-        string="Partner Country",
-        related="partner_id.country_id",
-    )
-
-    partner_state_id = fields.Many2one(
-        comodel_name="res.country.state",
-        string="Partner State",
-        related="partner_id.state_id",
-    )
-
-    partner_city_id = fields.Many2one(
-        comodel_name="res.city",
-        string="Partner City",
-        related="partner_id.city_id",
-    )
-
-    partner_zip = fields.Char(
-        string="Partner Zip",
-        related="partner_id.zip",
-    )
-
-    partner_phone = fields.Char(
-        string="Partner Phone",
-        related="partner_id.phone",
-    )
-
-    partner_is_company = fields.Boolean(
-        string="Partner Is Company?",
-        related="partner_id.is_company",
-    )
-
     processador_edoc = fields.Selection(
         related="company_id.processador_edoc",
     )
-
-    company_legal_name = fields.Char(
-        string="Company Legal Name",
-        related="company_id.legal_name",
-    )
-
-    company_name = fields.Char(
-        string="Company Name",
-        size=128,
-        related="company_id.name",
-    )
-
-    company_cnpj_cpf = fields.Char(
-        string="Company CNPJ",
-        related="company_id.vat",
-    )
-
-    company_l10n_br_ie_code = fields.Char(
-        string="Company State Tax Number",
-        related="company_id.l10n_br_ie_code",
-    )
-
     company_l10n_br_ie_code_st = fields.Char(
         string="Company ST State Tax Number",
-    )
-
-    company_l10n_br_im_code = fields.Char(
-        string="Company Municipal Tax Number",
-        related="company_id.l10n_br_im_code",
-    )
-
-    company_l10n_br_isuf_code = fields.Char(
-        string="Company Suframa",
-        related="company_id.l10n_br_isuf_code",
-    )
-
-    company_cnae_main_id = fields.Many2one(
-        comodel_name="l10n_br_fiscal.cnae",
-        string="Company Main CNAE",
-        related="company_id.cnae_main_id",
-    )
-
-    company_tax_framework = fields.Selection(
-        string="Company Tax Framework",
-        related="company_id.tax_framework",
-    )
-
-    company_street = fields.Char(
-        string="Company Street",
-        related="company_id.street",
-    )
-
-    company_number = fields.Char(
-        string="Company Number",
-        related="company_id.street_number",
-    )
-
-    company_street2 = fields.Char(
-        string="Company Street2",
-        related="company_id.street2",
-    )
-
-    company_district = fields.Char(
-        string="Company District",
-        related="company_id.district",
-    )
-
-    company_country_id = fields.Many2one(
-        comodel_name="res.country",
-        string="Company Country",
-        related="company_id.country_id",
-    )
-
-    company_state_id = fields.Many2one(
-        comodel_name="res.country.state",
-        string="Company State",
-        related="company_id.state_id",
-    )
-
-    company_city_id = fields.Many2one(
-        comodel_name="res.city",
-        string="Company City",
-        related="company_id.city_id",
-    )
-
-    company_zip = fields.Char(
-        string="Company ZIP",
-        related="company_id.zip",
-    )
-
-    company_phone = fields.Char(
-        string="Company Phone",
-        related="company_id.phone",
     )
 
     @api.constrains("document_key")
@@ -523,19 +343,19 @@ class Document(models.Model):
             name += "/" + type_serie_number
             if self.document_date:
                 name += " - " + self.document_date.strftime("%d/%m/%Y")
-            if not self.partner_cnpj_cpf:
+            if not self.partner_id.vat:
                 name += " - " + _("Unidentified Consumer")
-            elif self.partner_legal_name:
-                name += " - " + self.partner_legal_name
-                name += " - " + self.partner_cnpj_cpf
+            elif self.partner_id.legal_name:
+                name += " - " + self.partner_id.legal_name
+                name += " - " + self.partner_id.vat
             else:
-                name += " - " + self.partner_name
-                name += " - " + self.partner_cnpj_cpf
+                name += " - " + self.partner_id.name
+                name += " - " + self.partner_id.vat
         elif self._context.get("fiscal_document_no_company"):
             name += type_serie_number
         else:
             name += "{name}/{type_serie_number}".format(
-                name=self.company_name or "",
+                name=self.company_id.name or "",
                 type_serie_number=type_serie_number,
             )
         return name

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -294,68 +294,17 @@
                 </group>
               </group>
               <group name="company_info" string="Company">
-		<field name="company_id" invisible="1" />
+		            <field name="company_id" invisible="1" />
                 <field
                                     name="company_id"
                                     required="1"
                                     groups="base.group_multi_company"
                                 />
               </group>
-              <group>
-                <group name="company_left">
-                  <field name="company_legal_name" readonly="1" />
-                  <field name="company_name" readonly="1" />
-                  <field name="company_cnpj_cpf" readonly="1" />
-                  <field name="company_l10n_br_ie_code" readonly="1" />
-                  <field name="company_l10n_br_ie_code_st" readonly="1" />
-                  <field name="company_street" readonly="1" />
-                  <field name="company_number" readonly="1" />
-                  <field name="company_street2" readonly="1" />
-                  <field name="company_district" readonly="1" />
-                </group>
-                <group name="company_right">
-                  <field name="company_l10n_br_im_code" readonly="1" />
-                  <field name="company_l10n_br_isuf_code" readonly="1" />
-                  <field name="company_cnae_main_id" readonly="1" />
-                  <field name="company_tax_framework" readonly="1" />
-                  <field name="company_country_id" readonly="1" />
-                  <field name="company_state_id" readonly="1" />
-                  <field name="company_city_id" readonly="1" />
-                  <field name="company_zip" readonly="1" />
-                  <field name="company_phone" readonly="1" />
-                </group>
-              </group>
             </page>
             <page name="partners" string="Partners">
               <group name="partner">
                 <field name="partner_id" />
-              </group>
-              <group>
-                <group name="partner_left">
-                  <field name="partner_legal_name" readonly="1" />
-                  <field name="partner_name" readonly="1" />
-                  <field name="partner_cnpj_cpf" readonly="1" />
-                  <field name="partner_l10n_br_ie_code" readonly="1" />
-                  <field name="partner_ind_ie_dest" readonly="1" />
-                  <field name="partner_street" readonly="1" />
-                  <field name="partner_number" readonly="1" />
-                  <field name="partner_street2" readonly="1" />
-                  <field name="partner_district" readonly="1" />
-                </group>
-                <group name="partner_right">
-                  <field name="partner_l10n_br_im_code" readonly="1" />
-                  <field name="partner_l10n_br_isuf_code" readonly="1" />
-                  <field name="partner_cnae_main_id" readonly="1" />
-                  <field name="partner_tax_framework" readonly="1" />
-                  <field name="partner_is_company" readonly="1" />
-                  <field name="partner_country_id" readonly="1" />
-                  <field name="partner_state_id" readonly="1" />
-                  <field name="partner_city_id" readonly="1" />
-                  <field name="partner_zip" readonly="1" />
-                  <field name="partner_phone" readonly="1" />
-                </group>
-              </group>
-              <group>
                 <field name="partner_shipping_id" />
               </group>
             </page>

--- a/l10n_br_fiscal_closing/models/closing.py
+++ b/l10n_br_fiscal_closing/models/closing.py
@@ -192,7 +192,7 @@ class FiscalClosing(models.Model):
         if document.issuer == DOCUMENT_ISSUER_COMPANY:
             document_path = "/".join(
                 [
-                    misc.punctuation_rm(document.company_cnpj_cpf),
+                    misc.punctuation_rm(document.company_id.vat),
                     document.document_date.strftime("%m-%Y"),
                     document.issuer,
                     PATH_MODELO[document.document_type_id.code],
@@ -210,7 +210,7 @@ class FiscalClosing(models.Model):
         else:
             document_path = "/".join(
                 [
-                    misc.punctuation_rm(document.company_cnpj_cpf),
+                    misc.punctuation_rm(document.company_id.vat),
                     document.document_date.strftime("%m-%Y"),
                     document.issuer,
                     misc.punctuation_rm(document.partner_cnpj_cpf),

--- a/l10n_br_fiscal_edi/models/document_workflow.py
+++ b/l10n_br_fiscal_edi/models/document_workflow.py
@@ -240,10 +240,10 @@ class DocumentWorkflow(models.AbstractModel):
                 date = fields.Datetime.context_timestamp(record, record.document_date)
                 chave_edoc = ChaveEdoc(
                     ano_mes=date.strftime("%y%m").zfill(4),
-                    cnpj_cpf_emitente=record.company_cnpj_cpf,
+                    cnpj_cpf_emitente=record.company_id.vat,
                     codigo_uf=(
-                        record.company_state_id
-                        and record.company_state_id.ibge_code
+                        record.company_id.state_id
+                        and record.company_id.state_id.ibge_code
                         or ""
                     ),
                     forma_emissao=1,  # TODO: Implementar campo no Odoo

--- a/l10n_br_fiscal_edi/views/document_event_template.xml
+++ b/l10n_br_fiscal_edi/views/document_event_template.xml
@@ -50,7 +50,7 @@ row {
               </div>
               <div id="company_cnpj_cpf" class="col-6 bl">
                   <strong style="font-size:18px;">CNPJ:</strong>
-                  <p t-field="o.document_id.company_cnpj_cpf" />
+                  <p t-field="o.document_id.company_id.vat" />
               </div>
         </div>
         <div class="row bb bl br">

--- a/l10n_br_mdfe/models/document.py
+++ b/l10n_br_mdfe/models/document.py
@@ -942,9 +942,11 @@ class MDFe(spec_models.StackedModel):
             date = fields.Datetime.context_timestamp(record, record.document_date)
             chave_edoc = ChaveEdoc(
                 ano_mes=date.strftime("%y%m").zfill(4),
-                cnpj_cpf_emitente=record.company_cnpj_cpf,
+                cnpj_cpf_emitente=record.company_id.vat,
                 codigo_uf=(
-                    record.company_state_id and record.company_state_id.ibge_code or ""
+                    record.company_id.state_id
+                    and record.company_id.state_id.ibge_code
+                    or ""
                 ),
                 forma_emissao=int(self.mdfe_transmission),
                 modelo_documento=record.document_type_id.code or "",

--- a/l10n_br_nfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_nfe/demo/fiscal_document_demo.xml
@@ -10,7 +10,6 @@
             ref="l10n_br_fiscal.empresa_lc_document_55_serie_1"
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
-        <field name="company_number">3</field>
         <field name="document_serie">1</field>
         <field name="nfe_environment">2</field>
         <field name="processador_edoc">oca</field>
@@ -174,7 +173,6 @@
             ref="l10n_br_fiscal.empresa_lc_document_65_serie_1"
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
-        <field name="company_number">3</field>
         <field name="document_serie">1</field>
         <field name="document_key">33230807984267003800650040000000321935136447</field>
         <field name="document_date">2023-08-01 11:00:00</field>

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -384,7 +384,7 @@ class NFe(spec_models.StackedModel):
     )
 
     nfe40_CRT = fields.Selection(
-        related="company_tax_framework",
+        related="company_id.tax_framework",
         string="Código de Regime Tributário (NFe)",
     )
 
@@ -422,7 +422,7 @@ class NFe(spec_models.StackedModel):
     )
 
     nfe40_indIEDest = fields.Selection(
-        related="partner_ind_ie_dest",
+        related="partner_id.ind_ie_dest",
         string="Contribuinte do ICMS (NFe)",
     )
 
@@ -1102,9 +1102,9 @@ class NFe(spec_models.StackedModel):
 
         for record in self.filtered(filter_processador_edoc_nfe):
             required_fields_gen_edoc = []
-            if not record.company_cnpj_cpf:
+            if not record.company_id.vat:
                 required_fields_gen_edoc.append("CNPJ/CPF")
-            elif not record.company_state_id:
+            elif not record.company_id.state_id:
                 required_fields_gen_edoc.append("State Company")
             elif not record.document_type_id:
                 required_fields_gen_edoc.append("Document Type")
@@ -1121,9 +1121,11 @@ class NFe(spec_models.StackedModel):
             date = fields.Datetime.context_timestamp(record, record.document_date)
             chave_edoc = ChaveEdoc(
                 ano_mes=date.strftime("%y%m").zfill(4),
-                cnpj_cpf_emitente=record.company_cnpj_cpf,
+                cnpj_cpf_emitente=record.company_id.vat,
                 codigo_uf=(
-                    record.company_state_id and record.company_state_id.ibge_code or ""
+                    record.company_id.state_id
+                    and record.company_id.state_id.ibge_code
+                    or ""
                 ),
                 forma_emissao=int(self.nfe_transmission),
                 modelo_documento=record.document_type_id.code or "",


### PR DESCRIPTION
Remoção do excesso de campos relateds aos modelos `company_id` e `partner_id` no documento fiscal.
Hoje esses campos são usados apenas para exibição na visão, mas não há necessidade.
