### PR TITLE
[17.0] l10n_br_base: fix cnpj_cpf/vat / fwp 3983

### DIFF
--- a/l10n_br_base/views/res_company_view.xml
+++ b/l10n_br_base/views/res_company_view.xml
@@ -68,7 +68,7 @@
         <field name="inherit_id" ref="base.view_company_tree" />
         <field name="arch" type="xml">
             <field name="name" position="after">
-                <field name="cnpj_cpf" />
+                <field name="vat" />
             </field>
         </field>
     </record>

--- a/l10n_br_base/views/res_partner_view.xml
+++ b/l10n_br_base/views/res_partner_view.xml
@@ -39,10 +39,7 @@
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="arch" type="xml">
             <field name="vat" position="attributes">
-                <attribute name="force_save">1</attribute>
-                <attribute
-                    name="readonly"
-                >vat not in [False, ''] or parent_id</attribute>
+                <attribute name="invisible">1</attribute>
             </field>
             <xpath expr="//h1" position="after">
                 <field name="city_id" invisible="1" />


### PR DESCRIPTION
- fix de um erro de rebase durante a migração
- fwp de #3983

OBS: @CristianoMafraJunior eu tb gastei uma meia hora para tentar trazer de volta a busca do cnpj_cpf_stripped pela busca do name como vc observou aqui https://github.com/OCA/l10n-brazil/pull/3964#issuecomment-3210062529 porem não consegui de forma simples, proponho de deixar esse detalhe para depois, afinal a gente conseguiu viver 15 anos sem ele, podemos ver depois.