### PR TITLE
[16.0][FIX] l10n_br_contract: fix precompute warning

### DIFF
--- a/l10n_br_contract/models/contract_line.py
+++ b/l10n_br_contract/models/contract_line.py
@@ -8,9 +8,6 @@ class ContractLine(models.Model):
     _name = "contract.line"
     _inherit = [_name, "l10n_br_fiscal.document.line.mixin"]
 
-    company_id = fields.Many2one(
-        related="contract_id.company_id",
-    )
     country_id = fields.Many2one(related="company_id.country_id", store=True)
 
     fiscal_tax_ids = fields.Many2many(
@@ -43,6 +40,11 @@ class ContractLine(models.Model):
     )
 
     line_recurrence = fields.Boolean(related="contract_id.line_recurrence")
+
+    def _get_fiscal_tax_ids_dependencies(self):
+        fields = super()._get_fiscal_tax_ids_dependencies()
+        fields.remove("company_id")
+        return fields
 
     def _prepare_invoice_line(self):
         self.ensure_one()


### PR DESCRIPTION
evita um montão de warning assim nos logs:

```
2025-08-27 04:37:00,959 32093 WARNING odoo16 py.warnings: /home/rvalyi/DEV/odoo16/odoo/src/odoo/fields.py:804: UserWarning: Field contract.line.comment_ids cannot be precomputed as it depends on non-precomputed field contract.line.company_id
  File "/home/rvalyi/DEV/odoo16/odoo/bin/odoo", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/home/rvalyi/DEV/odoo16/odoo/src/setup/odoo", line 8, in <module>
    odoo.cli.main()
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/cli/command.py", line 66, in main
    o.run(args)
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/cli/server.py", line 187, in run
    main(args)
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/cli/server.py", line 180, in main
    rc = odoo.service.server.start(preload=preload, stop=stop)
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/service/server.py", line 1427, in start
    rc = server.run(preload, stop)
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/service/server.py", line 596, in run
    rc = preload_registries(preload)
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/service/server.py", line 1327, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/home/rvalyi/DEV/odoo16/odoo/lib/python3.11/site-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/modules/registry.py", line 87, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/modules/loading.py", line 489, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/modules/loading.py", line 374, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/modules/loading.py", line 232, in load_module_graph
    module.write(module.get_values_from_terp(package.data))
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/models.py", line 3766, in write
    if self.pool.is_modifying_relations(field):
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/modules/registry.py", line 458, in is_modifying_relations
    result = field in self._field_triggers and (
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/tools/func.py", line 28, in __get__
    value = self.fget(obj)
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/modules/registry.py", line 439, in _field_triggers
    dependencies = list(field.resolve_depends(self))
  File "/home/rvalyi/DEV/odoo16/odoo/src/odoo/fields.py", line 804, in resolve_depends
    warnings.warn(f"Field {self} cannot be precomputed as it depends on non-precomputed field {field}")

2025-08-27 04:37:00,961 32093 INFO odoo16 odoo.modules.loading: loading l10n_br_contract/data/company.xml
```

Eu confesso que eu não entendi bem porque o company_id não é considerado precompute ja que parece ser apenas um campo m2o no contract.abstract.contract. Mas enfim já que é raro a pessoa criar um contrato e ficar alterando a empresa depois, basta remover das dependências co compute.  

OBS: eu tb tirei o related no inicio do arquivo, pois já era definido no modulo contract, era inútil.

cc @marcelsavegnago 