### PR TITLE
[17.0][REF] l10n_br_fiscal: code lint

### DIFF
--- a/l10n_br_fiscal/models/comment.py
+++ b/l10n_br_fiscal/models/comment.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 from dateutil.relativedelta import relativedelta
 
-from odoo import api, fields, models, tools
+from odoo import api, fields, models
 from odoo.osv import expression
 
 from ..constants.fiscal import (
@@ -165,7 +165,7 @@ class Comment(models.Model):
 
         comments = [manual_comment] if manual_comment else []
         for record in self:
-            template = mako_safe_env.from_string(tools.ustr(record.comment))
+            template = mako_safe_env.from_string(record.comment)
             comments.append(template.render(vals))
         return " - ".join(comments)
 

--- a/l10n_br_fiscal/models/ibpt.py
+++ b/l10n_br_fiscal/models/ibpt.py
@@ -45,7 +45,7 @@ def _request(ws_url, params, ibpt_request_timeout=30):
         elif response.status_code == requests.codes.service_unavailable:
             raise UserError(_("IBPT Service Unavailable - {!r}").format(ws_url))
     except Exception as e:
-        raise UserError(_("Error in the request: {}").format(e)) from e
+        raise UserError(f"Error in the request: {e}") from e
 
 
 def get_ibpt_product(

--- a/l10n_br_fiscal/models/invalidate_number.py
+++ b/l10n_br_fiscal/models/invalidate_number.py
@@ -99,11 +99,10 @@ class InvalidateNumber(models.Model):
     @api.depends("document_type_id", "document_serie_id", "number_start", "number_end")
     def _compute_name(self):
         for record in self:
-            record.name = "{type}/({serie}): {start} - {end}".format(
-                type=record.document_type_id.type,
-                serie=record.document_serie_id.name,
-                start=record.number_start,
-                end=record.number_end,
+            record.name = (
+                f"{record.document_type_id.type}/"
+                f"({record.document_serie_id.name}): "
+                f"{record.number_start} - {record.number_end}"
             )
 
     def unlink(self):

--- a/l10n_br_fiscal/models/operation_dashboard.py
+++ b/l10n_br_fiscal/models/operation_dashboard.py
@@ -157,7 +157,7 @@ class Operation(models.Model):
             }
         )
 
-        [action] = self.env.ref("l10n_br_fiscal.%s" % action_name).read()
+        [action] = self.env.ref("l10n_br_fiscal.{action_name}").read()
         action["context"] = ctx
         action["domain"] = self._context.get("use_domain", [])
         action["domain"] += [

--- a/l10n_br_fiscal/tests/test_fiscal_document_generic.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_generic.py
@@ -77,9 +77,10 @@ class TestFiscalDocumentGeneric(TransactionCase):
             # ICMS
             self.assertTrue(
                 is_icms_internal,
-                "Error to mapping ICMS Inernal for {}"
+                "Error to mapping ICMS Inernal for "
+                f"{self.nfe_same_state.partner_id.state_id.name}"
                 " for Venda de Contribuinte Dentro do "
-                "Estado.".format(self.nfe_same_state.partner_id.state_id.name),
+                "Estado.",
             )
             self.assertEqual(
                 line.icms_cst_id.code,


### PR DESCRIPTION
backport de https://github.com/OCA/l10n-brazil/commit/9a927fe9a6b5c894dc0628169e784cd6f170e73c para diminuir o diff

OBS: no raise do IBT não existe env para saber a lingua e usar _(), a v18 é mais rigorosa com isso; por isso tive que corrigir aqui e em vários outros lugares durante a migração.