### PR TITLE
[16.0][FIX] l10n_br_account_nfe: permitido informar a tag pag com o tpag = 90

### DIFF
--- a/l10n_br_account_nfe/models/document.py
+++ b/l10n_br_account_nfe/models/document.py
@@ -125,6 +125,7 @@ class DocumentNfe(models.Model):
             and self.amount_financial_total > 0
             and self.nfe40_tpNF == NFE_OUT
             and self.document_type != "65"
+            and self._is_installment()
         ):
             return True
         else:
@@ -136,6 +137,10 @@ class DocumentNfe(models.Model):
         if not self.amount_financial_total:
             return True
         if self.nfe40_tpNF == NFE_IN:
+            return True
+        if not self.move_ids.payment_mode_id:
+            return True
+        if self.move_ids.payment_mode_id.fiscal_payment_mode == "90":
             return True
         else:
             return False


### PR DESCRIPTION
Supersedes #3872

Fiz a verificação do `_is_installment()` dentro do método `_need_compute_nfe40_dup()`