### PR TITLE
[16.0] l10n_br_fiscal clean fiscal document form

### DIFF
--- a/l10n_br_account/models/document.py
+++ b/l10n_br_account/models/document.py
@@ -198,9 +198,11 @@ class FiscalDocument(models.Model):
         messages in a fiscal document chatter are visible in the
         related account moves.
         """
+        res = super().message_post(**kwargs)
         for doc in self:
             for move in doc.move_ids:
                 move.message_post(**kwargs)
+        return res
 
     def cancel_move_ids(self):
         for record in self:

--- a/l10n_br_account/views/fiscal_invoice_view.xml
+++ b/l10n_br_account/views/fiscal_invoice_view.xml
@@ -95,16 +95,10 @@
                   <field name="product_uom_id" />
                   <field name="price_unit" />
                   <field name="quantity" />
-                  <field name="amount_total" />
+                  <field name="fiscal_tax_ids" widget="many2many_tags" />
+                  <field name="amount_total" sum="Total" />
                 </tree>
             </field>
-        </xpath>
-        <xpath expr="//sheet" position="after">
-            <div class="oe_chatter">
-                <field name="message_follower_ids" widget="mail_followers" />
-                <field name="activity_ids" widget="mail_activity" />
-                <field name="message_ids" widget="mail_thread" />
-            </div>
         </xpath>
       </field>
     </record>

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -61,6 +61,7 @@ class Document(models.Model):
     _inherit = [
         "l10n_br_fiscal.document.mixin",
         "mail.thread",
+        "mail.activity.mixin",
     ]
     _description = "Fiscal Document"
     _check_company_auto = True

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -220,45 +220,40 @@
                             />
             </h1>
           </div>
-          <group name="l10n_br_fiscal" colspan="4">
-            <field
-                            name="fiscal_operation_id"
-                            options="{'no_create': True, 'no_create_edit': True}"
-                        /> <!-- USE MIXIN VIEW -->
-            <field name="edoc_purpose" />
-            <field name="ind_final" />
-            <field name="ind_pres" />
-          </group>
           <group>
-            <field name="issuer" />
-            <field name="document_type_id" required="1" />
-            <label
-                            for="document_key"
-                            attrs="{'invisible': [('document_electronic', '=', False)]}"
-                        />
-            <div
-                            class="o_row"
-                            attrs="{'readonly': [('issuer', '=', 'company')], 'required': [('issuer', '=', 'partner'), ('document_electronic', '=', True)], 'invisible': [('document_electronic', '=', False)]}"
-                        >
-              <field name="document_key" force_save="1" class="oe_inline" />
-              <!--button
-                                name="action_search_key"
-                                type="object"
-                                class="oe_inline btn-sm btn-link mb4 fa fa-search oe_edit_only"
-                                aria-label="Pesquisar Chave"
-                                title="Pesquisar Chave"
+            <group name="partner_info">
+              <field
+                                name="partner_id"
+                                widget="res_partner_many2one"
+                                context="{
+                            'show_address': 1, 'default_is_company': True, 'show_vat': True}"
+                                options='{"always_reload": True, "no_quick_create": True}'
                             />
-              <button
-                                name="action_import_xml"
-                                type="object"
-                                class="oe_inline btn-sm btn-link mb4 fa fa-upload oe_edit_only"
-                                aria-label="Upload"
-                                title="Upload"
-                            /-->
-            </div>
-          </group>
-          <group>
-            <group name="document_header_right">
+              <field name="partner_shipping_id" />
+            </group>
+            <group name="l10n_br_fiscal">
+              <field
+                                name="fiscal_operation_id"
+                                options="{'no_create': True, 'no_create_edit': True}"
+                            />
+              <field name="edoc_purpose" />
+              <field name="ind_final" />
+              <field name="ind_pres" />
+            </group>
+            <group name="document_numbers">
+              <field name="issuer" />
+              <field name="document_type_id" required="1" />
+              <label
+                                for="document_key"
+                                attrs="{'invisible': [('document_electronic', '=', False)]}"
+                            />
+              <div
+                                class="o_row"
+                                attrs="{'readonly': [('issuer', '=', 'company')], 'required': [('issuer', '=', 'partner'), ('document_electronic', '=', True)], 'invisible': [('document_electronic', '=', False)]}"
+                            >
+              <field name="document_key" force_save="1" class="oe_inline" />
+              </div>
+
               <field
                                 name="document_serie_id"
                                 attrs="{'invisible': [('issuer', '!=', 'company')], 'required': [('issuer', '=', 'company')]}"
@@ -268,46 +263,29 @@
                                 name="document_serie"
                                 attrs="{'invisible': [('issuer', '!=', 'partner')], 'required': [('issuer', '=', 'partner')]}"
                             />
-            </group>
-            <group name="document_header_left">
               <field
                                 name="document_number"
                                 force_save="1"
                                 attrs="{'readonly': [('issuer', '=', 'company')], 'required': [('issuer', '=', 'partner')]}"
                             />
+            </group>
+            <group name="document_extra">
               <field name="state_fiscal" />
+              <field name="document_date" />
+              <field name="date_in_out" />
+              <field name='user_id' />
+              <field name="company_id" required="1" groups="base.group_multi_company" />
+              <field name='company_id' invisible="1" />
+            </group>
+            <group
+                            name="CT-e Info"
+                            invisible="[('document_type_id.code', 'in', ['57', '08', '09', '10', '11', '26', '67', '8B'])]"
+                        >
+              <field name="transport_modal" />
+              <field name="service_provider" />
             </group>
           </group>
-          <group name="CT-e Info">
-            <field name="transport_modal" />
-            <field name="service_provider" />
-          </group>
           <notebook>
-            <page name="document" string="Document Info">
-              <group name="Document">
-                <group>
-                  <field name="document_date" />
-                  <field name="date_in_out" />
-                </group>
-                <group>
-                  <field name='user_id' />
-                </group>
-              </group>
-              <group name="company_info" string="Company">
-		            <field name="company_id" invisible="1" />
-                <field
-                                    name="company_id"
-                                    required="1"
-                                    groups="base.group_multi_company"
-                                />
-              </group>
-            </page>
-            <page name="partners" string="Partners">
-              <group name="partner">
-                <field name="partner_id" />
-                <field name="partner_shipping_id" />
-              </group>
-            </page>
             <page name="products" string="Products and Services">
               <field
                                 name="fiscal_line_ids"
@@ -318,7 +296,8 @@
                   <field name="uom_id" />
                   <field name="price_unit" />
                   <field name="quantity" />
-                  <field name="amount_total" />
+                  <field name="fiscal_tax_ids" widget="many2many_tags" />
+                  <field name="amount_total" sum="Total" />
                 </tree>
               </field>
             </page>

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -416,7 +416,13 @@
                 </group>
             </page>
           </notebook>
-        </sheet>
+          </sheet>
+          <div class="o_attachment_preview" />
+          <div class="oe_chatter">
+              <field name="message_follower_ids" groups="base.group_user" />
+              <field name="activity_ids" />
+              <field name="message_ids" />
+          </div>
       </form>
     </field>
   </record>

--- a/l10n_br_mdfe/views/document.xml
+++ b/l10n_br_mdfe/views/document.xml
@@ -24,7 +24,7 @@
                 >{'invisible': [('document_type', 'in', ['58'])]}</attribute>
             </xpath>
 
-            <xpath expr="//page[@name='partners']" position="attributes">
+            <xpath expr="//group[@name='partner_info']" position="attributes">
                 <attribute
                     name="attrs"
                 >{'invisible': [('document_type', 'in', ['58'])]}</attribute>

--- a/l10n_br_nfse/views/document_view.xml
+++ b/l10n_br_nfse/views/document_view.xml
@@ -11,7 +11,7 @@
             <field name="status_description" position="after">
                 <field name="edoc_error_message" />
             </field>
-            <group name="document_header_right" position="before">
+            <group name="document_numbers" position="before">
                 <group
                     name="nfse_operation"
                     attrs="{'invisible': [('document_type', '!=', 'SE')]}"


### PR DESCRIPTION
PR por cima de #3996, até para validar ele.

O objetivo dos campos related no #3996 era uma mistura de querer denormalizar alguns dados importantes 10 anos atrás (acho que veio do @mileo) para persistir os dados relacionadas de parceiros e empresa. Porem com os documentos fiscais eletrônicos e com os mappings do SPED entrando isso realmente se torna inútil e como era campo related mesmo era inútil mesmo.

Mas eu acho que servia tb para poder visualizar melhor o endereço do parceiro do documento fiscal. Mas hoje podemos usar o widget res_partner_many2one que mostra o endereço completo. Foi que eu fiz neste PR.

Eu tb aproveitei para melhorar outras coisas: eu tirei a aba "documento info" e joguei os campos numa segunda coluna da parte de cima.

Eu tb joguei a aba produtos e serviços na primeira aba e adicionei o campo fiscal_tax_ids com widget many2many_tags para melhoar a visualização das informações mais importantes.

vale a pena notar que esse XML tem uma indentação bem zoada... Eu proponho de fazer um commit para limpar a indentação de todos XMLs depois desse merge para limpar os XMLs todos antes de jogar os módulos para as v17 e v18 e minimizar o diff.

EDIT: 
Eu tb adicionei o chatter + activity que eu peguei do PR #3842 do @antoniospneto e deixando ele como autor do commit. Eu tive que resolver um bug no message_post no l10n_br_account pro broadcast de uma mensagem num documento fiscal pros account.move funcionar mesmo.

ficou assim:

NF-e:
<img width="1595" height="849" alt="2025-08-27_02-34" src="https://github.com/user-attachments/assets/3da2c3e5-4329-477a-b731-8bcb23efcaca" />

NFS-e:
<img width="1595" height="849" alt="2025-08-27_03-26" src="https://github.com/user-attachments/assets/132fec6e-8f18-44f9-93d1-172802ae2d2c" />

CT-e:
<img width="1595" height="849" alt="2025-08-27_02-35" src="https://github.com/user-attachments/assets/f81e4393-e53b-4c99-baf1-08535c515411" />

MDF-e:
<img width="1595" height="849" alt="2025-08-27_02-38" src="https://github.com/user-attachments/assets/b345e1cc-7683-469f-889f-22b1af2a7eec" />




