### PR TITLE
[16.0][FIX] l10n_br_cte: DeprecationWarning

### DIFF
--- a/l10n_br_cte/tests/test_cte_structure.py
+++ b/l10n_br_cte/tests/test_cte_structure.py
@@ -3,16 +3,12 @@
 
 from io import StringIO
 
-from odoo.tests import SavepointCase
+from odoo.tests import TransactionCase
 
 from odoo.addons.spec_driven_model.models.spec_models import SpecModel
 
 
-class CTeStructure(SavepointCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-
+class CTeStructure(TransactionCase):
     @classmethod
     def get_stacked_tree(cls, klass):
         """


### PR DESCRIPTION
Apenas para remover o warn:

> 2025-08-30 14:10:18,057 493 WARNING odoo py.warnings: /__w/l10n-brazil/l10n-brazil/l10n_br_cte/tests/test_cte_structure.py:11: DeprecationWarning: Deprecated class SavepointCase has been merged into TransactionCase