### PR TITLE
[18.0][REF] l10n_br_base: Removendo aspas "" dos arquivos CSV

### DIFF
--- a/l10n_br_base/data/res.city.csv
+++ b/l10n_br_base/data/res.city.csv
@@ -1,5571 +1,5571 @@
-"id","name","ibge_code","state_id:id","country_id:id"
-"city_1100015","Alta Floresta D'Oeste","1100015","base.state_br_ro","base.br"
-"city_1100379","Alto Alegre dos Parecis","1100379","base.state_br_ro","base.br"
-"city_1100403","Alto Paraíso","1100403","base.state_br_ro","base.br"
-"city_1100346","Alvorada D'Oeste","1100346","base.state_br_ro","base.br"
-"city_1100023","Ariquemes","1100023","base.state_br_ro","base.br"
-"city_1100452","Buritis","1100452","base.state_br_ro","base.br"
-"city_1100031","Cabixi","1100031","base.state_br_ro","base.br"
-"city_1100601","Cacaulândia","1100601","base.state_br_ro","base.br"
-"city_1100049","Cacoal","1100049","base.state_br_ro","base.br"
-"city_1100700","Campo Novo de Rondônia","1100700","base.state_br_ro","base.br"
-"city_1100809","Candeias do Jamari","1100809","base.state_br_ro","base.br"
-"city_1100908","Castanheiras","1100908","base.state_br_ro","base.br"
-"city_1100056","Cerejeiras","1100056","base.state_br_ro","base.br"
-"city_1100924","Chupinguaia","1100924","base.state_br_ro","base.br"
-"city_1100064","Colorado do Oeste","1100064","base.state_br_ro","base.br"
-"city_1100072","Corumbiara","1100072","base.state_br_ro","base.br"
-"city_1100080","Costa Marques","1100080","base.state_br_ro","base.br"
-"city_1100940","Cujubim","1100940","base.state_br_ro","base.br"
-"city_1100098","Espigão D'Oeste","1100098","base.state_br_ro","base.br"
-"city_1101005","Governador Jorge Teixeira","1101005","base.state_br_ro","base.br"
-"city_1100106","Guajará-Mirim","1100106","base.state_br_ro","base.br"
-"city_1101104","Itapuã do Oeste","1101104","base.state_br_ro","base.br"
-"city_1100114","Jaru","1100114","base.state_br_ro","base.br"
-"city_1100122","Ji-Paraná","1100122","base.state_br_ro","base.br"
-"city_1100130","Machadinho D'Oeste","1100130","base.state_br_ro","base.br"
-"city_1101203","Ministro Andreazza","1101203","base.state_br_ro","base.br"
-"city_1101302","Mirante da Serra","1101302","base.state_br_ro","base.br"
-"city_1101401","Monte Negro","1101401","base.state_br_ro","base.br"
-"city_1100148","Nova Brasilândia D'Oeste","1100148","base.state_br_ro","base.br"
-"city_1100338","Nova Mamoré","1100338","base.state_br_ro","base.br"
-"city_1101435","Nova União","1101435","base.state_br_ro","base.br"
-"city_1100502","Novo Horizonte do Oeste","1100502","base.state_br_ro","base.br"
-"city_1100155","Ouro Preto do Oeste","1100155","base.state_br_ro","base.br"
-"city_1101450","Parecis","1101450","base.state_br_ro","base.br"
-"city_1100189","Pimenta Bueno","1100189","base.state_br_ro","base.br"
-"city_1101468","Pimenteiras do Oeste","1101468","base.state_br_ro","base.br"
-"city_1100205","Porto Velho","1100205","base.state_br_ro","base.br"
-"city_1100254","Presidente Médici","1100254","base.state_br_ro","base.br"
-"city_1101476","Primavera de Rondônia","1101476","base.state_br_ro","base.br"
-"city_1100262","Rio Crespo","1100262","base.state_br_ro","base.br"
-"city_1100288","Rolim de Moura","1100288","base.state_br_ro","base.br"
-"city_1100296","Santa Luzia D'Oeste","1100296","base.state_br_ro","base.br"
-"city_1101484","São Felipe D'Oeste","1101484","base.state_br_ro","base.br"
-"city_1101492","São Francisco do Guaporé","1101492","base.state_br_ro","base.br"
-"city_1100320","São Miguel do Guaporé","1100320","base.state_br_ro","base.br"
-"city_1101500","Seringueiras","1101500","base.state_br_ro","base.br"
-"city_1101559","Teixeirópolis","1101559","base.state_br_ro","base.br"
-"city_1101609","Theobroma","1101609","base.state_br_ro","base.br"
-"city_1101708","Urupá","1101708","base.state_br_ro","base.br"
-"city_1101757","Vale do Anari","1101757","base.state_br_ro","base.br"
-"city_1101807","Vale do Paraíso","1101807","base.state_br_ro","base.br"
-"city_1100304","Vilhena","1100304","base.state_br_ro","base.br"
-"city_1200013","Acrelândia","1200013","base.state_br_ac","base.br"
-"city_1200054","Assis Brasil","1200054","base.state_br_ac","base.br"
-"city_1200104","Brasiléia","1200104","base.state_br_ac","base.br"
-"city_1200138","Bujari","1200138","base.state_br_ac","base.br"
-"city_1200179","Capixaba","1200179","base.state_br_ac","base.br"
-"city_1200203","Cruzeiro do Sul","1200203","base.state_br_ac","base.br"
-"city_1200252","Epitaciolândia","1200252","base.state_br_ac","base.br"
-"city_1200302","Feijó","1200302","base.state_br_ac","base.br"
-"city_1200328","Jordão","1200328","base.state_br_ac","base.br"
-"city_1200336","Mâncio Lima","1200336","base.state_br_ac","base.br"
-"city_1200344","Manoel Urbano","1200344","base.state_br_ac","base.br"
-"city_1200351","Marechal Thaumaturgo","1200351","base.state_br_ac","base.br"
-"city_1200385","Plácido de Castro","1200385","base.state_br_ac","base.br"
-"city_1200807","Porto Acre","1200807","base.state_br_ac","base.br"
-"city_1200393","Porto Walter","1200393","base.state_br_ac","base.br"
-"city_1200401","Rio Branco","1200401","base.state_br_ac","base.br"
-"city_1200427","Rodrigues Alves","1200427","base.state_br_ac","base.br"
-"city_1200435","Santa Rosa do Purus","1200435","base.state_br_ac","base.br"
-"city_1200500","Sena Madureira","1200500","base.state_br_ac","base.br"
-"city_1200450","Senador Guiomard","1200450","base.state_br_ac","base.br"
-"city_1200609","Tarauacá","1200609","base.state_br_ac","base.br"
-"city_1200708","Xapuri","1200708","base.state_br_ac","base.br"
-"city_1300029","Alvarães","1300029","base.state_br_am","base.br"
-"city_1300060","Amaturá","1300060","base.state_br_am","base.br"
-"city_1300086","Anamã","1300086","base.state_br_am","base.br"
-"city_1300102","Anori","1300102","base.state_br_am","base.br"
-"city_1300144","Apuí","1300144","base.state_br_am","base.br"
-"city_1300201","Atalaia do Norte","1300201","base.state_br_am","base.br"
-"city_1300300","Autazes","1300300","base.state_br_am","base.br"
-"city_1300409","Barcelos","1300409","base.state_br_am","base.br"
-"city_1300508","Barreirinha","1300508","base.state_br_am","base.br"
-"city_1300607","Benjamin Constant","1300607","base.state_br_am","base.br"
-"city_1300631","Beruri","1300631","base.state_br_am","base.br"
-"city_1300680","Boa Vista do Ramos","1300680","base.state_br_am","base.br"
-"city_1300706","Boca do Acre","1300706","base.state_br_am","base.br"
-"city_1300805","Borba","1300805","base.state_br_am","base.br"
-"city_1300839","Caapiranga","1300839","base.state_br_am","base.br"
-"city_1300904","Canutama","1300904","base.state_br_am","base.br"
-"city_1301001","Carauari","1301001","base.state_br_am","base.br"
-"city_1301100","Careiro","1301100","base.state_br_am","base.br"
-"city_1301159","Careiro da Várzea","1301159","base.state_br_am","base.br"
-"city_1301209","Coari","1301209","base.state_br_am","base.br"
-"city_1301308","Codajás","1301308","base.state_br_am","base.br"
-"city_1301407","Eirunepé","1301407","base.state_br_am","base.br"
-"city_1301506","Envira","1301506","base.state_br_am","base.br"
-"city_1301605","Fonte Boa","1301605","base.state_br_am","base.br"
-"city_1301654","Guajará","1301654","base.state_br_am","base.br"
-"city_1301704","Humaitá","1301704","base.state_br_am","base.br"
-"city_1301803","Ipixuna","1301803","base.state_br_am","base.br"
-"city_1301852","Iranduba","1301852","base.state_br_am","base.br"
-"city_1301902","Itacoatiara","1301902","base.state_br_am","base.br"
-"city_1301951","Itamarati","1301951","base.state_br_am","base.br"
-"city_1302009","Itapiranga","1302009","base.state_br_am","base.br"
-"city_1302108","Japurá","1302108","base.state_br_am","base.br"
-"city_1302207","Juruá","1302207","base.state_br_am","base.br"
-"city_1302306","Jutaí","1302306","base.state_br_am","base.br"
-"city_1302405","Lábrea","1302405","base.state_br_am","base.br"
-"city_1302504","Manacapuru","1302504","base.state_br_am","base.br"
-"city_1302553","Manaquiri","1302553","base.state_br_am","base.br"
-"city_1302603","Manaus","1302603","base.state_br_am","base.br"
-"city_1302702","Manicoré","1302702","base.state_br_am","base.br"
-"city_1302801","Maraã","1302801","base.state_br_am","base.br"
-"city_1302900","Maués","1302900","base.state_br_am","base.br"
-"city_1303007","Nhamundá","1303007","base.state_br_am","base.br"
-"city_1303106","Nova Olinda do Norte","1303106","base.state_br_am","base.br"
-"city_1303205","Novo Airão","1303205","base.state_br_am","base.br"
-"city_1303304","Novo Aripuanã","1303304","base.state_br_am","base.br"
-"city_1303403","Parintins","1303403","base.state_br_am","base.br"
-"city_1303502","Pauini","1303502","base.state_br_am","base.br"
-"city_1303536","Presidente Figueiredo","1303536","base.state_br_am","base.br"
-"city_1303569","Rio Preto da Eva","1303569","base.state_br_am","base.br"
-"city_1303601","Santa Isabel do Rio Negro","1303601","base.state_br_am","base.br"
-"city_1303700","Santo Antônio do Içá","1303700","base.state_br_am","base.br"
-"city_1303809","São Gabriel da Cachoeira","1303809","base.state_br_am","base.br"
-"city_1303908","São Paulo de Olivença","1303908","base.state_br_am","base.br"
-"city_1303957","São Sebastião do Uatumã","1303957","base.state_br_am","base.br"
-"city_1304005","Silves","1304005","base.state_br_am","base.br"
-"city_1304062","Tabatinga","1304062","base.state_br_am","base.br"
-"city_1304104","Tapauá","1304104","base.state_br_am","base.br"
-"city_1304203","Tefé","1304203","base.state_br_am","base.br"
-"city_1304237","Tonantins","1304237","base.state_br_am","base.br"
-"city_1304260","Uarini","1304260","base.state_br_am","base.br"
-"city_1304302","Urucará","1304302","base.state_br_am","base.br"
-"city_1304401","Urucurituba","1304401","base.state_br_am","base.br"
-"city_1400050","Alto Alegre","1400050","base.state_br_rr","base.br"
-"city_1400027","Amajari","1400027","base.state_br_rr","base.br"
-"city_1400100","Boa Vista","1400100","base.state_br_rr","base.br"
-"city_1400159","Bonfim","1400159","base.state_br_rr","base.br"
-"city_1400175","Cantá","1400175","base.state_br_rr","base.br"
-"city_1400209","Caracaraí","1400209","base.state_br_rr","base.br"
-"city_1400233","Caroebe","1400233","base.state_br_rr","base.br"
-"city_1400282","Iracema","1400282","base.state_br_rr","base.br"
-"city_1400308","Mucajaí","1400308","base.state_br_rr","base.br"
-"city_1400407","Normandia","1400407","base.state_br_rr","base.br"
-"city_1400456","Pacaraima","1400456","base.state_br_rr","base.br"
-"city_1400472","Rorainópolis","1400472","base.state_br_rr","base.br"
-"city_1400506","São João da Baliza","1400506","base.state_br_rr","base.br"
-"city_1400605","São Luiz","1400605","base.state_br_rr","base.br"
-"city_1400704","Uiramutã","1400704","base.state_br_rr","base.br"
-"city_1500107","Abaetetuba","1500107","base.state_br_pa","base.br"
-"city_1500131","Abel Figueiredo","1500131","base.state_br_pa","base.br"
-"city_1500206","Acará","1500206","base.state_br_pa","base.br"
-"city_1500305","Afuá","1500305","base.state_br_pa","base.br"
-"city_1500347","Água Azul do Norte","1500347","base.state_br_pa","base.br"
-"city_1500404","Alenquer","1500404","base.state_br_pa","base.br"
-"city_1500503","Almeirim","1500503","base.state_br_pa","base.br"
-"city_1500602","Altamira","1500602","base.state_br_pa","base.br"
-"city_1500701","Anajás","1500701","base.state_br_pa","base.br"
-"city_1500800","Ananindeua","1500800","base.state_br_pa","base.br"
-"city_1500859","Anapu","1500859","base.state_br_pa","base.br"
-"city_1500909","Augusto Corrêa","1500909","base.state_br_pa","base.br"
-"city_1500958","Aurora do Pará","1500958","base.state_br_pa","base.br"
-"city_1501006","Aveiro","1501006","base.state_br_pa","base.br"
-"city_1501105","Bagre","1501105","base.state_br_pa","base.br"
-"city_1501204","Baião","1501204","base.state_br_pa","base.br"
-"city_1501253","Bannach","1501253","base.state_br_pa","base.br"
-"city_1501303","Barcarena","1501303","base.state_br_pa","base.br"
-"city_1501402","Belém","1501402","base.state_br_pa","base.br"
-"city_1501451","Belterra","1501451","base.state_br_pa","base.br"
-"city_1501501","Benevides","1501501","base.state_br_pa","base.br"
-"city_1501576","Bom Jesus do Tocantins","1501576","base.state_br_pa","base.br"
-"city_1501600","Bonito","1501600","base.state_br_pa","base.br"
-"city_1501709","Bragança","1501709","base.state_br_pa","base.br"
-"city_1501725","Brasil Novo","1501725","base.state_br_pa","base.br"
-"city_1501758","Brejo Grande do Araguaia","1501758","base.state_br_pa","base.br"
-"city_1501782","Breu Branco","1501782","base.state_br_pa","base.br"
-"city_1501808","Breves","1501808","base.state_br_pa","base.br"
-"city_1501907","Bujaru","1501907","base.state_br_pa","base.br"
-"city_1502004","Cachoeira do Arari","1502004","base.state_br_pa","base.br"
-"city_1501956","Cachoeira do Piriá","1501956","base.state_br_pa","base.br"
-"city_1502103","Cametá","1502103","base.state_br_pa","base.br"
-"city_1502152","Canaã dos Carajás","1502152","base.state_br_pa","base.br"
-"city_1502202","Capanema","1502202","base.state_br_pa","base.br"
-"city_1502301","Capitão Poço","1502301","base.state_br_pa","base.br"
-"city_1502400","Castanhal","1502400","base.state_br_pa","base.br"
-"city_1502509","Chaves","1502509","base.state_br_pa","base.br"
-"city_1502608","Colares","1502608","base.state_br_pa","base.br"
-"city_1502707","Conceição do Araguaia","1502707","base.state_br_pa","base.br"
-"city_1502756","Concórdia do Pará","1502756","base.state_br_pa","base.br"
-"city_1502764","Cumaru do Norte","1502764","base.state_br_pa","base.br"
-"city_1502772","Curionópolis","1502772","base.state_br_pa","base.br"
-"city_1502806","Curralinho","1502806","base.state_br_pa","base.br"
-"city_1502855","Curuá","1502855","base.state_br_pa","base.br"
-"city_1502905","Curuçá","1502905","base.state_br_pa","base.br"
-"city_1502939","Dom Eliseu","1502939","base.state_br_pa","base.br"
-"city_1502954","Eldorado do Carajás","1502954","base.state_br_pa","base.br"
-"city_1503002","Faro","1503002","base.state_br_pa","base.br"
-"city_1503044","Floresta do Araguaia","1503044","base.state_br_pa","base.br"
-"city_1503077","Garrafão do Norte","1503077","base.state_br_pa","base.br"
-"city_1503093","Goianésia do Pará","1503093","base.state_br_pa","base.br"
-"city_1503101","Gurupá","1503101","base.state_br_pa","base.br"
-"city_1503200","Igarapé-Açu","1503200","base.state_br_pa","base.br"
-"city_1503309","Igarapé-Miri","1503309","base.state_br_pa","base.br"
-"city_1503408","Inhangapi","1503408","base.state_br_pa","base.br"
-"city_1503457","Ipixuna do Pará","1503457","base.state_br_pa","base.br"
-"city_1503507","Irituia","1503507","base.state_br_pa","base.br"
-"city_1503606","Itaituba","1503606","base.state_br_pa","base.br"
-"city_1503705","Itupiranga","1503705","base.state_br_pa","base.br"
-"city_1503754","Jacareacanga","1503754","base.state_br_pa","base.br"
-"city_1503804","Jacundá","1503804","base.state_br_pa","base.br"
-"city_1503903","Juruti","1503903","base.state_br_pa","base.br"
-"city_1504000","Limoeiro do Ajuru","1504000","base.state_br_pa","base.br"
-"city_1504059","Mãe do Rio","1504059","base.state_br_pa","base.br"
-"city_1504109","Magalhães Barata","1504109","base.state_br_pa","base.br"
-"city_1504208","Marabá","1504208","base.state_br_pa","base.br"
-"city_1504307","Maracanã","1504307","base.state_br_pa","base.br"
-"city_1504406","Marapanim","1504406","base.state_br_pa","base.br"
-"city_1504422","Marituba","1504422","base.state_br_pa","base.br"
-"city_1504455","Medicilândia","1504455","base.state_br_pa","base.br"
-"city_1504505","Melgaço","1504505","base.state_br_pa","base.br"
-"city_1504604","Mocajuba","1504604","base.state_br_pa","base.br"
-"city_1504703","Moju","1504703","base.state_br_pa","base.br"
-"city_1504752","Mojuí dos Campos","1504752","base.state_br_pa","base.br"
-"city_1504802","Monte Alegre","1504802","base.state_br_pa","base.br"
-"city_1504901","Muaná","1504901","base.state_br_pa","base.br"
-"city_1504950","Nova Esperança do Piriá","1504950","base.state_br_pa","base.br"
-"city_1504976","Nova Ipixuna","1504976","base.state_br_pa","base.br"
-"city_1505007","Nova Timboteua","1505007","base.state_br_pa","base.br"
-"city_1505031","Novo Progresso","1505031","base.state_br_pa","base.br"
-"city_1505064","Novo Repartimento","1505064","base.state_br_pa","base.br"
-"city_1505106","Óbidos","1505106","base.state_br_pa","base.br"
-"city_1505205","Oeiras do Pará","1505205","base.state_br_pa","base.br"
-"city_1505304","Oriximiná","1505304","base.state_br_pa","base.br"
-"city_1505403","Ourém","1505403","base.state_br_pa","base.br"
-"city_1505437","Ourilândia do Norte","1505437","base.state_br_pa","base.br"
-"city_1505486","Pacajá","1505486","base.state_br_pa","base.br"
-"city_1505494","Palestina do Pará","1505494","base.state_br_pa","base.br"
-"city_1505502","Paragominas","1505502","base.state_br_pa","base.br"
-"city_1505536","Parauapebas","1505536","base.state_br_pa","base.br"
-"city_1505551","Pau D'Arco","1505551","base.state_br_pa","base.br"
-"city_1505601","Peixe-Boi","1505601","base.state_br_pa","base.br"
-"city_1505635","Piçarra","1505635","base.state_br_pa","base.br"
-"city_1505650","Placas","1505650","base.state_br_pa","base.br"
-"city_1505700","Ponta de Pedras","1505700","base.state_br_pa","base.br"
-"city_1505809","Portel","1505809","base.state_br_pa","base.br"
-"city_1505908","Porto de Moz","1505908","base.state_br_pa","base.br"
-"city_1506005","Prainha","1506005","base.state_br_pa","base.br"
-"city_1506104","Primavera","1506104","base.state_br_pa","base.br"
-"city_1506112","Quatipuru","1506112","base.state_br_pa","base.br"
-"city_1506138","Redenção","1506138","base.state_br_pa","base.br"
-"city_1506161","Rio Maria","1506161","base.state_br_pa","base.br"
-"city_1506187","Rondon do Pará","1506187","base.state_br_pa","base.br"
-"city_1506195","Rurópolis","1506195","base.state_br_pa","base.br"
-"city_1506203","Salinópolis","1506203","base.state_br_pa","base.br"
-"city_1506302","Salvaterra","1506302","base.state_br_pa","base.br"
-"city_1506351","Santa Bárbara do Pará","1506351","base.state_br_pa","base.br"
-"city_1506401","Santa Cruz do Arari","1506401","base.state_br_pa","base.br"
-"city_1506500","Santa Izabel do Pará","1506500","base.state_br_pa","base.br"
-"city_1506559","Santa Luzia do Pará","1506559","base.state_br_pa","base.br"
-"city_1506583","Santa Maria das Barreiras","1506583","base.state_br_pa","base.br"
-"city_1506609","Santa Maria do Pará","1506609","base.state_br_pa","base.br"
-"city_1506708","Santana do Araguaia","1506708","base.state_br_pa","base.br"
-"city_1506807","Santarém","1506807","base.state_br_pa","base.br"
-"city_1506906","Santarém Novo","1506906","base.state_br_pa","base.br"
-"city_1507003","Santo Antônio do Tauá","1507003","base.state_br_pa","base.br"
-"city_1507102","São Caetano de Odivelas","1507102","base.state_br_pa","base.br"
-"city_1507151","São Domingos do Araguaia","1507151","base.state_br_pa","base.br"
-"city_1507201","São Domingos do Capim","1507201","base.state_br_pa","base.br"
-"city_1507300","São Félix do Xingu","1507300","base.state_br_pa","base.br"
-"city_1507409","São Francisco do Pará","1507409","base.state_br_pa","base.br"
-"city_1507458","São Geraldo do Araguaia","1507458","base.state_br_pa","base.br"
-"city_1507466","São João da Ponta","1507466","base.state_br_pa","base.br"
-"city_1507474","São João de Pirabas","1507474","base.state_br_pa","base.br"
-"city_1507508","São João do Araguaia","1507508","base.state_br_pa","base.br"
-"city_1507607","São Miguel do Guamá","1507607","base.state_br_pa","base.br"
-"city_1507706","São Sebastião da Boa Vista","1507706","base.state_br_pa","base.br"
-"city_1507755","Sapucaia","1507755","base.state_br_pa","base.br"
-"city_1507805","Senador José Porfírio","1507805","base.state_br_pa","base.br"
-"city_1507904","Soure","1507904","base.state_br_pa","base.br"
-"city_1507953","Tailândia","1507953","base.state_br_pa","base.br"
-"city_1507961","Terra Alta","1507961","base.state_br_pa","base.br"
-"city_1507979","Terra Santa","1507979","base.state_br_pa","base.br"
-"city_1508001","Tomé-Açu","1508001","base.state_br_pa","base.br"
-"city_1508035","Tracuateua","1508035","base.state_br_pa","base.br"
-"city_1508050","Trairão","1508050","base.state_br_pa","base.br"
-"city_1508084","Tucumã","1508084","base.state_br_pa","base.br"
-"city_1508100","Tucuruí","1508100","base.state_br_pa","base.br"
-"city_1508126","Ulianópolis","1508126","base.state_br_pa","base.br"
-"city_1508159","Uruará","1508159","base.state_br_pa","base.br"
-"city_1508209","Vigia","1508209","base.state_br_pa","base.br"
-"city_1508308","Viseu","1508308","base.state_br_pa","base.br"
-"city_1508357","Vitória do Xingu","1508357","base.state_br_pa","base.br"
-"city_1508407","Xinguara","1508407","base.state_br_pa","base.br"
-"city_1600105","Amapá","1600105","base.state_br_ap","base.br"
-"city_1600204","Calçoene","1600204","base.state_br_ap","base.br"
-"city_1600212","Cutias","1600212","base.state_br_ap","base.br"
-"city_1600238","Ferreira Gomes","1600238","base.state_br_ap","base.br"
-"city_1600253","Itaubal","1600253","base.state_br_ap","base.br"
-"city_1600279","Laranjal do Jari","1600279","base.state_br_ap","base.br"
-"city_1600303","Macapá","1600303","base.state_br_ap","base.br"
-"city_1600402","Mazagão","1600402","base.state_br_ap","base.br"
-"city_1600501","Oiapoque","1600501","base.state_br_ap","base.br"
-"city_1600154","Pedra Branca do Amapari","1600154","base.state_br_ap","base.br"
-"city_1600535","Porto Grande","1600535","base.state_br_ap","base.br"
-"city_1600550","Pracuúba","1600550","base.state_br_ap","base.br"
-"city_1600600","Santana","1600600","base.state_br_ap","base.br"
-"city_1600055","Serra do Navio","1600055","base.state_br_ap","base.br"
-"city_1600709","Tartarugalzinho","1600709","base.state_br_ap","base.br"
-"city_1600808","Vitória do Jari","1600808","base.state_br_ap","base.br"
-"city_1700251","Abreulândia","1700251","base.state_br_to","base.br"
-"city_1700301","Aguiarnópolis","1700301","base.state_br_to","base.br"
-"city_1700350","Aliança do Tocantins","1700350","base.state_br_to","base.br"
-"city_1700400","Almas","1700400","base.state_br_to","base.br"
-"city_1700707","Alvorada","1700707","base.state_br_to","base.br"
-"city_1701002","Ananás","1701002","base.state_br_to","base.br"
-"city_1701051","Angico","1701051","base.state_br_to","base.br"
-"city_1701101","Aparecida do Rio Negro","1701101","base.state_br_to","base.br"
-"city_1701309","Aragominas","1701309","base.state_br_to","base.br"
-"city_1701903","Araguacema","1701903","base.state_br_to","base.br"
-"city_1702000","Araguaçu","1702000","base.state_br_to","base.br"
-"city_1702109","Araguaína","1702109","base.state_br_to","base.br"
-"city_1702158","Araguanã","1702158","base.state_br_to","base.br"
-"city_1702208","Araguatins","1702208","base.state_br_to","base.br"
-"city_1702307","Arapoema","1702307","base.state_br_to","base.br"
-"city_1702406","Arraias","1702406","base.state_br_to","base.br"
-"city_1702554","Augustinópolis","1702554","base.state_br_to","base.br"
-"city_1702703","Aurora do Tocantins","1702703","base.state_br_to","base.br"
-"city_1702901","Axixá do Tocantins","1702901","base.state_br_to","base.br"
-"city_1703008","Babaçulândia","1703008","base.state_br_to","base.br"
-"city_1703057","Bandeirantes do Tocantins","1703057","base.state_br_to","base.br"
-"city_1703073","Barra do Ouro","1703073","base.state_br_to","base.br"
-"city_1703107","Barrolândia","1703107","base.state_br_to","base.br"
-"city_1703206","Bernardo Sayão","1703206","base.state_br_to","base.br"
-"city_1703305","Bom Jesus do Tocantins","1703305","base.state_br_to","base.br"
-"city_1703602","Brasilândia do Tocantins","1703602","base.state_br_to","base.br"
-"city_1703701","Brejinho de Nazaré","1703701","base.state_br_to","base.br"
-"city_1703800","Buriti do Tocantins","1703800","base.state_br_to","base.br"
-"city_1703826","Cachoeirinha","1703826","base.state_br_to","base.br"
-"city_1703842","Campos Lindos","1703842","base.state_br_to","base.br"
-"city_1703867","Cariri do Tocantins","1703867","base.state_br_to","base.br"
-"city_1703883","Carmolândia","1703883","base.state_br_to","base.br"
-"city_1703891","Carrasco Bonito","1703891","base.state_br_to","base.br"
-"city_1703909","Caseara","1703909","base.state_br_to","base.br"
-"city_1704105","Centenário","1704105","base.state_br_to","base.br"
-"city_1705102","Chapada da Natividade","1705102","base.state_br_to","base.br"
-"city_1704600","Chapada de Areia","1704600","base.state_br_to","base.br"
-"city_1705508","Colinas do Tocantins","1705508","base.state_br_to","base.br"
-"city_1716703","Colméia","1716703","base.state_br_to","base.br"
-"city_1705557","Combinado","1705557","base.state_br_to","base.br"
-"city_1705607","Conceição do Tocantins","1705607","base.state_br_to","base.br"
-"city_1706001","Couto Magalhães","1706001","base.state_br_to","base.br"
-"city_1706100","Cristalândia","1706100","base.state_br_to","base.br"
-"city_1706258","Crixás do Tocantins","1706258","base.state_br_to","base.br"
-"city_1706506","Darcinópolis","1706506","base.state_br_to","base.br"
-"city_1707009","Dianópolis","1707009","base.state_br_to","base.br"
-"city_1707108","Divinópolis do Tocantins","1707108","base.state_br_to","base.br"
-"city_1707207","Dois Irmãos do Tocantins","1707207","base.state_br_to","base.br"
-"city_1707306","Dueré","1707306","base.state_br_to","base.br"
-"city_1707405","Esperantina","1707405","base.state_br_to","base.br"
-"city_1707553","Fátima","1707553","base.state_br_to","base.br"
-"city_1707652","Figueirópolis","1707652","base.state_br_to","base.br"
-"city_1707702","Filadélfia","1707702","base.state_br_to","base.br"
-"city_1708205","Formoso do Araguaia","1708205","base.state_br_to","base.br"
-"city_1708304","Goianorte","1708304","base.state_br_to","base.br"
-"city_1709005","Goiatins","1709005","base.state_br_to","base.br"
-"city_1709302","Guaraí","1709302","base.state_br_to","base.br"
-"city_1709500","Gurupi","1709500","base.state_br_to","base.br"
-"city_1709807","Ipueiras","1709807","base.state_br_to","base.br"
-"city_1710508","Itacajá","1710508","base.state_br_to","base.br"
-"city_1710706","Itaguatins","1710706","base.state_br_to","base.br"
-"city_1710904","Itapiratins","1710904","base.state_br_to","base.br"
-"city_1711100","Itaporã do Tocantins","1711100","base.state_br_to","base.br"
-"city_1711506","Jaú do Tocantins","1711506","base.state_br_to","base.br"
-"city_1711803","Juarina","1711803","base.state_br_to","base.br"
-"city_1711902","Lagoa da Confusão","1711902","base.state_br_to","base.br"
-"city_1711951","Lagoa do Tocantins","1711951","base.state_br_to","base.br"
-"city_1712009","Lajeado","1712009","base.state_br_to","base.br"
-"city_1712157","Lavandeira","1712157","base.state_br_to","base.br"
-"city_1712405","Lizarda","1712405","base.state_br_to","base.br"
-"city_1712454","Luzinópolis","1712454","base.state_br_to","base.br"
-"city_1712504","Marianópolis do Tocantins","1712504","base.state_br_to","base.br"
-"city_1712702","Mateiros","1712702","base.state_br_to","base.br"
-"city_1712801","Maurilândia do Tocantins","1712801","base.state_br_to","base.br"
-"city_1713205","Miracema do Tocantins","1713205","base.state_br_to","base.br"
-"city_1713304","Miranorte","1713304","base.state_br_to","base.br"
-"city_1713601","Monte do Carmo","1713601","base.state_br_to","base.br"
-"city_1713700","Monte Santo do Tocantins","1713700","base.state_br_to","base.br"
-"city_1713957","Muricilândia","1713957","base.state_br_to","base.br"
-"city_1714203","Natividade","1714203","base.state_br_to","base.br"
-"city_1714302","Nazaré","1714302","base.state_br_to","base.br"
-"city_1714880","Nova Olinda","1714880","base.state_br_to","base.br"
-"city_1715002","Nova Rosalândia","1715002","base.state_br_to","base.br"
-"city_1715101","Novo Acordo","1715101","base.state_br_to","base.br"
-"city_1715150","Novo Alegre","1715150","base.state_br_to","base.br"
-"city_1715259","Novo Jardim","1715259","base.state_br_to","base.br"
-"city_1715507","Oliveira de Fátima","1715507","base.state_br_to","base.br"
-"city_1721000","Palmas","1721000","base.state_br_to","base.br"
-"city_1715705","Palmeirante","1715705","base.state_br_to","base.br"
-"city_1713809","Palmeiras do Tocantins","1713809","base.state_br_to","base.br"
-"city_1715754","Palmeirópolis","1715754","base.state_br_to","base.br"
-"city_1716109","Paraíso do Tocantins","1716109","base.state_br_to","base.br"
-"city_1716208","Paranã","1716208","base.state_br_to","base.br"
-"city_1716307","Pau D'Arco","1716307","base.state_br_to","base.br"
-"city_1716505","Pedro Afonso","1716505","base.state_br_to","base.br"
-"city_1716604","Peixe","1716604","base.state_br_to","base.br"
-"city_1716653","Pequizeiro","1716653","base.state_br_to","base.br"
-"city_1717008","Pindorama do Tocantins","1717008","base.state_br_to","base.br"
-"city_1717206","Piraquê","1717206","base.state_br_to","base.br"
-"city_1717503","Pium","1717503","base.state_br_to","base.br"
-"city_1717800","Ponte Alta do Bom Jesus","1717800","base.state_br_to","base.br"
-"city_1717909","Ponte Alta do Tocantins","1717909","base.state_br_to","base.br"
-"city_1718006","Porto Alegre do Tocantins","1718006","base.state_br_to","base.br"
-"city_1718204","Porto Nacional","1718204","base.state_br_to","base.br"
-"city_1718303","Praia Norte","1718303","base.state_br_to","base.br"
-"city_1718402","Presidente Kennedy","1718402","base.state_br_to","base.br"
-"city_1718451","Pugmil","1718451","base.state_br_to","base.br"
-"city_1718501","Recursolândia","1718501","base.state_br_to","base.br"
-"city_1718550","Riachinho","1718550","base.state_br_to","base.br"
-"city_1718659","Rio da Conceição","1718659","base.state_br_to","base.br"
-"city_1718709","Rio dos Bois","1718709","base.state_br_to","base.br"
-"city_1718758","Rio Sono","1718758","base.state_br_to","base.br"
-"city_1718808","Sampaio","1718808","base.state_br_to","base.br"
-"city_1718840","Sandolândia","1718840","base.state_br_to","base.br"
-"city_1718865","Santa Fé do Araguaia","1718865","base.state_br_to","base.br"
-"city_1718881","Santa Maria do Tocantins","1718881","base.state_br_to","base.br"
-"city_1718899","Santa Rita do Tocantins","1718899","base.state_br_to","base.br"
-"city_1718907","Santa Rosa do Tocantins","1718907","base.state_br_to","base.br"
-"city_1719004","Santa Tereza do Tocantins","1719004","base.state_br_to","base.br"
-"city_1720002","Santa Terezinha do Tocantins","1720002","base.state_br_to","base.br"
-"city_1720101","São Bento do Tocantins","1720101","base.state_br_to","base.br"
-"city_1720150","São Félix do Tocantins","1720150","base.state_br_to","base.br"
-"city_1720200","São Miguel do Tocantins","1720200","base.state_br_to","base.br"
-"city_1720259","São Salvador do Tocantins","1720259","base.state_br_to","base.br"
-"city_1720309","São Sebastião do Tocantins","1720309","base.state_br_to","base.br"
-"city_1720499","São Valério","1720499","base.state_br_to","base.br"
-"city_1720655","Silvanópolis","1720655","base.state_br_to","base.br"
-"city_1720804","Sítio Novo do Tocantins","1720804","base.state_br_to","base.br"
-"city_1720853","Sucupira","1720853","base.state_br_to","base.br"
-"city_1708254","Tabocão","1708254","base.state_br_to","base.br"
-"city_1720903","Taguatinga","1720903","base.state_br_to","base.br"
-"city_1720937","Taipas do Tocantins","1720937","base.state_br_to","base.br"
-"city_1720978","Talismã","1720978","base.state_br_to","base.br"
-"city_1721109","Tocantínia","1721109","base.state_br_to","base.br"
-"city_1721208","Tocantinópolis","1721208","base.state_br_to","base.br"
-"city_1721257","Tupirama","1721257","base.state_br_to","base.br"
-"city_1721307","Tupiratins","1721307","base.state_br_to","base.br"
-"city_1722081","Wanderlândia","1722081","base.state_br_to","base.br"
-"city_1722107","Xambioá","1722107","base.state_br_to","base.br"
-"city_2100055","Açailândia","2100055","base.state_br_ma","base.br"
-"city_2100105","Afonso Cunha","2100105","base.state_br_ma","base.br"
-"city_2100154","Água Doce do Maranhão","2100154","base.state_br_ma","base.br"
-"city_2100204","Alcântara","2100204","base.state_br_ma","base.br"
-"city_2100303","Aldeias Altas","2100303","base.state_br_ma","base.br"
-"city_2100402","Altamira do Maranhão","2100402","base.state_br_ma","base.br"
-"city_2100436","Alto Alegre do Maranhão","2100436","base.state_br_ma","base.br"
-"city_2100477","Alto Alegre do Pindaré","2100477","base.state_br_ma","base.br"
-"city_2100501","Alto Parnaíba","2100501","base.state_br_ma","base.br"
-"city_2100550","Amapá do Maranhão","2100550","base.state_br_ma","base.br"
-"city_2100600","Amarante do Maranhão","2100600","base.state_br_ma","base.br"
-"city_2100709","Anajatuba","2100709","base.state_br_ma","base.br"
-"city_2100808","Anapurus","2100808","base.state_br_ma","base.br"
-"city_2100832","Apicum-Açu","2100832","base.state_br_ma","base.br"
-"city_2100873","Araguanã","2100873","base.state_br_ma","base.br"
-"city_2100907","Araioses","2100907","base.state_br_ma","base.br"
-"city_2100956","Arame","2100956","base.state_br_ma","base.br"
-"city_2101004","Arari","2101004","base.state_br_ma","base.br"
-"city_2101103","Axixá","2101103","base.state_br_ma","base.br"
-"city_2101202","Bacabal","2101202","base.state_br_ma","base.br"
-"city_2101251","Bacabeira","2101251","base.state_br_ma","base.br"
-"city_2101301","Bacuri","2101301","base.state_br_ma","base.br"
-"city_2101350","Bacurituba","2101350","base.state_br_ma","base.br"
-"city_2101400","Balsas","2101400","base.state_br_ma","base.br"
-"city_2101509","Barão de Grajaú","2101509","base.state_br_ma","base.br"
-"city_2101608","Barra do Corda","2101608","base.state_br_ma","base.br"
-"city_2101707","Barreirinhas","2101707","base.state_br_ma","base.br"
-"city_2101772","Bela Vista do Maranhão","2101772","base.state_br_ma","base.br"
-"city_2101731","Belágua","2101731","base.state_br_ma","base.br"
-"city_2101806","Benedito Leite","2101806","base.state_br_ma","base.br"
-"city_2101905","Bequimão","2101905","base.state_br_ma","base.br"
-"city_2101939","Bernardo do Mearim","2101939","base.state_br_ma","base.br"
-"city_2101970","Boa Vista do Gurupi","2101970","base.state_br_ma","base.br"
-"city_2102002","Bom Jardim","2102002","base.state_br_ma","base.br"
-"city_2102036","Bom Jesus das Selvas","2102036","base.state_br_ma","base.br"
-"city_2102077","Bom Lugar","2102077","base.state_br_ma","base.br"
-"city_2102101","Brejo","2102101","base.state_br_ma","base.br"
-"city_2102150","Brejo de Areia","2102150","base.state_br_ma","base.br"
-"city_2102200","Buriti","2102200","base.state_br_ma","base.br"
-"city_2102309","Buriti Bravo","2102309","base.state_br_ma","base.br"
-"city_2102325","Buriticupu","2102325","base.state_br_ma","base.br"
-"city_2102358","Buritirana","2102358","base.state_br_ma","base.br"
-"city_2102374","Cachoeira Grande","2102374","base.state_br_ma","base.br"
-"city_2102408","Cajapió","2102408","base.state_br_ma","base.br"
-"city_2102507","Cajari","2102507","base.state_br_ma","base.br"
-"city_2102556","Campestre do Maranhão","2102556","base.state_br_ma","base.br"
-"city_2102606","Cândido Mendes","2102606","base.state_br_ma","base.br"
-"city_2102705","Cantanhede","2102705","base.state_br_ma","base.br"
-"city_2102754","Capinzal do Norte","2102754","base.state_br_ma","base.br"
-"city_2102804","Carolina","2102804","base.state_br_ma","base.br"
-"city_2102903","Carutapera","2102903","base.state_br_ma","base.br"
-"city_2103000","Caxias","2103000","base.state_br_ma","base.br"
-"city_2103109","Cedral","2103109","base.state_br_ma","base.br"
-"city_2103125","Central do Maranhão","2103125","base.state_br_ma","base.br"
-"city_2103158","Centro do Guilherme","2103158","base.state_br_ma","base.br"
-"city_2103174","Centro Novo do Maranhão","2103174","base.state_br_ma","base.br"
-"city_2103208","Chapadinha","2103208","base.state_br_ma","base.br"
-"city_2103257","Cidelândia","2103257","base.state_br_ma","base.br"
-"city_2103307","Codó","2103307","base.state_br_ma","base.br"
-"city_2103406","Coelho Neto","2103406","base.state_br_ma","base.br"
-"city_2103505","Colinas","2103505","base.state_br_ma","base.br"
-"city_2103554","Conceição do Lago-Açu","2103554","base.state_br_ma","base.br"
-"city_2103604","Coroatá","2103604","base.state_br_ma","base.br"
-"city_2103703","Cururupu","2103703","base.state_br_ma","base.br"
-"city_2103752","Davinópolis","2103752","base.state_br_ma","base.br"
-"city_2103802","Dom Pedro","2103802","base.state_br_ma","base.br"
-"city_2103901","Duque Bacelar","2103901","base.state_br_ma","base.br"
-"city_2104008","Esperantinópolis","2104008","base.state_br_ma","base.br"
-"city_2104057","Estreito","2104057","base.state_br_ma","base.br"
-"city_2104073","Feira Nova do Maranhão","2104073","base.state_br_ma","base.br"
-"city_2104081","Fernando Falcão","2104081","base.state_br_ma","base.br"
-"city_2104099","Formosa da Serra Negra","2104099","base.state_br_ma","base.br"
-"city_2104107","Fortaleza dos Nogueiras","2104107","base.state_br_ma","base.br"
-"city_2104206","Fortuna","2104206","base.state_br_ma","base.br"
-"city_2104305","Godofredo Viana","2104305","base.state_br_ma","base.br"
-"city_2104404","Gonçalves Dias","2104404","base.state_br_ma","base.br"
-"city_2104503","Governador Archer","2104503","base.state_br_ma","base.br"
-"city_2104552","Governador Edison Lobão","2104552","base.state_br_ma","base.br"
-"city_2104602","Governador Eugênio Barros","2104602","base.state_br_ma","base.br"
-"city_2104628","Governador Luiz Rocha","2104628","base.state_br_ma","base.br"
-"city_2104651","Governador Newton Bello","2104651","base.state_br_ma","base.br"
-"city_2104677","Governador Nunes Freire","2104677","base.state_br_ma","base.br"
-"city_2104701","Graça Aranha","2104701","base.state_br_ma","base.br"
-"city_2104800","Grajaú","2104800","base.state_br_ma","base.br"
-"city_2104909","Guimarães","2104909","base.state_br_ma","base.br"
-"city_2105005","Humberto de Campos","2105005","base.state_br_ma","base.br"
-"city_2105104","Icatu","2105104","base.state_br_ma","base.br"
-"city_2105153","Igarapé do Meio","2105153","base.state_br_ma","base.br"
-"city_2105203","Igarapé Grande","2105203","base.state_br_ma","base.br"
-"city_2105302","Imperatriz","2105302","base.state_br_ma","base.br"
-"city_2105351","Itaipava do Grajaú","2105351","base.state_br_ma","base.br"
-"city_2105401","Itapecuru Mirim","2105401","base.state_br_ma","base.br"
-"city_2105427","Itinga do Maranhão","2105427","base.state_br_ma","base.br"
-"city_2105450","Jatobá","2105450","base.state_br_ma","base.br"
-"city_2105476","Jenipapo dos Vieiras","2105476","base.state_br_ma","base.br"
-"city_2105500","João Lisboa","2105500","base.state_br_ma","base.br"
-"city_2105609","Joselândia","2105609","base.state_br_ma","base.br"
-"city_2105658","Junco do Maranhão","2105658","base.state_br_ma","base.br"
-"city_2105708","Lago da Pedra","2105708","base.state_br_ma","base.br"
-"city_2105807","Lago do Junco","2105807","base.state_br_ma","base.br"
-"city_2105948","Lago dos Rodrigues","2105948","base.state_br_ma","base.br"
-"city_2105906","Lago Verde","2105906","base.state_br_ma","base.br"
-"city_2105922","Lagoa do Mato","2105922","base.state_br_ma","base.br"
-"city_2105963","Lagoa Grande do Maranhão","2105963","base.state_br_ma","base.br"
-"city_2105989","Lajeado Novo","2105989","base.state_br_ma","base.br"
-"city_2106003","Lima Campos","2106003","base.state_br_ma","base.br"
-"city_2106102","Loreto","2106102","base.state_br_ma","base.br"
-"city_2106201","Luís Domingues","2106201","base.state_br_ma","base.br"
-"city_2106300","Magalhães de Almeida","2106300","base.state_br_ma","base.br"
-"city_2106326","Maracaçumé","2106326","base.state_br_ma","base.br"
-"city_2106359","Marajá do Sena","2106359","base.state_br_ma","base.br"
-"city_2106375","Maranhãozinho","2106375","base.state_br_ma","base.br"
-"city_2106409","Mata Roma","2106409","base.state_br_ma","base.br"
-"city_2106508","Matinha","2106508","base.state_br_ma","base.br"
-"city_2106607","Matões","2106607","base.state_br_ma","base.br"
-"city_2106631","Matões do Norte","2106631","base.state_br_ma","base.br"
-"city_2106672","Milagres do Maranhão","2106672","base.state_br_ma","base.br"
-"city_2106706","Mirador","2106706","base.state_br_ma","base.br"
-"city_2106755","Miranda do Norte","2106755","base.state_br_ma","base.br"
-"city_2106805","Mirinzal","2106805","base.state_br_ma","base.br"
-"city_2106904","Monção","2106904","base.state_br_ma","base.br"
-"city_2107001","Montes Altos","2107001","base.state_br_ma","base.br"
-"city_2107100","Morros","2107100","base.state_br_ma","base.br"
-"city_2107209","Nina Rodrigues","2107209","base.state_br_ma","base.br"
-"city_2107258","Nova Colinas","2107258","base.state_br_ma","base.br"
-"city_2107308","Nova Iorque","2107308","base.state_br_ma","base.br"
-"city_2107357","Nova Olinda do Maranhão","2107357","base.state_br_ma","base.br"
-"city_2107407","Olho d'Água das Cunhãs","2107407","base.state_br_ma","base.br"
-"city_2107456","Olinda Nova do Maranhão","2107456","base.state_br_ma","base.br"
-"city_2107506","Paço do Lumiar","2107506","base.state_br_ma","base.br"
-"city_2107605","Palmeirândia","2107605","base.state_br_ma","base.br"
-"city_2107704","Paraibano","2107704","base.state_br_ma","base.br"
-"city_2107803","Parnarama","2107803","base.state_br_ma","base.br"
-"city_2107902","Passagem Franca","2107902","base.state_br_ma","base.br"
-"city_2108009","Pastos Bons","2108009","base.state_br_ma","base.br"
-"city_2108058","Paulino Neves","2108058","base.state_br_ma","base.br"
-"city_2108108","Paulo Ramos","2108108","base.state_br_ma","base.br"
-"city_2108207","Pedreiras","2108207","base.state_br_ma","base.br"
-"city_2108256","Pedro do Rosário","2108256","base.state_br_ma","base.br"
-"city_2108306","Penalva","2108306","base.state_br_ma","base.br"
-"city_2108405","Peri Mirim","2108405","base.state_br_ma","base.br"
-"city_2108454","Peritoró","2108454","base.state_br_ma","base.br"
-"city_2108504","Pindaré-Mirim","2108504","base.state_br_ma","base.br"
-"city_2108603","Pinheiro","2108603","base.state_br_ma","base.br"
-"city_2108702","Pio XII","2108702","base.state_br_ma","base.br"
-"city_2108801","Pirapemas","2108801","base.state_br_ma","base.br"
-"city_2108900","Poção de Pedras","2108900","base.state_br_ma","base.br"
-"city_2109007","Porto Franco","2109007","base.state_br_ma","base.br"
-"city_2109056","Porto Rico do Maranhão","2109056","base.state_br_ma","base.br"
-"city_2109106","Presidente Dutra","2109106","base.state_br_ma","base.br"
-"city_2109205","Presidente Juscelino","2109205","base.state_br_ma","base.br"
-"city_2109239","Presidente Médici","2109239","base.state_br_ma","base.br"
-"city_2109270","Presidente Sarney","2109270","base.state_br_ma","base.br"
-"city_2109304","Presidente Vargas","2109304","base.state_br_ma","base.br"
-"city_2109403","Primeira Cruz","2109403","base.state_br_ma","base.br"
-"city_2109452","Raposa","2109452","base.state_br_ma","base.br"
-"city_2109502","Riachão","2109502","base.state_br_ma","base.br"
-"city_2109551","Ribamar Fiquene","2109551","base.state_br_ma","base.br"
-"city_2109601","Rosário","2109601","base.state_br_ma","base.br"
-"city_2109700","Sambaíba","2109700","base.state_br_ma","base.br"
-"city_2109759","Santa Filomena do Maranhão","2109759","base.state_br_ma","base.br"
-"city_2109809","Santa Helena","2109809","base.state_br_ma","base.br"
-"city_2109908","Santa Inês","2109908","base.state_br_ma","base.br"
-"city_2110005","Santa Luzia","2110005","base.state_br_ma","base.br"
-"city_2110039","Santa Luzia do Paruá","2110039","base.state_br_ma","base.br"
-"city_2110104","Santa Quitéria do Maranhão","2110104","base.state_br_ma","base.br"
-"city_2110203","Santa Rita","2110203","base.state_br_ma","base.br"
-"city_2110237","Santana do Maranhão","2110237","base.state_br_ma","base.br"
-"city_2110278","Santo Amaro do Maranhão","2110278","base.state_br_ma","base.br"
-"city_2110302","Santo Antônio dos Lopes","2110302","base.state_br_ma","base.br"
-"city_2110401","São Benedito do Rio Preto","2110401","base.state_br_ma","base.br"
-"city_2110500","São Bento","2110500","base.state_br_ma","base.br"
-"city_2110609","São Bernardo","2110609","base.state_br_ma","base.br"
-"city_2110658","São Domingos do Azeitão","2110658","base.state_br_ma","base.br"
-"city_2110708","São Domingos do Maranhão","2110708","base.state_br_ma","base.br"
-"city_2110807","São Félix de Balsas","2110807","base.state_br_ma","base.br"
-"city_2110856","São Francisco do Brejão","2110856","base.state_br_ma","base.br"
-"city_2110906","São Francisco do Maranhão","2110906","base.state_br_ma","base.br"
-"city_2111003","São João Batista","2111003","base.state_br_ma","base.br"
-"city_2111029","São João do Carú","2111029","base.state_br_ma","base.br"
-"city_2111052","São João do Paraíso","2111052","base.state_br_ma","base.br"
-"city_2111078","São João do Soter","2111078","base.state_br_ma","base.br"
-"city_2111102","São João dos Patos","2111102","base.state_br_ma","base.br"
-"city_2111201","São José de Ribamar","2111201","base.state_br_ma","base.br"
-"city_2111250","São José dos Basílios","2111250","base.state_br_ma","base.br"
-"city_2111300","São Luís","2111300","base.state_br_ma","base.br"
-"city_2111409","São Luís Gonzaga do Maranhão","2111409","base.state_br_ma","base.br"
-"city_2111508","São Mateus do Maranhão","2111508","base.state_br_ma","base.br"
-"city_2111532","São Pedro da Água Branca","2111532","base.state_br_ma","base.br"
-"city_2111573","São Pedro dos Crentes","2111573","base.state_br_ma","base.br"
-"city_2111607","São Raimundo das Mangabeiras","2111607","base.state_br_ma","base.br"
-"city_2111631","São Raimundo do Doca Bezerra","2111631","base.state_br_ma","base.br"
-"city_2111672","São Roberto","2111672","base.state_br_ma","base.br"
-"city_2111706","São Vicente Ferrer","2111706","base.state_br_ma","base.br"
-"city_2111722","Satubinha","2111722","base.state_br_ma","base.br"
-"city_2111748","Senador Alexandre Costa","2111748","base.state_br_ma","base.br"
-"city_2111763","Senador La Rocque","2111763","base.state_br_ma","base.br"
-"city_2111789","Serrano do Maranhão","2111789","base.state_br_ma","base.br"
-"city_2111805","Sítio Novo","2111805","base.state_br_ma","base.br"
-"city_2111904","Sucupira do Norte","2111904","base.state_br_ma","base.br"
-"city_2111953","Sucupira do Riachão","2111953","base.state_br_ma","base.br"
-"city_2112001","Tasso Fragoso","2112001","base.state_br_ma","base.br"
-"city_2112100","Timbiras","2112100","base.state_br_ma","base.br"
-"city_2112209","Timon","2112209","base.state_br_ma","base.br"
-"city_2112233","Trizidela do Vale","2112233","base.state_br_ma","base.br"
-"city_2112274","Tufilândia","2112274","base.state_br_ma","base.br"
-"city_2112308","Tuntum","2112308","base.state_br_ma","base.br"
-"city_2112407","Turiaçu","2112407","base.state_br_ma","base.br"
-"city_2112456","Turilândia","2112456","base.state_br_ma","base.br"
-"city_2112506","Tutóia","2112506","base.state_br_ma","base.br"
-"city_2112605","Urbano Santos","2112605","base.state_br_ma","base.br"
-"city_2112704","Vargem Grande","2112704","base.state_br_ma","base.br"
-"city_2112803","Viana","2112803","base.state_br_ma","base.br"
-"city_2112852","Vila Nova dos Martírios","2112852","base.state_br_ma","base.br"
-"city_2112902","Vitória do Mearim","2112902","base.state_br_ma","base.br"
-"city_2113009","Vitorino Freire","2113009","base.state_br_ma","base.br"
-"city_2114007","Zé Doca","2114007","base.state_br_ma","base.br"
-"city_2200053","Acauã","2200053","base.state_br_pi","base.br"
-"city_2200103","Agricolândia","2200103","base.state_br_pi","base.br"
-"city_2200202","Água Branca","2200202","base.state_br_pi","base.br"
-"city_2200251","Alagoinha do Piauí","2200251","base.state_br_pi","base.br"
-"city_2200277","Alegrete do Piauí","2200277","base.state_br_pi","base.br"
-"city_2200301","Alto Longá","2200301","base.state_br_pi","base.br"
-"city_2200400","Altos","2200400","base.state_br_pi","base.br"
-"city_2200459","Alvorada do Gurguéia","2200459","base.state_br_pi","base.br"
-"city_2200509","Amarante","2200509","base.state_br_pi","base.br"
-"city_2200608","Angical do Piauí","2200608","base.state_br_pi","base.br"
-"city_2200707","Anísio de Abreu","2200707","base.state_br_pi","base.br"
-"city_2200806","Antônio Almeida","2200806","base.state_br_pi","base.br"
-"city_2200905","Aroazes","2200905","base.state_br_pi","base.br"
-"city_2200954","Aroeiras do Itaim","2200954","base.state_br_pi","base.br"
-"city_2201002","Arraial","2201002","base.state_br_pi","base.br"
-"city_2201051","Assunção do Piauí","2201051","base.state_br_pi","base.br"
-"city_2201101","Avelino Lopes","2201101","base.state_br_pi","base.br"
-"city_2201150","Baixa Grande do Ribeiro","2201150","base.state_br_pi","base.br"
-"city_2201176","Barra D'Alcântara","2201176","base.state_br_pi","base.br"
-"city_2201200","Barras","2201200","base.state_br_pi","base.br"
-"city_2201309","Barreiras do Piauí","2201309","base.state_br_pi","base.br"
-"city_2201408","Barro Duro","2201408","base.state_br_pi","base.br"
-"city_2201507","Batalha","2201507","base.state_br_pi","base.br"
-"city_2201556","Bela Vista do Piauí","2201556","base.state_br_pi","base.br"
-"city_2201572","Belém do Piauí","2201572","base.state_br_pi","base.br"
-"city_2201606","Beneditinos","2201606","base.state_br_pi","base.br"
-"city_2201705","Bertolínia","2201705","base.state_br_pi","base.br"
-"city_2201739","Betânia do Piauí","2201739","base.state_br_pi","base.br"
-"city_2201770","Boa Hora","2201770","base.state_br_pi","base.br"
-"city_2201804","Bocaina","2201804","base.state_br_pi","base.br"
-"city_2201903","Bom Jesus","2201903","base.state_br_pi","base.br"
-"city_2201919","Bom Princípio do Piauí","2201919","base.state_br_pi","base.br"
-"city_2201929","Bonfim do Piauí","2201929","base.state_br_pi","base.br"
-"city_2201945","Boqueirão do Piauí","2201945","base.state_br_pi","base.br"
-"city_2201960","Brasileira","2201960","base.state_br_pi","base.br"
-"city_2201988","Brejo do Piauí","2201988","base.state_br_pi","base.br"
-"city_2202000","Buriti dos Lopes","2202000","base.state_br_pi","base.br"
-"city_2202026","Buriti dos Montes","2202026","base.state_br_pi","base.br"
-"city_2202059","Cabeceiras do Piauí","2202059","base.state_br_pi","base.br"
-"city_2202075","Cajazeiras do Piauí","2202075","base.state_br_pi","base.br"
-"city_2202083","Cajueiro da Praia","2202083","base.state_br_pi","base.br"
-"city_2202091","Caldeirão Grande do Piauí","2202091","base.state_br_pi","base.br"
-"city_2202109","Campinas do Piauí","2202109","base.state_br_pi","base.br"
-"city_2202117","Campo Alegre do Fidalgo","2202117","base.state_br_pi","base.br"
-"city_2202133","Campo Grande do Piauí","2202133","base.state_br_pi","base.br"
-"city_2202174","Campo Largo do Piauí","2202174","base.state_br_pi","base.br"
-"city_2202208","Campo Maior","2202208","base.state_br_pi","base.br"
-"city_2202251","Canavieira","2202251","base.state_br_pi","base.br"
-"city_2202307","Canto do Buriti","2202307","base.state_br_pi","base.br"
-"city_2202406","Capitão de Campos","2202406","base.state_br_pi","base.br"
-"city_2202455","Capitão Gervásio Oliveira","2202455","base.state_br_pi","base.br"
-"city_2202505","Caracol","2202505","base.state_br_pi","base.br"
-"city_2202539","Caraúbas do Piauí","2202539","base.state_br_pi","base.br"
-"city_2202554","Caridade do Piauí","2202554","base.state_br_pi","base.br"
-"city_2202604","Castelo do Piauí","2202604","base.state_br_pi","base.br"
-"city_2202653","Caxingó","2202653","base.state_br_pi","base.br"
-"city_2202703","Cocal","2202703","base.state_br_pi","base.br"
-"city_2202711","Cocal de Telha","2202711","base.state_br_pi","base.br"
-"city_2202729","Cocal dos Alves","2202729","base.state_br_pi","base.br"
-"city_2202737","Coivaras","2202737","base.state_br_pi","base.br"
-"city_2202752","Colônia do Gurguéia","2202752","base.state_br_pi","base.br"
-"city_2202778","Colônia do Piauí","2202778","base.state_br_pi","base.br"
-"city_2202802","Conceição do Canindé","2202802","base.state_br_pi","base.br"
-"city_2202851","Coronel José Dias","2202851","base.state_br_pi","base.br"
-"city_2202901","Corrente","2202901","base.state_br_pi","base.br"
-"city_2203008","Cristalândia do Piauí","2203008","base.state_br_pi","base.br"
-"city_2203107","Cristino Castro","2203107","base.state_br_pi","base.br"
-"city_2203206","Curimatá","2203206","base.state_br_pi","base.br"
-"city_2203230","Currais","2203230","base.state_br_pi","base.br"
-"city_2203271","Curral Novo do Piauí","2203271","base.state_br_pi","base.br"
-"city_2203255","Curralinhos","2203255","base.state_br_pi","base.br"
-"city_2203305","Demerval Lobão","2203305","base.state_br_pi","base.br"
-"city_2203354","Dirceu Arcoverde","2203354","base.state_br_pi","base.br"
-"city_2203404","Dom Expedito Lopes","2203404","base.state_br_pi","base.br"
-"city_2203453","Dom Inocêncio","2203453","base.state_br_pi","base.br"
-"city_2203420","Domingos Mourão","2203420","base.state_br_pi","base.br"
-"city_2203503","Elesbão Veloso","2203503","base.state_br_pi","base.br"
-"city_2203602","Eliseu Martins","2203602","base.state_br_pi","base.br"
-"city_2203701","Esperantina","2203701","base.state_br_pi","base.br"
-"city_2203750","Fartura do Piauí","2203750","base.state_br_pi","base.br"
-"city_2203800","Flores do Piauí","2203800","base.state_br_pi","base.br"
-"city_2203859","Floresta do Piauí","2203859","base.state_br_pi","base.br"
-"city_2203909","Floriano","2203909","base.state_br_pi","base.br"
-"city_2204006","Francinópolis","2204006","base.state_br_pi","base.br"
-"city_2204105","Francisco Ayres","2204105","base.state_br_pi","base.br"
-"city_2204154","Francisco Macedo","2204154","base.state_br_pi","base.br"
-"city_2204204","Francisco Santos","2204204","base.state_br_pi","base.br"
-"city_2204303","Fronteiras","2204303","base.state_br_pi","base.br"
-"city_2204352","Geminiano","2204352","base.state_br_pi","base.br"
-"city_2204402","Gilbués","2204402","base.state_br_pi","base.br"
-"city_2204501","Guadalupe","2204501","base.state_br_pi","base.br"
-"city_2204550","Guaribas","2204550","base.state_br_pi","base.br"
-"city_2204600","Hugo Napoleão","2204600","base.state_br_pi","base.br"
-"city_2204659","Ilha Grande","2204659","base.state_br_pi","base.br"
-"city_2204709","Inhuma","2204709","base.state_br_pi","base.br"
-"city_2204808","Ipiranga do Piauí","2204808","base.state_br_pi","base.br"
-"city_2204907","Isaías Coelho","2204907","base.state_br_pi","base.br"
-"city_2205003","Itainópolis","2205003","base.state_br_pi","base.br"
-"city_2205102","Itaueira","2205102","base.state_br_pi","base.br"
-"city_2205151","Jacobina do Piauí","2205151","base.state_br_pi","base.br"
-"city_2205201","Jaicós","2205201","base.state_br_pi","base.br"
-"city_2205250","Jardim do Mulato","2205250","base.state_br_pi","base.br"
-"city_2205276","Jatobá do Piauí","2205276","base.state_br_pi","base.br"
-"city_2205300","Jerumenha","2205300","base.state_br_pi","base.br"
-"city_2205359","João Costa","2205359","base.state_br_pi","base.br"
-"city_2205409","Joaquim Pires","2205409","base.state_br_pi","base.br"
-"city_2205458","Joca Marques","2205458","base.state_br_pi","base.br"
-"city_2205508","José de Freitas","2205508","base.state_br_pi","base.br"
-"city_2205516","Juazeiro do Piauí","2205516","base.state_br_pi","base.br"
-"city_2205524","Júlio Borges","2205524","base.state_br_pi","base.br"
-"city_2205532","Jurema","2205532","base.state_br_pi","base.br"
-"city_2205557","Lagoa Alegre","2205557","base.state_br_pi","base.br"
-"city_2205573","Lagoa de São Francisco","2205573","base.state_br_pi","base.br"
-"city_2205565","Lagoa do Barro do Piauí","2205565","base.state_br_pi","base.br"
-"city_2205581","Lagoa do Piauí","2205581","base.state_br_pi","base.br"
-"city_2205599","Lagoa do Sítio","2205599","base.state_br_pi","base.br"
-"city_2205540","Lagoinha do Piauí","2205540","base.state_br_pi","base.br"
-"city_2205607","Landri Sales","2205607","base.state_br_pi","base.br"
-"city_2205706","Luís Correia","2205706","base.state_br_pi","base.br"
-"city_2205805","Luzilândia","2205805","base.state_br_pi","base.br"
-"city_2205854","Madeiro","2205854","base.state_br_pi","base.br"
-"city_2205904","Manoel Emídio","2205904","base.state_br_pi","base.br"
-"city_2205953","Marcolândia","2205953","base.state_br_pi","base.br"
-"city_2206001","Marcos Parente","2206001","base.state_br_pi","base.br"
-"city_2206050","Massapê do Piauí","2206050","base.state_br_pi","base.br"
-"city_2206100","Matias Olímpio","2206100","base.state_br_pi","base.br"
-"city_2206209","Miguel Alves","2206209","base.state_br_pi","base.br"
-"city_2206308","Miguel Leão","2206308","base.state_br_pi","base.br"
-"city_2206357","Milton Brandão","2206357","base.state_br_pi","base.br"
-"city_2206407","Monsenhor Gil","2206407","base.state_br_pi","base.br"
-"city_2206506","Monsenhor Hipólito","2206506","base.state_br_pi","base.br"
-"city_2206605","Monte Alegre do Piauí","2206605","base.state_br_pi","base.br"
-"city_2206654","Morro Cabeça no Tempo","2206654","base.state_br_pi","base.br"
-"city_2206670","Morro do Chapéu do Piauí","2206670","base.state_br_pi","base.br"
-"city_2206696","Murici dos Portelas","2206696","base.state_br_pi","base.br"
-"city_2206704","Nazaré do Piauí","2206704","base.state_br_pi","base.br"
-"city_2206720","Nazária","2206720","base.state_br_pi","base.br"
-"city_2206753","Nossa Senhora de Nazaré","2206753","base.state_br_pi","base.br"
-"city_2206803","Nossa Senhora dos Remédios","2206803","base.state_br_pi","base.br"
-"city_2207959","Nova Santa Rita","2207959","base.state_br_pi","base.br"
-"city_2206902","Novo Oriente do Piauí","2206902","base.state_br_pi","base.br"
-"city_2206951","Novo Santo Antônio","2206951","base.state_br_pi","base.br"
-"city_2207009","Oeiras","2207009","base.state_br_pi","base.br"
-"city_2207108","Olho D'Água do Piauí","2207108","base.state_br_pi","base.br"
-"city_2207207","Padre Marcos","2207207","base.state_br_pi","base.br"
-"city_2207306","Paes Landim","2207306","base.state_br_pi","base.br"
-"city_2207355","Pajeú do Piauí","2207355","base.state_br_pi","base.br"
-"city_2207405","Palmeira do Piauí","2207405","base.state_br_pi","base.br"
-"city_2207504","Palmeirais","2207504","base.state_br_pi","base.br"
-"city_2207553","Paquetá","2207553","base.state_br_pi","base.br"
-"city_2207603","Parnaguá","2207603","base.state_br_pi","base.br"
-"city_2207702","Parnaíba","2207702","base.state_br_pi","base.br"
-"city_2207751","Passagem Franca do Piauí","2207751","base.state_br_pi","base.br"
-"city_2207777","Patos do Piauí","2207777","base.state_br_pi","base.br"
-"city_2207793","Pau D'Arco do Piauí","2207793","base.state_br_pi","base.br"
-"city_2207801","Paulistana","2207801","base.state_br_pi","base.br"
-"city_2207850","Pavussu","2207850","base.state_br_pi","base.br"
-"city_2207900","Pedro II","2207900","base.state_br_pi","base.br"
-"city_2207934","Pedro Laurentino","2207934","base.state_br_pi","base.br"
-"city_2208007","Picos","2208007","base.state_br_pi","base.br"
-"city_2208106","Pimenteiras","2208106","base.state_br_pi","base.br"
-"city_2208205","Pio IX","2208205","base.state_br_pi","base.br"
-"city_2208304","Piracuruca","2208304","base.state_br_pi","base.br"
-"city_2208403","Piripiri","2208403","base.state_br_pi","base.br"
-"city_2208502","Porto","2208502","base.state_br_pi","base.br"
-"city_2208551","Porto Alegre do Piauí","2208551","base.state_br_pi","base.br"
-"city_2208601","Prata do Piauí","2208601","base.state_br_pi","base.br"
-"city_2208650","Queimada Nova","2208650","base.state_br_pi","base.br"
-"city_2208700","Redenção do Gurguéia","2208700","base.state_br_pi","base.br"
-"city_2208809","Regeneração","2208809","base.state_br_pi","base.br"
-"city_2208858","Riacho Frio","2208858","base.state_br_pi","base.br"
-"city_2208874","Ribeira do Piauí","2208874","base.state_br_pi","base.br"
-"city_2208908","Ribeiro Gonçalves","2208908","base.state_br_pi","base.br"
-"city_2209005","Rio Grande do Piauí","2209005","base.state_br_pi","base.br"
-"city_2209104","Santa Cruz do Piauí","2209104","base.state_br_pi","base.br"
-"city_2209153","Santa Cruz dos Milagres","2209153","base.state_br_pi","base.br"
-"city_2209203","Santa Filomena","2209203","base.state_br_pi","base.br"
-"city_2209302","Santa Luz","2209302","base.state_br_pi","base.br"
-"city_2209377","Santa Rosa do Piauí","2209377","base.state_br_pi","base.br"
-"city_2209351","Santana do Piauí","2209351","base.state_br_pi","base.br"
-"city_2209401","Santo Antônio de Lisboa","2209401","base.state_br_pi","base.br"
-"city_2209450","Santo Antônio dos Milagres","2209450","base.state_br_pi","base.br"
-"city_2209500","Santo Inácio do Piauí","2209500","base.state_br_pi","base.br"
-"city_2209559","São Braz do Piauí","2209559","base.state_br_pi","base.br"
-"city_2209609","São Félix do Piauí","2209609","base.state_br_pi","base.br"
-"city_2209658","São Francisco de Assis do Piauí","2209658","base.state_br_pi","base.br"
-"city_2209708","São Francisco do Piauí","2209708","base.state_br_pi","base.br"
-"city_2209757","São Gonçalo do Gurguéia","2209757","base.state_br_pi","base.br"
-"city_2209807","São Gonçalo do Piauí","2209807","base.state_br_pi","base.br"
-"city_2209856","São João da Canabrava","2209856","base.state_br_pi","base.br"
-"city_2209872","São João da Fronteira","2209872","base.state_br_pi","base.br"
-"city_2209906","São João da Serra","2209906","base.state_br_pi","base.br"
-"city_2209955","São João da Varjota","2209955","base.state_br_pi","base.br"
-"city_2209971","São João do Arraial","2209971","base.state_br_pi","base.br"
-"city_2210003","São João do Piauí","2210003","base.state_br_pi","base.br"
-"city_2210052","São José do Divino","2210052","base.state_br_pi","base.br"
-"city_2210102","São José do Peixe","2210102","base.state_br_pi","base.br"
-"city_2210201","São José do Piauí","2210201","base.state_br_pi","base.br"
-"city_2210300","São Julião","2210300","base.state_br_pi","base.br"
-"city_2210359","São Lourenço do Piauí","2210359","base.state_br_pi","base.br"
-"city_2210375","São Luis do Piauí","2210375","base.state_br_pi","base.br"
-"city_2210383","São Miguel da Baixa Grande","2210383","base.state_br_pi","base.br"
-"city_2210391","São Miguel do Fidalgo","2210391","base.state_br_pi","base.br"
-"city_2210409","São Miguel do Tapuio","2210409","base.state_br_pi","base.br"
-"city_2210508","São Pedro do Piauí","2210508","base.state_br_pi","base.br"
-"city_2210607","São Raimundo Nonato","2210607","base.state_br_pi","base.br"
-"city_2210623","Sebastião Barros","2210623","base.state_br_pi","base.br"
-"city_2210631","Sebastião Leal","2210631","base.state_br_pi","base.br"
-"city_2210656","Sigefredo Pacheco","2210656","base.state_br_pi","base.br"
-"city_2210706","Simões","2210706","base.state_br_pi","base.br"
-"city_2210805","Simplício Mendes","2210805","base.state_br_pi","base.br"
-"city_2210904","Socorro do Piauí","2210904","base.state_br_pi","base.br"
-"city_2210938","Sussuapara","2210938","base.state_br_pi","base.br"
-"city_2210953","Tamboril do Piauí","2210953","base.state_br_pi","base.br"
-"city_2210979","Tanque do Piauí","2210979","base.state_br_pi","base.br"
-"city_2211001","Teresina","2211001","base.state_br_pi","base.br"
-"city_2211100","União","2211100","base.state_br_pi","base.br"
-"city_2211209","Uruçuí","2211209","base.state_br_pi","base.br"
-"city_2211308","Valença do Piauí","2211308","base.state_br_pi","base.br"
-"city_2211357","Várzea Branca","2211357","base.state_br_pi","base.br"
-"city_2211407","Várzea Grande","2211407","base.state_br_pi","base.br"
-"city_2211506","Vera Mendes","2211506","base.state_br_pi","base.br"
-"city_2211605","Vila Nova do Piauí","2211605","base.state_br_pi","base.br"
-"city_2211704","Wall Ferraz","2211704","base.state_br_pi","base.br"
-"city_2300101","Abaiara","2300101","base.state_br_ce","base.br"
-"city_2300150","Acarape","2300150","base.state_br_ce","base.br"
-"city_2300200","Acaraú","2300200","base.state_br_ce","base.br"
-"city_2300309","Acopiara","2300309","base.state_br_ce","base.br"
-"city_2300408","Aiuaba","2300408","base.state_br_ce","base.br"
-"city_2300507","Alcântaras","2300507","base.state_br_ce","base.br"
-"city_2300606","Altaneira","2300606","base.state_br_ce","base.br"
-"city_2300705","Alto Santo","2300705","base.state_br_ce","base.br"
-"city_2300754","Amontada","2300754","base.state_br_ce","base.br"
-"city_2300804","Antonina do Norte","2300804","base.state_br_ce","base.br"
-"city_2300903","Apuiarés","2300903","base.state_br_ce","base.br"
-"city_2301000","Aquiraz","2301000","base.state_br_ce","base.br"
-"city_2301109","Aracati","2301109","base.state_br_ce","base.br"
-"city_2301208","Aracoiaba","2301208","base.state_br_ce","base.br"
-"city_2301257","Ararendá","2301257","base.state_br_ce","base.br"
-"city_2301307","Araripe","2301307","base.state_br_ce","base.br"
-"city_2301406","Aratuba","2301406","base.state_br_ce","base.br"
-"city_2301505","Arneiroz","2301505","base.state_br_ce","base.br"
-"city_2301604","Assaré","2301604","base.state_br_ce","base.br"
-"city_2301703","Aurora","2301703","base.state_br_ce","base.br"
-"city_2301802","Baixio","2301802","base.state_br_ce","base.br"
-"city_2301851","Banabuiú","2301851","base.state_br_ce","base.br"
-"city_2301901","Barbalha","2301901","base.state_br_ce","base.br"
-"city_2301950","Barreira","2301950","base.state_br_ce","base.br"
-"city_2302008","Barro","2302008","base.state_br_ce","base.br"
-"city_2302057","Barroquinha","2302057","base.state_br_ce","base.br"
-"city_2302107","Baturité","2302107","base.state_br_ce","base.br"
-"city_2302206","Beberibe","2302206","base.state_br_ce","base.br"
-"city_2302305","Bela Cruz","2302305","base.state_br_ce","base.br"
-"city_2302404","Boa Viagem","2302404","base.state_br_ce","base.br"
-"city_2302503","Brejo Santo","2302503","base.state_br_ce","base.br"
-"city_2302602","Camocim","2302602","base.state_br_ce","base.br"
-"city_2302701","Campos Sales","2302701","base.state_br_ce","base.br"
-"city_2302800","Canindé","2302800","base.state_br_ce","base.br"
-"city_2302909","Capistrano","2302909","base.state_br_ce","base.br"
-"city_2303006","Caridade","2303006","base.state_br_ce","base.br"
-"city_2303105","Cariré","2303105","base.state_br_ce","base.br"
-"city_2303204","Caririaçu","2303204","base.state_br_ce","base.br"
-"city_2303303","Cariús","2303303","base.state_br_ce","base.br"
-"city_2303402","Carnaubal","2303402","base.state_br_ce","base.br"
-"city_2303501","Cascavel","2303501","base.state_br_ce","base.br"
-"city_2303600","Catarina","2303600","base.state_br_ce","base.br"
-"city_2303659","Catunda","2303659","base.state_br_ce","base.br"
-"city_2303709","Caucaia","2303709","base.state_br_ce","base.br"
-"city_2303808","Cedro","2303808","base.state_br_ce","base.br"
-"city_2303907","Chaval","2303907","base.state_br_ce","base.br"
-"city_2303931","Choró","2303931","base.state_br_ce","base.br"
-"city_2303956","Chorozinho","2303956","base.state_br_ce","base.br"
-"city_2304004","Coreaú","2304004","base.state_br_ce","base.br"
-"city_2304103","Crateús","2304103","base.state_br_ce","base.br"
-"city_2304202","Crato","2304202","base.state_br_ce","base.br"
-"city_2304236","Croatá","2304236","base.state_br_ce","base.br"
-"city_2304251","Cruz","2304251","base.state_br_ce","base.br"
-"city_2304269","Deputado Irapuan Pinheiro","2304269","base.state_br_ce","base.br"
-"city_2304277","Ereré","2304277","base.state_br_ce","base.br"
-"city_2304285","Eusébio","2304285","base.state_br_ce","base.br"
-"city_2304301","Farias Brito","2304301","base.state_br_ce","base.br"
-"city_2304350","Forquilha","2304350","base.state_br_ce","base.br"
-"city_2304400","Fortaleza","2304400","base.state_br_ce","base.br"
-"city_2304459","Fortim","2304459","base.state_br_ce","base.br"
-"city_2304509","Frecheirinha","2304509","base.state_br_ce","base.br"
-"city_2304608","General Sampaio","2304608","base.state_br_ce","base.br"
-"city_2304657","Graça","2304657","base.state_br_ce","base.br"
-"city_2304707","Granja","2304707","base.state_br_ce","base.br"
-"city_2304806","Granjeiro","2304806","base.state_br_ce","base.br"
-"city_2304905","Groaíras","2304905","base.state_br_ce","base.br"
-"city_2304954","Guaiúba","2304954","base.state_br_ce","base.br"
-"city_2305001","Guaraciaba do Norte","2305001","base.state_br_ce","base.br"
-"city_2305100","Guaramiranga","2305100","base.state_br_ce","base.br"
-"city_2305209","Hidrolândia","2305209","base.state_br_ce","base.br"
-"city_2305233","Horizonte","2305233","base.state_br_ce","base.br"
-"city_2305266","Ibaretama","2305266","base.state_br_ce","base.br"
-"city_2305308","Ibiapina","2305308","base.state_br_ce","base.br"
-"city_2305332","Ibicuitinga","2305332","base.state_br_ce","base.br"
-"city_2305357","Icapuí","2305357","base.state_br_ce","base.br"
-"city_2305407","Icó","2305407","base.state_br_ce","base.br"
-"city_2305506","Iguatu","2305506","base.state_br_ce","base.br"
-"city_2305605","Independência","2305605","base.state_br_ce","base.br"
-"city_2305654","Ipaporanga","2305654","base.state_br_ce","base.br"
-"city_2305704","Ipaumirim","2305704","base.state_br_ce","base.br"
-"city_2305803","Ipu","2305803","base.state_br_ce","base.br"
-"city_2305902","Ipueiras","2305902","base.state_br_ce","base.br"
-"city_2306009","Iracema","2306009","base.state_br_ce","base.br"
-"city_2306108","Irauçuba","2306108","base.state_br_ce","base.br"
-"city_2306207","Itaiçaba","2306207","base.state_br_ce","base.br"
-"city_2306256","Itaitinga","2306256","base.state_br_ce","base.br"
-"city_2306306","Itapajé","2306306","base.state_br_ce","base.br"
-"city_2306405","Itapipoca","2306405","base.state_br_ce","base.br"
-"city_2306504","Itapiúna","2306504","base.state_br_ce","base.br"
-"city_2306553","Itarema","2306553","base.state_br_ce","base.br"
-"city_2306603","Itatira","2306603","base.state_br_ce","base.br"
-"city_2306702","Jaguaretama","2306702","base.state_br_ce","base.br"
-"city_2306801","Jaguaribara","2306801","base.state_br_ce","base.br"
-"city_2306900","Jaguaribe","2306900","base.state_br_ce","base.br"
-"city_2307007","Jaguaruana","2307007","base.state_br_ce","base.br"
-"city_2307106","Jardim","2307106","base.state_br_ce","base.br"
-"city_2307205","Jati","2307205","base.state_br_ce","base.br"
-"city_2307254","Jijoca de Jericoacoara","2307254","base.state_br_ce","base.br"
-"city_2307304","Juazeiro do Norte","2307304","base.state_br_ce","base.br"
-"city_2307403","Jucás","2307403","base.state_br_ce","base.br"
-"city_2307502","Lavras da Mangabeira","2307502","base.state_br_ce","base.br"
-"city_2307601","Limoeiro do Norte","2307601","base.state_br_ce","base.br"
-"city_2307635","Madalena","2307635","base.state_br_ce","base.br"
-"city_2307650","Maracanaú","2307650","base.state_br_ce","base.br"
-"city_2307700","Maranguape","2307700","base.state_br_ce","base.br"
-"city_2307809","Marco","2307809","base.state_br_ce","base.br"
-"city_2307908","Martinópole","2307908","base.state_br_ce","base.br"
-"city_2308005","Massapê","2308005","base.state_br_ce","base.br"
-"city_2308104","Mauriti","2308104","base.state_br_ce","base.br"
-"city_2308203","Meruoca","2308203","base.state_br_ce","base.br"
-"city_2308302","Milagres","2308302","base.state_br_ce","base.br"
-"city_2308351","Milhã","2308351","base.state_br_ce","base.br"
-"city_2308377","Miraíma","2308377","base.state_br_ce","base.br"
-"city_2308401","Missão Velha","2308401","base.state_br_ce","base.br"
-"city_2308500","Mombaça","2308500","base.state_br_ce","base.br"
-"city_2308609","Monsenhor Tabosa","2308609","base.state_br_ce","base.br"
-"city_2308708","Morada Nova","2308708","base.state_br_ce","base.br"
-"city_2308807","Moraújo","2308807","base.state_br_ce","base.br"
-"city_2308906","Morrinhos","2308906","base.state_br_ce","base.br"
-"city_2309003","Mucambo","2309003","base.state_br_ce","base.br"
-"city_2309102","Mulungu","2309102","base.state_br_ce","base.br"
-"city_2309201","Nova Olinda","2309201","base.state_br_ce","base.br"
-"city_2309300","Nova Russas","2309300","base.state_br_ce","base.br"
-"city_2309409","Novo Oriente","2309409","base.state_br_ce","base.br"
-"city_2309458","Ocara","2309458","base.state_br_ce","base.br"
-"city_2309508","Orós","2309508","base.state_br_ce","base.br"
-"city_2309607","Pacajus","2309607","base.state_br_ce","base.br"
-"city_2309706","Pacatuba","2309706","base.state_br_ce","base.br"
-"city_2309805","Pacoti","2309805","base.state_br_ce","base.br"
-"city_2309904","Pacujá","2309904","base.state_br_ce","base.br"
-"city_2310001","Palhano","2310001","base.state_br_ce","base.br"
-"city_2310100","Palmácia","2310100","base.state_br_ce","base.br"
-"city_2310209","Paracuru","2310209","base.state_br_ce","base.br"
-"city_2310258","Paraipaba","2310258","base.state_br_ce","base.br"
-"city_2310308","Parambu","2310308","base.state_br_ce","base.br"
-"city_2310407","Paramoti","2310407","base.state_br_ce","base.br"
-"city_2310506","Pedra Branca","2310506","base.state_br_ce","base.br"
-"city_2310605","Penaforte","2310605","base.state_br_ce","base.br"
-"city_2310704","Pentecoste","2310704","base.state_br_ce","base.br"
-"city_2310803","Pereiro","2310803","base.state_br_ce","base.br"
-"city_2310852","Pindoretama","2310852","base.state_br_ce","base.br"
-"city_2310902","Piquet Carneiro","2310902","base.state_br_ce","base.br"
-"city_2310951","Pires Ferreira","2310951","base.state_br_ce","base.br"
-"city_2311009","Poranga","2311009","base.state_br_ce","base.br"
-"city_2311108","Porteiras","2311108","base.state_br_ce","base.br"
-"city_2311207","Potengi","2311207","base.state_br_ce","base.br"
-"city_2311231","Potiretama","2311231","base.state_br_ce","base.br"
-"city_2311264","Quiterianópolis","2311264","base.state_br_ce","base.br"
-"city_2311306","Quixadá","2311306","base.state_br_ce","base.br"
-"city_2311355","Quixelô","2311355","base.state_br_ce","base.br"
-"city_2311405","Quixeramobim","2311405","base.state_br_ce","base.br"
-"city_2311504","Quixeré","2311504","base.state_br_ce","base.br"
-"city_2311603","Redenção","2311603","base.state_br_ce","base.br"
-"city_2311702","Reriutaba","2311702","base.state_br_ce","base.br"
-"city_2311801","Russas","2311801","base.state_br_ce","base.br"
-"city_2311900","Saboeiro","2311900","base.state_br_ce","base.br"
-"city_2311959","Salitre","2311959","base.state_br_ce","base.br"
-"city_2312205","Santa Quitéria","2312205","base.state_br_ce","base.br"
-"city_2312007","Santana do Acaraú","2312007","base.state_br_ce","base.br"
-"city_2312106","Santana do Cariri","2312106","base.state_br_ce","base.br"
-"city_2312304","São Benedito","2312304","base.state_br_ce","base.br"
-"city_2312403","São Gonçalo do Amarante","2312403","base.state_br_ce","base.br"
-"city_2312502","São João do Jaguaribe","2312502","base.state_br_ce","base.br"
-"city_2312601","São Luís do Curu","2312601","base.state_br_ce","base.br"
-"city_2312700","Senador Pompeu","2312700","base.state_br_ce","base.br"
-"city_2312809","Senador Sá","2312809","base.state_br_ce","base.br"
-"city_2312908","Sobral","2312908","base.state_br_ce","base.br"
-"city_2313005","Solonópole","2313005","base.state_br_ce","base.br"
-"city_2313104","Tabuleiro do Norte","2313104","base.state_br_ce","base.br"
-"city_2313203","Tamboril","2313203","base.state_br_ce","base.br"
-"city_2313252","Tarrafas","2313252","base.state_br_ce","base.br"
-"city_2313302","Tauá","2313302","base.state_br_ce","base.br"
-"city_2313351","Tejuçuoca","2313351","base.state_br_ce","base.br"
-"city_2313401","Tianguá","2313401","base.state_br_ce","base.br"
-"city_2313500","Trairi","2313500","base.state_br_ce","base.br"
-"city_2313559","Tururu","2313559","base.state_br_ce","base.br"
-"city_2313609","Ubajara","2313609","base.state_br_ce","base.br"
-"city_2313708","Umari","2313708","base.state_br_ce","base.br"
-"city_2313757","Umirim","2313757","base.state_br_ce","base.br"
-"city_2313807","Uruburetama","2313807","base.state_br_ce","base.br"
-"city_2313906","Uruoca","2313906","base.state_br_ce","base.br"
-"city_2313955","Varjota","2313955","base.state_br_ce","base.br"
-"city_2314003","Várzea Alegre","2314003","base.state_br_ce","base.br"
-"city_2314102","Viçosa do Ceará","2314102","base.state_br_ce","base.br"
-"city_2400109","Acari","2400109","base.state_br_rn","base.br"
-"city_2400208","Açu","2400208","base.state_br_rn","base.br"
-"city_2400307","Afonso Bezerra","2400307","base.state_br_rn","base.br"
-"city_2400406","Água Nova","2400406","base.state_br_rn","base.br"
-"city_2400505","Alexandria","2400505","base.state_br_rn","base.br"
-"city_2400604","Almino Afonso","2400604","base.state_br_rn","base.br"
-"city_2400703","Alto do Rodrigues","2400703","base.state_br_rn","base.br"
-"city_2400802","Angicos","2400802","base.state_br_rn","base.br"
-"city_2400901","Antônio Martins","2400901","base.state_br_rn","base.br"
-"city_2401008","Apodi","2401008","base.state_br_rn","base.br"
-"city_2401107","Areia Branca","2401107","base.state_br_rn","base.br"
-"city_2401206","Arês","2401206","base.state_br_rn","base.br"
-"city_2401404","Baía Formosa","2401404","base.state_br_rn","base.br"
-"city_2401453","Baraúna","2401453","base.state_br_rn","base.br"
-"city_2401503","Barcelona","2401503","base.state_br_rn","base.br"
-"city_2401602","Bento Fernandes","2401602","base.state_br_rn","base.br"
-"city_2401651","Bodó","2401651","base.state_br_rn","base.br"
-"city_2401701","Bom Jesus","2401701","base.state_br_rn","base.br"
-"city_2401800","Brejinho","2401800","base.state_br_rn","base.br"
-"city_2401859","Caiçara do Norte","2401859","base.state_br_rn","base.br"
-"city_2401909","Caiçara do Rio do Vento","2401909","base.state_br_rn","base.br"
-"city_2402006","Caicó","2402006","base.state_br_rn","base.br"
-"city_2401305","Campo Grande","2401305","base.state_br_rn","base.br"
-"city_2402105","Campo Redondo","2402105","base.state_br_rn","base.br"
-"city_2402204","Canguaretama","2402204","base.state_br_rn","base.br"
-"city_2402303","Caraúbas","2402303","base.state_br_rn","base.br"
-"city_2402402","Carnaúba dos Dantas","2402402","base.state_br_rn","base.br"
-"city_2402501","Carnaubais","2402501","base.state_br_rn","base.br"
-"city_2402600","Ceará-Mirim","2402600","base.state_br_rn","base.br"
-"city_2402709","Cerro Corá","2402709","base.state_br_rn","base.br"
-"city_2402808","Coronel Ezequiel","2402808","base.state_br_rn","base.br"
-"city_2402907","Coronel João Pessoa","2402907","base.state_br_rn","base.br"
-"city_2403004","Cruzeta","2403004","base.state_br_rn","base.br"
-"city_2403103","Currais Novos","2403103","base.state_br_rn","base.br"
-"city_2403202","Doutor Severiano","2403202","base.state_br_rn","base.br"
-"city_2403301","Encanto","2403301","base.state_br_rn","base.br"
-"city_2403400","Equador","2403400","base.state_br_rn","base.br"
-"city_2403509","Espírito Santo","2403509","base.state_br_rn","base.br"
-"city_2403608","Extremoz","2403608","base.state_br_rn","base.br"
-"city_2403707","Felipe Guerra","2403707","base.state_br_rn","base.br"
-"city_2403756","Fernando Pedroza","2403756","base.state_br_rn","base.br"
-"city_2403806","Florânia","2403806","base.state_br_rn","base.br"
-"city_2403905","Francisco Dantas","2403905","base.state_br_rn","base.br"
-"city_2404002","Frutuoso Gomes","2404002","base.state_br_rn","base.br"
-"city_2404101","Galinhos","2404101","base.state_br_rn","base.br"
-"city_2404200","Goianinha","2404200","base.state_br_rn","base.br"
-"city_2404309","Governador Dix-Sept Rosado","2404309","base.state_br_rn","base.br"
-"city_2404408","Grossos","2404408","base.state_br_rn","base.br"
-"city_2404507","Guamaré","2404507","base.state_br_rn","base.br"
-"city_2404606","Ielmo Marinho","2404606","base.state_br_rn","base.br"
-"city_2404705","Ipanguaçu","2404705","base.state_br_rn","base.br"
-"city_2404804","Ipueira","2404804","base.state_br_rn","base.br"
-"city_2404853","Itajá","2404853","base.state_br_rn","base.br"
-"city_2404903","Itaú","2404903","base.state_br_rn","base.br"
-"city_2405009","Jaçanã","2405009","base.state_br_rn","base.br"
-"city_2405108","Jandaíra","2405108","base.state_br_rn","base.br"
-"city_2405207","Janduís","2405207","base.state_br_rn","base.br"
-"city_2405306","Januário Cicco","2405306","base.state_br_rn","base.br"
-"city_2405405","Japi","2405405","base.state_br_rn","base.br"
-"city_2405504","Jardim de Angicos","2405504","base.state_br_rn","base.br"
-"city_2405603","Jardim de Piranhas","2405603","base.state_br_rn","base.br"
-"city_2405702","Jardim do Seridó","2405702","base.state_br_rn","base.br"
-"city_2405801","João Câmara","2405801","base.state_br_rn","base.br"
-"city_2405900","João Dias","2405900","base.state_br_rn","base.br"
-"city_2406007","José da Penha","2406007","base.state_br_rn","base.br"
-"city_2406106","Jucurutu","2406106","base.state_br_rn","base.br"
-"city_2406155","Jundiá","2406155","base.state_br_rn","base.br"
-"city_2406205","Lagoa d'Anta","2406205","base.state_br_rn","base.br"
-"city_2406304","Lagoa de Pedras","2406304","base.state_br_rn","base.br"
-"city_2406403","Lagoa de Velhos","2406403","base.state_br_rn","base.br"
-"city_2406502","Lagoa Nova","2406502","base.state_br_rn","base.br"
-"city_2406601","Lagoa Salgada","2406601","base.state_br_rn","base.br"
-"city_2406700","Lajes","2406700","base.state_br_rn","base.br"
-"city_2406809","Lajes Pintadas","2406809","base.state_br_rn","base.br"
-"city_2406908","Lucrécia","2406908","base.state_br_rn","base.br"
-"city_2407005","Luís Gomes","2407005","base.state_br_rn","base.br"
-"city_2407104","Macaíba","2407104","base.state_br_rn","base.br"
-"city_2407203","Macau","2407203","base.state_br_rn","base.br"
-"city_2407252","Major Sales","2407252","base.state_br_rn","base.br"
-"city_2407302","Marcelino Vieira","2407302","base.state_br_rn","base.br"
-"city_2407401","Martins","2407401","base.state_br_rn","base.br"
-"city_2407500","Maxaranguape","2407500","base.state_br_rn","base.br"
-"city_2407609","Messias Targino","2407609","base.state_br_rn","base.br"
-"city_2407708","Montanhas","2407708","base.state_br_rn","base.br"
-"city_2407807","Monte Alegre","2407807","base.state_br_rn","base.br"
-"city_2407906","Monte das Gameleiras","2407906","base.state_br_rn","base.br"
-"city_2408003","Mossoró","2408003","base.state_br_rn","base.br"
-"city_2408102","Natal","2408102","base.state_br_rn","base.br"
-"city_2408201","Nísia Floresta","2408201","base.state_br_rn","base.br"
-"city_2408300","Nova Cruz","2408300","base.state_br_rn","base.br"
-"city_2408409","Olho d'Água do Borges","2408409","base.state_br_rn","base.br"
-"city_2408508","Ouro Branco","2408508","base.state_br_rn","base.br"
-"city_2408607","Paraná","2408607","base.state_br_rn","base.br"
-"city_2408706","Paraú","2408706","base.state_br_rn","base.br"
-"city_2408805","Parazinho","2408805","base.state_br_rn","base.br"
-"city_2408904","Parelhas","2408904","base.state_br_rn","base.br"
-"city_2403251","Parnamirim","2403251","base.state_br_rn","base.br"
-"city_2409100","Passa e Fica","2409100","base.state_br_rn","base.br"
-"city_2409209","Passagem","2409209","base.state_br_rn","base.br"
-"city_2409308","Patu","2409308","base.state_br_rn","base.br"
-"city_2409407","Pau dos Ferros","2409407","base.state_br_rn","base.br"
-"city_2409506","Pedra Grande","2409506","base.state_br_rn","base.br"
-"city_2409605","Pedra Preta","2409605","base.state_br_rn","base.br"
-"city_2409704","Pedro Avelino","2409704","base.state_br_rn","base.br"
-"city_2409803","Pedro Velho","2409803","base.state_br_rn","base.br"
-"city_2409902","Pendências","2409902","base.state_br_rn","base.br"
-"city_2410009","Pilões","2410009","base.state_br_rn","base.br"
-"city_2410108","Poço Branco","2410108","base.state_br_rn","base.br"
-"city_2410207","Portalegre","2410207","base.state_br_rn","base.br"
-"city_2410256","Porto do Mangue","2410256","base.state_br_rn","base.br"
-"city_2410405","Pureza","2410405","base.state_br_rn","base.br"
-"city_2410504","Rafael Fernandes","2410504","base.state_br_rn","base.br"
-"city_2410603","Rafael Godeiro","2410603","base.state_br_rn","base.br"
-"city_2410702","Riacho da Cruz","2410702","base.state_br_rn","base.br"
-"city_2410801","Riacho de Santana","2410801","base.state_br_rn","base.br"
-"city_2410900","Riachuelo","2410900","base.state_br_rn","base.br"
-"city_2408953","Rio do Fogo","2408953","base.state_br_rn","base.br"
-"city_2411007","Rodolfo Fernandes","2411007","base.state_br_rn","base.br"
-"city_2411106","Ruy Barbosa","2411106","base.state_br_rn","base.br"
-"city_2411205","Santa Cruz","2411205","base.state_br_rn","base.br"
-"city_2409332","Santa Maria","2409332","base.state_br_rn","base.br"
-"city_2411403","Santana do Matos","2411403","base.state_br_rn","base.br"
-"city_2411429","Santana do Seridó","2411429","base.state_br_rn","base.br"
-"city_2411502","Santo Antônio","2411502","base.state_br_rn","base.br"
-"city_2411601","São Bento do Norte","2411601","base.state_br_rn","base.br"
-"city_2411700","São Bento do Trairí","2411700","base.state_br_rn","base.br"
-"city_2411809","São Fernando","2411809","base.state_br_rn","base.br"
-"city_2411908","São Francisco do Oeste","2411908","base.state_br_rn","base.br"
-"city_2412005","São Gonçalo do Amarante","2412005","base.state_br_rn","base.br"
-"city_2412104","São João do Sabugi","2412104","base.state_br_rn","base.br"
-"city_2412203","São José de Mipibu","2412203","base.state_br_rn","base.br"
-"city_2412302","São José do Campestre","2412302","base.state_br_rn","base.br"
-"city_2412401","São José do Seridó","2412401","base.state_br_rn","base.br"
-"city_2412500","São Miguel","2412500","base.state_br_rn","base.br"
-"city_2412559","São Miguel do Gostoso","2412559","base.state_br_rn","base.br"
-"city_2412609","São Paulo do Potengi","2412609","base.state_br_rn","base.br"
-"city_2412708","São Pedro","2412708","base.state_br_rn","base.br"
-"city_2412807","São Rafael","2412807","base.state_br_rn","base.br"
-"city_2412906","São Tomé","2412906","base.state_br_rn","base.br"
-"city_2413003","São Vicente","2413003","base.state_br_rn","base.br"
-"city_2413102","Senador Elói de Souza","2413102","base.state_br_rn","base.br"
-"city_2413201","Senador Georgino Avelino","2413201","base.state_br_rn","base.br"
-"city_2410306","Serra Caiada","2410306","base.state_br_rn","base.br"
-"city_2413300","Serra de São Bento","2413300","base.state_br_rn","base.br"
-"city_2413359","Serra do Mel","2413359","base.state_br_rn","base.br"
-"city_2413409","Serra Negra do Norte","2413409","base.state_br_rn","base.br"
-"city_2413508","Serrinha","2413508","base.state_br_rn","base.br"
-"city_2413557","Serrinha dos Pintos","2413557","base.state_br_rn","base.br"
-"city_2413607","Severiano Melo","2413607","base.state_br_rn","base.br"
-"city_2413706","Sítio Novo","2413706","base.state_br_rn","base.br"
-"city_2413805","Taboleiro Grande","2413805","base.state_br_rn","base.br"
-"city_2413904","Taipu","2413904","base.state_br_rn","base.br"
-"city_2414001","Tangará","2414001","base.state_br_rn","base.br"
-"city_2414100","Tenente Ananias","2414100","base.state_br_rn","base.br"
-"city_2414159","Tenente Laurentino Cruz","2414159","base.state_br_rn","base.br"
-"city_2411056","Tibau","2411056","base.state_br_rn","base.br"
-"city_2414209","Tibau do Sul","2414209","base.state_br_rn","base.br"
-"city_2414308","Timbaúba dos Batistas","2414308","base.state_br_rn","base.br"
-"city_2414407","Touros","2414407","base.state_br_rn","base.br"
-"city_2414456","Triunfo Potiguar","2414456","base.state_br_rn","base.br"
-"city_2414506","Umarizal","2414506","base.state_br_rn","base.br"
-"city_2414605","Upanema","2414605","base.state_br_rn","base.br"
-"city_2414704","Várzea","2414704","base.state_br_rn","base.br"
-"city_2414753","Venha-Ver","2414753","base.state_br_rn","base.br"
-"city_2414803","Vera Cruz","2414803","base.state_br_rn","base.br"
-"city_2414902","Viçosa","2414902","base.state_br_rn","base.br"
-"city_2415008","Vila Flor","2415008","base.state_br_rn","base.br"
-"city_2500106","Água Branca","2500106","base.state_br_pb","base.br"
-"city_2500205","Aguiar","2500205","base.state_br_pb","base.br"
-"city_2500304","Alagoa Grande","2500304","base.state_br_pb","base.br"
-"city_2500403","Alagoa Nova","2500403","base.state_br_pb","base.br"
-"city_2500502","Alagoinha","2500502","base.state_br_pb","base.br"
-"city_2500536","Alcantil","2500536","base.state_br_pb","base.br"
-"city_2500577","Algodão de Jandaíra","2500577","base.state_br_pb","base.br"
-"city_2500601","Alhandra","2500601","base.state_br_pb","base.br"
-"city_2500734","Amparo","2500734","base.state_br_pb","base.br"
-"city_2500775","Aparecida","2500775","base.state_br_pb","base.br"
-"city_2500809","Araçagi","2500809","base.state_br_pb","base.br"
-"city_2500908","Arara","2500908","base.state_br_pb","base.br"
-"city_2501005","Araruna","2501005","base.state_br_pb","base.br"
-"city_2501104","Areia","2501104","base.state_br_pb","base.br"
-"city_2501153","Areia de Baraúnas","2501153","base.state_br_pb","base.br"
-"city_2501203","Areial","2501203","base.state_br_pb","base.br"
-"city_2501302","Aroeiras","2501302","base.state_br_pb","base.br"
-"city_2501351","Assunção","2501351","base.state_br_pb","base.br"
-"city_2501401","Baía da Traição","2501401","base.state_br_pb","base.br"
-"city_2501500","Bananeiras","2501500","base.state_br_pb","base.br"
-"city_2501534","Baraúna","2501534","base.state_br_pb","base.br"
-"city_2501609","Barra de Santa Rosa","2501609","base.state_br_pb","base.br"
-"city_2501575","Barra de Santana","2501575","base.state_br_pb","base.br"
-"city_2501708","Barra de São Miguel","2501708","base.state_br_pb","base.br"
-"city_2501807","Bayeux","2501807","base.state_br_pb","base.br"
-"city_2501906","Belém","2501906","base.state_br_pb","base.br"
-"city_2502003","Belém do Brejo do Cruz","2502003","base.state_br_pb","base.br"
-"city_2502052","Bernardino Batista","2502052","base.state_br_pb","base.br"
-"city_2502102","Boa Ventura","2502102","base.state_br_pb","base.br"
-"city_2502151","Boa Vista","2502151","base.state_br_pb","base.br"
-"city_2502201","Bom Jesus","2502201","base.state_br_pb","base.br"
-"city_2502300","Bom Sucesso","2502300","base.state_br_pb","base.br"
-"city_2502409","Bonito de Santa Fé","2502409","base.state_br_pb","base.br"
-"city_2502508","Boqueirão","2502508","base.state_br_pb","base.br"
-"city_2502706","Borborema","2502706","base.state_br_pb","base.br"
-"city_2502805","Brejo do Cruz","2502805","base.state_br_pb","base.br"
-"city_2502904","Brejo dos Santos","2502904","base.state_br_pb","base.br"
-"city_2503001","Caaporã","2503001","base.state_br_pb","base.br"
-"city_2503100","Cabaceiras","2503100","base.state_br_pb","base.br"
-"city_2503209","Cabedelo","2503209","base.state_br_pb","base.br"
-"city_2503308","Cachoeira dos Índios","2503308","base.state_br_pb","base.br"
-"city_2503407","Cacimba de Areia","2503407","base.state_br_pb","base.br"
-"city_2503506","Cacimba de Dentro","2503506","base.state_br_pb","base.br"
-"city_2503555","Cacimbas","2503555","base.state_br_pb","base.br"
-"city_2503605","Caiçara","2503605","base.state_br_pb","base.br"
-"city_2503704","Cajazeiras","2503704","base.state_br_pb","base.br"
-"city_2503753","Cajazeirinhas","2503753","base.state_br_pb","base.br"
-"city_2503803","Caldas Brandão","2503803","base.state_br_pb","base.br"
-"city_2503902","Camalaú","2503902","base.state_br_pb","base.br"
-"city_2504009","Campina Grande","2504009","base.state_br_pb","base.br"
-"city_2504033","Capim","2504033","base.state_br_pb","base.br"
-"city_2504074","Caraúbas","2504074","base.state_br_pb","base.br"
-"city_2504108","Carrapateira","2504108","base.state_br_pb","base.br"
-"city_2504157","Casserengue","2504157","base.state_br_pb","base.br"
-"city_2504207","Catingueira","2504207","base.state_br_pb","base.br"
-"city_2504306","Catolé do Rocha","2504306","base.state_br_pb","base.br"
-"city_2504355","Caturité","2504355","base.state_br_pb","base.br"
-"city_2504405","Conceição","2504405","base.state_br_pb","base.br"
-"city_2504504","Condado","2504504","base.state_br_pb","base.br"
-"city_2504603","Conde","2504603","base.state_br_pb","base.br"
-"city_2504702","Congo","2504702","base.state_br_pb","base.br"
-"city_2504801","Coremas","2504801","base.state_br_pb","base.br"
-"city_2504850","Coxixola","2504850","base.state_br_pb","base.br"
-"city_2504900","Cruz do Espírito Santo","2504900","base.state_br_pb","base.br"
-"city_2505006","Cubati","2505006","base.state_br_pb","base.br"
-"city_2505105","Cuité","2505105","base.state_br_pb","base.br"
-"city_2505238","Cuité de Mamanguape","2505238","base.state_br_pb","base.br"
-"city_2505204","Cuitegi","2505204","base.state_br_pb","base.br"
-"city_2505279","Curral de Cima","2505279","base.state_br_pb","base.br"
-"city_2505303","Curral Velho","2505303","base.state_br_pb","base.br"
-"city_2505352","Damião","2505352","base.state_br_pb","base.br"
-"city_2505402","Desterro","2505402","base.state_br_pb","base.br"
-"city_2505600","Diamante","2505600","base.state_br_pb","base.br"
-"city_2505709","Dona Inês","2505709","base.state_br_pb","base.br"
-"city_2505808","Duas Estradas","2505808","base.state_br_pb","base.br"
-"city_2505907","Emas","2505907","base.state_br_pb","base.br"
-"city_2506004","Esperança","2506004","base.state_br_pb","base.br"
-"city_2506103","Fagundes","2506103","base.state_br_pb","base.br"
-"city_2506202","Frei Martinho","2506202","base.state_br_pb","base.br"
-"city_2506251","Gado Bravo","2506251","base.state_br_pb","base.br"
-"city_2506301","Guarabira","2506301","base.state_br_pb","base.br"
-"city_2506400","Gurinhém","2506400","base.state_br_pb","base.br"
-"city_2506509","Gurjão","2506509","base.state_br_pb","base.br"
-"city_2506608","Ibiara","2506608","base.state_br_pb","base.br"
-"city_2502607","Igaracy","2502607","base.state_br_pb","base.br"
-"city_2506707","Imaculada","2506707","base.state_br_pb","base.br"
-"city_2506806","Ingá","2506806","base.state_br_pb","base.br"
-"city_2506905","Itabaiana","2506905","base.state_br_pb","base.br"
-"city_2507002","Itaporanga","2507002","base.state_br_pb","base.br"
-"city_2507101","Itapororoca","2507101","base.state_br_pb","base.br"
-"city_2507200","Itatuba","2507200","base.state_br_pb","base.br"
-"city_2507309","Jacaraú","2507309","base.state_br_pb","base.br"
-"city_2507408","Jericó","2507408","base.state_br_pb","base.br"
-"city_2507507","João Pessoa","2507507","base.state_br_pb","base.br"
-"city_2513653","Joca Claudino","2513653","base.state_br_pb","base.br"
-"city_2507606","Juarez Távora","2507606","base.state_br_pb","base.br"
-"city_2507705","Juazeirinho","2507705","base.state_br_pb","base.br"
-"city_2507804","Junco do Seridó","2507804","base.state_br_pb","base.br"
-"city_2507903","Juripiranga","2507903","base.state_br_pb","base.br"
-"city_2508000","Juru","2508000","base.state_br_pb","base.br"
-"city_2508109","Lagoa","2508109","base.state_br_pb","base.br"
-"city_2508208","Lagoa de Dentro","2508208","base.state_br_pb","base.br"
-"city_2508307","Lagoa Seca","2508307","base.state_br_pb","base.br"
-"city_2508406","Lastro","2508406","base.state_br_pb","base.br"
-"city_2508505","Livramento","2508505","base.state_br_pb","base.br"
-"city_2508554","Logradouro","2508554","base.state_br_pb","base.br"
-"city_2508604","Lucena","2508604","base.state_br_pb","base.br"
-"city_2508703","Mãe d'Água","2508703","base.state_br_pb","base.br"
-"city_2508802","Malta","2508802","base.state_br_pb","base.br"
-"city_2508901","Mamanguape","2508901","base.state_br_pb","base.br"
-"city_2509008","Manaíra","2509008","base.state_br_pb","base.br"
-"city_2509057","Marcação","2509057","base.state_br_pb","base.br"
-"city_2509107","Mari","2509107","base.state_br_pb","base.br"
-"city_2509156","Marizópolis","2509156","base.state_br_pb","base.br"
-"city_2509206","Massaranduba","2509206","base.state_br_pb","base.br"
-"city_2509305","Mataraca","2509305","base.state_br_pb","base.br"
-"city_2509339","Matinhas","2509339","base.state_br_pb","base.br"
-"city_2509370","Mato Grosso","2509370","base.state_br_pb","base.br"
-"city_2509396","Maturéia","2509396","base.state_br_pb","base.br"
-"city_2509404","Mogeiro","2509404","base.state_br_pb","base.br"
-"city_2509503","Montadas","2509503","base.state_br_pb","base.br"
-"city_2509602","Monte Horebe","2509602","base.state_br_pb","base.br"
-"city_2509701","Monteiro","2509701","base.state_br_pb","base.br"
-"city_2509800","Mulungu","2509800","base.state_br_pb","base.br"
-"city_2509909","Natuba","2509909","base.state_br_pb","base.br"
-"city_2510006","Nazarezinho","2510006","base.state_br_pb","base.br"
-"city_2510105","Nova Floresta","2510105","base.state_br_pb","base.br"
-"city_2510204","Nova Olinda","2510204","base.state_br_pb","base.br"
-"city_2510303","Nova Palmeira","2510303","base.state_br_pb","base.br"
-"city_2510402","Olho d'Água","2510402","base.state_br_pb","base.br"
-"city_2510501","Olivedos","2510501","base.state_br_pb","base.br"
-"city_2510600","Ouro Velho","2510600","base.state_br_pb","base.br"
-"city_2510659","Parari","2510659","base.state_br_pb","base.br"
-"city_2510709","Passagem","2510709","base.state_br_pb","base.br"
-"city_2510808","Patos","2510808","base.state_br_pb","base.br"
-"city_2510907","Paulista","2510907","base.state_br_pb","base.br"
-"city_2511004","Pedra Branca","2511004","base.state_br_pb","base.br"
-"city_2511103","Pedra Lavrada","2511103","base.state_br_pb","base.br"
-"city_2511202","Pedras de Fogo","2511202","base.state_br_pb","base.br"
-"city_2512721","Pedro Régis","2512721","base.state_br_pb","base.br"
-"city_2511301","Piancó","2511301","base.state_br_pb","base.br"
-"city_2511400","Picuí","2511400","base.state_br_pb","base.br"
-"city_2511509","Pilar","2511509","base.state_br_pb","base.br"
-"city_2511608","Pilões","2511608","base.state_br_pb","base.br"
-"city_2511707","Pilõezinhos","2511707","base.state_br_pb","base.br"
-"city_2511806","Pirpirituba","2511806","base.state_br_pb","base.br"
-"city_2511905","Pitimbu","2511905","base.state_br_pb","base.br"
-"city_2512002","Pocinhos","2512002","base.state_br_pb","base.br"
-"city_2512036","Poço Dantas","2512036","base.state_br_pb","base.br"
-"city_2512077","Poço de José de Moura","2512077","base.state_br_pb","base.br"
-"city_2512101","Pombal","2512101","base.state_br_pb","base.br"
-"city_2512200","Prata","2512200","base.state_br_pb","base.br"
-"city_2512309","Princesa Isabel","2512309","base.state_br_pb","base.br"
-"city_2512408","Puxinanã","2512408","base.state_br_pb","base.br"
-"city_2512507","Queimadas","2512507","base.state_br_pb","base.br"
-"city_2512606","Quixaba","2512606","base.state_br_pb","base.br"
-"city_2512705","Remígio","2512705","base.state_br_pb","base.br"
-"city_2512747","Riachão","2512747","base.state_br_pb","base.br"
-"city_2512754","Riachão do Bacamarte","2512754","base.state_br_pb","base.br"
-"city_2512762","Riachão do Poço","2512762","base.state_br_pb","base.br"
-"city_2512788","Riacho de Santo Antônio","2512788","base.state_br_pb","base.br"
-"city_2512804","Riacho dos Cavalos","2512804","base.state_br_pb","base.br"
-"city_2512903","Rio Tinto","2512903","base.state_br_pb","base.br"
-"city_2513000","Salgadinho","2513000","base.state_br_pb","base.br"
-"city_2513109","Salgado de São Félix","2513109","base.state_br_pb","base.br"
-"city_2513158","Santa Cecília","2513158","base.state_br_pb","base.br"
-"city_2513208","Santa Cruz","2513208","base.state_br_pb","base.br"
-"city_2513307","Santa Helena","2513307","base.state_br_pb","base.br"
-"city_2513356","Santa Inês","2513356","base.state_br_pb","base.br"
-"city_2513406","Santa Luzia","2513406","base.state_br_pb","base.br"
-"city_2513703","Santa Rita","2513703","base.state_br_pb","base.br"
-"city_2513802","Santa Teresinha","2513802","base.state_br_pb","base.br"
-"city_2513505","Santana de Mangueira","2513505","base.state_br_pb","base.br"
-"city_2513604","Santana dos Garrotes","2513604","base.state_br_pb","base.br"
-"city_2513851","Santo André","2513851","base.state_br_pb","base.br"
-"city_2513927","São Bentinho","2513927","base.state_br_pb","base.br"
-"city_2513901","São Bento","2513901","base.state_br_pb","base.br"
-"city_2513968","São Domingos","2513968","base.state_br_pb","base.br"
-"city_2513943","São Domingos do Cariri","2513943","base.state_br_pb","base.br"
-"city_2513984","São Francisco","2513984","base.state_br_pb","base.br"
-"city_2514008","São João do Cariri","2514008","base.state_br_pb","base.br"
-"city_2500700","São João do Rio do Peixe","2500700","base.state_br_pb","base.br"
-"city_2514107","São João do Tigre","2514107","base.state_br_pb","base.br"
-"city_2514206","São José da Lagoa Tapada","2514206","base.state_br_pb","base.br"
-"city_2514305","São José de Caiana","2514305","base.state_br_pb","base.br"
-"city_2514404","São José de Espinharas","2514404","base.state_br_pb","base.br"
-"city_2514503","São José de Piranhas","2514503","base.state_br_pb","base.br"
-"city_2514552","São José de Princesa","2514552","base.state_br_pb","base.br"
-"city_2514602","São José do Bonfim","2514602","base.state_br_pb","base.br"
-"city_2514651","São José do Brejo do Cruz","2514651","base.state_br_pb","base.br"
-"city_2514701","São José do Sabugi","2514701","base.state_br_pb","base.br"
-"city_2514800","São José dos Cordeiros","2514800","base.state_br_pb","base.br"
-"city_2514453","São José dos Ramos","2514453","base.state_br_pb","base.br"
-"city_2514909","São Mamede","2514909","base.state_br_pb","base.br"
-"city_2515005","São Miguel de Taipu","2515005","base.state_br_pb","base.br"
-"city_2515104","São Sebastião de Lagoa de Roça","2515104","base.state_br_pb","base.br"
-"city_2515203","São Sebastião do Umbuzeiro","2515203","base.state_br_pb","base.br"
-"city_2515401","São Vicente do Seridó","2515401","base.state_br_pb","base.br"
-"city_2515302","Sapé","2515302","base.state_br_pb","base.br"
-"city_2515500","Serra Branca","2515500","base.state_br_pb","base.br"
-"city_2515609","Serra da Raiz","2515609","base.state_br_pb","base.br"
-"city_2515708","Serra Grande","2515708","base.state_br_pb","base.br"
-"city_2515807","Serra Redonda","2515807","base.state_br_pb","base.br"
-"city_2515906","Serraria","2515906","base.state_br_pb","base.br"
-"city_2515930","Sertãozinho","2515930","base.state_br_pb","base.br"
-"city_2515971","Sobrado","2515971","base.state_br_pb","base.br"
-"city_2516003","Solânea","2516003","base.state_br_pb","base.br"
-"city_2516102","Soledade","2516102","base.state_br_pb","base.br"
-"city_2516151","Sossêgo","2516151","base.state_br_pb","base.br"
-"city_2516201","Sousa","2516201","base.state_br_pb","base.br"
-"city_2516300","Sumé","2516300","base.state_br_pb","base.br"
-"city_2516409","Tacima","2516409","base.state_br_pb","base.br"
-"city_2516508","Taperoá","2516508","base.state_br_pb","base.br"
-"city_2516607","Tavares","2516607","base.state_br_pb","base.br"
-"city_2516706","Teixeira","2516706","base.state_br_pb","base.br"
-"city_2516755","Tenório","2516755","base.state_br_pb","base.br"
-"city_2516805","Triunfo","2516805","base.state_br_pb","base.br"
-"city_2516904","Uiraúna","2516904","base.state_br_pb","base.br"
-"city_2517001","Umbuzeiro","2517001","base.state_br_pb","base.br"
-"city_2517100","Várzea","2517100","base.state_br_pb","base.br"
-"city_2517209","Vieirópolis","2517209","base.state_br_pb","base.br"
-"city_2505501","Vista Serrana","2505501","base.state_br_pb","base.br"
-"city_2517407","Zabelê","2517407","base.state_br_pb","base.br"
-"city_2600054","Abreu e Lima","2600054","base.state_br_pe","base.br"
-"city_2600104","Afogados da Ingazeira","2600104","base.state_br_pe","base.br"
-"city_2600203","Afrânio","2600203","base.state_br_pe","base.br"
-"city_2600302","Agrestina","2600302","base.state_br_pe","base.br"
-"city_2600401","Água Preta","2600401","base.state_br_pe","base.br"
-"city_2600500","Águas Belas","2600500","base.state_br_pe","base.br"
-"city_2600609","Alagoinha","2600609","base.state_br_pe","base.br"
-"city_2600708","Aliança","2600708","base.state_br_pe","base.br"
-"city_2600807","Altinho","2600807","base.state_br_pe","base.br"
-"city_2600906","Amaraji","2600906","base.state_br_pe","base.br"
-"city_2601003","Angelim","2601003","base.state_br_pe","base.br"
-"city_2601052","Araçoiaba","2601052","base.state_br_pe","base.br"
-"city_2601102","Araripina","2601102","base.state_br_pe","base.br"
-"city_2601201","Arcoverde","2601201","base.state_br_pe","base.br"
-"city_2601300","Barra de Guabiraba","2601300","base.state_br_pe","base.br"
-"city_2601409","Barreiros","2601409","base.state_br_pe","base.br"
-"city_2601508","Belém de Maria","2601508","base.state_br_pe","base.br"
-"city_2601607","Belém do São Francisco","2601607","base.state_br_pe","base.br"
-"city_2601706","Belo Jardim","2601706","base.state_br_pe","base.br"
-"city_2601805","Betânia","2601805","base.state_br_pe","base.br"
-"city_2601904","Bezerros","2601904","base.state_br_pe","base.br"
-"city_2602001","Bodocó","2602001","base.state_br_pe","base.br"
-"city_2602100","Bom Conselho","2602100","base.state_br_pe","base.br"
-"city_2602209","Bom Jardim","2602209","base.state_br_pe","base.br"
-"city_2602308","Bonito","2602308","base.state_br_pe","base.br"
-"city_2602407","Brejão","2602407","base.state_br_pe","base.br"
-"city_2602506","Brejinho","2602506","base.state_br_pe","base.br"
-"city_2602605","Brejo da Madre de Deus","2602605","base.state_br_pe","base.br"
-"city_2602704","Buenos Aires","2602704","base.state_br_pe","base.br"
-"city_2602803","Buíque","2602803","base.state_br_pe","base.br"
-"city_2602902","Cabo de Santo Agostinho","2602902","base.state_br_pe","base.br"
-"city_2603009","Cabrobó","2603009","base.state_br_pe","base.br"
-"city_2603108","Cachoeirinha","2603108","base.state_br_pe","base.br"
-"city_2603207","Caetés","2603207","base.state_br_pe","base.br"
-"city_2603306","Calçado","2603306","base.state_br_pe","base.br"
-"city_2603405","Calumbi","2603405","base.state_br_pe","base.br"
-"city_2603454","Camaragibe","2603454","base.state_br_pe","base.br"
-"city_2603504","Camocim de São Félix","2603504","base.state_br_pe","base.br"
-"city_2603603","Camutanga","2603603","base.state_br_pe","base.br"
-"city_2603702","Canhotinho","2603702","base.state_br_pe","base.br"
-"city_2603801","Capoeiras","2603801","base.state_br_pe","base.br"
-"city_2603900","Carnaíba","2603900","base.state_br_pe","base.br"
-"city_2603926","Carnaubeira da Penha","2603926","base.state_br_pe","base.br"
-"city_2604007","Carpina","2604007","base.state_br_pe","base.br"
-"city_2604106","Caruaru","2604106","base.state_br_pe","base.br"
-"city_2604155","Casinhas","2604155","base.state_br_pe","base.br"
-"city_2604205","Catende","2604205","base.state_br_pe","base.br"
-"city_2604304","Cedro","2604304","base.state_br_pe","base.br"
-"city_2604403","Chã de Alegria","2604403","base.state_br_pe","base.br"
-"city_2604502","Chã Grande","2604502","base.state_br_pe","base.br"
-"city_2604601","Condado","2604601","base.state_br_pe","base.br"
-"city_2604700","Correntes","2604700","base.state_br_pe","base.br"
-"city_2604809","Cortês","2604809","base.state_br_pe","base.br"
-"city_2604908","Cumaru","2604908","base.state_br_pe","base.br"
-"city_2605004","Cupira","2605004","base.state_br_pe","base.br"
-"city_2605103","Custódia","2605103","base.state_br_pe","base.br"
-"city_2605152","Dormentes","2605152","base.state_br_pe","base.br"
-"city_2605202","Escada","2605202","base.state_br_pe","base.br"
-"city_2605301","Exu","2605301","base.state_br_pe","base.br"
-"city_2605400","Feira Nova","2605400","base.state_br_pe","base.br"
-"city_2605459","Fernando de Noronha","2605459","base.state_br_pe","base.br"
-"city_2605509","Ferreiros","2605509","base.state_br_pe","base.br"
-"city_2605608","Flores","2605608","base.state_br_pe","base.br"
-"city_2605707","Floresta","2605707","base.state_br_pe","base.br"
-"city_2605806","Frei Miguelinho","2605806","base.state_br_pe","base.br"
-"city_2605905","Gameleira","2605905","base.state_br_pe","base.br"
-"city_2606002","Garanhuns","2606002","base.state_br_pe","base.br"
-"city_2606101","Glória do Goitá","2606101","base.state_br_pe","base.br"
-"city_2606200","Goiana","2606200","base.state_br_pe","base.br"
-"city_2606309","Granito","2606309","base.state_br_pe","base.br"
-"city_2606408","Gravatá","2606408","base.state_br_pe","base.br"
-"city_2606507","Iati","2606507","base.state_br_pe","base.br"
-"city_2606606","Ibimirim","2606606","base.state_br_pe","base.br"
-"city_2606705","Ibirajuba","2606705","base.state_br_pe","base.br"
-"city_2606804","Igarassu","2606804","base.state_br_pe","base.br"
-"city_2606903","Iguaracy","2606903","base.state_br_pe","base.br"
-"city_2607604","Ilha de Itamaracá","2607604","base.state_br_pe","base.br"
-"city_2607000","Inajá","2607000","base.state_br_pe","base.br"
-"city_2607109","Ingazeira","2607109","base.state_br_pe","base.br"
-"city_2607208","Ipojuca","2607208","base.state_br_pe","base.br"
-"city_2607307","Ipubi","2607307","base.state_br_pe","base.br"
-"city_2607406","Itacuruba","2607406","base.state_br_pe","base.br"
-"city_2607505","Itaíba","2607505","base.state_br_pe","base.br"
-"city_2607653","Itambé","2607653","base.state_br_pe","base.br"
-"city_2607703","Itapetim","2607703","base.state_br_pe","base.br"
-"city_2607752","Itapissuma","2607752","base.state_br_pe","base.br"
-"city_2607802","Itaquitinga","2607802","base.state_br_pe","base.br"
-"city_2607901","Jaboatão dos Guararapes","2607901","base.state_br_pe","base.br"
-"city_2607950","Jaqueira","2607950","base.state_br_pe","base.br"
-"city_2608008","Jataúba","2608008","base.state_br_pe","base.br"
-"city_2608057","Jatobá","2608057","base.state_br_pe","base.br"
-"city_2608107","João Alfredo","2608107","base.state_br_pe","base.br"
-"city_2608206","Joaquim Nabuco","2608206","base.state_br_pe","base.br"
-"city_2608255","Jucati","2608255","base.state_br_pe","base.br"
-"city_2608305","Jupi","2608305","base.state_br_pe","base.br"
-"city_2608404","Jurema","2608404","base.state_br_pe","base.br"
-"city_2608503","Lagoa de Itaenga","2608503","base.state_br_pe","base.br"
-"city_2608453","Lagoa do Carro","2608453","base.state_br_pe","base.br"
-"city_2608602","Lagoa do Ouro","2608602","base.state_br_pe","base.br"
-"city_2608701","Lagoa dos Gatos","2608701","base.state_br_pe","base.br"
-"city_2608750","Lagoa Grande","2608750","base.state_br_pe","base.br"
-"city_2608800","Lajedo","2608800","base.state_br_pe","base.br"
-"city_2608909","Limoeiro","2608909","base.state_br_pe","base.br"
-"city_2609006","Macaparana","2609006","base.state_br_pe","base.br"
-"city_2609105","Machados","2609105","base.state_br_pe","base.br"
-"city_2609154","Manari","2609154","base.state_br_pe","base.br"
-"city_2609204","Maraial","2609204","base.state_br_pe","base.br"
-"city_2609303","Mirandiba","2609303","base.state_br_pe","base.br"
-"city_2614303","Moreilândia","2614303","base.state_br_pe","base.br"
-"city_2609402","Moreno","2609402","base.state_br_pe","base.br"
-"city_2609501","Nazaré da Mata","2609501","base.state_br_pe","base.br"
-"city_2609600","Olinda","2609600","base.state_br_pe","base.br"
-"city_2609709","Orobó","2609709","base.state_br_pe","base.br"
-"city_2609808","Orocó","2609808","base.state_br_pe","base.br"
-"city_2609907","Ouricuri","2609907","base.state_br_pe","base.br"
-"city_2610004","Palmares","2610004","base.state_br_pe","base.br"
-"city_2610103","Palmeirina","2610103","base.state_br_pe","base.br"
-"city_2610202","Panelas","2610202","base.state_br_pe","base.br"
-"city_2610301","Paranatama","2610301","base.state_br_pe","base.br"
-"city_2610400","Parnamirim","2610400","base.state_br_pe","base.br"
-"city_2610509","Passira","2610509","base.state_br_pe","base.br"
-"city_2610608","Paudalho","2610608","base.state_br_pe","base.br"
-"city_2610707","Paulista","2610707","base.state_br_pe","base.br"
-"city_2610806","Pedra","2610806","base.state_br_pe","base.br"
-"city_2610905","Pesqueira","2610905","base.state_br_pe","base.br"
-"city_2611002","Petrolândia","2611002","base.state_br_pe","base.br"
-"city_2611101","Petrolina","2611101","base.state_br_pe","base.br"
-"city_2611200","Poção","2611200","base.state_br_pe","base.br"
-"city_2611309","Pombos","2611309","base.state_br_pe","base.br"
-"city_2611408","Primavera","2611408","base.state_br_pe","base.br"
-"city_2611507","Quipapá","2611507","base.state_br_pe","base.br"
-"city_2611533","Quixaba","2611533","base.state_br_pe","base.br"
-"city_2611606","Recife","2611606","base.state_br_pe","base.br"
-"city_2611705","Riacho das Almas","2611705","base.state_br_pe","base.br"
-"city_2611804","Ribeirão","2611804","base.state_br_pe","base.br"
-"city_2611903","Rio Formoso","2611903","base.state_br_pe","base.br"
-"city_2612000","Sairé","2612000","base.state_br_pe","base.br"
-"city_2612109","Salgadinho","2612109","base.state_br_pe","base.br"
-"city_2612208","Salgueiro","2612208","base.state_br_pe","base.br"
-"city_2612307","Saloá","2612307","base.state_br_pe","base.br"
-"city_2612406","Sanharó","2612406","base.state_br_pe","base.br"
-"city_2612455","Santa Cruz","2612455","base.state_br_pe","base.br"
-"city_2612471","Santa Cruz da Baixa Verde","2612471","base.state_br_pe","base.br"
-"city_2612505","Santa Cruz do Capibaribe","2612505","base.state_br_pe","base.br"
-"city_2612554","Santa Filomena","2612554","base.state_br_pe","base.br"
-"city_2612604","Santa Maria da Boa Vista","2612604","base.state_br_pe","base.br"
-"city_2612703","Santa Maria do Cambucá","2612703","base.state_br_pe","base.br"
-"city_2612802","Santa Terezinha","2612802","base.state_br_pe","base.br"
-"city_2612901","São Benedito do Sul","2612901","base.state_br_pe","base.br"
-"city_2613008","São Bento do Una","2613008","base.state_br_pe","base.br"
-"city_2613107","São Caitano","2613107","base.state_br_pe","base.br"
-"city_2613206","São João","2613206","base.state_br_pe","base.br"
-"city_2613305","São Joaquim do Monte","2613305","base.state_br_pe","base.br"
-"city_2613404","São José da Coroa Grande","2613404","base.state_br_pe","base.br"
-"city_2613503","São José do Belmonte","2613503","base.state_br_pe","base.br"
-"city_2613602","São José do Egito","2613602","base.state_br_pe","base.br"
-"city_2613701","São Lourenço da Mata","2613701","base.state_br_pe","base.br"
-"city_2613800","São Vicente Férrer","2613800","base.state_br_pe","base.br"
-"city_2613909","Serra Talhada","2613909","base.state_br_pe","base.br"
-"city_2614006","Serrita","2614006","base.state_br_pe","base.br"
-"city_2614105","Sertânia","2614105","base.state_br_pe","base.br"
-"city_2614204","Sirinhaém","2614204","base.state_br_pe","base.br"
-"city_2614402","Solidão","2614402","base.state_br_pe","base.br"
-"city_2614501","Surubim","2614501","base.state_br_pe","base.br"
-"city_2614600","Tabira","2614600","base.state_br_pe","base.br"
-"city_2614709","Tacaimbó","2614709","base.state_br_pe","base.br"
-"city_2614808","Tacaratu","2614808","base.state_br_pe","base.br"
-"city_2614857","Tamandaré","2614857","base.state_br_pe","base.br"
-"city_2615003","Taquaritinga do Norte","2615003","base.state_br_pe","base.br"
-"city_2615102","Terezinha","2615102","base.state_br_pe","base.br"
-"city_2615201","Terra Nova","2615201","base.state_br_pe","base.br"
-"city_2615300","Timbaúba","2615300","base.state_br_pe","base.br"
-"city_2615409","Toritama","2615409","base.state_br_pe","base.br"
-"city_2615508","Tracunhaém","2615508","base.state_br_pe","base.br"
-"city_2615607","Trindade","2615607","base.state_br_pe","base.br"
-"city_2615706","Triunfo","2615706","base.state_br_pe","base.br"
-"city_2615805","Tupanatinga","2615805","base.state_br_pe","base.br"
-"city_2615904","Tuparetama","2615904","base.state_br_pe","base.br"
-"city_2616001","Venturosa","2616001","base.state_br_pe","base.br"
-"city_2616100","Verdejante","2616100","base.state_br_pe","base.br"
-"city_2616183","Vertente do Lério","2616183","base.state_br_pe","base.br"
-"city_2616209","Vertentes","2616209","base.state_br_pe","base.br"
-"city_2616308","Vicência","2616308","base.state_br_pe","base.br"
-"city_2616407","Vitória de Santo Antão","2616407","base.state_br_pe","base.br"
-"city_2616506","Xexéu","2616506","base.state_br_pe","base.br"
-"city_2700102","Água Branca","2700102","base.state_br_al","base.br"
-"city_2700201","Anadia","2700201","base.state_br_al","base.br"
-"city_2700300","Arapiraca","2700300","base.state_br_al","base.br"
-"city_2700409","Atalaia","2700409","base.state_br_al","base.br"
-"city_2700508","Barra de Santo Antônio","2700508","base.state_br_al","base.br"
-"city_2700607","Barra de São Miguel","2700607","base.state_br_al","base.br"
-"city_2700706","Batalha","2700706","base.state_br_al","base.br"
-"city_2700805","Belém","2700805","base.state_br_al","base.br"
-"city_2700904","Belo Monte","2700904","base.state_br_al","base.br"
-"city_2701001","Boca da Mata","2701001","base.state_br_al","base.br"
-"city_2701100","Branquinha","2701100","base.state_br_al","base.br"
-"city_2701209","Cacimbinhas","2701209","base.state_br_al","base.br"
-"city_2701308","Cajueiro","2701308","base.state_br_al","base.br"
-"city_2701357","Campestre","2701357","base.state_br_al","base.br"
-"city_2701407","Campo Alegre","2701407","base.state_br_al","base.br"
-"city_2701506","Campo Grande","2701506","base.state_br_al","base.br"
-"city_2701605","Canapi","2701605","base.state_br_al","base.br"
-"city_2701704","Capela","2701704","base.state_br_al","base.br"
-"city_2701803","Carneiros","2701803","base.state_br_al","base.br"
-"city_2701902","Chã Preta","2701902","base.state_br_al","base.br"
-"city_2702009","Coité do Nóia","2702009","base.state_br_al","base.br"
-"city_2702108","Colônia Leopoldina","2702108","base.state_br_al","base.br"
-"city_2702207","Coqueiro Seco","2702207","base.state_br_al","base.br"
-"city_2702306","Coruripe","2702306","base.state_br_al","base.br"
-"city_2702355","Craíbas","2702355","base.state_br_al","base.br"
-"city_2702405","Delmiro Gouveia","2702405","base.state_br_al","base.br"
-"city_2702504","Dois Riachos","2702504","base.state_br_al","base.br"
-"city_2702553","Estrela de Alagoas","2702553","base.state_br_al","base.br"
-"city_2702603","Feira Grande","2702603","base.state_br_al","base.br"
-"city_2702702","Feliz Deserto","2702702","base.state_br_al","base.br"
-"city_2702801","Flexeiras","2702801","base.state_br_al","base.br"
-"city_2702900","Girau do Ponciano","2702900","base.state_br_al","base.br"
-"city_2703007","Ibateguara","2703007","base.state_br_al","base.br"
-"city_2703106","Igaci","2703106","base.state_br_al","base.br"
-"city_2703205","Igreja Nova","2703205","base.state_br_al","base.br"
-"city_2703304","Inhapi","2703304","base.state_br_al","base.br"
-"city_2703403","Jacaré dos Homens","2703403","base.state_br_al","base.br"
-"city_2703502","Jacuípe","2703502","base.state_br_al","base.br"
-"city_2703601","Japaratinga","2703601","base.state_br_al","base.br"
-"city_2703700","Jaramataia","2703700","base.state_br_al","base.br"
-"city_2703759","Jequiá da Praia","2703759","base.state_br_al","base.br"
-"city_2703809","Joaquim Gomes","2703809","base.state_br_al","base.br"
-"city_2703908","Jundiá","2703908","base.state_br_al","base.br"
-"city_2704005","Junqueiro","2704005","base.state_br_al","base.br"
-"city_2704104","Lagoa da Canoa","2704104","base.state_br_al","base.br"
-"city_2704203","Limoeiro de Anadia","2704203","base.state_br_al","base.br"
-"city_2704302","Maceió","2704302","base.state_br_al","base.br"
-"city_2704401","Major Isidoro","2704401","base.state_br_al","base.br"
-"city_2704906","Mar Vermelho","2704906","base.state_br_al","base.br"
-"city_2704500","Maragogi","2704500","base.state_br_al","base.br"
-"city_2704609","Maravilha","2704609","base.state_br_al","base.br"
-"city_2704708","Marechal Deodoro","2704708","base.state_br_al","base.br"
-"city_2704807","Maribondo","2704807","base.state_br_al","base.br"
-"city_2705002","Mata Grande","2705002","base.state_br_al","base.br"
-"city_2705101","Matriz de Camaragibe","2705101","base.state_br_al","base.br"
-"city_2705200","Messias","2705200","base.state_br_al","base.br"
-"city_2705309","Minador do Negrão","2705309","base.state_br_al","base.br"
-"city_2705408","Monteirópolis","2705408","base.state_br_al","base.br"
-"city_2705507","Murici","2705507","base.state_br_al","base.br"
-"city_2705606","Novo Lino","2705606","base.state_br_al","base.br"
-"city_2705705","Olho d'Água das Flores","2705705","base.state_br_al","base.br"
-"city_2705804","Olho d'Água do Casado","2705804","base.state_br_al","base.br"
-"city_2705903","Olho d'Água Grande","2705903","base.state_br_al","base.br"
-"city_2706000","Olivença","2706000","base.state_br_al","base.br"
-"city_2706109","Ouro Branco","2706109","base.state_br_al","base.br"
-"city_2706208","Palestina","2706208","base.state_br_al","base.br"
-"city_2706307","Palmeira dos Índios","2706307","base.state_br_al","base.br"
-"city_2706406","Pão de Açúcar","2706406","base.state_br_al","base.br"
-"city_2706422","Pariconha","2706422","base.state_br_al","base.br"
-"city_2706448","Paripueira","2706448","base.state_br_al","base.br"
-"city_2706505","Passo de Camaragibe","2706505","base.state_br_al","base.br"
-"city_2706604","Paulo Jacinto","2706604","base.state_br_al","base.br"
-"city_2706703","Penedo","2706703","base.state_br_al","base.br"
-"city_2706802","Piaçabuçu","2706802","base.state_br_al","base.br"
-"city_2706901","Pilar","2706901","base.state_br_al","base.br"
-"city_2707008","Pindoba","2707008","base.state_br_al","base.br"
-"city_2707107","Piranhas","2707107","base.state_br_al","base.br"
-"city_2707206","Poço das Trincheiras","2707206","base.state_br_al","base.br"
-"city_2707305","Porto Calvo","2707305","base.state_br_al","base.br"
-"city_2707404","Porto de Pedras","2707404","base.state_br_al","base.br"
-"city_2707503","Porto Real do Colégio","2707503","base.state_br_al","base.br"
-"city_2707602","Quebrangulo","2707602","base.state_br_al","base.br"
-"city_2707701","Rio Largo","2707701","base.state_br_al","base.br"
-"city_2707800","Roteiro","2707800","base.state_br_al","base.br"
-"city_2707909","Santa Luzia do Norte","2707909","base.state_br_al","base.br"
-"city_2708006","Santana do Ipanema","2708006","base.state_br_al","base.br"
-"city_2708105","Santana do Mundaú","2708105","base.state_br_al","base.br"
-"city_2708204","São Brás","2708204","base.state_br_al","base.br"
-"city_2708303","São José da Laje","2708303","base.state_br_al","base.br"
-"city_2708402","São José da Tapera","2708402","base.state_br_al","base.br"
-"city_2708501","São Luís do Quitunde","2708501","base.state_br_al","base.br"
-"city_2708600","São Miguel dos Campos","2708600","base.state_br_al","base.br"
-"city_2708709","São Miguel dos Milagres","2708709","base.state_br_al","base.br"
-"city_2708808","São Sebastião","2708808","base.state_br_al","base.br"
-"city_2708907","Satuba","2708907","base.state_br_al","base.br"
-"city_2708956","Senador Rui Palmeira","2708956","base.state_br_al","base.br"
-"city_2709004","Tanque d'Arca","2709004","base.state_br_al","base.br"
-"city_2709103","Taquarana","2709103","base.state_br_al","base.br"
-"city_2709152","Teotônio Vilela","2709152","base.state_br_al","base.br"
-"city_2709202","Traipu","2709202","base.state_br_al","base.br"
-"city_2709301","União dos Palmares","2709301","base.state_br_al","base.br"
-"city_2709400","Viçosa","2709400","base.state_br_al","base.br"
-"city_2800100","Amparo do São Francisco","2800100","base.state_br_se","base.br"
-"city_2800209","Aquidabã","2800209","base.state_br_se","base.br"
-"city_2800308","Aracaju","2800308","base.state_br_se","base.br"
-"city_2800407","Arauá","2800407","base.state_br_se","base.br"
-"city_2800506","Areia Branca","2800506","base.state_br_se","base.br"
-"city_2800605","Barra dos Coqueiros","2800605","base.state_br_se","base.br"
-"city_2800670","Boquim","2800670","base.state_br_se","base.br"
-"city_2800704","Brejo Grande","2800704","base.state_br_se","base.br"
-"city_2801009","Campo do Brito","2801009","base.state_br_se","base.br"
-"city_2801108","Canhoba","2801108","base.state_br_se","base.br"
-"city_2801207","Canindé de São Francisco","2801207","base.state_br_se","base.br"
-"city_2801306","Capela","2801306","base.state_br_se","base.br"
-"city_2801405","Carira","2801405","base.state_br_se","base.br"
-"city_2801504","Carmópolis","2801504","base.state_br_se","base.br"
-"city_2801603","Cedro de São João","2801603","base.state_br_se","base.br"
-"city_2801702","Cristinápolis","2801702","base.state_br_se","base.br"
-"city_2801900","Cumbe","2801900","base.state_br_se","base.br"
-"city_2802007","Divina Pastora","2802007","base.state_br_se","base.br"
-"city_2802106","Estância","2802106","base.state_br_se","base.br"
-"city_2802205","Feira Nova","2802205","base.state_br_se","base.br"
-"city_2802304","Frei Paulo","2802304","base.state_br_se","base.br"
-"city_2802403","Gararu","2802403","base.state_br_se","base.br"
-"city_2802502","General Maynard","2802502","base.state_br_se","base.br"
-"city_2802601","Gracho Cardoso","2802601","base.state_br_se","base.br"
-"city_2802700","Ilha das Flores","2802700","base.state_br_se","base.br"
-"city_2802809","Indiaroba","2802809","base.state_br_se","base.br"
-"city_2802908","Itabaiana","2802908","base.state_br_se","base.br"
-"city_2803005","Itabaianinha","2803005","base.state_br_se","base.br"
-"city_2803104","Itabi","2803104","base.state_br_se","base.br"
-"city_2803203","Itaporanga d'Ajuda","2803203","base.state_br_se","base.br"
-"city_2803302","Japaratuba","2803302","base.state_br_se","base.br"
-"city_2803401","Japoatã","2803401","base.state_br_se","base.br"
-"city_2803500","Lagarto","2803500","base.state_br_se","base.br"
-"city_2803609","Laranjeiras","2803609","base.state_br_se","base.br"
-"city_2803708","Macambira","2803708","base.state_br_se","base.br"
-"city_2803807","Malhada dos Bois","2803807","base.state_br_se","base.br"
-"city_2803906","Malhador","2803906","base.state_br_se","base.br"
-"city_2804003","Maruim","2804003","base.state_br_se","base.br"
-"city_2804102","Moita Bonita","2804102","base.state_br_se","base.br"
-"city_2804201","Monte Alegre de Sergipe","2804201","base.state_br_se","base.br"
-"city_2804300","Muribeca","2804300","base.state_br_se","base.br"
-"city_2804409","Neópolis","2804409","base.state_br_se","base.br"
-"city_2804458","Nossa Senhora Aparecida","2804458","base.state_br_se","base.br"
-"city_2804508","Nossa Senhora da Glória","2804508","base.state_br_se","base.br"
-"city_2804607","Nossa Senhora das Dores","2804607","base.state_br_se","base.br"
-"city_2804706","Nossa Senhora de Lourdes","2804706","base.state_br_se","base.br"
-"city_2804805","Nossa Senhora do Socorro","2804805","base.state_br_se","base.br"
-"city_2804904","Pacatuba","2804904","base.state_br_se","base.br"
-"city_2805000","Pedra Mole","2805000","base.state_br_se","base.br"
-"city_2805109","Pedrinhas","2805109","base.state_br_se","base.br"
-"city_2805208","Pinhão","2805208","base.state_br_se","base.br"
-"city_2805307","Pirambu","2805307","base.state_br_se","base.br"
-"city_2805406","Poço Redondo","2805406","base.state_br_se","base.br"
-"city_2805505","Poço Verde","2805505","base.state_br_se","base.br"
-"city_2805604","Porto da Folha","2805604","base.state_br_se","base.br"
-"city_2805703","Propriá","2805703","base.state_br_se","base.br"
-"city_2805802","Riachão do Dantas","2805802","base.state_br_se","base.br"
-"city_2805901","Riachuelo","2805901","base.state_br_se","base.br"
-"city_2806008","Ribeirópolis","2806008","base.state_br_se","base.br"
-"city_2806107","Rosário do Catete","2806107","base.state_br_se","base.br"
-"city_2806206","Salgado","2806206","base.state_br_se","base.br"
-"city_2806305","Santa Luzia do Itanhy","2806305","base.state_br_se","base.br"
-"city_2806503","Santa Rosa de Lima","2806503","base.state_br_se","base.br"
-"city_2806404","Santana do São Francisco","2806404","base.state_br_se","base.br"
-"city_2806602","Santo Amaro das Brotas","2806602","base.state_br_se","base.br"
-"city_2806701","São Cristóvão","2806701","base.state_br_se","base.br"
-"city_2806800","São Domingos","2806800","base.state_br_se","base.br"
-"city_2806909","São Francisco","2806909","base.state_br_se","base.br"
-"city_2807006","São Miguel do Aleixo","2807006","base.state_br_se","base.br"
-"city_2807105","Simão Dias","2807105","base.state_br_se","base.br"
-"city_2807204","Siriri","2807204","base.state_br_se","base.br"
-"city_2807303","Telha","2807303","base.state_br_se","base.br"
-"city_2807402","Tobias Barreto","2807402","base.state_br_se","base.br"
-"city_2807501","Tomar do Geru","2807501","base.state_br_se","base.br"
-"city_2807600","Umbaúba","2807600","base.state_br_se","base.br"
-"city_2900108","Abaíra","2900108","base.state_br_ba","base.br"
-"city_2900207","Abaré","2900207","base.state_br_ba","base.br"
-"city_2900306","Acajutiba","2900306","base.state_br_ba","base.br"
-"city_2900355","Adustina","2900355","base.state_br_ba","base.br"
-"city_2900405","Água Fria","2900405","base.state_br_ba","base.br"
-"city_2900603","Aiquara","2900603","base.state_br_ba","base.br"
-"city_2900702","Alagoinhas","2900702","base.state_br_ba","base.br"
-"city_2900801","Alcobaça","2900801","base.state_br_ba","base.br"
-"city_2900900","Almadina","2900900","base.state_br_ba","base.br"
-"city_2901007","Amargosa","2901007","base.state_br_ba","base.br"
-"city_2901106","Amélia Rodrigues","2901106","base.state_br_ba","base.br"
-"city_2901155","América Dourada","2901155","base.state_br_ba","base.br"
-"city_2901205","Anagé","2901205","base.state_br_ba","base.br"
-"city_2901304","Andaraí","2901304","base.state_br_ba","base.br"
-"city_2901353","Andorinha","2901353","base.state_br_ba","base.br"
-"city_2901403","Angical","2901403","base.state_br_ba","base.br"
-"city_2901502","Anguera","2901502","base.state_br_ba","base.br"
-"city_2901601","Antas","2901601","base.state_br_ba","base.br"
-"city_2901700","Antônio Cardoso","2901700","base.state_br_ba","base.br"
-"city_2901809","Antônio Gonçalves","2901809","base.state_br_ba","base.br"
-"city_2901908","Aporá","2901908","base.state_br_ba","base.br"
-"city_2901957","Apuarema","2901957","base.state_br_ba","base.br"
-"city_2902054","Araçás","2902054","base.state_br_ba","base.br"
-"city_2902005","Aracatu","2902005","base.state_br_ba","base.br"
-"city_2902104","Araci","2902104","base.state_br_ba","base.br"
-"city_2902203","Aramari","2902203","base.state_br_ba","base.br"
-"city_2902252","Arataca","2902252","base.state_br_ba","base.br"
-"city_2902302","Aratuípe","2902302","base.state_br_ba","base.br"
-"city_2902401","Aurelino Leal","2902401","base.state_br_ba","base.br"
-"city_2902500","Baianópolis","2902500","base.state_br_ba","base.br"
-"city_2902609","Baixa Grande","2902609","base.state_br_ba","base.br"
-"city_2902658","Banzaê","2902658","base.state_br_ba","base.br"
-"city_2902708","Barra","2902708","base.state_br_ba","base.br"
-"city_2902807","Barra da Estiva","2902807","base.state_br_ba","base.br"
-"city_2902906","Barra do Choça","2902906","base.state_br_ba","base.br"
-"city_2903003","Barra do Mendes","2903003","base.state_br_ba","base.br"
-"city_2903102","Barra do Rocha","2903102","base.state_br_ba","base.br"
-"city_2903201","Barreiras","2903201","base.state_br_ba","base.br"
-"city_2903235","Barro Alto","2903235","base.state_br_ba","base.br"
-"city_2903300","Barro Preto","2903300","base.state_br_ba","base.br"
-"city_2903276","Barrocas","2903276","base.state_br_ba","base.br"
-"city_2903409","Belmonte","2903409","base.state_br_ba","base.br"
-"city_2903508","Belo Campo","2903508","base.state_br_ba","base.br"
-"city_2903607","Biritinga","2903607","base.state_br_ba","base.br"
-"city_2903706","Boa Nova","2903706","base.state_br_ba","base.br"
-"city_2903805","Boa Vista do Tupim","2903805","base.state_br_ba","base.br"
-"city_2903904","Bom Jesus da Lapa","2903904","base.state_br_ba","base.br"
-"city_2903953","Bom Jesus da Serra","2903953","base.state_br_ba","base.br"
-"city_2904001","Boninal","2904001","base.state_br_ba","base.br"
-"city_2904050","Bonito","2904050","base.state_br_ba","base.br"
-"city_2904100","Boquira","2904100","base.state_br_ba","base.br"
-"city_2904209","Botuporã","2904209","base.state_br_ba","base.br"
-"city_2904308","Brejões","2904308","base.state_br_ba","base.br"
-"city_2904407","Brejolândia","2904407","base.state_br_ba","base.br"
-"city_2904506","Brotas de Macaúbas","2904506","base.state_br_ba","base.br"
-"city_2904605","Brumado","2904605","base.state_br_ba","base.br"
-"city_2904704","Buerarema","2904704","base.state_br_ba","base.br"
-"city_2904753","Buritirama","2904753","base.state_br_ba","base.br"
-"city_2904803","Caatiba","2904803","base.state_br_ba","base.br"
-"city_2904852","Cabaceiras do Paraguaçu","2904852","base.state_br_ba","base.br"
-"city_2904902","Cachoeira","2904902","base.state_br_ba","base.br"
-"city_2905008","Caculé","2905008","base.state_br_ba","base.br"
-"city_2905107","Caém","2905107","base.state_br_ba","base.br"
-"city_2905156","Caetanos","2905156","base.state_br_ba","base.br"
-"city_2905206","Caetité","2905206","base.state_br_ba","base.br"
-"city_2905305","Cafarnaum","2905305","base.state_br_ba","base.br"
-"city_2905404","Cairu","2905404","base.state_br_ba","base.br"
-"city_2905503","Caldeirão Grande","2905503","base.state_br_ba","base.br"
-"city_2905602","Camacan","2905602","base.state_br_ba","base.br"
-"city_2905701","Camaçari","2905701","base.state_br_ba","base.br"
-"city_2905800","Camamu","2905800","base.state_br_ba","base.br"
-"city_2905909","Campo Alegre de Lourdes","2905909","base.state_br_ba","base.br"
-"city_2906006","Campo Formoso","2906006","base.state_br_ba","base.br"
-"city_2906105","Canápolis","2906105","base.state_br_ba","base.br"
-"city_2906204","Canarana","2906204","base.state_br_ba","base.br"
-"city_2906303","Canavieiras","2906303","base.state_br_ba","base.br"
-"city_2906402","Candeal","2906402","base.state_br_ba","base.br"
-"city_2906501","Candeias","2906501","base.state_br_ba","base.br"
-"city_2906600","Candiba","2906600","base.state_br_ba","base.br"
-"city_2906709","Cândido Sales","2906709","base.state_br_ba","base.br"
-"city_2906808","Cansanção","2906808","base.state_br_ba","base.br"
-"city_2906824","Canudos","2906824","base.state_br_ba","base.br"
-"city_2906857","Capela do Alto Alegre","2906857","base.state_br_ba","base.br"
-"city_2906873","Capim Grosso","2906873","base.state_br_ba","base.br"
-"city_2906899","Caraíbas","2906899","base.state_br_ba","base.br"
-"city_2906907","Caravelas","2906907","base.state_br_ba","base.br"
-"city_2907004","Cardeal da Silva","2907004","base.state_br_ba","base.br"
-"city_2907103","Carinhanha","2907103","base.state_br_ba","base.br"
-"city_2907202","Casa Nova","2907202","base.state_br_ba","base.br"
-"city_2907301","Castro Alves","2907301","base.state_br_ba","base.br"
-"city_2907400","Catolândia","2907400","base.state_br_ba","base.br"
-"city_2907509","Catu","2907509","base.state_br_ba","base.br"
-"city_2907558","Caturama","2907558","base.state_br_ba","base.br"
-"city_2907608","Central","2907608","base.state_br_ba","base.br"
-"city_2907707","Chorrochó","2907707","base.state_br_ba","base.br"
-"city_2907806","Cícero Dantas","2907806","base.state_br_ba","base.br"
-"city_2907905","Cipó","2907905","base.state_br_ba","base.br"
-"city_2908002","Coaraci","2908002","base.state_br_ba","base.br"
-"city_2908101","Cocos","2908101","base.state_br_ba","base.br"
-"city_2908200","Conceição da Feira","2908200","base.state_br_ba","base.br"
-"city_2908309","Conceição do Almeida","2908309","base.state_br_ba","base.br"
-"city_2908408","Conceição do Coité","2908408","base.state_br_ba","base.br"
-"city_2908507","Conceição do Jacuípe","2908507","base.state_br_ba","base.br"
-"city_2908606","Conde","2908606","base.state_br_ba","base.br"
-"city_2908705","Condeúba","2908705","base.state_br_ba","base.br"
-"city_2908804","Contendas do Sincorá","2908804","base.state_br_ba","base.br"
-"city_2908903","Coração de Maria","2908903","base.state_br_ba","base.br"
-"city_2909000","Cordeiros","2909000","base.state_br_ba","base.br"
-"city_2909109","Coribe","2909109","base.state_br_ba","base.br"
-"city_2909208","Coronel João Sá","2909208","base.state_br_ba","base.br"
-"city_2909307","Correntina","2909307","base.state_br_ba","base.br"
-"city_2909406","Cotegipe","2909406","base.state_br_ba","base.br"
-"city_2909505","Cravolândia","2909505","base.state_br_ba","base.br"
-"city_2909604","Crisópolis","2909604","base.state_br_ba","base.br"
-"city_2909703","Cristópolis","2909703","base.state_br_ba","base.br"
-"city_2909802","Cruz das Almas","2909802","base.state_br_ba","base.br"
-"city_2909901","Curaçá","2909901","base.state_br_ba","base.br"
-"city_2910008","Dário Meira","2910008","base.state_br_ba","base.br"
-"city_2910057","Dias d'Ávila","2910057","base.state_br_ba","base.br"
-"city_2910107","Dom Basílio","2910107","base.state_br_ba","base.br"
-"city_2910206","Dom Macedo Costa","2910206","base.state_br_ba","base.br"
-"city_2910305","Elísio Medrado","2910305","base.state_br_ba","base.br"
-"city_2910404","Encruzilhada","2910404","base.state_br_ba","base.br"
-"city_2910503","Entre Rios","2910503","base.state_br_ba","base.br"
-"city_2900504","Érico Cardoso","2900504","base.state_br_ba","base.br"
-"city_2910602","Esplanada","2910602","base.state_br_ba","base.br"
-"city_2910701","Euclides da Cunha","2910701","base.state_br_ba","base.br"
-"city_2910727","Eunápolis","2910727","base.state_br_ba","base.br"
-"city_2910750","Fátima","2910750","base.state_br_ba","base.br"
-"city_2910776","Feira da Mata","2910776","base.state_br_ba","base.br"
-"city_2910800","Feira de Santana","2910800","base.state_br_ba","base.br"
-"city_2910859","Filadélfia","2910859","base.state_br_ba","base.br"
-"city_2910909","Firmino Alves","2910909","base.state_br_ba","base.br"
-"city_2911006","Floresta Azul","2911006","base.state_br_ba","base.br"
-"city_2911105","Formosa do Rio Preto","2911105","base.state_br_ba","base.br"
-"city_2911204","Gandu","2911204","base.state_br_ba","base.br"
-"city_2911253","Gavião","2911253","base.state_br_ba","base.br"
-"city_2911303","Gentio do Ouro","2911303","base.state_br_ba","base.br"
-"city_2911402","Glória","2911402","base.state_br_ba","base.br"
-"city_2911501","Gongogi","2911501","base.state_br_ba","base.br"
-"city_2911600","Governador Mangabeira","2911600","base.state_br_ba","base.br"
-"city_2911659","Guajeru","2911659","base.state_br_ba","base.br"
-"city_2911709","Guanambi","2911709","base.state_br_ba","base.br"
-"city_2911808","Guaratinga","2911808","base.state_br_ba","base.br"
-"city_2911857","Heliópolis","2911857","base.state_br_ba","base.br"
-"city_2911907","Iaçu","2911907","base.state_br_ba","base.br"
-"city_2912004","Ibiassucê","2912004","base.state_br_ba","base.br"
-"city_2912103","Ibicaraí","2912103","base.state_br_ba","base.br"
-"city_2912202","Ibicoara","2912202","base.state_br_ba","base.br"
-"city_2912301","Ibicuí","2912301","base.state_br_ba","base.br"
-"city_2912400","Ibipeba","2912400","base.state_br_ba","base.br"
-"city_2912509","Ibipitanga","2912509","base.state_br_ba","base.br"
-"city_2912608","Ibiquera","2912608","base.state_br_ba","base.br"
-"city_2912707","Ibirapitanga","2912707","base.state_br_ba","base.br"
-"city_2912806","Ibirapuã","2912806","base.state_br_ba","base.br"
-"city_2912905","Ibirataia","2912905","base.state_br_ba","base.br"
-"city_2913002","Ibitiara","2913002","base.state_br_ba","base.br"
-"city_2913101","Ibititá","2913101","base.state_br_ba","base.br"
-"city_2913200","Ibotirama","2913200","base.state_br_ba","base.br"
-"city_2913309","Ichu","2913309","base.state_br_ba","base.br"
-"city_2913408","Igaporã","2913408","base.state_br_ba","base.br"
-"city_2913457","Igrapiúna","2913457","base.state_br_ba","base.br"
-"city_2913507","Iguaí","2913507","base.state_br_ba","base.br"
-"city_2913606","Ilhéus","2913606","base.state_br_ba","base.br"
-"city_2913705","Inhambupe","2913705","base.state_br_ba","base.br"
-"city_2913804","Ipecaetá","2913804","base.state_br_ba","base.br"
-"city_2913903","Ipiaú","2913903","base.state_br_ba","base.br"
-"city_2914000","Ipirá","2914000","base.state_br_ba","base.br"
-"city_2914109","Ipupiara","2914109","base.state_br_ba","base.br"
-"city_2914208","Irajuba","2914208","base.state_br_ba","base.br"
-"city_2914307","Iramaia","2914307","base.state_br_ba","base.br"
-"city_2914406","Iraquara","2914406","base.state_br_ba","base.br"
-"city_2914505","Irará","2914505","base.state_br_ba","base.br"
-"city_2914604","Irecê","2914604","base.state_br_ba","base.br"
-"city_2914653","Itabela","2914653","base.state_br_ba","base.br"
-"city_2914703","Itaberaba","2914703","base.state_br_ba","base.br"
-"city_2914802","Itabuna","2914802","base.state_br_ba","base.br"
-"city_2914901","Itacaré","2914901","base.state_br_ba","base.br"
-"city_2915007","Itaeté","2915007","base.state_br_ba","base.br"
-"city_2915106","Itagi","2915106","base.state_br_ba","base.br"
-"city_2915205","Itagibá","2915205","base.state_br_ba","base.br"
-"city_2915304","Itagimirim","2915304","base.state_br_ba","base.br"
-"city_2915353","Itaguaçu da Bahia","2915353","base.state_br_ba","base.br"
-"city_2915403","Itaju do Colônia","2915403","base.state_br_ba","base.br"
-"city_2915502","Itajuípe","2915502","base.state_br_ba","base.br"
-"city_2915601","Itamaraju","2915601","base.state_br_ba","base.br"
-"city_2915700","Itamari","2915700","base.state_br_ba","base.br"
-"city_2915809","Itambé","2915809","base.state_br_ba","base.br"
-"city_2915908","Itanagra","2915908","base.state_br_ba","base.br"
-"city_2916005","Itanhém","2916005","base.state_br_ba","base.br"
-"city_2916104","Itaparica","2916104","base.state_br_ba","base.br"
-"city_2916203","Itapé","2916203","base.state_br_ba","base.br"
-"city_2916302","Itapebi","2916302","base.state_br_ba","base.br"
-"city_2916401","Itapetinga","2916401","base.state_br_ba","base.br"
-"city_2916500","Itapicuru","2916500","base.state_br_ba","base.br"
-"city_2916609","Itapitanga","2916609","base.state_br_ba","base.br"
-"city_2916708","Itaquara","2916708","base.state_br_ba","base.br"
-"city_2916807","Itarantim","2916807","base.state_br_ba","base.br"
-"city_2916856","Itatim","2916856","base.state_br_ba","base.br"
-"city_2916906","Itiruçu","2916906","base.state_br_ba","base.br"
-"city_2917003","Itiúba","2917003","base.state_br_ba","base.br"
-"city_2917102","Itororó","2917102","base.state_br_ba","base.br"
-"city_2917201","Ituaçu","2917201","base.state_br_ba","base.br"
-"city_2917300","Ituberá","2917300","base.state_br_ba","base.br"
-"city_2917334","Iuiu","2917334","base.state_br_ba","base.br"
-"city_2917359","Jaborandi","2917359","base.state_br_ba","base.br"
-"city_2917409","Jacaraci","2917409","base.state_br_ba","base.br"
-"city_2917508","Jacobina","2917508","base.state_br_ba","base.br"
-"city_2917607","Jaguaquara","2917607","base.state_br_ba","base.br"
-"city_2917706","Jaguarari","2917706","base.state_br_ba","base.br"
-"city_2917805","Jaguaripe","2917805","base.state_br_ba","base.br"
-"city_2917904","Jandaíra","2917904","base.state_br_ba","base.br"
-"city_2918001","Jequié","2918001","base.state_br_ba","base.br"
-"city_2918100","Jeremoabo","2918100","base.state_br_ba","base.br"
-"city_2918209","Jiquiriçá","2918209","base.state_br_ba","base.br"
-"city_2918308","Jitaúna","2918308","base.state_br_ba","base.br"
-"city_2918357","João Dourado","2918357","base.state_br_ba","base.br"
-"city_2918407","Juazeiro","2918407","base.state_br_ba","base.br"
-"city_2918456","Jucuruçu","2918456","base.state_br_ba","base.br"
-"city_2918506","Jussara","2918506","base.state_br_ba","base.br"
-"city_2918555","Jussari","2918555","base.state_br_ba","base.br"
-"city_2918605","Jussiape","2918605","base.state_br_ba","base.br"
-"city_2918704","Lafaiete Coutinho","2918704","base.state_br_ba","base.br"
-"city_2918753","Lagoa Real","2918753","base.state_br_ba","base.br"
-"city_2918803","Laje","2918803","base.state_br_ba","base.br"
-"city_2918902","Lajedão","2918902","base.state_br_ba","base.br"
-"city_2919009","Lajedinho","2919009","base.state_br_ba","base.br"
-"city_2919058","Lajedo do Tabocal","2919058","base.state_br_ba","base.br"
-"city_2919108","Lamarão","2919108","base.state_br_ba","base.br"
-"city_2919157","Lapão","2919157","base.state_br_ba","base.br"
-"city_2919207","Lauro de Freitas","2919207","base.state_br_ba","base.br"
-"city_2919306","Lençóis","2919306","base.state_br_ba","base.br"
-"city_2919405","Licínio de Almeida","2919405","base.state_br_ba","base.br"
-"city_2919504","Livramento de Nossa Senhora","2919504","base.state_br_ba","base.br"
-"city_2919553","Luís Eduardo Magalhães","2919553","base.state_br_ba","base.br"
-"city_2919603","Macajuba","2919603","base.state_br_ba","base.br"
-"city_2919702","Macarani","2919702","base.state_br_ba","base.br"
-"city_2919801","Macaúbas","2919801","base.state_br_ba","base.br"
-"city_2919900","Macururé","2919900","base.state_br_ba","base.br"
-"city_2919926","Madre de Deus","2919926","base.state_br_ba","base.br"
-"city_2919959","Maetinga","2919959","base.state_br_ba","base.br"
-"city_2920007","Maiquinique","2920007","base.state_br_ba","base.br"
-"city_2920106","Mairi","2920106","base.state_br_ba","base.br"
-"city_2920205","Malhada","2920205","base.state_br_ba","base.br"
-"city_2920304","Malhada de Pedras","2920304","base.state_br_ba","base.br"
-"city_2920403","Manoel Vitorino","2920403","base.state_br_ba","base.br"
-"city_2920452","Mansidão","2920452","base.state_br_ba","base.br"
-"city_2920502","Maracás","2920502","base.state_br_ba","base.br"
-"city_2920601","Maragogipe","2920601","base.state_br_ba","base.br"
-"city_2920700","Maraú","2920700","base.state_br_ba","base.br"
-"city_2920809","Marcionílio Souza","2920809","base.state_br_ba","base.br"
-"city_2920908","Mascote","2920908","base.state_br_ba","base.br"
-"city_2921005","Mata de São João","2921005","base.state_br_ba","base.br"
-"city_2921054","Matina","2921054","base.state_br_ba","base.br"
-"city_2921104","Medeiros Neto","2921104","base.state_br_ba","base.br"
-"city_2921203","Miguel Calmon","2921203","base.state_br_ba","base.br"
-"city_2921302","Milagres","2921302","base.state_br_ba","base.br"
-"city_2921401","Mirangaba","2921401","base.state_br_ba","base.br"
-"city_2921450","Mirante","2921450","base.state_br_ba","base.br"
-"city_2921500","Monte Santo","2921500","base.state_br_ba","base.br"
-"city_2921609","Morpará","2921609","base.state_br_ba","base.br"
-"city_2921708","Morro do Chapéu","2921708","base.state_br_ba","base.br"
-"city_2921807","Mortugaba","2921807","base.state_br_ba","base.br"
-"city_2921906","Mucugê","2921906","base.state_br_ba","base.br"
-"city_2922003","Mucuri","2922003","base.state_br_ba","base.br"
-"city_2922052","Mulungu do Morro","2922052","base.state_br_ba","base.br"
-"city_2922102","Mundo Novo","2922102","base.state_br_ba","base.br"
-"city_2922201","Muniz Ferreira","2922201","base.state_br_ba","base.br"
-"city_2922250","Muquém do São Francisco","2922250","base.state_br_ba","base.br"
-"city_2922300","Muritiba","2922300","base.state_br_ba","base.br"
-"city_2922409","Mutuípe","2922409","base.state_br_ba","base.br"
-"city_2922508","Nazaré","2922508","base.state_br_ba","base.br"
-"city_2922607","Nilo Peçanha","2922607","base.state_br_ba","base.br"
-"city_2922656","Nordestina","2922656","base.state_br_ba","base.br"
-"city_2922706","Nova Canaã","2922706","base.state_br_ba","base.br"
-"city_2922730","Nova Fátima","2922730","base.state_br_ba","base.br"
-"city_2922755","Nova Ibiá","2922755","base.state_br_ba","base.br"
-"city_2922805","Nova Itarana","2922805","base.state_br_ba","base.br"
-"city_2922854","Nova Redenção","2922854","base.state_br_ba","base.br"
-"city_2922904","Nova Soure","2922904","base.state_br_ba","base.br"
-"city_2923001","Nova Viçosa","2923001","base.state_br_ba","base.br"
-"city_2923035","Novo Horizonte","2923035","base.state_br_ba","base.br"
-"city_2923050","Novo Triunfo","2923050","base.state_br_ba","base.br"
-"city_2923100","Olindina","2923100","base.state_br_ba","base.br"
-"city_2923209","Oliveira dos Brejinhos","2923209","base.state_br_ba","base.br"
-"city_2923308","Ouriçangas","2923308","base.state_br_ba","base.br"
-"city_2923357","Ourolândia","2923357","base.state_br_ba","base.br"
-"city_2923407","Palmas de Monte Alto","2923407","base.state_br_ba","base.br"
-"city_2923506","Palmeiras","2923506","base.state_br_ba","base.br"
-"city_2923605","Paramirim","2923605","base.state_br_ba","base.br"
-"city_2923704","Paratinga","2923704","base.state_br_ba","base.br"
-"city_2923803","Paripiranga","2923803","base.state_br_ba","base.br"
-"city_2923902","Pau Brasil","2923902","base.state_br_ba","base.br"
-"city_2924009","Paulo Afonso","2924009","base.state_br_ba","base.br"
-"city_2924058","Pé de Serra","2924058","base.state_br_ba","base.br"
-"city_2924108","Pedrão","2924108","base.state_br_ba","base.br"
-"city_2924207","Pedro Alexandre","2924207","base.state_br_ba","base.br"
-"city_2924306","Piatã","2924306","base.state_br_ba","base.br"
-"city_2924405","Pilão Arcado","2924405","base.state_br_ba","base.br"
-"city_2924504","Pindaí","2924504","base.state_br_ba","base.br"
-"city_2924603","Pindobaçu","2924603","base.state_br_ba","base.br"
-"city_2924652","Pintadas","2924652","base.state_br_ba","base.br"
-"city_2924678","Piraí do Norte","2924678","base.state_br_ba","base.br"
-"city_2924702","Piripá","2924702","base.state_br_ba","base.br"
-"city_2924801","Piritiba","2924801","base.state_br_ba","base.br"
-"city_2924900","Planaltino","2924900","base.state_br_ba","base.br"
-"city_2925006","Planalto","2925006","base.state_br_ba","base.br"
-"city_2925105","Poções","2925105","base.state_br_ba","base.br"
-"city_2925204","Pojuca","2925204","base.state_br_ba","base.br"
-"city_2925253","Ponto Novo","2925253","base.state_br_ba","base.br"
-"city_2925303","Porto Seguro","2925303","base.state_br_ba","base.br"
-"city_2925402","Potiraguá","2925402","base.state_br_ba","base.br"
-"city_2925501","Prado","2925501","base.state_br_ba","base.br"
-"city_2925600","Presidente Dutra","2925600","base.state_br_ba","base.br"
-"city_2925709","Presidente Jânio Quadros","2925709","base.state_br_ba","base.br"
-"city_2925758","Presidente Tancredo Neves","2925758","base.state_br_ba","base.br"
-"city_2925808","Queimadas","2925808","base.state_br_ba","base.br"
-"city_2925907","Quijingue","2925907","base.state_br_ba","base.br"
-"city_2925931","Quixabeira","2925931","base.state_br_ba","base.br"
-"city_2925956","Rafael Jambeiro","2925956","base.state_br_ba","base.br"
-"city_2926004","Remanso","2926004","base.state_br_ba","base.br"
-"city_2926103","Retirolândia","2926103","base.state_br_ba","base.br"
-"city_2926202","Riachão das Neves","2926202","base.state_br_ba","base.br"
-"city_2926301","Riachão do Jacuípe","2926301","base.state_br_ba","base.br"
-"city_2926400","Riacho de Santana","2926400","base.state_br_ba","base.br"
-"city_2926509","Ribeira do Amparo","2926509","base.state_br_ba","base.br"
-"city_2926608","Ribeira do Pombal","2926608","base.state_br_ba","base.br"
-"city_2926657","Ribeirão do Largo","2926657","base.state_br_ba","base.br"
-"city_2926707","Rio de Contas","2926707","base.state_br_ba","base.br"
-"city_2926806","Rio do Antônio","2926806","base.state_br_ba","base.br"
-"city_2926905","Rio do Pires","2926905","base.state_br_ba","base.br"
-"city_2927002","Rio Real","2927002","base.state_br_ba","base.br"
-"city_2927101","Rodelas","2927101","base.state_br_ba","base.br"
-"city_2927200","Ruy Barbosa","2927200","base.state_br_ba","base.br"
-"city_2927309","Salinas da Margarida","2927309","base.state_br_ba","base.br"
-"city_2927408","Salvador","2927408","base.state_br_ba","base.br"
-"city_2927507","Santa Bárbara","2927507","base.state_br_ba","base.br"
-"city_2927606","Santa Brígida","2927606","base.state_br_ba","base.br"
-"city_2927705","Santa Cruz Cabrália","2927705","base.state_br_ba","base.br"
-"city_2927804","Santa Cruz da Vitória","2927804","base.state_br_ba","base.br"
-"city_2927903","Santa Inês","2927903","base.state_br_ba","base.br"
-"city_2928059","Santa Luzia","2928059","base.state_br_ba","base.br"
-"city_2928109","Santa Maria da Vitória","2928109","base.state_br_ba","base.br"
-"city_2928406","Santa Rita de Cássia","2928406","base.state_br_ba","base.br"
-"city_2928505","Santa Terezinha","2928505","base.state_br_ba","base.br"
-"city_2928000","Santaluz","2928000","base.state_br_ba","base.br"
-"city_2928208","Santana","2928208","base.state_br_ba","base.br"
-"city_2928307","Santanópolis","2928307","base.state_br_ba","base.br"
-"city_2928604","Santo Amaro","2928604","base.state_br_ba","base.br"
-"city_2928703","Santo Antônio de Jesus","2928703","base.state_br_ba","base.br"
-"city_2928802","Santo Estêvão","2928802","base.state_br_ba","base.br"
-"city_2928901","São Desidério","2928901","base.state_br_ba","base.br"
-"city_2928950","São Domingos","2928950","base.state_br_ba","base.br"
-"city_2929107","São Felipe","2929107","base.state_br_ba","base.br"
-"city_2929008","São Félix","2929008","base.state_br_ba","base.br"
-"city_2929057","São Félix do Coribe","2929057","base.state_br_ba","base.br"
-"city_2929206","São Francisco do Conde","2929206","base.state_br_ba","base.br"
-"city_2929255","São Gabriel","2929255","base.state_br_ba","base.br"
-"city_2929305","São Gonçalo dos Campos","2929305","base.state_br_ba","base.br"
-"city_2929354","São José da Vitória","2929354","base.state_br_ba","base.br"
-"city_2929370","São José do Jacuípe","2929370","base.state_br_ba","base.br"
-"city_2929404","São Miguel das Matas","2929404","base.state_br_ba","base.br"
-"city_2929503","São Sebastião do Passé","2929503","base.state_br_ba","base.br"
-"city_2929602","Sapeaçu","2929602","base.state_br_ba","base.br"
-"city_2929701","Sátiro Dias","2929701","base.state_br_ba","base.br"
-"city_2929750","Saubara","2929750","base.state_br_ba","base.br"
-"city_2929800","Saúde","2929800","base.state_br_ba","base.br"
-"city_2929909","Seabra","2929909","base.state_br_ba","base.br"
-"city_2930006","Sebastião Laranjeiras","2930006","base.state_br_ba","base.br"
-"city_2930105","Senhor do Bonfim","2930105","base.state_br_ba","base.br"
-"city_2930204","Sento Sé","2930204","base.state_br_ba","base.br"
-"city_2930154","Serra do Ramalho","2930154","base.state_br_ba","base.br"
-"city_2930303","Serra Dourada","2930303","base.state_br_ba","base.br"
-"city_2930402","Serra Preta","2930402","base.state_br_ba","base.br"
-"city_2930501","Serrinha","2930501","base.state_br_ba","base.br"
-"city_2930600","Serrolândia","2930600","base.state_br_ba","base.br"
-"city_2930709","Simões Filho","2930709","base.state_br_ba","base.br"
-"city_2930758","Sítio do Mato","2930758","base.state_br_ba","base.br"
-"city_2930766","Sítio do Quinto","2930766","base.state_br_ba","base.br"
-"city_2930774","Sobradinho","2930774","base.state_br_ba","base.br"
-"city_2930808","Souto Soares","2930808","base.state_br_ba","base.br"
-"city_2930907","Tabocas do Brejo Velho","2930907","base.state_br_ba","base.br"
-"city_2931004","Tanhaçu","2931004","base.state_br_ba","base.br"
-"city_2931053","Tanque Novo","2931053","base.state_br_ba","base.br"
-"city_2931103","Tanquinho","2931103","base.state_br_ba","base.br"
-"city_2931202","Taperoá","2931202","base.state_br_ba","base.br"
-"city_2931301","Tapiramutá","2931301","base.state_br_ba","base.br"
-"city_2931350","Teixeira de Freitas","2931350","base.state_br_ba","base.br"
-"city_2931400","Teodoro Sampaio","2931400","base.state_br_ba","base.br"
-"city_2931509","Teofilândia","2931509","base.state_br_ba","base.br"
-"city_2931608","Teolândia","2931608","base.state_br_ba","base.br"
-"city_2931707","Terra Nova","2931707","base.state_br_ba","base.br"
-"city_2931806","Tremedal","2931806","base.state_br_ba","base.br"
-"city_2931905","Tucano","2931905","base.state_br_ba","base.br"
-"city_2932002","Uauá","2932002","base.state_br_ba","base.br"
-"city_2932101","Ubaíra","2932101","base.state_br_ba","base.br"
-"city_2932200","Ubaitaba","2932200","base.state_br_ba","base.br"
-"city_2932309","Ubatã","2932309","base.state_br_ba","base.br"
-"city_2932408","Uibaí","2932408","base.state_br_ba","base.br"
-"city_2932457","Umburanas","2932457","base.state_br_ba","base.br"
-"city_2932507","Una","2932507","base.state_br_ba","base.br"
-"city_2932606","Urandi","2932606","base.state_br_ba","base.br"
-"city_2932705","Uruçuca","2932705","base.state_br_ba","base.br"
-"city_2932804","Utinga","2932804","base.state_br_ba","base.br"
-"city_2932903","Valença","2932903","base.state_br_ba","base.br"
-"city_2933000","Valente","2933000","base.state_br_ba","base.br"
-"city_2933059","Várzea da Roça","2933059","base.state_br_ba","base.br"
-"city_2933109","Várzea do Poço","2933109","base.state_br_ba","base.br"
-"city_2933158","Várzea Nova","2933158","base.state_br_ba","base.br"
-"city_2933174","Varzedo","2933174","base.state_br_ba","base.br"
-"city_2933208","Vera Cruz","2933208","base.state_br_ba","base.br"
-"city_2933257","Vereda","2933257","base.state_br_ba","base.br"
-"city_2933307","Vitória da Conquista","2933307","base.state_br_ba","base.br"
-"city_2933406","Wagner","2933406","base.state_br_ba","base.br"
-"city_2933455","Wanderley","2933455","base.state_br_ba","base.br"
-"city_2933505","Wenceslau Guimarães","2933505","base.state_br_ba","base.br"
-"city_2933604","Xique-Xique","2933604","base.state_br_ba","base.br"
-"city_3100104","Abadia dos Dourados","3100104","base.state_br_mg","base.br"
-"city_3100203","Abaeté","3100203","base.state_br_mg","base.br"
-"city_3100302","Abre Campo","3100302","base.state_br_mg","base.br"
-"city_3100401","Acaiaca","3100401","base.state_br_mg","base.br"
-"city_3100500","Açucena","3100500","base.state_br_mg","base.br"
-"city_3100609","Água Boa","3100609","base.state_br_mg","base.br"
-"city_3100708","Água Comprida","3100708","base.state_br_mg","base.br"
-"city_3100807","Aguanil","3100807","base.state_br_mg","base.br"
-"city_3100906","Águas Formosas","3100906","base.state_br_mg","base.br"
-"city_3101003","Águas Vermelhas","3101003","base.state_br_mg","base.br"
-"city_3101102","Aimorés","3101102","base.state_br_mg","base.br"
-"city_3101201","Aiuruoca","3101201","base.state_br_mg","base.br"
-"city_3101300","Alagoa","3101300","base.state_br_mg","base.br"
-"city_3101409","Albertina","3101409","base.state_br_mg","base.br"
-"city_3101508","Além Paraíba","3101508","base.state_br_mg","base.br"
-"city_3101607","Alfenas","3101607","base.state_br_mg","base.br"
-"city_3101631","Alfredo Vasconcelos","3101631","base.state_br_mg","base.br"
-"city_3101706","Almenara","3101706","base.state_br_mg","base.br"
-"city_3101805","Alpercata","3101805","base.state_br_mg","base.br"
-"city_3101904","Alpinópolis","3101904","base.state_br_mg","base.br"
-"city_3102001","Alterosa","3102001","base.state_br_mg","base.br"
-"city_3102050","Alto Caparaó","3102050","base.state_br_mg","base.br"
-"city_3153509","Alto Jequitibá","3153509","base.state_br_mg","base.br"
-"city_3102100","Alto Rio Doce","3102100","base.state_br_mg","base.br"
-"city_3102209","Alvarenga","3102209","base.state_br_mg","base.br"
-"city_3102308","Alvinópolis","3102308","base.state_br_mg","base.br"
-"city_3102407","Alvorada de Minas","3102407","base.state_br_mg","base.br"
-"city_3102506","Amparo do Serra","3102506","base.state_br_mg","base.br"
-"city_3102605","Andradas","3102605","base.state_br_mg","base.br"
-"city_3102803","Andrelândia","3102803","base.state_br_mg","base.br"
-"city_3102852","Angelândia","3102852","base.state_br_mg","base.br"
-"city_3102902","Antônio Carlos","3102902","base.state_br_mg","base.br"
-"city_3103009","Antônio Dias","3103009","base.state_br_mg","base.br"
-"city_3103108","Antônio Prado de Minas","3103108","base.state_br_mg","base.br"
-"city_3103207","Araçaí","3103207","base.state_br_mg","base.br"
-"city_3103306","Aracitaba","3103306","base.state_br_mg","base.br"
-"city_3103405","Araçuaí","3103405","base.state_br_mg","base.br"
-"city_3103504","Araguari","3103504","base.state_br_mg","base.br"
-"city_3103603","Arantina","3103603","base.state_br_mg","base.br"
-"city_3103702","Araponga","3103702","base.state_br_mg","base.br"
-"city_3103751","Araporã","3103751","base.state_br_mg","base.br"
-"city_3103801","Arapuá","3103801","base.state_br_mg","base.br"
-"city_3103900","Araújos","3103900","base.state_br_mg","base.br"
-"city_3104007","Araxá","3104007","base.state_br_mg","base.br"
-"city_3104106","Arceburgo","3104106","base.state_br_mg","base.br"
-"city_3104205","Arcos","3104205","base.state_br_mg","base.br"
-"city_3104304","Areado","3104304","base.state_br_mg","base.br"
-"city_3104403","Argirita","3104403","base.state_br_mg","base.br"
-"city_3104452","Aricanduva","3104452","base.state_br_mg","base.br"
-"city_3104502","Arinos","3104502","base.state_br_mg","base.br"
-"city_3104601","Astolfo Dutra","3104601","base.state_br_mg","base.br"
-"city_3104700","Ataléia","3104700","base.state_br_mg","base.br"
-"city_3104809","Augusto de Lima","3104809","base.state_br_mg","base.br"
-"city_3104908","Baependi","3104908","base.state_br_mg","base.br"
-"city_3105004","Baldim","3105004","base.state_br_mg","base.br"
-"city_3105103","Bambuí","3105103","base.state_br_mg","base.br"
-"city_3105202","Bandeira","3105202","base.state_br_mg","base.br"
-"city_3105301","Bandeira do Sul","3105301","base.state_br_mg","base.br"
-"city_3105400","Barão de Cocais","3105400","base.state_br_mg","base.br"
-"city_3105509","Barão de Monte Alto","3105509","base.state_br_mg","base.br"
-"city_3105608","Barbacena","3105608","base.state_br_mg","base.br"
-"city_3105707","Barra Longa","3105707","base.state_br_mg","base.br"
-"city_3105905","Barroso","3105905","base.state_br_mg","base.br"
-"city_3106002","Bela Vista de Minas","3106002","base.state_br_mg","base.br"
-"city_3106101","Belmiro Braga","3106101","base.state_br_mg","base.br"
-"city_3106200","Belo Horizonte","3106200","base.state_br_mg","base.br"
-"city_3106309","Belo Oriente","3106309","base.state_br_mg","base.br"
-"city_3106408","Belo Vale","3106408","base.state_br_mg","base.br"
-"city_3106507","Berilo","3106507","base.state_br_mg","base.br"
-"city_3106655","Berizal","3106655","base.state_br_mg","base.br"
-"city_3106606","Bertópolis","3106606","base.state_br_mg","base.br"
-"city_3106705","Betim","3106705","base.state_br_mg","base.br"
-"city_3106804","Bias Fortes","3106804","base.state_br_mg","base.br"
-"city_3106903","Bicas","3106903","base.state_br_mg","base.br"
-"city_3107000","Biquinhas","3107000","base.state_br_mg","base.br"
-"city_3107109","Boa Esperança","3107109","base.state_br_mg","base.br"
-"city_3107208","Bocaina de Minas","3107208","base.state_br_mg","base.br"
-"city_3107307","Bocaiúva","3107307","base.state_br_mg","base.br"
-"city_3107406","Bom Despacho","3107406","base.state_br_mg","base.br"
-"city_3107505","Bom Jardim de Minas","3107505","base.state_br_mg","base.br"
-"city_3107604","Bom Jesus da Penha","3107604","base.state_br_mg","base.br"
-"city_3107703","Bom Jesus do Amparo","3107703","base.state_br_mg","base.br"
-"city_3107802","Bom Jesus do Galho","3107802","base.state_br_mg","base.br"
-"city_3107901","Bom Repouso","3107901","base.state_br_mg","base.br"
-"city_3108008","Bom Sucesso","3108008","base.state_br_mg","base.br"
-"city_3108107","Bonfim","3108107","base.state_br_mg","base.br"
-"city_3108206","Bonfinópolis de Minas","3108206","base.state_br_mg","base.br"
-"city_3108255","Bonito de Minas","3108255","base.state_br_mg","base.br"
-"city_3108305","Borda da Mata","3108305","base.state_br_mg","base.br"
-"city_3108404","Botelhos","3108404","base.state_br_mg","base.br"
-"city_3108503","Botumirim","3108503","base.state_br_mg","base.br"
-"city_3108701","Brás Pires","3108701","base.state_br_mg","base.br"
-"city_3108552","Brasilândia de Minas","3108552","base.state_br_mg","base.br"
-"city_3108602","Brasília de Minas","3108602","base.state_br_mg","base.br"
-"city_3108800","Braúnas","3108800","base.state_br_mg","base.br"
-"city_3108909","Brazópolis","3108909","base.state_br_mg","base.br"
-"city_3109006","Brumadinho","3109006","base.state_br_mg","base.br"
-"city_3109105","Bueno Brandão","3109105","base.state_br_mg","base.br"
-"city_3109204","Buenópolis","3109204","base.state_br_mg","base.br"
-"city_3109253","Bugre","3109253","base.state_br_mg","base.br"
-"city_3109303","Buritis","3109303","base.state_br_mg","base.br"
-"city_3109402","Buritizeiro","3109402","base.state_br_mg","base.br"
-"city_3109451","Cabeceira Grande","3109451","base.state_br_mg","base.br"
-"city_3109501","Cabo Verde","3109501","base.state_br_mg","base.br"
-"city_3109600","Cachoeira da Prata","3109600","base.state_br_mg","base.br"
-"city_3109709","Cachoeira de Minas","3109709","base.state_br_mg","base.br"
-"city_3102704","Cachoeira de Pajeú","3102704","base.state_br_mg","base.br"
-"city_3109808","Cachoeira Dourada","3109808","base.state_br_mg","base.br"
-"city_3109907","Caetanópolis","3109907","base.state_br_mg","base.br"
-"city_3110004","Caeté","3110004","base.state_br_mg","base.br"
-"city_3110103","Caiana","3110103","base.state_br_mg","base.br"
-"city_3110202","Cajuri","3110202","base.state_br_mg","base.br"
-"city_3110301","Caldas","3110301","base.state_br_mg","base.br"
-"city_3110400","Camacho","3110400","base.state_br_mg","base.br"
-"city_3110509","Camanducaia","3110509","base.state_br_mg","base.br"
-"city_3110608","Cambuí","3110608","base.state_br_mg","base.br"
-"city_3110707","Cambuquira","3110707","base.state_br_mg","base.br"
-"city_3110806","Campanário","3110806","base.state_br_mg","base.br"
-"city_3110905","Campanha","3110905","base.state_br_mg","base.br"
-"city_3111002","Campestre","3111002","base.state_br_mg","base.br"
-"city_3111101","Campina Verde","3111101","base.state_br_mg","base.br"
-"city_3111150","Campo Azul","3111150","base.state_br_mg","base.br"
-"city_3111200","Campo Belo","3111200","base.state_br_mg","base.br"
-"city_3111309","Campo do Meio","3111309","base.state_br_mg","base.br"
-"city_3111408","Campo Florido","3111408","base.state_br_mg","base.br"
-"city_3111507","Campos Altos","3111507","base.state_br_mg","base.br"
-"city_3111606","Campos Gerais","3111606","base.state_br_mg","base.br"
-"city_3111903","Cana Verde","3111903","base.state_br_mg","base.br"
-"city_3111705","Canaã","3111705","base.state_br_mg","base.br"
-"city_3111804","Canápolis","3111804","base.state_br_mg","base.br"
-"city_3112000","Candeias","3112000","base.state_br_mg","base.br"
-"city_3112059","Cantagalo","3112059","base.state_br_mg","base.br"
-"city_3112109","Caparaó","3112109","base.state_br_mg","base.br"
-"city_3112208","Capela Nova","3112208","base.state_br_mg","base.br"
-"city_3112307","Capelinha","3112307","base.state_br_mg","base.br"
-"city_3112406","Capetinga","3112406","base.state_br_mg","base.br"
-"city_3112505","Capim Branco","3112505","base.state_br_mg","base.br"
-"city_3112604","Capinópolis","3112604","base.state_br_mg","base.br"
-"city_3112653","Capitão Andrade","3112653","base.state_br_mg","base.br"
-"city_3112703","Capitão Enéas","3112703","base.state_br_mg","base.br"
-"city_3112802","Capitólio","3112802","base.state_br_mg","base.br"
-"city_3112901","Caputira","3112901","base.state_br_mg","base.br"
-"city_3113008","Caraí","3113008","base.state_br_mg","base.br"
-"city_3113107","Caranaíba","3113107","base.state_br_mg","base.br"
-"city_3113206","Carandaí","3113206","base.state_br_mg","base.br"
-"city_3113305","Carangola","3113305","base.state_br_mg","base.br"
-"city_3113404","Caratinga","3113404","base.state_br_mg","base.br"
-"city_3113503","Carbonita","3113503","base.state_br_mg","base.br"
-"city_3113602","Careaçu","3113602","base.state_br_mg","base.br"
-"city_3113701","Carlos Chagas","3113701","base.state_br_mg","base.br"
-"city_3113800","Carmésia","3113800","base.state_br_mg","base.br"
-"city_3113909","Carmo da Cachoeira","3113909","base.state_br_mg","base.br"
-"city_3114006","Carmo da Mata","3114006","base.state_br_mg","base.br"
-"city_3114105","Carmo de Minas","3114105","base.state_br_mg","base.br"
-"city_3114204","Carmo do Cajuru","3114204","base.state_br_mg","base.br"
-"city_3114303","Carmo do Paranaíba","3114303","base.state_br_mg","base.br"
-"city_3114402","Carmo do Rio Claro","3114402","base.state_br_mg","base.br"
-"city_3114501","Carmópolis de Minas","3114501","base.state_br_mg","base.br"
-"city_3114550","Carneirinho","3114550","base.state_br_mg","base.br"
-"city_3114600","Carrancas","3114600","base.state_br_mg","base.br"
-"city_3114709","Carvalhópolis","3114709","base.state_br_mg","base.br"
-"city_3114808","Carvalhos","3114808","base.state_br_mg","base.br"
-"city_3114907","Casa Grande","3114907","base.state_br_mg","base.br"
-"city_3115003","Cascalho Rico","3115003","base.state_br_mg","base.br"
-"city_3115102","Cássia","3115102","base.state_br_mg","base.br"
-"city_3115300","Cataguases","3115300","base.state_br_mg","base.br"
-"city_3115359","Catas Altas","3115359","base.state_br_mg","base.br"
-"city_3115409","Catas Altas da Noruega","3115409","base.state_br_mg","base.br"
-"city_3115458","Catuji","3115458","base.state_br_mg","base.br"
-"city_3115474","Catuti","3115474","base.state_br_mg","base.br"
-"city_3115508","Caxambu","3115508","base.state_br_mg","base.br"
-"city_3115607","Cedro do Abaeté","3115607","base.state_br_mg","base.br"
-"city_3115706","Central de Minas","3115706","base.state_br_mg","base.br"
-"city_3115805","Centralina","3115805","base.state_br_mg","base.br"
-"city_3115904","Chácara","3115904","base.state_br_mg","base.br"
-"city_3116001","Chalé","3116001","base.state_br_mg","base.br"
-"city_3116100","Chapada do Norte","3116100","base.state_br_mg","base.br"
-"city_3116159","Chapada Gaúcha","3116159","base.state_br_mg","base.br"
-"city_3116209","Chiador","3116209","base.state_br_mg","base.br"
-"city_3116308","Cipotânea","3116308","base.state_br_mg","base.br"
-"city_3116407","Claraval","3116407","base.state_br_mg","base.br"
-"city_3116506","Claro dos Poções","3116506","base.state_br_mg","base.br"
-"city_3116605","Cláudio","3116605","base.state_br_mg","base.br"
-"city_3116704","Coimbra","3116704","base.state_br_mg","base.br"
-"city_3116803","Coluna","3116803","base.state_br_mg","base.br"
-"city_3116902","Comendador Gomes","3116902","base.state_br_mg","base.br"
-"city_3117009","Comercinho","3117009","base.state_br_mg","base.br"
-"city_3117108","Conceição da Aparecida","3117108","base.state_br_mg","base.br"
-"city_3115201","Conceição da Barra de Minas","3115201","base.state_br_mg","base.br"
-"city_3117306","Conceição das Alagoas","3117306","base.state_br_mg","base.br"
-"city_3117207","Conceição das Pedras","3117207","base.state_br_mg","base.br"
-"city_3117405","Conceição de Ipanema","3117405","base.state_br_mg","base.br"
-"city_3117504","Conceição do Mato Dentro","3117504","base.state_br_mg","base.br"
-"city_3117603","Conceição do Pará","3117603","base.state_br_mg","base.br"
-"city_3117702","Conceição do Rio Verde","3117702","base.state_br_mg","base.br"
-"city_3117801","Conceição dos Ouros","3117801","base.state_br_mg","base.br"
-"city_3117836","Cônego Marinho","3117836","base.state_br_mg","base.br"
-"city_3117876","Confins","3117876","base.state_br_mg","base.br"
-"city_3117900","Congonhal","3117900","base.state_br_mg","base.br"
-"city_3118007","Congonhas","3118007","base.state_br_mg","base.br"
-"city_3118106","Congonhas do Norte","3118106","base.state_br_mg","base.br"
-"city_3118205","Conquista","3118205","base.state_br_mg","base.br"
-"city_3118304","Conselheiro Lafaiete","3118304","base.state_br_mg","base.br"
-"city_3118403","Conselheiro Pena","3118403","base.state_br_mg","base.br"
-"city_3118502","Consolação","3118502","base.state_br_mg","base.br"
-"city_3118601","Contagem","3118601","base.state_br_mg","base.br"
-"city_3118700","Coqueiral","3118700","base.state_br_mg","base.br"
-"city_3118809","Coração de Jesus","3118809","base.state_br_mg","base.br"
-"city_3118908","Cordisburgo","3118908","base.state_br_mg","base.br"
-"city_3119005","Cordislândia","3119005","base.state_br_mg","base.br"
-"city_3119104","Corinto","3119104","base.state_br_mg","base.br"
-"city_3119203","Coroaci","3119203","base.state_br_mg","base.br"
-"city_3119302","Coromandel","3119302","base.state_br_mg","base.br"
-"city_3119401","Coronel Fabriciano","3119401","base.state_br_mg","base.br"
-"city_3119500","Coronel Murta","3119500","base.state_br_mg","base.br"
-"city_3119609","Coronel Pacheco","3119609","base.state_br_mg","base.br"
-"city_3119708","Coronel Xavier Chaves","3119708","base.state_br_mg","base.br"
-"city_3119807","Córrego Danta","3119807","base.state_br_mg","base.br"
-"city_3119906","Córrego do Bom Jesus","3119906","base.state_br_mg","base.br"
-"city_3119955","Córrego Fundo","3119955","base.state_br_mg","base.br"
-"city_3120003","Córrego Novo","3120003","base.state_br_mg","base.br"
-"city_3120102","Couto de Magalhães de Minas","3120102","base.state_br_mg","base.br"
-"city_3120151","Crisólita","3120151","base.state_br_mg","base.br"
-"city_3120201","Cristais","3120201","base.state_br_mg","base.br"
-"city_3120300","Cristália","3120300","base.state_br_mg","base.br"
-"city_3120409","Cristiano Otoni","3120409","base.state_br_mg","base.br"
-"city_3120508","Cristina","3120508","base.state_br_mg","base.br"
-"city_3120607","Crucilândia","3120607","base.state_br_mg","base.br"
-"city_3120706","Cruzeiro da Fortaleza","3120706","base.state_br_mg","base.br"
-"city_3120805","Cruzília","3120805","base.state_br_mg","base.br"
-"city_3120839","Cuparaque","3120839","base.state_br_mg","base.br"
-"city_3120870","Curral de Dentro","3120870","base.state_br_mg","base.br"
-"city_3120904","Curvelo","3120904","base.state_br_mg","base.br"
-"city_3121001","Datas","3121001","base.state_br_mg","base.br"
-"city_3121100","Delfim Moreira","3121100","base.state_br_mg","base.br"
-"city_3121209","Delfinópolis","3121209","base.state_br_mg","base.br"
-"city_3121258","Delta","3121258","base.state_br_mg","base.br"
-"city_3121308","Descoberto","3121308","base.state_br_mg","base.br"
-"city_3121407","Desterro de Entre Rios","3121407","base.state_br_mg","base.br"
-"city_3121506","Desterro do Melo","3121506","base.state_br_mg","base.br"
-"city_3121605","Diamantina","3121605","base.state_br_mg","base.br"
-"city_3121704","Diogo de Vasconcelos","3121704","base.state_br_mg","base.br"
-"city_3121803","Dionísio","3121803","base.state_br_mg","base.br"
-"city_3121902","Divinésia","3121902","base.state_br_mg","base.br"
-"city_3122009","Divino","3122009","base.state_br_mg","base.br"
-"city_3122108","Divino das Laranjeiras","3122108","base.state_br_mg","base.br"
-"city_3122207","Divinolândia de Minas","3122207","base.state_br_mg","base.br"
-"city_3122306","Divinópolis","3122306","base.state_br_mg","base.br"
-"city_3122355","Divisa Alegre","3122355","base.state_br_mg","base.br"
-"city_3122405","Divisa Nova","3122405","base.state_br_mg","base.br"
-"city_3122454","Divisópolis","3122454","base.state_br_mg","base.br"
-"city_3122470","Dom Bosco","3122470","base.state_br_mg","base.br"
-"city_3122504","Dom Cavati","3122504","base.state_br_mg","base.br"
-"city_3122603","Dom Joaquim","3122603","base.state_br_mg","base.br"
-"city_3122702","Dom Silvério","3122702","base.state_br_mg","base.br"
-"city_3122801","Dom Viçoso","3122801","base.state_br_mg","base.br"
-"city_3122900","Dona Euzébia","3122900","base.state_br_mg","base.br"
-"city_3123007","Dores de Campos","3123007","base.state_br_mg","base.br"
-"city_3123106","Dores de Guanhães","3123106","base.state_br_mg","base.br"
-"city_3123205","Dores do Indaiá","3123205","base.state_br_mg","base.br"
-"city_3123304","Dores do Turvo","3123304","base.state_br_mg","base.br"
-"city_3123403","Doresópolis","3123403","base.state_br_mg","base.br"
-"city_3123502","Douradoquara","3123502","base.state_br_mg","base.br"
-"city_3123528","Durandé","3123528","base.state_br_mg","base.br"
-"city_3123601","Elói Mendes","3123601","base.state_br_mg","base.br"
-"city_3123700","Engenheiro Caldas","3123700","base.state_br_mg","base.br"
-"city_3123809","Engenheiro Navarro","3123809","base.state_br_mg","base.br"
-"city_3123858","Entre Folhas","3123858","base.state_br_mg","base.br"
-"city_3123908","Entre Rios de Minas","3123908","base.state_br_mg","base.br"
-"city_3124005","Ervália","3124005","base.state_br_mg","base.br"
-"city_3124104","Esmeraldas","3124104","base.state_br_mg","base.br"
-"city_3124203","Espera Feliz","3124203","base.state_br_mg","base.br"
-"city_3124302","Espinosa","3124302","base.state_br_mg","base.br"
-"city_3124401","Espírito Santo do Dourado","3124401","base.state_br_mg","base.br"
-"city_3124500","Estiva","3124500","base.state_br_mg","base.br"
-"city_3124609","Estrela Dalva","3124609","base.state_br_mg","base.br"
-"city_3124708","Estrela do Indaiá","3124708","base.state_br_mg","base.br"
-"city_3124807","Estrela do Sul","3124807","base.state_br_mg","base.br"
-"city_3124906","Eugenópolis","3124906","base.state_br_mg","base.br"
-"city_3125002","Ewbank da Câmara","3125002","base.state_br_mg","base.br"
-"city_3125101","Extrema","3125101","base.state_br_mg","base.br"
-"city_3125200","Fama","3125200","base.state_br_mg","base.br"
-"city_3125309","Faria Lemos","3125309","base.state_br_mg","base.br"
-"city_3125408","Felício dos Santos","3125408","base.state_br_mg","base.br"
-"city_3125606","Felisburgo","3125606","base.state_br_mg","base.br"
-"city_3125705","Felixlândia","3125705","base.state_br_mg","base.br"
-"city_3125804","Fernandes Tourinho","3125804","base.state_br_mg","base.br"
-"city_3125903","Ferros","3125903","base.state_br_mg","base.br"
-"city_3125952","Fervedouro","3125952","base.state_br_mg","base.br"
-"city_3126000","Florestal","3126000","base.state_br_mg","base.br"
-"city_3126109","Formiga","3126109","base.state_br_mg","base.br"
-"city_3126208","Formoso","3126208","base.state_br_mg","base.br"
-"city_3126307","Fortaleza de Minas","3126307","base.state_br_mg","base.br"
-"city_3126406","Fortuna de Minas","3126406","base.state_br_mg","base.br"
-"city_3126505","Francisco Badaró","3126505","base.state_br_mg","base.br"
-"city_3126604","Francisco Dumont","3126604","base.state_br_mg","base.br"
-"city_3126703","Francisco Sá","3126703","base.state_br_mg","base.br"
-"city_3126752","Franciscópolis","3126752","base.state_br_mg","base.br"
-"city_3126802","Frei Gaspar","3126802","base.state_br_mg","base.br"
-"city_3126901","Frei Inocêncio","3126901","base.state_br_mg","base.br"
-"city_3126950","Frei Lagonegro","3126950","base.state_br_mg","base.br"
-"city_3127008","Fronteira","3127008","base.state_br_mg","base.br"
-"city_3127057","Fronteira dos Vales","3127057","base.state_br_mg","base.br"
-"city_3127073","Fruta de Leite","3127073","base.state_br_mg","base.br"
-"city_3127107","Frutal","3127107","base.state_br_mg","base.br"
-"city_3127206","Funilândia","3127206","base.state_br_mg","base.br"
-"city_3127305","Galiléia","3127305","base.state_br_mg","base.br"
-"city_3127339","Gameleiras","3127339","base.state_br_mg","base.br"
-"city_3127354","Glaucilândia","3127354","base.state_br_mg","base.br"
-"city_3127370","Goiabeira","3127370","base.state_br_mg","base.br"
-"city_3127388","Goianá","3127388","base.state_br_mg","base.br"
-"city_3127404","Gonçalves","3127404","base.state_br_mg","base.br"
-"city_3127503","Gonzaga","3127503","base.state_br_mg","base.br"
-"city_3127602","Gouveia","3127602","base.state_br_mg","base.br"
-"city_3127701","Governador Valadares","3127701","base.state_br_mg","base.br"
-"city_3127800","Grão Mogol","3127800","base.state_br_mg","base.br"
-"city_3127909","Grupiara","3127909","base.state_br_mg","base.br"
-"city_3128006","Guanhães","3128006","base.state_br_mg","base.br"
-"city_3128105","Guapé","3128105","base.state_br_mg","base.br"
-"city_3128204","Guaraciaba","3128204","base.state_br_mg","base.br"
-"city_3128253","Guaraciama","3128253","base.state_br_mg","base.br"
-"city_3128303","Guaranésia","3128303","base.state_br_mg","base.br"
-"city_3128402","Guarani","3128402","base.state_br_mg","base.br"
-"city_3128501","Guarará","3128501","base.state_br_mg","base.br"
-"city_3128600","Guarda-Mor","3128600","base.state_br_mg","base.br"
-"city_3128709","Guaxupé","3128709","base.state_br_mg","base.br"
-"city_3128808","Guidoval","3128808","base.state_br_mg","base.br"
-"city_3128907","Guimarânia","3128907","base.state_br_mg","base.br"
-"city_3129004","Guiricema","3129004","base.state_br_mg","base.br"
-"city_3129103","Gurinhatã","3129103","base.state_br_mg","base.br"
-"city_3129202","Heliodora","3129202","base.state_br_mg","base.br"
-"city_3129301","Iapu","3129301","base.state_br_mg","base.br"
-"city_3129400","Ibertioga","3129400","base.state_br_mg","base.br"
-"city_3129509","Ibiá","3129509","base.state_br_mg","base.br"
-"city_3129608","Ibiaí","3129608","base.state_br_mg","base.br"
-"city_3129657","Ibiracatu","3129657","base.state_br_mg","base.br"
-"city_3129707","Ibiraci","3129707","base.state_br_mg","base.br"
-"city_3129806","Ibirité","3129806","base.state_br_mg","base.br"
-"city_3129905","Ibitiúra de Minas","3129905","base.state_br_mg","base.br"
-"city_3130002","Ibituruna","3130002","base.state_br_mg","base.br"
-"city_3130051","Icaraí de Minas","3130051","base.state_br_mg","base.br"
-"city_3130101","Igarapé","3130101","base.state_br_mg","base.br"
-"city_3130200","Igaratinga","3130200","base.state_br_mg","base.br"
-"city_3130309","Iguatama","3130309","base.state_br_mg","base.br"
-"city_3130408","Ijaci","3130408","base.state_br_mg","base.br"
-"city_3130507","Ilicínea","3130507","base.state_br_mg","base.br"
-"city_3130556","Imbé de Minas","3130556","base.state_br_mg","base.br"
-"city_3130606","Inconfidentes","3130606","base.state_br_mg","base.br"
-"city_3130655","Indaiabira","3130655","base.state_br_mg","base.br"
-"city_3130705","Indianópolis","3130705","base.state_br_mg","base.br"
-"city_3130804","Ingaí","3130804","base.state_br_mg","base.br"
-"city_3130903","Inhapim","3130903","base.state_br_mg","base.br"
-"city_3131000","Inhaúma","3131000","base.state_br_mg","base.br"
-"city_3131109","Inimutaba","3131109","base.state_br_mg","base.br"
-"city_3131158","Ipaba","3131158","base.state_br_mg","base.br"
-"city_3131208","Ipanema","3131208","base.state_br_mg","base.br"
-"city_3131307","Ipatinga","3131307","base.state_br_mg","base.br"
-"city_3131406","Ipiaçu","3131406","base.state_br_mg","base.br"
-"city_3131505","Ipuiúna","3131505","base.state_br_mg","base.br"
-"city_3131604","Iraí de Minas","3131604","base.state_br_mg","base.br"
-"city_3131703","Itabira","3131703","base.state_br_mg","base.br"
-"city_3131802","Itabirinha","3131802","base.state_br_mg","base.br"
-"city_3131901","Itabirito","3131901","base.state_br_mg","base.br"
-"city_3132008","Itacambira","3132008","base.state_br_mg","base.br"
-"city_3132107","Itacarambi","3132107","base.state_br_mg","base.br"
-"city_3132206","Itaguara","3132206","base.state_br_mg","base.br"
-"city_3132305","Itaipé","3132305","base.state_br_mg","base.br"
-"city_3132404","Itajubá","3132404","base.state_br_mg","base.br"
-"city_3132503","Itamarandiba","3132503","base.state_br_mg","base.br"
-"city_3132602","Itamarati de Minas","3132602","base.state_br_mg","base.br"
-"city_3132701","Itambacuri","3132701","base.state_br_mg","base.br"
-"city_3132800","Itambé do Mato Dentro","3132800","base.state_br_mg","base.br"
-"city_3132909","Itamogi","3132909","base.state_br_mg","base.br"
-"city_3133006","Itamonte","3133006","base.state_br_mg","base.br"
-"city_3133105","Itanhandu","3133105","base.state_br_mg","base.br"
-"city_3133204","Itanhomi","3133204","base.state_br_mg","base.br"
-"city_3133303","Itaobim","3133303","base.state_br_mg","base.br"
-"city_3133402","Itapagipe","3133402","base.state_br_mg","base.br"
-"city_3133501","Itapecerica","3133501","base.state_br_mg","base.br"
-"city_3133600","Itapeva","3133600","base.state_br_mg","base.br"
-"city_3133709","Itatiaiuçu","3133709","base.state_br_mg","base.br"
-"city_3133758","Itaú de Minas","3133758","base.state_br_mg","base.br"
-"city_3133808","Itaúna","3133808","base.state_br_mg","base.br"
-"city_3133907","Itaverava","3133907","base.state_br_mg","base.br"
-"city_3134004","Itinga","3134004","base.state_br_mg","base.br"
-"city_3134103","Itueta","3134103","base.state_br_mg","base.br"
-"city_3134202","Ituiutaba","3134202","base.state_br_mg","base.br"
-"city_3134301","Itumirim","3134301","base.state_br_mg","base.br"
-"city_3134400","Iturama","3134400","base.state_br_mg","base.br"
-"city_3134509","Itutinga","3134509","base.state_br_mg","base.br"
-"city_3134608","Jaboticatubas","3134608","base.state_br_mg","base.br"
-"city_3134707","Jacinto","3134707","base.state_br_mg","base.br"
-"city_3134806","Jacuí","3134806","base.state_br_mg","base.br"
-"city_3134905","Jacutinga","3134905","base.state_br_mg","base.br"
-"city_3135001","Jaguaraçu","3135001","base.state_br_mg","base.br"
-"city_3135050","Jaíba","3135050","base.state_br_mg","base.br"
-"city_3135076","Jampruca","3135076","base.state_br_mg","base.br"
-"city_3135100","Janaúba","3135100","base.state_br_mg","base.br"
-"city_3135209","Januária","3135209","base.state_br_mg","base.br"
-"city_3135308","Japaraíba","3135308","base.state_br_mg","base.br"
-"city_3135357","Japonvar","3135357","base.state_br_mg","base.br"
-"city_3135407","Jeceaba","3135407","base.state_br_mg","base.br"
-"city_3135456","Jenipapo de Minas","3135456","base.state_br_mg","base.br"
-"city_3135506","Jequeri","3135506","base.state_br_mg","base.br"
-"city_3135605","Jequitaí","3135605","base.state_br_mg","base.br"
-"city_3135704","Jequitibá","3135704","base.state_br_mg","base.br"
-"city_3135803","Jequitinhonha","3135803","base.state_br_mg","base.br"
-"city_3135902","Jesuânia","3135902","base.state_br_mg","base.br"
-"city_3136009","Joaíma","3136009","base.state_br_mg","base.br"
-"city_3136108","Joanésia","3136108","base.state_br_mg","base.br"
-"city_3136207","João Monlevade","3136207","base.state_br_mg","base.br"
-"city_3136306","João Pinheiro","3136306","base.state_br_mg","base.br"
-"city_3136405","Joaquim Felício","3136405","base.state_br_mg","base.br"
-"city_3136504","Jordânia","3136504","base.state_br_mg","base.br"
-"city_3136520","José Gonçalves de Minas","3136520","base.state_br_mg","base.br"
-"city_3136553","José Raydan","3136553","base.state_br_mg","base.br"
-"city_3136579","Josenópolis","3136579","base.state_br_mg","base.br"
-"city_3136652","Juatuba","3136652","base.state_br_mg","base.br"
-"city_3136702","Juiz de Fora","3136702","base.state_br_mg","base.br"
-"city_3136801","Juramento","3136801","base.state_br_mg","base.br"
-"city_3136900","Juruaia","3136900","base.state_br_mg","base.br"
-"city_3136959","Juvenília","3136959","base.state_br_mg","base.br"
-"city_3137007","Ladainha","3137007","base.state_br_mg","base.br"
-"city_3137106","Lagamar","3137106","base.state_br_mg","base.br"
-"city_3137205","Lagoa da Prata","3137205","base.state_br_mg","base.br"
-"city_3137304","Lagoa dos Patos","3137304","base.state_br_mg","base.br"
-"city_3137403","Lagoa Dourada","3137403","base.state_br_mg","base.br"
-"city_3137502","Lagoa Formosa","3137502","base.state_br_mg","base.br"
-"city_3137536","Lagoa Grande","3137536","base.state_br_mg","base.br"
-"city_3137601","Lagoa Santa","3137601","base.state_br_mg","base.br"
-"city_3137700","Lajinha","3137700","base.state_br_mg","base.br"
-"city_3137809","Lambari","3137809","base.state_br_mg","base.br"
-"city_3137908","Lamim","3137908","base.state_br_mg","base.br"
-"city_3138005","Laranjal","3138005","base.state_br_mg","base.br"
-"city_3138104","Lassance","3138104","base.state_br_mg","base.br"
-"city_3138203","Lavras","3138203","base.state_br_mg","base.br"
-"city_3138302","Leandro Ferreira","3138302","base.state_br_mg","base.br"
-"city_3138351","Leme do Prado","3138351","base.state_br_mg","base.br"
-"city_3138401","Leopoldina","3138401","base.state_br_mg","base.br"
-"city_3138500","Liberdade","3138500","base.state_br_mg","base.br"
-"city_3138609","Lima Duarte","3138609","base.state_br_mg","base.br"
-"city_3138625","Limeira do Oeste","3138625","base.state_br_mg","base.br"
-"city_3138658","Lontra","3138658","base.state_br_mg","base.br"
-"city_3138674","Luisburgo","3138674","base.state_br_mg","base.br"
-"city_3138682","Luislândia","3138682","base.state_br_mg","base.br"
-"city_3138708","Luminárias","3138708","base.state_br_mg","base.br"
-"city_3138807","Luz","3138807","base.state_br_mg","base.br"
-"city_3138906","Machacalis","3138906","base.state_br_mg","base.br"
-"city_3139003","Machado","3139003","base.state_br_mg","base.br"
-"city_3139102","Madre de Deus de Minas","3139102","base.state_br_mg","base.br"
-"city_3139201","Malacacheta","3139201","base.state_br_mg","base.br"
-"city_3139250","Mamonas","3139250","base.state_br_mg","base.br"
-"city_3139300","Manga","3139300","base.state_br_mg","base.br"
-"city_3139409","Manhuaçu","3139409","base.state_br_mg","base.br"
-"city_3139508","Manhumirim","3139508","base.state_br_mg","base.br"
-"city_3139607","Mantena","3139607","base.state_br_mg","base.br"
-"city_3139805","Mar de Espanha","3139805","base.state_br_mg","base.br"
-"city_3139706","Maravilhas","3139706","base.state_br_mg","base.br"
-"city_3139904","Maria da Fé","3139904","base.state_br_mg","base.br"
-"city_3140001","Mariana","3140001","base.state_br_mg","base.br"
-"city_3140100","Marilac","3140100","base.state_br_mg","base.br"
-"city_3140159","Mário Campos","3140159","base.state_br_mg","base.br"
-"city_3140209","Maripá de Minas","3140209","base.state_br_mg","base.br"
-"city_3140308","Marliéria","3140308","base.state_br_mg","base.br"
-"city_3140407","Marmelópolis","3140407","base.state_br_mg","base.br"
-"city_3140506","Martinho Campos","3140506","base.state_br_mg","base.br"
-"city_3140530","Martins Soares","3140530","base.state_br_mg","base.br"
-"city_3140555","Mata Verde","3140555","base.state_br_mg","base.br"
-"city_3140605","Materlândia","3140605","base.state_br_mg","base.br"
-"city_3140704","Mateus Leme","3140704","base.state_br_mg","base.br"
-"city_3171501","Mathias Lobato","3171501","base.state_br_mg","base.br"
-"city_3140803","Matias Barbosa","3140803","base.state_br_mg","base.br"
-"city_3140852","Matias Cardoso","3140852","base.state_br_mg","base.br"
-"city_3140902","Matipó","3140902","base.state_br_mg","base.br"
-"city_3141009","Mato Verde","3141009","base.state_br_mg","base.br"
-"city_3141108","Matozinhos","3141108","base.state_br_mg","base.br"
-"city_3141207","Matutina","3141207","base.state_br_mg","base.br"
-"city_3141306","Medeiros","3141306","base.state_br_mg","base.br"
-"city_3141405","Medina","3141405","base.state_br_mg","base.br"
-"city_3141504","Mendes Pimentel","3141504","base.state_br_mg","base.br"
-"city_3141603","Mercês","3141603","base.state_br_mg","base.br"
-"city_3141702","Mesquita","3141702","base.state_br_mg","base.br"
-"city_3141801","Minas Novas","3141801","base.state_br_mg","base.br"
-"city_3141900","Minduri","3141900","base.state_br_mg","base.br"
-"city_3142007","Mirabela","3142007","base.state_br_mg","base.br"
-"city_3142106","Miradouro","3142106","base.state_br_mg","base.br"
-"city_3142205","Miraí","3142205","base.state_br_mg","base.br"
-"city_3142254","Miravânia","3142254","base.state_br_mg","base.br"
-"city_3142304","Moeda","3142304","base.state_br_mg","base.br"
-"city_3142403","Moema","3142403","base.state_br_mg","base.br"
-"city_3142502","Monjolos","3142502","base.state_br_mg","base.br"
-"city_3142601","Monsenhor Paulo","3142601","base.state_br_mg","base.br"
-"city_3142700","Montalvânia","3142700","base.state_br_mg","base.br"
-"city_3142809","Monte Alegre de Minas","3142809","base.state_br_mg","base.br"
-"city_3142908","Monte Azul","3142908","base.state_br_mg","base.br"
-"city_3143005","Monte Belo","3143005","base.state_br_mg","base.br"
-"city_3143104","Monte Carmelo","3143104","base.state_br_mg","base.br"
-"city_3143153","Monte Formoso","3143153","base.state_br_mg","base.br"
-"city_3143203","Monte Santo de Minas","3143203","base.state_br_mg","base.br"
-"city_3143401","Monte Sião","3143401","base.state_br_mg","base.br"
-"city_3143302","Montes Claros","3143302","base.state_br_mg","base.br"
-"city_3143450","Montezuma","3143450","base.state_br_mg","base.br"
-"city_3143500","Morada Nova de Minas","3143500","base.state_br_mg","base.br"
-"city_3143609","Morro da Garça","3143609","base.state_br_mg","base.br"
-"city_3143708","Morro do Pilar","3143708","base.state_br_mg","base.br"
-"city_3143807","Munhoz","3143807","base.state_br_mg","base.br"
-"city_3143906","Muriaé","3143906","base.state_br_mg","base.br"
-"city_3144003","Mutum","3144003","base.state_br_mg","base.br"
-"city_3144102","Muzambinho","3144102","base.state_br_mg","base.br"
-"city_3144201","Nacip Raydan","3144201","base.state_br_mg","base.br"
-"city_3144300","Nanuque","3144300","base.state_br_mg","base.br"
-"city_3144359","Naque","3144359","base.state_br_mg","base.br"
-"city_3144375","Natalândia","3144375","base.state_br_mg","base.br"
-"city_3144409","Natércia","3144409","base.state_br_mg","base.br"
-"city_3144508","Nazareno","3144508","base.state_br_mg","base.br"
-"city_3144607","Nepomuceno","3144607","base.state_br_mg","base.br"
-"city_3144656","Ninheira","3144656","base.state_br_mg","base.br"
-"city_3144672","Nova Belém","3144672","base.state_br_mg","base.br"
-"city_3144706","Nova Era","3144706","base.state_br_mg","base.br"
-"city_3144805","Nova Lima","3144805","base.state_br_mg","base.br"
-"city_3144904","Nova Módica","3144904","base.state_br_mg","base.br"
-"city_3145000","Nova Ponte","3145000","base.state_br_mg","base.br"
-"city_3145059","Nova Porteirinha","3145059","base.state_br_mg","base.br"
-"city_3145109","Nova Resende","3145109","base.state_br_mg","base.br"
-"city_3145208","Nova Serrana","3145208","base.state_br_mg","base.br"
-"city_3136603","Nova União","3136603","base.state_br_mg","base.br"
-"city_3145307","Novo Cruzeiro","3145307","base.state_br_mg","base.br"
-"city_3145356","Novo Oriente de Minas","3145356","base.state_br_mg","base.br"
-"city_3145372","Novorizonte","3145372","base.state_br_mg","base.br"
-"city_3145406","Olaria","3145406","base.state_br_mg","base.br"
-"city_3145455","Olhos-d'Água","3145455","base.state_br_mg","base.br"
-"city_3145505","Olímpio Noronha","3145505","base.state_br_mg","base.br"
-"city_3145604","Oliveira","3145604","base.state_br_mg","base.br"
-"city_3145703","Oliveira Fortes","3145703","base.state_br_mg","base.br"
-"city_3145802","Onça de Pitangui","3145802","base.state_br_mg","base.br"
-"city_3145851","Oratórios","3145851","base.state_br_mg","base.br"
-"city_3145877","Orizânia","3145877","base.state_br_mg","base.br"
-"city_3145901","Ouro Branco","3145901","base.state_br_mg","base.br"
-"city_3146008","Ouro Fino","3146008","base.state_br_mg","base.br"
-"city_3146107","Ouro Preto","3146107","base.state_br_mg","base.br"
-"city_3146206","Ouro Verde de Minas","3146206","base.state_br_mg","base.br"
-"city_3146255","Padre Carvalho","3146255","base.state_br_mg","base.br"
-"city_3146305","Padre Paraíso","3146305","base.state_br_mg","base.br"
-"city_3146552","Pai Pedro","3146552","base.state_br_mg","base.br"
-"city_3146404","Paineiras","3146404","base.state_br_mg","base.br"
-"city_3146503","Pains","3146503","base.state_br_mg","base.br"
-"city_3146602","Paiva","3146602","base.state_br_mg","base.br"
-"city_3146701","Palma","3146701","base.state_br_mg","base.br"
-"city_3146750","Palmópolis","3146750","base.state_br_mg","base.br"
-"city_3146909","Papagaios","3146909","base.state_br_mg","base.br"
-"city_3147105","Pará de Minas","3147105","base.state_br_mg","base.br"
-"city_3147006","Paracatu","3147006","base.state_br_mg","base.br"
-"city_3147204","Paraguaçu","3147204","base.state_br_mg","base.br"
-"city_3147303","Paraisópolis","3147303","base.state_br_mg","base.br"
-"city_3147402","Paraopeba","3147402","base.state_br_mg","base.br"
-"city_3147600","Passa Quatro","3147600","base.state_br_mg","base.br"
-"city_3147709","Passa Tempo","3147709","base.state_br_mg","base.br"
-"city_3147808","Passa Vinte","3147808","base.state_br_mg","base.br"
-"city_3147501","Passabém","3147501","base.state_br_mg","base.br"
-"city_3147907","Passos","3147907","base.state_br_mg","base.br"
-"city_3147956","Patis","3147956","base.state_br_mg","base.br"
-"city_3148004","Patos de Minas","3148004","base.state_br_mg","base.br"
-"city_3148103","Patrocínio","3148103","base.state_br_mg","base.br"
-"city_3148202","Patrocínio do Muriaé","3148202","base.state_br_mg","base.br"
-"city_3148301","Paula Cândido","3148301","base.state_br_mg","base.br"
-"city_3148400","Paulistas","3148400","base.state_br_mg","base.br"
-"city_3148509","Pavão","3148509","base.state_br_mg","base.br"
-"city_3148608","Peçanha","3148608","base.state_br_mg","base.br"
-"city_3148707","Pedra Azul","3148707","base.state_br_mg","base.br"
-"city_3148756","Pedra Bonita","3148756","base.state_br_mg","base.br"
-"city_3148806","Pedra do Anta","3148806","base.state_br_mg","base.br"
-"city_3148905","Pedra do Indaiá","3148905","base.state_br_mg","base.br"
-"city_3149002","Pedra Dourada","3149002","base.state_br_mg","base.br"
-"city_3149101","Pedralva","3149101","base.state_br_mg","base.br"
-"city_3149150","Pedras de Maria da Cruz","3149150","base.state_br_mg","base.br"
-"city_3149200","Pedrinópolis","3149200","base.state_br_mg","base.br"
-"city_3149309","Pedro Leopoldo","3149309","base.state_br_mg","base.br"
-"city_3149408","Pedro Teixeira","3149408","base.state_br_mg","base.br"
-"city_3149507","Pequeri","3149507","base.state_br_mg","base.br"
-"city_3149606","Pequi","3149606","base.state_br_mg","base.br"
-"city_3149705","Perdigão","3149705","base.state_br_mg","base.br"
-"city_3149804","Perdizes","3149804","base.state_br_mg","base.br"
-"city_3149903","Perdões","3149903","base.state_br_mg","base.br"
-"city_3149952","Periquito","3149952","base.state_br_mg","base.br"
-"city_3150000","Pescador","3150000","base.state_br_mg","base.br"
-"city_3150109","Piau","3150109","base.state_br_mg","base.br"
-"city_3150158","Piedade de Caratinga","3150158","base.state_br_mg","base.br"
-"city_3150208","Piedade de Ponte Nova","3150208","base.state_br_mg","base.br"
-"city_3150307","Piedade do Rio Grande","3150307","base.state_br_mg","base.br"
-"city_3150406","Piedade dos Gerais","3150406","base.state_br_mg","base.br"
-"city_3150505","Pimenta","3150505","base.state_br_mg","base.br"
-"city_3150539","Pingo-d'Água","3150539","base.state_br_mg","base.br"
-"city_3150570","Pintópolis","3150570","base.state_br_mg","base.br"
-"city_3150604","Piracema","3150604","base.state_br_mg","base.br"
-"city_3150703","Pirajuba","3150703","base.state_br_mg","base.br"
-"city_3150802","Piranga","3150802","base.state_br_mg","base.br"
-"city_3150901","Piranguçu","3150901","base.state_br_mg","base.br"
-"city_3151008","Piranguinho","3151008","base.state_br_mg","base.br"
-"city_3151107","Pirapetinga","3151107","base.state_br_mg","base.br"
-"city_3151206","Pirapora","3151206","base.state_br_mg","base.br"
-"city_3151305","Piraúba","3151305","base.state_br_mg","base.br"
-"city_3151404","Pitangui","3151404","base.state_br_mg","base.br"
-"city_3151503","Piumhi","3151503","base.state_br_mg","base.br"
-"city_3151602","Planura","3151602","base.state_br_mg","base.br"
-"city_3151701","Poço Fundo","3151701","base.state_br_mg","base.br"
-"city_3151800","Poços de Caldas","3151800","base.state_br_mg","base.br"
-"city_3151909","Pocrane","3151909","base.state_br_mg","base.br"
-"city_3152006","Pompéu","3152006","base.state_br_mg","base.br"
-"city_3152105","Ponte Nova","3152105","base.state_br_mg","base.br"
-"city_3152131","Ponto Chique","3152131","base.state_br_mg","base.br"
-"city_3152170","Ponto dos Volantes","3152170","base.state_br_mg","base.br"
-"city_3152204","Porteirinha","3152204","base.state_br_mg","base.br"
-"city_3152303","Porto Firme","3152303","base.state_br_mg","base.br"
-"city_3152402","Poté","3152402","base.state_br_mg","base.br"
-"city_3152501","Pouso Alegre","3152501","base.state_br_mg","base.br"
-"city_3152600","Pouso Alto","3152600","base.state_br_mg","base.br"
-"city_3152709","Prados","3152709","base.state_br_mg","base.br"
-"city_3152808","Prata","3152808","base.state_br_mg","base.br"
-"city_3152907","Pratápolis","3152907","base.state_br_mg","base.br"
-"city_3153004","Pratinha","3153004","base.state_br_mg","base.br"
-"city_3153103","Presidente Bernardes","3153103","base.state_br_mg","base.br"
-"city_3153202","Presidente Juscelino","3153202","base.state_br_mg","base.br"
-"city_3153301","Presidente Kubitschek","3153301","base.state_br_mg","base.br"
-"city_3153400","Presidente Olegário","3153400","base.state_br_mg","base.br"
-"city_3153608","Prudente de Morais","3153608","base.state_br_mg","base.br"
-"city_3153707","Quartel Geral","3153707","base.state_br_mg","base.br"
-"city_3153806","Queluzito","3153806","base.state_br_mg","base.br"
-"city_3153905","Raposos","3153905","base.state_br_mg","base.br"
-"city_3154002","Raul Soares","3154002","base.state_br_mg","base.br"
-"city_3154101","Recreio","3154101","base.state_br_mg","base.br"
-"city_3154150","Reduto","3154150","base.state_br_mg","base.br"
-"city_3154200","Resende Costa","3154200","base.state_br_mg","base.br"
-"city_3154309","Resplendor","3154309","base.state_br_mg","base.br"
-"city_3154408","Ressaquinha","3154408","base.state_br_mg","base.br"
-"city_3154457","Riachinho","3154457","base.state_br_mg","base.br"
-"city_3154507","Riacho dos Machados","3154507","base.state_br_mg","base.br"
-"city_3154606","Ribeirão das Neves","3154606","base.state_br_mg","base.br"
-"city_3154705","Ribeirão Vermelho","3154705","base.state_br_mg","base.br"
-"city_3154804","Rio Acima","3154804","base.state_br_mg","base.br"
-"city_3154903","Rio Casca","3154903","base.state_br_mg","base.br"
-"city_3155108","Rio do Prado","3155108","base.state_br_mg","base.br"
-"city_3155009","Rio Doce","3155009","base.state_br_mg","base.br"
-"city_3155207","Rio Espera","3155207","base.state_br_mg","base.br"
-"city_3155306","Rio Manso","3155306","base.state_br_mg","base.br"
-"city_3155405","Rio Novo","3155405","base.state_br_mg","base.br"
-"city_3155504","Rio Paranaíba","3155504","base.state_br_mg","base.br"
-"city_3155603","Rio Pardo de Minas","3155603","base.state_br_mg","base.br"
-"city_3155702","Rio Piracicaba","3155702","base.state_br_mg","base.br"
-"city_3155801","Rio Pomba","3155801","base.state_br_mg","base.br"
-"city_3155900","Rio Preto","3155900","base.state_br_mg","base.br"
-"city_3156007","Rio Vermelho","3156007","base.state_br_mg","base.br"
-"city_3156106","Ritápolis","3156106","base.state_br_mg","base.br"
-"city_3156205","Rochedo de Minas","3156205","base.state_br_mg","base.br"
-"city_3156304","Rodeiro","3156304","base.state_br_mg","base.br"
-"city_3156403","Romaria","3156403","base.state_br_mg","base.br"
-"city_3156452","Rosário da Limeira","3156452","base.state_br_mg","base.br"
-"city_3156502","Rubelita","3156502","base.state_br_mg","base.br"
-"city_3156601","Rubim","3156601","base.state_br_mg","base.br"
-"city_3156700","Sabará","3156700","base.state_br_mg","base.br"
-"city_3156809","Sabinópolis","3156809","base.state_br_mg","base.br"
-"city_3156908","Sacramento","3156908","base.state_br_mg","base.br"
-"city_3157005","Salinas","3157005","base.state_br_mg","base.br"
-"city_3157104","Salto da Divisa","3157104","base.state_br_mg","base.br"
-"city_3157203","Santa Bárbara","3157203","base.state_br_mg","base.br"
-"city_3157252","Santa Bárbara do Leste","3157252","base.state_br_mg","base.br"
-"city_3157278","Santa Bárbara do Monte Verde","3157278","base.state_br_mg","base.br"
-"city_3157302","Santa Bárbara do Tugúrio","3157302","base.state_br_mg","base.br"
-"city_3157336","Santa Cruz de Minas","3157336","base.state_br_mg","base.br"
-"city_3157377","Santa Cruz de Salinas","3157377","base.state_br_mg","base.br"
-"city_3157401","Santa Cruz do Escalvado","3157401","base.state_br_mg","base.br"
-"city_3157500","Santa Efigênia de Minas","3157500","base.state_br_mg","base.br"
-"city_3157609","Santa Fé de Minas","3157609","base.state_br_mg","base.br"
-"city_3157658","Santa Helena de Minas","3157658","base.state_br_mg","base.br"
-"city_3157708","Santa Juliana","3157708","base.state_br_mg","base.br"
-"city_3157807","Santa Luzia","3157807","base.state_br_mg","base.br"
-"city_3157906","Santa Margarida","3157906","base.state_br_mg","base.br"
-"city_3158003","Santa Maria de Itabira","3158003","base.state_br_mg","base.br"
-"city_3158102","Santa Maria do Salto","3158102","base.state_br_mg","base.br"
-"city_3158201","Santa Maria do Suaçuí","3158201","base.state_br_mg","base.br"
-"city_3159209","Santa Rita de Caldas","3159209","base.state_br_mg","base.br"
-"city_3159407","Santa Rita de Ibitipoca","3159407","base.state_br_mg","base.br"
-"city_3159308","Santa Rita de Jacutinga","3159308","base.state_br_mg","base.br"
-"city_3159357","Santa Rita de Minas","3159357","base.state_br_mg","base.br"
-"city_3159506","Santa Rita do Itueto","3159506","base.state_br_mg","base.br"
-"city_3159605","Santa Rita do Sapucaí","3159605","base.state_br_mg","base.br"
-"city_3159704","Santa Rosa da Serra","3159704","base.state_br_mg","base.br"
-"city_3159803","Santa Vitória","3159803","base.state_br_mg","base.br"
-"city_3158300","Santana da Vargem","3158300","base.state_br_mg","base.br"
-"city_3158409","Santana de Cataguases","3158409","base.state_br_mg","base.br"
-"city_3158508","Santana de Pirapama","3158508","base.state_br_mg","base.br"
-"city_3158607","Santana do Deserto","3158607","base.state_br_mg","base.br"
-"city_3158706","Santana do Garambéu","3158706","base.state_br_mg","base.br"
-"city_3158805","Santana do Jacaré","3158805","base.state_br_mg","base.br"
-"city_3158904","Santana do Manhuaçu","3158904","base.state_br_mg","base.br"
-"city_3158953","Santana do Paraíso","3158953","base.state_br_mg","base.br"
-"city_3159001","Santana do Riacho","3159001","base.state_br_mg","base.br"
-"city_3159100","Santana dos Montes","3159100","base.state_br_mg","base.br"
-"city_3159902","Santo Antônio do Amparo","3159902","base.state_br_mg","base.br"
-"city_3160009","Santo Antônio do Aventureiro","3160009","base.state_br_mg","base.br"
-"city_3160108","Santo Antônio do Grama","3160108","base.state_br_mg","base.br"
-"city_3160207","Santo Antônio do Itambé","3160207","base.state_br_mg","base.br"
-"city_3160306","Santo Antônio do Jacinto","3160306","base.state_br_mg","base.br"
-"city_3160405","Santo Antônio do Monte","3160405","base.state_br_mg","base.br"
-"city_3160454","Santo Antônio do Retiro","3160454","base.state_br_mg","base.br"
-"city_3160504","Santo Antônio do Rio Abaixo","3160504","base.state_br_mg","base.br"
-"city_3160603","Santo Hipólito","3160603","base.state_br_mg","base.br"
-"city_3160702","Santos Dumont","3160702","base.state_br_mg","base.br"
-"city_3160801","São Bento Abade","3160801","base.state_br_mg","base.br"
-"city_3160900","São Brás do Suaçuí","3160900","base.state_br_mg","base.br"
-"city_3160959","São Domingos das Dores","3160959","base.state_br_mg","base.br"
-"city_3161007","São Domingos do Prata","3161007","base.state_br_mg","base.br"
-"city_3161056","São Félix de Minas","3161056","base.state_br_mg","base.br"
-"city_3161106","São Francisco","3161106","base.state_br_mg","base.br"
-"city_3161205","São Francisco de Paula","3161205","base.state_br_mg","base.br"
-"city_3161304","São Francisco de Sales","3161304","base.state_br_mg","base.br"
-"city_3161403","São Francisco do Glória","3161403","base.state_br_mg","base.br"
-"city_3161502","São Geraldo","3161502","base.state_br_mg","base.br"
-"city_3161601","São Geraldo da Piedade","3161601","base.state_br_mg","base.br"
-"city_3161650","São Geraldo do Baixio","3161650","base.state_br_mg","base.br"
-"city_3161700","São Gonçalo do Abaeté","3161700","base.state_br_mg","base.br"
-"city_3161809","São Gonçalo do Pará","3161809","base.state_br_mg","base.br"
-"city_3161908","São Gonçalo do Rio Abaixo","3161908","base.state_br_mg","base.br"
-"city_3125507","São Gonçalo do Rio Preto","3125507","base.state_br_mg","base.br"
-"city_3162005","São Gonçalo do Sapucaí","3162005","base.state_br_mg","base.br"
-"city_3162104","São Gotardo","3162104","base.state_br_mg","base.br"
-"city_3162203","São João Batista do Glória","3162203","base.state_br_mg","base.br"
-"city_3162252","São João da Lagoa","3162252","base.state_br_mg","base.br"
-"city_3162302","São João da Mata","3162302","base.state_br_mg","base.br"
-"city_3162401","São João da Ponte","3162401","base.state_br_mg","base.br"
-"city_3162450","São João das Missões","3162450","base.state_br_mg","base.br"
-"city_3162500","São João del Rei","3162500","base.state_br_mg","base.br"
-"city_3162559","São João do Manhuaçu","3162559","base.state_br_mg","base.br"
-"city_3162575","São João do Manteninha","3162575","base.state_br_mg","base.br"
-"city_3162609","São João do Oriente","3162609","base.state_br_mg","base.br"
-"city_3162658","São João do Pacuí","3162658","base.state_br_mg","base.br"
-"city_3162708","São João do Paraíso","3162708","base.state_br_mg","base.br"
-"city_3162807","São João Evangelista","3162807","base.state_br_mg","base.br"
-"city_3162906","São João Nepomuceno","3162906","base.state_br_mg","base.br"
-"city_3162922","São Joaquim de Bicas","3162922","base.state_br_mg","base.br"
-"city_3162948","São José da Barra","3162948","base.state_br_mg","base.br"
-"city_3162955","São José da Lapa","3162955","base.state_br_mg","base.br"
-"city_3163003","São José da Safira","3163003","base.state_br_mg","base.br"
-"city_3163102","São José da Varginha","3163102","base.state_br_mg","base.br"
-"city_3163201","São José do Alegre","3163201","base.state_br_mg","base.br"
-"city_3163300","São José do Divino","3163300","base.state_br_mg","base.br"
-"city_3163409","São José do Goiabal","3163409","base.state_br_mg","base.br"
-"city_3163508","São José do Jacuri","3163508","base.state_br_mg","base.br"
-"city_3163607","São José do Mantimento","3163607","base.state_br_mg","base.br"
-"city_3163706","São Lourenço","3163706","base.state_br_mg","base.br"
-"city_3163805","São Miguel do Anta","3163805","base.state_br_mg","base.br"
-"city_3163904","São Pedro da União","3163904","base.state_br_mg","base.br"
-"city_3164100","São Pedro do Suaçuí","3164100","base.state_br_mg","base.br"
-"city_3164001","São Pedro dos Ferros","3164001","base.state_br_mg","base.br"
-"city_3164209","São Romão","3164209","base.state_br_mg","base.br"
-"city_3164308","São Roque de Minas","3164308","base.state_br_mg","base.br"
-"city_3164407","São Sebastião da Bela Vista","3164407","base.state_br_mg","base.br"
-"city_3164431","São Sebastião da Vargem Alegre","3164431","base.state_br_mg","base.br"
-"city_3164472","São Sebastião do Anta","3164472","base.state_br_mg","base.br"
-"city_3164506","São Sebastião do Maranhão","3164506","base.state_br_mg","base.br"
-"city_3164605","São Sebastião do Oeste","3164605","base.state_br_mg","base.br"
-"city_3164704","São Sebastião do Paraíso","3164704","base.state_br_mg","base.br"
-"city_3164803","São Sebastião do Rio Preto","3164803","base.state_br_mg","base.br"
-"city_3164902","São Sebastião do Rio Verde","3164902","base.state_br_mg","base.br"
-"city_3165008","São Tiago","3165008","base.state_br_mg","base.br"
-"city_3165107","São Tomás de Aquino","3165107","base.state_br_mg","base.br"
-"city_3165206","São Tomé das Letras","3165206","base.state_br_mg","base.br"
-"city_3165305","São Vicente de Minas","3165305","base.state_br_mg","base.br"
-"city_3165404","Sapucaí-Mirim","3165404","base.state_br_mg","base.br"
-"city_3165503","Sardoá","3165503","base.state_br_mg","base.br"
-"city_3165537","Sarzedo","3165537","base.state_br_mg","base.br"
-"city_3165560","Sem-Peixe","3165560","base.state_br_mg","base.br"
-"city_3165578","Senador Amaral","3165578","base.state_br_mg","base.br"
-"city_3165602","Senador Cortes","3165602","base.state_br_mg","base.br"
-"city_3165701","Senador Firmino","3165701","base.state_br_mg","base.br"
-"city_3165800","Senador José Bento","3165800","base.state_br_mg","base.br"
-"city_3165909","Senador Modestino Gonçalves","3165909","base.state_br_mg","base.br"
-"city_3166006","Senhora de Oliveira","3166006","base.state_br_mg","base.br"
-"city_3166105","Senhora do Porto","3166105","base.state_br_mg","base.br"
-"city_3166204","Senhora dos Remédios","3166204","base.state_br_mg","base.br"
-"city_3166303","Sericita","3166303","base.state_br_mg","base.br"
-"city_3166402","Seritinga","3166402","base.state_br_mg","base.br"
-"city_3166501","Serra Azul de Minas","3166501","base.state_br_mg","base.br"
-"city_3166600","Serra da Saudade","3166600","base.state_br_mg","base.br"
-"city_3166808","Serra do Salitre","3166808","base.state_br_mg","base.br"
-"city_3166709","Serra dos Aimorés","3166709","base.state_br_mg","base.br"
-"city_3166907","Serrania","3166907","base.state_br_mg","base.br"
-"city_3166956","Serranópolis de Minas","3166956","base.state_br_mg","base.br"
-"city_3167004","Serranos","3167004","base.state_br_mg","base.br"
-"city_3167103","Serro","3167103","base.state_br_mg","base.br"
-"city_3167202","Sete Lagoas","3167202","base.state_br_mg","base.br"
-"city_3165552","Setubinha","3165552","base.state_br_mg","base.br"
-"city_3167301","Silveirânia","3167301","base.state_br_mg","base.br"
-"city_3167400","Silvianópolis","3167400","base.state_br_mg","base.br"
-"city_3167509","Simão Pereira","3167509","base.state_br_mg","base.br"
-"city_3167608","Simonésia","3167608","base.state_br_mg","base.br"
-"city_3167707","Sobrália","3167707","base.state_br_mg","base.br"
-"city_3167806","Soledade de Minas","3167806","base.state_br_mg","base.br"
-"city_3167905","Tabuleiro","3167905","base.state_br_mg","base.br"
-"city_3168002","Taiobeiras","3168002","base.state_br_mg","base.br"
-"city_3168051","Taparuba","3168051","base.state_br_mg","base.br"
-"city_3168101","Tapira","3168101","base.state_br_mg","base.br"
-"city_3168200","Tapiraí","3168200","base.state_br_mg","base.br"
-"city_3168309","Taquaraçu de Minas","3168309","base.state_br_mg","base.br"
-"city_3168408","Tarumirim","3168408","base.state_br_mg","base.br"
-"city_3168507","Teixeiras","3168507","base.state_br_mg","base.br"
-"city_3168606","Teófilo Otoni","3168606","base.state_br_mg","base.br"
-"city_3168705","Timóteo","3168705","base.state_br_mg","base.br"
-"city_3168804","Tiradentes","3168804","base.state_br_mg","base.br"
-"city_3168903","Tiros","3168903","base.state_br_mg","base.br"
-"city_3169000","Tocantins","3169000","base.state_br_mg","base.br"
-"city_3169059","Tocos do Moji","3169059","base.state_br_mg","base.br"
-"city_3169109","Toledo","3169109","base.state_br_mg","base.br"
-"city_3169208","Tombos","3169208","base.state_br_mg","base.br"
-"city_3169307","Três Corações","3169307","base.state_br_mg","base.br"
-"city_3169356","Três Marias","3169356","base.state_br_mg","base.br"
-"city_3169406","Três Pontas","3169406","base.state_br_mg","base.br"
-"city_3169505","Tumiritinga","3169505","base.state_br_mg","base.br"
-"city_3169604","Tupaciguara","3169604","base.state_br_mg","base.br"
-"city_3169703","Turmalina","3169703","base.state_br_mg","base.br"
-"city_3169802","Turvolândia","3169802","base.state_br_mg","base.br"
-"city_3169901","Ubá","3169901","base.state_br_mg","base.br"
-"city_3170008","Ubaí","3170008","base.state_br_mg","base.br"
-"city_3170057","Ubaporanga","3170057","base.state_br_mg","base.br"
-"city_3170107","Uberaba","3170107","base.state_br_mg","base.br"
-"city_3170206","Uberlândia","3170206","base.state_br_mg","base.br"
-"city_3170305","Umburatiba","3170305","base.state_br_mg","base.br"
-"city_3170404","Unaí","3170404","base.state_br_mg","base.br"
-"city_3170438","União de Minas","3170438","base.state_br_mg","base.br"
-"city_3170479","Uruana de Minas","3170479","base.state_br_mg","base.br"
-"city_3170503","Urucânia","3170503","base.state_br_mg","base.br"
-"city_3170529","Urucuia","3170529","base.state_br_mg","base.br"
-"city_3170578","Vargem Alegre","3170578","base.state_br_mg","base.br"
-"city_3170602","Vargem Bonita","3170602","base.state_br_mg","base.br"
-"city_3170651","Vargem Grande do Rio Pardo","3170651","base.state_br_mg","base.br"
-"city_3170701","Varginha","3170701","base.state_br_mg","base.br"
-"city_3170750","Varjão de Minas","3170750","base.state_br_mg","base.br"
-"city_3170800","Várzea da Palma","3170800","base.state_br_mg","base.br"
-"city_3170909","Varzelândia","3170909","base.state_br_mg","base.br"
-"city_3171006","Vazante","3171006","base.state_br_mg","base.br"
-"city_3171030","Verdelândia","3171030","base.state_br_mg","base.br"
-"city_3171071","Veredinha","3171071","base.state_br_mg","base.br"
-"city_3171105","Veríssimo","3171105","base.state_br_mg","base.br"
-"city_3171154","Vermelho Novo","3171154","base.state_br_mg","base.br"
-"city_3171204","Vespasiano","3171204","base.state_br_mg","base.br"
-"city_3171303","Viçosa","3171303","base.state_br_mg","base.br"
-"city_3171402","Vieiras","3171402","base.state_br_mg","base.br"
-"city_3171600","Virgem da Lapa","3171600","base.state_br_mg","base.br"
-"city_3171709","Virgínia","3171709","base.state_br_mg","base.br"
-"city_3171808","Virginópolis","3171808","base.state_br_mg","base.br"
-"city_3171907","Virgolândia","3171907","base.state_br_mg","base.br"
-"city_3172004","Visconde do Rio Branco","3172004","base.state_br_mg","base.br"
-"city_3172103","Volta Grande","3172103","base.state_br_mg","base.br"
-"city_3172202","Wenceslau Braz","3172202","base.state_br_mg","base.br"
-"city_3200102","Afonso Cláudio","3200102","base.state_br_es","base.br"
-"city_3200169","Água Doce do Norte","3200169","base.state_br_es","base.br"
-"city_3200136","Águia Branca","3200136","base.state_br_es","base.br"
-"city_3200201","Alegre","3200201","base.state_br_es","base.br"
-"city_3200300","Alfredo Chaves","3200300","base.state_br_es","base.br"
-"city_3200359","Alto Rio Novo","3200359","base.state_br_es","base.br"
-"city_3200409","Anchieta","3200409","base.state_br_es","base.br"
-"city_3200508","Apiacá","3200508","base.state_br_es","base.br"
-"city_3200607","Aracruz","3200607","base.state_br_es","base.br"
-"city_3200706","Atílio Vivácqua","3200706","base.state_br_es","base.br"
-"city_3200805","Baixo Guandu","3200805","base.state_br_es","base.br"
-"city_3200904","Barra de São Francisco","3200904","base.state_br_es","base.br"
-"city_3201001","Boa Esperança","3201001","base.state_br_es","base.br"
-"city_3201100","Bom Jesus do Norte","3201100","base.state_br_es","base.br"
-"city_3201159","Brejetuba","3201159","base.state_br_es","base.br"
-"city_3201209","Cachoeiro de Itapemirim","3201209","base.state_br_es","base.br"
-"city_3201308","Cariacica","3201308","base.state_br_es","base.br"
-"city_3201407","Castelo","3201407","base.state_br_es","base.br"
-"city_3201506","Colatina","3201506","base.state_br_es","base.br"
-"city_3201605","Conceição da Barra","3201605","base.state_br_es","base.br"
-"city_3201704","Conceição do Castelo","3201704","base.state_br_es","base.br"
-"city_3201803","Divino de São Lourenço","3201803","base.state_br_es","base.br"
-"city_3201902","Domingos Martins","3201902","base.state_br_es","base.br"
-"city_3202009","Dores do Rio Preto","3202009","base.state_br_es","base.br"
-"city_3202108","Ecoporanga","3202108","base.state_br_es","base.br"
-"city_3202207","Fundão","3202207","base.state_br_es","base.br"
-"city_3202256","Governador Lindenberg","3202256","base.state_br_es","base.br"
-"city_3202306","Guaçuí","3202306","base.state_br_es","base.br"
-"city_3202405","Guarapari","3202405","base.state_br_es","base.br"
-"city_3202454","Ibatiba","3202454","base.state_br_es","base.br"
-"city_3202504","Ibiraçu","3202504","base.state_br_es","base.br"
-"city_3202553","Ibitirama","3202553","base.state_br_es","base.br"
-"city_3202603","Iconha","3202603","base.state_br_es","base.br"
-"city_3202652","Irupi","3202652","base.state_br_es","base.br"
-"city_3202702","Itaguaçu","3202702","base.state_br_es","base.br"
-"city_3202801","Itapemirim","3202801","base.state_br_es","base.br"
-"city_3202900","Itarana","3202900","base.state_br_es","base.br"
-"city_3203007","Iúna","3203007","base.state_br_es","base.br"
-"city_3203056","Jaguaré","3203056","base.state_br_es","base.br"
-"city_3203106","Jerônimo Monteiro","3203106","base.state_br_es","base.br"
-"city_3203130","João Neiva","3203130","base.state_br_es","base.br"
-"city_3203163","Laranja da Terra","3203163","base.state_br_es","base.br"
-"city_3203205","Linhares","3203205","base.state_br_es","base.br"
-"city_3203304","Mantenópolis","3203304","base.state_br_es","base.br"
-"city_3203320","Marataízes","3203320","base.state_br_es","base.br"
-"city_3203346","Marechal Floriano","3203346","base.state_br_es","base.br"
-"city_3203353","Marilândia","3203353","base.state_br_es","base.br"
-"city_3203403","Mimoso do Sul","3203403","base.state_br_es","base.br"
-"city_3203502","Montanha","3203502","base.state_br_es","base.br"
-"city_3203601","Mucurici","3203601","base.state_br_es","base.br"
-"city_3203700","Muniz Freire","3203700","base.state_br_es","base.br"
-"city_3203809","Muqui","3203809","base.state_br_es","base.br"
-"city_3203908","Nova Venécia","3203908","base.state_br_es","base.br"
-"city_3204005","Pancas","3204005","base.state_br_es","base.br"
-"city_3204054","Pedro Canário","3204054","base.state_br_es","base.br"
-"city_3204104","Pinheiros","3204104","base.state_br_es","base.br"
-"city_3204203","Piúma","3204203","base.state_br_es","base.br"
-"city_3204252","Ponto Belo","3204252","base.state_br_es","base.br"
-"city_3204302","Presidente Kennedy","3204302","base.state_br_es","base.br"
-"city_3204351","Rio Bananal","3204351","base.state_br_es","base.br"
-"city_3204401","Rio Novo do Sul","3204401","base.state_br_es","base.br"
-"city_3204500","Santa Leopoldina","3204500","base.state_br_es","base.br"
-"city_3204559","Santa Maria de Jetibá","3204559","base.state_br_es","base.br"
-"city_3204609","Santa Teresa","3204609","base.state_br_es","base.br"
-"city_3204658","São Domingos do Norte","3204658","base.state_br_es","base.br"
-"city_3204708","São Gabriel da Palha","3204708","base.state_br_es","base.br"
-"city_3204807","São José do Calçado","3204807","base.state_br_es","base.br"
-"city_3204906","São Mateus","3204906","base.state_br_es","base.br"
-"city_3204955","São Roque do Canaã","3204955","base.state_br_es","base.br"
-"city_3205002","Serra","3205002","base.state_br_es","base.br"
-"city_3205010","Sooretama","3205010","base.state_br_es","base.br"
-"city_3205036","Vargem Alta","3205036","base.state_br_es","base.br"
-"city_3205069","Venda Nova do Imigrante","3205069","base.state_br_es","base.br"
-"city_3205101","Viana","3205101","base.state_br_es","base.br"
-"city_3205150","Vila Pavão","3205150","base.state_br_es","base.br"
-"city_3205176","Vila Valério","3205176","base.state_br_es","base.br"
-"city_3205200","Vila Velha","3205200","base.state_br_es","base.br"
-"city_3205309","Vitória","3205309","base.state_br_es","base.br"
-"city_3300100","Angra dos Reis","3300100","base.state_br_rj","base.br"
-"city_3300159","Aperibé","3300159","base.state_br_rj","base.br"
-"city_3300209","Araruama","3300209","base.state_br_rj","base.br"
-"city_3300225","Areal","3300225","base.state_br_rj","base.br"
-"city_3300233","Armação dos Búzios","3300233","base.state_br_rj","base.br"
-"city_3300258","Arraial do Cabo","3300258","base.state_br_rj","base.br"
-"city_3300308","Barra do Piraí","3300308","base.state_br_rj","base.br"
-"city_3300407","Barra Mansa","3300407","base.state_br_rj","base.br"
-"city_3300456","Belford Roxo","3300456","base.state_br_rj","base.br"
-"city_3300506","Bom Jardim","3300506","base.state_br_rj","base.br"
-"city_3300605","Bom Jesus do Itabapoana","3300605","base.state_br_rj","base.br"
-"city_3300704","Cabo Frio","3300704","base.state_br_rj","base.br"
-"city_3300803","Cachoeiras de Macacu","3300803","base.state_br_rj","base.br"
-"city_3300902","Cambuci","3300902","base.state_br_rj","base.br"
-"city_3301009","Campos dos Goytacazes","3301009","base.state_br_rj","base.br"
-"city_3301108","Cantagalo","3301108","base.state_br_rj","base.br"
-"city_3300936","Carapebus","3300936","base.state_br_rj","base.br"
-"city_3301157","Cardoso Moreira","3301157","base.state_br_rj","base.br"
-"city_3301207","Carmo","3301207","base.state_br_rj","base.br"
-"city_3301306","Casimiro de Abreu","3301306","base.state_br_rj","base.br"
-"city_3300951","Comendador Levy Gasparian","3300951","base.state_br_rj","base.br"
-"city_3301405","Conceição de Macabu","3301405","base.state_br_rj","base.br"
-"city_3301504","Cordeiro","3301504","base.state_br_rj","base.br"
-"city_3301603","Duas Barras","3301603","base.state_br_rj","base.br"
-"city_3301702","Duque de Caxias","3301702","base.state_br_rj","base.br"
-"city_3301801","Engenheiro Paulo de Frontin","3301801","base.state_br_rj","base.br"
-"city_3301850","Guapimirim","3301850","base.state_br_rj","base.br"
-"city_3301876","Iguaba Grande","3301876","base.state_br_rj","base.br"
-"city_3301900","Itaboraí","3301900","base.state_br_rj","base.br"
-"city_3302007","Itaguaí","3302007","base.state_br_rj","base.br"
-"city_3302056","Italva","3302056","base.state_br_rj","base.br"
-"city_3302106","Itaocara","3302106","base.state_br_rj","base.br"
-"city_3302205","Itaperuna","3302205","base.state_br_rj","base.br"
-"city_3302254","Itatiaia","3302254","base.state_br_rj","base.br"
-"city_3302270","Japeri","3302270","base.state_br_rj","base.br"
-"city_3302304","Laje do Muriaé","3302304","base.state_br_rj","base.br"
-"city_3302403","Macaé","3302403","base.state_br_rj","base.br"
-"city_3302452","Macuco","3302452","base.state_br_rj","base.br"
-"city_3302502","Magé","3302502","base.state_br_rj","base.br"
-"city_3302601","Mangaratiba","3302601","base.state_br_rj","base.br"
-"city_3302700","Maricá","3302700","base.state_br_rj","base.br"
-"city_3302809","Mendes","3302809","base.state_br_rj","base.br"
-"city_3302858","Mesquita","3302858","base.state_br_rj","base.br"
-"city_3302908","Miguel Pereira","3302908","base.state_br_rj","base.br"
-"city_3303005","Miracema","3303005","base.state_br_rj","base.br"
-"city_3303104","Natividade","3303104","base.state_br_rj","base.br"
-"city_3303203","Nilópolis","3303203","base.state_br_rj","base.br"
-"city_3303302","Niterói","3303302","base.state_br_rj","base.br"
-"city_3303401","Nova Friburgo","3303401","base.state_br_rj","base.br"
-"city_3303500","Nova Iguaçu","3303500","base.state_br_rj","base.br"
-"city_3303609","Paracambi","3303609","base.state_br_rj","base.br"
-"city_3303708","Paraíba do Sul","3303708","base.state_br_rj","base.br"
-"city_3303807","Paraty","3303807","base.state_br_rj","base.br"
-"city_3303856","Paty do Alferes","3303856","base.state_br_rj","base.br"
-"city_3303906","Petrópolis","3303906","base.state_br_rj","base.br"
-"city_3303955","Pinheiral","3303955","base.state_br_rj","base.br"
-"city_3304003","Piraí","3304003","base.state_br_rj","base.br"
-"city_3304102","Porciúncula","3304102","base.state_br_rj","base.br"
-"city_3304110","Porto Real","3304110","base.state_br_rj","base.br"
-"city_3304128","Quatis","3304128","base.state_br_rj","base.br"
-"city_3304144","Queimados","3304144","base.state_br_rj","base.br"
-"city_3304151","Quissamã","3304151","base.state_br_rj","base.br"
-"city_3304201","Resende","3304201","base.state_br_rj","base.br"
-"city_3304300","Rio Bonito","3304300","base.state_br_rj","base.br"
-"city_3304409","Rio Claro","3304409","base.state_br_rj","base.br"
-"city_3304508","Rio das Flores","3304508","base.state_br_rj","base.br"
-"city_3304524","Rio das Ostras","3304524","base.state_br_rj","base.br"
-"city_3304557","Rio de Janeiro","3304557","base.state_br_rj","base.br"
-"city_3304607","Santa Maria Madalena","3304607","base.state_br_rj","base.br"
-"city_3304706","Santo Antônio de Pádua","3304706","base.state_br_rj","base.br"
-"city_3304805","São Fidélis","3304805","base.state_br_rj","base.br"
-"city_3304755","São Francisco de Itabapoana","3304755","base.state_br_rj","base.br"
-"city_3304904","São Gonçalo","3304904","base.state_br_rj","base.br"
-"city_3305000","São João da Barra","3305000","base.state_br_rj","base.br"
-"city_3305109","São João de Meriti","3305109","base.state_br_rj","base.br"
-"city_3305133","São José de Ubá","3305133","base.state_br_rj","base.br"
-"city_3305158","São José do Vale do Rio Preto","3305158","base.state_br_rj","base.br"
-"city_3305208","São Pedro da Aldeia","3305208","base.state_br_rj","base.br"
-"city_3305307","São Sebastião do Alto","3305307","base.state_br_rj","base.br"
-"city_3305406","Sapucaia","3305406","base.state_br_rj","base.br"
-"city_3305505","Saquarema","3305505","base.state_br_rj","base.br"
-"city_3305554","Seropédica","3305554","base.state_br_rj","base.br"
-"city_3305604","Silva Jardim","3305604","base.state_br_rj","base.br"
-"city_3305703","Sumidouro","3305703","base.state_br_rj","base.br"
-"city_3305752","Tanguá","3305752","base.state_br_rj","base.br"
-"city_3305802","Teresópolis","3305802","base.state_br_rj","base.br"
-"city_3305901","Trajano de Moraes","3305901","base.state_br_rj","base.br"
-"city_3306008","Três Rios","3306008","base.state_br_rj","base.br"
-"city_3306107","Valença","3306107","base.state_br_rj","base.br"
-"city_3306156","Varre-Sai","3306156","base.state_br_rj","base.br"
-"city_3306206","Vassouras","3306206","base.state_br_rj","base.br"
-"city_3306305","Volta Redonda","3306305","base.state_br_rj","base.br"
-"city_3500105","Adamantina","3500105","base.state_br_sp","base.br"
-"city_3500204","Adolfo","3500204","base.state_br_sp","base.br"
-"city_3500303","Aguaí","3500303","base.state_br_sp","base.br"
-"city_3500402","Águas da Prata","3500402","base.state_br_sp","base.br"
-"city_3500501","Águas de Lindóia","3500501","base.state_br_sp","base.br"
-"city_3500550","Águas de Santa Bárbara","3500550","base.state_br_sp","base.br"
-"city_3500600","Águas de São Pedro","3500600","base.state_br_sp","base.br"
-"city_3500709","Agudos","3500709","base.state_br_sp","base.br"
-"city_3500758","Alambari","3500758","base.state_br_sp","base.br"
-"city_3500808","Alfredo Marcondes","3500808","base.state_br_sp","base.br"
-"city_3500907","Altair","3500907","base.state_br_sp","base.br"
-"city_3501004","Altinópolis","3501004","base.state_br_sp","base.br"
-"city_3501103","Alto Alegre","3501103","base.state_br_sp","base.br"
-"city_3501152","Alumínio","3501152","base.state_br_sp","base.br"
-"city_3501202","Álvares Florence","3501202","base.state_br_sp","base.br"
-"city_3501301","Álvares Machado","3501301","base.state_br_sp","base.br"
-"city_3501400","Álvaro de Carvalho","3501400","base.state_br_sp","base.br"
-"city_3501509","Alvinlândia","3501509","base.state_br_sp","base.br"
-"city_3501608","Americana","3501608","base.state_br_sp","base.br"
-"city_3501707","Américo Brasiliense","3501707","base.state_br_sp","base.br"
-"city_3501806","Américo de Campos","3501806","base.state_br_sp","base.br"
-"city_3501905","Amparo","3501905","base.state_br_sp","base.br"
-"city_3502002","Analândia","3502002","base.state_br_sp","base.br"
-"city_3502101","Andradina","3502101","base.state_br_sp","base.br"
-"city_3502200","Angatuba","3502200","base.state_br_sp","base.br"
-"city_3502309","Anhembi","3502309","base.state_br_sp","base.br"
-"city_3502408","Anhumas","3502408","base.state_br_sp","base.br"
-"city_3502507","Aparecida","3502507","base.state_br_sp","base.br"
-"city_3502606","Aparecida d'Oeste","3502606","base.state_br_sp","base.br"
-"city_3502705","Apiaí","3502705","base.state_br_sp","base.br"
-"city_3502754","Araçariguama","3502754","base.state_br_sp","base.br"
-"city_3502804","Araçatuba","3502804","base.state_br_sp","base.br"
-"city_3502903","Araçoiaba da Serra","3502903","base.state_br_sp","base.br"
-"city_3503000","Aramina","3503000","base.state_br_sp","base.br"
-"city_3503109","Arandu","3503109","base.state_br_sp","base.br"
-"city_3503158","Arapeí","3503158","base.state_br_sp","base.br"
-"city_3503208","Araraquara","3503208","base.state_br_sp","base.br"
-"city_3503307","Araras","3503307","base.state_br_sp","base.br"
-"city_3503356","Arco-Íris","3503356","base.state_br_sp","base.br"
-"city_3503406","Arealva","3503406","base.state_br_sp","base.br"
-"city_3503505","Areias","3503505","base.state_br_sp","base.br"
-"city_3503604","Areiópolis","3503604","base.state_br_sp","base.br"
-"city_3503703","Ariranha","3503703","base.state_br_sp","base.br"
-"city_3503802","Artur Nogueira","3503802","base.state_br_sp","base.br"
-"city_3503901","Arujá","3503901","base.state_br_sp","base.br"
-"city_3503950","Aspásia","3503950","base.state_br_sp","base.br"
-"city_3504008","Assis","3504008","base.state_br_sp","base.br"
-"city_3504107","Atibaia","3504107","base.state_br_sp","base.br"
-"city_3504206","Auriflama","3504206","base.state_br_sp","base.br"
-"city_3504305","Avaí","3504305","base.state_br_sp","base.br"
-"city_3504404","Avanhandava","3504404","base.state_br_sp","base.br"
-"city_3504503","Avaré","3504503","base.state_br_sp","base.br"
-"city_3504602","Bady Bassitt","3504602","base.state_br_sp","base.br"
-"city_3504701","Balbinos","3504701","base.state_br_sp","base.br"
-"city_3504800","Bálsamo","3504800","base.state_br_sp","base.br"
-"city_3504909","Bananal","3504909","base.state_br_sp","base.br"
-"city_3505005","Barão de Antonina","3505005","base.state_br_sp","base.br"
-"city_3505104","Barbosa","3505104","base.state_br_sp","base.br"
-"city_3505203","Bariri","3505203","base.state_br_sp","base.br"
-"city_3505302","Barra Bonita","3505302","base.state_br_sp","base.br"
-"city_3505351","Barra do Chapéu","3505351","base.state_br_sp","base.br"
-"city_3505401","Barra do Turvo","3505401","base.state_br_sp","base.br"
-"city_3505500","Barretos","3505500","base.state_br_sp","base.br"
-"city_3505609","Barrinha","3505609","base.state_br_sp","base.br"
-"city_3505708","Barueri","3505708","base.state_br_sp","base.br"
-"city_3505807","Bastos","3505807","base.state_br_sp","base.br"
-"city_3505906","Batatais","3505906","base.state_br_sp","base.br"
-"city_3506003","Bauru","3506003","base.state_br_sp","base.br"
-"city_3506102","Bebedouro","3506102","base.state_br_sp","base.br"
-"city_3506201","Bento de Abreu","3506201","base.state_br_sp","base.br"
-"city_3506300","Bernardino de Campos","3506300","base.state_br_sp","base.br"
-"city_3506359","Bertioga","3506359","base.state_br_sp","base.br"
-"city_3506409","Bilac","3506409","base.state_br_sp","base.br"
-"city_3506508","Birigui","3506508","base.state_br_sp","base.br"
-"city_3506607","Biritiba Mirim","3506607","base.state_br_sp","base.br"
-"city_3506706","Boa Esperança do Sul","3506706","base.state_br_sp","base.br"
-"city_3506805","Bocaina","3506805","base.state_br_sp","base.br"
-"city_3506904","Bofete","3506904","base.state_br_sp","base.br"
-"city_3507001","Boituva","3507001","base.state_br_sp","base.br"
-"city_3507100","Bom Jesus dos Perdões","3507100","base.state_br_sp","base.br"
-"city_3507159","Bom Sucesso de Itararé","3507159","base.state_br_sp","base.br"
-"city_3507209","Borá","3507209","base.state_br_sp","base.br"
-"city_3507308","Boracéia","3507308","base.state_br_sp","base.br"
-"city_3507407","Borborema","3507407","base.state_br_sp","base.br"
-"city_3507456","Borebi","3507456","base.state_br_sp","base.br"
-"city_3507506","Botucatu","3507506","base.state_br_sp","base.br"
-"city_3507605","Bragança Paulista","3507605","base.state_br_sp","base.br"
-"city_3507704","Braúna","3507704","base.state_br_sp","base.br"
-"city_3507753","Brejo Alegre","3507753","base.state_br_sp","base.br"
-"city_3507803","Brodowski","3507803","base.state_br_sp","base.br"
-"city_3507902","Brotas","3507902","base.state_br_sp","base.br"
-"city_3508009","Buri","3508009","base.state_br_sp","base.br"
-"city_3508108","Buritama","3508108","base.state_br_sp","base.br"
-"city_3508207","Buritizal","3508207","base.state_br_sp","base.br"
-"city_3508306","Cabrália Paulista","3508306","base.state_br_sp","base.br"
-"city_3508405","Cabreúva","3508405","base.state_br_sp","base.br"
-"city_3508504","Caçapava","3508504","base.state_br_sp","base.br"
-"city_3508603","Cachoeira Paulista","3508603","base.state_br_sp","base.br"
-"city_3508702","Caconde","3508702","base.state_br_sp","base.br"
-"city_3508801","Cafelândia","3508801","base.state_br_sp","base.br"
-"city_3508900","Caiabu","3508900","base.state_br_sp","base.br"
-"city_3509007","Caieiras","3509007","base.state_br_sp","base.br"
-"city_3509106","Caiuá","3509106","base.state_br_sp","base.br"
-"city_3509205","Cajamar","3509205","base.state_br_sp","base.br"
-"city_3509254","Cajati","3509254","base.state_br_sp","base.br"
-"city_3509304","Cajobi","3509304","base.state_br_sp","base.br"
-"city_3509403","Cajuru","3509403","base.state_br_sp","base.br"
-"city_3509452","Campina do Monte Alegre","3509452","base.state_br_sp","base.br"
-"city_3509502","Campinas","3509502","base.state_br_sp","base.br"
-"city_3509601","Campo Limpo Paulista","3509601","base.state_br_sp","base.br"
-"city_3509700","Campos do Jordão","3509700","base.state_br_sp","base.br"
-"city_3509809","Campos Novos Paulista","3509809","base.state_br_sp","base.br"
-"city_3509908","Cananéia","3509908","base.state_br_sp","base.br"
-"city_3509957","Canas","3509957","base.state_br_sp","base.br"
-"city_3510005","Cândido Mota","3510005","base.state_br_sp","base.br"
-"city_3510104","Cândido Rodrigues","3510104","base.state_br_sp","base.br"
-"city_3510153","Canitar","3510153","base.state_br_sp","base.br"
-"city_3510203","Capão Bonito","3510203","base.state_br_sp","base.br"
-"city_3510302","Capela do Alto","3510302","base.state_br_sp","base.br"
-"city_3510401","Capivari","3510401","base.state_br_sp","base.br"
-"city_3510500","Caraguatatuba","3510500","base.state_br_sp","base.br"
-"city_3510609","Carapicuíba","3510609","base.state_br_sp","base.br"
-"city_3510708","Cardoso","3510708","base.state_br_sp","base.br"
-"city_3510807","Casa Branca","3510807","base.state_br_sp","base.br"
-"city_3510906","Cássia dos Coqueiros","3510906","base.state_br_sp","base.br"
-"city_3511003","Castilho","3511003","base.state_br_sp","base.br"
-"city_3511102","Catanduva","3511102","base.state_br_sp","base.br"
-"city_3511201","Catiguá","3511201","base.state_br_sp","base.br"
-"city_3511300","Cedral","3511300","base.state_br_sp","base.br"
-"city_3511409","Cerqueira César","3511409","base.state_br_sp","base.br"
-"city_3511508","Cerquilho","3511508","base.state_br_sp","base.br"
-"city_3511607","Cesário Lange","3511607","base.state_br_sp","base.br"
-"city_3511706","Charqueada","3511706","base.state_br_sp","base.br"
-"city_3557204","Chavantes","3557204","base.state_br_sp","base.br"
-"city_3511904","Clementina","3511904","base.state_br_sp","base.br"
-"city_3512001","Colina","3512001","base.state_br_sp","base.br"
-"city_3512100","Colômbia","3512100","base.state_br_sp","base.br"
-"city_3512209","Conchal","3512209","base.state_br_sp","base.br"
-"city_3512308","Conchas","3512308","base.state_br_sp","base.br"
-"city_3512407","Cordeirópolis","3512407","base.state_br_sp","base.br"
-"city_3512506","Coroados","3512506","base.state_br_sp","base.br"
-"city_3512605","Coronel Macedo","3512605","base.state_br_sp","base.br"
-"city_3512704","Corumbataí","3512704","base.state_br_sp","base.br"
-"city_3512803","Cosmópolis","3512803","base.state_br_sp","base.br"
-"city_3512902","Cosmorama","3512902","base.state_br_sp","base.br"
-"city_3513009","Cotia","3513009","base.state_br_sp","base.br"
-"city_3513108","Cravinhos","3513108","base.state_br_sp","base.br"
-"city_3513207","Cristais Paulista","3513207","base.state_br_sp","base.br"
-"city_3513306","Cruzália","3513306","base.state_br_sp","base.br"
-"city_3513405","Cruzeiro","3513405","base.state_br_sp","base.br"
-"city_3513504","Cubatão","3513504","base.state_br_sp","base.br"
-"city_3513603","Cunha","3513603","base.state_br_sp","base.br"
-"city_3513702","Descalvado","3513702","base.state_br_sp","base.br"
-"city_3513801","Diadema","3513801","base.state_br_sp","base.br"
-"city_3513850","Dirce Reis","3513850","base.state_br_sp","base.br"
-"city_3513900","Divinolândia","3513900","base.state_br_sp","base.br"
-"city_3514007","Dobrada","3514007","base.state_br_sp","base.br"
-"city_3514106","Dois Córregos","3514106","base.state_br_sp","base.br"
-"city_3514205","Dolcinópolis","3514205","base.state_br_sp","base.br"
-"city_3514304","Dourado","3514304","base.state_br_sp","base.br"
-"city_3514403","Dracena","3514403","base.state_br_sp","base.br"
-"city_3514502","Duartina","3514502","base.state_br_sp","base.br"
-"city_3514601","Dumont","3514601","base.state_br_sp","base.br"
-"city_3514700","Echaporã","3514700","base.state_br_sp","base.br"
-"city_3514809","Eldorado","3514809","base.state_br_sp","base.br"
-"city_3514908","Elias Fausto","3514908","base.state_br_sp","base.br"
-"city_3514924","Elisiário","3514924","base.state_br_sp","base.br"
-"city_3514957","Embaúba","3514957","base.state_br_sp","base.br"
-"city_3515004","Embu das Artes","3515004","base.state_br_sp","base.br"
-"city_3515103","Embu-Guaçu","3515103","base.state_br_sp","base.br"
-"city_3515129","Emilianópolis","3515129","base.state_br_sp","base.br"
-"city_3515152","Engenheiro Coelho","3515152","base.state_br_sp","base.br"
-"city_3515186","Espírito Santo do Pinhal","3515186","base.state_br_sp","base.br"
-"city_3515194","Espírito Santo do Turvo","3515194","base.state_br_sp","base.br"
-"city_3557303","Estiva Gerbi","3557303","base.state_br_sp","base.br"
-"city_3515301","Estrela do Norte","3515301","base.state_br_sp","base.br"
-"city_3515202","Estrela d'Oeste","3515202","base.state_br_sp","base.br"
-"city_3515350","Euclides da Cunha Paulista","3515350","base.state_br_sp","base.br"
-"city_3515400","Fartura","3515400","base.state_br_sp","base.br"
-"city_3515608","Fernando Prestes","3515608","base.state_br_sp","base.br"
-"city_3515509","Fernandópolis","3515509","base.state_br_sp","base.br"
-"city_3515657","Fernão","3515657","base.state_br_sp","base.br"
-"city_3515707","Ferraz de Vasconcelos","3515707","base.state_br_sp","base.br"
-"city_3515806","Flora Rica","3515806","base.state_br_sp","base.br"
-"city_3515905","Floreal","3515905","base.state_br_sp","base.br"
-"city_3516002","Flórida Paulista","3516002","base.state_br_sp","base.br"
-"city_3516101","Florínea","3516101","base.state_br_sp","base.br"
-"city_3516200","Franca","3516200","base.state_br_sp","base.br"
-"city_3516309","Francisco Morato","3516309","base.state_br_sp","base.br"
-"city_3516408","Franco da Rocha","3516408","base.state_br_sp","base.br"
-"city_3516507","Gabriel Monteiro","3516507","base.state_br_sp","base.br"
-"city_3516606","Gália","3516606","base.state_br_sp","base.br"
-"city_3516705","Garça","3516705","base.state_br_sp","base.br"
-"city_3516804","Gastão Vidigal","3516804","base.state_br_sp","base.br"
-"city_3516853","Gavião Peixoto","3516853","base.state_br_sp","base.br"
-"city_3516903","General Salgado","3516903","base.state_br_sp","base.br"
-"city_3517000","Getulina","3517000","base.state_br_sp","base.br"
-"city_3517109","Glicério","3517109","base.state_br_sp","base.br"
-"city_3517208","Guaiçara","3517208","base.state_br_sp","base.br"
-"city_3517307","Guaimbê","3517307","base.state_br_sp","base.br"
-"city_3517406","Guaíra","3517406","base.state_br_sp","base.br"
-"city_3517505","Guapiaçu","3517505","base.state_br_sp","base.br"
-"city_3517604","Guapiara","3517604","base.state_br_sp","base.br"
-"city_3517703","Guará","3517703","base.state_br_sp","base.br"
-"city_3517802","Guaraçaí","3517802","base.state_br_sp","base.br"
-"city_3517901","Guaraci","3517901","base.state_br_sp","base.br"
-"city_3518008","Guarani d'Oeste","3518008","base.state_br_sp","base.br"
-"city_3518107","Guarantã","3518107","base.state_br_sp","base.br"
-"city_3518206","Guararapes","3518206","base.state_br_sp","base.br"
-"city_3518305","Guararema","3518305","base.state_br_sp","base.br"
-"city_3518404","Guaratinguetá","3518404","base.state_br_sp","base.br"
-"city_3518503","Guareí","3518503","base.state_br_sp","base.br"
-"city_3518602","Guariba","3518602","base.state_br_sp","base.br"
-"city_3518701","Guarujá","3518701","base.state_br_sp","base.br"
-"city_3518800","Guarulhos","3518800","base.state_br_sp","base.br"
-"city_3518859","Guatapará","3518859","base.state_br_sp","base.br"
-"city_3518909","Guzolândia","3518909","base.state_br_sp","base.br"
-"city_3519006","Herculândia","3519006","base.state_br_sp","base.br"
-"city_3519055","Holambra","3519055","base.state_br_sp","base.br"
-"city_3519071","Hortolândia","3519071","base.state_br_sp","base.br"
-"city_3519105","Iacanga","3519105","base.state_br_sp","base.br"
-"city_3519204","Iacri","3519204","base.state_br_sp","base.br"
-"city_3519253","Iaras","3519253","base.state_br_sp","base.br"
-"city_3519303","Ibaté","3519303","base.state_br_sp","base.br"
-"city_3519402","Ibirá","3519402","base.state_br_sp","base.br"
-"city_3519501","Ibirarema","3519501","base.state_br_sp","base.br"
-"city_3519600","Ibitinga","3519600","base.state_br_sp","base.br"
-"city_3519709","Ibiúna","3519709","base.state_br_sp","base.br"
-"city_3519808","Icém","3519808","base.state_br_sp","base.br"
-"city_3519907","Iepê","3519907","base.state_br_sp","base.br"
-"city_3520004","Igaraçu do Tietê","3520004","base.state_br_sp","base.br"
-"city_3520103","Igarapava","3520103","base.state_br_sp","base.br"
-"city_3520202","Igaratá","3520202","base.state_br_sp","base.br"
-"city_3520301","Iguape","3520301","base.state_br_sp","base.br"
-"city_3520426","Ilha Comprida","3520426","base.state_br_sp","base.br"
-"city_3520442","Ilha Solteira","3520442","base.state_br_sp","base.br"
-"city_3520400","Ilhabela","3520400","base.state_br_sp","base.br"
-"city_3520509","Indaiatuba","3520509","base.state_br_sp","base.br"
-"city_3520608","Indiana","3520608","base.state_br_sp","base.br"
-"city_3520707","Indiaporã","3520707","base.state_br_sp","base.br"
-"city_3520806","Inúbia Paulista","3520806","base.state_br_sp","base.br"
-"city_3520905","Ipaussu","3520905","base.state_br_sp","base.br"
-"city_3521002","Iperó","3521002","base.state_br_sp","base.br"
-"city_3521101","Ipeúna","3521101","base.state_br_sp","base.br"
-"city_3521150","Ipiguá","3521150","base.state_br_sp","base.br"
-"city_3521200","Iporanga","3521200","base.state_br_sp","base.br"
-"city_3521309","Ipuã","3521309","base.state_br_sp","base.br"
-"city_3521408","Iracemápolis","3521408","base.state_br_sp","base.br"
-"city_3521507","Irapuã","3521507","base.state_br_sp","base.br"
-"city_3521606","Irapuru","3521606","base.state_br_sp","base.br"
-"city_3521705","Itaberá","3521705","base.state_br_sp","base.br"
-"city_3521804","Itaí","3521804","base.state_br_sp","base.br"
-"city_3521903","Itajobi","3521903","base.state_br_sp","base.br"
-"city_3522000","Itaju","3522000","base.state_br_sp","base.br"
-"city_3522109","Itanhaém","3522109","base.state_br_sp","base.br"
-"city_3522158","Itaoca","3522158","base.state_br_sp","base.br"
-"city_3522208","Itapecerica da Serra","3522208","base.state_br_sp","base.br"
-"city_3522307","Itapetininga","3522307","base.state_br_sp","base.br"
-"city_3522406","Itapeva","3522406","base.state_br_sp","base.br"
-"city_3522505","Itapevi","3522505","base.state_br_sp","base.br"
-"city_3522604","Itapira","3522604","base.state_br_sp","base.br"
-"city_3522653","Itapirapuã Paulista","3522653","base.state_br_sp","base.br"
-"city_3522703","Itápolis","3522703","base.state_br_sp","base.br"
-"city_3522802","Itaporanga","3522802","base.state_br_sp","base.br"
-"city_3522901","Itapuí","3522901","base.state_br_sp","base.br"
-"city_3523008","Itapura","3523008","base.state_br_sp","base.br"
-"city_3523107","Itaquaquecetuba","3523107","base.state_br_sp","base.br"
-"city_3523206","Itararé","3523206","base.state_br_sp","base.br"
-"city_3523305","Itariri","3523305","base.state_br_sp","base.br"
-"city_3523404","Itatiba","3523404","base.state_br_sp","base.br"
-"city_3523503","Itatinga","3523503","base.state_br_sp","base.br"
-"city_3523602","Itirapina","3523602","base.state_br_sp","base.br"
-"city_3523701","Itirapuã","3523701","base.state_br_sp","base.br"
-"city_3523800","Itobi","3523800","base.state_br_sp","base.br"
-"city_3523909","Itu","3523909","base.state_br_sp","base.br"
-"city_3524006","Itupeva","3524006","base.state_br_sp","base.br"
-"city_3524105","Ituverava","3524105","base.state_br_sp","base.br"
-"city_3524204","Jaborandi","3524204","base.state_br_sp","base.br"
-"city_3524303","Jaboticabal","3524303","base.state_br_sp","base.br"
-"city_3524402","Jacareí","3524402","base.state_br_sp","base.br"
-"city_3524501","Jaci","3524501","base.state_br_sp","base.br"
-"city_3524600","Jacupiranga","3524600","base.state_br_sp","base.br"
-"city_3524709","Jaguariúna","3524709","base.state_br_sp","base.br"
-"city_3524808","Jales","3524808","base.state_br_sp","base.br"
-"city_3524907","Jambeiro","3524907","base.state_br_sp","base.br"
-"city_3525003","Jandira","3525003","base.state_br_sp","base.br"
-"city_3525102","Jardinópolis","3525102","base.state_br_sp","base.br"
-"city_3525201","Jarinu","3525201","base.state_br_sp","base.br"
-"city_3525300","Jaú","3525300","base.state_br_sp","base.br"
-"city_3525409","Jeriquara","3525409","base.state_br_sp","base.br"
-"city_3525508","Joanópolis","3525508","base.state_br_sp","base.br"
-"city_3525607","João Ramalho","3525607","base.state_br_sp","base.br"
-"city_3525706","José Bonifácio","3525706","base.state_br_sp","base.br"
-"city_3525805","Júlio Mesquita","3525805","base.state_br_sp","base.br"
-"city_3525854","Jumirim","3525854","base.state_br_sp","base.br"
-"city_3525904","Jundiaí","3525904","base.state_br_sp","base.br"
-"city_3526001","Junqueirópolis","3526001","base.state_br_sp","base.br"
-"city_3526100","Juquiá","3526100","base.state_br_sp","base.br"
-"city_3526209","Juquitiba","3526209","base.state_br_sp","base.br"
-"city_3526308","Lagoinha","3526308","base.state_br_sp","base.br"
-"city_3526407","Laranjal Paulista","3526407","base.state_br_sp","base.br"
-"city_3526506","Lavínia","3526506","base.state_br_sp","base.br"
-"city_3526605","Lavrinhas","3526605","base.state_br_sp","base.br"
-"city_3526704","Leme","3526704","base.state_br_sp","base.br"
-"city_3526803","Lençóis Paulista","3526803","base.state_br_sp","base.br"
-"city_3526902","Limeira","3526902","base.state_br_sp","base.br"
-"city_3527009","Lindóia","3527009","base.state_br_sp","base.br"
-"city_3527108","Lins","3527108","base.state_br_sp","base.br"
-"city_3527207","Lorena","3527207","base.state_br_sp","base.br"
-"city_3527256","Lourdes","3527256","base.state_br_sp","base.br"
-"city_3527306","Louveira","3527306","base.state_br_sp","base.br"
-"city_3527405","Lucélia","3527405","base.state_br_sp","base.br"
-"city_3527504","Lucianópolis","3527504","base.state_br_sp","base.br"
-"city_3527603","Luís Antônio","3527603","base.state_br_sp","base.br"
-"city_3527702","Luiziânia","3527702","base.state_br_sp","base.br"
-"city_3527801","Lupércio","3527801","base.state_br_sp","base.br"
-"city_3527900","Lutécia","3527900","base.state_br_sp","base.br"
-"city_3528007","Macatuba","3528007","base.state_br_sp","base.br"
-"city_3528106","Macaubal","3528106","base.state_br_sp","base.br"
-"city_3528205","Macedônia","3528205","base.state_br_sp","base.br"
-"city_3528304","Magda","3528304","base.state_br_sp","base.br"
-"city_3528403","Mairinque","3528403","base.state_br_sp","base.br"
-"city_3528502","Mairiporã","3528502","base.state_br_sp","base.br"
-"city_3528601","Manduri","3528601","base.state_br_sp","base.br"
-"city_3528700","Marabá Paulista","3528700","base.state_br_sp","base.br"
-"city_3528809","Maracaí","3528809","base.state_br_sp","base.br"
-"city_3528858","Marapoama","3528858","base.state_br_sp","base.br"
-"city_3528908","Mariápolis","3528908","base.state_br_sp","base.br"
-"city_3529005","Marília","3529005","base.state_br_sp","base.br"
-"city_3529104","Marinópolis","3529104","base.state_br_sp","base.br"
-"city_3529203","Martinópolis","3529203","base.state_br_sp","base.br"
-"city_3529302","Matão","3529302","base.state_br_sp","base.br"
-"city_3529401","Mauá","3529401","base.state_br_sp","base.br"
-"city_3529500","Mendonça","3529500","base.state_br_sp","base.br"
-"city_3529609","Meridiano","3529609","base.state_br_sp","base.br"
-"city_3529658","Mesópolis","3529658","base.state_br_sp","base.br"
-"city_3529708","Miguelópolis","3529708","base.state_br_sp","base.br"
-"city_3529807","Mineiros do Tietê","3529807","base.state_br_sp","base.br"
-"city_3530003","Mira Estrela","3530003","base.state_br_sp","base.br"
-"city_3529906","Miracatu","3529906","base.state_br_sp","base.br"
-"city_3530102","Mirandópolis","3530102","base.state_br_sp","base.br"
-"city_3530201","Mirante do Paranapanema","3530201","base.state_br_sp","base.br"
-"city_3530300","Mirassol","3530300","base.state_br_sp","base.br"
-"city_3530409","Mirassolândia","3530409","base.state_br_sp","base.br"
-"city_3530508","Mococa","3530508","base.state_br_sp","base.br"
-"city_3530607","Mogi das Cruzes","3530607","base.state_br_sp","base.br"
-"city_3530706","Mogi Guaçu","3530706","base.state_br_sp","base.br"
-"city_3530805","Mogi Mirim","3530805","base.state_br_sp","base.br"
-"city_3530904","Mombuca","3530904","base.state_br_sp","base.br"
-"city_3531001","Monções","3531001","base.state_br_sp","base.br"
-"city_3531100","Mongaguá","3531100","base.state_br_sp","base.br"
-"city_3531209","Monte Alegre do Sul","3531209","base.state_br_sp","base.br"
-"city_3531308","Monte Alto","3531308","base.state_br_sp","base.br"
-"city_3531407","Monte Aprazível","3531407","base.state_br_sp","base.br"
-"city_3531506","Monte Azul Paulista","3531506","base.state_br_sp","base.br"
-"city_3531605","Monte Castelo","3531605","base.state_br_sp","base.br"
-"city_3531803","Monte Mor","3531803","base.state_br_sp","base.br"
-"city_3531704","Monteiro Lobato","3531704","base.state_br_sp","base.br"
-"city_3531902","Morro Agudo","3531902","base.state_br_sp","base.br"
-"city_3532009","Morungaba","3532009","base.state_br_sp","base.br"
-"city_3532058","Motuca","3532058","base.state_br_sp","base.br"
-"city_3532108","Murutinga do Sul","3532108","base.state_br_sp","base.br"
-"city_3532157","Nantes","3532157","base.state_br_sp","base.br"
-"city_3532207","Narandiba","3532207","base.state_br_sp","base.br"
-"city_3532306","Natividade da Serra","3532306","base.state_br_sp","base.br"
-"city_3532405","Nazaré Paulista","3532405","base.state_br_sp","base.br"
-"city_3532504","Neves Paulista","3532504","base.state_br_sp","base.br"
-"city_3532603","Nhandeara","3532603","base.state_br_sp","base.br"
-"city_3532702","Nipoã","3532702","base.state_br_sp","base.br"
-"city_3532801","Nova Aliança","3532801","base.state_br_sp","base.br"
-"city_3532827","Nova Campina","3532827","base.state_br_sp","base.br"
-"city_3532843","Nova Canaã Paulista","3532843","base.state_br_sp","base.br"
-"city_3532868","Nova Castilho","3532868","base.state_br_sp","base.br"
-"city_3532900","Nova Europa","3532900","base.state_br_sp","base.br"
-"city_3533007","Nova Granada","3533007","base.state_br_sp","base.br"
-"city_3533106","Nova Guataporanga","3533106","base.state_br_sp","base.br"
-"city_3533205","Nova Independência","3533205","base.state_br_sp","base.br"
-"city_3533304","Nova Luzitânia","3533304","base.state_br_sp","base.br"
-"city_3533403","Nova Odessa","3533403","base.state_br_sp","base.br"
-"city_3533254","Novais","3533254","base.state_br_sp","base.br"
-"city_3533502","Novo Horizonte","3533502","base.state_br_sp","base.br"
-"city_3533601","Nuporanga","3533601","base.state_br_sp","base.br"
-"city_3533700","Ocauçu","3533700","base.state_br_sp","base.br"
-"city_3533809","Óleo","3533809","base.state_br_sp","base.br"
-"city_3533908","Olímpia","3533908","base.state_br_sp","base.br"
-"city_3534005","Onda Verde","3534005","base.state_br_sp","base.br"
-"city_3534104","Oriente","3534104","base.state_br_sp","base.br"
-"city_3534203","Orindiúva","3534203","base.state_br_sp","base.br"
-"city_3534302","Orlândia","3534302","base.state_br_sp","base.br"
-"city_3534401","Osasco","3534401","base.state_br_sp","base.br"
-"city_3534500","Oscar Bressane","3534500","base.state_br_sp","base.br"
-"city_3534609","Osvaldo Cruz","3534609","base.state_br_sp","base.br"
-"city_3534708","Ourinhos","3534708","base.state_br_sp","base.br"
-"city_3534807","Ouro Verde","3534807","base.state_br_sp","base.br"
-"city_3534757","Ouroeste","3534757","base.state_br_sp","base.br"
-"city_3534906","Pacaembu","3534906","base.state_br_sp","base.br"
-"city_3535002","Palestina","3535002","base.state_br_sp","base.br"
-"city_3535101","Palmares Paulista","3535101","base.state_br_sp","base.br"
-"city_3535200","Palmeira d'Oeste","3535200","base.state_br_sp","base.br"
-"city_3535309","Palmital","3535309","base.state_br_sp","base.br"
-"city_3535408","Panorama","3535408","base.state_br_sp","base.br"
-"city_3535507","Paraguaçu Paulista","3535507","base.state_br_sp","base.br"
-"city_3535606","Paraibuna","3535606","base.state_br_sp","base.br"
-"city_3535705","Paraíso","3535705","base.state_br_sp","base.br"
-"city_3535804","Paranapanema","3535804","base.state_br_sp","base.br"
-"city_3535903","Paranapuã","3535903","base.state_br_sp","base.br"
-"city_3536000","Parapuã","3536000","base.state_br_sp","base.br"
-"city_3536109","Pardinho","3536109","base.state_br_sp","base.br"
-"city_3536208","Pariquera-Açu","3536208","base.state_br_sp","base.br"
-"city_3536257","Parisi","3536257","base.state_br_sp","base.br"
-"city_3536307","Patrocínio Paulista","3536307","base.state_br_sp","base.br"
-"city_3536406","Paulicéia","3536406","base.state_br_sp","base.br"
-"city_3536505","Paulínia","3536505","base.state_br_sp","base.br"
-"city_3536570","Paulistânia","3536570","base.state_br_sp","base.br"
-"city_3536604","Paulo de Faria","3536604","base.state_br_sp","base.br"
-"city_3536703","Pederneiras","3536703","base.state_br_sp","base.br"
-"city_3536802","Pedra Bela","3536802","base.state_br_sp","base.br"
-"city_3536901","Pedranópolis","3536901","base.state_br_sp","base.br"
-"city_3537008","Pedregulho","3537008","base.state_br_sp","base.br"
-"city_3537107","Pedreira","3537107","base.state_br_sp","base.br"
-"city_3537156","Pedrinhas Paulista","3537156","base.state_br_sp","base.br"
-"city_3537206","Pedro de Toledo","3537206","base.state_br_sp","base.br"
-"city_3537305","Penápolis","3537305","base.state_br_sp","base.br"
-"city_3537404","Pereira Barreto","3537404","base.state_br_sp","base.br"
-"city_3537503","Pereiras","3537503","base.state_br_sp","base.br"
-"city_3537602","Peruíbe","3537602","base.state_br_sp","base.br"
-"city_3537701","Piacatu","3537701","base.state_br_sp","base.br"
-"city_3537800","Piedade","3537800","base.state_br_sp","base.br"
-"city_3537909","Pilar do Sul","3537909","base.state_br_sp","base.br"
-"city_3538006","Pindamonhangaba","3538006","base.state_br_sp","base.br"
-"city_3538105","Pindorama","3538105","base.state_br_sp","base.br"
-"city_3538204","Pinhalzinho","3538204","base.state_br_sp","base.br"
-"city_3538303","Piquerobi","3538303","base.state_br_sp","base.br"
-"city_3538501","Piquete","3538501","base.state_br_sp","base.br"
-"city_3538600","Piracaia","3538600","base.state_br_sp","base.br"
-"city_3538709","Piracicaba","3538709","base.state_br_sp","base.br"
-"city_3538808","Piraju","3538808","base.state_br_sp","base.br"
-"city_3538907","Pirajuí","3538907","base.state_br_sp","base.br"
-"city_3539004","Pirangi","3539004","base.state_br_sp","base.br"
-"city_3539103","Pirapora do Bom Jesus","3539103","base.state_br_sp","base.br"
-"city_3539202","Pirapozinho","3539202","base.state_br_sp","base.br"
-"city_3539301","Pirassununga","3539301","base.state_br_sp","base.br"
-"city_3539400","Piratininga","3539400","base.state_br_sp","base.br"
-"city_3539509","Pitangueiras","3539509","base.state_br_sp","base.br"
-"city_3539608","Planalto","3539608","base.state_br_sp","base.br"
-"city_3539707","Platina","3539707","base.state_br_sp","base.br"
-"city_3539806","Poá","3539806","base.state_br_sp","base.br"
-"city_3539905","Poloni","3539905","base.state_br_sp","base.br"
-"city_3540002","Pompéia","3540002","base.state_br_sp","base.br"
-"city_3540101","Pongaí","3540101","base.state_br_sp","base.br"
-"city_3540200","Pontal","3540200","base.state_br_sp","base.br"
-"city_3540259","Pontalinda","3540259","base.state_br_sp","base.br"
-"city_3540309","Pontes Gestal","3540309","base.state_br_sp","base.br"
-"city_3540408","Populina","3540408","base.state_br_sp","base.br"
-"city_3540507","Porangaba","3540507","base.state_br_sp","base.br"
-"city_3540606","Porto Feliz","3540606","base.state_br_sp","base.br"
-"city_3540705","Porto Ferreira","3540705","base.state_br_sp","base.br"
-"city_3540754","Potim","3540754","base.state_br_sp","base.br"
-"city_3540804","Potirendaba","3540804","base.state_br_sp","base.br"
-"city_3540853","Pracinha","3540853","base.state_br_sp","base.br"
-"city_3540903","Pradópolis","3540903","base.state_br_sp","base.br"
-"city_3541000","Praia Grande","3541000","base.state_br_sp","base.br"
-"city_3541059","Pratânia","3541059","base.state_br_sp","base.br"
-"city_3541109","Presidente Alves","3541109","base.state_br_sp","base.br"
-"city_3541208","Presidente Bernardes","3541208","base.state_br_sp","base.br"
-"city_3541307","Presidente Epitácio","3541307","base.state_br_sp","base.br"
-"city_3541406","Presidente Prudente","3541406","base.state_br_sp","base.br"
-"city_3541505","Presidente Venceslau","3541505","base.state_br_sp","base.br"
-"city_3541604","Promissão","3541604","base.state_br_sp","base.br"
-"city_3541653","Quadra","3541653","base.state_br_sp","base.br"
-"city_3541703","Quatá","3541703","base.state_br_sp","base.br"
-"city_3541802","Queiroz","3541802","base.state_br_sp","base.br"
-"city_3541901","Queluz","3541901","base.state_br_sp","base.br"
-"city_3542008","Quintana","3542008","base.state_br_sp","base.br"
-"city_3542107","Rafard","3542107","base.state_br_sp","base.br"
-"city_3542206","Rancharia","3542206","base.state_br_sp","base.br"
-"city_3542305","Redenção da Serra","3542305","base.state_br_sp","base.br"
-"city_3542404","Regente Feijó","3542404","base.state_br_sp","base.br"
-"city_3542503","Reginópolis","3542503","base.state_br_sp","base.br"
-"city_3542602","Registro","3542602","base.state_br_sp","base.br"
-"city_3542701","Restinga","3542701","base.state_br_sp","base.br"
-"city_3542800","Ribeira","3542800","base.state_br_sp","base.br"
-"city_3542909","Ribeirão Bonito","3542909","base.state_br_sp","base.br"
-"city_3543006","Ribeirão Branco","3543006","base.state_br_sp","base.br"
-"city_3543105","Ribeirão Corrente","3543105","base.state_br_sp","base.br"
-"city_3543204","Ribeirão do Sul","3543204","base.state_br_sp","base.br"
-"city_3543238","Ribeirão dos Índios","3543238","base.state_br_sp","base.br"
-"city_3543253","Ribeirão Grande","3543253","base.state_br_sp","base.br"
-"city_3543303","Ribeirão Pires","3543303","base.state_br_sp","base.br"
-"city_3543402","Ribeirão Preto","3543402","base.state_br_sp","base.br"
-"city_3543600","Rifaina","3543600","base.state_br_sp","base.br"
-"city_3543709","Rincão","3543709","base.state_br_sp","base.br"
-"city_3543808","Rinópolis","3543808","base.state_br_sp","base.br"
-"city_3543907","Rio Claro","3543907","base.state_br_sp","base.br"
-"city_3544004","Rio das Pedras","3544004","base.state_br_sp","base.br"
-"city_3544103","Rio Grande da Serra","3544103","base.state_br_sp","base.br"
-"city_3544202","Riolândia","3544202","base.state_br_sp","base.br"
-"city_3543501","Riversul","3543501","base.state_br_sp","base.br"
-"city_3544251","Rosana","3544251","base.state_br_sp","base.br"
-"city_3544301","Roseira","3544301","base.state_br_sp","base.br"
-"city_3544400","Rubiácea","3544400","base.state_br_sp","base.br"
-"city_3544509","Rubinéia","3544509","base.state_br_sp","base.br"
-"city_3544608","Sabino","3544608","base.state_br_sp","base.br"
-"city_3544707","Sagres","3544707","base.state_br_sp","base.br"
-"city_3544806","Sales","3544806","base.state_br_sp","base.br"
-"city_3544905","Sales Oliveira","3544905","base.state_br_sp","base.br"
-"city_3545001","Salesópolis","3545001","base.state_br_sp","base.br"
-"city_3545100","Salmourão","3545100","base.state_br_sp","base.br"
-"city_3545159","Saltinho","3545159","base.state_br_sp","base.br"
-"city_3545209","Salto","3545209","base.state_br_sp","base.br"
-"city_3545308","Salto de Pirapora","3545308","base.state_br_sp","base.br"
-"city_3545407","Salto Grande","3545407","base.state_br_sp","base.br"
-"city_3545506","Sandovalina","3545506","base.state_br_sp","base.br"
-"city_3545605","Santa Adélia","3545605","base.state_br_sp","base.br"
-"city_3545704","Santa Albertina","3545704","base.state_br_sp","base.br"
-"city_3545803","Santa Bárbara d'Oeste","3545803","base.state_br_sp","base.br"
-"city_3546009","Santa Branca","3546009","base.state_br_sp","base.br"
-"city_3546108","Santa Clara d'Oeste","3546108","base.state_br_sp","base.br"
-"city_3546207","Santa Cruz da Conceição","3546207","base.state_br_sp","base.br"
-"city_3546256","Santa Cruz da Esperança","3546256","base.state_br_sp","base.br"
-"city_3546306","Santa Cruz das Palmeiras","3546306","base.state_br_sp","base.br"
-"city_3546405","Santa Cruz do Rio Pardo","3546405","base.state_br_sp","base.br"
-"city_3546504","Santa Ernestina","3546504","base.state_br_sp","base.br"
-"city_3546603","Santa Fé do Sul","3546603","base.state_br_sp","base.br"
-"city_3546702","Santa Gertrudes","3546702","base.state_br_sp","base.br"
-"city_3546801","Santa Isabel","3546801","base.state_br_sp","base.br"
-"city_3546900","Santa Lúcia","3546900","base.state_br_sp","base.br"
-"city_3547007","Santa Maria da Serra","3547007","base.state_br_sp","base.br"
-"city_3547106","Santa Mercedes","3547106","base.state_br_sp","base.br"
-"city_3547502","Santa Rita do Passa Quatro","3547502","base.state_br_sp","base.br"
-"city_3547403","Santa Rita d'Oeste","3547403","base.state_br_sp","base.br"
-"city_3547601","Santa Rosa de Viterbo","3547601","base.state_br_sp","base.br"
-"city_3547650","Santa Salete","3547650","base.state_br_sp","base.br"
-"city_3547205","Santana da Ponte Pensa","3547205","base.state_br_sp","base.br"
-"city_3547304","Santana de Parnaíba","3547304","base.state_br_sp","base.br"
-"city_3547700","Santo Anastácio","3547700","base.state_br_sp","base.br"
-"city_3547809","Santo André","3547809","base.state_br_sp","base.br"
-"city_3547908","Santo Antônio da Alegria","3547908","base.state_br_sp","base.br"
-"city_3548005","Santo Antônio de Posse","3548005","base.state_br_sp","base.br"
-"city_3548054","Santo Antônio do Aracanguá","3548054","base.state_br_sp","base.br"
-"city_3548104","Santo Antônio do Jardim","3548104","base.state_br_sp","base.br"
-"city_3548203","Santo Antônio do Pinhal","3548203","base.state_br_sp","base.br"
-"city_3548302","Santo Expedito","3548302","base.state_br_sp","base.br"
-"city_3548401","Santópolis do Aguapeí","3548401","base.state_br_sp","base.br"
-"city_3548500","Santos","3548500","base.state_br_sp","base.br"
-"city_3548609","São Bento do Sapucaí","3548609","base.state_br_sp","base.br"
-"city_3548708","São Bernardo do Campo","3548708","base.state_br_sp","base.br"
-"city_3548807","São Caetano do Sul","3548807","base.state_br_sp","base.br"
-"city_3548906","São Carlos","3548906","base.state_br_sp","base.br"
-"city_3549003","São Francisco","3549003","base.state_br_sp","base.br"
-"city_3549102","São João da Boa Vista","3549102","base.state_br_sp","base.br"
-"city_3549201","São João das Duas Pontes","3549201","base.state_br_sp","base.br"
-"city_3549250","São João de Iracema","3549250","base.state_br_sp","base.br"
-"city_3549300","São João do Pau d'Alho","3549300","base.state_br_sp","base.br"
-"city_3549409","São Joaquim da Barra","3549409","base.state_br_sp","base.br"
-"city_3549508","São José da Bela Vista","3549508","base.state_br_sp","base.br"
-"city_3549607","São José do Barreiro","3549607","base.state_br_sp","base.br"
-"city_3549706","São José do Rio Pardo","3549706","base.state_br_sp","base.br"
-"city_3549805","São José do Rio Preto","3549805","base.state_br_sp","base.br"
-"city_3549904","São José dos Campos","3549904","base.state_br_sp","base.br"
-"city_3549953","São Lourenço da Serra","3549953","base.state_br_sp","base.br"
-"city_3550001","São Luiz do Paraitinga","3550001","base.state_br_sp","base.br"
-"city_3550100","São Manuel","3550100","base.state_br_sp","base.br"
-"city_3550209","São Miguel Arcanjo","3550209","base.state_br_sp","base.br"
-"city_3550308","São Paulo","3550308","base.state_br_sp","base.br"
-"city_3550407","São Pedro","3550407","base.state_br_sp","base.br"
-"city_3550506","São Pedro do Turvo","3550506","base.state_br_sp","base.br"
-"city_3550605","São Roque","3550605","base.state_br_sp","base.br"
-"city_3550704","São Sebastião","3550704","base.state_br_sp","base.br"
-"city_3550803","São Sebastião da Grama","3550803","base.state_br_sp","base.br"
-"city_3550902","São Simão","3550902","base.state_br_sp","base.br"
-"city_3551009","São Vicente","3551009","base.state_br_sp","base.br"
-"city_3551108","Sarapuí","3551108","base.state_br_sp","base.br"
-"city_3551207","Sarutaiá","3551207","base.state_br_sp","base.br"
-"city_3551306","Sebastianópolis do Sul","3551306","base.state_br_sp","base.br"
-"city_3551405","Serra Azul","3551405","base.state_br_sp","base.br"
-"city_3551603","Serra Negra","3551603","base.state_br_sp","base.br"
-"city_3551504","Serrana","3551504","base.state_br_sp","base.br"
-"city_3551702","Sertãozinho","3551702","base.state_br_sp","base.br"
-"city_3551801","Sete Barras","3551801","base.state_br_sp","base.br"
-"city_3551900","Severínia","3551900","base.state_br_sp","base.br"
-"city_3552007","Silveiras","3552007","base.state_br_sp","base.br"
-"city_3552106","Socorro","3552106","base.state_br_sp","base.br"
-"city_3552205","Sorocaba","3552205","base.state_br_sp","base.br"
-"city_3552304","Sud Mennucci","3552304","base.state_br_sp","base.br"
-"city_3552403","Sumaré","3552403","base.state_br_sp","base.br"
-"city_3552551","Suzanápolis","3552551","base.state_br_sp","base.br"
-"city_3552502","Suzano","3552502","base.state_br_sp","base.br"
-"city_3552601","Tabapuã","3552601","base.state_br_sp","base.br"
-"city_3552700","Tabatinga","3552700","base.state_br_sp","base.br"
-"city_3552809","Taboão da Serra","3552809","base.state_br_sp","base.br"
-"city_3552908","Taciba","3552908","base.state_br_sp","base.br"
-"city_3553005","Taguaí","3553005","base.state_br_sp","base.br"
-"city_3553104","Taiaçu","3553104","base.state_br_sp","base.br"
-"city_3553203","Taiúva","3553203","base.state_br_sp","base.br"
-"city_3553302","Tambaú","3553302","base.state_br_sp","base.br"
-"city_3553401","Tanabi","3553401","base.state_br_sp","base.br"
-"city_3553500","Tapiraí","3553500","base.state_br_sp","base.br"
-"city_3553609","Tapiratiba","3553609","base.state_br_sp","base.br"
-"city_3553658","Taquaral","3553658","base.state_br_sp","base.br"
-"city_3553708","Taquaritinga","3553708","base.state_br_sp","base.br"
-"city_3553807","Taquarituba","3553807","base.state_br_sp","base.br"
-"city_3553856","Taquarivaí","3553856","base.state_br_sp","base.br"
-"city_3553906","Tarabai","3553906","base.state_br_sp","base.br"
-"city_3553955","Tarumã","3553955","base.state_br_sp","base.br"
-"city_3554003","Tatuí","3554003","base.state_br_sp","base.br"
-"city_3554102","Taubaté","3554102","base.state_br_sp","base.br"
-"city_3554201","Tejupá","3554201","base.state_br_sp","base.br"
-"city_3554300","Teodoro Sampaio","3554300","base.state_br_sp","base.br"
-"city_3554409","Terra Roxa","3554409","base.state_br_sp","base.br"
-"city_3554508","Tietê","3554508","base.state_br_sp","base.br"
-"city_3554607","Timburi","3554607","base.state_br_sp","base.br"
-"city_3554656","Torre de Pedra","3554656","base.state_br_sp","base.br"
-"city_3554706","Torrinha","3554706","base.state_br_sp","base.br"
-"city_3554755","Trabiju","3554755","base.state_br_sp","base.br"
-"city_3554805","Tremembé","3554805","base.state_br_sp","base.br"
-"city_3554904","Três Fronteiras","3554904","base.state_br_sp","base.br"
-"city_3554953","Tuiuti","3554953","base.state_br_sp","base.br"
-"city_3555000","Tupã","3555000","base.state_br_sp","base.br"
-"city_3555109","Tupi Paulista","3555109","base.state_br_sp","base.br"
-"city_3555208","Turiúba","3555208","base.state_br_sp","base.br"
-"city_3555307","Turmalina","3555307","base.state_br_sp","base.br"
-"city_3555356","Ubarana","3555356","base.state_br_sp","base.br"
-"city_3555406","Ubatuba","3555406","base.state_br_sp","base.br"
-"city_3555505","Ubirajara","3555505","base.state_br_sp","base.br"
-"city_3555604","Uchoa","3555604","base.state_br_sp","base.br"
-"city_3555703","União Paulista","3555703","base.state_br_sp","base.br"
-"city_3555802","Urânia","3555802","base.state_br_sp","base.br"
-"city_3555901","Uru","3555901","base.state_br_sp","base.br"
-"city_3556008","Urupês","3556008","base.state_br_sp","base.br"
-"city_3556107","Valentim Gentil","3556107","base.state_br_sp","base.br"
-"city_3556206","Valinhos","3556206","base.state_br_sp","base.br"
-"city_3556305","Valparaíso","3556305","base.state_br_sp","base.br"
-"city_3556354","Vargem","3556354","base.state_br_sp","base.br"
-"city_3556404","Vargem Grande do Sul","3556404","base.state_br_sp","base.br"
-"city_3556453","Vargem Grande Paulista","3556453","base.state_br_sp","base.br"
-"city_3556503","Várzea Paulista","3556503","base.state_br_sp","base.br"
-"city_3556602","Vera Cruz","3556602","base.state_br_sp","base.br"
-"city_3556701","Vinhedo","3556701","base.state_br_sp","base.br"
-"city_3556800","Viradouro","3556800","base.state_br_sp","base.br"
-"city_3556909","Vista Alegre do Alto","3556909","base.state_br_sp","base.br"
-"city_3556958","Vitória Brasil","3556958","base.state_br_sp","base.br"
-"city_3557006","Votorantim","3557006","base.state_br_sp","base.br"
-"city_3557105","Votuporanga","3557105","base.state_br_sp","base.br"
-"city_3557154","Zacarias","3557154","base.state_br_sp","base.br"
-"city_4100103","Abatiá","4100103","base.state_br_pr","base.br"
-"city_4100202","Adrianópolis","4100202","base.state_br_pr","base.br"
-"city_4100301","Agudos do Sul","4100301","base.state_br_pr","base.br"
-"city_4100400","Almirante Tamandaré","4100400","base.state_br_pr","base.br"
-"city_4100459","Altamira do Paraná","4100459","base.state_br_pr","base.br"
-"city_4128625","Alto Paraíso","4128625","base.state_br_pr","base.br"
-"city_4100608","Alto Paraná","4100608","base.state_br_pr","base.br"
-"city_4100707","Alto Piquiri","4100707","base.state_br_pr","base.br"
-"city_4100509","Altônia","4100509","base.state_br_pr","base.br"
-"city_4100806","Alvorada do Sul","4100806","base.state_br_pr","base.br"
-"city_4100905","Amaporã","4100905","base.state_br_pr","base.br"
-"city_4101002","Ampére","4101002","base.state_br_pr","base.br"
-"city_4101051","Anahy","4101051","base.state_br_pr","base.br"
-"city_4101101","Andirá","4101101","base.state_br_pr","base.br"
-"city_4101150","Ângulo","4101150","base.state_br_pr","base.br"
-"city_4101200","Antonina","4101200","base.state_br_pr","base.br"
-"city_4101309","Antônio Olinto","4101309","base.state_br_pr","base.br"
-"city_4101408","Apucarana","4101408","base.state_br_pr","base.br"
-"city_4101507","Arapongas","4101507","base.state_br_pr","base.br"
-"city_4101606","Arapoti","4101606","base.state_br_pr","base.br"
-"city_4101655","Arapuã","4101655","base.state_br_pr","base.br"
-"city_4101705","Araruna","4101705","base.state_br_pr","base.br"
-"city_4101804","Araucária","4101804","base.state_br_pr","base.br"
-"city_4101853","Ariranha do Ivaí","4101853","base.state_br_pr","base.br"
-"city_4101903","Assaí","4101903","base.state_br_pr","base.br"
-"city_4102000","Assis Chateaubriand","4102000","base.state_br_pr","base.br"
-"city_4102109","Astorga","4102109","base.state_br_pr","base.br"
-"city_4102208","Atalaia","4102208","base.state_br_pr","base.br"
-"city_4102307","Balsa Nova","4102307","base.state_br_pr","base.br"
-"city_4102406","Bandeirantes","4102406","base.state_br_pr","base.br"
-"city_4102505","Barbosa Ferraz","4102505","base.state_br_pr","base.br"
-"city_4102703","Barra do Jacaré","4102703","base.state_br_pr","base.br"
-"city_4102604","Barracão","4102604","base.state_br_pr","base.br"
-"city_4102752","Bela Vista da Caroba","4102752","base.state_br_pr","base.br"
-"city_4102802","Bela Vista do Paraíso","4102802","base.state_br_pr","base.br"
-"city_4102901","Bituruna","4102901","base.state_br_pr","base.br"
-"city_4103008","Boa Esperança","4103008","base.state_br_pr","base.br"
-"city_4103024","Boa Esperança do Iguaçu","4103024","base.state_br_pr","base.br"
-"city_4103040","Boa Ventura de São Roque","4103040","base.state_br_pr","base.br"
-"city_4103057","Boa Vista da Aparecida","4103057","base.state_br_pr","base.br"
-"city_4103107","Bocaiúva do Sul","4103107","base.state_br_pr","base.br"
-"city_4103156","Bom Jesus do Sul","4103156","base.state_br_pr","base.br"
-"city_4103206","Bom Sucesso","4103206","base.state_br_pr","base.br"
-"city_4103222","Bom Sucesso do Sul","4103222","base.state_br_pr","base.br"
-"city_4103305","Borrazópolis","4103305","base.state_br_pr","base.br"
-"city_4103354","Braganey","4103354","base.state_br_pr","base.br"
-"city_4103370","Brasilândia do Sul","4103370","base.state_br_pr","base.br"
-"city_4103404","Cafeara","4103404","base.state_br_pr","base.br"
-"city_4103453","Cafelândia","4103453","base.state_br_pr","base.br"
-"city_4103479","Cafezal do Sul","4103479","base.state_br_pr","base.br"
-"city_4103503","Califórnia","4103503","base.state_br_pr","base.br"
-"city_4103602","Cambará","4103602","base.state_br_pr","base.br"
-"city_4103701","Cambé","4103701","base.state_br_pr","base.br"
-"city_4103800","Cambira","4103800","base.state_br_pr","base.br"
-"city_4103909","Campina da Lagoa","4103909","base.state_br_pr","base.br"
-"city_4103958","Campina do Simão","4103958","base.state_br_pr","base.br"
-"city_4104006","Campina Grande do Sul","4104006","base.state_br_pr","base.br"
-"city_4104055","Campo Bonito","4104055","base.state_br_pr","base.br"
-"city_4104105","Campo do Tenente","4104105","base.state_br_pr","base.br"
-"city_4104204","Campo Largo","4104204","base.state_br_pr","base.br"
-"city_4104253","Campo Magro","4104253","base.state_br_pr","base.br"
-"city_4104303","Campo Mourão","4104303","base.state_br_pr","base.br"
-"city_4104402","Cândido de Abreu","4104402","base.state_br_pr","base.br"
-"city_4104428","Candói","4104428","base.state_br_pr","base.br"
-"city_4104451","Cantagalo","4104451","base.state_br_pr","base.br"
-"city_4104501","Capanema","4104501","base.state_br_pr","base.br"
-"city_4104600","Capitão Leônidas Marques","4104600","base.state_br_pr","base.br"
-"city_4104659","Carambeí","4104659","base.state_br_pr","base.br"
-"city_4104709","Carlópolis","4104709","base.state_br_pr","base.br"
-"city_4104808","Cascavel","4104808","base.state_br_pr","base.br"
-"city_4104907","Castro","4104907","base.state_br_pr","base.br"
-"city_4105003","Catanduvas","4105003","base.state_br_pr","base.br"
-"city_4105102","Centenário do Sul","4105102","base.state_br_pr","base.br"
-"city_4105201","Cerro Azul","4105201","base.state_br_pr","base.br"
-"city_4105300","Céu Azul","4105300","base.state_br_pr","base.br"
-"city_4105409","Chopinzinho","4105409","base.state_br_pr","base.br"
-"city_4105508","Cianorte","4105508","base.state_br_pr","base.br"
-"city_4105607","Cidade Gaúcha","4105607","base.state_br_pr","base.br"
-"city_4105706","Clevelândia","4105706","base.state_br_pr","base.br"
-"city_4105805","Colombo","4105805","base.state_br_pr","base.br"
-"city_4105904","Colorado","4105904","base.state_br_pr","base.br"
-"city_4106001","Congonhinhas","4106001","base.state_br_pr","base.br"
-"city_4106100","Conselheiro Mairinck","4106100","base.state_br_pr","base.br"
-"city_4106209","Contenda","4106209","base.state_br_pr","base.br"
-"city_4106308","Corbélia","4106308","base.state_br_pr","base.br"
-"city_4106407","Cornélio Procópio","4106407","base.state_br_pr","base.br"
-"city_4106456","Coronel Domingos Soares","4106456","base.state_br_pr","base.br"
-"city_4106506","Coronel Vivida","4106506","base.state_br_pr","base.br"
-"city_4106555","Corumbataí do Sul","4106555","base.state_br_pr","base.br"
-"city_4106803","Cruz Machado","4106803","base.state_br_pr","base.br"
-"city_4106571","Cruzeiro do Iguaçu","4106571","base.state_br_pr","base.br"
-"city_4106605","Cruzeiro do Oeste","4106605","base.state_br_pr","base.br"
-"city_4106704","Cruzeiro do Sul","4106704","base.state_br_pr","base.br"
-"city_4106852","Cruzmaltina","4106852","base.state_br_pr","base.br"
-"city_4106902","Curitiba","4106902","base.state_br_pr","base.br"
-"city_4107009","Curiúva","4107009","base.state_br_pr","base.br"
-"city_4107108","Diamante do Norte","4107108","base.state_br_pr","base.br"
-"city_4107124","Diamante do Sul","4107124","base.state_br_pr","base.br"
-"city_4107157","Diamante D'Oeste","4107157","base.state_br_pr","base.br"
-"city_4107207","Dois Vizinhos","4107207","base.state_br_pr","base.br"
-"city_4107256","Douradina","4107256","base.state_br_pr","base.br"
-"city_4107306","Doutor Camargo","4107306","base.state_br_pr","base.br"
-"city_4128633","Doutor Ulysses","4128633","base.state_br_pr","base.br"
-"city_4107405","Enéas Marques","4107405","base.state_br_pr","base.br"
-"city_4107504","Engenheiro Beltrão","4107504","base.state_br_pr","base.br"
-"city_4107538","Entre Rios do Oeste","4107538","base.state_br_pr","base.br"
-"city_4107520","Esperança Nova","4107520","base.state_br_pr","base.br"
-"city_4107546","Espigão Alto do Iguaçu","4107546","base.state_br_pr","base.br"
-"city_4107553","Farol","4107553","base.state_br_pr","base.br"
-"city_4107603","Faxinal","4107603","base.state_br_pr","base.br"
-"city_4107652","Fazenda Rio Grande","4107652","base.state_br_pr","base.br"
-"city_4107702","Fênix","4107702","base.state_br_pr","base.br"
-"city_4107736","Fernandes Pinheiro","4107736","base.state_br_pr","base.br"
-"city_4107751","Figueira","4107751","base.state_br_pr","base.br"
-"city_4107850","Flor da Serra do Sul","4107850","base.state_br_pr","base.br"
-"city_4107801","Floraí","4107801","base.state_br_pr","base.br"
-"city_4107900","Floresta","4107900","base.state_br_pr","base.br"
-"city_4108007","Florestópolis","4108007","base.state_br_pr","base.br"
-"city_4108106","Flórida","4108106","base.state_br_pr","base.br"
-"city_4108205","Formosa do Oeste","4108205","base.state_br_pr","base.br"
-"city_4108304","Foz do Iguaçu","4108304","base.state_br_pr","base.br"
-"city_4108452","Foz do Jordão","4108452","base.state_br_pr","base.br"
-"city_4108320","Francisco Alves","4108320","base.state_br_pr","base.br"
-"city_4108403","Francisco Beltrão","4108403","base.state_br_pr","base.br"
-"city_4108502","General Carneiro","4108502","base.state_br_pr","base.br"
-"city_4108551","Godoy Moreira","4108551","base.state_br_pr","base.br"
-"city_4108601","Goioerê","4108601","base.state_br_pr","base.br"
-"city_4108650","Goioxim","4108650","base.state_br_pr","base.br"
-"city_4108700","Grandes Rios","4108700","base.state_br_pr","base.br"
-"city_4108809","Guaíra","4108809","base.state_br_pr","base.br"
-"city_4108908","Guairaçá","4108908","base.state_br_pr","base.br"
-"city_4108957","Guamiranga","4108957","base.state_br_pr","base.br"
-"city_4109005","Guapirama","4109005","base.state_br_pr","base.br"
-"city_4109104","Guaporema","4109104","base.state_br_pr","base.br"
-"city_4109203","Guaraci","4109203","base.state_br_pr","base.br"
-"city_4109302","Guaraniaçu","4109302","base.state_br_pr","base.br"
-"city_4109401","Guarapuava","4109401","base.state_br_pr","base.br"
-"city_4109500","Guaraqueçaba","4109500","base.state_br_pr","base.br"
-"city_4109609","Guaratuba","4109609","base.state_br_pr","base.br"
-"city_4109658","Honório Serpa","4109658","base.state_br_pr","base.br"
-"city_4109708","Ibaiti","4109708","base.state_br_pr","base.br"
-"city_4109757","Ibema","4109757","base.state_br_pr","base.br"
-"city_4109807","Ibiporã","4109807","base.state_br_pr","base.br"
-"city_4109906","Icaraíma","4109906","base.state_br_pr","base.br"
-"city_4110003","Iguaraçu","4110003","base.state_br_pr","base.br"
-"city_4110052","Iguatu","4110052","base.state_br_pr","base.br"
-"city_4110078","Imbaú","4110078","base.state_br_pr","base.br"
-"city_4110102","Imbituva","4110102","base.state_br_pr","base.br"
-"city_4110201","Inácio Martins","4110201","base.state_br_pr","base.br"
-"city_4110300","Inajá","4110300","base.state_br_pr","base.br"
-"city_4110409","Indianópolis","4110409","base.state_br_pr","base.br"
-"city_4110508","Ipiranga","4110508","base.state_br_pr","base.br"
-"city_4110607","Iporã","4110607","base.state_br_pr","base.br"
-"city_4110656","Iracema do Oeste","4110656","base.state_br_pr","base.br"
-"city_4110706","Irati","4110706","base.state_br_pr","base.br"
-"city_4110805","Iretama","4110805","base.state_br_pr","base.br"
-"city_4110904","Itaguajé","4110904","base.state_br_pr","base.br"
-"city_4110953","Itaipulândia","4110953","base.state_br_pr","base.br"
-"city_4111001","Itambaracá","4111001","base.state_br_pr","base.br"
-"city_4111100","Itambé","4111100","base.state_br_pr","base.br"
-"city_4111209","Itapejara d'Oeste","4111209","base.state_br_pr","base.br"
-"city_4111258","Itaperuçu","4111258","base.state_br_pr","base.br"
-"city_4111308","Itaúna do Sul","4111308","base.state_br_pr","base.br"
-"city_4111407","Ivaí","4111407","base.state_br_pr","base.br"
-"city_4111506","Ivaiporã","4111506","base.state_br_pr","base.br"
-"city_4111555","Ivaté","4111555","base.state_br_pr","base.br"
-"city_4111605","Ivatuba","4111605","base.state_br_pr","base.br"
-"city_4111704","Jaboti","4111704","base.state_br_pr","base.br"
-"city_4111803","Jacarezinho","4111803","base.state_br_pr","base.br"
-"city_4111902","Jaguapitã","4111902","base.state_br_pr","base.br"
-"city_4112009","Jaguariaíva","4112009","base.state_br_pr","base.br"
-"city_4112108","Jandaia do Sul","4112108","base.state_br_pr","base.br"
-"city_4112207","Janiópolis","4112207","base.state_br_pr","base.br"
-"city_4112306","Japira","4112306","base.state_br_pr","base.br"
-"city_4112405","Japurá","4112405","base.state_br_pr","base.br"
-"city_4112504","Jardim Alegre","4112504","base.state_br_pr","base.br"
-"city_4112603","Jardim Olinda","4112603","base.state_br_pr","base.br"
-"city_4112702","Jataizinho","4112702","base.state_br_pr","base.br"
-"city_4112751","Jesuítas","4112751","base.state_br_pr","base.br"
-"city_4112801","Joaquim Távora","4112801","base.state_br_pr","base.br"
-"city_4112900","Jundiaí do Sul","4112900","base.state_br_pr","base.br"
-"city_4112959","Juranda","4112959","base.state_br_pr","base.br"
-"city_4113007","Jussara","4113007","base.state_br_pr","base.br"
-"city_4113106","Kaloré","4113106","base.state_br_pr","base.br"
-"city_4113205","Lapa","4113205","base.state_br_pr","base.br"
-"city_4113254","Laranjal","4113254","base.state_br_pr","base.br"
-"city_4113304","Laranjeiras do Sul","4113304","base.state_br_pr","base.br"
-"city_4113403","Leópolis","4113403","base.state_br_pr","base.br"
-"city_4113429","Lidianópolis","4113429","base.state_br_pr","base.br"
-"city_4113452","Lindoeste","4113452","base.state_br_pr","base.br"
-"city_4113502","Loanda","4113502","base.state_br_pr","base.br"
-"city_4113601","Lobato","4113601","base.state_br_pr","base.br"
-"city_4113700","Londrina","4113700","base.state_br_pr","base.br"
-"city_4113734","Luiziana","4113734","base.state_br_pr","base.br"
-"city_4113759","Lunardelli","4113759","base.state_br_pr","base.br"
-"city_4113809","Lupionópolis","4113809","base.state_br_pr","base.br"
-"city_4113908","Mallet","4113908","base.state_br_pr","base.br"
-"city_4114005","Mamborê","4114005","base.state_br_pr","base.br"
-"city_4114104","Mandaguaçu","4114104","base.state_br_pr","base.br"
-"city_4114203","Mandaguari","4114203","base.state_br_pr","base.br"
-"city_4114302","Mandirituba","4114302","base.state_br_pr","base.br"
-"city_4114351","Manfrinópolis","4114351","base.state_br_pr","base.br"
-"city_4114401","Mangueirinha","4114401","base.state_br_pr","base.br"
-"city_4114500","Manoel Ribas","4114500","base.state_br_pr","base.br"
-"city_4114609","Marechal Cândido Rondon","4114609","base.state_br_pr","base.br"
-"city_4114708","Maria Helena","4114708","base.state_br_pr","base.br"
-"city_4114807","Marialva","4114807","base.state_br_pr","base.br"
-"city_4114906","Marilândia do Sul","4114906","base.state_br_pr","base.br"
-"city_4115002","Marilena","4115002","base.state_br_pr","base.br"
-"city_4115101","Mariluz","4115101","base.state_br_pr","base.br"
-"city_4115200","Maringá","4115200","base.state_br_pr","base.br"
-"city_4115309","Mariópolis","4115309","base.state_br_pr","base.br"
-"city_4115358","Maripá","4115358","base.state_br_pr","base.br"
-"city_4115408","Marmeleiro","4115408","base.state_br_pr","base.br"
-"city_4115457","Marquinho","4115457","base.state_br_pr","base.br"
-"city_4115507","Marumbi","4115507","base.state_br_pr","base.br"
-"city_4115606","Matelândia","4115606","base.state_br_pr","base.br"
-"city_4115705","Matinhos","4115705","base.state_br_pr","base.br"
-"city_4115739","Mato Rico","4115739","base.state_br_pr","base.br"
-"city_4115754","Mauá da Serra","4115754","base.state_br_pr","base.br"
-"city_4115804","Medianeira","4115804","base.state_br_pr","base.br"
-"city_4115853","Mercedes","4115853","base.state_br_pr","base.br"
-"city_4115903","Mirador","4115903","base.state_br_pr","base.br"
-"city_4116000","Miraselva","4116000","base.state_br_pr","base.br"
-"city_4116059","Missal","4116059","base.state_br_pr","base.br"
-"city_4116109","Moreira Sales","4116109","base.state_br_pr","base.br"
-"city_4116208","Morretes","4116208","base.state_br_pr","base.br"
-"city_4116307","Munhoz de Melo","4116307","base.state_br_pr","base.br"
-"city_4116406","Nossa Senhora das Graças","4116406","base.state_br_pr","base.br"
-"city_4116505","Nova Aliança do Ivaí","4116505","base.state_br_pr","base.br"
-"city_4116604","Nova América da Colina","4116604","base.state_br_pr","base.br"
-"city_4116703","Nova Aurora","4116703","base.state_br_pr","base.br"
-"city_4116802","Nova Cantu","4116802","base.state_br_pr","base.br"
-"city_4116901","Nova Esperança","4116901","base.state_br_pr","base.br"
-"city_4116950","Nova Esperança do Sudoeste","4116950","base.state_br_pr","base.br"
-"city_4117008","Nova Fátima","4117008","base.state_br_pr","base.br"
-"city_4117057","Nova Laranjeiras","4117057","base.state_br_pr","base.br"
-"city_4117107","Nova Londrina","4117107","base.state_br_pr","base.br"
-"city_4117206","Nova Olímpia","4117206","base.state_br_pr","base.br"
-"city_4117255","Nova Prata do Iguaçu","4117255","base.state_br_pr","base.br"
-"city_4117214","Nova Santa Bárbara","4117214","base.state_br_pr","base.br"
-"city_4117222","Nova Santa Rosa","4117222","base.state_br_pr","base.br"
-"city_4117271","Nova Tebas","4117271","base.state_br_pr","base.br"
-"city_4117297","Novo Itacolomi","4117297","base.state_br_pr","base.br"
-"city_4117305","Ortigueira","4117305","base.state_br_pr","base.br"
-"city_4117404","Ourizona","4117404","base.state_br_pr","base.br"
-"city_4117453","Ouro Verde do Oeste","4117453","base.state_br_pr","base.br"
-"city_4117503","Paiçandu","4117503","base.state_br_pr","base.br"
-"city_4117602","Palmas","4117602","base.state_br_pr","base.br"
-"city_4117701","Palmeira","4117701","base.state_br_pr","base.br"
-"city_4117800","Palmital","4117800","base.state_br_pr","base.br"
-"city_4117909","Palotina","4117909","base.state_br_pr","base.br"
-"city_4118006","Paraíso do Norte","4118006","base.state_br_pr","base.br"
-"city_4118105","Paranacity","4118105","base.state_br_pr","base.br"
-"city_4118204","Paranaguá","4118204","base.state_br_pr","base.br"
-"city_4118303","Paranapoema","4118303","base.state_br_pr","base.br"
-"city_4118402","Paranavaí","4118402","base.state_br_pr","base.br"
-"city_4118451","Pato Bragado","4118451","base.state_br_pr","base.br"
-"city_4118501","Pato Branco","4118501","base.state_br_pr","base.br"
-"city_4118600","Paula Freitas","4118600","base.state_br_pr","base.br"
-"city_4118709","Paulo Frontin","4118709","base.state_br_pr","base.br"
-"city_4118808","Peabiru","4118808","base.state_br_pr","base.br"
-"city_4118857","Perobal","4118857","base.state_br_pr","base.br"
-"city_4118907","Pérola","4118907","base.state_br_pr","base.br"
-"city_4119004","Pérola d'Oeste","4119004","base.state_br_pr","base.br"
-"city_4119103","Piên","4119103","base.state_br_pr","base.br"
-"city_4119152","Pinhais","4119152","base.state_br_pr","base.br"
-"city_4119251","Pinhal de São Bento","4119251","base.state_br_pr","base.br"
-"city_4119202","Pinhalão","4119202","base.state_br_pr","base.br"
-"city_4119301","Pinhão","4119301","base.state_br_pr","base.br"
-"city_4119400","Piraí do Sul","4119400","base.state_br_pr","base.br"
-"city_4119509","Piraquara","4119509","base.state_br_pr","base.br"
-"city_4119608","Pitanga","4119608","base.state_br_pr","base.br"
-"city_4119657","Pitangueiras","4119657","base.state_br_pr","base.br"
-"city_4119707","Planaltina do Paraná","4119707","base.state_br_pr","base.br"
-"city_4119806","Planalto","4119806","base.state_br_pr","base.br"
-"city_4119905","Ponta Grossa","4119905","base.state_br_pr","base.br"
-"city_4119954","Pontal do Paraná","4119954","base.state_br_pr","base.br"
-"city_4120002","Porecatu","4120002","base.state_br_pr","base.br"
-"city_4120101","Porto Amazonas","4120101","base.state_br_pr","base.br"
-"city_4120150","Porto Barreiro","4120150","base.state_br_pr","base.br"
-"city_4120200","Porto Rico","4120200","base.state_br_pr","base.br"
-"city_4120309","Porto Vitória","4120309","base.state_br_pr","base.br"
-"city_4120333","Prado Ferreira","4120333","base.state_br_pr","base.br"
-"city_4120358","Pranchita","4120358","base.state_br_pr","base.br"
-"city_4120408","Presidente Castelo Branco","4120408","base.state_br_pr","base.br"
-"city_4120507","Primeiro de Maio","4120507","base.state_br_pr","base.br"
-"city_4120606","Prudentópolis","4120606","base.state_br_pr","base.br"
-"city_4120655","Quarto Centenário","4120655","base.state_br_pr","base.br"
-"city_4120705","Quatiguá","4120705","base.state_br_pr","base.br"
-"city_4120804","Quatro Barras","4120804","base.state_br_pr","base.br"
-"city_4120853","Quatro Pontes","4120853","base.state_br_pr","base.br"
-"city_4120903","Quedas do Iguaçu","4120903","base.state_br_pr","base.br"
-"city_4121000","Querência do Norte","4121000","base.state_br_pr","base.br"
-"city_4121109","Quinta do Sol","4121109","base.state_br_pr","base.br"
-"city_4121208","Quitandinha","4121208","base.state_br_pr","base.br"
-"city_4121257","Ramilândia","4121257","base.state_br_pr","base.br"
-"city_4121307","Rancho Alegre","4121307","base.state_br_pr","base.br"
-"city_4121356","Rancho Alegre D'Oeste","4121356","base.state_br_pr","base.br"
-"city_4121406","Realeza","4121406","base.state_br_pr","base.br"
-"city_4121505","Rebouças","4121505","base.state_br_pr","base.br"
-"city_4121604","Renascença","4121604","base.state_br_pr","base.br"
-"city_4121703","Reserva","4121703","base.state_br_pr","base.br"
-"city_4121752","Reserva do Iguaçu","4121752","base.state_br_pr","base.br"
-"city_4121802","Ribeirão Claro","4121802","base.state_br_pr","base.br"
-"city_4121901","Ribeirão do Pinhal","4121901","base.state_br_pr","base.br"
-"city_4122008","Rio Azul","4122008","base.state_br_pr","base.br"
-"city_4122107","Rio Bom","4122107","base.state_br_pr","base.br"
-"city_4122156","Rio Bonito do Iguaçu","4122156","base.state_br_pr","base.br"
-"city_4122172","Rio Branco do Ivaí","4122172","base.state_br_pr","base.br"
-"city_4122206","Rio Branco do Sul","4122206","base.state_br_pr","base.br"
-"city_4122305","Rio Negro","4122305","base.state_br_pr","base.br"
-"city_4122404","Rolândia","4122404","base.state_br_pr","base.br"
-"city_4122503","Roncador","4122503","base.state_br_pr","base.br"
-"city_4122602","Rondon","4122602","base.state_br_pr","base.br"
-"city_4122651","Rosário do Ivaí","4122651","base.state_br_pr","base.br"
-"city_4122701","Sabáudia","4122701","base.state_br_pr","base.br"
-"city_4122800","Salgado Filho","4122800","base.state_br_pr","base.br"
-"city_4122909","Salto do Itararé","4122909","base.state_br_pr","base.br"
-"city_4123006","Salto do Lontra","4123006","base.state_br_pr","base.br"
-"city_4123105","Santa Amélia","4123105","base.state_br_pr","base.br"
-"city_4123204","Santa Cecília do Pavão","4123204","base.state_br_pr","base.br"
-"city_4123303","Santa Cruz de Monte Castelo","4123303","base.state_br_pr","base.br"
-"city_4123402","Santa Fé","4123402","base.state_br_pr","base.br"
-"city_4123501","Santa Helena","4123501","base.state_br_pr","base.br"
-"city_4123600","Santa Inês","4123600","base.state_br_pr","base.br"
-"city_4123709","Santa Isabel do Ivaí","4123709","base.state_br_pr","base.br"
-"city_4123808","Santa Izabel do Oeste","4123808","base.state_br_pr","base.br"
-"city_4123824","Santa Lúcia","4123824","base.state_br_pr","base.br"
-"city_4123857","Santa Maria do Oeste","4123857","base.state_br_pr","base.br"
-"city_4123907","Santa Mariana","4123907","base.state_br_pr","base.br"
-"city_4123956","Santa Mônica","4123956","base.state_br_pr","base.br"
-"city_4124020","Santa Tereza do Oeste","4124020","base.state_br_pr","base.br"
-"city_4124053","Santa Terezinha de Itaipu","4124053","base.state_br_pr","base.br"
-"city_4124004","Santana do Itararé","4124004","base.state_br_pr","base.br"
-"city_4124103","Santo Antônio da Platina","4124103","base.state_br_pr","base.br"
-"city_4124202","Santo Antônio do Caiuá","4124202","base.state_br_pr","base.br"
-"city_4124301","Santo Antônio do Paraíso","4124301","base.state_br_pr","base.br"
-"city_4124400","Santo Antônio do Sudoeste","4124400","base.state_br_pr","base.br"
-"city_4124509","Santo Inácio","4124509","base.state_br_pr","base.br"
-"city_4124608","São Carlos do Ivaí","4124608","base.state_br_pr","base.br"
-"city_4124707","São Jerônimo da Serra","4124707","base.state_br_pr","base.br"
-"city_4124806","São João","4124806","base.state_br_pr","base.br"
-"city_4124905","São João do Caiuá","4124905","base.state_br_pr","base.br"
-"city_4125001","São João do Ivaí","4125001","base.state_br_pr","base.br"
-"city_4125100","São João do Triunfo","4125100","base.state_br_pr","base.br"
-"city_4125308","São Jorge do Ivaí","4125308","base.state_br_pr","base.br"
-"city_4125357","São Jorge do Patrocínio","4125357","base.state_br_pr","base.br"
-"city_4125209","São Jorge d'Oeste","4125209","base.state_br_pr","base.br"
-"city_4125407","São José da Boa Vista","4125407","base.state_br_pr","base.br"
-"city_4125456","São José das Palmeiras","4125456","base.state_br_pr","base.br"
-"city_4125506","São José dos Pinhais","4125506","base.state_br_pr","base.br"
-"city_4125555","São Manoel do Paraná","4125555","base.state_br_pr","base.br"
-"city_4125605","São Mateus do Sul","4125605","base.state_br_pr","base.br"
-"city_4125704","São Miguel do Iguaçu","4125704","base.state_br_pr","base.br"
-"city_4125753","São Pedro do Iguaçu","4125753","base.state_br_pr","base.br"
-"city_4125803","São Pedro do Ivaí","4125803","base.state_br_pr","base.br"
-"city_4125902","São Pedro do Paraná","4125902","base.state_br_pr","base.br"
-"city_4126009","São Sebastião da Amoreira","4126009","base.state_br_pr","base.br"
-"city_4126108","São Tomé","4126108","base.state_br_pr","base.br"
-"city_4126207","Sapopema","4126207","base.state_br_pr","base.br"
-"city_4126256","Sarandi","4126256","base.state_br_pr","base.br"
-"city_4126272","Saudade do Iguaçu","4126272","base.state_br_pr","base.br"
-"city_4126306","Sengés","4126306","base.state_br_pr","base.br"
-"city_4126355","Serranópolis do Iguaçu","4126355","base.state_br_pr","base.br"
-"city_4126405","Sertaneja","4126405","base.state_br_pr","base.br"
-"city_4126504","Sertanópolis","4126504","base.state_br_pr","base.br"
-"city_4126603","Siqueira Campos","4126603","base.state_br_pr","base.br"
-"city_4126652","Sulina","4126652","base.state_br_pr","base.br"
-"city_4126678","Tamarana","4126678","base.state_br_pr","base.br"
-"city_4126702","Tamboara","4126702","base.state_br_pr","base.br"
-"city_4126801","Tapejara","4126801","base.state_br_pr","base.br"
-"city_4126900","Tapira","4126900","base.state_br_pr","base.br"
-"city_4127007","Teixeira Soares","4127007","base.state_br_pr","base.br"
-"city_4127106","Telêmaco Borba","4127106","base.state_br_pr","base.br"
-"city_4127205","Terra Boa","4127205","base.state_br_pr","base.br"
-"city_4127304","Terra Rica","4127304","base.state_br_pr","base.br"
-"city_4127403","Terra Roxa","4127403","base.state_br_pr","base.br"
-"city_4127502","Tibagi","4127502","base.state_br_pr","base.br"
-"city_4127601","Tijucas do Sul","4127601","base.state_br_pr","base.br"
-"city_4127700","Toledo","4127700","base.state_br_pr","base.br"
-"city_4127809","Tomazina","4127809","base.state_br_pr","base.br"
-"city_4127858","Três Barras do Paraná","4127858","base.state_br_pr","base.br"
-"city_4127882","Tunas do Paraná","4127882","base.state_br_pr","base.br"
-"city_4127908","Tuneiras do Oeste","4127908","base.state_br_pr","base.br"
-"city_4127957","Tupãssi","4127957","base.state_br_pr","base.br"
-"city_4127965","Turvo","4127965","base.state_br_pr","base.br"
-"city_4128005","Ubiratã","4128005","base.state_br_pr","base.br"
-"city_4128104","Umuarama","4128104","base.state_br_pr","base.br"
-"city_4128203","União da Vitória","4128203","base.state_br_pr","base.br"
-"city_4128302","Uniflor","4128302","base.state_br_pr","base.br"
-"city_4128401","Uraí","4128401","base.state_br_pr","base.br"
-"city_4128534","Ventania","4128534","base.state_br_pr","base.br"
-"city_4128559","Vera Cruz do Oeste","4128559","base.state_br_pr","base.br"
-"city_4128609","Verê","4128609","base.state_br_pr","base.br"
-"city_4128658","Virmond","4128658","base.state_br_pr","base.br"
-"city_4128708","Vitorino","4128708","base.state_br_pr","base.br"
-"city_4128500","Wenceslau Braz","4128500","base.state_br_pr","base.br"
-"city_4128807","Xambrê","4128807","base.state_br_pr","base.br"
-"city_4200051","Abdon Batista","4200051","base.state_br_sc","base.br"
-"city_4200101","Abelardo Luz","4200101","base.state_br_sc","base.br"
-"city_4200200","Agrolândia","4200200","base.state_br_sc","base.br"
-"city_4200309","Agronômica","4200309","base.state_br_sc","base.br"
-"city_4200408","Água Doce","4200408","base.state_br_sc","base.br"
-"city_4200507","Águas de Chapecó","4200507","base.state_br_sc","base.br"
-"city_4200556","Águas Frias","4200556","base.state_br_sc","base.br"
-"city_4200606","Águas Mornas","4200606","base.state_br_sc","base.br"
-"city_4200705","Alfredo Wagner","4200705","base.state_br_sc","base.br"
-"city_4200754","Alto Bela Vista","4200754","base.state_br_sc","base.br"
-"city_4200804","Anchieta","4200804","base.state_br_sc","base.br"
-"city_4200903","Angelina","4200903","base.state_br_sc","base.br"
-"city_4201000","Anita Garibaldi","4201000","base.state_br_sc","base.br"
-"city_4201109","Anitápolis","4201109","base.state_br_sc","base.br"
-"city_4201208","Antônio Carlos","4201208","base.state_br_sc","base.br"
-"city_4201257","Apiúna","4201257","base.state_br_sc","base.br"
-"city_4201273","Arabutã","4201273","base.state_br_sc","base.br"
-"city_4201307","Araquari","4201307","base.state_br_sc","base.br"
-"city_4201406","Araranguá","4201406","base.state_br_sc","base.br"
-"city_4201505","Armazém","4201505","base.state_br_sc","base.br"
-"city_4201604","Arroio Trinta","4201604","base.state_br_sc","base.br"
-"city_4201653","Arvoredo","4201653","base.state_br_sc","base.br"
-"city_4201703","Ascurra","4201703","base.state_br_sc","base.br"
-"city_4201802","Atalanta","4201802","base.state_br_sc","base.br"
-"city_4201901","Aurora","4201901","base.state_br_sc","base.br"
-"city_4201950","Balneário Arroio do Silva","4201950","base.state_br_sc","base.br"
-"city_4202057","Balneário Barra do Sul","4202057","base.state_br_sc","base.br"
-"city_4202008","Balneário Camboriú","4202008","base.state_br_sc","base.br"
-"city_4202073","Balneário Gaivota","4202073","base.state_br_sc","base.br"
-"city_4212809","Balneário Piçarras","4212809","base.state_br_sc","base.br"
-"city_4220000","Balneário Rincão","4220000","base.state_br_sc","base.br"
-"city_4202081","Bandeirante","4202081","base.state_br_sc","base.br"
-"city_4202099","Barra Bonita","4202099","base.state_br_sc","base.br"
-"city_4202107","Barra Velha","4202107","base.state_br_sc","base.br"
-"city_4202131","Bela Vista do Toldo","4202131","base.state_br_sc","base.br"
-"city_4202156","Belmonte","4202156","base.state_br_sc","base.br"
-"city_4202206","Benedito Novo","4202206","base.state_br_sc","base.br"
-"city_4202305","Biguaçu","4202305","base.state_br_sc","base.br"
-"city_4202404","Blumenau","4202404","base.state_br_sc","base.br"
-"city_4202438","Bocaina do Sul","4202438","base.state_br_sc","base.br"
-"city_4202503","Bom Jardim da Serra","4202503","base.state_br_sc","base.br"
-"city_4202537","Bom Jesus","4202537","base.state_br_sc","base.br"
-"city_4202578","Bom Jesus do Oeste","4202578","base.state_br_sc","base.br"
-"city_4202602","Bom Retiro","4202602","base.state_br_sc","base.br"
-"city_4202453","Bombinhas","4202453","base.state_br_sc","base.br"
-"city_4202701","Botuverá","4202701","base.state_br_sc","base.br"
-"city_4202800","Braço do Norte","4202800","base.state_br_sc","base.br"
-"city_4202859","Braço do Trombudo","4202859","base.state_br_sc","base.br"
-"city_4202875","Brunópolis","4202875","base.state_br_sc","base.br"
-"city_4202909","Brusque","4202909","base.state_br_sc","base.br"
-"city_4203006","Caçador","4203006","base.state_br_sc","base.br"
-"city_4203105","Caibi","4203105","base.state_br_sc","base.br"
-"city_4203154","Calmon","4203154","base.state_br_sc","base.br"
-"city_4203204","Camboriú","4203204","base.state_br_sc","base.br"
-"city_4203303","Campo Alegre","4203303","base.state_br_sc","base.br"
-"city_4203402","Campo Belo do Sul","4203402","base.state_br_sc","base.br"
-"city_4203501","Campo Erê","4203501","base.state_br_sc","base.br"
-"city_4203600","Campos Novos","4203600","base.state_br_sc","base.br"
-"city_4203709","Canelinha","4203709","base.state_br_sc","base.br"
-"city_4203808","Canoinhas","4203808","base.state_br_sc","base.br"
-"city_4203253","Capão Alto","4203253","base.state_br_sc","base.br"
-"city_4203907","Capinzal","4203907","base.state_br_sc","base.br"
-"city_4203956","Capivari de Baixo","4203956","base.state_br_sc","base.br"
-"city_4204004","Catanduvas","4204004","base.state_br_sc","base.br"
-"city_4204103","Caxambu do Sul","4204103","base.state_br_sc","base.br"
-"city_4204152","Celso Ramos","4204152","base.state_br_sc","base.br"
-"city_4204178","Cerro Negro","4204178","base.state_br_sc","base.br"
-"city_4204194","Chapadão do Lageado","4204194","base.state_br_sc","base.br"
-"city_4204202","Chapecó","4204202","base.state_br_sc","base.br"
-"city_4204251","Cocal do Sul","4204251","base.state_br_sc","base.br"
-"city_4204301","Concórdia","4204301","base.state_br_sc","base.br"
-"city_4204350","Cordilheira Alta","4204350","base.state_br_sc","base.br"
-"city_4204400","Coronel Freitas","4204400","base.state_br_sc","base.br"
-"city_4204459","Coronel Martins","4204459","base.state_br_sc","base.br"
-"city_4204558","Correia Pinto","4204558","base.state_br_sc","base.br"
-"city_4204509","Corupá","4204509","base.state_br_sc","base.br"
-"city_4204608","Criciúma","4204608","base.state_br_sc","base.br"
-"city_4204707","Cunha Porã","4204707","base.state_br_sc","base.br"
-"city_4204756","Cunhataí","4204756","base.state_br_sc","base.br"
-"city_4204806","Curitibanos","4204806","base.state_br_sc","base.br"
-"city_4204905","Descanso","4204905","base.state_br_sc","base.br"
-"city_4205001","Dionísio Cerqueira","4205001","base.state_br_sc","base.br"
-"city_4205100","Dona Emma","4205100","base.state_br_sc","base.br"
-"city_4205159","Doutor Pedrinho","4205159","base.state_br_sc","base.br"
-"city_4205175","Entre Rios","4205175","base.state_br_sc","base.br"
-"city_4205191","Ermo","4205191","base.state_br_sc","base.br"
-"city_4205209","Erval Velho","4205209","base.state_br_sc","base.br"
-"city_4205308","Faxinal dos Guedes","4205308","base.state_br_sc","base.br"
-"city_4205357","Flor do Sertão","4205357","base.state_br_sc","base.br"
-"city_4205407","Florianópolis","4205407","base.state_br_sc","base.br"
-"city_4205431","Formosa do Sul","4205431","base.state_br_sc","base.br"
-"city_4205456","Forquilhinha","4205456","base.state_br_sc","base.br"
-"city_4205506","Fraiburgo","4205506","base.state_br_sc","base.br"
-"city_4205555","Frei Rogério","4205555","base.state_br_sc","base.br"
-"city_4205605","Galvão","4205605","base.state_br_sc","base.br"
-"city_4205704","Garopaba","4205704","base.state_br_sc","base.br"
-"city_4205803","Garuva","4205803","base.state_br_sc","base.br"
-"city_4205902","Gaspar","4205902","base.state_br_sc","base.br"
-"city_4206009","Governador Celso Ramos","4206009","base.state_br_sc","base.br"
-"city_4206108","Grão-Pará","4206108","base.state_br_sc","base.br"
-"city_4206207","Gravatal","4206207","base.state_br_sc","base.br"
-"city_4206306","Guabiruba","4206306","base.state_br_sc","base.br"
-"city_4206405","Guaraciaba","4206405","base.state_br_sc","base.br"
-"city_4206504","Guaramirim","4206504","base.state_br_sc","base.br"
-"city_4206603","Guarujá do Sul","4206603","base.state_br_sc","base.br"
-"city_4206652","Guatambú","4206652","base.state_br_sc","base.br"
-"city_4206702","Herval d'Oeste","4206702","base.state_br_sc","base.br"
-"city_4206751","Ibiam","4206751","base.state_br_sc","base.br"
-"city_4206801","Ibicaré","4206801","base.state_br_sc","base.br"
-"city_4206900","Ibirama","4206900","base.state_br_sc","base.br"
-"city_4207007","Içara","4207007","base.state_br_sc","base.br"
-"city_4207106","Ilhota","4207106","base.state_br_sc","base.br"
-"city_4207205","Imaruí","4207205","base.state_br_sc","base.br"
-"city_4207304","Imbituba","4207304","base.state_br_sc","base.br"
-"city_4207403","Imbuia","4207403","base.state_br_sc","base.br"
-"city_4207502","Indaial","4207502","base.state_br_sc","base.br"
-"city_4207577","Iomerê","4207577","base.state_br_sc","base.br"
-"city_4207601","Ipira","4207601","base.state_br_sc","base.br"
-"city_4207650","Iporã do Oeste","4207650","base.state_br_sc","base.br"
-"city_4207684","Ipuaçu","4207684","base.state_br_sc","base.br"
-"city_4207700","Ipumirim","4207700","base.state_br_sc","base.br"
-"city_4207759","Iraceminha","4207759","base.state_br_sc","base.br"
-"city_4207809","Irani","4207809","base.state_br_sc","base.br"
-"city_4207858","Irati","4207858","base.state_br_sc","base.br"
-"city_4207908","Irineópolis","4207908","base.state_br_sc","base.br"
-"city_4208005","Itá","4208005","base.state_br_sc","base.br"
-"city_4208104","Itaiópolis","4208104","base.state_br_sc","base.br"
-"city_4208203","Itajaí","4208203","base.state_br_sc","base.br"
-"city_4208302","Itapema","4208302","base.state_br_sc","base.br"
-"city_4208401","Itapiranga","4208401","base.state_br_sc","base.br"
-"city_4208450","Itapoá","4208450","base.state_br_sc","base.br"
-"city_4208500","Ituporanga","4208500","base.state_br_sc","base.br"
-"city_4208609","Jaborá","4208609","base.state_br_sc","base.br"
-"city_4208708","Jacinto Machado","4208708","base.state_br_sc","base.br"
-"city_4208807","Jaguaruna","4208807","base.state_br_sc","base.br"
-"city_4208906","Jaraguá do Sul","4208906","base.state_br_sc","base.br"
-"city_4208955","Jardinópolis","4208955","base.state_br_sc","base.br"
-"city_4209003","Joaçaba","4209003","base.state_br_sc","base.br"
-"city_4209102","Joinville","4209102","base.state_br_sc","base.br"
-"city_4209151","José Boiteux","4209151","base.state_br_sc","base.br"
-"city_4209177","Jupiá","4209177","base.state_br_sc","base.br"
-"city_4209201","Lacerdópolis","4209201","base.state_br_sc","base.br"
-"city_4209300","Lages","4209300","base.state_br_sc","base.br"
-"city_4209409","Laguna","4209409","base.state_br_sc","base.br"
-"city_4209458","Lajeado Grande","4209458","base.state_br_sc","base.br"
-"city_4209508","Laurentino","4209508","base.state_br_sc","base.br"
-"city_4209607","Lauro Müller","4209607","base.state_br_sc","base.br"
-"city_4209706","Lebon Régis","4209706","base.state_br_sc","base.br"
-"city_4209805","Leoberto Leal","4209805","base.state_br_sc","base.br"
-"city_4209854","Lindóia do Sul","4209854","base.state_br_sc","base.br"
-"city_4209904","Lontras","4209904","base.state_br_sc","base.br"
-"city_4210001","Luiz Alves","4210001","base.state_br_sc","base.br"
-"city_4210035","Luzerna","4210035","base.state_br_sc","base.br"
-"city_4210050","Macieira","4210050","base.state_br_sc","base.br"
-"city_4210100","Mafra","4210100","base.state_br_sc","base.br"
-"city_4210209","Major Gercino","4210209","base.state_br_sc","base.br"
-"city_4210308","Major Vieira","4210308","base.state_br_sc","base.br"
-"city_4210407","Maracajá","4210407","base.state_br_sc","base.br"
-"city_4210506","Maravilha","4210506","base.state_br_sc","base.br"
-"city_4210555","Marema","4210555","base.state_br_sc","base.br"
-"city_4210605","Massaranduba","4210605","base.state_br_sc","base.br"
-"city_4210704","Matos Costa","4210704","base.state_br_sc","base.br"
-"city_4210803","Meleiro","4210803","base.state_br_sc","base.br"
-"city_4210852","Mirim Doce","4210852","base.state_br_sc","base.br"
-"city_4210902","Modelo","4210902","base.state_br_sc","base.br"
-"city_4211009","Mondaí","4211009","base.state_br_sc","base.br"
-"city_4211058","Monte Carlo","4211058","base.state_br_sc","base.br"
-"city_4211108","Monte Castelo","4211108","base.state_br_sc","base.br"
-"city_4211207","Morro da Fumaça","4211207","base.state_br_sc","base.br"
-"city_4211256","Morro Grande","4211256","base.state_br_sc","base.br"
-"city_4211306","Navegantes","4211306","base.state_br_sc","base.br"
-"city_4211405","Nova Erechim","4211405","base.state_br_sc","base.br"
-"city_4211454","Nova Itaberaba","4211454","base.state_br_sc","base.br"
-"city_4211504","Nova Trento","4211504","base.state_br_sc","base.br"
-"city_4211603","Nova Veneza","4211603","base.state_br_sc","base.br"
-"city_4211652","Novo Horizonte","4211652","base.state_br_sc","base.br"
-"city_4211702","Orleans","4211702","base.state_br_sc","base.br"
-"city_4211751","Otacílio Costa","4211751","base.state_br_sc","base.br"
-"city_4211801","Ouro","4211801","base.state_br_sc","base.br"
-"city_4211850","Ouro Verde","4211850","base.state_br_sc","base.br"
-"city_4211876","Paial","4211876","base.state_br_sc","base.br"
-"city_4211892","Painel","4211892","base.state_br_sc","base.br"
-"city_4211900","Palhoça","4211900","base.state_br_sc","base.br"
-"city_4212007","Palma Sola","4212007","base.state_br_sc","base.br"
-"city_4212056","Palmeira","4212056","base.state_br_sc","base.br"
-"city_4212106","Palmitos","4212106","base.state_br_sc","base.br"
-"city_4212205","Papanduva","4212205","base.state_br_sc","base.br"
-"city_4212239","Paraíso","4212239","base.state_br_sc","base.br"
-"city_4212254","Passo de Torres","4212254","base.state_br_sc","base.br"
-"city_4212270","Passos Maia","4212270","base.state_br_sc","base.br"
-"city_4212304","Paulo Lopes","4212304","base.state_br_sc","base.br"
-"city_4212403","Pedras Grandes","4212403","base.state_br_sc","base.br"
-"city_4212502","Penha","4212502","base.state_br_sc","base.br"
-"city_4212601","Peritiba","4212601","base.state_br_sc","base.br"
-"city_4212650","Pescaria Brava","4212650","base.state_br_sc","base.br"
-"city_4212700","Petrolândia","4212700","base.state_br_sc","base.br"
-"city_4212908","Pinhalzinho","4212908","base.state_br_sc","base.br"
-"city_4213005","Pinheiro Preto","4213005","base.state_br_sc","base.br"
-"city_4213104","Piratuba","4213104","base.state_br_sc","base.br"
-"city_4213153","Planalto Alegre","4213153","base.state_br_sc","base.br"
-"city_4213203","Pomerode","4213203","base.state_br_sc","base.br"
-"city_4213302","Ponte Alta","4213302","base.state_br_sc","base.br"
-"city_4213351","Ponte Alta do Norte","4213351","base.state_br_sc","base.br"
-"city_4213401","Ponte Serrada","4213401","base.state_br_sc","base.br"
-"city_4213500","Porto Belo","4213500","base.state_br_sc","base.br"
-"city_4213609","Porto União","4213609","base.state_br_sc","base.br"
-"city_4213708","Pouso Redondo","4213708","base.state_br_sc","base.br"
-"city_4213807","Praia Grande","4213807","base.state_br_sc","base.br"
-"city_4213906","Presidente Castello Branco","4213906","base.state_br_sc","base.br"
-"city_4214003","Presidente Getúlio","4214003","base.state_br_sc","base.br"
-"city_4214102","Presidente Nereu","4214102","base.state_br_sc","base.br"
-"city_4214151","Princesa","4214151","base.state_br_sc","base.br"
-"city_4214201","Quilombo","4214201","base.state_br_sc","base.br"
-"city_4214300","Rancho Queimado","4214300","base.state_br_sc","base.br"
-"city_4214409","Rio das Antas","4214409","base.state_br_sc","base.br"
-"city_4214508","Rio do Campo","4214508","base.state_br_sc","base.br"
-"city_4214607","Rio do Oeste","4214607","base.state_br_sc","base.br"
-"city_4214805","Rio do Sul","4214805","base.state_br_sc","base.br"
-"city_4214706","Rio dos Cedros","4214706","base.state_br_sc","base.br"
-"city_4214904","Rio Fortuna","4214904","base.state_br_sc","base.br"
-"city_4215000","Rio Negrinho","4215000","base.state_br_sc","base.br"
-"city_4215059","Rio Rufino","4215059","base.state_br_sc","base.br"
-"city_4215075","Riqueza","4215075","base.state_br_sc","base.br"
-"city_4215109","Rodeio","4215109","base.state_br_sc","base.br"
-"city_4215208","Romelândia","4215208","base.state_br_sc","base.br"
-"city_4215307","Salete","4215307","base.state_br_sc","base.br"
-"city_4215356","Saltinho","4215356","base.state_br_sc","base.br"
-"city_4215406","Salto Veloso","4215406","base.state_br_sc","base.br"
-"city_4215455","Sangão","4215455","base.state_br_sc","base.br"
-"city_4215505","Santa Cecília","4215505","base.state_br_sc","base.br"
-"city_4215554","Santa Helena","4215554","base.state_br_sc","base.br"
-"city_4215604","Santa Rosa de Lima","4215604","base.state_br_sc","base.br"
-"city_4215653","Santa Rosa do Sul","4215653","base.state_br_sc","base.br"
-"city_4215679","Santa Terezinha","4215679","base.state_br_sc","base.br"
-"city_4215687","Santa Terezinha do Progresso","4215687","base.state_br_sc","base.br"
-"city_4215695","Santiago do Sul","4215695","base.state_br_sc","base.br"
-"city_4215703","Santo Amaro da Imperatriz","4215703","base.state_br_sc","base.br"
-"city_4215802","São Bento do Sul","4215802","base.state_br_sc","base.br"
-"city_4215752","São Bernardino","4215752","base.state_br_sc","base.br"
-"city_4215901","São Bonifácio","4215901","base.state_br_sc","base.br"
-"city_4216008","São Carlos","4216008","base.state_br_sc","base.br"
-"city_4216057","São Cristóvão do Sul","4216057","base.state_br_sc","base.br"
-"city_4216107","São Domingos","4216107","base.state_br_sc","base.br"
-"city_4216206","São Francisco do Sul","4216206","base.state_br_sc","base.br"
-"city_4216305","São João Batista","4216305","base.state_br_sc","base.br"
-"city_4216354","São João do Itaperiú","4216354","base.state_br_sc","base.br"
-"city_4216255","São João do Oeste","4216255","base.state_br_sc","base.br"
-"city_4216404","São João do Sul","4216404","base.state_br_sc","base.br"
-"city_4216503","São Joaquim","4216503","base.state_br_sc","base.br"
-"city_4216602","São José","4216602","base.state_br_sc","base.br"
-"city_4216701","São José do Cedro","4216701","base.state_br_sc","base.br"
-"city_4216800","São José do Cerrito","4216800","base.state_br_sc","base.br"
-"city_4216909","São Lourenço do Oeste","4216909","base.state_br_sc","base.br"
-"city_4217006","São Ludgero","4217006","base.state_br_sc","base.br"
-"city_4217105","São Martinho","4217105","base.state_br_sc","base.br"
-"city_4217154","São Miguel da Boa Vista","4217154","base.state_br_sc","base.br"
-"city_4217204","São Miguel do Oeste","4217204","base.state_br_sc","base.br"
-"city_4217253","São Pedro de Alcântara","4217253","base.state_br_sc","base.br"
-"city_4217303","Saudades","4217303","base.state_br_sc","base.br"
-"city_4217402","Schroeder","4217402","base.state_br_sc","base.br"
-"city_4217501","Seara","4217501","base.state_br_sc","base.br"
-"city_4217550","Serra Alta","4217550","base.state_br_sc","base.br"
-"city_4217600","Siderópolis","4217600","base.state_br_sc","base.br"
-"city_4217709","Sombrio","4217709","base.state_br_sc","base.br"
-"city_4217758","Sul Brasil","4217758","base.state_br_sc","base.br"
-"city_4217808","Taió","4217808","base.state_br_sc","base.br"
-"city_4217907","Tangará","4217907","base.state_br_sc","base.br"
-"city_4217956","Tigrinhos","4217956","base.state_br_sc","base.br"
-"city_4218004","Tijucas","4218004","base.state_br_sc","base.br"
-"city_4218103","Timbé do Sul","4218103","base.state_br_sc","base.br"
-"city_4218202","Timbó","4218202","base.state_br_sc","base.br"
-"city_4218251","Timbó Grande","4218251","base.state_br_sc","base.br"
-"city_4218301","Três Barras","4218301","base.state_br_sc","base.br"
-"city_4218350","Treviso","4218350","base.state_br_sc","base.br"
-"city_4218400","Treze de Maio","4218400","base.state_br_sc","base.br"
-"city_4218509","Treze Tílias","4218509","base.state_br_sc","base.br"
-"city_4218608","Trombudo Central","4218608","base.state_br_sc","base.br"
-"city_4218707","Tubarão","4218707","base.state_br_sc","base.br"
-"city_4218756","Tunápolis","4218756","base.state_br_sc","base.br"
-"city_4218806","Turvo","4218806","base.state_br_sc","base.br"
-"city_4218855","União do Oeste","4218855","base.state_br_sc","base.br"
-"city_4218905","Urubici","4218905","base.state_br_sc","base.br"
-"city_4218954","Urupema","4218954","base.state_br_sc","base.br"
-"city_4219002","Urussanga","4219002","base.state_br_sc","base.br"
-"city_4219101","Vargeão","4219101","base.state_br_sc","base.br"
-"city_4219150","Vargem","4219150","base.state_br_sc","base.br"
-"city_4219176","Vargem Bonita","4219176","base.state_br_sc","base.br"
-"city_4219200","Vidal Ramos","4219200","base.state_br_sc","base.br"
-"city_4219309","Videira","4219309","base.state_br_sc","base.br"
-"city_4219358","Vitor Meireles","4219358","base.state_br_sc","base.br"
-"city_4219408","Witmarsum","4219408","base.state_br_sc","base.br"
-"city_4219507","Xanxerê","4219507","base.state_br_sc","base.br"
-"city_4219606","Xavantina","4219606","base.state_br_sc","base.br"
-"city_4219705","Xaxim","4219705","base.state_br_sc","base.br"
-"city_4219853","Zortéa","4219853","base.state_br_sc","base.br"
-"city_4300034","Aceguá","4300034","base.state_br_rs","base.br"
-"city_4300059","Água Santa","4300059","base.state_br_rs","base.br"
-"city_4300109","Agudo","4300109","base.state_br_rs","base.br"
-"city_4300208","Ajuricaba","4300208","base.state_br_rs","base.br"
-"city_4300307","Alecrim","4300307","base.state_br_rs","base.br"
-"city_4300406","Alegrete","4300406","base.state_br_rs","base.br"
-"city_4300455","Alegria","4300455","base.state_br_rs","base.br"
-"city_4300471","Almirante Tamandaré do Sul","4300471","base.state_br_rs","base.br"
-"city_4300505","Alpestre","4300505","base.state_br_rs","base.br"
-"city_4300554","Alto Alegre","4300554","base.state_br_rs","base.br"
-"city_4300570","Alto Feliz","4300570","base.state_br_rs","base.br"
-"city_4300604","Alvorada","4300604","base.state_br_rs","base.br"
-"city_4300638","Amaral Ferrador","4300638","base.state_br_rs","base.br"
-"city_4300646","Ametista do Sul","4300646","base.state_br_rs","base.br"
-"city_4300661","André da Rocha","4300661","base.state_br_rs","base.br"
-"city_4300703","Anta Gorda","4300703","base.state_br_rs","base.br"
-"city_4300802","Antônio Prado","4300802","base.state_br_rs","base.br"
-"city_4300851","Arambaré","4300851","base.state_br_rs","base.br"
-"city_4300877","Araricá","4300877","base.state_br_rs","base.br"
-"city_4300901","Aratiba","4300901","base.state_br_rs","base.br"
-"city_4301008","Arroio do Meio","4301008","base.state_br_rs","base.br"
-"city_4301073","Arroio do Padre","4301073","base.state_br_rs","base.br"
-"city_4301057","Arroio do Sal","4301057","base.state_br_rs","base.br"
-"city_4301206","Arroio do Tigre","4301206","base.state_br_rs","base.br"
-"city_4301107","Arroio dos Ratos","4301107","base.state_br_rs","base.br"
-"city_4301305","Arroio Grande","4301305","base.state_br_rs","base.br"
-"city_4301404","Arvorezinha","4301404","base.state_br_rs","base.br"
-"city_4301503","Augusto Pestana","4301503","base.state_br_rs","base.br"
-"city_4301552","Áurea","4301552","base.state_br_rs","base.br"
-"city_4301602","Bagé","4301602","base.state_br_rs","base.br"
-"city_4301636","Balneário Pinhal","4301636","base.state_br_rs","base.br"
-"city_4301651","Barão","4301651","base.state_br_rs","base.br"
-"city_4301701","Barão de Cotegipe","4301701","base.state_br_rs","base.br"
-"city_4301750","Barão do Triunfo","4301750","base.state_br_rs","base.br"
-"city_4301859","Barra do Guarita","4301859","base.state_br_rs","base.br"
-"city_4301875","Barra do Quaraí","4301875","base.state_br_rs","base.br"
-"city_4301909","Barra do Ribeiro","4301909","base.state_br_rs","base.br"
-"city_4301925","Barra do Rio Azul","4301925","base.state_br_rs","base.br"
-"city_4301958","Barra Funda","4301958","base.state_br_rs","base.br"
-"city_4301800","Barracão","4301800","base.state_br_rs","base.br"
-"city_4302006","Barros Cassal","4302006","base.state_br_rs","base.br"
-"city_4302055","Benjamin Constant do Sul","4302055","base.state_br_rs","base.br"
-"city_4302105","Bento Gonçalves","4302105","base.state_br_rs","base.br"
-"city_4302154","Boa Vista das Missões","4302154","base.state_br_rs","base.br"
-"city_4302204","Boa Vista do Buricá","4302204","base.state_br_rs","base.br"
-"city_4302220","Boa Vista do Cadeado","4302220","base.state_br_rs","base.br"
-"city_4302238","Boa Vista do Incra","4302238","base.state_br_rs","base.br"
-"city_4302253","Boa Vista do Sul","4302253","base.state_br_rs","base.br"
-"city_4302303","Bom Jesus","4302303","base.state_br_rs","base.br"
-"city_4302352","Bom Princípio","4302352","base.state_br_rs","base.br"
-"city_4302378","Bom Progresso","4302378","base.state_br_rs","base.br"
-"city_4302402","Bom Retiro do Sul","4302402","base.state_br_rs","base.br"
-"city_4302451","Boqueirão do Leão","4302451","base.state_br_rs","base.br"
-"city_4302501","Bossoroca","4302501","base.state_br_rs","base.br"
-"city_4302584","Bozano","4302584","base.state_br_rs","base.br"
-"city_4302600","Braga","4302600","base.state_br_rs","base.br"
-"city_4302659","Brochier","4302659","base.state_br_rs","base.br"
-"city_4302709","Butiá","4302709","base.state_br_rs","base.br"
-"city_4302808","Caçapava do Sul","4302808","base.state_br_rs","base.br"
-"city_4302907","Cacequi","4302907","base.state_br_rs","base.br"
-"city_4303004","Cachoeira do Sul","4303004","base.state_br_rs","base.br"
-"city_4303103","Cachoeirinha","4303103","base.state_br_rs","base.br"
-"city_4303202","Cacique Doble","4303202","base.state_br_rs","base.br"
-"city_4303301","Caibaté","4303301","base.state_br_rs","base.br"
-"city_4303400","Caiçara","4303400","base.state_br_rs","base.br"
-"city_4303509","Camaquã","4303509","base.state_br_rs","base.br"
-"city_4303558","Camargo","4303558","base.state_br_rs","base.br"
-"city_4303608","Cambará do Sul","4303608","base.state_br_rs","base.br"
-"city_4303673","Campestre da Serra","4303673","base.state_br_rs","base.br"
-"city_4303707","Campina das Missões","4303707","base.state_br_rs","base.br"
-"city_4303806","Campinas do Sul","4303806","base.state_br_rs","base.br"
-"city_4303905","Campo Bom","4303905","base.state_br_rs","base.br"
-"city_4304002","Campo Novo","4304002","base.state_br_rs","base.br"
-"city_4304101","Campos Borges","4304101","base.state_br_rs","base.br"
-"city_4304200","Candelária","4304200","base.state_br_rs","base.br"
-"city_4304309","Cândido Godói","4304309","base.state_br_rs","base.br"
-"city_4304358","Candiota","4304358","base.state_br_rs","base.br"
-"city_4304408","Canela","4304408","base.state_br_rs","base.br"
-"city_4304507","Canguçu","4304507","base.state_br_rs","base.br"
-"city_4304606","Canoas","4304606","base.state_br_rs","base.br"
-"city_4304614","Canudos do Vale","4304614","base.state_br_rs","base.br"
-"city_4304622","Capão Bonito do Sul","4304622","base.state_br_rs","base.br"
-"city_4304630","Capão da Canoa","4304630","base.state_br_rs","base.br"
-"city_4304655","Capão do Cipó","4304655","base.state_br_rs","base.br"
-"city_4304663","Capão do Leão","4304663","base.state_br_rs","base.br"
-"city_4304689","Capela de Santana","4304689","base.state_br_rs","base.br"
-"city_4304697","Capitão","4304697","base.state_br_rs","base.br"
-"city_4304671","Capivari do Sul","4304671","base.state_br_rs","base.br"
-"city_4304713","Caraá","4304713","base.state_br_rs","base.br"
-"city_4304705","Carazinho","4304705","base.state_br_rs","base.br"
-"city_4304804","Carlos Barbosa","4304804","base.state_br_rs","base.br"
-"city_4304853","Carlos Gomes","4304853","base.state_br_rs","base.br"
-"city_4304903","Casca","4304903","base.state_br_rs","base.br"
-"city_4304952","Caseiros","4304952","base.state_br_rs","base.br"
-"city_4305009","Catuípe","4305009","base.state_br_rs","base.br"
-"city_4305108","Caxias do Sul","4305108","base.state_br_rs","base.br"
-"city_4305116","Centenário","4305116","base.state_br_rs","base.br"
-"city_4305124","Cerrito","4305124","base.state_br_rs","base.br"
-"city_4305132","Cerro Branco","4305132","base.state_br_rs","base.br"
-"city_4305157","Cerro Grande","4305157","base.state_br_rs","base.br"
-"city_4305173","Cerro Grande do Sul","4305173","base.state_br_rs","base.br"
-"city_4305207","Cerro Largo","4305207","base.state_br_rs","base.br"
-"city_4305306","Chapada","4305306","base.state_br_rs","base.br"
-"city_4305355","Charqueadas","4305355","base.state_br_rs","base.br"
-"city_4305371","Charrua","4305371","base.state_br_rs","base.br"
-"city_4305405","Chiapetta","4305405","base.state_br_rs","base.br"
-"city_4305439","Chuí","4305439","base.state_br_rs","base.br"
-"city_4305447","Chuvisca","4305447","base.state_br_rs","base.br"
-"city_4305454","Cidreira","4305454","base.state_br_rs","base.br"
-"city_4305504","Ciríaco","4305504","base.state_br_rs","base.br"
-"city_4305587","Colinas","4305587","base.state_br_rs","base.br"
-"city_4305603","Colorado","4305603","base.state_br_rs","base.br"
-"city_4305702","Condor","4305702","base.state_br_rs","base.br"
-"city_4305801","Constantina","4305801","base.state_br_rs","base.br"
-"city_4305835","Coqueiro Baixo","4305835","base.state_br_rs","base.br"
-"city_4305850","Coqueiros do Sul","4305850","base.state_br_rs","base.br"
-"city_4305871","Coronel Barros","4305871","base.state_br_rs","base.br"
-"city_4305900","Coronel Bicaco","4305900","base.state_br_rs","base.br"
-"city_4305934","Coronel Pilar","4305934","base.state_br_rs","base.br"
-"city_4305959","Cotiporã","4305959","base.state_br_rs","base.br"
-"city_4305975","Coxilha","4305975","base.state_br_rs","base.br"
-"city_4306007","Crissiumal","4306007","base.state_br_rs","base.br"
-"city_4306056","Cristal","4306056","base.state_br_rs","base.br"
-"city_4306072","Cristal do Sul","4306072","base.state_br_rs","base.br"
-"city_4306106","Cruz Alta","4306106","base.state_br_rs","base.br"
-"city_4306130","Cruzaltense","4306130","base.state_br_rs","base.br"
-"city_4306205","Cruzeiro do Sul","4306205","base.state_br_rs","base.br"
-"city_4306304","David Canabarro","4306304","base.state_br_rs","base.br"
-"city_4306320","Derrubadas","4306320","base.state_br_rs","base.br"
-"city_4306353","Dezesseis de Novembro","4306353","base.state_br_rs","base.br"
-"city_4306379","Dilermando de Aguiar","4306379","base.state_br_rs","base.br"
-"city_4306403","Dois Irmãos","4306403","base.state_br_rs","base.br"
-"city_4306429","Dois Irmãos das Missões","4306429","base.state_br_rs","base.br"
-"city_4306452","Dois Lajeados","4306452","base.state_br_rs","base.br"
-"city_4306502","Dom Feliciano","4306502","base.state_br_rs","base.br"
-"city_4306601","Dom Pedrito","4306601","base.state_br_rs","base.br"
-"city_4306551","Dom Pedro de Alcântara","4306551","base.state_br_rs","base.br"
-"city_4306700","Dona Francisca","4306700","base.state_br_rs","base.br"
-"city_4306734","Doutor Maurício Cardoso","4306734","base.state_br_rs","base.br"
-"city_4306759","Doutor Ricardo","4306759","base.state_br_rs","base.br"
-"city_4306767","Eldorado do Sul","4306767","base.state_br_rs","base.br"
-"city_4306809","Encantado","4306809","base.state_br_rs","base.br"
-"city_4306908","Encruzilhada do Sul","4306908","base.state_br_rs","base.br"
-"city_4306924","Engenho Velho","4306924","base.state_br_rs","base.br"
-"city_4306957","Entre Rios do Sul","4306957","base.state_br_rs","base.br"
-"city_4306932","Entre-Ijuís","4306932","base.state_br_rs","base.br"
-"city_4306973","Erebango","4306973","base.state_br_rs","base.br"
-"city_4307005","Erechim","4307005","base.state_br_rs","base.br"
-"city_4307054","Ernestina","4307054","base.state_br_rs","base.br"
-"city_4307203","Erval Grande","4307203","base.state_br_rs","base.br"
-"city_4307302","Erval Seco","4307302","base.state_br_rs","base.br"
-"city_4307401","Esmeralda","4307401","base.state_br_rs","base.br"
-"city_4307450","Esperança do Sul","4307450","base.state_br_rs","base.br"
-"city_4307500","Espumoso","4307500","base.state_br_rs","base.br"
-"city_4307559","Estação","4307559","base.state_br_rs","base.br"
-"city_4307609","Estância Velha","4307609","base.state_br_rs","base.br"
-"city_4307708","Esteio","4307708","base.state_br_rs","base.br"
-"city_4307807","Estrela","4307807","base.state_br_rs","base.br"
-"city_4307815","Estrela Velha","4307815","base.state_br_rs","base.br"
-"city_4307831","Eugênio de Castro","4307831","base.state_br_rs","base.br"
-"city_4307864","Fagundes Varela","4307864","base.state_br_rs","base.br"
-"city_4307906","Farroupilha","4307906","base.state_br_rs","base.br"
-"city_4308003","Faxinal do Soturno","4308003","base.state_br_rs","base.br"
-"city_4308052","Faxinalzinho","4308052","base.state_br_rs","base.br"
-"city_4308078","Fazenda Vilanova","4308078","base.state_br_rs","base.br"
-"city_4308102","Feliz","4308102","base.state_br_rs","base.br"
-"city_4308201","Flores da Cunha","4308201","base.state_br_rs","base.br"
-"city_4308250","Floriano Peixoto","4308250","base.state_br_rs","base.br"
-"city_4308300","Fontoura Xavier","4308300","base.state_br_rs","base.br"
-"city_4308409","Formigueiro","4308409","base.state_br_rs","base.br"
-"city_4308433","Forquetinha","4308433","base.state_br_rs","base.br"
-"city_4308458","Fortaleza dos Valos","4308458","base.state_br_rs","base.br"
-"city_4308508","Frederico Westphalen","4308508","base.state_br_rs","base.br"
-"city_4308607","Garibaldi","4308607","base.state_br_rs","base.br"
-"city_4308656","Garruchos","4308656","base.state_br_rs","base.br"
-"city_4308706","Gaurama","4308706","base.state_br_rs","base.br"
-"city_4308805","General Câmara","4308805","base.state_br_rs","base.br"
-"city_4308854","Gentil","4308854","base.state_br_rs","base.br"
-"city_4308904","Getúlio Vargas","4308904","base.state_br_rs","base.br"
-"city_4309001","Giruá","4309001","base.state_br_rs","base.br"
-"city_4309050","Glorinha","4309050","base.state_br_rs","base.br"
-"city_4309100","Gramado","4309100","base.state_br_rs","base.br"
-"city_4309126","Gramado dos Loureiros","4309126","base.state_br_rs","base.br"
-"city_4309159","Gramado Xavier","4309159","base.state_br_rs","base.br"
-"city_4309209","Gravataí","4309209","base.state_br_rs","base.br"
-"city_4309258","Guabiju","4309258","base.state_br_rs","base.br"
-"city_4309308","Guaíba","4309308","base.state_br_rs","base.br"
-"city_4309407","Guaporé","4309407","base.state_br_rs","base.br"
-"city_4309506","Guarani das Missões","4309506","base.state_br_rs","base.br"
-"city_4309555","Harmonia","4309555","base.state_br_rs","base.br"
-"city_4307104","Herval","4307104","base.state_br_rs","base.br"
-"city_4309571","Herveiras","4309571","base.state_br_rs","base.br"
-"city_4309605","Horizontina","4309605","base.state_br_rs","base.br"
-"city_4309654","Hulha Negra","4309654","base.state_br_rs","base.br"
-"city_4309704","Humaitá","4309704","base.state_br_rs","base.br"
-"city_4309753","Ibarama","4309753","base.state_br_rs","base.br"
-"city_4309803","Ibiaçá","4309803","base.state_br_rs","base.br"
-"city_4309902","Ibiraiaras","4309902","base.state_br_rs","base.br"
-"city_4309951","Ibirapuitã","4309951","base.state_br_rs","base.br"
-"city_4310009","Ibirubá","4310009","base.state_br_rs","base.br"
-"city_4310108","Igrejinha","4310108","base.state_br_rs","base.br"
-"city_4310207","Ijuí","4310207","base.state_br_rs","base.br"
-"city_4310306","Ilópolis","4310306","base.state_br_rs","base.br"
-"city_4310330","Imbé","4310330","base.state_br_rs","base.br"
-"city_4310363","Imigrante","4310363","base.state_br_rs","base.br"
-"city_4310405","Independência","4310405","base.state_br_rs","base.br"
-"city_4310413","Inhacorá","4310413","base.state_br_rs","base.br"
-"city_4310439","Ipê","4310439","base.state_br_rs","base.br"
-"city_4310462","Ipiranga do Sul","4310462","base.state_br_rs","base.br"
-"city_4310504","Iraí","4310504","base.state_br_rs","base.br"
-"city_4310538","Itaara","4310538","base.state_br_rs","base.br"
-"city_4310553","Itacurubi","4310553","base.state_br_rs","base.br"
-"city_4310579","Itapuca","4310579","base.state_br_rs","base.br"
-"city_4310603","Itaqui","4310603","base.state_br_rs","base.br"
-"city_4310652","Itati","4310652","base.state_br_rs","base.br"
-"city_4310702","Itatiba do Sul","4310702","base.state_br_rs","base.br"
-"city_4310751","Ivorá","4310751","base.state_br_rs","base.br"
-"city_4310801","Ivoti","4310801","base.state_br_rs","base.br"
-"city_4310850","Jaboticaba","4310850","base.state_br_rs","base.br"
-"city_4310876","Jacuizinho","4310876","base.state_br_rs","base.br"
-"city_4310900","Jacutinga","4310900","base.state_br_rs","base.br"
-"city_4311007","Jaguarão","4311007","base.state_br_rs","base.br"
-"city_4311106","Jaguari","4311106","base.state_br_rs","base.br"
-"city_4311122","Jaquirana","4311122","base.state_br_rs","base.br"
-"city_4311130","Jari","4311130","base.state_br_rs","base.br"
-"city_4311155","Jóia","4311155","base.state_br_rs","base.br"
-"city_4311205","Júlio de Castilhos","4311205","base.state_br_rs","base.br"
-"city_4311239","Lagoa Bonita do Sul","4311239","base.state_br_rs","base.br"
-"city_4311270","Lagoa dos Três Cantos","4311270","base.state_br_rs","base.br"
-"city_4311304","Lagoa Vermelha","4311304","base.state_br_rs","base.br"
-"city_4311254","Lagoão","4311254","base.state_br_rs","base.br"
-"city_4311403","Lajeado","4311403","base.state_br_rs","base.br"
-"city_4311429","Lajeado do Bugre","4311429","base.state_br_rs","base.br"
-"city_4311502","Lavras do Sul","4311502","base.state_br_rs","base.br"
-"city_4311601","Liberato Salzano","4311601","base.state_br_rs","base.br"
-"city_4311627","Lindolfo Collor","4311627","base.state_br_rs","base.br"
-"city_4311643","Linha Nova","4311643","base.state_br_rs","base.br"
-"city_4311718","Maçambará","4311718","base.state_br_rs","base.br"
-"city_4311700","Machadinho","4311700","base.state_br_rs","base.br"
-"city_4311734","Mampituba","4311734","base.state_br_rs","base.br"
-"city_4311759","Manoel Viana","4311759","base.state_br_rs","base.br"
-"city_4311775","Maquiné","4311775","base.state_br_rs","base.br"
-"city_4311791","Maratá","4311791","base.state_br_rs","base.br"
-"city_4311809","Marau","4311809","base.state_br_rs","base.br"
-"city_4311908","Marcelino Ramos","4311908","base.state_br_rs","base.br"
-"city_4311981","Mariana Pimentel","4311981","base.state_br_rs","base.br"
-"city_4312005","Mariano Moro","4312005","base.state_br_rs","base.br"
-"city_4312054","Marques de Souza","4312054","base.state_br_rs","base.br"
-"city_4312104","Mata","4312104","base.state_br_rs","base.br"
-"city_4312138","Mato Castelhano","4312138","base.state_br_rs","base.br"
-"city_4312153","Mato Leitão","4312153","base.state_br_rs","base.br"
-"city_4312179","Mato Queimado","4312179","base.state_br_rs","base.br"
-"city_4312203","Maximiliano de Almeida","4312203","base.state_br_rs","base.br"
-"city_4312252","Minas do Leão","4312252","base.state_br_rs","base.br"
-"city_4312302","Miraguaí","4312302","base.state_br_rs","base.br"
-"city_4312351","Montauri","4312351","base.state_br_rs","base.br"
-"city_4312377","Monte Alegre dos Campos","4312377","base.state_br_rs","base.br"
-"city_4312385","Monte Belo do Sul","4312385","base.state_br_rs","base.br"
-"city_4312401","Montenegro","4312401","base.state_br_rs","base.br"
-"city_4312427","Mormaço","4312427","base.state_br_rs","base.br"
-"city_4312443","Morrinhos do Sul","4312443","base.state_br_rs","base.br"
-"city_4312450","Morro Redondo","4312450","base.state_br_rs","base.br"
-"city_4312476","Morro Reuter","4312476","base.state_br_rs","base.br"
-"city_4312500","Mostardas","4312500","base.state_br_rs","base.br"
-"city_4312609","Muçum","4312609","base.state_br_rs","base.br"
-"city_4312617","Muitos Capões","4312617","base.state_br_rs","base.br"
-"city_4312625","Muliterno","4312625","base.state_br_rs","base.br"
-"city_4312658","Não-Me-Toque","4312658","base.state_br_rs","base.br"
-"city_4312674","Nicolau Vergueiro","4312674","base.state_br_rs","base.br"
-"city_4312708","Nonoai","4312708","base.state_br_rs","base.br"
-"city_4312757","Nova Alvorada","4312757","base.state_br_rs","base.br"
-"city_4312807","Nova Araçá","4312807","base.state_br_rs","base.br"
-"city_4312906","Nova Bassano","4312906","base.state_br_rs","base.br"
-"city_4312955","Nova Boa Vista","4312955","base.state_br_rs","base.br"
-"city_4313003","Nova Bréscia","4313003","base.state_br_rs","base.br"
-"city_4313011","Nova Candelária","4313011","base.state_br_rs","base.br"
-"city_4313037","Nova Esperança do Sul","4313037","base.state_br_rs","base.br"
-"city_4313060","Nova Hartz","4313060","base.state_br_rs","base.br"
-"city_4313086","Nova Pádua","4313086","base.state_br_rs","base.br"
-"city_4313102","Nova Palma","4313102","base.state_br_rs","base.br"
-"city_4313201","Nova Petrópolis","4313201","base.state_br_rs","base.br"
-"city_4313300","Nova Prata","4313300","base.state_br_rs","base.br"
-"city_4313334","Nova Ramada","4313334","base.state_br_rs","base.br"
-"city_4313359","Nova Roma do Sul","4313359","base.state_br_rs","base.br"
-"city_4313375","Nova Santa Rita","4313375","base.state_br_rs","base.br"
-"city_4313490","Novo Barreiro","4313490","base.state_br_rs","base.br"
-"city_4313391","Novo Cabrais","4313391","base.state_br_rs","base.br"
-"city_4313409","Novo Hamburgo","4313409","base.state_br_rs","base.br"
-"city_4313425","Novo Machado","4313425","base.state_br_rs","base.br"
-"city_4313441","Novo Tiradentes","4313441","base.state_br_rs","base.br"
-"city_4313466","Novo Xingu","4313466","base.state_br_rs","base.br"
-"city_4313508","Osório","4313508","base.state_br_rs","base.br"
-"city_4313607","Paim Filho","4313607","base.state_br_rs","base.br"
-"city_4313656","Palmares do Sul","4313656","base.state_br_rs","base.br"
-"city_4313706","Palmeira das Missões","4313706","base.state_br_rs","base.br"
-"city_4313805","Palmitinho","4313805","base.state_br_rs","base.br"
-"city_4313904","Panambi","4313904","base.state_br_rs","base.br"
-"city_4313953","Pantano Grande","4313953","base.state_br_rs","base.br"
-"city_4314001","Paraí","4314001","base.state_br_rs","base.br"
-"city_4314027","Paraíso do Sul","4314027","base.state_br_rs","base.br"
-"city_4314035","Pareci Novo","4314035","base.state_br_rs","base.br"
-"city_4314050","Parobé","4314050","base.state_br_rs","base.br"
-"city_4314068","Passa Sete","4314068","base.state_br_rs","base.br"
-"city_4314076","Passo do Sobrado","4314076","base.state_br_rs","base.br"
-"city_4314100","Passo Fundo","4314100","base.state_br_rs","base.br"
-"city_4314134","Paulo Bento","4314134","base.state_br_rs","base.br"
-"city_4314159","Paverama","4314159","base.state_br_rs","base.br"
-"city_4314175","Pedras Altas","4314175","base.state_br_rs","base.br"
-"city_4314209","Pedro Osório","4314209","base.state_br_rs","base.br"
-"city_4314308","Pejuçara","4314308","base.state_br_rs","base.br"
-"city_4314407","Pelotas","4314407","base.state_br_rs","base.br"
-"city_4314423","Picada Café","4314423","base.state_br_rs","base.br"
-"city_4314456","Pinhal","4314456","base.state_br_rs","base.br"
-"city_4314464","Pinhal da Serra","4314464","base.state_br_rs","base.br"
-"city_4314472","Pinhal Grande","4314472","base.state_br_rs","base.br"
-"city_4314498","Pinheirinho do Vale","4314498","base.state_br_rs","base.br"
-"city_4314506","Pinheiro Machado","4314506","base.state_br_rs","base.br"
-"city_4314548","Pinto Bandeira","4314548","base.state_br_rs","base.br"
-"city_4314555","Pirapó","4314555","base.state_br_rs","base.br"
-"city_4314605","Piratini","4314605","base.state_br_rs","base.br"
-"city_4314704","Planalto","4314704","base.state_br_rs","base.br"
-"city_4314753","Poço das Antas","4314753","base.state_br_rs","base.br"
-"city_4314779","Pontão","4314779","base.state_br_rs","base.br"
-"city_4314787","Ponte Preta","4314787","base.state_br_rs","base.br"
-"city_4314803","Portão","4314803","base.state_br_rs","base.br"
-"city_4314902","Porto Alegre","4314902","base.state_br_rs","base.br"
-"city_4315008","Porto Lucena","4315008","base.state_br_rs","base.br"
-"city_4315057","Porto Mauá","4315057","base.state_br_rs","base.br"
-"city_4315073","Porto Vera Cruz","4315073","base.state_br_rs","base.br"
-"city_4315107","Porto Xavier","4315107","base.state_br_rs","base.br"
-"city_4315131","Pouso Novo","4315131","base.state_br_rs","base.br"
-"city_4315149","Presidente Lucena","4315149","base.state_br_rs","base.br"
-"city_4315156","Progresso","4315156","base.state_br_rs","base.br"
-"city_4315172","Protásio Alves","4315172","base.state_br_rs","base.br"
-"city_4315206","Putinga","4315206","base.state_br_rs","base.br"
-"city_4315305","Quaraí","4315305","base.state_br_rs","base.br"
-"city_4315313","Quatro Irmãos","4315313","base.state_br_rs","base.br"
-"city_4315321","Quevedos","4315321","base.state_br_rs","base.br"
-"city_4315354","Quinze de Novembro","4315354","base.state_br_rs","base.br"
-"city_4315404","Redentora","4315404","base.state_br_rs","base.br"
-"city_4315453","Relvado","4315453","base.state_br_rs","base.br"
-"city_4315503","Restinga Sêca","4315503","base.state_br_rs","base.br"
-"city_4315552","Rio dos Índios","4315552","base.state_br_rs","base.br"
-"city_4315602","Rio Grande","4315602","base.state_br_rs","base.br"
-"city_4315701","Rio Pardo","4315701","base.state_br_rs","base.br"
-"city_4315750","Riozinho","4315750","base.state_br_rs","base.br"
-"city_4315800","Roca Sales","4315800","base.state_br_rs","base.br"
-"city_4315909","Rodeio Bonito","4315909","base.state_br_rs","base.br"
-"city_4315958","Rolador","4315958","base.state_br_rs","base.br"
-"city_4316006","Rolante","4316006","base.state_br_rs","base.br"
-"city_4316105","Ronda Alta","4316105","base.state_br_rs","base.br"
-"city_4316204","Rondinha","4316204","base.state_br_rs","base.br"
-"city_4316303","Roque Gonzales","4316303","base.state_br_rs","base.br"
-"city_4316402","Rosário do Sul","4316402","base.state_br_rs","base.br"
-"city_4316428","Sagrada Família","4316428","base.state_br_rs","base.br"
-"city_4316436","Saldanha Marinho","4316436","base.state_br_rs","base.br"
-"city_4316451","Salto do Jacuí","4316451","base.state_br_rs","base.br"
-"city_4316477","Salvador das Missões","4316477","base.state_br_rs","base.br"
-"city_4316501","Salvador do Sul","4316501","base.state_br_rs","base.br"
-"city_4316600","Sananduva","4316600","base.state_br_rs","base.br"
-"city_4316709","Santa Bárbara do Sul","4316709","base.state_br_rs","base.br"
-"city_4316733","Santa Cecília do Sul","4316733","base.state_br_rs","base.br"
-"city_4316758","Santa Clara do Sul","4316758","base.state_br_rs","base.br"
-"city_4316808","Santa Cruz do Sul","4316808","base.state_br_rs","base.br"
-"city_4316972","Santa Margarida do Sul","4316972","base.state_br_rs","base.br"
-"city_4316907","Santa Maria","4316907","base.state_br_rs","base.br"
-"city_4316956","Santa Maria do Herval","4316956","base.state_br_rs","base.br"
-"city_4317202","Santa Rosa","4317202","base.state_br_rs","base.br"
-"city_4317251","Santa Tereza","4317251","base.state_br_rs","base.br"
-"city_4317301","Santa Vitória do Palmar","4317301","base.state_br_rs","base.br"
-"city_4317004","Santana da Boa Vista","4317004","base.state_br_rs","base.br"
-"city_4317103","Sant'Ana do Livramento","4317103","base.state_br_rs","base.br"
-"city_4317400","Santiago","4317400","base.state_br_rs","base.br"
-"city_4317509","Santo Ângelo","4317509","base.state_br_rs","base.br"
-"city_4317608","Santo Antônio da Patrulha","4317608","base.state_br_rs","base.br"
-"city_4317707","Santo Antônio das Missões","4317707","base.state_br_rs","base.br"
-"city_4317558","Santo Antônio do Palma","4317558","base.state_br_rs","base.br"
-"city_4317756","Santo Antônio do Planalto","4317756","base.state_br_rs","base.br"
-"city_4317806","Santo Augusto","4317806","base.state_br_rs","base.br"
-"city_4317905","Santo Cristo","4317905","base.state_br_rs","base.br"
-"city_4317954","Santo Expedito do Sul","4317954","base.state_br_rs","base.br"
-"city_4318002","São Borja","4318002","base.state_br_rs","base.br"
-"city_4318051","São Domingos do Sul","4318051","base.state_br_rs","base.br"
-"city_4318101","São Francisco de Assis","4318101","base.state_br_rs","base.br"
-"city_4318200","São Francisco de Paula","4318200","base.state_br_rs","base.br"
-"city_4318309","São Gabriel","4318309","base.state_br_rs","base.br"
-"city_4318408","São Jerônimo","4318408","base.state_br_rs","base.br"
-"city_4318424","São João da Urtiga","4318424","base.state_br_rs","base.br"
-"city_4318432","São João do Polêsine","4318432","base.state_br_rs","base.br"
-"city_4318440","São Jorge","4318440","base.state_br_rs","base.br"
-"city_4318457","São José das Missões","4318457","base.state_br_rs","base.br"
-"city_4318465","São José do Herval","4318465","base.state_br_rs","base.br"
-"city_4318481","São José do Hortêncio","4318481","base.state_br_rs","base.br"
-"city_4318499","São José do Inhacorá","4318499","base.state_br_rs","base.br"
-"city_4318507","São José do Norte","4318507","base.state_br_rs","base.br"
-"city_4318606","São José do Ouro","4318606","base.state_br_rs","base.br"
-"city_4318614","São José do Sul","4318614","base.state_br_rs","base.br"
-"city_4318622","São José dos Ausentes","4318622","base.state_br_rs","base.br"
-"city_4318705","São Leopoldo","4318705","base.state_br_rs","base.br"
-"city_4318804","São Lourenço do Sul","4318804","base.state_br_rs","base.br"
-"city_4318903","São Luiz Gonzaga","4318903","base.state_br_rs","base.br"
-"city_4319000","São Marcos","4319000","base.state_br_rs","base.br"
-"city_4319109","São Martinho","4319109","base.state_br_rs","base.br"
-"city_4319125","São Martinho da Serra","4319125","base.state_br_rs","base.br"
-"city_4319158","São Miguel das Missões","4319158","base.state_br_rs","base.br"
-"city_4319208","São Nicolau","4319208","base.state_br_rs","base.br"
-"city_4319307","São Paulo das Missões","4319307","base.state_br_rs","base.br"
-"city_4319356","São Pedro da Serra","4319356","base.state_br_rs","base.br"
-"city_4319364","São Pedro das Missões","4319364","base.state_br_rs","base.br"
-"city_4319372","São Pedro do Butiá","4319372","base.state_br_rs","base.br"
-"city_4319406","São Pedro do Sul","4319406","base.state_br_rs","base.br"
-"city_4319505","São Sebastião do Caí","4319505","base.state_br_rs","base.br"
-"city_4319604","São Sepé","4319604","base.state_br_rs","base.br"
-"city_4319703","São Valentim","4319703","base.state_br_rs","base.br"
-"city_4319711","São Valentim do Sul","4319711","base.state_br_rs","base.br"
-"city_4319737","São Valério do Sul","4319737","base.state_br_rs","base.br"
-"city_4319752","São Vendelino","4319752","base.state_br_rs","base.br"
-"city_4319802","São Vicente do Sul","4319802","base.state_br_rs","base.br"
-"city_4319901","Sapiranga","4319901","base.state_br_rs","base.br"
-"city_4320008","Sapucaia do Sul","4320008","base.state_br_rs","base.br"
-"city_4320107","Sarandi","4320107","base.state_br_rs","base.br"
-"city_4320206","Seberi","4320206","base.state_br_rs","base.br"
-"city_4320230","Sede Nova","4320230","base.state_br_rs","base.br"
-"city_4320263","Segredo","4320263","base.state_br_rs","base.br"
-"city_4320305","Selbach","4320305","base.state_br_rs","base.br"
-"city_4320321","Senador Salgado Filho","4320321","base.state_br_rs","base.br"
-"city_4320354","Sentinela do Sul","4320354","base.state_br_rs","base.br"
-"city_4320404","Serafina Corrêa","4320404","base.state_br_rs","base.br"
-"city_4320453","Sério","4320453","base.state_br_rs","base.br"
-"city_4320503","Sertão","4320503","base.state_br_rs","base.br"
-"city_4320552","Sertão Santana","4320552","base.state_br_rs","base.br"
-"city_4320578","Sete de Setembro","4320578","base.state_br_rs","base.br"
-"city_4320602","Severiano de Almeida","4320602","base.state_br_rs","base.br"
-"city_4320651","Silveira Martins","4320651","base.state_br_rs","base.br"
-"city_4320677","Sinimbu","4320677","base.state_br_rs","base.br"
-"city_4320701","Sobradinho","4320701","base.state_br_rs","base.br"
-"city_4320800","Soledade","4320800","base.state_br_rs","base.br"
-"city_4320859","Tabaí","4320859","base.state_br_rs","base.br"
-"city_4320909","Tapejara","4320909","base.state_br_rs","base.br"
-"city_4321006","Tapera","4321006","base.state_br_rs","base.br"
-"city_4321105","Tapes","4321105","base.state_br_rs","base.br"
-"city_4321204","Taquara","4321204","base.state_br_rs","base.br"
-"city_4321303","Taquari","4321303","base.state_br_rs","base.br"
-"city_4321329","Taquaruçu do Sul","4321329","base.state_br_rs","base.br"
-"city_4321352","Tavares","4321352","base.state_br_rs","base.br"
-"city_4321402","Tenente Portela","4321402","base.state_br_rs","base.br"
-"city_4321436","Terra de Areia","4321436","base.state_br_rs","base.br"
-"city_4321451","Teutônia","4321451","base.state_br_rs","base.br"
-"city_4321469","Tio Hugo","4321469","base.state_br_rs","base.br"
-"city_4321477","Tiradentes do Sul","4321477","base.state_br_rs","base.br"
-"city_4321493","Toropi","4321493","base.state_br_rs","base.br"
-"city_4321501","Torres","4321501","base.state_br_rs","base.br"
-"city_4321600","Tramandaí","4321600","base.state_br_rs","base.br"
-"city_4321626","Travesseiro","4321626","base.state_br_rs","base.br"
-"city_4321634","Três Arroios","4321634","base.state_br_rs","base.br"
-"city_4321667","Três Cachoeiras","4321667","base.state_br_rs","base.br"
-"city_4321709","Três Coroas","4321709","base.state_br_rs","base.br"
-"city_4321808","Três de Maio","4321808","base.state_br_rs","base.br"
-"city_4321832","Três Forquilhas","4321832","base.state_br_rs","base.br"
-"city_4321857","Três Palmeiras","4321857","base.state_br_rs","base.br"
-"city_4321907","Três Passos","4321907","base.state_br_rs","base.br"
-"city_4321956","Trindade do Sul","4321956","base.state_br_rs","base.br"
-"city_4322004","Triunfo","4322004","base.state_br_rs","base.br"
-"city_4322103","Tucunduva","4322103","base.state_br_rs","base.br"
-"city_4322152","Tunas","4322152","base.state_br_rs","base.br"
-"city_4322186","Tupanci do Sul","4322186","base.state_br_rs","base.br"
-"city_4322202","Tupanciretã","4322202","base.state_br_rs","base.br"
-"city_4322251","Tupandi","4322251","base.state_br_rs","base.br"
-"city_4322301","Tuparendi","4322301","base.state_br_rs","base.br"
-"city_4322327","Turuçu","4322327","base.state_br_rs","base.br"
-"city_4322343","Ubiretama","4322343","base.state_br_rs","base.br"
-"city_4322350","União da Serra","4322350","base.state_br_rs","base.br"
-"city_4322376","Unistalda","4322376","base.state_br_rs","base.br"
-"city_4322400","Uruguaiana","4322400","base.state_br_rs","base.br"
-"city_4322509","Vacaria","4322509","base.state_br_rs","base.br"
-"city_4322533","Vale do Sol","4322533","base.state_br_rs","base.br"
-"city_4322541","Vale Real","4322541","base.state_br_rs","base.br"
-"city_4322525","Vale Verde","4322525","base.state_br_rs","base.br"
-"city_4322558","Vanini","4322558","base.state_br_rs","base.br"
-"city_4322608","Venâncio Aires","4322608","base.state_br_rs","base.br"
-"city_4322707","Vera Cruz","4322707","base.state_br_rs","base.br"
-"city_4322806","Veranópolis","4322806","base.state_br_rs","base.br"
-"city_4322855","Vespasiano Corrêa","4322855","base.state_br_rs","base.br"
-"city_4322905","Viadutos","4322905","base.state_br_rs","base.br"
-"city_4323002","Viamão","4323002","base.state_br_rs","base.br"
-"city_4323101","Vicente Dutra","4323101","base.state_br_rs","base.br"
-"city_4323200","Victor Graeff","4323200","base.state_br_rs","base.br"
-"city_4323309","Vila Flores","4323309","base.state_br_rs","base.br"
-"city_4323358","Vila Lângaro","4323358","base.state_br_rs","base.br"
-"city_4323408","Vila Maria","4323408","base.state_br_rs","base.br"
-"city_4323457","Vila Nova do Sul","4323457","base.state_br_rs","base.br"
-"city_4323507","Vista Alegre","4323507","base.state_br_rs","base.br"
-"city_4323606","Vista Alegre do Prata","4323606","base.state_br_rs","base.br"
-"city_4323705","Vista Gaúcha","4323705","base.state_br_rs","base.br"
-"city_4323754","Vitória das Missões","4323754","base.state_br_rs","base.br"
-"city_4323770","Westfália","4323770","base.state_br_rs","base.br"
-"city_4323804","Xangri-lá","4323804","base.state_br_rs","base.br"
-"city_5000203","Água Clara","5000203","base.state_br_ms","base.br"
-"city_5000252","Alcinópolis","5000252","base.state_br_ms","base.br"
-"city_5000609","Amambai","5000609","base.state_br_ms","base.br"
-"city_5000708","Anastácio","5000708","base.state_br_ms","base.br"
-"city_5000807","Anaurilândia","5000807","base.state_br_ms","base.br"
-"city_5000856","Angélica","5000856","base.state_br_ms","base.br"
-"city_5000906","Antônio João","5000906","base.state_br_ms","base.br"
-"city_5001003","Aparecida do Taboado","5001003","base.state_br_ms","base.br"
-"city_5001102","Aquidauana","5001102","base.state_br_ms","base.br"
-"city_5001243","Aral Moreira","5001243","base.state_br_ms","base.br"
-"city_5001508","Bandeirantes","5001508","base.state_br_ms","base.br"
-"city_5001904","Bataguassu","5001904","base.state_br_ms","base.br"
-"city_5002001","Batayporã","5002001","base.state_br_ms","base.br"
-"city_5002100","Bela Vista","5002100","base.state_br_ms","base.br"
-"city_5002159","Bodoquena","5002159","base.state_br_ms","base.br"
-"city_5002209","Bonito","5002209","base.state_br_ms","base.br"
-"city_5002308","Brasilândia","5002308","base.state_br_ms","base.br"
-"city_5002407","Caarapó","5002407","base.state_br_ms","base.br"
-"city_5002605","Camapuã","5002605","base.state_br_ms","base.br"
-"city_5002704","Campo Grande","5002704","base.state_br_ms","base.br"
-"city_5002803","Caracol","5002803","base.state_br_ms","base.br"
-"city_5002902","Cassilândia","5002902","base.state_br_ms","base.br"
-"city_5002951","Chapadão do Sul","5002951","base.state_br_ms","base.br"
-"city_5003108","Corguinho","5003108","base.state_br_ms","base.br"
-"city_5003157","Coronel Sapucaia","5003157","base.state_br_ms","base.br"
-"city_5003207","Corumbá","5003207","base.state_br_ms","base.br"
-"city_5003256","Costa Rica","5003256","base.state_br_ms","base.br"
-"city_5003306","Coxim","5003306","base.state_br_ms","base.br"
-"city_5003454","Deodápolis","5003454","base.state_br_ms","base.br"
-"city_5003488","Dois Irmãos do Buriti","5003488","base.state_br_ms","base.br"
-"city_5003504","Douradina","5003504","base.state_br_ms","base.br"
-"city_5003702","Dourados","5003702","base.state_br_ms","base.br"
-"city_5003751","Eldorado","5003751","base.state_br_ms","base.br"
-"city_5003801","Fátima do Sul","5003801","base.state_br_ms","base.br"
-"city_5003900","Figueirão","5003900","base.state_br_ms","base.br"
-"city_5004007","Glória de Dourados","5004007","base.state_br_ms","base.br"
-"city_5004106","Guia Lopes da Laguna","5004106","base.state_br_ms","base.br"
-"city_5004304","Iguatemi","5004304","base.state_br_ms","base.br"
-"city_5004403","Inocência","5004403","base.state_br_ms","base.br"
-"city_5004502","Itaporã","5004502","base.state_br_ms","base.br"
-"city_5004601","Itaquiraí","5004601","base.state_br_ms","base.br"
-"city_5004700","Ivinhema","5004700","base.state_br_ms","base.br"
-"city_5004809","Japorã","5004809","base.state_br_ms","base.br"
-"city_5004908","Jaraguari","5004908","base.state_br_ms","base.br"
-"city_5005004","Jardim","5005004","base.state_br_ms","base.br"
-"city_5005103","Jateí","5005103","base.state_br_ms","base.br"
-"city_5005152","Juti","5005152","base.state_br_ms","base.br"
-"city_5005202","Ladário","5005202","base.state_br_ms","base.br"
-"city_5005251","Laguna Carapã","5005251","base.state_br_ms","base.br"
-"city_5005400","Maracaju","5005400","base.state_br_ms","base.br"
-"city_5005608","Miranda","5005608","base.state_br_ms","base.br"
-"city_5005681","Mundo Novo","5005681","base.state_br_ms","base.br"
-"city_5005707","Naviraí","5005707","base.state_br_ms","base.br"
-"city_5005806","Nioaque","5005806","base.state_br_ms","base.br"
-"city_5006002","Nova Alvorada do Sul","5006002","base.state_br_ms","base.br"
-"city_5006200","Nova Andradina","5006200","base.state_br_ms","base.br"
-"city_5006259","Novo Horizonte do Sul","5006259","base.state_br_ms","base.br"
-"city_5006275","Paraíso das Águas","5006275","base.state_br_ms","base.br"
-"city_5006309","Paranaíba","5006309","base.state_br_ms","base.br"
-"city_5006358","Paranhos","5006358","base.state_br_ms","base.br"
-"city_5006408","Pedro Gomes","5006408","base.state_br_ms","base.br"
-"city_5006606","Ponta Porã","5006606","base.state_br_ms","base.br"
-"city_5006903","Porto Murtinho","5006903","base.state_br_ms","base.br"
-"city_5007109","Ribas do Rio Pardo","5007109","base.state_br_ms","base.br"
-"city_5007208","Rio Brilhante","5007208","base.state_br_ms","base.br"
-"city_5007307","Rio Negro","5007307","base.state_br_ms","base.br"
-"city_5007406","Rio Verde de Mato Grosso","5007406","base.state_br_ms","base.br"
-"city_5007505","Rochedo","5007505","base.state_br_ms","base.br"
-"city_5007554","Santa Rita do Pardo","5007554","base.state_br_ms","base.br"
-"city_5007695","São Gabriel do Oeste","5007695","base.state_br_ms","base.br"
-"city_5007802","Selvíria","5007802","base.state_br_ms","base.br"
-"city_5007703","Sete Quedas","5007703","base.state_br_ms","base.br"
-"city_5007901","Sidrolândia","5007901","base.state_br_ms","base.br"
-"city_5007935","Sonora","5007935","base.state_br_ms","base.br"
-"city_5007950","Tacuru","5007950","base.state_br_ms","base.br"
-"city_5007976","Taquarussu","5007976","base.state_br_ms","base.br"
-"city_5008008","Terenos","5008008","base.state_br_ms","base.br"
-"city_5008305","Três Lagoas","5008305","base.state_br_ms","base.br"
-"city_5008404","Vicentina","5008404","base.state_br_ms","base.br"
-"city_5100102","Acorizal","5100102","base.state_br_mt","base.br"
-"city_5100201","Água Boa","5100201","base.state_br_mt","base.br"
-"city_5100250","Alta Floresta","5100250","base.state_br_mt","base.br"
-"city_5100300","Alto Araguaia","5100300","base.state_br_mt","base.br"
-"city_5100359","Alto Boa Vista","5100359","base.state_br_mt","base.br"
-"city_5100409","Alto Garças","5100409","base.state_br_mt","base.br"
-"city_5100508","Alto Paraguai","5100508","base.state_br_mt","base.br"
-"city_5100607","Alto Taquari","5100607","base.state_br_mt","base.br"
-"city_5100805","Apiacás","5100805","base.state_br_mt","base.br"
-"city_5101001","Araguaiana","5101001","base.state_br_mt","base.br"
-"city_5101209","Araguainha","5101209","base.state_br_mt","base.br"
-"city_5101258","Araputanga","5101258","base.state_br_mt","base.br"
-"city_5101308","Arenápolis","5101308","base.state_br_mt","base.br"
-"city_5101407","Aripuanã","5101407","base.state_br_mt","base.br"
-"city_5101605","Barão de Melgaço","5101605","base.state_br_mt","base.br"
-"city_5101704","Barra do Bugres","5101704","base.state_br_mt","base.br"
-"city_5101803","Barra do Garças","5101803","base.state_br_mt","base.br"
-"city_5101852","Bom Jesus do Araguaia","5101852","base.state_br_mt","base.br"
-"city_5101902","Brasnorte","5101902","base.state_br_mt","base.br"
-"city_5102504","Cáceres","5102504","base.state_br_mt","base.br"
-"city_5102603","Campinápolis","5102603","base.state_br_mt","base.br"
-"city_5102637","Campo Novo do Parecis","5102637","base.state_br_mt","base.br"
-"city_5102678","Campo Verde","5102678","base.state_br_mt","base.br"
-"city_5102686","Campos de Júlio","5102686","base.state_br_mt","base.br"
-"city_5102694","Canabrava do Norte","5102694","base.state_br_mt","base.br"
-"city_5102702","Canarana","5102702","base.state_br_mt","base.br"
-"city_5102793","Carlinda","5102793","base.state_br_mt","base.br"
-"city_5102850","Castanheira","5102850","base.state_br_mt","base.br"
-"city_5103007","Chapada dos Guimarães","5103007","base.state_br_mt","base.br"
-"city_5103056","Cláudia","5103056","base.state_br_mt","base.br"
-"city_5103106","Cocalinho","5103106","base.state_br_mt","base.br"
-"city_5103205","Colíder","5103205","base.state_br_mt","base.br"
-"city_5103254","Colniza","5103254","base.state_br_mt","base.br"
-"city_5103304","Comodoro","5103304","base.state_br_mt","base.br"
-"city_5103353","Confresa","5103353","base.state_br_mt","base.br"
-"city_5103361","Conquista D'Oeste","5103361","base.state_br_mt","base.br"
-"city_5103379","Cotriguaçu","5103379","base.state_br_mt","base.br"
-"city_5103403","Cuiabá","5103403","base.state_br_mt","base.br"
-"city_5103437","Curvelândia","5103437","base.state_br_mt","base.br"
-"city_5103452","Denise","5103452","base.state_br_mt","base.br"
-"city_5103502","Diamantino","5103502","base.state_br_mt","base.br"
-"city_5103601","Dom Aquino","5103601","base.state_br_mt","base.br"
-"city_5103700","Feliz Natal","5103700","base.state_br_mt","base.br"
-"city_5103809","Figueirópolis D'Oeste","5103809","base.state_br_mt","base.br"
-"city_5103858","Gaúcha do Norte","5103858","base.state_br_mt","base.br"
-"city_5103908","General Carneiro","5103908","base.state_br_mt","base.br"
-"city_5103957","Glória D'Oeste","5103957","base.state_br_mt","base.br"
-"city_5104104","Guarantã do Norte","5104104","base.state_br_mt","base.br"
-"city_5104203","Guiratinga","5104203","base.state_br_mt","base.br"
-"city_5104500","Indiavaí","5104500","base.state_br_mt","base.br"
-"city_5104526","Ipiranga do Norte","5104526","base.state_br_mt","base.br"
-"city_5104542","Itanhangá","5104542","base.state_br_mt","base.br"
-"city_5104559","Itaúba","5104559","base.state_br_mt","base.br"
-"city_5104609","Itiquira","5104609","base.state_br_mt","base.br"
-"city_5104807","Jaciara","5104807","base.state_br_mt","base.br"
-"city_5104906","Jangada","5104906","base.state_br_mt","base.br"
-"city_5105002","Jauru","5105002","base.state_br_mt","base.br"
-"city_5105101","Juara","5105101","base.state_br_mt","base.br"
-"city_5105150","Juína","5105150","base.state_br_mt","base.br"
-"city_5105176","Juruena","5105176","base.state_br_mt","base.br"
-"city_5105200","Juscimeira","5105200","base.state_br_mt","base.br"
-"city_5105234","Lambari D'Oeste","5105234","base.state_br_mt","base.br"
-"city_5105259","Lucas do Rio Verde","5105259","base.state_br_mt","base.br"
-"city_5105309","Luciara","5105309","base.state_br_mt","base.br"
-"city_5105580","Marcelândia","5105580","base.state_br_mt","base.br"
-"city_5105606","Matupá","5105606","base.state_br_mt","base.br"
-"city_5105622","Mirassol d'Oeste","5105622","base.state_br_mt","base.br"
-"city_5105903","Nobres","5105903","base.state_br_mt","base.br"
-"city_5106000","Nortelândia","5106000","base.state_br_mt","base.br"
-"city_5106109","Nossa Senhora do Livramento","5106109","base.state_br_mt","base.br"
-"city_5106158","Nova Bandeirantes","5106158","base.state_br_mt","base.br"
-"city_5106208","Nova Brasilândia","5106208","base.state_br_mt","base.br"
-"city_5106216","Nova Canaã do Norte","5106216","base.state_br_mt","base.br"
-"city_5108808","Nova Guarita","5108808","base.state_br_mt","base.br"
-"city_5106182","Nova Lacerda","5106182","base.state_br_mt","base.br"
-"city_5108857","Nova Marilândia","5108857","base.state_br_mt","base.br"
-"city_5108907","Nova Maringá","5108907","base.state_br_mt","base.br"
-"city_5108956","Nova Monte Verde","5108956","base.state_br_mt","base.br"
-"city_5106224","Nova Mutum","5106224","base.state_br_mt","base.br"
-"city_5106174","Nova Nazaré","5106174","base.state_br_mt","base.br"
-"city_5106232","Nova Olímpia","5106232","base.state_br_mt","base.br"
-"city_5106190","Nova Santa Helena","5106190","base.state_br_mt","base.br"
-"city_5106240","Nova Ubiratã","5106240","base.state_br_mt","base.br"
-"city_5106257","Nova Xavantina","5106257","base.state_br_mt","base.br"
-"city_5106273","Novo Horizonte do Norte","5106273","base.state_br_mt","base.br"
-"city_5106265","Novo Mundo","5106265","base.state_br_mt","base.br"
-"city_5106315","Novo Santo Antônio","5106315","base.state_br_mt","base.br"
-"city_5106281","Novo São Joaquim","5106281","base.state_br_mt","base.br"
-"city_5106299","Paranaíta","5106299","base.state_br_mt","base.br"
-"city_5106307","Paranatinga","5106307","base.state_br_mt","base.br"
-"city_5106372","Pedra Preta","5106372","base.state_br_mt","base.br"
-"city_5106422","Peixoto de Azevedo","5106422","base.state_br_mt","base.br"
-"city_5106455","Planalto da Serra","5106455","base.state_br_mt","base.br"
-"city_5106505","Poconé","5106505","base.state_br_mt","base.br"
-"city_5106653","Pontal do Araguaia","5106653","base.state_br_mt","base.br"
-"city_5106703","Ponte Branca","5106703","base.state_br_mt","base.br"
-"city_5106752","Pontes e Lacerda","5106752","base.state_br_mt","base.br"
-"city_5106778","Porto Alegre do Norte","5106778","base.state_br_mt","base.br"
-"city_5106802","Porto dos Gaúchos","5106802","base.state_br_mt","base.br"
-"city_5106828","Porto Esperidião","5106828","base.state_br_mt","base.br"
-"city_5106851","Porto Estrela","5106851","base.state_br_mt","base.br"
-"city_5107008","Poxoréu","5107008","base.state_br_mt","base.br"
-"city_5107040","Primavera do Leste","5107040","base.state_br_mt","base.br"
-"city_5107065","Querência","5107065","base.state_br_mt","base.br"
-"city_5107156","Reserva do Cabaçal","5107156","base.state_br_mt","base.br"
-"city_5107180","Ribeirão Cascalheira","5107180","base.state_br_mt","base.br"
-"city_5107198","Ribeirãozinho","5107198","base.state_br_mt","base.br"
-"city_5107206","Rio Branco","5107206","base.state_br_mt","base.br"
-"city_5107578","Rondolândia","5107578","base.state_br_mt","base.br"
-"city_5107602","Rondonópolis","5107602","base.state_br_mt","base.br"
-"city_5107701","Rosário Oeste","5107701","base.state_br_mt","base.br"
-"city_5107750","Salto do Céu","5107750","base.state_br_mt","base.br"
-"city_5107248","Santa Carmem","5107248","base.state_br_mt","base.br"
-"city_5107743","Santa Cruz do Xingu","5107743","base.state_br_mt","base.br"
-"city_5107768","Santa Rita do Trivelato","5107768","base.state_br_mt","base.br"
-"city_5107776","Santa Terezinha","5107776","base.state_br_mt","base.br"
-"city_5107263","Santo Afonso","5107263","base.state_br_mt","base.br"
-"city_5107800","Santo Antônio de Leverger","5107800","base.state_br_mt","base.br"
-"city_5107792","Santo Antônio do Leste","5107792","base.state_br_mt","base.br"
-"city_5107859","São Félix do Araguaia","5107859","base.state_br_mt","base.br"
-"city_5107297","São José do Povo","5107297","base.state_br_mt","base.br"
-"city_5107305","São José do Rio Claro","5107305","base.state_br_mt","base.br"
-"city_5107354","São José do Xingu","5107354","base.state_br_mt","base.br"
-"city_5107107","São José dos Quatro Marcos","5107107","base.state_br_mt","base.br"
-"city_5107404","São Pedro da Cipa","5107404","base.state_br_mt","base.br"
-"city_5107875","Sapezal","5107875","base.state_br_mt","base.br"
-"city_5107883","Serra Nova Dourada","5107883","base.state_br_mt","base.br"
-"city_5107909","Sinop","5107909","base.state_br_mt","base.br"
-"city_5107925","Sorriso","5107925","base.state_br_mt","base.br"
-"city_5107941","Tabaporã","5107941","base.state_br_mt","base.br"
-"city_5107958","Tangará da Serra","5107958","base.state_br_mt","base.br"
-"city_5108006","Tapurah","5108006","base.state_br_mt","base.br"
-"city_5108055","Terra Nova do Norte","5108055","base.state_br_mt","base.br"
-"city_5108105","Tesouro","5108105","base.state_br_mt","base.br"
-"city_5108204","Torixoréu","5108204","base.state_br_mt","base.br"
-"city_5108303","União do Sul","5108303","base.state_br_mt","base.br"
-"city_5108352","Vale de São Domingos","5108352","base.state_br_mt","base.br"
-"city_5108402","Várzea Grande","5108402","base.state_br_mt","base.br"
-"city_5108501","Vera","5108501","base.state_br_mt","base.br"
-"city_5105507","Vila Bela da Santíssima Trindade","5105507","base.state_br_mt","base.br"
-"city_5108600","Vila Rica","5108600","base.state_br_mt","base.br"
-"city_5200050","Abadia de Goiás","5200050","base.state_br_go","base.br"
-"city_5200100","Abadiânia","5200100","base.state_br_go","base.br"
-"city_5200134","Acreúna","5200134","base.state_br_go","base.br"
-"city_5200159","Adelândia","5200159","base.state_br_go","base.br"
-"city_5200175","Água Fria de Goiás","5200175","base.state_br_go","base.br"
-"city_5200209","Água Limpa","5200209","base.state_br_go","base.br"
-"city_5200258","Águas Lindas de Goiás","5200258","base.state_br_go","base.br"
-"city_5200308","Alexânia","5200308","base.state_br_go","base.br"
-"city_5200506","Aloândia","5200506","base.state_br_go","base.br"
-"city_5200555","Alto Horizonte","5200555","base.state_br_go","base.br"
-"city_5200605","Alto Paraíso de Goiás","5200605","base.state_br_go","base.br"
-"city_5200803","Alvorada do Norte","5200803","base.state_br_go","base.br"
-"city_5200829","Amaralina","5200829","base.state_br_go","base.br"
-"city_5200852","Americano do Brasil","5200852","base.state_br_go","base.br"
-"city_5200902","Amorinópolis","5200902","base.state_br_go","base.br"
-"city_5201108","Anápolis","5201108","base.state_br_go","base.br"
-"city_5201207","Anhanguera","5201207","base.state_br_go","base.br"
-"city_5201306","Anicuns","5201306","base.state_br_go","base.br"
-"city_5201405","Aparecida de Goiânia","5201405","base.state_br_go","base.br"
-"city_5201454","Aparecida do Rio Doce","5201454","base.state_br_go","base.br"
-"city_5201504","Aporé","5201504","base.state_br_go","base.br"
-"city_5201603","Araçu","5201603","base.state_br_go","base.br"
-"city_5201702","Aragarças","5201702","base.state_br_go","base.br"
-"city_5201801","Aragoiânia","5201801","base.state_br_go","base.br"
-"city_5202155","Araguapaz","5202155","base.state_br_go","base.br"
-"city_5202353","Arenópolis","5202353","base.state_br_go","base.br"
-"city_5202502","Aruanã","5202502","base.state_br_go","base.br"
-"city_5202601","Aurilândia","5202601","base.state_br_go","base.br"
-"city_5202809","Avelinópolis","5202809","base.state_br_go","base.br"
-"city_5203104","Baliza","5203104","base.state_br_go","base.br"
-"city_5203203","Barro Alto","5203203","base.state_br_go","base.br"
-"city_5203302","Bela Vista de Goiás","5203302","base.state_br_go","base.br"
-"city_5203401","Bom Jardim de Goiás","5203401","base.state_br_go","base.br"
-"city_5203500","Bom Jesus de Goiás","5203500","base.state_br_go","base.br"
-"city_5203559","Bonfinópolis","5203559","base.state_br_go","base.br"
-"city_5203575","Bonópolis","5203575","base.state_br_go","base.br"
-"city_5203609","Brazabrantes","5203609","base.state_br_go","base.br"
-"city_5203807","Britânia","5203807","base.state_br_go","base.br"
-"city_5203906","Buriti Alegre","5203906","base.state_br_go","base.br"
-"city_5203939","Buriti de Goiás","5203939","base.state_br_go","base.br"
-"city_5203962","Buritinópolis","5203962","base.state_br_go","base.br"
-"city_5204003","Cabeceiras","5204003","base.state_br_go","base.br"
-"city_5204102","Cachoeira Alta","5204102","base.state_br_go","base.br"
-"city_5204201","Cachoeira de Goiás","5204201","base.state_br_go","base.br"
-"city_5204250","Cachoeira Dourada","5204250","base.state_br_go","base.br"
-"city_5204300","Caçu","5204300","base.state_br_go","base.br"
-"city_5204409","Caiapônia","5204409","base.state_br_go","base.br"
-"city_5204508","Caldas Novas","5204508","base.state_br_go","base.br"
-"city_5204557","Caldazinha","5204557","base.state_br_go","base.br"
-"city_5204607","Campestre de Goiás","5204607","base.state_br_go","base.br"
-"city_5204656","Campinaçu","5204656","base.state_br_go","base.br"
-"city_5204706","Campinorte","5204706","base.state_br_go","base.br"
-"city_5204805","Campo Alegre de Goiás","5204805","base.state_br_go","base.br"
-"city_5204854","Campo Limpo de Goiás","5204854","base.state_br_go","base.br"
-"city_5204904","Campos Belos","5204904","base.state_br_go","base.br"
-"city_5204953","Campos Verdes","5204953","base.state_br_go","base.br"
-"city_5205000","Carmo do Rio Verde","5205000","base.state_br_go","base.br"
-"city_5205059","Castelândia","5205059","base.state_br_go","base.br"
-"city_5205109","Catalão","5205109","base.state_br_go","base.br"
-"city_5205208","Caturaí","5205208","base.state_br_go","base.br"
-"city_5205307","Cavalcante","5205307","base.state_br_go","base.br"
-"city_5205406","Ceres","5205406","base.state_br_go","base.br"
-"city_5205455","Cezarina","5205455","base.state_br_go","base.br"
-"city_5205471","Chapadão do Céu","5205471","base.state_br_go","base.br"
-"city_5205497","Cidade Ocidental","5205497","base.state_br_go","base.br"
-"city_5205513","Cocalzinho de Goiás","5205513","base.state_br_go","base.br"
-"city_5205521","Colinas do Sul","5205521","base.state_br_go","base.br"
-"city_5205703","Córrego do Ouro","5205703","base.state_br_go","base.br"
-"city_5205802","Corumbá de Goiás","5205802","base.state_br_go","base.br"
-"city_5205901","Corumbaíba","5205901","base.state_br_go","base.br"
-"city_5206206","Cristalina","5206206","base.state_br_go","base.br"
-"city_5206305","Cristianópolis","5206305","base.state_br_go","base.br"
-"city_5206404","Crixás","5206404","base.state_br_go","base.br"
-"city_5206503","Cromínia","5206503","base.state_br_go","base.br"
-"city_5206602","Cumari","5206602","base.state_br_go","base.br"
-"city_5206701","Damianópolis","5206701","base.state_br_go","base.br"
-"city_5206800","Damolândia","5206800","base.state_br_go","base.br"
-"city_5206909","Davinópolis","5206909","base.state_br_go","base.br"
-"city_5207105","Diorama","5207105","base.state_br_go","base.br"
-"city_5208301","Divinópolis de Goiás","5208301","base.state_br_go","base.br"
-"city_5207253","Doverlândia","5207253","base.state_br_go","base.br"
-"city_5207352","Edealina","5207352","base.state_br_go","base.br"
-"city_5207402","Edéia","5207402","base.state_br_go","base.br"
-"city_5207501","Estrela do Norte","5207501","base.state_br_go","base.br"
-"city_5207535","Faina","5207535","base.state_br_go","base.br"
-"city_5207600","Fazenda Nova","5207600","base.state_br_go","base.br"
-"city_5207808","Firminópolis","5207808","base.state_br_go","base.br"
-"city_5207907","Flores de Goiás","5207907","base.state_br_go","base.br"
-"city_5208004","Formosa","5208004","base.state_br_go","base.br"
-"city_5208103","Formoso","5208103","base.state_br_go","base.br"
-"city_5208152","Gameleira de Goiás","5208152","base.state_br_go","base.br"
-"city_5208400","Goianápolis","5208400","base.state_br_go","base.br"
-"city_5208509","Goiandira","5208509","base.state_br_go","base.br"
-"city_5208608","Goianésia","5208608","base.state_br_go","base.br"
-"city_5208707","Goiânia","5208707","base.state_br_go","base.br"
-"city_5208806","Goianira","5208806","base.state_br_go","base.br"
-"city_5208905","Goiás","5208905","base.state_br_go","base.br"
-"city_5209101","Goiatuba","5209101","base.state_br_go","base.br"
-"city_5209150","Gouvelândia","5209150","base.state_br_go","base.br"
-"city_5209200","Guapó","5209200","base.state_br_go","base.br"
-"city_5209291","Guaraíta","5209291","base.state_br_go","base.br"
-"city_5209408","Guarani de Goiás","5209408","base.state_br_go","base.br"
-"city_5209457","Guarinos","5209457","base.state_br_go","base.br"
-"city_5209606","Heitoraí","5209606","base.state_br_go","base.br"
-"city_5209705","Hidrolândia","5209705","base.state_br_go","base.br"
-"city_5209804","Hidrolina","5209804","base.state_br_go","base.br"
-"city_5209903","Iaciara","5209903","base.state_br_go","base.br"
-"city_5209937","Inaciolândia","5209937","base.state_br_go","base.br"
-"city_5209952","Indiara","5209952","base.state_br_go","base.br"
-"city_5210000","Inhumas","5210000","base.state_br_go","base.br"
-"city_5210109","Ipameri","5210109","base.state_br_go","base.br"
-"city_5210158","Ipiranga de Goiás","5210158","base.state_br_go","base.br"
-"city_5210208","Iporá","5210208","base.state_br_go","base.br"
-"city_5210307","Israelândia","5210307","base.state_br_go","base.br"
-"city_5210406","Itaberaí","5210406","base.state_br_go","base.br"
-"city_5210562","Itaguari","5210562","base.state_br_go","base.br"
-"city_5210604","Itaguaru","5210604","base.state_br_go","base.br"
-"city_5210802","Itajá","5210802","base.state_br_go","base.br"
-"city_5210901","Itapaci","5210901","base.state_br_go","base.br"
-"city_5211008","Itapirapuã","5211008","base.state_br_go","base.br"
-"city_5211206","Itapuranga","5211206","base.state_br_go","base.br"
-"city_5211305","Itarumã","5211305","base.state_br_go","base.br"
-"city_5211404","Itauçu","5211404","base.state_br_go","base.br"
-"city_5211503","Itumbiara","5211503","base.state_br_go","base.br"
-"city_5211602","Ivolândia","5211602","base.state_br_go","base.br"
-"city_5211701","Jandaia","5211701","base.state_br_go","base.br"
-"city_5211800","Jaraguá","5211800","base.state_br_go","base.br"
-"city_5211909","Jataí","5211909","base.state_br_go","base.br"
-"city_5212006","Jaupaci","5212006","base.state_br_go","base.br"
-"city_5212055","Jesúpolis","5212055","base.state_br_go","base.br"
-"city_5212105","Joviânia","5212105","base.state_br_go","base.br"
-"city_5212204","Jussara","5212204","base.state_br_go","base.br"
-"city_5212253","Lagoa Santa","5212253","base.state_br_go","base.br"
-"city_5212303","Leopoldo de Bulhões","5212303","base.state_br_go","base.br"
-"city_5212501","Luziânia","5212501","base.state_br_go","base.br"
-"city_5212600","Mairipotaba","5212600","base.state_br_go","base.br"
-"city_5212709","Mambaí","5212709","base.state_br_go","base.br"
-"city_5212808","Mara Rosa","5212808","base.state_br_go","base.br"
-"city_5212907","Marzagão","5212907","base.state_br_go","base.br"
-"city_5212956","Matrinchã","5212956","base.state_br_go","base.br"
-"city_5213004","Maurilândia","5213004","base.state_br_go","base.br"
-"city_5213053","Mimoso de Goiás","5213053","base.state_br_go","base.br"
-"city_5213087","Minaçu","5213087","base.state_br_go","base.br"
-"city_5213103","Mineiros","5213103","base.state_br_go","base.br"
-"city_5213400","Moiporá","5213400","base.state_br_go","base.br"
-"city_5213509","Monte Alegre de Goiás","5213509","base.state_br_go","base.br"
-"city_5213707","Montes Claros de Goiás","5213707","base.state_br_go","base.br"
-"city_5213756","Montividiu","5213756","base.state_br_go","base.br"
-"city_5213772","Montividiu do Norte","5213772","base.state_br_go","base.br"
-"city_5213806","Morrinhos","5213806","base.state_br_go","base.br"
-"city_5213855","Morro Agudo de Goiás","5213855","base.state_br_go","base.br"
-"city_5213905","Mossâmedes","5213905","base.state_br_go","base.br"
-"city_5214002","Mozarlândia","5214002","base.state_br_go","base.br"
-"city_5214051","Mundo Novo","5214051","base.state_br_go","base.br"
-"city_5214101","Mutunópolis","5214101","base.state_br_go","base.br"
-"city_5214408","Nazário","5214408","base.state_br_go","base.br"
-"city_5214507","Nerópolis","5214507","base.state_br_go","base.br"
-"city_5214606","Niquelândia","5214606","base.state_br_go","base.br"
-"city_5214705","Nova América","5214705","base.state_br_go","base.br"
-"city_5214804","Nova Aurora","5214804","base.state_br_go","base.br"
-"city_5214838","Nova Crixás","5214838","base.state_br_go","base.br"
-"city_5214861","Nova Glória","5214861","base.state_br_go","base.br"
-"city_5214879","Nova Iguaçu de Goiás","5214879","base.state_br_go","base.br"
-"city_5214903","Nova Roma","5214903","base.state_br_go","base.br"
-"city_5215009","Nova Veneza","5215009","base.state_br_go","base.br"
-"city_5215207","Novo Brasil","5215207","base.state_br_go","base.br"
-"city_5215231","Novo Gama","5215231","base.state_br_go","base.br"
-"city_5215256","Novo Planalto","5215256","base.state_br_go","base.br"
-"city_5215306","Orizona","5215306","base.state_br_go","base.br"
-"city_5215405","Ouro Verde de Goiás","5215405","base.state_br_go","base.br"
-"city_5215504","Ouvidor","5215504","base.state_br_go","base.br"
-"city_5215603","Padre Bernardo","5215603","base.state_br_go","base.br"
-"city_5215652","Palestina de Goiás","5215652","base.state_br_go","base.br"
-"city_5215702","Palmeiras de Goiás","5215702","base.state_br_go","base.br"
-"city_5215801","Palmelo","5215801","base.state_br_go","base.br"
-"city_5215900","Palminópolis","5215900","base.state_br_go","base.br"
-"city_5216007","Panamá","5216007","base.state_br_go","base.br"
-"city_5216304","Paranaiguara","5216304","base.state_br_go","base.br"
-"city_5216403","Paraúna","5216403","base.state_br_go","base.br"
-"city_5216452","Perolândia","5216452","base.state_br_go","base.br"
-"city_5216809","Petrolina de Goiás","5216809","base.state_br_go","base.br"
-"city_5216908","Pilar de Goiás","5216908","base.state_br_go","base.br"
-"city_5217104","Piracanjuba","5217104","base.state_br_go","base.br"
-"city_5217203","Piranhas","5217203","base.state_br_go","base.br"
-"city_5217302","Pirenópolis","5217302","base.state_br_go","base.br"
-"city_5217401","Pires do Rio","5217401","base.state_br_go","base.br"
-"city_5217609","Planaltina","5217609","base.state_br_go","base.br"
-"city_5217708","Pontalina","5217708","base.state_br_go","base.br"
-"city_5218003","Porangatu","5218003","base.state_br_go","base.br"
-"city_5218052","Porteirão","5218052","base.state_br_go","base.br"
-"city_5218102","Portelândia","5218102","base.state_br_go","base.br"
-"city_5218300","Posse","5218300","base.state_br_go","base.br"
-"city_5218391","Professor Jamil","5218391","base.state_br_go","base.br"
-"city_5218508","Quirinópolis","5218508","base.state_br_go","base.br"
-"city_5218607","Rialma","5218607","base.state_br_go","base.br"
-"city_5218706","Rianápolis","5218706","base.state_br_go","base.br"
-"city_5218789","Rio Quente","5218789","base.state_br_go","base.br"
-"city_5218805","Rio Verde","5218805","base.state_br_go","base.br"
-"city_5218904","Rubiataba","5218904","base.state_br_go","base.br"
-"city_5219001","Sanclerlândia","5219001","base.state_br_go","base.br"
-"city_5219100","Santa Bárbara de Goiás","5219100","base.state_br_go","base.br"
-"city_5219209","Santa Cruz de Goiás","5219209","base.state_br_go","base.br"
-"city_5219258","Santa Fé de Goiás","5219258","base.state_br_go","base.br"
-"city_5219308","Santa Helena de Goiás","5219308","base.state_br_go","base.br"
-"city_5219357","Santa Isabel","5219357","base.state_br_go","base.br"
-"city_5219407","Santa Rita do Araguaia","5219407","base.state_br_go","base.br"
-"city_5219456","Santa Rita do Novo Destino","5219456","base.state_br_go","base.br"
-"city_5219506","Santa Rosa de Goiás","5219506","base.state_br_go","base.br"
-"city_5219605","Santa Tereza de Goiás","5219605","base.state_br_go","base.br"
-"city_5219704","Santa Terezinha de Goiás","5219704","base.state_br_go","base.br"
-"city_5219712","Santo Antônio da Barra","5219712","base.state_br_go","base.br"
-"city_5219738","Santo Antônio de Goiás","5219738","base.state_br_go","base.br"
-"city_5219753","Santo Antônio do Descoberto","5219753","base.state_br_go","base.br"
-"city_5219803","São Domingos","5219803","base.state_br_go","base.br"
-"city_5219902","São Francisco de Goiás","5219902","base.state_br_go","base.br"
-"city_5220058","São João da Paraúna","5220058","base.state_br_go","base.br"
-"city_5220009","São João d'Aliança","5220009","base.state_br_go","base.br"
-"city_5220108","São Luís de Montes Belos","5220108","base.state_br_go","base.br"
-"city_5220157","São Luiz do Norte","5220157","base.state_br_go","base.br"
-"city_5220207","São Miguel do Araguaia","5220207","base.state_br_go","base.br"
-"city_5220264","São Miguel do Passa Quatro","5220264","base.state_br_go","base.br"
-"city_5220280","São Patrício","5220280","base.state_br_go","base.br"
-"city_5220405","São Simão","5220405","base.state_br_go","base.br"
-"city_5220454","Senador Canedo","5220454","base.state_br_go","base.br"
-"city_5220504","Serranópolis","5220504","base.state_br_go","base.br"
-"city_5220603","Silvânia","5220603","base.state_br_go","base.br"
-"city_5220686","Simolândia","5220686","base.state_br_go","base.br"
-"city_5220702","Sítio d'Abadia","5220702","base.state_br_go","base.br"
-"city_5221007","Taquaral de Goiás","5221007","base.state_br_go","base.br"
-"city_5221080","Teresina de Goiás","5221080","base.state_br_go","base.br"
-"city_5221197","Terezópolis de Goiás","5221197","base.state_br_go","base.br"
-"city_5221304","Três Ranchos","5221304","base.state_br_go","base.br"
-"city_5221403","Trindade","5221403","base.state_br_go","base.br"
-"city_5221452","Trombas","5221452","base.state_br_go","base.br"
-"city_5221502","Turvânia","5221502","base.state_br_go","base.br"
-"city_5221551","Turvelândia","5221551","base.state_br_go","base.br"
-"city_5221577","Uirapuru","5221577","base.state_br_go","base.br"
-"city_5221601","Uruaçu","5221601","base.state_br_go","base.br"
-"city_5221700","Uruana","5221700","base.state_br_go","base.br"
-"city_5221809","Urutaí","5221809","base.state_br_go","base.br"
-"city_5221858","Valparaíso de Goiás","5221858","base.state_br_go","base.br"
-"city_5221908","Varjão","5221908","base.state_br_go","base.br"
-"city_5222005","Vianópolis","5222005","base.state_br_go","base.br"
-"city_5222054","Vicentinópolis","5222054","base.state_br_go","base.br"
-"city_5222203","Vila Boa","5222203","base.state_br_go","base.br"
-"city_5222302","Vila Propício","5222302","base.state_br_go","base.br"
-"city_5300108","Brasília","5300108","base.state_br_df","base.br"
+id,name,ibge_code,state_id:id,country_id:id
+city_1100015,Alta Floresta D'Oeste,1100015,base.state_br_ro,base.br
+city_1100379,Alto Alegre dos Parecis,1100379,base.state_br_ro,base.br
+city_1100403,Alto Paraíso,1100403,base.state_br_ro,base.br
+city_1100346,Alvorada D'Oeste,1100346,base.state_br_ro,base.br
+city_1100023,Ariquemes,1100023,base.state_br_ro,base.br
+city_1100452,Buritis,1100452,base.state_br_ro,base.br
+city_1100031,Cabixi,1100031,base.state_br_ro,base.br
+city_1100601,Cacaulândia,1100601,base.state_br_ro,base.br
+city_1100049,Cacoal,1100049,base.state_br_ro,base.br
+city_1100700,Campo Novo de Rondônia,1100700,base.state_br_ro,base.br
+city_1100809,Candeias do Jamari,1100809,base.state_br_ro,base.br
+city_1100908,Castanheiras,1100908,base.state_br_ro,base.br
+city_1100056,Cerejeiras,1100056,base.state_br_ro,base.br
+city_1100924,Chupinguaia,1100924,base.state_br_ro,base.br
+city_1100064,Colorado do Oeste,1100064,base.state_br_ro,base.br
+city_1100072,Corumbiara,1100072,base.state_br_ro,base.br
+city_1100080,Costa Marques,1100080,base.state_br_ro,base.br
+city_1100940,Cujubim,1100940,base.state_br_ro,base.br
+city_1100098,Espigão D'Oeste,1100098,base.state_br_ro,base.br
+city_1101005,Governador Jorge Teixeira,1101005,base.state_br_ro,base.br
+city_1100106,Guajará-Mirim,1100106,base.state_br_ro,base.br
+city_1101104,Itapuã do Oeste,1101104,base.state_br_ro,base.br
+city_1100114,Jaru,1100114,base.state_br_ro,base.br
+city_1100122,Ji-Paraná,1100122,base.state_br_ro,base.br
+city_1100130,Machadinho D'Oeste,1100130,base.state_br_ro,base.br
+city_1101203,Ministro Andreazza,1101203,base.state_br_ro,base.br
+city_1101302,Mirante da Serra,1101302,base.state_br_ro,base.br
+city_1101401,Monte Negro,1101401,base.state_br_ro,base.br
+city_1100148,Nova Brasilândia D'Oeste,1100148,base.state_br_ro,base.br
+city_1100338,Nova Mamoré,1100338,base.state_br_ro,base.br
+city_1101435,Nova União,1101435,base.state_br_ro,base.br
+city_1100502,Novo Horizonte do Oeste,1100502,base.state_br_ro,base.br
+city_1100155,Ouro Preto do Oeste,1100155,base.state_br_ro,base.br
+city_1101450,Parecis,1101450,base.state_br_ro,base.br
+city_1100189,Pimenta Bueno,1100189,base.state_br_ro,base.br
+city_1101468,Pimenteiras do Oeste,1101468,base.state_br_ro,base.br
+city_1100205,Porto Velho,1100205,base.state_br_ro,base.br
+city_1100254,Presidente Médici,1100254,base.state_br_ro,base.br
+city_1101476,Primavera de Rondônia,1101476,base.state_br_ro,base.br
+city_1100262,Rio Crespo,1100262,base.state_br_ro,base.br
+city_1100288,Rolim de Moura,1100288,base.state_br_ro,base.br
+city_1100296,Santa Luzia D'Oeste,1100296,base.state_br_ro,base.br
+city_1101484,São Felipe D'Oeste,1101484,base.state_br_ro,base.br
+city_1101492,São Francisco do Guaporé,1101492,base.state_br_ro,base.br
+city_1100320,São Miguel do Guaporé,1100320,base.state_br_ro,base.br
+city_1101500,Seringueiras,1101500,base.state_br_ro,base.br
+city_1101559,Teixeirópolis,1101559,base.state_br_ro,base.br
+city_1101609,Theobroma,1101609,base.state_br_ro,base.br
+city_1101708,Urupá,1101708,base.state_br_ro,base.br
+city_1101757,Vale do Anari,1101757,base.state_br_ro,base.br
+city_1101807,Vale do Paraíso,1101807,base.state_br_ro,base.br
+city_1100304,Vilhena,1100304,base.state_br_ro,base.br
+city_1200013,Acrelândia,1200013,base.state_br_ac,base.br
+city_1200054,Assis Brasil,1200054,base.state_br_ac,base.br
+city_1200104,Brasiléia,1200104,base.state_br_ac,base.br
+city_1200138,Bujari,1200138,base.state_br_ac,base.br
+city_1200179,Capixaba,1200179,base.state_br_ac,base.br
+city_1200203,Cruzeiro do Sul,1200203,base.state_br_ac,base.br
+city_1200252,Epitaciolândia,1200252,base.state_br_ac,base.br
+city_1200302,Feijó,1200302,base.state_br_ac,base.br
+city_1200328,Jordão,1200328,base.state_br_ac,base.br
+city_1200336,Mâncio Lima,1200336,base.state_br_ac,base.br
+city_1200344,Manoel Urbano,1200344,base.state_br_ac,base.br
+city_1200351,Marechal Thaumaturgo,1200351,base.state_br_ac,base.br
+city_1200385,Plácido de Castro,1200385,base.state_br_ac,base.br
+city_1200807,Porto Acre,1200807,base.state_br_ac,base.br
+city_1200393,Porto Walter,1200393,base.state_br_ac,base.br
+city_1200401,Rio Branco,1200401,base.state_br_ac,base.br
+city_1200427,Rodrigues Alves,1200427,base.state_br_ac,base.br
+city_1200435,Santa Rosa do Purus,1200435,base.state_br_ac,base.br
+city_1200500,Sena Madureira,1200500,base.state_br_ac,base.br
+city_1200450,Senador Guiomard,1200450,base.state_br_ac,base.br
+city_1200609,Tarauacá,1200609,base.state_br_ac,base.br
+city_1200708,Xapuri,1200708,base.state_br_ac,base.br
+city_1300029,Alvarães,1300029,base.state_br_am,base.br
+city_1300060,Amaturá,1300060,base.state_br_am,base.br
+city_1300086,Anamã,1300086,base.state_br_am,base.br
+city_1300102,Anori,1300102,base.state_br_am,base.br
+city_1300144,Apuí,1300144,base.state_br_am,base.br
+city_1300201,Atalaia do Norte,1300201,base.state_br_am,base.br
+city_1300300,Autazes,1300300,base.state_br_am,base.br
+city_1300409,Barcelos,1300409,base.state_br_am,base.br
+city_1300508,Barreirinha,1300508,base.state_br_am,base.br
+city_1300607,Benjamin Constant,1300607,base.state_br_am,base.br
+city_1300631,Beruri,1300631,base.state_br_am,base.br
+city_1300680,Boa Vista do Ramos,1300680,base.state_br_am,base.br
+city_1300706,Boca do Acre,1300706,base.state_br_am,base.br
+city_1300805,Borba,1300805,base.state_br_am,base.br
+city_1300839,Caapiranga,1300839,base.state_br_am,base.br
+city_1300904,Canutama,1300904,base.state_br_am,base.br
+city_1301001,Carauari,1301001,base.state_br_am,base.br
+city_1301100,Careiro,1301100,base.state_br_am,base.br
+city_1301159,Careiro da Várzea,1301159,base.state_br_am,base.br
+city_1301209,Coari,1301209,base.state_br_am,base.br
+city_1301308,Codajás,1301308,base.state_br_am,base.br
+city_1301407,Eirunepé,1301407,base.state_br_am,base.br
+city_1301506,Envira,1301506,base.state_br_am,base.br
+city_1301605,Fonte Boa,1301605,base.state_br_am,base.br
+city_1301654,Guajará,1301654,base.state_br_am,base.br
+city_1301704,Humaitá,1301704,base.state_br_am,base.br
+city_1301803,Ipixuna,1301803,base.state_br_am,base.br
+city_1301852,Iranduba,1301852,base.state_br_am,base.br
+city_1301902,Itacoatiara,1301902,base.state_br_am,base.br
+city_1301951,Itamarati,1301951,base.state_br_am,base.br
+city_1302009,Itapiranga,1302009,base.state_br_am,base.br
+city_1302108,Japurá,1302108,base.state_br_am,base.br
+city_1302207,Juruá,1302207,base.state_br_am,base.br
+city_1302306,Jutaí,1302306,base.state_br_am,base.br
+city_1302405,Lábrea,1302405,base.state_br_am,base.br
+city_1302504,Manacapuru,1302504,base.state_br_am,base.br
+city_1302553,Manaquiri,1302553,base.state_br_am,base.br
+city_1302603,Manaus,1302603,base.state_br_am,base.br
+city_1302702,Manicoré,1302702,base.state_br_am,base.br
+city_1302801,Maraã,1302801,base.state_br_am,base.br
+city_1302900,Maués,1302900,base.state_br_am,base.br
+city_1303007,Nhamundá,1303007,base.state_br_am,base.br
+city_1303106,Nova Olinda do Norte,1303106,base.state_br_am,base.br
+city_1303205,Novo Airão,1303205,base.state_br_am,base.br
+city_1303304,Novo Aripuanã,1303304,base.state_br_am,base.br
+city_1303403,Parintins,1303403,base.state_br_am,base.br
+city_1303502,Pauini,1303502,base.state_br_am,base.br
+city_1303536,Presidente Figueiredo,1303536,base.state_br_am,base.br
+city_1303569,Rio Preto da Eva,1303569,base.state_br_am,base.br
+city_1303601,Santa Isabel do Rio Negro,1303601,base.state_br_am,base.br
+city_1303700,Santo Antônio do Içá,1303700,base.state_br_am,base.br
+city_1303809,São Gabriel da Cachoeira,1303809,base.state_br_am,base.br
+city_1303908,São Paulo de Olivença,1303908,base.state_br_am,base.br
+city_1303957,São Sebastião do Uatumã,1303957,base.state_br_am,base.br
+city_1304005,Silves,1304005,base.state_br_am,base.br
+city_1304062,Tabatinga,1304062,base.state_br_am,base.br
+city_1304104,Tapauá,1304104,base.state_br_am,base.br
+city_1304203,Tefé,1304203,base.state_br_am,base.br
+city_1304237,Tonantins,1304237,base.state_br_am,base.br
+city_1304260,Uarini,1304260,base.state_br_am,base.br
+city_1304302,Urucará,1304302,base.state_br_am,base.br
+city_1304401,Urucurituba,1304401,base.state_br_am,base.br
+city_1400050,Alto Alegre,1400050,base.state_br_rr,base.br
+city_1400027,Amajari,1400027,base.state_br_rr,base.br
+city_1400100,Boa Vista,1400100,base.state_br_rr,base.br
+city_1400159,Bonfim,1400159,base.state_br_rr,base.br
+city_1400175,Cantá,1400175,base.state_br_rr,base.br
+city_1400209,Caracaraí,1400209,base.state_br_rr,base.br
+city_1400233,Caroebe,1400233,base.state_br_rr,base.br
+city_1400282,Iracema,1400282,base.state_br_rr,base.br
+city_1400308,Mucajaí,1400308,base.state_br_rr,base.br
+city_1400407,Normandia,1400407,base.state_br_rr,base.br
+city_1400456,Pacaraima,1400456,base.state_br_rr,base.br
+city_1400472,Rorainópolis,1400472,base.state_br_rr,base.br
+city_1400506,São João da Baliza,1400506,base.state_br_rr,base.br
+city_1400605,São Luiz,1400605,base.state_br_rr,base.br
+city_1400704,Uiramutã,1400704,base.state_br_rr,base.br
+city_1500107,Abaetetuba,1500107,base.state_br_pa,base.br
+city_1500131,Abel Figueiredo,1500131,base.state_br_pa,base.br
+city_1500206,Acará,1500206,base.state_br_pa,base.br
+city_1500305,Afuá,1500305,base.state_br_pa,base.br
+city_1500347,Água Azul do Norte,1500347,base.state_br_pa,base.br
+city_1500404,Alenquer,1500404,base.state_br_pa,base.br
+city_1500503,Almeirim,1500503,base.state_br_pa,base.br
+city_1500602,Altamira,1500602,base.state_br_pa,base.br
+city_1500701,Anajás,1500701,base.state_br_pa,base.br
+city_1500800,Ananindeua,1500800,base.state_br_pa,base.br
+city_1500859,Anapu,1500859,base.state_br_pa,base.br
+city_1500909,Augusto Corrêa,1500909,base.state_br_pa,base.br
+city_1500958,Aurora do Pará,1500958,base.state_br_pa,base.br
+city_1501006,Aveiro,1501006,base.state_br_pa,base.br
+city_1501105,Bagre,1501105,base.state_br_pa,base.br
+city_1501204,Baião,1501204,base.state_br_pa,base.br
+city_1501253,Bannach,1501253,base.state_br_pa,base.br
+city_1501303,Barcarena,1501303,base.state_br_pa,base.br
+city_1501402,Belém,1501402,base.state_br_pa,base.br
+city_1501451,Belterra,1501451,base.state_br_pa,base.br
+city_1501501,Benevides,1501501,base.state_br_pa,base.br
+city_1501576,Bom Jesus do Tocantins,1501576,base.state_br_pa,base.br
+city_1501600,Bonito,1501600,base.state_br_pa,base.br
+city_1501709,Bragança,1501709,base.state_br_pa,base.br
+city_1501725,Brasil Novo,1501725,base.state_br_pa,base.br
+city_1501758,Brejo Grande do Araguaia,1501758,base.state_br_pa,base.br
+city_1501782,Breu Branco,1501782,base.state_br_pa,base.br
+city_1501808,Breves,1501808,base.state_br_pa,base.br
+city_1501907,Bujaru,1501907,base.state_br_pa,base.br
+city_1502004,Cachoeira do Arari,1502004,base.state_br_pa,base.br
+city_1501956,Cachoeira do Piriá,1501956,base.state_br_pa,base.br
+city_1502103,Cametá,1502103,base.state_br_pa,base.br
+city_1502152,Canaã dos Carajás,1502152,base.state_br_pa,base.br
+city_1502202,Capanema,1502202,base.state_br_pa,base.br
+city_1502301,Capitão Poço,1502301,base.state_br_pa,base.br
+city_1502400,Castanhal,1502400,base.state_br_pa,base.br
+city_1502509,Chaves,1502509,base.state_br_pa,base.br
+city_1502608,Colares,1502608,base.state_br_pa,base.br
+city_1502707,Conceição do Araguaia,1502707,base.state_br_pa,base.br
+city_1502756,Concórdia do Pará,1502756,base.state_br_pa,base.br
+city_1502764,Cumaru do Norte,1502764,base.state_br_pa,base.br
+city_1502772,Curionópolis,1502772,base.state_br_pa,base.br
+city_1502806,Curralinho,1502806,base.state_br_pa,base.br
+city_1502855,Curuá,1502855,base.state_br_pa,base.br
+city_1502905,Curuçá,1502905,base.state_br_pa,base.br
+city_1502939,Dom Eliseu,1502939,base.state_br_pa,base.br
+city_1502954,Eldorado do Carajás,1502954,base.state_br_pa,base.br
+city_1503002,Faro,1503002,base.state_br_pa,base.br
+city_1503044,Floresta do Araguaia,1503044,base.state_br_pa,base.br
+city_1503077,Garrafão do Norte,1503077,base.state_br_pa,base.br
+city_1503093,Goianésia do Pará,1503093,base.state_br_pa,base.br
+city_1503101,Gurupá,1503101,base.state_br_pa,base.br
+city_1503200,Igarapé-Açu,1503200,base.state_br_pa,base.br
+city_1503309,Igarapé-Miri,1503309,base.state_br_pa,base.br
+city_1503408,Inhangapi,1503408,base.state_br_pa,base.br
+city_1503457,Ipixuna do Pará,1503457,base.state_br_pa,base.br
+city_1503507,Irituia,1503507,base.state_br_pa,base.br
+city_1503606,Itaituba,1503606,base.state_br_pa,base.br
+city_1503705,Itupiranga,1503705,base.state_br_pa,base.br
+city_1503754,Jacareacanga,1503754,base.state_br_pa,base.br
+city_1503804,Jacundá,1503804,base.state_br_pa,base.br
+city_1503903,Juruti,1503903,base.state_br_pa,base.br
+city_1504000,Limoeiro do Ajuru,1504000,base.state_br_pa,base.br
+city_1504059,Mãe do Rio,1504059,base.state_br_pa,base.br
+city_1504109,Magalhães Barata,1504109,base.state_br_pa,base.br
+city_1504208,Marabá,1504208,base.state_br_pa,base.br
+city_1504307,Maracanã,1504307,base.state_br_pa,base.br
+city_1504406,Marapanim,1504406,base.state_br_pa,base.br
+city_1504422,Marituba,1504422,base.state_br_pa,base.br
+city_1504455,Medicilândia,1504455,base.state_br_pa,base.br
+city_1504505,Melgaço,1504505,base.state_br_pa,base.br
+city_1504604,Mocajuba,1504604,base.state_br_pa,base.br
+city_1504703,Moju,1504703,base.state_br_pa,base.br
+city_1504752,Mojuí dos Campos,1504752,base.state_br_pa,base.br
+city_1504802,Monte Alegre,1504802,base.state_br_pa,base.br
+city_1504901,Muaná,1504901,base.state_br_pa,base.br
+city_1504950,Nova Esperança do Piriá,1504950,base.state_br_pa,base.br
+city_1504976,Nova Ipixuna,1504976,base.state_br_pa,base.br
+city_1505007,Nova Timboteua,1505007,base.state_br_pa,base.br
+city_1505031,Novo Progresso,1505031,base.state_br_pa,base.br
+city_1505064,Novo Repartimento,1505064,base.state_br_pa,base.br
+city_1505106,Óbidos,1505106,base.state_br_pa,base.br
+city_1505205,Oeiras do Pará,1505205,base.state_br_pa,base.br
+city_1505304,Oriximiná,1505304,base.state_br_pa,base.br
+city_1505403,Ourém,1505403,base.state_br_pa,base.br
+city_1505437,Ourilândia do Norte,1505437,base.state_br_pa,base.br
+city_1505486,Pacajá,1505486,base.state_br_pa,base.br
+city_1505494,Palestina do Pará,1505494,base.state_br_pa,base.br
+city_1505502,Paragominas,1505502,base.state_br_pa,base.br
+city_1505536,Parauapebas,1505536,base.state_br_pa,base.br
+city_1505551,Pau D'Arco,1505551,base.state_br_pa,base.br
+city_1505601,Peixe-Boi,1505601,base.state_br_pa,base.br
+city_1505635,Piçarra,1505635,base.state_br_pa,base.br
+city_1505650,Placas,1505650,base.state_br_pa,base.br
+city_1505700,Ponta de Pedras,1505700,base.state_br_pa,base.br
+city_1505809,Portel,1505809,base.state_br_pa,base.br
+city_1505908,Porto de Moz,1505908,base.state_br_pa,base.br
+city_1506005,Prainha,1506005,base.state_br_pa,base.br
+city_1506104,Primavera,1506104,base.state_br_pa,base.br
+city_1506112,Quatipuru,1506112,base.state_br_pa,base.br
+city_1506138,Redenção,1506138,base.state_br_pa,base.br
+city_1506161,Rio Maria,1506161,base.state_br_pa,base.br
+city_1506187,Rondon do Pará,1506187,base.state_br_pa,base.br
+city_1506195,Rurópolis,1506195,base.state_br_pa,base.br
+city_1506203,Salinópolis,1506203,base.state_br_pa,base.br
+city_1506302,Salvaterra,1506302,base.state_br_pa,base.br
+city_1506351,Santa Bárbara do Pará,1506351,base.state_br_pa,base.br
+city_1506401,Santa Cruz do Arari,1506401,base.state_br_pa,base.br
+city_1506500,Santa Izabel do Pará,1506500,base.state_br_pa,base.br
+city_1506559,Santa Luzia do Pará,1506559,base.state_br_pa,base.br
+city_1506583,Santa Maria das Barreiras,1506583,base.state_br_pa,base.br
+city_1506609,Santa Maria do Pará,1506609,base.state_br_pa,base.br
+city_1506708,Santana do Araguaia,1506708,base.state_br_pa,base.br
+city_1506807,Santarém,1506807,base.state_br_pa,base.br
+city_1506906,Santarém Novo,1506906,base.state_br_pa,base.br
+city_1507003,Santo Antônio do Tauá,1507003,base.state_br_pa,base.br
+city_1507102,São Caetano de Odivelas,1507102,base.state_br_pa,base.br
+city_1507151,São Domingos do Araguaia,1507151,base.state_br_pa,base.br
+city_1507201,São Domingos do Capim,1507201,base.state_br_pa,base.br
+city_1507300,São Félix do Xingu,1507300,base.state_br_pa,base.br
+city_1507409,São Francisco do Pará,1507409,base.state_br_pa,base.br
+city_1507458,São Geraldo do Araguaia,1507458,base.state_br_pa,base.br
+city_1507466,São João da Ponta,1507466,base.state_br_pa,base.br
+city_1507474,São João de Pirabas,1507474,base.state_br_pa,base.br
+city_1507508,São João do Araguaia,1507508,base.state_br_pa,base.br
+city_1507607,São Miguel do Guamá,1507607,base.state_br_pa,base.br
+city_1507706,São Sebastião da Boa Vista,1507706,base.state_br_pa,base.br
+city_1507755,Sapucaia,1507755,base.state_br_pa,base.br
+city_1507805,Senador José Porfírio,1507805,base.state_br_pa,base.br
+city_1507904,Soure,1507904,base.state_br_pa,base.br
+city_1507953,Tailândia,1507953,base.state_br_pa,base.br
+city_1507961,Terra Alta,1507961,base.state_br_pa,base.br
+city_1507979,Terra Santa,1507979,base.state_br_pa,base.br
+city_1508001,Tomé-Açu,1508001,base.state_br_pa,base.br
+city_1508035,Tracuateua,1508035,base.state_br_pa,base.br
+city_1508050,Trairão,1508050,base.state_br_pa,base.br
+city_1508084,Tucumã,1508084,base.state_br_pa,base.br
+city_1508100,Tucuruí,1508100,base.state_br_pa,base.br
+city_1508126,Ulianópolis,1508126,base.state_br_pa,base.br
+city_1508159,Uruará,1508159,base.state_br_pa,base.br
+city_1508209,Vigia,1508209,base.state_br_pa,base.br
+city_1508308,Viseu,1508308,base.state_br_pa,base.br
+city_1508357,Vitória do Xingu,1508357,base.state_br_pa,base.br
+city_1508407,Xinguara,1508407,base.state_br_pa,base.br
+city_1600105,Amapá,1600105,base.state_br_ap,base.br
+city_1600204,Calçoene,1600204,base.state_br_ap,base.br
+city_1600212,Cutias,1600212,base.state_br_ap,base.br
+city_1600238,Ferreira Gomes,1600238,base.state_br_ap,base.br
+city_1600253,Itaubal,1600253,base.state_br_ap,base.br
+city_1600279,Laranjal do Jari,1600279,base.state_br_ap,base.br
+city_1600303,Macapá,1600303,base.state_br_ap,base.br
+city_1600402,Mazagão,1600402,base.state_br_ap,base.br
+city_1600501,Oiapoque,1600501,base.state_br_ap,base.br
+city_1600154,Pedra Branca do Amapari,1600154,base.state_br_ap,base.br
+city_1600535,Porto Grande,1600535,base.state_br_ap,base.br
+city_1600550,Pracuúba,1600550,base.state_br_ap,base.br
+city_1600600,Santana,1600600,base.state_br_ap,base.br
+city_1600055,Serra do Navio,1600055,base.state_br_ap,base.br
+city_1600709,Tartarugalzinho,1600709,base.state_br_ap,base.br
+city_1600808,Vitória do Jari,1600808,base.state_br_ap,base.br
+city_1700251,Abreulândia,1700251,base.state_br_to,base.br
+city_1700301,Aguiarnópolis,1700301,base.state_br_to,base.br
+city_1700350,Aliança do Tocantins,1700350,base.state_br_to,base.br
+city_1700400,Almas,1700400,base.state_br_to,base.br
+city_1700707,Alvorada,1700707,base.state_br_to,base.br
+city_1701002,Ananás,1701002,base.state_br_to,base.br
+city_1701051,Angico,1701051,base.state_br_to,base.br
+city_1701101,Aparecida do Rio Negro,1701101,base.state_br_to,base.br
+city_1701309,Aragominas,1701309,base.state_br_to,base.br
+city_1701903,Araguacema,1701903,base.state_br_to,base.br
+city_1702000,Araguaçu,1702000,base.state_br_to,base.br
+city_1702109,Araguaína,1702109,base.state_br_to,base.br
+city_1702158,Araguanã,1702158,base.state_br_to,base.br
+city_1702208,Araguatins,1702208,base.state_br_to,base.br
+city_1702307,Arapoema,1702307,base.state_br_to,base.br
+city_1702406,Arraias,1702406,base.state_br_to,base.br
+city_1702554,Augustinópolis,1702554,base.state_br_to,base.br
+city_1702703,Aurora do Tocantins,1702703,base.state_br_to,base.br
+city_1702901,Axixá do Tocantins,1702901,base.state_br_to,base.br
+city_1703008,Babaçulândia,1703008,base.state_br_to,base.br
+city_1703057,Bandeirantes do Tocantins,1703057,base.state_br_to,base.br
+city_1703073,Barra do Ouro,1703073,base.state_br_to,base.br
+city_1703107,Barrolândia,1703107,base.state_br_to,base.br
+city_1703206,Bernardo Sayão,1703206,base.state_br_to,base.br
+city_1703305,Bom Jesus do Tocantins,1703305,base.state_br_to,base.br
+city_1703602,Brasilândia do Tocantins,1703602,base.state_br_to,base.br
+city_1703701,Brejinho de Nazaré,1703701,base.state_br_to,base.br
+city_1703800,Buriti do Tocantins,1703800,base.state_br_to,base.br
+city_1703826,Cachoeirinha,1703826,base.state_br_to,base.br
+city_1703842,Campos Lindos,1703842,base.state_br_to,base.br
+city_1703867,Cariri do Tocantins,1703867,base.state_br_to,base.br
+city_1703883,Carmolândia,1703883,base.state_br_to,base.br
+city_1703891,Carrasco Bonito,1703891,base.state_br_to,base.br
+city_1703909,Caseara,1703909,base.state_br_to,base.br
+city_1704105,Centenário,1704105,base.state_br_to,base.br
+city_1705102,Chapada da Natividade,1705102,base.state_br_to,base.br
+city_1704600,Chapada de Areia,1704600,base.state_br_to,base.br
+city_1705508,Colinas do Tocantins,1705508,base.state_br_to,base.br
+city_1716703,Colméia,1716703,base.state_br_to,base.br
+city_1705557,Combinado,1705557,base.state_br_to,base.br
+city_1705607,Conceição do Tocantins,1705607,base.state_br_to,base.br
+city_1706001,Couto Magalhães,1706001,base.state_br_to,base.br
+city_1706100,Cristalândia,1706100,base.state_br_to,base.br
+city_1706258,Crixás do Tocantins,1706258,base.state_br_to,base.br
+city_1706506,Darcinópolis,1706506,base.state_br_to,base.br
+city_1707009,Dianópolis,1707009,base.state_br_to,base.br
+city_1707108,Divinópolis do Tocantins,1707108,base.state_br_to,base.br
+city_1707207,Dois Irmãos do Tocantins,1707207,base.state_br_to,base.br
+city_1707306,Dueré,1707306,base.state_br_to,base.br
+city_1707405,Esperantina,1707405,base.state_br_to,base.br
+city_1707553,Fátima,1707553,base.state_br_to,base.br
+city_1707652,Figueirópolis,1707652,base.state_br_to,base.br
+city_1707702,Filadélfia,1707702,base.state_br_to,base.br
+city_1708205,Formoso do Araguaia,1708205,base.state_br_to,base.br
+city_1708304,Goianorte,1708304,base.state_br_to,base.br
+city_1709005,Goiatins,1709005,base.state_br_to,base.br
+city_1709302,Guaraí,1709302,base.state_br_to,base.br
+city_1709500,Gurupi,1709500,base.state_br_to,base.br
+city_1709807,Ipueiras,1709807,base.state_br_to,base.br
+city_1710508,Itacajá,1710508,base.state_br_to,base.br
+city_1710706,Itaguatins,1710706,base.state_br_to,base.br
+city_1710904,Itapiratins,1710904,base.state_br_to,base.br
+city_1711100,Itaporã do Tocantins,1711100,base.state_br_to,base.br
+city_1711506,Jaú do Tocantins,1711506,base.state_br_to,base.br
+city_1711803,Juarina,1711803,base.state_br_to,base.br
+city_1711902,Lagoa da Confusão,1711902,base.state_br_to,base.br
+city_1711951,Lagoa do Tocantins,1711951,base.state_br_to,base.br
+city_1712009,Lajeado,1712009,base.state_br_to,base.br
+city_1712157,Lavandeira,1712157,base.state_br_to,base.br
+city_1712405,Lizarda,1712405,base.state_br_to,base.br
+city_1712454,Luzinópolis,1712454,base.state_br_to,base.br
+city_1712504,Marianópolis do Tocantins,1712504,base.state_br_to,base.br
+city_1712702,Mateiros,1712702,base.state_br_to,base.br
+city_1712801,Maurilândia do Tocantins,1712801,base.state_br_to,base.br
+city_1713205,Miracema do Tocantins,1713205,base.state_br_to,base.br
+city_1713304,Miranorte,1713304,base.state_br_to,base.br
+city_1713601,Monte do Carmo,1713601,base.state_br_to,base.br
+city_1713700,Monte Santo do Tocantins,1713700,base.state_br_to,base.br
+city_1713957,Muricilândia,1713957,base.state_br_to,base.br
+city_1714203,Natividade,1714203,base.state_br_to,base.br
+city_1714302,Nazaré,1714302,base.state_br_to,base.br
+city_1714880,Nova Olinda,1714880,base.state_br_to,base.br
+city_1715002,Nova Rosalândia,1715002,base.state_br_to,base.br
+city_1715101,Novo Acordo,1715101,base.state_br_to,base.br
+city_1715150,Novo Alegre,1715150,base.state_br_to,base.br
+city_1715259,Novo Jardim,1715259,base.state_br_to,base.br
+city_1715507,Oliveira de Fátima,1715507,base.state_br_to,base.br
+city_1721000,Palmas,1721000,base.state_br_to,base.br
+city_1715705,Palmeirante,1715705,base.state_br_to,base.br
+city_1713809,Palmeiras do Tocantins,1713809,base.state_br_to,base.br
+city_1715754,Palmeirópolis,1715754,base.state_br_to,base.br
+city_1716109,Paraíso do Tocantins,1716109,base.state_br_to,base.br
+city_1716208,Paranã,1716208,base.state_br_to,base.br
+city_1716307,Pau D'Arco,1716307,base.state_br_to,base.br
+city_1716505,Pedro Afonso,1716505,base.state_br_to,base.br
+city_1716604,Peixe,1716604,base.state_br_to,base.br
+city_1716653,Pequizeiro,1716653,base.state_br_to,base.br
+city_1717008,Pindorama do Tocantins,1717008,base.state_br_to,base.br
+city_1717206,Piraquê,1717206,base.state_br_to,base.br
+city_1717503,Pium,1717503,base.state_br_to,base.br
+city_1717800,Ponte Alta do Bom Jesus,1717800,base.state_br_to,base.br
+city_1717909,Ponte Alta do Tocantins,1717909,base.state_br_to,base.br
+city_1718006,Porto Alegre do Tocantins,1718006,base.state_br_to,base.br
+city_1718204,Porto Nacional,1718204,base.state_br_to,base.br
+city_1718303,Praia Norte,1718303,base.state_br_to,base.br
+city_1718402,Presidente Kennedy,1718402,base.state_br_to,base.br
+city_1718451,Pugmil,1718451,base.state_br_to,base.br
+city_1718501,Recursolândia,1718501,base.state_br_to,base.br
+city_1718550,Riachinho,1718550,base.state_br_to,base.br
+city_1718659,Rio da Conceição,1718659,base.state_br_to,base.br
+city_1718709,Rio dos Bois,1718709,base.state_br_to,base.br
+city_1718758,Rio Sono,1718758,base.state_br_to,base.br
+city_1718808,Sampaio,1718808,base.state_br_to,base.br
+city_1718840,Sandolândia,1718840,base.state_br_to,base.br
+city_1718865,Santa Fé do Araguaia,1718865,base.state_br_to,base.br
+city_1718881,Santa Maria do Tocantins,1718881,base.state_br_to,base.br
+city_1718899,Santa Rita do Tocantins,1718899,base.state_br_to,base.br
+city_1718907,Santa Rosa do Tocantins,1718907,base.state_br_to,base.br
+city_1719004,Santa Tereza do Tocantins,1719004,base.state_br_to,base.br
+city_1720002,Santa Terezinha do Tocantins,1720002,base.state_br_to,base.br
+city_1720101,São Bento do Tocantins,1720101,base.state_br_to,base.br
+city_1720150,São Félix do Tocantins,1720150,base.state_br_to,base.br
+city_1720200,São Miguel do Tocantins,1720200,base.state_br_to,base.br
+city_1720259,São Salvador do Tocantins,1720259,base.state_br_to,base.br
+city_1720309,São Sebastião do Tocantins,1720309,base.state_br_to,base.br
+city_1720499,São Valério,1720499,base.state_br_to,base.br
+city_1720655,Silvanópolis,1720655,base.state_br_to,base.br
+city_1720804,Sítio Novo do Tocantins,1720804,base.state_br_to,base.br
+city_1720853,Sucupira,1720853,base.state_br_to,base.br
+city_1708254,Tabocão,1708254,base.state_br_to,base.br
+city_1720903,Taguatinga,1720903,base.state_br_to,base.br
+city_1720937,Taipas do Tocantins,1720937,base.state_br_to,base.br
+city_1720978,Talismã,1720978,base.state_br_to,base.br
+city_1721109,Tocantínia,1721109,base.state_br_to,base.br
+city_1721208,Tocantinópolis,1721208,base.state_br_to,base.br
+city_1721257,Tupirama,1721257,base.state_br_to,base.br
+city_1721307,Tupiratins,1721307,base.state_br_to,base.br
+city_1722081,Wanderlândia,1722081,base.state_br_to,base.br
+city_1722107,Xambioá,1722107,base.state_br_to,base.br
+city_2100055,Açailândia,2100055,base.state_br_ma,base.br
+city_2100105,Afonso Cunha,2100105,base.state_br_ma,base.br
+city_2100154,Água Doce do Maranhão,2100154,base.state_br_ma,base.br
+city_2100204,Alcântara,2100204,base.state_br_ma,base.br
+city_2100303,Aldeias Altas,2100303,base.state_br_ma,base.br
+city_2100402,Altamira do Maranhão,2100402,base.state_br_ma,base.br
+city_2100436,Alto Alegre do Maranhão,2100436,base.state_br_ma,base.br
+city_2100477,Alto Alegre do Pindaré,2100477,base.state_br_ma,base.br
+city_2100501,Alto Parnaíba,2100501,base.state_br_ma,base.br
+city_2100550,Amapá do Maranhão,2100550,base.state_br_ma,base.br
+city_2100600,Amarante do Maranhão,2100600,base.state_br_ma,base.br
+city_2100709,Anajatuba,2100709,base.state_br_ma,base.br
+city_2100808,Anapurus,2100808,base.state_br_ma,base.br
+city_2100832,Apicum-Açu,2100832,base.state_br_ma,base.br
+city_2100873,Araguanã,2100873,base.state_br_ma,base.br
+city_2100907,Araioses,2100907,base.state_br_ma,base.br
+city_2100956,Arame,2100956,base.state_br_ma,base.br
+city_2101004,Arari,2101004,base.state_br_ma,base.br
+city_2101103,Axixá,2101103,base.state_br_ma,base.br
+city_2101202,Bacabal,2101202,base.state_br_ma,base.br
+city_2101251,Bacabeira,2101251,base.state_br_ma,base.br
+city_2101301,Bacuri,2101301,base.state_br_ma,base.br
+city_2101350,Bacurituba,2101350,base.state_br_ma,base.br
+city_2101400,Balsas,2101400,base.state_br_ma,base.br
+city_2101509,Barão de Grajaú,2101509,base.state_br_ma,base.br
+city_2101608,Barra do Corda,2101608,base.state_br_ma,base.br
+city_2101707,Barreirinhas,2101707,base.state_br_ma,base.br
+city_2101772,Bela Vista do Maranhão,2101772,base.state_br_ma,base.br
+city_2101731,Belágua,2101731,base.state_br_ma,base.br
+city_2101806,Benedito Leite,2101806,base.state_br_ma,base.br
+city_2101905,Bequimão,2101905,base.state_br_ma,base.br
+city_2101939,Bernardo do Mearim,2101939,base.state_br_ma,base.br
+city_2101970,Boa Vista do Gurupi,2101970,base.state_br_ma,base.br
+city_2102002,Bom Jardim,2102002,base.state_br_ma,base.br
+city_2102036,Bom Jesus das Selvas,2102036,base.state_br_ma,base.br
+city_2102077,Bom Lugar,2102077,base.state_br_ma,base.br
+city_2102101,Brejo,2102101,base.state_br_ma,base.br
+city_2102150,Brejo de Areia,2102150,base.state_br_ma,base.br
+city_2102200,Buriti,2102200,base.state_br_ma,base.br
+city_2102309,Buriti Bravo,2102309,base.state_br_ma,base.br
+city_2102325,Buriticupu,2102325,base.state_br_ma,base.br
+city_2102358,Buritirana,2102358,base.state_br_ma,base.br
+city_2102374,Cachoeira Grande,2102374,base.state_br_ma,base.br
+city_2102408,Cajapió,2102408,base.state_br_ma,base.br
+city_2102507,Cajari,2102507,base.state_br_ma,base.br
+city_2102556,Campestre do Maranhão,2102556,base.state_br_ma,base.br
+city_2102606,Cândido Mendes,2102606,base.state_br_ma,base.br
+city_2102705,Cantanhede,2102705,base.state_br_ma,base.br
+city_2102754,Capinzal do Norte,2102754,base.state_br_ma,base.br
+city_2102804,Carolina,2102804,base.state_br_ma,base.br
+city_2102903,Carutapera,2102903,base.state_br_ma,base.br
+city_2103000,Caxias,2103000,base.state_br_ma,base.br
+city_2103109,Cedral,2103109,base.state_br_ma,base.br
+city_2103125,Central do Maranhão,2103125,base.state_br_ma,base.br
+city_2103158,Centro do Guilherme,2103158,base.state_br_ma,base.br
+city_2103174,Centro Novo do Maranhão,2103174,base.state_br_ma,base.br
+city_2103208,Chapadinha,2103208,base.state_br_ma,base.br
+city_2103257,Cidelândia,2103257,base.state_br_ma,base.br
+city_2103307,Codó,2103307,base.state_br_ma,base.br
+city_2103406,Coelho Neto,2103406,base.state_br_ma,base.br
+city_2103505,Colinas,2103505,base.state_br_ma,base.br
+city_2103554,Conceição do Lago-Açu,2103554,base.state_br_ma,base.br
+city_2103604,Coroatá,2103604,base.state_br_ma,base.br
+city_2103703,Cururupu,2103703,base.state_br_ma,base.br
+city_2103752,Davinópolis,2103752,base.state_br_ma,base.br
+city_2103802,Dom Pedro,2103802,base.state_br_ma,base.br
+city_2103901,Duque Bacelar,2103901,base.state_br_ma,base.br
+city_2104008,Esperantinópolis,2104008,base.state_br_ma,base.br
+city_2104057,Estreito,2104057,base.state_br_ma,base.br
+city_2104073,Feira Nova do Maranhão,2104073,base.state_br_ma,base.br
+city_2104081,Fernando Falcão,2104081,base.state_br_ma,base.br
+city_2104099,Formosa da Serra Negra,2104099,base.state_br_ma,base.br
+city_2104107,Fortaleza dos Nogueiras,2104107,base.state_br_ma,base.br
+city_2104206,Fortuna,2104206,base.state_br_ma,base.br
+city_2104305,Godofredo Viana,2104305,base.state_br_ma,base.br
+city_2104404,Gonçalves Dias,2104404,base.state_br_ma,base.br
+city_2104503,Governador Archer,2104503,base.state_br_ma,base.br
+city_2104552,Governador Edison Lobão,2104552,base.state_br_ma,base.br
+city_2104602,Governador Eugênio Barros,2104602,base.state_br_ma,base.br
+city_2104628,Governador Luiz Rocha,2104628,base.state_br_ma,base.br
+city_2104651,Governador Newton Bello,2104651,base.state_br_ma,base.br
+city_2104677,Governador Nunes Freire,2104677,base.state_br_ma,base.br
+city_2104701,Graça Aranha,2104701,base.state_br_ma,base.br
+city_2104800,Grajaú,2104800,base.state_br_ma,base.br
+city_2104909,Guimarães,2104909,base.state_br_ma,base.br
+city_2105005,Humberto de Campos,2105005,base.state_br_ma,base.br
+city_2105104,Icatu,2105104,base.state_br_ma,base.br
+city_2105153,Igarapé do Meio,2105153,base.state_br_ma,base.br
+city_2105203,Igarapé Grande,2105203,base.state_br_ma,base.br
+city_2105302,Imperatriz,2105302,base.state_br_ma,base.br
+city_2105351,Itaipava do Grajaú,2105351,base.state_br_ma,base.br
+city_2105401,Itapecuru Mirim,2105401,base.state_br_ma,base.br
+city_2105427,Itinga do Maranhão,2105427,base.state_br_ma,base.br
+city_2105450,Jatobá,2105450,base.state_br_ma,base.br
+city_2105476,Jenipapo dos Vieiras,2105476,base.state_br_ma,base.br
+city_2105500,João Lisboa,2105500,base.state_br_ma,base.br
+city_2105609,Joselândia,2105609,base.state_br_ma,base.br
+city_2105658,Junco do Maranhão,2105658,base.state_br_ma,base.br
+city_2105708,Lago da Pedra,2105708,base.state_br_ma,base.br
+city_2105807,Lago do Junco,2105807,base.state_br_ma,base.br
+city_2105948,Lago dos Rodrigues,2105948,base.state_br_ma,base.br
+city_2105906,Lago Verde,2105906,base.state_br_ma,base.br
+city_2105922,Lagoa do Mato,2105922,base.state_br_ma,base.br
+city_2105963,Lagoa Grande do Maranhão,2105963,base.state_br_ma,base.br
+city_2105989,Lajeado Novo,2105989,base.state_br_ma,base.br
+city_2106003,Lima Campos,2106003,base.state_br_ma,base.br
+city_2106102,Loreto,2106102,base.state_br_ma,base.br
+city_2106201,Luís Domingues,2106201,base.state_br_ma,base.br
+city_2106300,Magalhães de Almeida,2106300,base.state_br_ma,base.br
+city_2106326,Maracaçumé,2106326,base.state_br_ma,base.br
+city_2106359,Marajá do Sena,2106359,base.state_br_ma,base.br
+city_2106375,Maranhãozinho,2106375,base.state_br_ma,base.br
+city_2106409,Mata Roma,2106409,base.state_br_ma,base.br
+city_2106508,Matinha,2106508,base.state_br_ma,base.br
+city_2106607,Matões,2106607,base.state_br_ma,base.br
+city_2106631,Matões do Norte,2106631,base.state_br_ma,base.br
+city_2106672,Milagres do Maranhão,2106672,base.state_br_ma,base.br
+city_2106706,Mirador,2106706,base.state_br_ma,base.br
+city_2106755,Miranda do Norte,2106755,base.state_br_ma,base.br
+city_2106805,Mirinzal,2106805,base.state_br_ma,base.br
+city_2106904,Monção,2106904,base.state_br_ma,base.br
+city_2107001,Montes Altos,2107001,base.state_br_ma,base.br
+city_2107100,Morros,2107100,base.state_br_ma,base.br
+city_2107209,Nina Rodrigues,2107209,base.state_br_ma,base.br
+city_2107258,Nova Colinas,2107258,base.state_br_ma,base.br
+city_2107308,Nova Iorque,2107308,base.state_br_ma,base.br
+city_2107357,Nova Olinda do Maranhão,2107357,base.state_br_ma,base.br
+city_2107407,Olho d'Água das Cunhãs,2107407,base.state_br_ma,base.br
+city_2107456,Olinda Nova do Maranhão,2107456,base.state_br_ma,base.br
+city_2107506,Paço do Lumiar,2107506,base.state_br_ma,base.br
+city_2107605,Palmeirândia,2107605,base.state_br_ma,base.br
+city_2107704,Paraibano,2107704,base.state_br_ma,base.br
+city_2107803,Parnarama,2107803,base.state_br_ma,base.br
+city_2107902,Passagem Franca,2107902,base.state_br_ma,base.br
+city_2108009,Pastos Bons,2108009,base.state_br_ma,base.br
+city_2108058,Paulino Neves,2108058,base.state_br_ma,base.br
+city_2108108,Paulo Ramos,2108108,base.state_br_ma,base.br
+city_2108207,Pedreiras,2108207,base.state_br_ma,base.br
+city_2108256,Pedro do Rosário,2108256,base.state_br_ma,base.br
+city_2108306,Penalva,2108306,base.state_br_ma,base.br
+city_2108405,Peri Mirim,2108405,base.state_br_ma,base.br
+city_2108454,Peritoró,2108454,base.state_br_ma,base.br
+city_2108504,Pindaré-Mirim,2108504,base.state_br_ma,base.br
+city_2108603,Pinheiro,2108603,base.state_br_ma,base.br
+city_2108702,Pio XII,2108702,base.state_br_ma,base.br
+city_2108801,Pirapemas,2108801,base.state_br_ma,base.br
+city_2108900,Poção de Pedras,2108900,base.state_br_ma,base.br
+city_2109007,Porto Franco,2109007,base.state_br_ma,base.br
+city_2109056,Porto Rico do Maranhão,2109056,base.state_br_ma,base.br
+city_2109106,Presidente Dutra,2109106,base.state_br_ma,base.br
+city_2109205,Presidente Juscelino,2109205,base.state_br_ma,base.br
+city_2109239,Presidente Médici,2109239,base.state_br_ma,base.br
+city_2109270,Presidente Sarney,2109270,base.state_br_ma,base.br
+city_2109304,Presidente Vargas,2109304,base.state_br_ma,base.br
+city_2109403,Primeira Cruz,2109403,base.state_br_ma,base.br
+city_2109452,Raposa,2109452,base.state_br_ma,base.br
+city_2109502,Riachão,2109502,base.state_br_ma,base.br
+city_2109551,Ribamar Fiquene,2109551,base.state_br_ma,base.br
+city_2109601,Rosário,2109601,base.state_br_ma,base.br
+city_2109700,Sambaíba,2109700,base.state_br_ma,base.br
+city_2109759,Santa Filomena do Maranhão,2109759,base.state_br_ma,base.br
+city_2109809,Santa Helena,2109809,base.state_br_ma,base.br
+city_2109908,Santa Inês,2109908,base.state_br_ma,base.br
+city_2110005,Santa Luzia,2110005,base.state_br_ma,base.br
+city_2110039,Santa Luzia do Paruá,2110039,base.state_br_ma,base.br
+city_2110104,Santa Quitéria do Maranhão,2110104,base.state_br_ma,base.br
+city_2110203,Santa Rita,2110203,base.state_br_ma,base.br
+city_2110237,Santana do Maranhão,2110237,base.state_br_ma,base.br
+city_2110278,Santo Amaro do Maranhão,2110278,base.state_br_ma,base.br
+city_2110302,Santo Antônio dos Lopes,2110302,base.state_br_ma,base.br
+city_2110401,São Benedito do Rio Preto,2110401,base.state_br_ma,base.br
+city_2110500,São Bento,2110500,base.state_br_ma,base.br
+city_2110609,São Bernardo,2110609,base.state_br_ma,base.br
+city_2110658,São Domingos do Azeitão,2110658,base.state_br_ma,base.br
+city_2110708,São Domingos do Maranhão,2110708,base.state_br_ma,base.br
+city_2110807,São Félix de Balsas,2110807,base.state_br_ma,base.br
+city_2110856,São Francisco do Brejão,2110856,base.state_br_ma,base.br
+city_2110906,São Francisco do Maranhão,2110906,base.state_br_ma,base.br
+city_2111003,São João Batista,2111003,base.state_br_ma,base.br
+city_2111029,São João do Carú,2111029,base.state_br_ma,base.br
+city_2111052,São João do Paraíso,2111052,base.state_br_ma,base.br
+city_2111078,São João do Soter,2111078,base.state_br_ma,base.br
+city_2111102,São João dos Patos,2111102,base.state_br_ma,base.br
+city_2111201,São José de Ribamar,2111201,base.state_br_ma,base.br
+city_2111250,São José dos Basílios,2111250,base.state_br_ma,base.br
+city_2111300,São Luís,2111300,base.state_br_ma,base.br
+city_2111409,São Luís Gonzaga do Maranhão,2111409,base.state_br_ma,base.br
+city_2111508,São Mateus do Maranhão,2111508,base.state_br_ma,base.br
+city_2111532,São Pedro da Água Branca,2111532,base.state_br_ma,base.br
+city_2111573,São Pedro dos Crentes,2111573,base.state_br_ma,base.br
+city_2111607,São Raimundo das Mangabeiras,2111607,base.state_br_ma,base.br
+city_2111631,São Raimundo do Doca Bezerra,2111631,base.state_br_ma,base.br
+city_2111672,São Roberto,2111672,base.state_br_ma,base.br
+city_2111706,São Vicente Ferrer,2111706,base.state_br_ma,base.br
+city_2111722,Satubinha,2111722,base.state_br_ma,base.br
+city_2111748,Senador Alexandre Costa,2111748,base.state_br_ma,base.br
+city_2111763,Senador La Rocque,2111763,base.state_br_ma,base.br
+city_2111789,Serrano do Maranhão,2111789,base.state_br_ma,base.br
+city_2111805,Sítio Novo,2111805,base.state_br_ma,base.br
+city_2111904,Sucupira do Norte,2111904,base.state_br_ma,base.br
+city_2111953,Sucupira do Riachão,2111953,base.state_br_ma,base.br
+city_2112001,Tasso Fragoso,2112001,base.state_br_ma,base.br
+city_2112100,Timbiras,2112100,base.state_br_ma,base.br
+city_2112209,Timon,2112209,base.state_br_ma,base.br
+city_2112233,Trizidela do Vale,2112233,base.state_br_ma,base.br
+city_2112274,Tufilândia,2112274,base.state_br_ma,base.br
+city_2112308,Tuntum,2112308,base.state_br_ma,base.br
+city_2112407,Turiaçu,2112407,base.state_br_ma,base.br
+city_2112456,Turilândia,2112456,base.state_br_ma,base.br
+city_2112506,Tutóia,2112506,base.state_br_ma,base.br
+city_2112605,Urbano Santos,2112605,base.state_br_ma,base.br
+city_2112704,Vargem Grande,2112704,base.state_br_ma,base.br
+city_2112803,Viana,2112803,base.state_br_ma,base.br
+city_2112852,Vila Nova dos Martírios,2112852,base.state_br_ma,base.br
+city_2112902,Vitória do Mearim,2112902,base.state_br_ma,base.br
+city_2113009,Vitorino Freire,2113009,base.state_br_ma,base.br
+city_2114007,Zé Doca,2114007,base.state_br_ma,base.br
+city_2200053,Acauã,2200053,base.state_br_pi,base.br
+city_2200103,Agricolândia,2200103,base.state_br_pi,base.br
+city_2200202,Água Branca,2200202,base.state_br_pi,base.br
+city_2200251,Alagoinha do Piauí,2200251,base.state_br_pi,base.br
+city_2200277,Alegrete do Piauí,2200277,base.state_br_pi,base.br
+city_2200301,Alto Longá,2200301,base.state_br_pi,base.br
+city_2200400,Altos,2200400,base.state_br_pi,base.br
+city_2200459,Alvorada do Gurguéia,2200459,base.state_br_pi,base.br
+city_2200509,Amarante,2200509,base.state_br_pi,base.br
+city_2200608,Angical do Piauí,2200608,base.state_br_pi,base.br
+city_2200707,Anísio de Abreu,2200707,base.state_br_pi,base.br
+city_2200806,Antônio Almeida,2200806,base.state_br_pi,base.br
+city_2200905,Aroazes,2200905,base.state_br_pi,base.br
+city_2200954,Aroeiras do Itaim,2200954,base.state_br_pi,base.br
+city_2201002,Arraial,2201002,base.state_br_pi,base.br
+city_2201051,Assunção do Piauí,2201051,base.state_br_pi,base.br
+city_2201101,Avelino Lopes,2201101,base.state_br_pi,base.br
+city_2201150,Baixa Grande do Ribeiro,2201150,base.state_br_pi,base.br
+city_2201176,Barra D'Alcântara,2201176,base.state_br_pi,base.br
+city_2201200,Barras,2201200,base.state_br_pi,base.br
+city_2201309,Barreiras do Piauí,2201309,base.state_br_pi,base.br
+city_2201408,Barro Duro,2201408,base.state_br_pi,base.br
+city_2201507,Batalha,2201507,base.state_br_pi,base.br
+city_2201556,Bela Vista do Piauí,2201556,base.state_br_pi,base.br
+city_2201572,Belém do Piauí,2201572,base.state_br_pi,base.br
+city_2201606,Beneditinos,2201606,base.state_br_pi,base.br
+city_2201705,Bertolínia,2201705,base.state_br_pi,base.br
+city_2201739,Betânia do Piauí,2201739,base.state_br_pi,base.br
+city_2201770,Boa Hora,2201770,base.state_br_pi,base.br
+city_2201804,Bocaina,2201804,base.state_br_pi,base.br
+city_2201903,Bom Jesus,2201903,base.state_br_pi,base.br
+city_2201919,Bom Princípio do Piauí,2201919,base.state_br_pi,base.br
+city_2201929,Bonfim do Piauí,2201929,base.state_br_pi,base.br
+city_2201945,Boqueirão do Piauí,2201945,base.state_br_pi,base.br
+city_2201960,Brasileira,2201960,base.state_br_pi,base.br
+city_2201988,Brejo do Piauí,2201988,base.state_br_pi,base.br
+city_2202000,Buriti dos Lopes,2202000,base.state_br_pi,base.br
+city_2202026,Buriti dos Montes,2202026,base.state_br_pi,base.br
+city_2202059,Cabeceiras do Piauí,2202059,base.state_br_pi,base.br
+city_2202075,Cajazeiras do Piauí,2202075,base.state_br_pi,base.br
+city_2202083,Cajueiro da Praia,2202083,base.state_br_pi,base.br
+city_2202091,Caldeirão Grande do Piauí,2202091,base.state_br_pi,base.br
+city_2202109,Campinas do Piauí,2202109,base.state_br_pi,base.br
+city_2202117,Campo Alegre do Fidalgo,2202117,base.state_br_pi,base.br
+city_2202133,Campo Grande do Piauí,2202133,base.state_br_pi,base.br
+city_2202174,Campo Largo do Piauí,2202174,base.state_br_pi,base.br
+city_2202208,Campo Maior,2202208,base.state_br_pi,base.br
+city_2202251,Canavieira,2202251,base.state_br_pi,base.br
+city_2202307,Canto do Buriti,2202307,base.state_br_pi,base.br
+city_2202406,Capitão de Campos,2202406,base.state_br_pi,base.br
+city_2202455,Capitão Gervásio Oliveira,2202455,base.state_br_pi,base.br
+city_2202505,Caracol,2202505,base.state_br_pi,base.br
+city_2202539,Caraúbas do Piauí,2202539,base.state_br_pi,base.br
+city_2202554,Caridade do Piauí,2202554,base.state_br_pi,base.br
+city_2202604,Castelo do Piauí,2202604,base.state_br_pi,base.br
+city_2202653,Caxingó,2202653,base.state_br_pi,base.br
+city_2202703,Cocal,2202703,base.state_br_pi,base.br
+city_2202711,Cocal de Telha,2202711,base.state_br_pi,base.br
+city_2202729,Cocal dos Alves,2202729,base.state_br_pi,base.br
+city_2202737,Coivaras,2202737,base.state_br_pi,base.br
+city_2202752,Colônia do Gurguéia,2202752,base.state_br_pi,base.br
+city_2202778,Colônia do Piauí,2202778,base.state_br_pi,base.br
+city_2202802,Conceição do Canindé,2202802,base.state_br_pi,base.br
+city_2202851,Coronel José Dias,2202851,base.state_br_pi,base.br
+city_2202901,Corrente,2202901,base.state_br_pi,base.br
+city_2203008,Cristalândia do Piauí,2203008,base.state_br_pi,base.br
+city_2203107,Cristino Castro,2203107,base.state_br_pi,base.br
+city_2203206,Curimatá,2203206,base.state_br_pi,base.br
+city_2203230,Currais,2203230,base.state_br_pi,base.br
+city_2203271,Curral Novo do Piauí,2203271,base.state_br_pi,base.br
+city_2203255,Curralinhos,2203255,base.state_br_pi,base.br
+city_2203305,Demerval Lobão,2203305,base.state_br_pi,base.br
+city_2203354,Dirceu Arcoverde,2203354,base.state_br_pi,base.br
+city_2203404,Dom Expedito Lopes,2203404,base.state_br_pi,base.br
+city_2203453,Dom Inocêncio,2203453,base.state_br_pi,base.br
+city_2203420,Domingos Mourão,2203420,base.state_br_pi,base.br
+city_2203503,Elesbão Veloso,2203503,base.state_br_pi,base.br
+city_2203602,Eliseu Martins,2203602,base.state_br_pi,base.br
+city_2203701,Esperantina,2203701,base.state_br_pi,base.br
+city_2203750,Fartura do Piauí,2203750,base.state_br_pi,base.br
+city_2203800,Flores do Piauí,2203800,base.state_br_pi,base.br
+city_2203859,Floresta do Piauí,2203859,base.state_br_pi,base.br
+city_2203909,Floriano,2203909,base.state_br_pi,base.br
+city_2204006,Francinópolis,2204006,base.state_br_pi,base.br
+city_2204105,Francisco Ayres,2204105,base.state_br_pi,base.br
+city_2204154,Francisco Macedo,2204154,base.state_br_pi,base.br
+city_2204204,Francisco Santos,2204204,base.state_br_pi,base.br
+city_2204303,Fronteiras,2204303,base.state_br_pi,base.br
+city_2204352,Geminiano,2204352,base.state_br_pi,base.br
+city_2204402,Gilbués,2204402,base.state_br_pi,base.br
+city_2204501,Guadalupe,2204501,base.state_br_pi,base.br
+city_2204550,Guaribas,2204550,base.state_br_pi,base.br
+city_2204600,Hugo Napoleão,2204600,base.state_br_pi,base.br
+city_2204659,Ilha Grande,2204659,base.state_br_pi,base.br
+city_2204709,Inhuma,2204709,base.state_br_pi,base.br
+city_2204808,Ipiranga do Piauí,2204808,base.state_br_pi,base.br
+city_2204907,Isaías Coelho,2204907,base.state_br_pi,base.br
+city_2205003,Itainópolis,2205003,base.state_br_pi,base.br
+city_2205102,Itaueira,2205102,base.state_br_pi,base.br
+city_2205151,Jacobina do Piauí,2205151,base.state_br_pi,base.br
+city_2205201,Jaicós,2205201,base.state_br_pi,base.br
+city_2205250,Jardim do Mulato,2205250,base.state_br_pi,base.br
+city_2205276,Jatobá do Piauí,2205276,base.state_br_pi,base.br
+city_2205300,Jerumenha,2205300,base.state_br_pi,base.br
+city_2205359,João Costa,2205359,base.state_br_pi,base.br
+city_2205409,Joaquim Pires,2205409,base.state_br_pi,base.br
+city_2205458,Joca Marques,2205458,base.state_br_pi,base.br
+city_2205508,José de Freitas,2205508,base.state_br_pi,base.br
+city_2205516,Juazeiro do Piauí,2205516,base.state_br_pi,base.br
+city_2205524,Júlio Borges,2205524,base.state_br_pi,base.br
+city_2205532,Jurema,2205532,base.state_br_pi,base.br
+city_2205557,Lagoa Alegre,2205557,base.state_br_pi,base.br
+city_2205573,Lagoa de São Francisco,2205573,base.state_br_pi,base.br
+city_2205565,Lagoa do Barro do Piauí,2205565,base.state_br_pi,base.br
+city_2205581,Lagoa do Piauí,2205581,base.state_br_pi,base.br
+city_2205599,Lagoa do Sítio,2205599,base.state_br_pi,base.br
+city_2205540,Lagoinha do Piauí,2205540,base.state_br_pi,base.br
+city_2205607,Landri Sales,2205607,base.state_br_pi,base.br
+city_2205706,Luís Correia,2205706,base.state_br_pi,base.br
+city_2205805,Luzilândia,2205805,base.state_br_pi,base.br
+city_2205854,Madeiro,2205854,base.state_br_pi,base.br
+city_2205904,Manoel Emídio,2205904,base.state_br_pi,base.br
+city_2205953,Marcolândia,2205953,base.state_br_pi,base.br
+city_2206001,Marcos Parente,2206001,base.state_br_pi,base.br
+city_2206050,Massapê do Piauí,2206050,base.state_br_pi,base.br
+city_2206100,Matias Olímpio,2206100,base.state_br_pi,base.br
+city_2206209,Miguel Alves,2206209,base.state_br_pi,base.br
+city_2206308,Miguel Leão,2206308,base.state_br_pi,base.br
+city_2206357,Milton Brandão,2206357,base.state_br_pi,base.br
+city_2206407,Monsenhor Gil,2206407,base.state_br_pi,base.br
+city_2206506,Monsenhor Hipólito,2206506,base.state_br_pi,base.br
+city_2206605,Monte Alegre do Piauí,2206605,base.state_br_pi,base.br
+city_2206654,Morro Cabeça no Tempo,2206654,base.state_br_pi,base.br
+city_2206670,Morro do Chapéu do Piauí,2206670,base.state_br_pi,base.br
+city_2206696,Murici dos Portelas,2206696,base.state_br_pi,base.br
+city_2206704,Nazaré do Piauí,2206704,base.state_br_pi,base.br
+city_2206720,Nazária,2206720,base.state_br_pi,base.br
+city_2206753,Nossa Senhora de Nazaré,2206753,base.state_br_pi,base.br
+city_2206803,Nossa Senhora dos Remédios,2206803,base.state_br_pi,base.br
+city_2207959,Nova Santa Rita,2207959,base.state_br_pi,base.br
+city_2206902,Novo Oriente do Piauí,2206902,base.state_br_pi,base.br
+city_2206951,Novo Santo Antônio,2206951,base.state_br_pi,base.br
+city_2207009,Oeiras,2207009,base.state_br_pi,base.br
+city_2207108,Olho D'Água do Piauí,2207108,base.state_br_pi,base.br
+city_2207207,Padre Marcos,2207207,base.state_br_pi,base.br
+city_2207306,Paes Landim,2207306,base.state_br_pi,base.br
+city_2207355,Pajeú do Piauí,2207355,base.state_br_pi,base.br
+city_2207405,Palmeira do Piauí,2207405,base.state_br_pi,base.br
+city_2207504,Palmeirais,2207504,base.state_br_pi,base.br
+city_2207553,Paquetá,2207553,base.state_br_pi,base.br
+city_2207603,Parnaguá,2207603,base.state_br_pi,base.br
+city_2207702,Parnaíba,2207702,base.state_br_pi,base.br
+city_2207751,Passagem Franca do Piauí,2207751,base.state_br_pi,base.br
+city_2207777,Patos do Piauí,2207777,base.state_br_pi,base.br
+city_2207793,Pau D'Arco do Piauí,2207793,base.state_br_pi,base.br
+city_2207801,Paulistana,2207801,base.state_br_pi,base.br
+city_2207850,Pavussu,2207850,base.state_br_pi,base.br
+city_2207900,Pedro II,2207900,base.state_br_pi,base.br
+city_2207934,Pedro Laurentino,2207934,base.state_br_pi,base.br
+city_2208007,Picos,2208007,base.state_br_pi,base.br
+city_2208106,Pimenteiras,2208106,base.state_br_pi,base.br
+city_2208205,Pio IX,2208205,base.state_br_pi,base.br
+city_2208304,Piracuruca,2208304,base.state_br_pi,base.br
+city_2208403,Piripiri,2208403,base.state_br_pi,base.br
+city_2208502,Porto,2208502,base.state_br_pi,base.br
+city_2208551,Porto Alegre do Piauí,2208551,base.state_br_pi,base.br
+city_2208601,Prata do Piauí,2208601,base.state_br_pi,base.br
+city_2208650,Queimada Nova,2208650,base.state_br_pi,base.br
+city_2208700,Redenção do Gurguéia,2208700,base.state_br_pi,base.br
+city_2208809,Regeneração,2208809,base.state_br_pi,base.br
+city_2208858,Riacho Frio,2208858,base.state_br_pi,base.br
+city_2208874,Ribeira do Piauí,2208874,base.state_br_pi,base.br
+city_2208908,Ribeiro Gonçalves,2208908,base.state_br_pi,base.br
+city_2209005,Rio Grande do Piauí,2209005,base.state_br_pi,base.br
+city_2209104,Santa Cruz do Piauí,2209104,base.state_br_pi,base.br
+city_2209153,Santa Cruz dos Milagres,2209153,base.state_br_pi,base.br
+city_2209203,Santa Filomena,2209203,base.state_br_pi,base.br
+city_2209302,Santa Luz,2209302,base.state_br_pi,base.br
+city_2209377,Santa Rosa do Piauí,2209377,base.state_br_pi,base.br
+city_2209351,Santana do Piauí,2209351,base.state_br_pi,base.br
+city_2209401,Santo Antônio de Lisboa,2209401,base.state_br_pi,base.br
+city_2209450,Santo Antônio dos Milagres,2209450,base.state_br_pi,base.br
+city_2209500,Santo Inácio do Piauí,2209500,base.state_br_pi,base.br
+city_2209559,São Braz do Piauí,2209559,base.state_br_pi,base.br
+city_2209609,São Félix do Piauí,2209609,base.state_br_pi,base.br
+city_2209658,São Francisco de Assis do Piauí,2209658,base.state_br_pi,base.br
+city_2209708,São Francisco do Piauí,2209708,base.state_br_pi,base.br
+city_2209757,São Gonçalo do Gurguéia,2209757,base.state_br_pi,base.br
+city_2209807,São Gonçalo do Piauí,2209807,base.state_br_pi,base.br
+city_2209856,São João da Canabrava,2209856,base.state_br_pi,base.br
+city_2209872,São João da Fronteira,2209872,base.state_br_pi,base.br
+city_2209906,São João da Serra,2209906,base.state_br_pi,base.br
+city_2209955,São João da Varjota,2209955,base.state_br_pi,base.br
+city_2209971,São João do Arraial,2209971,base.state_br_pi,base.br
+city_2210003,São João do Piauí,2210003,base.state_br_pi,base.br
+city_2210052,São José do Divino,2210052,base.state_br_pi,base.br
+city_2210102,São José do Peixe,2210102,base.state_br_pi,base.br
+city_2210201,São José do Piauí,2210201,base.state_br_pi,base.br
+city_2210300,São Julião,2210300,base.state_br_pi,base.br
+city_2210359,São Lourenço do Piauí,2210359,base.state_br_pi,base.br
+city_2210375,São Luis do Piauí,2210375,base.state_br_pi,base.br
+city_2210383,São Miguel da Baixa Grande,2210383,base.state_br_pi,base.br
+city_2210391,São Miguel do Fidalgo,2210391,base.state_br_pi,base.br
+city_2210409,São Miguel do Tapuio,2210409,base.state_br_pi,base.br
+city_2210508,São Pedro do Piauí,2210508,base.state_br_pi,base.br
+city_2210607,São Raimundo Nonato,2210607,base.state_br_pi,base.br
+city_2210623,Sebastião Barros,2210623,base.state_br_pi,base.br
+city_2210631,Sebastião Leal,2210631,base.state_br_pi,base.br
+city_2210656,Sigefredo Pacheco,2210656,base.state_br_pi,base.br
+city_2210706,Simões,2210706,base.state_br_pi,base.br
+city_2210805,Simplício Mendes,2210805,base.state_br_pi,base.br
+city_2210904,Socorro do Piauí,2210904,base.state_br_pi,base.br
+city_2210938,Sussuapara,2210938,base.state_br_pi,base.br
+city_2210953,Tamboril do Piauí,2210953,base.state_br_pi,base.br
+city_2210979,Tanque do Piauí,2210979,base.state_br_pi,base.br
+city_2211001,Teresina,2211001,base.state_br_pi,base.br
+city_2211100,União,2211100,base.state_br_pi,base.br
+city_2211209,Uruçuí,2211209,base.state_br_pi,base.br
+city_2211308,Valença do Piauí,2211308,base.state_br_pi,base.br
+city_2211357,Várzea Branca,2211357,base.state_br_pi,base.br
+city_2211407,Várzea Grande,2211407,base.state_br_pi,base.br
+city_2211506,Vera Mendes,2211506,base.state_br_pi,base.br
+city_2211605,Vila Nova do Piauí,2211605,base.state_br_pi,base.br
+city_2211704,Wall Ferraz,2211704,base.state_br_pi,base.br
+city_2300101,Abaiara,2300101,base.state_br_ce,base.br
+city_2300150,Acarape,2300150,base.state_br_ce,base.br
+city_2300200,Acaraú,2300200,base.state_br_ce,base.br
+city_2300309,Acopiara,2300309,base.state_br_ce,base.br
+city_2300408,Aiuaba,2300408,base.state_br_ce,base.br
+city_2300507,Alcântaras,2300507,base.state_br_ce,base.br
+city_2300606,Altaneira,2300606,base.state_br_ce,base.br
+city_2300705,Alto Santo,2300705,base.state_br_ce,base.br
+city_2300754,Amontada,2300754,base.state_br_ce,base.br
+city_2300804,Antonina do Norte,2300804,base.state_br_ce,base.br
+city_2300903,Apuiarés,2300903,base.state_br_ce,base.br
+city_2301000,Aquiraz,2301000,base.state_br_ce,base.br
+city_2301109,Aracati,2301109,base.state_br_ce,base.br
+city_2301208,Aracoiaba,2301208,base.state_br_ce,base.br
+city_2301257,Ararendá,2301257,base.state_br_ce,base.br
+city_2301307,Araripe,2301307,base.state_br_ce,base.br
+city_2301406,Aratuba,2301406,base.state_br_ce,base.br
+city_2301505,Arneiroz,2301505,base.state_br_ce,base.br
+city_2301604,Assaré,2301604,base.state_br_ce,base.br
+city_2301703,Aurora,2301703,base.state_br_ce,base.br
+city_2301802,Baixio,2301802,base.state_br_ce,base.br
+city_2301851,Banabuiú,2301851,base.state_br_ce,base.br
+city_2301901,Barbalha,2301901,base.state_br_ce,base.br
+city_2301950,Barreira,2301950,base.state_br_ce,base.br
+city_2302008,Barro,2302008,base.state_br_ce,base.br
+city_2302057,Barroquinha,2302057,base.state_br_ce,base.br
+city_2302107,Baturité,2302107,base.state_br_ce,base.br
+city_2302206,Beberibe,2302206,base.state_br_ce,base.br
+city_2302305,Bela Cruz,2302305,base.state_br_ce,base.br
+city_2302404,Boa Viagem,2302404,base.state_br_ce,base.br
+city_2302503,Brejo Santo,2302503,base.state_br_ce,base.br
+city_2302602,Camocim,2302602,base.state_br_ce,base.br
+city_2302701,Campos Sales,2302701,base.state_br_ce,base.br
+city_2302800,Canindé,2302800,base.state_br_ce,base.br
+city_2302909,Capistrano,2302909,base.state_br_ce,base.br
+city_2303006,Caridade,2303006,base.state_br_ce,base.br
+city_2303105,Cariré,2303105,base.state_br_ce,base.br
+city_2303204,Caririaçu,2303204,base.state_br_ce,base.br
+city_2303303,Cariús,2303303,base.state_br_ce,base.br
+city_2303402,Carnaubal,2303402,base.state_br_ce,base.br
+city_2303501,Cascavel,2303501,base.state_br_ce,base.br
+city_2303600,Catarina,2303600,base.state_br_ce,base.br
+city_2303659,Catunda,2303659,base.state_br_ce,base.br
+city_2303709,Caucaia,2303709,base.state_br_ce,base.br
+city_2303808,Cedro,2303808,base.state_br_ce,base.br
+city_2303907,Chaval,2303907,base.state_br_ce,base.br
+city_2303931,Choró,2303931,base.state_br_ce,base.br
+city_2303956,Chorozinho,2303956,base.state_br_ce,base.br
+city_2304004,Coreaú,2304004,base.state_br_ce,base.br
+city_2304103,Crateús,2304103,base.state_br_ce,base.br
+city_2304202,Crato,2304202,base.state_br_ce,base.br
+city_2304236,Croatá,2304236,base.state_br_ce,base.br
+city_2304251,Cruz,2304251,base.state_br_ce,base.br
+city_2304269,Deputado Irapuan Pinheiro,2304269,base.state_br_ce,base.br
+city_2304277,Ereré,2304277,base.state_br_ce,base.br
+city_2304285,Eusébio,2304285,base.state_br_ce,base.br
+city_2304301,Farias Brito,2304301,base.state_br_ce,base.br
+city_2304350,Forquilha,2304350,base.state_br_ce,base.br
+city_2304400,Fortaleza,2304400,base.state_br_ce,base.br
+city_2304459,Fortim,2304459,base.state_br_ce,base.br
+city_2304509,Frecheirinha,2304509,base.state_br_ce,base.br
+city_2304608,General Sampaio,2304608,base.state_br_ce,base.br
+city_2304657,Graça,2304657,base.state_br_ce,base.br
+city_2304707,Granja,2304707,base.state_br_ce,base.br
+city_2304806,Granjeiro,2304806,base.state_br_ce,base.br
+city_2304905,Groaíras,2304905,base.state_br_ce,base.br
+city_2304954,Guaiúba,2304954,base.state_br_ce,base.br
+city_2305001,Guaraciaba do Norte,2305001,base.state_br_ce,base.br
+city_2305100,Guaramiranga,2305100,base.state_br_ce,base.br
+city_2305209,Hidrolândia,2305209,base.state_br_ce,base.br
+city_2305233,Horizonte,2305233,base.state_br_ce,base.br
+city_2305266,Ibaretama,2305266,base.state_br_ce,base.br
+city_2305308,Ibiapina,2305308,base.state_br_ce,base.br
+city_2305332,Ibicuitinga,2305332,base.state_br_ce,base.br
+city_2305357,Icapuí,2305357,base.state_br_ce,base.br
+city_2305407,Icó,2305407,base.state_br_ce,base.br
+city_2305506,Iguatu,2305506,base.state_br_ce,base.br
+city_2305605,Independência,2305605,base.state_br_ce,base.br
+city_2305654,Ipaporanga,2305654,base.state_br_ce,base.br
+city_2305704,Ipaumirim,2305704,base.state_br_ce,base.br
+city_2305803,Ipu,2305803,base.state_br_ce,base.br
+city_2305902,Ipueiras,2305902,base.state_br_ce,base.br
+city_2306009,Iracema,2306009,base.state_br_ce,base.br
+city_2306108,Irauçuba,2306108,base.state_br_ce,base.br
+city_2306207,Itaiçaba,2306207,base.state_br_ce,base.br
+city_2306256,Itaitinga,2306256,base.state_br_ce,base.br
+city_2306306,Itapajé,2306306,base.state_br_ce,base.br
+city_2306405,Itapipoca,2306405,base.state_br_ce,base.br
+city_2306504,Itapiúna,2306504,base.state_br_ce,base.br
+city_2306553,Itarema,2306553,base.state_br_ce,base.br
+city_2306603,Itatira,2306603,base.state_br_ce,base.br
+city_2306702,Jaguaretama,2306702,base.state_br_ce,base.br
+city_2306801,Jaguaribara,2306801,base.state_br_ce,base.br
+city_2306900,Jaguaribe,2306900,base.state_br_ce,base.br
+city_2307007,Jaguaruana,2307007,base.state_br_ce,base.br
+city_2307106,Jardim,2307106,base.state_br_ce,base.br
+city_2307205,Jati,2307205,base.state_br_ce,base.br
+city_2307254,Jijoca de Jericoacoara,2307254,base.state_br_ce,base.br
+city_2307304,Juazeiro do Norte,2307304,base.state_br_ce,base.br
+city_2307403,Jucás,2307403,base.state_br_ce,base.br
+city_2307502,Lavras da Mangabeira,2307502,base.state_br_ce,base.br
+city_2307601,Limoeiro do Norte,2307601,base.state_br_ce,base.br
+city_2307635,Madalena,2307635,base.state_br_ce,base.br
+city_2307650,Maracanaú,2307650,base.state_br_ce,base.br
+city_2307700,Maranguape,2307700,base.state_br_ce,base.br
+city_2307809,Marco,2307809,base.state_br_ce,base.br
+city_2307908,Martinópole,2307908,base.state_br_ce,base.br
+city_2308005,Massapê,2308005,base.state_br_ce,base.br
+city_2308104,Mauriti,2308104,base.state_br_ce,base.br
+city_2308203,Meruoca,2308203,base.state_br_ce,base.br
+city_2308302,Milagres,2308302,base.state_br_ce,base.br
+city_2308351,Milhã,2308351,base.state_br_ce,base.br
+city_2308377,Miraíma,2308377,base.state_br_ce,base.br
+city_2308401,Missão Velha,2308401,base.state_br_ce,base.br
+city_2308500,Mombaça,2308500,base.state_br_ce,base.br
+city_2308609,Monsenhor Tabosa,2308609,base.state_br_ce,base.br
+city_2308708,Morada Nova,2308708,base.state_br_ce,base.br
+city_2308807,Moraújo,2308807,base.state_br_ce,base.br
+city_2308906,Morrinhos,2308906,base.state_br_ce,base.br
+city_2309003,Mucambo,2309003,base.state_br_ce,base.br
+city_2309102,Mulungu,2309102,base.state_br_ce,base.br
+city_2309201,Nova Olinda,2309201,base.state_br_ce,base.br
+city_2309300,Nova Russas,2309300,base.state_br_ce,base.br
+city_2309409,Novo Oriente,2309409,base.state_br_ce,base.br
+city_2309458,Ocara,2309458,base.state_br_ce,base.br
+city_2309508,Orós,2309508,base.state_br_ce,base.br
+city_2309607,Pacajus,2309607,base.state_br_ce,base.br
+city_2309706,Pacatuba,2309706,base.state_br_ce,base.br
+city_2309805,Pacoti,2309805,base.state_br_ce,base.br
+city_2309904,Pacujá,2309904,base.state_br_ce,base.br
+city_2310001,Palhano,2310001,base.state_br_ce,base.br
+city_2310100,Palmácia,2310100,base.state_br_ce,base.br
+city_2310209,Paracuru,2310209,base.state_br_ce,base.br
+city_2310258,Paraipaba,2310258,base.state_br_ce,base.br
+city_2310308,Parambu,2310308,base.state_br_ce,base.br
+city_2310407,Paramoti,2310407,base.state_br_ce,base.br
+city_2310506,Pedra Branca,2310506,base.state_br_ce,base.br
+city_2310605,Penaforte,2310605,base.state_br_ce,base.br
+city_2310704,Pentecoste,2310704,base.state_br_ce,base.br
+city_2310803,Pereiro,2310803,base.state_br_ce,base.br
+city_2310852,Pindoretama,2310852,base.state_br_ce,base.br
+city_2310902,Piquet Carneiro,2310902,base.state_br_ce,base.br
+city_2310951,Pires Ferreira,2310951,base.state_br_ce,base.br
+city_2311009,Poranga,2311009,base.state_br_ce,base.br
+city_2311108,Porteiras,2311108,base.state_br_ce,base.br
+city_2311207,Potengi,2311207,base.state_br_ce,base.br
+city_2311231,Potiretama,2311231,base.state_br_ce,base.br
+city_2311264,Quiterianópolis,2311264,base.state_br_ce,base.br
+city_2311306,Quixadá,2311306,base.state_br_ce,base.br
+city_2311355,Quixelô,2311355,base.state_br_ce,base.br
+city_2311405,Quixeramobim,2311405,base.state_br_ce,base.br
+city_2311504,Quixeré,2311504,base.state_br_ce,base.br
+city_2311603,Redenção,2311603,base.state_br_ce,base.br
+city_2311702,Reriutaba,2311702,base.state_br_ce,base.br
+city_2311801,Russas,2311801,base.state_br_ce,base.br
+city_2311900,Saboeiro,2311900,base.state_br_ce,base.br
+city_2311959,Salitre,2311959,base.state_br_ce,base.br
+city_2312205,Santa Quitéria,2312205,base.state_br_ce,base.br
+city_2312007,Santana do Acaraú,2312007,base.state_br_ce,base.br
+city_2312106,Santana do Cariri,2312106,base.state_br_ce,base.br
+city_2312304,São Benedito,2312304,base.state_br_ce,base.br
+city_2312403,São Gonçalo do Amarante,2312403,base.state_br_ce,base.br
+city_2312502,São João do Jaguaribe,2312502,base.state_br_ce,base.br
+city_2312601,São Luís do Curu,2312601,base.state_br_ce,base.br
+city_2312700,Senador Pompeu,2312700,base.state_br_ce,base.br
+city_2312809,Senador Sá,2312809,base.state_br_ce,base.br
+city_2312908,Sobral,2312908,base.state_br_ce,base.br
+city_2313005,Solonópole,2313005,base.state_br_ce,base.br
+city_2313104,Tabuleiro do Norte,2313104,base.state_br_ce,base.br
+city_2313203,Tamboril,2313203,base.state_br_ce,base.br
+city_2313252,Tarrafas,2313252,base.state_br_ce,base.br
+city_2313302,Tauá,2313302,base.state_br_ce,base.br
+city_2313351,Tejuçuoca,2313351,base.state_br_ce,base.br
+city_2313401,Tianguá,2313401,base.state_br_ce,base.br
+city_2313500,Trairi,2313500,base.state_br_ce,base.br
+city_2313559,Tururu,2313559,base.state_br_ce,base.br
+city_2313609,Ubajara,2313609,base.state_br_ce,base.br
+city_2313708,Umari,2313708,base.state_br_ce,base.br
+city_2313757,Umirim,2313757,base.state_br_ce,base.br
+city_2313807,Uruburetama,2313807,base.state_br_ce,base.br
+city_2313906,Uruoca,2313906,base.state_br_ce,base.br
+city_2313955,Varjota,2313955,base.state_br_ce,base.br
+city_2314003,Várzea Alegre,2314003,base.state_br_ce,base.br
+city_2314102,Viçosa do Ceará,2314102,base.state_br_ce,base.br
+city_2400109,Acari,2400109,base.state_br_rn,base.br
+city_2400208,Açu,2400208,base.state_br_rn,base.br
+city_2400307,Afonso Bezerra,2400307,base.state_br_rn,base.br
+city_2400406,Água Nova,2400406,base.state_br_rn,base.br
+city_2400505,Alexandria,2400505,base.state_br_rn,base.br
+city_2400604,Almino Afonso,2400604,base.state_br_rn,base.br
+city_2400703,Alto do Rodrigues,2400703,base.state_br_rn,base.br
+city_2400802,Angicos,2400802,base.state_br_rn,base.br
+city_2400901,Antônio Martins,2400901,base.state_br_rn,base.br
+city_2401008,Apodi,2401008,base.state_br_rn,base.br
+city_2401107,Areia Branca,2401107,base.state_br_rn,base.br
+city_2401206,Arês,2401206,base.state_br_rn,base.br
+city_2401404,Baía Formosa,2401404,base.state_br_rn,base.br
+city_2401453,Baraúna,2401453,base.state_br_rn,base.br
+city_2401503,Barcelona,2401503,base.state_br_rn,base.br
+city_2401602,Bento Fernandes,2401602,base.state_br_rn,base.br
+city_2401651,Bodó,2401651,base.state_br_rn,base.br
+city_2401701,Bom Jesus,2401701,base.state_br_rn,base.br
+city_2401800,Brejinho,2401800,base.state_br_rn,base.br
+city_2401859,Caiçara do Norte,2401859,base.state_br_rn,base.br
+city_2401909,Caiçara do Rio do Vento,2401909,base.state_br_rn,base.br
+city_2402006,Caicó,2402006,base.state_br_rn,base.br
+city_2401305,Campo Grande,2401305,base.state_br_rn,base.br
+city_2402105,Campo Redondo,2402105,base.state_br_rn,base.br
+city_2402204,Canguaretama,2402204,base.state_br_rn,base.br
+city_2402303,Caraúbas,2402303,base.state_br_rn,base.br
+city_2402402,Carnaúba dos Dantas,2402402,base.state_br_rn,base.br
+city_2402501,Carnaubais,2402501,base.state_br_rn,base.br
+city_2402600,Ceará-Mirim,2402600,base.state_br_rn,base.br
+city_2402709,Cerro Corá,2402709,base.state_br_rn,base.br
+city_2402808,Coronel Ezequiel,2402808,base.state_br_rn,base.br
+city_2402907,Coronel João Pessoa,2402907,base.state_br_rn,base.br
+city_2403004,Cruzeta,2403004,base.state_br_rn,base.br
+city_2403103,Currais Novos,2403103,base.state_br_rn,base.br
+city_2403202,Doutor Severiano,2403202,base.state_br_rn,base.br
+city_2403301,Encanto,2403301,base.state_br_rn,base.br
+city_2403400,Equador,2403400,base.state_br_rn,base.br
+city_2403509,Espírito Santo,2403509,base.state_br_rn,base.br
+city_2403608,Extremoz,2403608,base.state_br_rn,base.br
+city_2403707,Felipe Guerra,2403707,base.state_br_rn,base.br
+city_2403756,Fernando Pedroza,2403756,base.state_br_rn,base.br
+city_2403806,Florânia,2403806,base.state_br_rn,base.br
+city_2403905,Francisco Dantas,2403905,base.state_br_rn,base.br
+city_2404002,Frutuoso Gomes,2404002,base.state_br_rn,base.br
+city_2404101,Galinhos,2404101,base.state_br_rn,base.br
+city_2404200,Goianinha,2404200,base.state_br_rn,base.br
+city_2404309,Governador Dix-Sept Rosado,2404309,base.state_br_rn,base.br
+city_2404408,Grossos,2404408,base.state_br_rn,base.br
+city_2404507,Guamaré,2404507,base.state_br_rn,base.br
+city_2404606,Ielmo Marinho,2404606,base.state_br_rn,base.br
+city_2404705,Ipanguaçu,2404705,base.state_br_rn,base.br
+city_2404804,Ipueira,2404804,base.state_br_rn,base.br
+city_2404853,Itajá,2404853,base.state_br_rn,base.br
+city_2404903,Itaú,2404903,base.state_br_rn,base.br
+city_2405009,Jaçanã,2405009,base.state_br_rn,base.br
+city_2405108,Jandaíra,2405108,base.state_br_rn,base.br
+city_2405207,Janduís,2405207,base.state_br_rn,base.br
+city_2405306,Januário Cicco,2405306,base.state_br_rn,base.br
+city_2405405,Japi,2405405,base.state_br_rn,base.br
+city_2405504,Jardim de Angicos,2405504,base.state_br_rn,base.br
+city_2405603,Jardim de Piranhas,2405603,base.state_br_rn,base.br
+city_2405702,Jardim do Seridó,2405702,base.state_br_rn,base.br
+city_2405801,João Câmara,2405801,base.state_br_rn,base.br
+city_2405900,João Dias,2405900,base.state_br_rn,base.br
+city_2406007,José da Penha,2406007,base.state_br_rn,base.br
+city_2406106,Jucurutu,2406106,base.state_br_rn,base.br
+city_2406155,Jundiá,2406155,base.state_br_rn,base.br
+city_2406205,Lagoa d'Anta,2406205,base.state_br_rn,base.br
+city_2406304,Lagoa de Pedras,2406304,base.state_br_rn,base.br
+city_2406403,Lagoa de Velhos,2406403,base.state_br_rn,base.br
+city_2406502,Lagoa Nova,2406502,base.state_br_rn,base.br
+city_2406601,Lagoa Salgada,2406601,base.state_br_rn,base.br
+city_2406700,Lajes,2406700,base.state_br_rn,base.br
+city_2406809,Lajes Pintadas,2406809,base.state_br_rn,base.br
+city_2406908,Lucrécia,2406908,base.state_br_rn,base.br
+city_2407005,Luís Gomes,2407005,base.state_br_rn,base.br
+city_2407104,Macaíba,2407104,base.state_br_rn,base.br
+city_2407203,Macau,2407203,base.state_br_rn,base.br
+city_2407252,Major Sales,2407252,base.state_br_rn,base.br
+city_2407302,Marcelino Vieira,2407302,base.state_br_rn,base.br
+city_2407401,Martins,2407401,base.state_br_rn,base.br
+city_2407500,Maxaranguape,2407500,base.state_br_rn,base.br
+city_2407609,Messias Targino,2407609,base.state_br_rn,base.br
+city_2407708,Montanhas,2407708,base.state_br_rn,base.br
+city_2407807,Monte Alegre,2407807,base.state_br_rn,base.br
+city_2407906,Monte das Gameleiras,2407906,base.state_br_rn,base.br
+city_2408003,Mossoró,2408003,base.state_br_rn,base.br
+city_2408102,Natal,2408102,base.state_br_rn,base.br
+city_2408201,Nísia Floresta,2408201,base.state_br_rn,base.br
+city_2408300,Nova Cruz,2408300,base.state_br_rn,base.br
+city_2408409,Olho d'Água do Borges,2408409,base.state_br_rn,base.br
+city_2408508,Ouro Branco,2408508,base.state_br_rn,base.br
+city_2408607,Paraná,2408607,base.state_br_rn,base.br
+city_2408706,Paraú,2408706,base.state_br_rn,base.br
+city_2408805,Parazinho,2408805,base.state_br_rn,base.br
+city_2408904,Parelhas,2408904,base.state_br_rn,base.br
+city_2403251,Parnamirim,2403251,base.state_br_rn,base.br
+city_2409100,Passa e Fica,2409100,base.state_br_rn,base.br
+city_2409209,Passagem,2409209,base.state_br_rn,base.br
+city_2409308,Patu,2409308,base.state_br_rn,base.br
+city_2409407,Pau dos Ferros,2409407,base.state_br_rn,base.br
+city_2409506,Pedra Grande,2409506,base.state_br_rn,base.br
+city_2409605,Pedra Preta,2409605,base.state_br_rn,base.br
+city_2409704,Pedro Avelino,2409704,base.state_br_rn,base.br
+city_2409803,Pedro Velho,2409803,base.state_br_rn,base.br
+city_2409902,Pendências,2409902,base.state_br_rn,base.br
+city_2410009,Pilões,2410009,base.state_br_rn,base.br
+city_2410108,Poço Branco,2410108,base.state_br_rn,base.br
+city_2410207,Portalegre,2410207,base.state_br_rn,base.br
+city_2410256,Porto do Mangue,2410256,base.state_br_rn,base.br
+city_2410405,Pureza,2410405,base.state_br_rn,base.br
+city_2410504,Rafael Fernandes,2410504,base.state_br_rn,base.br
+city_2410603,Rafael Godeiro,2410603,base.state_br_rn,base.br
+city_2410702,Riacho da Cruz,2410702,base.state_br_rn,base.br
+city_2410801,Riacho de Santana,2410801,base.state_br_rn,base.br
+city_2410900,Riachuelo,2410900,base.state_br_rn,base.br
+city_2408953,Rio do Fogo,2408953,base.state_br_rn,base.br
+city_2411007,Rodolfo Fernandes,2411007,base.state_br_rn,base.br
+city_2411106,Ruy Barbosa,2411106,base.state_br_rn,base.br
+city_2411205,Santa Cruz,2411205,base.state_br_rn,base.br
+city_2409332,Santa Maria,2409332,base.state_br_rn,base.br
+city_2411403,Santana do Matos,2411403,base.state_br_rn,base.br
+city_2411429,Santana do Seridó,2411429,base.state_br_rn,base.br
+city_2411502,Santo Antônio,2411502,base.state_br_rn,base.br
+city_2411601,São Bento do Norte,2411601,base.state_br_rn,base.br
+city_2411700,São Bento do Trairí,2411700,base.state_br_rn,base.br
+city_2411809,São Fernando,2411809,base.state_br_rn,base.br
+city_2411908,São Francisco do Oeste,2411908,base.state_br_rn,base.br
+city_2412005,São Gonçalo do Amarante,2412005,base.state_br_rn,base.br
+city_2412104,São João do Sabugi,2412104,base.state_br_rn,base.br
+city_2412203,São José de Mipibu,2412203,base.state_br_rn,base.br
+city_2412302,São José do Campestre,2412302,base.state_br_rn,base.br
+city_2412401,São José do Seridó,2412401,base.state_br_rn,base.br
+city_2412500,São Miguel,2412500,base.state_br_rn,base.br
+city_2412559,São Miguel do Gostoso,2412559,base.state_br_rn,base.br
+city_2412609,São Paulo do Potengi,2412609,base.state_br_rn,base.br
+city_2412708,São Pedro,2412708,base.state_br_rn,base.br
+city_2412807,São Rafael,2412807,base.state_br_rn,base.br
+city_2412906,São Tomé,2412906,base.state_br_rn,base.br
+city_2413003,São Vicente,2413003,base.state_br_rn,base.br
+city_2413102,Senador Elói de Souza,2413102,base.state_br_rn,base.br
+city_2413201,Senador Georgino Avelino,2413201,base.state_br_rn,base.br
+city_2410306,Serra Caiada,2410306,base.state_br_rn,base.br
+city_2413300,Serra de São Bento,2413300,base.state_br_rn,base.br
+city_2413359,Serra do Mel,2413359,base.state_br_rn,base.br
+city_2413409,Serra Negra do Norte,2413409,base.state_br_rn,base.br
+city_2413508,Serrinha,2413508,base.state_br_rn,base.br
+city_2413557,Serrinha dos Pintos,2413557,base.state_br_rn,base.br
+city_2413607,Severiano Melo,2413607,base.state_br_rn,base.br
+city_2413706,Sítio Novo,2413706,base.state_br_rn,base.br
+city_2413805,Taboleiro Grande,2413805,base.state_br_rn,base.br
+city_2413904,Taipu,2413904,base.state_br_rn,base.br
+city_2414001,Tangará,2414001,base.state_br_rn,base.br
+city_2414100,Tenente Ananias,2414100,base.state_br_rn,base.br
+city_2414159,Tenente Laurentino Cruz,2414159,base.state_br_rn,base.br
+city_2411056,Tibau,2411056,base.state_br_rn,base.br
+city_2414209,Tibau do Sul,2414209,base.state_br_rn,base.br
+city_2414308,Timbaúba dos Batistas,2414308,base.state_br_rn,base.br
+city_2414407,Touros,2414407,base.state_br_rn,base.br
+city_2414456,Triunfo Potiguar,2414456,base.state_br_rn,base.br
+city_2414506,Umarizal,2414506,base.state_br_rn,base.br
+city_2414605,Upanema,2414605,base.state_br_rn,base.br
+city_2414704,Várzea,2414704,base.state_br_rn,base.br
+city_2414753,Venha-Ver,2414753,base.state_br_rn,base.br
+city_2414803,Vera Cruz,2414803,base.state_br_rn,base.br
+city_2414902,Viçosa,2414902,base.state_br_rn,base.br
+city_2415008,Vila Flor,2415008,base.state_br_rn,base.br
+city_2500106,Água Branca,2500106,base.state_br_pb,base.br
+city_2500205,Aguiar,2500205,base.state_br_pb,base.br
+city_2500304,Alagoa Grande,2500304,base.state_br_pb,base.br
+city_2500403,Alagoa Nova,2500403,base.state_br_pb,base.br
+city_2500502,Alagoinha,2500502,base.state_br_pb,base.br
+city_2500536,Alcantil,2500536,base.state_br_pb,base.br
+city_2500577,Algodão de Jandaíra,2500577,base.state_br_pb,base.br
+city_2500601,Alhandra,2500601,base.state_br_pb,base.br
+city_2500734,Amparo,2500734,base.state_br_pb,base.br
+city_2500775,Aparecida,2500775,base.state_br_pb,base.br
+city_2500809,Araçagi,2500809,base.state_br_pb,base.br
+city_2500908,Arara,2500908,base.state_br_pb,base.br
+city_2501005,Araruna,2501005,base.state_br_pb,base.br
+city_2501104,Areia,2501104,base.state_br_pb,base.br
+city_2501153,Areia de Baraúnas,2501153,base.state_br_pb,base.br
+city_2501203,Areial,2501203,base.state_br_pb,base.br
+city_2501302,Aroeiras,2501302,base.state_br_pb,base.br
+city_2501351,Assunção,2501351,base.state_br_pb,base.br
+city_2501401,Baía da Traição,2501401,base.state_br_pb,base.br
+city_2501500,Bananeiras,2501500,base.state_br_pb,base.br
+city_2501534,Baraúna,2501534,base.state_br_pb,base.br
+city_2501609,Barra de Santa Rosa,2501609,base.state_br_pb,base.br
+city_2501575,Barra de Santana,2501575,base.state_br_pb,base.br
+city_2501708,Barra de São Miguel,2501708,base.state_br_pb,base.br
+city_2501807,Bayeux,2501807,base.state_br_pb,base.br
+city_2501906,Belém,2501906,base.state_br_pb,base.br
+city_2502003,Belém do Brejo do Cruz,2502003,base.state_br_pb,base.br
+city_2502052,Bernardino Batista,2502052,base.state_br_pb,base.br
+city_2502102,Boa Ventura,2502102,base.state_br_pb,base.br
+city_2502151,Boa Vista,2502151,base.state_br_pb,base.br
+city_2502201,Bom Jesus,2502201,base.state_br_pb,base.br
+city_2502300,Bom Sucesso,2502300,base.state_br_pb,base.br
+city_2502409,Bonito de Santa Fé,2502409,base.state_br_pb,base.br
+city_2502508,Boqueirão,2502508,base.state_br_pb,base.br
+city_2502706,Borborema,2502706,base.state_br_pb,base.br
+city_2502805,Brejo do Cruz,2502805,base.state_br_pb,base.br
+city_2502904,Brejo dos Santos,2502904,base.state_br_pb,base.br
+city_2503001,Caaporã,2503001,base.state_br_pb,base.br
+city_2503100,Cabaceiras,2503100,base.state_br_pb,base.br
+city_2503209,Cabedelo,2503209,base.state_br_pb,base.br
+city_2503308,Cachoeira dos Índios,2503308,base.state_br_pb,base.br
+city_2503407,Cacimba de Areia,2503407,base.state_br_pb,base.br
+city_2503506,Cacimba de Dentro,2503506,base.state_br_pb,base.br
+city_2503555,Cacimbas,2503555,base.state_br_pb,base.br
+city_2503605,Caiçara,2503605,base.state_br_pb,base.br
+city_2503704,Cajazeiras,2503704,base.state_br_pb,base.br
+city_2503753,Cajazeirinhas,2503753,base.state_br_pb,base.br
+city_2503803,Caldas Brandão,2503803,base.state_br_pb,base.br
+city_2503902,Camalaú,2503902,base.state_br_pb,base.br
+city_2504009,Campina Grande,2504009,base.state_br_pb,base.br
+city_2504033,Capim,2504033,base.state_br_pb,base.br
+city_2504074,Caraúbas,2504074,base.state_br_pb,base.br
+city_2504108,Carrapateira,2504108,base.state_br_pb,base.br
+city_2504157,Casserengue,2504157,base.state_br_pb,base.br
+city_2504207,Catingueira,2504207,base.state_br_pb,base.br
+city_2504306,Catolé do Rocha,2504306,base.state_br_pb,base.br
+city_2504355,Caturité,2504355,base.state_br_pb,base.br
+city_2504405,Conceição,2504405,base.state_br_pb,base.br
+city_2504504,Condado,2504504,base.state_br_pb,base.br
+city_2504603,Conde,2504603,base.state_br_pb,base.br
+city_2504702,Congo,2504702,base.state_br_pb,base.br
+city_2504801,Coremas,2504801,base.state_br_pb,base.br
+city_2504850,Coxixola,2504850,base.state_br_pb,base.br
+city_2504900,Cruz do Espírito Santo,2504900,base.state_br_pb,base.br
+city_2505006,Cubati,2505006,base.state_br_pb,base.br
+city_2505105,Cuité,2505105,base.state_br_pb,base.br
+city_2505238,Cuité de Mamanguape,2505238,base.state_br_pb,base.br
+city_2505204,Cuitegi,2505204,base.state_br_pb,base.br
+city_2505279,Curral de Cima,2505279,base.state_br_pb,base.br
+city_2505303,Curral Velho,2505303,base.state_br_pb,base.br
+city_2505352,Damião,2505352,base.state_br_pb,base.br
+city_2505402,Desterro,2505402,base.state_br_pb,base.br
+city_2505600,Diamante,2505600,base.state_br_pb,base.br
+city_2505709,Dona Inês,2505709,base.state_br_pb,base.br
+city_2505808,Duas Estradas,2505808,base.state_br_pb,base.br
+city_2505907,Emas,2505907,base.state_br_pb,base.br
+city_2506004,Esperança,2506004,base.state_br_pb,base.br
+city_2506103,Fagundes,2506103,base.state_br_pb,base.br
+city_2506202,Frei Martinho,2506202,base.state_br_pb,base.br
+city_2506251,Gado Bravo,2506251,base.state_br_pb,base.br
+city_2506301,Guarabira,2506301,base.state_br_pb,base.br
+city_2506400,Gurinhém,2506400,base.state_br_pb,base.br
+city_2506509,Gurjão,2506509,base.state_br_pb,base.br
+city_2506608,Ibiara,2506608,base.state_br_pb,base.br
+city_2502607,Igaracy,2502607,base.state_br_pb,base.br
+city_2506707,Imaculada,2506707,base.state_br_pb,base.br
+city_2506806,Ingá,2506806,base.state_br_pb,base.br
+city_2506905,Itabaiana,2506905,base.state_br_pb,base.br
+city_2507002,Itaporanga,2507002,base.state_br_pb,base.br
+city_2507101,Itapororoca,2507101,base.state_br_pb,base.br
+city_2507200,Itatuba,2507200,base.state_br_pb,base.br
+city_2507309,Jacaraú,2507309,base.state_br_pb,base.br
+city_2507408,Jericó,2507408,base.state_br_pb,base.br
+city_2507507,João Pessoa,2507507,base.state_br_pb,base.br
+city_2513653,Joca Claudino,2513653,base.state_br_pb,base.br
+city_2507606,Juarez Távora,2507606,base.state_br_pb,base.br
+city_2507705,Juazeirinho,2507705,base.state_br_pb,base.br
+city_2507804,Junco do Seridó,2507804,base.state_br_pb,base.br
+city_2507903,Juripiranga,2507903,base.state_br_pb,base.br
+city_2508000,Juru,2508000,base.state_br_pb,base.br
+city_2508109,Lagoa,2508109,base.state_br_pb,base.br
+city_2508208,Lagoa de Dentro,2508208,base.state_br_pb,base.br
+city_2508307,Lagoa Seca,2508307,base.state_br_pb,base.br
+city_2508406,Lastro,2508406,base.state_br_pb,base.br
+city_2508505,Livramento,2508505,base.state_br_pb,base.br
+city_2508554,Logradouro,2508554,base.state_br_pb,base.br
+city_2508604,Lucena,2508604,base.state_br_pb,base.br
+city_2508703,Mãe d'Água,2508703,base.state_br_pb,base.br
+city_2508802,Malta,2508802,base.state_br_pb,base.br
+city_2508901,Mamanguape,2508901,base.state_br_pb,base.br
+city_2509008,Manaíra,2509008,base.state_br_pb,base.br
+city_2509057,Marcação,2509057,base.state_br_pb,base.br
+city_2509107,Mari,2509107,base.state_br_pb,base.br
+city_2509156,Marizópolis,2509156,base.state_br_pb,base.br
+city_2509206,Massaranduba,2509206,base.state_br_pb,base.br
+city_2509305,Mataraca,2509305,base.state_br_pb,base.br
+city_2509339,Matinhas,2509339,base.state_br_pb,base.br
+city_2509370,Mato Grosso,2509370,base.state_br_pb,base.br
+city_2509396,Maturéia,2509396,base.state_br_pb,base.br
+city_2509404,Mogeiro,2509404,base.state_br_pb,base.br
+city_2509503,Montadas,2509503,base.state_br_pb,base.br
+city_2509602,Monte Horebe,2509602,base.state_br_pb,base.br
+city_2509701,Monteiro,2509701,base.state_br_pb,base.br
+city_2509800,Mulungu,2509800,base.state_br_pb,base.br
+city_2509909,Natuba,2509909,base.state_br_pb,base.br
+city_2510006,Nazarezinho,2510006,base.state_br_pb,base.br
+city_2510105,Nova Floresta,2510105,base.state_br_pb,base.br
+city_2510204,Nova Olinda,2510204,base.state_br_pb,base.br
+city_2510303,Nova Palmeira,2510303,base.state_br_pb,base.br
+city_2510402,Olho d'Água,2510402,base.state_br_pb,base.br
+city_2510501,Olivedos,2510501,base.state_br_pb,base.br
+city_2510600,Ouro Velho,2510600,base.state_br_pb,base.br
+city_2510659,Parari,2510659,base.state_br_pb,base.br
+city_2510709,Passagem,2510709,base.state_br_pb,base.br
+city_2510808,Patos,2510808,base.state_br_pb,base.br
+city_2510907,Paulista,2510907,base.state_br_pb,base.br
+city_2511004,Pedra Branca,2511004,base.state_br_pb,base.br
+city_2511103,Pedra Lavrada,2511103,base.state_br_pb,base.br
+city_2511202,Pedras de Fogo,2511202,base.state_br_pb,base.br
+city_2512721,Pedro Régis,2512721,base.state_br_pb,base.br
+city_2511301,Piancó,2511301,base.state_br_pb,base.br
+city_2511400,Picuí,2511400,base.state_br_pb,base.br
+city_2511509,Pilar,2511509,base.state_br_pb,base.br
+city_2511608,Pilões,2511608,base.state_br_pb,base.br
+city_2511707,Pilõezinhos,2511707,base.state_br_pb,base.br
+city_2511806,Pirpirituba,2511806,base.state_br_pb,base.br
+city_2511905,Pitimbu,2511905,base.state_br_pb,base.br
+city_2512002,Pocinhos,2512002,base.state_br_pb,base.br
+city_2512036,Poço Dantas,2512036,base.state_br_pb,base.br
+city_2512077,Poço de José de Moura,2512077,base.state_br_pb,base.br
+city_2512101,Pombal,2512101,base.state_br_pb,base.br
+city_2512200,Prata,2512200,base.state_br_pb,base.br
+city_2512309,Princesa Isabel,2512309,base.state_br_pb,base.br
+city_2512408,Puxinanã,2512408,base.state_br_pb,base.br
+city_2512507,Queimadas,2512507,base.state_br_pb,base.br
+city_2512606,Quixaba,2512606,base.state_br_pb,base.br
+city_2512705,Remígio,2512705,base.state_br_pb,base.br
+city_2512747,Riachão,2512747,base.state_br_pb,base.br
+city_2512754,Riachão do Bacamarte,2512754,base.state_br_pb,base.br
+city_2512762,Riachão do Poço,2512762,base.state_br_pb,base.br
+city_2512788,Riacho de Santo Antônio,2512788,base.state_br_pb,base.br
+city_2512804,Riacho dos Cavalos,2512804,base.state_br_pb,base.br
+city_2512903,Rio Tinto,2512903,base.state_br_pb,base.br
+city_2513000,Salgadinho,2513000,base.state_br_pb,base.br
+city_2513109,Salgado de São Félix,2513109,base.state_br_pb,base.br
+city_2513158,Santa Cecília,2513158,base.state_br_pb,base.br
+city_2513208,Santa Cruz,2513208,base.state_br_pb,base.br
+city_2513307,Santa Helena,2513307,base.state_br_pb,base.br
+city_2513356,Santa Inês,2513356,base.state_br_pb,base.br
+city_2513406,Santa Luzia,2513406,base.state_br_pb,base.br
+city_2513703,Santa Rita,2513703,base.state_br_pb,base.br
+city_2513802,Santa Teresinha,2513802,base.state_br_pb,base.br
+city_2513505,Santana de Mangueira,2513505,base.state_br_pb,base.br
+city_2513604,Santana dos Garrotes,2513604,base.state_br_pb,base.br
+city_2513851,Santo André,2513851,base.state_br_pb,base.br
+city_2513927,São Bentinho,2513927,base.state_br_pb,base.br
+city_2513901,São Bento,2513901,base.state_br_pb,base.br
+city_2513968,São Domingos,2513968,base.state_br_pb,base.br
+city_2513943,São Domingos do Cariri,2513943,base.state_br_pb,base.br
+city_2513984,São Francisco,2513984,base.state_br_pb,base.br
+city_2514008,São João do Cariri,2514008,base.state_br_pb,base.br
+city_2500700,São João do Rio do Peixe,2500700,base.state_br_pb,base.br
+city_2514107,São João do Tigre,2514107,base.state_br_pb,base.br
+city_2514206,São José da Lagoa Tapada,2514206,base.state_br_pb,base.br
+city_2514305,São José de Caiana,2514305,base.state_br_pb,base.br
+city_2514404,São José de Espinharas,2514404,base.state_br_pb,base.br
+city_2514503,São José de Piranhas,2514503,base.state_br_pb,base.br
+city_2514552,São José de Princesa,2514552,base.state_br_pb,base.br
+city_2514602,São José do Bonfim,2514602,base.state_br_pb,base.br
+city_2514651,São José do Brejo do Cruz,2514651,base.state_br_pb,base.br
+city_2514701,São José do Sabugi,2514701,base.state_br_pb,base.br
+city_2514800,São José dos Cordeiros,2514800,base.state_br_pb,base.br
+city_2514453,São José dos Ramos,2514453,base.state_br_pb,base.br
+city_2514909,São Mamede,2514909,base.state_br_pb,base.br
+city_2515005,São Miguel de Taipu,2515005,base.state_br_pb,base.br
+city_2515104,São Sebastião de Lagoa de Roça,2515104,base.state_br_pb,base.br
+city_2515203,São Sebastião do Umbuzeiro,2515203,base.state_br_pb,base.br
+city_2515401,São Vicente do Seridó,2515401,base.state_br_pb,base.br
+city_2515302,Sapé,2515302,base.state_br_pb,base.br
+city_2515500,Serra Branca,2515500,base.state_br_pb,base.br
+city_2515609,Serra da Raiz,2515609,base.state_br_pb,base.br
+city_2515708,Serra Grande,2515708,base.state_br_pb,base.br
+city_2515807,Serra Redonda,2515807,base.state_br_pb,base.br
+city_2515906,Serraria,2515906,base.state_br_pb,base.br
+city_2515930,Sertãozinho,2515930,base.state_br_pb,base.br
+city_2515971,Sobrado,2515971,base.state_br_pb,base.br
+city_2516003,Solânea,2516003,base.state_br_pb,base.br
+city_2516102,Soledade,2516102,base.state_br_pb,base.br
+city_2516151,Sossêgo,2516151,base.state_br_pb,base.br
+city_2516201,Sousa,2516201,base.state_br_pb,base.br
+city_2516300,Sumé,2516300,base.state_br_pb,base.br
+city_2516409,Tacima,2516409,base.state_br_pb,base.br
+city_2516508,Taperoá,2516508,base.state_br_pb,base.br
+city_2516607,Tavares,2516607,base.state_br_pb,base.br
+city_2516706,Teixeira,2516706,base.state_br_pb,base.br
+city_2516755,Tenório,2516755,base.state_br_pb,base.br
+city_2516805,Triunfo,2516805,base.state_br_pb,base.br
+city_2516904,Uiraúna,2516904,base.state_br_pb,base.br
+city_2517001,Umbuzeiro,2517001,base.state_br_pb,base.br
+city_2517100,Várzea,2517100,base.state_br_pb,base.br
+city_2517209,Vieirópolis,2517209,base.state_br_pb,base.br
+city_2505501,Vista Serrana,2505501,base.state_br_pb,base.br
+city_2517407,Zabelê,2517407,base.state_br_pb,base.br
+city_2600054,Abreu e Lima,2600054,base.state_br_pe,base.br
+city_2600104,Afogados da Ingazeira,2600104,base.state_br_pe,base.br
+city_2600203,Afrânio,2600203,base.state_br_pe,base.br
+city_2600302,Agrestina,2600302,base.state_br_pe,base.br
+city_2600401,Água Preta,2600401,base.state_br_pe,base.br
+city_2600500,Águas Belas,2600500,base.state_br_pe,base.br
+city_2600609,Alagoinha,2600609,base.state_br_pe,base.br
+city_2600708,Aliança,2600708,base.state_br_pe,base.br
+city_2600807,Altinho,2600807,base.state_br_pe,base.br
+city_2600906,Amaraji,2600906,base.state_br_pe,base.br
+city_2601003,Angelim,2601003,base.state_br_pe,base.br
+city_2601052,Araçoiaba,2601052,base.state_br_pe,base.br
+city_2601102,Araripina,2601102,base.state_br_pe,base.br
+city_2601201,Arcoverde,2601201,base.state_br_pe,base.br
+city_2601300,Barra de Guabiraba,2601300,base.state_br_pe,base.br
+city_2601409,Barreiros,2601409,base.state_br_pe,base.br
+city_2601508,Belém de Maria,2601508,base.state_br_pe,base.br
+city_2601607,Belém do São Francisco,2601607,base.state_br_pe,base.br
+city_2601706,Belo Jardim,2601706,base.state_br_pe,base.br
+city_2601805,Betânia,2601805,base.state_br_pe,base.br
+city_2601904,Bezerros,2601904,base.state_br_pe,base.br
+city_2602001,Bodocó,2602001,base.state_br_pe,base.br
+city_2602100,Bom Conselho,2602100,base.state_br_pe,base.br
+city_2602209,Bom Jardim,2602209,base.state_br_pe,base.br
+city_2602308,Bonito,2602308,base.state_br_pe,base.br
+city_2602407,Brejão,2602407,base.state_br_pe,base.br
+city_2602506,Brejinho,2602506,base.state_br_pe,base.br
+city_2602605,Brejo da Madre de Deus,2602605,base.state_br_pe,base.br
+city_2602704,Buenos Aires,2602704,base.state_br_pe,base.br
+city_2602803,Buíque,2602803,base.state_br_pe,base.br
+city_2602902,Cabo de Santo Agostinho,2602902,base.state_br_pe,base.br
+city_2603009,Cabrobó,2603009,base.state_br_pe,base.br
+city_2603108,Cachoeirinha,2603108,base.state_br_pe,base.br
+city_2603207,Caetés,2603207,base.state_br_pe,base.br
+city_2603306,Calçado,2603306,base.state_br_pe,base.br
+city_2603405,Calumbi,2603405,base.state_br_pe,base.br
+city_2603454,Camaragibe,2603454,base.state_br_pe,base.br
+city_2603504,Camocim de São Félix,2603504,base.state_br_pe,base.br
+city_2603603,Camutanga,2603603,base.state_br_pe,base.br
+city_2603702,Canhotinho,2603702,base.state_br_pe,base.br
+city_2603801,Capoeiras,2603801,base.state_br_pe,base.br
+city_2603900,Carnaíba,2603900,base.state_br_pe,base.br
+city_2603926,Carnaubeira da Penha,2603926,base.state_br_pe,base.br
+city_2604007,Carpina,2604007,base.state_br_pe,base.br
+city_2604106,Caruaru,2604106,base.state_br_pe,base.br
+city_2604155,Casinhas,2604155,base.state_br_pe,base.br
+city_2604205,Catende,2604205,base.state_br_pe,base.br
+city_2604304,Cedro,2604304,base.state_br_pe,base.br
+city_2604403,Chã de Alegria,2604403,base.state_br_pe,base.br
+city_2604502,Chã Grande,2604502,base.state_br_pe,base.br
+city_2604601,Condado,2604601,base.state_br_pe,base.br
+city_2604700,Correntes,2604700,base.state_br_pe,base.br
+city_2604809,Cortês,2604809,base.state_br_pe,base.br
+city_2604908,Cumaru,2604908,base.state_br_pe,base.br
+city_2605004,Cupira,2605004,base.state_br_pe,base.br
+city_2605103,Custódia,2605103,base.state_br_pe,base.br
+city_2605152,Dormentes,2605152,base.state_br_pe,base.br
+city_2605202,Escada,2605202,base.state_br_pe,base.br
+city_2605301,Exu,2605301,base.state_br_pe,base.br
+city_2605400,Feira Nova,2605400,base.state_br_pe,base.br
+city_2605459,Fernando de Noronha,2605459,base.state_br_pe,base.br
+city_2605509,Ferreiros,2605509,base.state_br_pe,base.br
+city_2605608,Flores,2605608,base.state_br_pe,base.br
+city_2605707,Floresta,2605707,base.state_br_pe,base.br
+city_2605806,Frei Miguelinho,2605806,base.state_br_pe,base.br
+city_2605905,Gameleira,2605905,base.state_br_pe,base.br
+city_2606002,Garanhuns,2606002,base.state_br_pe,base.br
+city_2606101,Glória do Goitá,2606101,base.state_br_pe,base.br
+city_2606200,Goiana,2606200,base.state_br_pe,base.br
+city_2606309,Granito,2606309,base.state_br_pe,base.br
+city_2606408,Gravatá,2606408,base.state_br_pe,base.br
+city_2606507,Iati,2606507,base.state_br_pe,base.br
+city_2606606,Ibimirim,2606606,base.state_br_pe,base.br
+city_2606705,Ibirajuba,2606705,base.state_br_pe,base.br
+city_2606804,Igarassu,2606804,base.state_br_pe,base.br
+city_2606903,Iguaracy,2606903,base.state_br_pe,base.br
+city_2607604,Ilha de Itamaracá,2607604,base.state_br_pe,base.br
+city_2607000,Inajá,2607000,base.state_br_pe,base.br
+city_2607109,Ingazeira,2607109,base.state_br_pe,base.br
+city_2607208,Ipojuca,2607208,base.state_br_pe,base.br
+city_2607307,Ipubi,2607307,base.state_br_pe,base.br
+city_2607406,Itacuruba,2607406,base.state_br_pe,base.br
+city_2607505,Itaíba,2607505,base.state_br_pe,base.br
+city_2607653,Itambé,2607653,base.state_br_pe,base.br
+city_2607703,Itapetim,2607703,base.state_br_pe,base.br
+city_2607752,Itapissuma,2607752,base.state_br_pe,base.br
+city_2607802,Itaquitinga,2607802,base.state_br_pe,base.br
+city_2607901,Jaboatão dos Guararapes,2607901,base.state_br_pe,base.br
+city_2607950,Jaqueira,2607950,base.state_br_pe,base.br
+city_2608008,Jataúba,2608008,base.state_br_pe,base.br
+city_2608057,Jatobá,2608057,base.state_br_pe,base.br
+city_2608107,João Alfredo,2608107,base.state_br_pe,base.br
+city_2608206,Joaquim Nabuco,2608206,base.state_br_pe,base.br
+city_2608255,Jucati,2608255,base.state_br_pe,base.br
+city_2608305,Jupi,2608305,base.state_br_pe,base.br
+city_2608404,Jurema,2608404,base.state_br_pe,base.br
+city_2608503,Lagoa de Itaenga,2608503,base.state_br_pe,base.br
+city_2608453,Lagoa do Carro,2608453,base.state_br_pe,base.br
+city_2608602,Lagoa do Ouro,2608602,base.state_br_pe,base.br
+city_2608701,Lagoa dos Gatos,2608701,base.state_br_pe,base.br
+city_2608750,Lagoa Grande,2608750,base.state_br_pe,base.br
+city_2608800,Lajedo,2608800,base.state_br_pe,base.br
+city_2608909,Limoeiro,2608909,base.state_br_pe,base.br
+city_2609006,Macaparana,2609006,base.state_br_pe,base.br
+city_2609105,Machados,2609105,base.state_br_pe,base.br
+city_2609154,Manari,2609154,base.state_br_pe,base.br
+city_2609204,Maraial,2609204,base.state_br_pe,base.br
+city_2609303,Mirandiba,2609303,base.state_br_pe,base.br
+city_2614303,Moreilândia,2614303,base.state_br_pe,base.br
+city_2609402,Moreno,2609402,base.state_br_pe,base.br
+city_2609501,Nazaré da Mata,2609501,base.state_br_pe,base.br
+city_2609600,Olinda,2609600,base.state_br_pe,base.br
+city_2609709,Orobó,2609709,base.state_br_pe,base.br
+city_2609808,Orocó,2609808,base.state_br_pe,base.br
+city_2609907,Ouricuri,2609907,base.state_br_pe,base.br
+city_2610004,Palmares,2610004,base.state_br_pe,base.br
+city_2610103,Palmeirina,2610103,base.state_br_pe,base.br
+city_2610202,Panelas,2610202,base.state_br_pe,base.br
+city_2610301,Paranatama,2610301,base.state_br_pe,base.br
+city_2610400,Parnamirim,2610400,base.state_br_pe,base.br
+city_2610509,Passira,2610509,base.state_br_pe,base.br
+city_2610608,Paudalho,2610608,base.state_br_pe,base.br
+city_2610707,Paulista,2610707,base.state_br_pe,base.br
+city_2610806,Pedra,2610806,base.state_br_pe,base.br
+city_2610905,Pesqueira,2610905,base.state_br_pe,base.br
+city_2611002,Petrolândia,2611002,base.state_br_pe,base.br
+city_2611101,Petrolina,2611101,base.state_br_pe,base.br
+city_2611200,Poção,2611200,base.state_br_pe,base.br
+city_2611309,Pombos,2611309,base.state_br_pe,base.br
+city_2611408,Primavera,2611408,base.state_br_pe,base.br
+city_2611507,Quipapá,2611507,base.state_br_pe,base.br
+city_2611533,Quixaba,2611533,base.state_br_pe,base.br
+city_2611606,Recife,2611606,base.state_br_pe,base.br
+city_2611705,Riacho das Almas,2611705,base.state_br_pe,base.br
+city_2611804,Ribeirão,2611804,base.state_br_pe,base.br
+city_2611903,Rio Formoso,2611903,base.state_br_pe,base.br
+city_2612000,Sairé,2612000,base.state_br_pe,base.br
+city_2612109,Salgadinho,2612109,base.state_br_pe,base.br
+city_2612208,Salgueiro,2612208,base.state_br_pe,base.br
+city_2612307,Saloá,2612307,base.state_br_pe,base.br
+city_2612406,Sanharó,2612406,base.state_br_pe,base.br
+city_2612455,Santa Cruz,2612455,base.state_br_pe,base.br
+city_2612471,Santa Cruz da Baixa Verde,2612471,base.state_br_pe,base.br
+city_2612505,Santa Cruz do Capibaribe,2612505,base.state_br_pe,base.br
+city_2612554,Santa Filomena,2612554,base.state_br_pe,base.br
+city_2612604,Santa Maria da Boa Vista,2612604,base.state_br_pe,base.br
+city_2612703,Santa Maria do Cambucá,2612703,base.state_br_pe,base.br
+city_2612802,Santa Terezinha,2612802,base.state_br_pe,base.br
+city_2612901,São Benedito do Sul,2612901,base.state_br_pe,base.br
+city_2613008,São Bento do Una,2613008,base.state_br_pe,base.br
+city_2613107,São Caitano,2613107,base.state_br_pe,base.br
+city_2613206,São João,2613206,base.state_br_pe,base.br
+city_2613305,São Joaquim do Monte,2613305,base.state_br_pe,base.br
+city_2613404,São José da Coroa Grande,2613404,base.state_br_pe,base.br
+city_2613503,São José do Belmonte,2613503,base.state_br_pe,base.br
+city_2613602,São José do Egito,2613602,base.state_br_pe,base.br
+city_2613701,São Lourenço da Mata,2613701,base.state_br_pe,base.br
+city_2613800,São Vicente Férrer,2613800,base.state_br_pe,base.br
+city_2613909,Serra Talhada,2613909,base.state_br_pe,base.br
+city_2614006,Serrita,2614006,base.state_br_pe,base.br
+city_2614105,Sertânia,2614105,base.state_br_pe,base.br
+city_2614204,Sirinhaém,2614204,base.state_br_pe,base.br
+city_2614402,Solidão,2614402,base.state_br_pe,base.br
+city_2614501,Surubim,2614501,base.state_br_pe,base.br
+city_2614600,Tabira,2614600,base.state_br_pe,base.br
+city_2614709,Tacaimbó,2614709,base.state_br_pe,base.br
+city_2614808,Tacaratu,2614808,base.state_br_pe,base.br
+city_2614857,Tamandaré,2614857,base.state_br_pe,base.br
+city_2615003,Taquaritinga do Norte,2615003,base.state_br_pe,base.br
+city_2615102,Terezinha,2615102,base.state_br_pe,base.br
+city_2615201,Terra Nova,2615201,base.state_br_pe,base.br
+city_2615300,Timbaúba,2615300,base.state_br_pe,base.br
+city_2615409,Toritama,2615409,base.state_br_pe,base.br
+city_2615508,Tracunhaém,2615508,base.state_br_pe,base.br
+city_2615607,Trindade,2615607,base.state_br_pe,base.br
+city_2615706,Triunfo,2615706,base.state_br_pe,base.br
+city_2615805,Tupanatinga,2615805,base.state_br_pe,base.br
+city_2615904,Tuparetama,2615904,base.state_br_pe,base.br
+city_2616001,Venturosa,2616001,base.state_br_pe,base.br
+city_2616100,Verdejante,2616100,base.state_br_pe,base.br
+city_2616183,Vertente do Lério,2616183,base.state_br_pe,base.br
+city_2616209,Vertentes,2616209,base.state_br_pe,base.br
+city_2616308,Vicência,2616308,base.state_br_pe,base.br
+city_2616407,Vitória de Santo Antão,2616407,base.state_br_pe,base.br
+city_2616506,Xexéu,2616506,base.state_br_pe,base.br
+city_2700102,Água Branca,2700102,base.state_br_al,base.br
+city_2700201,Anadia,2700201,base.state_br_al,base.br
+city_2700300,Arapiraca,2700300,base.state_br_al,base.br
+city_2700409,Atalaia,2700409,base.state_br_al,base.br
+city_2700508,Barra de Santo Antônio,2700508,base.state_br_al,base.br
+city_2700607,Barra de São Miguel,2700607,base.state_br_al,base.br
+city_2700706,Batalha,2700706,base.state_br_al,base.br
+city_2700805,Belém,2700805,base.state_br_al,base.br
+city_2700904,Belo Monte,2700904,base.state_br_al,base.br
+city_2701001,Boca da Mata,2701001,base.state_br_al,base.br
+city_2701100,Branquinha,2701100,base.state_br_al,base.br
+city_2701209,Cacimbinhas,2701209,base.state_br_al,base.br
+city_2701308,Cajueiro,2701308,base.state_br_al,base.br
+city_2701357,Campestre,2701357,base.state_br_al,base.br
+city_2701407,Campo Alegre,2701407,base.state_br_al,base.br
+city_2701506,Campo Grande,2701506,base.state_br_al,base.br
+city_2701605,Canapi,2701605,base.state_br_al,base.br
+city_2701704,Capela,2701704,base.state_br_al,base.br
+city_2701803,Carneiros,2701803,base.state_br_al,base.br
+city_2701902,Chã Preta,2701902,base.state_br_al,base.br
+city_2702009,Coité do Nóia,2702009,base.state_br_al,base.br
+city_2702108,Colônia Leopoldina,2702108,base.state_br_al,base.br
+city_2702207,Coqueiro Seco,2702207,base.state_br_al,base.br
+city_2702306,Coruripe,2702306,base.state_br_al,base.br
+city_2702355,Craíbas,2702355,base.state_br_al,base.br
+city_2702405,Delmiro Gouveia,2702405,base.state_br_al,base.br
+city_2702504,Dois Riachos,2702504,base.state_br_al,base.br
+city_2702553,Estrela de Alagoas,2702553,base.state_br_al,base.br
+city_2702603,Feira Grande,2702603,base.state_br_al,base.br
+city_2702702,Feliz Deserto,2702702,base.state_br_al,base.br
+city_2702801,Flexeiras,2702801,base.state_br_al,base.br
+city_2702900,Girau do Ponciano,2702900,base.state_br_al,base.br
+city_2703007,Ibateguara,2703007,base.state_br_al,base.br
+city_2703106,Igaci,2703106,base.state_br_al,base.br
+city_2703205,Igreja Nova,2703205,base.state_br_al,base.br
+city_2703304,Inhapi,2703304,base.state_br_al,base.br
+city_2703403,Jacaré dos Homens,2703403,base.state_br_al,base.br
+city_2703502,Jacuípe,2703502,base.state_br_al,base.br
+city_2703601,Japaratinga,2703601,base.state_br_al,base.br
+city_2703700,Jaramataia,2703700,base.state_br_al,base.br
+city_2703759,Jequiá da Praia,2703759,base.state_br_al,base.br
+city_2703809,Joaquim Gomes,2703809,base.state_br_al,base.br
+city_2703908,Jundiá,2703908,base.state_br_al,base.br
+city_2704005,Junqueiro,2704005,base.state_br_al,base.br
+city_2704104,Lagoa da Canoa,2704104,base.state_br_al,base.br
+city_2704203,Limoeiro de Anadia,2704203,base.state_br_al,base.br
+city_2704302,Maceió,2704302,base.state_br_al,base.br
+city_2704401,Major Isidoro,2704401,base.state_br_al,base.br
+city_2704906,Mar Vermelho,2704906,base.state_br_al,base.br
+city_2704500,Maragogi,2704500,base.state_br_al,base.br
+city_2704609,Maravilha,2704609,base.state_br_al,base.br
+city_2704708,Marechal Deodoro,2704708,base.state_br_al,base.br
+city_2704807,Maribondo,2704807,base.state_br_al,base.br
+city_2705002,Mata Grande,2705002,base.state_br_al,base.br
+city_2705101,Matriz de Camaragibe,2705101,base.state_br_al,base.br
+city_2705200,Messias,2705200,base.state_br_al,base.br
+city_2705309,Minador do Negrão,2705309,base.state_br_al,base.br
+city_2705408,Monteirópolis,2705408,base.state_br_al,base.br
+city_2705507,Murici,2705507,base.state_br_al,base.br
+city_2705606,Novo Lino,2705606,base.state_br_al,base.br
+city_2705705,Olho d'Água das Flores,2705705,base.state_br_al,base.br
+city_2705804,Olho d'Água do Casado,2705804,base.state_br_al,base.br
+city_2705903,Olho d'Água Grande,2705903,base.state_br_al,base.br
+city_2706000,Olivença,2706000,base.state_br_al,base.br
+city_2706109,Ouro Branco,2706109,base.state_br_al,base.br
+city_2706208,Palestina,2706208,base.state_br_al,base.br
+city_2706307,Palmeira dos Índios,2706307,base.state_br_al,base.br
+city_2706406,Pão de Açúcar,2706406,base.state_br_al,base.br
+city_2706422,Pariconha,2706422,base.state_br_al,base.br
+city_2706448,Paripueira,2706448,base.state_br_al,base.br
+city_2706505,Passo de Camaragibe,2706505,base.state_br_al,base.br
+city_2706604,Paulo Jacinto,2706604,base.state_br_al,base.br
+city_2706703,Penedo,2706703,base.state_br_al,base.br
+city_2706802,Piaçabuçu,2706802,base.state_br_al,base.br
+city_2706901,Pilar,2706901,base.state_br_al,base.br
+city_2707008,Pindoba,2707008,base.state_br_al,base.br
+city_2707107,Piranhas,2707107,base.state_br_al,base.br
+city_2707206,Poço das Trincheiras,2707206,base.state_br_al,base.br
+city_2707305,Porto Calvo,2707305,base.state_br_al,base.br
+city_2707404,Porto de Pedras,2707404,base.state_br_al,base.br
+city_2707503,Porto Real do Colégio,2707503,base.state_br_al,base.br
+city_2707602,Quebrangulo,2707602,base.state_br_al,base.br
+city_2707701,Rio Largo,2707701,base.state_br_al,base.br
+city_2707800,Roteiro,2707800,base.state_br_al,base.br
+city_2707909,Santa Luzia do Norte,2707909,base.state_br_al,base.br
+city_2708006,Santana do Ipanema,2708006,base.state_br_al,base.br
+city_2708105,Santana do Mundaú,2708105,base.state_br_al,base.br
+city_2708204,São Brás,2708204,base.state_br_al,base.br
+city_2708303,São José da Laje,2708303,base.state_br_al,base.br
+city_2708402,São José da Tapera,2708402,base.state_br_al,base.br
+city_2708501,São Luís do Quitunde,2708501,base.state_br_al,base.br
+city_2708600,São Miguel dos Campos,2708600,base.state_br_al,base.br
+city_2708709,São Miguel dos Milagres,2708709,base.state_br_al,base.br
+city_2708808,São Sebastião,2708808,base.state_br_al,base.br
+city_2708907,Satuba,2708907,base.state_br_al,base.br
+city_2708956,Senador Rui Palmeira,2708956,base.state_br_al,base.br
+city_2709004,Tanque d'Arca,2709004,base.state_br_al,base.br
+city_2709103,Taquarana,2709103,base.state_br_al,base.br
+city_2709152,Teotônio Vilela,2709152,base.state_br_al,base.br
+city_2709202,Traipu,2709202,base.state_br_al,base.br
+city_2709301,União dos Palmares,2709301,base.state_br_al,base.br
+city_2709400,Viçosa,2709400,base.state_br_al,base.br
+city_2800100,Amparo do São Francisco,2800100,base.state_br_se,base.br
+city_2800209,Aquidabã,2800209,base.state_br_se,base.br
+city_2800308,Aracaju,2800308,base.state_br_se,base.br
+city_2800407,Arauá,2800407,base.state_br_se,base.br
+city_2800506,Areia Branca,2800506,base.state_br_se,base.br
+city_2800605,Barra dos Coqueiros,2800605,base.state_br_se,base.br
+city_2800670,Boquim,2800670,base.state_br_se,base.br
+city_2800704,Brejo Grande,2800704,base.state_br_se,base.br
+city_2801009,Campo do Brito,2801009,base.state_br_se,base.br
+city_2801108,Canhoba,2801108,base.state_br_se,base.br
+city_2801207,Canindé de São Francisco,2801207,base.state_br_se,base.br
+city_2801306,Capela,2801306,base.state_br_se,base.br
+city_2801405,Carira,2801405,base.state_br_se,base.br
+city_2801504,Carmópolis,2801504,base.state_br_se,base.br
+city_2801603,Cedro de São João,2801603,base.state_br_se,base.br
+city_2801702,Cristinápolis,2801702,base.state_br_se,base.br
+city_2801900,Cumbe,2801900,base.state_br_se,base.br
+city_2802007,Divina Pastora,2802007,base.state_br_se,base.br
+city_2802106,Estância,2802106,base.state_br_se,base.br
+city_2802205,Feira Nova,2802205,base.state_br_se,base.br
+city_2802304,Frei Paulo,2802304,base.state_br_se,base.br
+city_2802403,Gararu,2802403,base.state_br_se,base.br
+city_2802502,General Maynard,2802502,base.state_br_se,base.br
+city_2802601,Gracho Cardoso,2802601,base.state_br_se,base.br
+city_2802700,Ilha das Flores,2802700,base.state_br_se,base.br
+city_2802809,Indiaroba,2802809,base.state_br_se,base.br
+city_2802908,Itabaiana,2802908,base.state_br_se,base.br
+city_2803005,Itabaianinha,2803005,base.state_br_se,base.br
+city_2803104,Itabi,2803104,base.state_br_se,base.br
+city_2803203,Itaporanga d'Ajuda,2803203,base.state_br_se,base.br
+city_2803302,Japaratuba,2803302,base.state_br_se,base.br
+city_2803401,Japoatã,2803401,base.state_br_se,base.br
+city_2803500,Lagarto,2803500,base.state_br_se,base.br
+city_2803609,Laranjeiras,2803609,base.state_br_se,base.br
+city_2803708,Macambira,2803708,base.state_br_se,base.br
+city_2803807,Malhada dos Bois,2803807,base.state_br_se,base.br
+city_2803906,Malhador,2803906,base.state_br_se,base.br
+city_2804003,Maruim,2804003,base.state_br_se,base.br
+city_2804102,Moita Bonita,2804102,base.state_br_se,base.br
+city_2804201,Monte Alegre de Sergipe,2804201,base.state_br_se,base.br
+city_2804300,Muribeca,2804300,base.state_br_se,base.br
+city_2804409,Neópolis,2804409,base.state_br_se,base.br
+city_2804458,Nossa Senhora Aparecida,2804458,base.state_br_se,base.br
+city_2804508,Nossa Senhora da Glória,2804508,base.state_br_se,base.br
+city_2804607,Nossa Senhora das Dores,2804607,base.state_br_se,base.br
+city_2804706,Nossa Senhora de Lourdes,2804706,base.state_br_se,base.br
+city_2804805,Nossa Senhora do Socorro,2804805,base.state_br_se,base.br
+city_2804904,Pacatuba,2804904,base.state_br_se,base.br
+city_2805000,Pedra Mole,2805000,base.state_br_se,base.br
+city_2805109,Pedrinhas,2805109,base.state_br_se,base.br
+city_2805208,Pinhão,2805208,base.state_br_se,base.br
+city_2805307,Pirambu,2805307,base.state_br_se,base.br
+city_2805406,Poço Redondo,2805406,base.state_br_se,base.br
+city_2805505,Poço Verde,2805505,base.state_br_se,base.br
+city_2805604,Porto da Folha,2805604,base.state_br_se,base.br
+city_2805703,Propriá,2805703,base.state_br_se,base.br
+city_2805802,Riachão do Dantas,2805802,base.state_br_se,base.br
+city_2805901,Riachuelo,2805901,base.state_br_se,base.br
+city_2806008,Ribeirópolis,2806008,base.state_br_se,base.br
+city_2806107,Rosário do Catete,2806107,base.state_br_se,base.br
+city_2806206,Salgado,2806206,base.state_br_se,base.br
+city_2806305,Santa Luzia do Itanhy,2806305,base.state_br_se,base.br
+city_2806503,Santa Rosa de Lima,2806503,base.state_br_se,base.br
+city_2806404,Santana do São Francisco,2806404,base.state_br_se,base.br
+city_2806602,Santo Amaro das Brotas,2806602,base.state_br_se,base.br
+city_2806701,São Cristóvão,2806701,base.state_br_se,base.br
+city_2806800,São Domingos,2806800,base.state_br_se,base.br
+city_2806909,São Francisco,2806909,base.state_br_se,base.br
+city_2807006,São Miguel do Aleixo,2807006,base.state_br_se,base.br
+city_2807105,Simão Dias,2807105,base.state_br_se,base.br
+city_2807204,Siriri,2807204,base.state_br_se,base.br
+city_2807303,Telha,2807303,base.state_br_se,base.br
+city_2807402,Tobias Barreto,2807402,base.state_br_se,base.br
+city_2807501,Tomar do Geru,2807501,base.state_br_se,base.br
+city_2807600,Umbaúba,2807600,base.state_br_se,base.br
+city_2900108,Abaíra,2900108,base.state_br_ba,base.br
+city_2900207,Abaré,2900207,base.state_br_ba,base.br
+city_2900306,Acajutiba,2900306,base.state_br_ba,base.br
+city_2900355,Adustina,2900355,base.state_br_ba,base.br
+city_2900405,Água Fria,2900405,base.state_br_ba,base.br
+city_2900603,Aiquara,2900603,base.state_br_ba,base.br
+city_2900702,Alagoinhas,2900702,base.state_br_ba,base.br
+city_2900801,Alcobaça,2900801,base.state_br_ba,base.br
+city_2900900,Almadina,2900900,base.state_br_ba,base.br
+city_2901007,Amargosa,2901007,base.state_br_ba,base.br
+city_2901106,Amélia Rodrigues,2901106,base.state_br_ba,base.br
+city_2901155,América Dourada,2901155,base.state_br_ba,base.br
+city_2901205,Anagé,2901205,base.state_br_ba,base.br
+city_2901304,Andaraí,2901304,base.state_br_ba,base.br
+city_2901353,Andorinha,2901353,base.state_br_ba,base.br
+city_2901403,Angical,2901403,base.state_br_ba,base.br
+city_2901502,Anguera,2901502,base.state_br_ba,base.br
+city_2901601,Antas,2901601,base.state_br_ba,base.br
+city_2901700,Antônio Cardoso,2901700,base.state_br_ba,base.br
+city_2901809,Antônio Gonçalves,2901809,base.state_br_ba,base.br
+city_2901908,Aporá,2901908,base.state_br_ba,base.br
+city_2901957,Apuarema,2901957,base.state_br_ba,base.br
+city_2902054,Araçás,2902054,base.state_br_ba,base.br
+city_2902005,Aracatu,2902005,base.state_br_ba,base.br
+city_2902104,Araci,2902104,base.state_br_ba,base.br
+city_2902203,Aramari,2902203,base.state_br_ba,base.br
+city_2902252,Arataca,2902252,base.state_br_ba,base.br
+city_2902302,Aratuípe,2902302,base.state_br_ba,base.br
+city_2902401,Aurelino Leal,2902401,base.state_br_ba,base.br
+city_2902500,Baianópolis,2902500,base.state_br_ba,base.br
+city_2902609,Baixa Grande,2902609,base.state_br_ba,base.br
+city_2902658,Banzaê,2902658,base.state_br_ba,base.br
+city_2902708,Barra,2902708,base.state_br_ba,base.br
+city_2902807,Barra da Estiva,2902807,base.state_br_ba,base.br
+city_2902906,Barra do Choça,2902906,base.state_br_ba,base.br
+city_2903003,Barra do Mendes,2903003,base.state_br_ba,base.br
+city_2903102,Barra do Rocha,2903102,base.state_br_ba,base.br
+city_2903201,Barreiras,2903201,base.state_br_ba,base.br
+city_2903235,Barro Alto,2903235,base.state_br_ba,base.br
+city_2903300,Barro Preto,2903300,base.state_br_ba,base.br
+city_2903276,Barrocas,2903276,base.state_br_ba,base.br
+city_2903409,Belmonte,2903409,base.state_br_ba,base.br
+city_2903508,Belo Campo,2903508,base.state_br_ba,base.br
+city_2903607,Biritinga,2903607,base.state_br_ba,base.br
+city_2903706,Boa Nova,2903706,base.state_br_ba,base.br
+city_2903805,Boa Vista do Tupim,2903805,base.state_br_ba,base.br
+city_2903904,Bom Jesus da Lapa,2903904,base.state_br_ba,base.br
+city_2903953,Bom Jesus da Serra,2903953,base.state_br_ba,base.br
+city_2904001,Boninal,2904001,base.state_br_ba,base.br
+city_2904050,Bonito,2904050,base.state_br_ba,base.br
+city_2904100,Boquira,2904100,base.state_br_ba,base.br
+city_2904209,Botuporã,2904209,base.state_br_ba,base.br
+city_2904308,Brejões,2904308,base.state_br_ba,base.br
+city_2904407,Brejolândia,2904407,base.state_br_ba,base.br
+city_2904506,Brotas de Macaúbas,2904506,base.state_br_ba,base.br
+city_2904605,Brumado,2904605,base.state_br_ba,base.br
+city_2904704,Buerarema,2904704,base.state_br_ba,base.br
+city_2904753,Buritirama,2904753,base.state_br_ba,base.br
+city_2904803,Caatiba,2904803,base.state_br_ba,base.br
+city_2904852,Cabaceiras do Paraguaçu,2904852,base.state_br_ba,base.br
+city_2904902,Cachoeira,2904902,base.state_br_ba,base.br
+city_2905008,Caculé,2905008,base.state_br_ba,base.br
+city_2905107,Caém,2905107,base.state_br_ba,base.br
+city_2905156,Caetanos,2905156,base.state_br_ba,base.br
+city_2905206,Caetité,2905206,base.state_br_ba,base.br
+city_2905305,Cafarnaum,2905305,base.state_br_ba,base.br
+city_2905404,Cairu,2905404,base.state_br_ba,base.br
+city_2905503,Caldeirão Grande,2905503,base.state_br_ba,base.br
+city_2905602,Camacan,2905602,base.state_br_ba,base.br
+city_2905701,Camaçari,2905701,base.state_br_ba,base.br
+city_2905800,Camamu,2905800,base.state_br_ba,base.br
+city_2905909,Campo Alegre de Lourdes,2905909,base.state_br_ba,base.br
+city_2906006,Campo Formoso,2906006,base.state_br_ba,base.br
+city_2906105,Canápolis,2906105,base.state_br_ba,base.br
+city_2906204,Canarana,2906204,base.state_br_ba,base.br
+city_2906303,Canavieiras,2906303,base.state_br_ba,base.br
+city_2906402,Candeal,2906402,base.state_br_ba,base.br
+city_2906501,Candeias,2906501,base.state_br_ba,base.br
+city_2906600,Candiba,2906600,base.state_br_ba,base.br
+city_2906709,Cândido Sales,2906709,base.state_br_ba,base.br
+city_2906808,Cansanção,2906808,base.state_br_ba,base.br
+city_2906824,Canudos,2906824,base.state_br_ba,base.br
+city_2906857,Capela do Alto Alegre,2906857,base.state_br_ba,base.br
+city_2906873,Capim Grosso,2906873,base.state_br_ba,base.br
+city_2906899,Caraíbas,2906899,base.state_br_ba,base.br
+city_2906907,Caravelas,2906907,base.state_br_ba,base.br
+city_2907004,Cardeal da Silva,2907004,base.state_br_ba,base.br
+city_2907103,Carinhanha,2907103,base.state_br_ba,base.br
+city_2907202,Casa Nova,2907202,base.state_br_ba,base.br
+city_2907301,Castro Alves,2907301,base.state_br_ba,base.br
+city_2907400,Catolândia,2907400,base.state_br_ba,base.br
+city_2907509,Catu,2907509,base.state_br_ba,base.br
+city_2907558,Caturama,2907558,base.state_br_ba,base.br
+city_2907608,Central,2907608,base.state_br_ba,base.br
+city_2907707,Chorrochó,2907707,base.state_br_ba,base.br
+city_2907806,Cícero Dantas,2907806,base.state_br_ba,base.br
+city_2907905,Cipó,2907905,base.state_br_ba,base.br
+city_2908002,Coaraci,2908002,base.state_br_ba,base.br
+city_2908101,Cocos,2908101,base.state_br_ba,base.br
+city_2908200,Conceição da Feira,2908200,base.state_br_ba,base.br
+city_2908309,Conceição do Almeida,2908309,base.state_br_ba,base.br
+city_2908408,Conceição do Coité,2908408,base.state_br_ba,base.br
+city_2908507,Conceição do Jacuípe,2908507,base.state_br_ba,base.br
+city_2908606,Conde,2908606,base.state_br_ba,base.br
+city_2908705,Condeúba,2908705,base.state_br_ba,base.br
+city_2908804,Contendas do Sincorá,2908804,base.state_br_ba,base.br
+city_2908903,Coração de Maria,2908903,base.state_br_ba,base.br
+city_2909000,Cordeiros,2909000,base.state_br_ba,base.br
+city_2909109,Coribe,2909109,base.state_br_ba,base.br
+city_2909208,Coronel João Sá,2909208,base.state_br_ba,base.br
+city_2909307,Correntina,2909307,base.state_br_ba,base.br
+city_2909406,Cotegipe,2909406,base.state_br_ba,base.br
+city_2909505,Cravolândia,2909505,base.state_br_ba,base.br
+city_2909604,Crisópolis,2909604,base.state_br_ba,base.br
+city_2909703,Cristópolis,2909703,base.state_br_ba,base.br
+city_2909802,Cruz das Almas,2909802,base.state_br_ba,base.br
+city_2909901,Curaçá,2909901,base.state_br_ba,base.br
+city_2910008,Dário Meira,2910008,base.state_br_ba,base.br
+city_2910057,Dias d'Ávila,2910057,base.state_br_ba,base.br
+city_2910107,Dom Basílio,2910107,base.state_br_ba,base.br
+city_2910206,Dom Macedo Costa,2910206,base.state_br_ba,base.br
+city_2910305,Elísio Medrado,2910305,base.state_br_ba,base.br
+city_2910404,Encruzilhada,2910404,base.state_br_ba,base.br
+city_2910503,Entre Rios,2910503,base.state_br_ba,base.br
+city_2900504,Érico Cardoso,2900504,base.state_br_ba,base.br
+city_2910602,Esplanada,2910602,base.state_br_ba,base.br
+city_2910701,Euclides da Cunha,2910701,base.state_br_ba,base.br
+city_2910727,Eunápolis,2910727,base.state_br_ba,base.br
+city_2910750,Fátima,2910750,base.state_br_ba,base.br
+city_2910776,Feira da Mata,2910776,base.state_br_ba,base.br
+city_2910800,Feira de Santana,2910800,base.state_br_ba,base.br
+city_2910859,Filadélfia,2910859,base.state_br_ba,base.br
+city_2910909,Firmino Alves,2910909,base.state_br_ba,base.br
+city_2911006,Floresta Azul,2911006,base.state_br_ba,base.br
+city_2911105,Formosa do Rio Preto,2911105,base.state_br_ba,base.br
+city_2911204,Gandu,2911204,base.state_br_ba,base.br
+city_2911253,Gavião,2911253,base.state_br_ba,base.br
+city_2911303,Gentio do Ouro,2911303,base.state_br_ba,base.br
+city_2911402,Glória,2911402,base.state_br_ba,base.br
+city_2911501,Gongogi,2911501,base.state_br_ba,base.br
+city_2911600,Governador Mangabeira,2911600,base.state_br_ba,base.br
+city_2911659,Guajeru,2911659,base.state_br_ba,base.br
+city_2911709,Guanambi,2911709,base.state_br_ba,base.br
+city_2911808,Guaratinga,2911808,base.state_br_ba,base.br
+city_2911857,Heliópolis,2911857,base.state_br_ba,base.br
+city_2911907,Iaçu,2911907,base.state_br_ba,base.br
+city_2912004,Ibiassucê,2912004,base.state_br_ba,base.br
+city_2912103,Ibicaraí,2912103,base.state_br_ba,base.br
+city_2912202,Ibicoara,2912202,base.state_br_ba,base.br
+city_2912301,Ibicuí,2912301,base.state_br_ba,base.br
+city_2912400,Ibipeba,2912400,base.state_br_ba,base.br
+city_2912509,Ibipitanga,2912509,base.state_br_ba,base.br
+city_2912608,Ibiquera,2912608,base.state_br_ba,base.br
+city_2912707,Ibirapitanga,2912707,base.state_br_ba,base.br
+city_2912806,Ibirapuã,2912806,base.state_br_ba,base.br
+city_2912905,Ibirataia,2912905,base.state_br_ba,base.br
+city_2913002,Ibitiara,2913002,base.state_br_ba,base.br
+city_2913101,Ibititá,2913101,base.state_br_ba,base.br
+city_2913200,Ibotirama,2913200,base.state_br_ba,base.br
+city_2913309,Ichu,2913309,base.state_br_ba,base.br
+city_2913408,Igaporã,2913408,base.state_br_ba,base.br
+city_2913457,Igrapiúna,2913457,base.state_br_ba,base.br
+city_2913507,Iguaí,2913507,base.state_br_ba,base.br
+city_2913606,Ilhéus,2913606,base.state_br_ba,base.br
+city_2913705,Inhambupe,2913705,base.state_br_ba,base.br
+city_2913804,Ipecaetá,2913804,base.state_br_ba,base.br
+city_2913903,Ipiaú,2913903,base.state_br_ba,base.br
+city_2914000,Ipirá,2914000,base.state_br_ba,base.br
+city_2914109,Ipupiara,2914109,base.state_br_ba,base.br
+city_2914208,Irajuba,2914208,base.state_br_ba,base.br
+city_2914307,Iramaia,2914307,base.state_br_ba,base.br
+city_2914406,Iraquara,2914406,base.state_br_ba,base.br
+city_2914505,Irará,2914505,base.state_br_ba,base.br
+city_2914604,Irecê,2914604,base.state_br_ba,base.br
+city_2914653,Itabela,2914653,base.state_br_ba,base.br
+city_2914703,Itaberaba,2914703,base.state_br_ba,base.br
+city_2914802,Itabuna,2914802,base.state_br_ba,base.br
+city_2914901,Itacaré,2914901,base.state_br_ba,base.br
+city_2915007,Itaeté,2915007,base.state_br_ba,base.br
+city_2915106,Itagi,2915106,base.state_br_ba,base.br
+city_2915205,Itagibá,2915205,base.state_br_ba,base.br
+city_2915304,Itagimirim,2915304,base.state_br_ba,base.br
+city_2915353,Itaguaçu da Bahia,2915353,base.state_br_ba,base.br
+city_2915403,Itaju do Colônia,2915403,base.state_br_ba,base.br
+city_2915502,Itajuípe,2915502,base.state_br_ba,base.br
+city_2915601,Itamaraju,2915601,base.state_br_ba,base.br
+city_2915700,Itamari,2915700,base.state_br_ba,base.br
+city_2915809,Itambé,2915809,base.state_br_ba,base.br
+city_2915908,Itanagra,2915908,base.state_br_ba,base.br
+city_2916005,Itanhém,2916005,base.state_br_ba,base.br
+city_2916104,Itaparica,2916104,base.state_br_ba,base.br
+city_2916203,Itapé,2916203,base.state_br_ba,base.br
+city_2916302,Itapebi,2916302,base.state_br_ba,base.br
+city_2916401,Itapetinga,2916401,base.state_br_ba,base.br
+city_2916500,Itapicuru,2916500,base.state_br_ba,base.br
+city_2916609,Itapitanga,2916609,base.state_br_ba,base.br
+city_2916708,Itaquara,2916708,base.state_br_ba,base.br
+city_2916807,Itarantim,2916807,base.state_br_ba,base.br
+city_2916856,Itatim,2916856,base.state_br_ba,base.br
+city_2916906,Itiruçu,2916906,base.state_br_ba,base.br
+city_2917003,Itiúba,2917003,base.state_br_ba,base.br
+city_2917102,Itororó,2917102,base.state_br_ba,base.br
+city_2917201,Ituaçu,2917201,base.state_br_ba,base.br
+city_2917300,Ituberá,2917300,base.state_br_ba,base.br
+city_2917334,Iuiu,2917334,base.state_br_ba,base.br
+city_2917359,Jaborandi,2917359,base.state_br_ba,base.br
+city_2917409,Jacaraci,2917409,base.state_br_ba,base.br
+city_2917508,Jacobina,2917508,base.state_br_ba,base.br
+city_2917607,Jaguaquara,2917607,base.state_br_ba,base.br
+city_2917706,Jaguarari,2917706,base.state_br_ba,base.br
+city_2917805,Jaguaripe,2917805,base.state_br_ba,base.br
+city_2917904,Jandaíra,2917904,base.state_br_ba,base.br
+city_2918001,Jequié,2918001,base.state_br_ba,base.br
+city_2918100,Jeremoabo,2918100,base.state_br_ba,base.br
+city_2918209,Jiquiriçá,2918209,base.state_br_ba,base.br
+city_2918308,Jitaúna,2918308,base.state_br_ba,base.br
+city_2918357,João Dourado,2918357,base.state_br_ba,base.br
+city_2918407,Juazeiro,2918407,base.state_br_ba,base.br
+city_2918456,Jucuruçu,2918456,base.state_br_ba,base.br
+city_2918506,Jussara,2918506,base.state_br_ba,base.br
+city_2918555,Jussari,2918555,base.state_br_ba,base.br
+city_2918605,Jussiape,2918605,base.state_br_ba,base.br
+city_2918704,Lafaiete Coutinho,2918704,base.state_br_ba,base.br
+city_2918753,Lagoa Real,2918753,base.state_br_ba,base.br
+city_2918803,Laje,2918803,base.state_br_ba,base.br
+city_2918902,Lajedão,2918902,base.state_br_ba,base.br
+city_2919009,Lajedinho,2919009,base.state_br_ba,base.br
+city_2919058,Lajedo do Tabocal,2919058,base.state_br_ba,base.br
+city_2919108,Lamarão,2919108,base.state_br_ba,base.br
+city_2919157,Lapão,2919157,base.state_br_ba,base.br
+city_2919207,Lauro de Freitas,2919207,base.state_br_ba,base.br
+city_2919306,Lençóis,2919306,base.state_br_ba,base.br
+city_2919405,Licínio de Almeida,2919405,base.state_br_ba,base.br
+city_2919504,Livramento de Nossa Senhora,2919504,base.state_br_ba,base.br
+city_2919553,Luís Eduardo Magalhães,2919553,base.state_br_ba,base.br
+city_2919603,Macajuba,2919603,base.state_br_ba,base.br
+city_2919702,Macarani,2919702,base.state_br_ba,base.br
+city_2919801,Macaúbas,2919801,base.state_br_ba,base.br
+city_2919900,Macururé,2919900,base.state_br_ba,base.br
+city_2919926,Madre de Deus,2919926,base.state_br_ba,base.br
+city_2919959,Maetinga,2919959,base.state_br_ba,base.br
+city_2920007,Maiquinique,2920007,base.state_br_ba,base.br
+city_2920106,Mairi,2920106,base.state_br_ba,base.br
+city_2920205,Malhada,2920205,base.state_br_ba,base.br
+city_2920304,Malhada de Pedras,2920304,base.state_br_ba,base.br
+city_2920403,Manoel Vitorino,2920403,base.state_br_ba,base.br
+city_2920452,Mansidão,2920452,base.state_br_ba,base.br
+city_2920502,Maracás,2920502,base.state_br_ba,base.br
+city_2920601,Maragogipe,2920601,base.state_br_ba,base.br
+city_2920700,Maraú,2920700,base.state_br_ba,base.br
+city_2920809,Marcionílio Souza,2920809,base.state_br_ba,base.br
+city_2920908,Mascote,2920908,base.state_br_ba,base.br
+city_2921005,Mata de São João,2921005,base.state_br_ba,base.br
+city_2921054,Matina,2921054,base.state_br_ba,base.br
+city_2921104,Medeiros Neto,2921104,base.state_br_ba,base.br
+city_2921203,Miguel Calmon,2921203,base.state_br_ba,base.br
+city_2921302,Milagres,2921302,base.state_br_ba,base.br
+city_2921401,Mirangaba,2921401,base.state_br_ba,base.br
+city_2921450,Mirante,2921450,base.state_br_ba,base.br
+city_2921500,Monte Santo,2921500,base.state_br_ba,base.br
+city_2921609,Morpará,2921609,base.state_br_ba,base.br
+city_2921708,Morro do Chapéu,2921708,base.state_br_ba,base.br
+city_2921807,Mortugaba,2921807,base.state_br_ba,base.br
+city_2921906,Mucugê,2921906,base.state_br_ba,base.br
+city_2922003,Mucuri,2922003,base.state_br_ba,base.br
+city_2922052,Mulungu do Morro,2922052,base.state_br_ba,base.br
+city_2922102,Mundo Novo,2922102,base.state_br_ba,base.br
+city_2922201,Muniz Ferreira,2922201,base.state_br_ba,base.br
+city_2922250,Muquém do São Francisco,2922250,base.state_br_ba,base.br
+city_2922300,Muritiba,2922300,base.state_br_ba,base.br
+city_2922409,Mutuípe,2922409,base.state_br_ba,base.br
+city_2922508,Nazaré,2922508,base.state_br_ba,base.br
+city_2922607,Nilo Peçanha,2922607,base.state_br_ba,base.br
+city_2922656,Nordestina,2922656,base.state_br_ba,base.br
+city_2922706,Nova Canaã,2922706,base.state_br_ba,base.br
+city_2922730,Nova Fátima,2922730,base.state_br_ba,base.br
+city_2922755,Nova Ibiá,2922755,base.state_br_ba,base.br
+city_2922805,Nova Itarana,2922805,base.state_br_ba,base.br
+city_2922854,Nova Redenção,2922854,base.state_br_ba,base.br
+city_2922904,Nova Soure,2922904,base.state_br_ba,base.br
+city_2923001,Nova Viçosa,2923001,base.state_br_ba,base.br
+city_2923035,Novo Horizonte,2923035,base.state_br_ba,base.br
+city_2923050,Novo Triunfo,2923050,base.state_br_ba,base.br
+city_2923100,Olindina,2923100,base.state_br_ba,base.br
+city_2923209,Oliveira dos Brejinhos,2923209,base.state_br_ba,base.br
+city_2923308,Ouriçangas,2923308,base.state_br_ba,base.br
+city_2923357,Ourolândia,2923357,base.state_br_ba,base.br
+city_2923407,Palmas de Monte Alto,2923407,base.state_br_ba,base.br
+city_2923506,Palmeiras,2923506,base.state_br_ba,base.br
+city_2923605,Paramirim,2923605,base.state_br_ba,base.br
+city_2923704,Paratinga,2923704,base.state_br_ba,base.br
+city_2923803,Paripiranga,2923803,base.state_br_ba,base.br
+city_2923902,Pau Brasil,2923902,base.state_br_ba,base.br
+city_2924009,Paulo Afonso,2924009,base.state_br_ba,base.br
+city_2924058,Pé de Serra,2924058,base.state_br_ba,base.br
+city_2924108,Pedrão,2924108,base.state_br_ba,base.br
+city_2924207,Pedro Alexandre,2924207,base.state_br_ba,base.br
+city_2924306,Piatã,2924306,base.state_br_ba,base.br
+city_2924405,Pilão Arcado,2924405,base.state_br_ba,base.br
+city_2924504,Pindaí,2924504,base.state_br_ba,base.br
+city_2924603,Pindobaçu,2924603,base.state_br_ba,base.br
+city_2924652,Pintadas,2924652,base.state_br_ba,base.br
+city_2924678,Piraí do Norte,2924678,base.state_br_ba,base.br
+city_2924702,Piripá,2924702,base.state_br_ba,base.br
+city_2924801,Piritiba,2924801,base.state_br_ba,base.br
+city_2924900,Planaltino,2924900,base.state_br_ba,base.br
+city_2925006,Planalto,2925006,base.state_br_ba,base.br
+city_2925105,Poções,2925105,base.state_br_ba,base.br
+city_2925204,Pojuca,2925204,base.state_br_ba,base.br
+city_2925253,Ponto Novo,2925253,base.state_br_ba,base.br
+city_2925303,Porto Seguro,2925303,base.state_br_ba,base.br
+city_2925402,Potiraguá,2925402,base.state_br_ba,base.br
+city_2925501,Prado,2925501,base.state_br_ba,base.br
+city_2925600,Presidente Dutra,2925600,base.state_br_ba,base.br
+city_2925709,Presidente Jânio Quadros,2925709,base.state_br_ba,base.br
+city_2925758,Presidente Tancredo Neves,2925758,base.state_br_ba,base.br
+city_2925808,Queimadas,2925808,base.state_br_ba,base.br
+city_2925907,Quijingue,2925907,base.state_br_ba,base.br
+city_2925931,Quixabeira,2925931,base.state_br_ba,base.br
+city_2925956,Rafael Jambeiro,2925956,base.state_br_ba,base.br
+city_2926004,Remanso,2926004,base.state_br_ba,base.br
+city_2926103,Retirolândia,2926103,base.state_br_ba,base.br
+city_2926202,Riachão das Neves,2926202,base.state_br_ba,base.br
+city_2926301,Riachão do Jacuípe,2926301,base.state_br_ba,base.br
+city_2926400,Riacho de Santana,2926400,base.state_br_ba,base.br
+city_2926509,Ribeira do Amparo,2926509,base.state_br_ba,base.br
+city_2926608,Ribeira do Pombal,2926608,base.state_br_ba,base.br
+city_2926657,Ribeirão do Largo,2926657,base.state_br_ba,base.br
+city_2926707,Rio de Contas,2926707,base.state_br_ba,base.br
+city_2926806,Rio do Antônio,2926806,base.state_br_ba,base.br
+city_2926905,Rio do Pires,2926905,base.state_br_ba,base.br
+city_2927002,Rio Real,2927002,base.state_br_ba,base.br
+city_2927101,Rodelas,2927101,base.state_br_ba,base.br
+city_2927200,Ruy Barbosa,2927200,base.state_br_ba,base.br
+city_2927309,Salinas da Margarida,2927309,base.state_br_ba,base.br
+city_2927408,Salvador,2927408,base.state_br_ba,base.br
+city_2927507,Santa Bárbara,2927507,base.state_br_ba,base.br
+city_2927606,Santa Brígida,2927606,base.state_br_ba,base.br
+city_2927705,Santa Cruz Cabrália,2927705,base.state_br_ba,base.br
+city_2927804,Santa Cruz da Vitória,2927804,base.state_br_ba,base.br
+city_2927903,Santa Inês,2927903,base.state_br_ba,base.br
+city_2928059,Santa Luzia,2928059,base.state_br_ba,base.br
+city_2928109,Santa Maria da Vitória,2928109,base.state_br_ba,base.br
+city_2928406,Santa Rita de Cássia,2928406,base.state_br_ba,base.br
+city_2928505,Santa Terezinha,2928505,base.state_br_ba,base.br
+city_2928000,Santaluz,2928000,base.state_br_ba,base.br
+city_2928208,Santana,2928208,base.state_br_ba,base.br
+city_2928307,Santanópolis,2928307,base.state_br_ba,base.br
+city_2928604,Santo Amaro,2928604,base.state_br_ba,base.br
+city_2928703,Santo Antônio de Jesus,2928703,base.state_br_ba,base.br
+city_2928802,Santo Estêvão,2928802,base.state_br_ba,base.br
+city_2928901,São Desidério,2928901,base.state_br_ba,base.br
+city_2928950,São Domingos,2928950,base.state_br_ba,base.br
+city_2929107,São Felipe,2929107,base.state_br_ba,base.br
+city_2929008,São Félix,2929008,base.state_br_ba,base.br
+city_2929057,São Félix do Coribe,2929057,base.state_br_ba,base.br
+city_2929206,São Francisco do Conde,2929206,base.state_br_ba,base.br
+city_2929255,São Gabriel,2929255,base.state_br_ba,base.br
+city_2929305,São Gonçalo dos Campos,2929305,base.state_br_ba,base.br
+city_2929354,São José da Vitória,2929354,base.state_br_ba,base.br
+city_2929370,São José do Jacuípe,2929370,base.state_br_ba,base.br
+city_2929404,São Miguel das Matas,2929404,base.state_br_ba,base.br
+city_2929503,São Sebastião do Passé,2929503,base.state_br_ba,base.br
+city_2929602,Sapeaçu,2929602,base.state_br_ba,base.br
+city_2929701,Sátiro Dias,2929701,base.state_br_ba,base.br
+city_2929750,Saubara,2929750,base.state_br_ba,base.br
+city_2929800,Saúde,2929800,base.state_br_ba,base.br
+city_2929909,Seabra,2929909,base.state_br_ba,base.br
+city_2930006,Sebastião Laranjeiras,2930006,base.state_br_ba,base.br
+city_2930105,Senhor do Bonfim,2930105,base.state_br_ba,base.br
+city_2930204,Sento Sé,2930204,base.state_br_ba,base.br
+city_2930154,Serra do Ramalho,2930154,base.state_br_ba,base.br
+city_2930303,Serra Dourada,2930303,base.state_br_ba,base.br
+city_2930402,Serra Preta,2930402,base.state_br_ba,base.br
+city_2930501,Serrinha,2930501,base.state_br_ba,base.br
+city_2930600,Serrolândia,2930600,base.state_br_ba,base.br
+city_2930709,Simões Filho,2930709,base.state_br_ba,base.br
+city_2930758,Sítio do Mato,2930758,base.state_br_ba,base.br
+city_2930766,Sítio do Quinto,2930766,base.state_br_ba,base.br
+city_2930774,Sobradinho,2930774,base.state_br_ba,base.br
+city_2930808,Souto Soares,2930808,base.state_br_ba,base.br
+city_2930907,Tabocas do Brejo Velho,2930907,base.state_br_ba,base.br
+city_2931004,Tanhaçu,2931004,base.state_br_ba,base.br
+city_2931053,Tanque Novo,2931053,base.state_br_ba,base.br
+city_2931103,Tanquinho,2931103,base.state_br_ba,base.br
+city_2931202,Taperoá,2931202,base.state_br_ba,base.br
+city_2931301,Tapiramutá,2931301,base.state_br_ba,base.br
+city_2931350,Teixeira de Freitas,2931350,base.state_br_ba,base.br
+city_2931400,Teodoro Sampaio,2931400,base.state_br_ba,base.br
+city_2931509,Teofilândia,2931509,base.state_br_ba,base.br
+city_2931608,Teolândia,2931608,base.state_br_ba,base.br
+city_2931707,Terra Nova,2931707,base.state_br_ba,base.br
+city_2931806,Tremedal,2931806,base.state_br_ba,base.br
+city_2931905,Tucano,2931905,base.state_br_ba,base.br
+city_2932002,Uauá,2932002,base.state_br_ba,base.br
+city_2932101,Ubaíra,2932101,base.state_br_ba,base.br
+city_2932200,Ubaitaba,2932200,base.state_br_ba,base.br
+city_2932309,Ubatã,2932309,base.state_br_ba,base.br
+city_2932408,Uibaí,2932408,base.state_br_ba,base.br
+city_2932457,Umburanas,2932457,base.state_br_ba,base.br
+city_2932507,Una,2932507,base.state_br_ba,base.br
+city_2932606,Urandi,2932606,base.state_br_ba,base.br
+city_2932705,Uruçuca,2932705,base.state_br_ba,base.br
+city_2932804,Utinga,2932804,base.state_br_ba,base.br
+city_2932903,Valença,2932903,base.state_br_ba,base.br
+city_2933000,Valente,2933000,base.state_br_ba,base.br
+city_2933059,Várzea da Roça,2933059,base.state_br_ba,base.br
+city_2933109,Várzea do Poço,2933109,base.state_br_ba,base.br
+city_2933158,Várzea Nova,2933158,base.state_br_ba,base.br
+city_2933174,Varzedo,2933174,base.state_br_ba,base.br
+city_2933208,Vera Cruz,2933208,base.state_br_ba,base.br
+city_2933257,Vereda,2933257,base.state_br_ba,base.br
+city_2933307,Vitória da Conquista,2933307,base.state_br_ba,base.br
+city_2933406,Wagner,2933406,base.state_br_ba,base.br
+city_2933455,Wanderley,2933455,base.state_br_ba,base.br
+city_2933505,Wenceslau Guimarães,2933505,base.state_br_ba,base.br
+city_2933604,Xique-Xique,2933604,base.state_br_ba,base.br
+city_3100104,Abadia dos Dourados,3100104,base.state_br_mg,base.br
+city_3100203,Abaeté,3100203,base.state_br_mg,base.br
+city_3100302,Abre Campo,3100302,base.state_br_mg,base.br
+city_3100401,Acaiaca,3100401,base.state_br_mg,base.br
+city_3100500,Açucena,3100500,base.state_br_mg,base.br
+city_3100609,Água Boa,3100609,base.state_br_mg,base.br
+city_3100708,Água Comprida,3100708,base.state_br_mg,base.br
+city_3100807,Aguanil,3100807,base.state_br_mg,base.br
+city_3100906,Águas Formosas,3100906,base.state_br_mg,base.br
+city_3101003,Águas Vermelhas,3101003,base.state_br_mg,base.br
+city_3101102,Aimorés,3101102,base.state_br_mg,base.br
+city_3101201,Aiuruoca,3101201,base.state_br_mg,base.br
+city_3101300,Alagoa,3101300,base.state_br_mg,base.br
+city_3101409,Albertina,3101409,base.state_br_mg,base.br
+city_3101508,Além Paraíba,3101508,base.state_br_mg,base.br
+city_3101607,Alfenas,3101607,base.state_br_mg,base.br
+city_3101631,Alfredo Vasconcelos,3101631,base.state_br_mg,base.br
+city_3101706,Almenara,3101706,base.state_br_mg,base.br
+city_3101805,Alpercata,3101805,base.state_br_mg,base.br
+city_3101904,Alpinópolis,3101904,base.state_br_mg,base.br
+city_3102001,Alterosa,3102001,base.state_br_mg,base.br
+city_3102050,Alto Caparaó,3102050,base.state_br_mg,base.br
+city_3153509,Alto Jequitibá,3153509,base.state_br_mg,base.br
+city_3102100,Alto Rio Doce,3102100,base.state_br_mg,base.br
+city_3102209,Alvarenga,3102209,base.state_br_mg,base.br
+city_3102308,Alvinópolis,3102308,base.state_br_mg,base.br
+city_3102407,Alvorada de Minas,3102407,base.state_br_mg,base.br
+city_3102506,Amparo do Serra,3102506,base.state_br_mg,base.br
+city_3102605,Andradas,3102605,base.state_br_mg,base.br
+city_3102803,Andrelândia,3102803,base.state_br_mg,base.br
+city_3102852,Angelândia,3102852,base.state_br_mg,base.br
+city_3102902,Antônio Carlos,3102902,base.state_br_mg,base.br
+city_3103009,Antônio Dias,3103009,base.state_br_mg,base.br
+city_3103108,Antônio Prado de Minas,3103108,base.state_br_mg,base.br
+city_3103207,Araçaí,3103207,base.state_br_mg,base.br
+city_3103306,Aracitaba,3103306,base.state_br_mg,base.br
+city_3103405,Araçuaí,3103405,base.state_br_mg,base.br
+city_3103504,Araguari,3103504,base.state_br_mg,base.br
+city_3103603,Arantina,3103603,base.state_br_mg,base.br
+city_3103702,Araponga,3103702,base.state_br_mg,base.br
+city_3103751,Araporã,3103751,base.state_br_mg,base.br
+city_3103801,Arapuá,3103801,base.state_br_mg,base.br
+city_3103900,Araújos,3103900,base.state_br_mg,base.br
+city_3104007,Araxá,3104007,base.state_br_mg,base.br
+city_3104106,Arceburgo,3104106,base.state_br_mg,base.br
+city_3104205,Arcos,3104205,base.state_br_mg,base.br
+city_3104304,Areado,3104304,base.state_br_mg,base.br
+city_3104403,Argirita,3104403,base.state_br_mg,base.br
+city_3104452,Aricanduva,3104452,base.state_br_mg,base.br
+city_3104502,Arinos,3104502,base.state_br_mg,base.br
+city_3104601,Astolfo Dutra,3104601,base.state_br_mg,base.br
+city_3104700,Ataléia,3104700,base.state_br_mg,base.br
+city_3104809,Augusto de Lima,3104809,base.state_br_mg,base.br
+city_3104908,Baependi,3104908,base.state_br_mg,base.br
+city_3105004,Baldim,3105004,base.state_br_mg,base.br
+city_3105103,Bambuí,3105103,base.state_br_mg,base.br
+city_3105202,Bandeira,3105202,base.state_br_mg,base.br
+city_3105301,Bandeira do Sul,3105301,base.state_br_mg,base.br
+city_3105400,Barão de Cocais,3105400,base.state_br_mg,base.br
+city_3105509,Barão de Monte Alto,3105509,base.state_br_mg,base.br
+city_3105608,Barbacena,3105608,base.state_br_mg,base.br
+city_3105707,Barra Longa,3105707,base.state_br_mg,base.br
+city_3105905,Barroso,3105905,base.state_br_mg,base.br
+city_3106002,Bela Vista de Minas,3106002,base.state_br_mg,base.br
+city_3106101,Belmiro Braga,3106101,base.state_br_mg,base.br
+city_3106200,Belo Horizonte,3106200,base.state_br_mg,base.br
+city_3106309,Belo Oriente,3106309,base.state_br_mg,base.br
+city_3106408,Belo Vale,3106408,base.state_br_mg,base.br
+city_3106507,Berilo,3106507,base.state_br_mg,base.br
+city_3106655,Berizal,3106655,base.state_br_mg,base.br
+city_3106606,Bertópolis,3106606,base.state_br_mg,base.br
+city_3106705,Betim,3106705,base.state_br_mg,base.br
+city_3106804,Bias Fortes,3106804,base.state_br_mg,base.br
+city_3106903,Bicas,3106903,base.state_br_mg,base.br
+city_3107000,Biquinhas,3107000,base.state_br_mg,base.br
+city_3107109,Boa Esperança,3107109,base.state_br_mg,base.br
+city_3107208,Bocaina de Minas,3107208,base.state_br_mg,base.br
+city_3107307,Bocaiúva,3107307,base.state_br_mg,base.br
+city_3107406,Bom Despacho,3107406,base.state_br_mg,base.br
+city_3107505,Bom Jardim de Minas,3107505,base.state_br_mg,base.br
+city_3107604,Bom Jesus da Penha,3107604,base.state_br_mg,base.br
+city_3107703,Bom Jesus do Amparo,3107703,base.state_br_mg,base.br
+city_3107802,Bom Jesus do Galho,3107802,base.state_br_mg,base.br
+city_3107901,Bom Repouso,3107901,base.state_br_mg,base.br
+city_3108008,Bom Sucesso,3108008,base.state_br_mg,base.br
+city_3108107,Bonfim,3108107,base.state_br_mg,base.br
+city_3108206,Bonfinópolis de Minas,3108206,base.state_br_mg,base.br
+city_3108255,Bonito de Minas,3108255,base.state_br_mg,base.br
+city_3108305,Borda da Mata,3108305,base.state_br_mg,base.br
+city_3108404,Botelhos,3108404,base.state_br_mg,base.br
+city_3108503,Botumirim,3108503,base.state_br_mg,base.br
+city_3108701,Brás Pires,3108701,base.state_br_mg,base.br
+city_3108552,Brasilândia de Minas,3108552,base.state_br_mg,base.br
+city_3108602,Brasília de Minas,3108602,base.state_br_mg,base.br
+city_3108800,Braúnas,3108800,base.state_br_mg,base.br
+city_3108909,Brazópolis,3108909,base.state_br_mg,base.br
+city_3109006,Brumadinho,3109006,base.state_br_mg,base.br
+city_3109105,Bueno Brandão,3109105,base.state_br_mg,base.br
+city_3109204,Buenópolis,3109204,base.state_br_mg,base.br
+city_3109253,Bugre,3109253,base.state_br_mg,base.br
+city_3109303,Buritis,3109303,base.state_br_mg,base.br
+city_3109402,Buritizeiro,3109402,base.state_br_mg,base.br
+city_3109451,Cabeceira Grande,3109451,base.state_br_mg,base.br
+city_3109501,Cabo Verde,3109501,base.state_br_mg,base.br
+city_3109600,Cachoeira da Prata,3109600,base.state_br_mg,base.br
+city_3109709,Cachoeira de Minas,3109709,base.state_br_mg,base.br
+city_3102704,Cachoeira de Pajeú,3102704,base.state_br_mg,base.br
+city_3109808,Cachoeira Dourada,3109808,base.state_br_mg,base.br
+city_3109907,Caetanópolis,3109907,base.state_br_mg,base.br
+city_3110004,Caeté,3110004,base.state_br_mg,base.br
+city_3110103,Caiana,3110103,base.state_br_mg,base.br
+city_3110202,Cajuri,3110202,base.state_br_mg,base.br
+city_3110301,Caldas,3110301,base.state_br_mg,base.br
+city_3110400,Camacho,3110400,base.state_br_mg,base.br
+city_3110509,Camanducaia,3110509,base.state_br_mg,base.br
+city_3110608,Cambuí,3110608,base.state_br_mg,base.br
+city_3110707,Cambuquira,3110707,base.state_br_mg,base.br
+city_3110806,Campanário,3110806,base.state_br_mg,base.br
+city_3110905,Campanha,3110905,base.state_br_mg,base.br
+city_3111002,Campestre,3111002,base.state_br_mg,base.br
+city_3111101,Campina Verde,3111101,base.state_br_mg,base.br
+city_3111150,Campo Azul,3111150,base.state_br_mg,base.br
+city_3111200,Campo Belo,3111200,base.state_br_mg,base.br
+city_3111309,Campo do Meio,3111309,base.state_br_mg,base.br
+city_3111408,Campo Florido,3111408,base.state_br_mg,base.br
+city_3111507,Campos Altos,3111507,base.state_br_mg,base.br
+city_3111606,Campos Gerais,3111606,base.state_br_mg,base.br
+city_3111903,Cana Verde,3111903,base.state_br_mg,base.br
+city_3111705,Canaã,3111705,base.state_br_mg,base.br
+city_3111804,Canápolis,3111804,base.state_br_mg,base.br
+city_3112000,Candeias,3112000,base.state_br_mg,base.br
+city_3112059,Cantagalo,3112059,base.state_br_mg,base.br
+city_3112109,Caparaó,3112109,base.state_br_mg,base.br
+city_3112208,Capela Nova,3112208,base.state_br_mg,base.br
+city_3112307,Capelinha,3112307,base.state_br_mg,base.br
+city_3112406,Capetinga,3112406,base.state_br_mg,base.br
+city_3112505,Capim Branco,3112505,base.state_br_mg,base.br
+city_3112604,Capinópolis,3112604,base.state_br_mg,base.br
+city_3112653,Capitão Andrade,3112653,base.state_br_mg,base.br
+city_3112703,Capitão Enéas,3112703,base.state_br_mg,base.br
+city_3112802,Capitólio,3112802,base.state_br_mg,base.br
+city_3112901,Caputira,3112901,base.state_br_mg,base.br
+city_3113008,Caraí,3113008,base.state_br_mg,base.br
+city_3113107,Caranaíba,3113107,base.state_br_mg,base.br
+city_3113206,Carandaí,3113206,base.state_br_mg,base.br
+city_3113305,Carangola,3113305,base.state_br_mg,base.br
+city_3113404,Caratinga,3113404,base.state_br_mg,base.br
+city_3113503,Carbonita,3113503,base.state_br_mg,base.br
+city_3113602,Careaçu,3113602,base.state_br_mg,base.br
+city_3113701,Carlos Chagas,3113701,base.state_br_mg,base.br
+city_3113800,Carmésia,3113800,base.state_br_mg,base.br
+city_3113909,Carmo da Cachoeira,3113909,base.state_br_mg,base.br
+city_3114006,Carmo da Mata,3114006,base.state_br_mg,base.br
+city_3114105,Carmo de Minas,3114105,base.state_br_mg,base.br
+city_3114204,Carmo do Cajuru,3114204,base.state_br_mg,base.br
+city_3114303,Carmo do Paranaíba,3114303,base.state_br_mg,base.br
+city_3114402,Carmo do Rio Claro,3114402,base.state_br_mg,base.br
+city_3114501,Carmópolis de Minas,3114501,base.state_br_mg,base.br
+city_3114550,Carneirinho,3114550,base.state_br_mg,base.br
+city_3114600,Carrancas,3114600,base.state_br_mg,base.br
+city_3114709,Carvalhópolis,3114709,base.state_br_mg,base.br
+city_3114808,Carvalhos,3114808,base.state_br_mg,base.br
+city_3114907,Casa Grande,3114907,base.state_br_mg,base.br
+city_3115003,Cascalho Rico,3115003,base.state_br_mg,base.br
+city_3115102,Cássia,3115102,base.state_br_mg,base.br
+city_3115300,Cataguases,3115300,base.state_br_mg,base.br
+city_3115359,Catas Altas,3115359,base.state_br_mg,base.br
+city_3115409,Catas Altas da Noruega,3115409,base.state_br_mg,base.br
+city_3115458,Catuji,3115458,base.state_br_mg,base.br
+city_3115474,Catuti,3115474,base.state_br_mg,base.br
+city_3115508,Caxambu,3115508,base.state_br_mg,base.br
+city_3115607,Cedro do Abaeté,3115607,base.state_br_mg,base.br
+city_3115706,Central de Minas,3115706,base.state_br_mg,base.br
+city_3115805,Centralina,3115805,base.state_br_mg,base.br
+city_3115904,Chácara,3115904,base.state_br_mg,base.br
+city_3116001,Chalé,3116001,base.state_br_mg,base.br
+city_3116100,Chapada do Norte,3116100,base.state_br_mg,base.br
+city_3116159,Chapada Gaúcha,3116159,base.state_br_mg,base.br
+city_3116209,Chiador,3116209,base.state_br_mg,base.br
+city_3116308,Cipotânea,3116308,base.state_br_mg,base.br
+city_3116407,Claraval,3116407,base.state_br_mg,base.br
+city_3116506,Claro dos Poções,3116506,base.state_br_mg,base.br
+city_3116605,Cláudio,3116605,base.state_br_mg,base.br
+city_3116704,Coimbra,3116704,base.state_br_mg,base.br
+city_3116803,Coluna,3116803,base.state_br_mg,base.br
+city_3116902,Comendador Gomes,3116902,base.state_br_mg,base.br
+city_3117009,Comercinho,3117009,base.state_br_mg,base.br
+city_3117108,Conceição da Aparecida,3117108,base.state_br_mg,base.br
+city_3115201,Conceição da Barra de Minas,3115201,base.state_br_mg,base.br
+city_3117306,Conceição das Alagoas,3117306,base.state_br_mg,base.br
+city_3117207,Conceição das Pedras,3117207,base.state_br_mg,base.br
+city_3117405,Conceição de Ipanema,3117405,base.state_br_mg,base.br
+city_3117504,Conceição do Mato Dentro,3117504,base.state_br_mg,base.br
+city_3117603,Conceição do Pará,3117603,base.state_br_mg,base.br
+city_3117702,Conceição do Rio Verde,3117702,base.state_br_mg,base.br
+city_3117801,Conceição dos Ouros,3117801,base.state_br_mg,base.br
+city_3117836,Cônego Marinho,3117836,base.state_br_mg,base.br
+city_3117876,Confins,3117876,base.state_br_mg,base.br
+city_3117900,Congonhal,3117900,base.state_br_mg,base.br
+city_3118007,Congonhas,3118007,base.state_br_mg,base.br
+city_3118106,Congonhas do Norte,3118106,base.state_br_mg,base.br
+city_3118205,Conquista,3118205,base.state_br_mg,base.br
+city_3118304,Conselheiro Lafaiete,3118304,base.state_br_mg,base.br
+city_3118403,Conselheiro Pena,3118403,base.state_br_mg,base.br
+city_3118502,Consolação,3118502,base.state_br_mg,base.br
+city_3118601,Contagem,3118601,base.state_br_mg,base.br
+city_3118700,Coqueiral,3118700,base.state_br_mg,base.br
+city_3118809,Coração de Jesus,3118809,base.state_br_mg,base.br
+city_3118908,Cordisburgo,3118908,base.state_br_mg,base.br
+city_3119005,Cordislândia,3119005,base.state_br_mg,base.br
+city_3119104,Corinto,3119104,base.state_br_mg,base.br
+city_3119203,Coroaci,3119203,base.state_br_mg,base.br
+city_3119302,Coromandel,3119302,base.state_br_mg,base.br
+city_3119401,Coronel Fabriciano,3119401,base.state_br_mg,base.br
+city_3119500,Coronel Murta,3119500,base.state_br_mg,base.br
+city_3119609,Coronel Pacheco,3119609,base.state_br_mg,base.br
+city_3119708,Coronel Xavier Chaves,3119708,base.state_br_mg,base.br
+city_3119807,Córrego Danta,3119807,base.state_br_mg,base.br
+city_3119906,Córrego do Bom Jesus,3119906,base.state_br_mg,base.br
+city_3119955,Córrego Fundo,3119955,base.state_br_mg,base.br
+city_3120003,Córrego Novo,3120003,base.state_br_mg,base.br
+city_3120102,Couto de Magalhães de Minas,3120102,base.state_br_mg,base.br
+city_3120151,Crisólita,3120151,base.state_br_mg,base.br
+city_3120201,Cristais,3120201,base.state_br_mg,base.br
+city_3120300,Cristália,3120300,base.state_br_mg,base.br
+city_3120409,Cristiano Otoni,3120409,base.state_br_mg,base.br
+city_3120508,Cristina,3120508,base.state_br_mg,base.br
+city_3120607,Crucilândia,3120607,base.state_br_mg,base.br
+city_3120706,Cruzeiro da Fortaleza,3120706,base.state_br_mg,base.br
+city_3120805,Cruzília,3120805,base.state_br_mg,base.br
+city_3120839,Cuparaque,3120839,base.state_br_mg,base.br
+city_3120870,Curral de Dentro,3120870,base.state_br_mg,base.br
+city_3120904,Curvelo,3120904,base.state_br_mg,base.br
+city_3121001,Datas,3121001,base.state_br_mg,base.br
+city_3121100,Delfim Moreira,3121100,base.state_br_mg,base.br
+city_3121209,Delfinópolis,3121209,base.state_br_mg,base.br
+city_3121258,Delta,3121258,base.state_br_mg,base.br
+city_3121308,Descoberto,3121308,base.state_br_mg,base.br
+city_3121407,Desterro de Entre Rios,3121407,base.state_br_mg,base.br
+city_3121506,Desterro do Melo,3121506,base.state_br_mg,base.br
+city_3121605,Diamantina,3121605,base.state_br_mg,base.br
+city_3121704,Diogo de Vasconcelos,3121704,base.state_br_mg,base.br
+city_3121803,Dionísio,3121803,base.state_br_mg,base.br
+city_3121902,Divinésia,3121902,base.state_br_mg,base.br
+city_3122009,Divino,3122009,base.state_br_mg,base.br
+city_3122108,Divino das Laranjeiras,3122108,base.state_br_mg,base.br
+city_3122207,Divinolândia de Minas,3122207,base.state_br_mg,base.br
+city_3122306,Divinópolis,3122306,base.state_br_mg,base.br
+city_3122355,Divisa Alegre,3122355,base.state_br_mg,base.br
+city_3122405,Divisa Nova,3122405,base.state_br_mg,base.br
+city_3122454,Divisópolis,3122454,base.state_br_mg,base.br
+city_3122470,Dom Bosco,3122470,base.state_br_mg,base.br
+city_3122504,Dom Cavati,3122504,base.state_br_mg,base.br
+city_3122603,Dom Joaquim,3122603,base.state_br_mg,base.br
+city_3122702,Dom Silvério,3122702,base.state_br_mg,base.br
+city_3122801,Dom Viçoso,3122801,base.state_br_mg,base.br
+city_3122900,Dona Euzébia,3122900,base.state_br_mg,base.br
+city_3123007,Dores de Campos,3123007,base.state_br_mg,base.br
+city_3123106,Dores de Guanhães,3123106,base.state_br_mg,base.br
+city_3123205,Dores do Indaiá,3123205,base.state_br_mg,base.br
+city_3123304,Dores do Turvo,3123304,base.state_br_mg,base.br
+city_3123403,Doresópolis,3123403,base.state_br_mg,base.br
+city_3123502,Douradoquara,3123502,base.state_br_mg,base.br
+city_3123528,Durandé,3123528,base.state_br_mg,base.br
+city_3123601,Elói Mendes,3123601,base.state_br_mg,base.br
+city_3123700,Engenheiro Caldas,3123700,base.state_br_mg,base.br
+city_3123809,Engenheiro Navarro,3123809,base.state_br_mg,base.br
+city_3123858,Entre Folhas,3123858,base.state_br_mg,base.br
+city_3123908,Entre Rios de Minas,3123908,base.state_br_mg,base.br
+city_3124005,Ervália,3124005,base.state_br_mg,base.br
+city_3124104,Esmeraldas,3124104,base.state_br_mg,base.br
+city_3124203,Espera Feliz,3124203,base.state_br_mg,base.br
+city_3124302,Espinosa,3124302,base.state_br_mg,base.br
+city_3124401,Espírito Santo do Dourado,3124401,base.state_br_mg,base.br
+city_3124500,Estiva,3124500,base.state_br_mg,base.br
+city_3124609,Estrela Dalva,3124609,base.state_br_mg,base.br
+city_3124708,Estrela do Indaiá,3124708,base.state_br_mg,base.br
+city_3124807,Estrela do Sul,3124807,base.state_br_mg,base.br
+city_3124906,Eugenópolis,3124906,base.state_br_mg,base.br
+city_3125002,Ewbank da Câmara,3125002,base.state_br_mg,base.br
+city_3125101,Extrema,3125101,base.state_br_mg,base.br
+city_3125200,Fama,3125200,base.state_br_mg,base.br
+city_3125309,Faria Lemos,3125309,base.state_br_mg,base.br
+city_3125408,Felício dos Santos,3125408,base.state_br_mg,base.br
+city_3125606,Felisburgo,3125606,base.state_br_mg,base.br
+city_3125705,Felixlândia,3125705,base.state_br_mg,base.br
+city_3125804,Fernandes Tourinho,3125804,base.state_br_mg,base.br
+city_3125903,Ferros,3125903,base.state_br_mg,base.br
+city_3125952,Fervedouro,3125952,base.state_br_mg,base.br
+city_3126000,Florestal,3126000,base.state_br_mg,base.br
+city_3126109,Formiga,3126109,base.state_br_mg,base.br
+city_3126208,Formoso,3126208,base.state_br_mg,base.br
+city_3126307,Fortaleza de Minas,3126307,base.state_br_mg,base.br
+city_3126406,Fortuna de Minas,3126406,base.state_br_mg,base.br
+city_3126505,Francisco Badaró,3126505,base.state_br_mg,base.br
+city_3126604,Francisco Dumont,3126604,base.state_br_mg,base.br
+city_3126703,Francisco Sá,3126703,base.state_br_mg,base.br
+city_3126752,Franciscópolis,3126752,base.state_br_mg,base.br
+city_3126802,Frei Gaspar,3126802,base.state_br_mg,base.br
+city_3126901,Frei Inocêncio,3126901,base.state_br_mg,base.br
+city_3126950,Frei Lagonegro,3126950,base.state_br_mg,base.br
+city_3127008,Fronteira,3127008,base.state_br_mg,base.br
+city_3127057,Fronteira dos Vales,3127057,base.state_br_mg,base.br
+city_3127073,Fruta de Leite,3127073,base.state_br_mg,base.br
+city_3127107,Frutal,3127107,base.state_br_mg,base.br
+city_3127206,Funilândia,3127206,base.state_br_mg,base.br
+city_3127305,Galiléia,3127305,base.state_br_mg,base.br
+city_3127339,Gameleiras,3127339,base.state_br_mg,base.br
+city_3127354,Glaucilândia,3127354,base.state_br_mg,base.br
+city_3127370,Goiabeira,3127370,base.state_br_mg,base.br
+city_3127388,Goianá,3127388,base.state_br_mg,base.br
+city_3127404,Gonçalves,3127404,base.state_br_mg,base.br
+city_3127503,Gonzaga,3127503,base.state_br_mg,base.br
+city_3127602,Gouveia,3127602,base.state_br_mg,base.br
+city_3127701,Governador Valadares,3127701,base.state_br_mg,base.br
+city_3127800,Grão Mogol,3127800,base.state_br_mg,base.br
+city_3127909,Grupiara,3127909,base.state_br_mg,base.br
+city_3128006,Guanhães,3128006,base.state_br_mg,base.br
+city_3128105,Guapé,3128105,base.state_br_mg,base.br
+city_3128204,Guaraciaba,3128204,base.state_br_mg,base.br
+city_3128253,Guaraciama,3128253,base.state_br_mg,base.br
+city_3128303,Guaranésia,3128303,base.state_br_mg,base.br
+city_3128402,Guarani,3128402,base.state_br_mg,base.br
+city_3128501,Guarará,3128501,base.state_br_mg,base.br
+city_3128600,Guarda-Mor,3128600,base.state_br_mg,base.br
+city_3128709,Guaxupé,3128709,base.state_br_mg,base.br
+city_3128808,Guidoval,3128808,base.state_br_mg,base.br
+city_3128907,Guimarânia,3128907,base.state_br_mg,base.br
+city_3129004,Guiricema,3129004,base.state_br_mg,base.br
+city_3129103,Gurinhatã,3129103,base.state_br_mg,base.br
+city_3129202,Heliodora,3129202,base.state_br_mg,base.br
+city_3129301,Iapu,3129301,base.state_br_mg,base.br
+city_3129400,Ibertioga,3129400,base.state_br_mg,base.br
+city_3129509,Ibiá,3129509,base.state_br_mg,base.br
+city_3129608,Ibiaí,3129608,base.state_br_mg,base.br
+city_3129657,Ibiracatu,3129657,base.state_br_mg,base.br
+city_3129707,Ibiraci,3129707,base.state_br_mg,base.br
+city_3129806,Ibirité,3129806,base.state_br_mg,base.br
+city_3129905,Ibitiúra de Minas,3129905,base.state_br_mg,base.br
+city_3130002,Ibituruna,3130002,base.state_br_mg,base.br
+city_3130051,Icaraí de Minas,3130051,base.state_br_mg,base.br
+city_3130101,Igarapé,3130101,base.state_br_mg,base.br
+city_3130200,Igaratinga,3130200,base.state_br_mg,base.br
+city_3130309,Iguatama,3130309,base.state_br_mg,base.br
+city_3130408,Ijaci,3130408,base.state_br_mg,base.br
+city_3130507,Ilicínea,3130507,base.state_br_mg,base.br
+city_3130556,Imbé de Minas,3130556,base.state_br_mg,base.br
+city_3130606,Inconfidentes,3130606,base.state_br_mg,base.br
+city_3130655,Indaiabira,3130655,base.state_br_mg,base.br
+city_3130705,Indianópolis,3130705,base.state_br_mg,base.br
+city_3130804,Ingaí,3130804,base.state_br_mg,base.br
+city_3130903,Inhapim,3130903,base.state_br_mg,base.br
+city_3131000,Inhaúma,3131000,base.state_br_mg,base.br
+city_3131109,Inimutaba,3131109,base.state_br_mg,base.br
+city_3131158,Ipaba,3131158,base.state_br_mg,base.br
+city_3131208,Ipanema,3131208,base.state_br_mg,base.br
+city_3131307,Ipatinga,3131307,base.state_br_mg,base.br
+city_3131406,Ipiaçu,3131406,base.state_br_mg,base.br
+city_3131505,Ipuiúna,3131505,base.state_br_mg,base.br
+city_3131604,Iraí de Minas,3131604,base.state_br_mg,base.br
+city_3131703,Itabira,3131703,base.state_br_mg,base.br
+city_3131802,Itabirinha,3131802,base.state_br_mg,base.br
+city_3131901,Itabirito,3131901,base.state_br_mg,base.br
+city_3132008,Itacambira,3132008,base.state_br_mg,base.br
+city_3132107,Itacarambi,3132107,base.state_br_mg,base.br
+city_3132206,Itaguara,3132206,base.state_br_mg,base.br
+city_3132305,Itaipé,3132305,base.state_br_mg,base.br
+city_3132404,Itajubá,3132404,base.state_br_mg,base.br
+city_3132503,Itamarandiba,3132503,base.state_br_mg,base.br
+city_3132602,Itamarati de Minas,3132602,base.state_br_mg,base.br
+city_3132701,Itambacuri,3132701,base.state_br_mg,base.br
+city_3132800,Itambé do Mato Dentro,3132800,base.state_br_mg,base.br
+city_3132909,Itamogi,3132909,base.state_br_mg,base.br
+city_3133006,Itamonte,3133006,base.state_br_mg,base.br
+city_3133105,Itanhandu,3133105,base.state_br_mg,base.br
+city_3133204,Itanhomi,3133204,base.state_br_mg,base.br
+city_3133303,Itaobim,3133303,base.state_br_mg,base.br
+city_3133402,Itapagipe,3133402,base.state_br_mg,base.br
+city_3133501,Itapecerica,3133501,base.state_br_mg,base.br
+city_3133600,Itapeva,3133600,base.state_br_mg,base.br
+city_3133709,Itatiaiuçu,3133709,base.state_br_mg,base.br
+city_3133758,Itaú de Minas,3133758,base.state_br_mg,base.br
+city_3133808,Itaúna,3133808,base.state_br_mg,base.br
+city_3133907,Itaverava,3133907,base.state_br_mg,base.br
+city_3134004,Itinga,3134004,base.state_br_mg,base.br
+city_3134103,Itueta,3134103,base.state_br_mg,base.br
+city_3134202,Ituiutaba,3134202,base.state_br_mg,base.br
+city_3134301,Itumirim,3134301,base.state_br_mg,base.br
+city_3134400,Iturama,3134400,base.state_br_mg,base.br
+city_3134509,Itutinga,3134509,base.state_br_mg,base.br
+city_3134608,Jaboticatubas,3134608,base.state_br_mg,base.br
+city_3134707,Jacinto,3134707,base.state_br_mg,base.br
+city_3134806,Jacuí,3134806,base.state_br_mg,base.br
+city_3134905,Jacutinga,3134905,base.state_br_mg,base.br
+city_3135001,Jaguaraçu,3135001,base.state_br_mg,base.br
+city_3135050,Jaíba,3135050,base.state_br_mg,base.br
+city_3135076,Jampruca,3135076,base.state_br_mg,base.br
+city_3135100,Janaúba,3135100,base.state_br_mg,base.br
+city_3135209,Januária,3135209,base.state_br_mg,base.br
+city_3135308,Japaraíba,3135308,base.state_br_mg,base.br
+city_3135357,Japonvar,3135357,base.state_br_mg,base.br
+city_3135407,Jeceaba,3135407,base.state_br_mg,base.br
+city_3135456,Jenipapo de Minas,3135456,base.state_br_mg,base.br
+city_3135506,Jequeri,3135506,base.state_br_mg,base.br
+city_3135605,Jequitaí,3135605,base.state_br_mg,base.br
+city_3135704,Jequitibá,3135704,base.state_br_mg,base.br
+city_3135803,Jequitinhonha,3135803,base.state_br_mg,base.br
+city_3135902,Jesuânia,3135902,base.state_br_mg,base.br
+city_3136009,Joaíma,3136009,base.state_br_mg,base.br
+city_3136108,Joanésia,3136108,base.state_br_mg,base.br
+city_3136207,João Monlevade,3136207,base.state_br_mg,base.br
+city_3136306,João Pinheiro,3136306,base.state_br_mg,base.br
+city_3136405,Joaquim Felício,3136405,base.state_br_mg,base.br
+city_3136504,Jordânia,3136504,base.state_br_mg,base.br
+city_3136520,José Gonçalves de Minas,3136520,base.state_br_mg,base.br
+city_3136553,José Raydan,3136553,base.state_br_mg,base.br
+city_3136579,Josenópolis,3136579,base.state_br_mg,base.br
+city_3136652,Juatuba,3136652,base.state_br_mg,base.br
+city_3136702,Juiz de Fora,3136702,base.state_br_mg,base.br
+city_3136801,Juramento,3136801,base.state_br_mg,base.br
+city_3136900,Juruaia,3136900,base.state_br_mg,base.br
+city_3136959,Juvenília,3136959,base.state_br_mg,base.br
+city_3137007,Ladainha,3137007,base.state_br_mg,base.br
+city_3137106,Lagamar,3137106,base.state_br_mg,base.br
+city_3137205,Lagoa da Prata,3137205,base.state_br_mg,base.br
+city_3137304,Lagoa dos Patos,3137304,base.state_br_mg,base.br
+city_3137403,Lagoa Dourada,3137403,base.state_br_mg,base.br
+city_3137502,Lagoa Formosa,3137502,base.state_br_mg,base.br
+city_3137536,Lagoa Grande,3137536,base.state_br_mg,base.br
+city_3137601,Lagoa Santa,3137601,base.state_br_mg,base.br
+city_3137700,Lajinha,3137700,base.state_br_mg,base.br
+city_3137809,Lambari,3137809,base.state_br_mg,base.br
+city_3137908,Lamim,3137908,base.state_br_mg,base.br
+city_3138005,Laranjal,3138005,base.state_br_mg,base.br
+city_3138104,Lassance,3138104,base.state_br_mg,base.br
+city_3138203,Lavras,3138203,base.state_br_mg,base.br
+city_3138302,Leandro Ferreira,3138302,base.state_br_mg,base.br
+city_3138351,Leme do Prado,3138351,base.state_br_mg,base.br
+city_3138401,Leopoldina,3138401,base.state_br_mg,base.br
+city_3138500,Liberdade,3138500,base.state_br_mg,base.br
+city_3138609,Lima Duarte,3138609,base.state_br_mg,base.br
+city_3138625,Limeira do Oeste,3138625,base.state_br_mg,base.br
+city_3138658,Lontra,3138658,base.state_br_mg,base.br
+city_3138674,Luisburgo,3138674,base.state_br_mg,base.br
+city_3138682,Luislândia,3138682,base.state_br_mg,base.br
+city_3138708,Luminárias,3138708,base.state_br_mg,base.br
+city_3138807,Luz,3138807,base.state_br_mg,base.br
+city_3138906,Machacalis,3138906,base.state_br_mg,base.br
+city_3139003,Machado,3139003,base.state_br_mg,base.br
+city_3139102,Madre de Deus de Minas,3139102,base.state_br_mg,base.br
+city_3139201,Malacacheta,3139201,base.state_br_mg,base.br
+city_3139250,Mamonas,3139250,base.state_br_mg,base.br
+city_3139300,Manga,3139300,base.state_br_mg,base.br
+city_3139409,Manhuaçu,3139409,base.state_br_mg,base.br
+city_3139508,Manhumirim,3139508,base.state_br_mg,base.br
+city_3139607,Mantena,3139607,base.state_br_mg,base.br
+city_3139805,Mar de Espanha,3139805,base.state_br_mg,base.br
+city_3139706,Maravilhas,3139706,base.state_br_mg,base.br
+city_3139904,Maria da Fé,3139904,base.state_br_mg,base.br
+city_3140001,Mariana,3140001,base.state_br_mg,base.br
+city_3140100,Marilac,3140100,base.state_br_mg,base.br
+city_3140159,Mário Campos,3140159,base.state_br_mg,base.br
+city_3140209,Maripá de Minas,3140209,base.state_br_mg,base.br
+city_3140308,Marliéria,3140308,base.state_br_mg,base.br
+city_3140407,Marmelópolis,3140407,base.state_br_mg,base.br
+city_3140506,Martinho Campos,3140506,base.state_br_mg,base.br
+city_3140530,Martins Soares,3140530,base.state_br_mg,base.br
+city_3140555,Mata Verde,3140555,base.state_br_mg,base.br
+city_3140605,Materlândia,3140605,base.state_br_mg,base.br
+city_3140704,Mateus Leme,3140704,base.state_br_mg,base.br
+city_3171501,Mathias Lobato,3171501,base.state_br_mg,base.br
+city_3140803,Matias Barbosa,3140803,base.state_br_mg,base.br
+city_3140852,Matias Cardoso,3140852,base.state_br_mg,base.br
+city_3140902,Matipó,3140902,base.state_br_mg,base.br
+city_3141009,Mato Verde,3141009,base.state_br_mg,base.br
+city_3141108,Matozinhos,3141108,base.state_br_mg,base.br
+city_3141207,Matutina,3141207,base.state_br_mg,base.br
+city_3141306,Medeiros,3141306,base.state_br_mg,base.br
+city_3141405,Medina,3141405,base.state_br_mg,base.br
+city_3141504,Mendes Pimentel,3141504,base.state_br_mg,base.br
+city_3141603,Mercês,3141603,base.state_br_mg,base.br
+city_3141702,Mesquita,3141702,base.state_br_mg,base.br
+city_3141801,Minas Novas,3141801,base.state_br_mg,base.br
+city_3141900,Minduri,3141900,base.state_br_mg,base.br
+city_3142007,Mirabela,3142007,base.state_br_mg,base.br
+city_3142106,Miradouro,3142106,base.state_br_mg,base.br
+city_3142205,Miraí,3142205,base.state_br_mg,base.br
+city_3142254,Miravânia,3142254,base.state_br_mg,base.br
+city_3142304,Moeda,3142304,base.state_br_mg,base.br
+city_3142403,Moema,3142403,base.state_br_mg,base.br
+city_3142502,Monjolos,3142502,base.state_br_mg,base.br
+city_3142601,Monsenhor Paulo,3142601,base.state_br_mg,base.br
+city_3142700,Montalvânia,3142700,base.state_br_mg,base.br
+city_3142809,Monte Alegre de Minas,3142809,base.state_br_mg,base.br
+city_3142908,Monte Azul,3142908,base.state_br_mg,base.br
+city_3143005,Monte Belo,3143005,base.state_br_mg,base.br
+city_3143104,Monte Carmelo,3143104,base.state_br_mg,base.br
+city_3143153,Monte Formoso,3143153,base.state_br_mg,base.br
+city_3143203,Monte Santo de Minas,3143203,base.state_br_mg,base.br
+city_3143401,Monte Sião,3143401,base.state_br_mg,base.br
+city_3143302,Montes Claros,3143302,base.state_br_mg,base.br
+city_3143450,Montezuma,3143450,base.state_br_mg,base.br
+city_3143500,Morada Nova de Minas,3143500,base.state_br_mg,base.br
+city_3143609,Morro da Garça,3143609,base.state_br_mg,base.br
+city_3143708,Morro do Pilar,3143708,base.state_br_mg,base.br
+city_3143807,Munhoz,3143807,base.state_br_mg,base.br
+city_3143906,Muriaé,3143906,base.state_br_mg,base.br
+city_3144003,Mutum,3144003,base.state_br_mg,base.br
+city_3144102,Muzambinho,3144102,base.state_br_mg,base.br
+city_3144201,Nacip Raydan,3144201,base.state_br_mg,base.br
+city_3144300,Nanuque,3144300,base.state_br_mg,base.br
+city_3144359,Naque,3144359,base.state_br_mg,base.br
+city_3144375,Natalândia,3144375,base.state_br_mg,base.br
+city_3144409,Natércia,3144409,base.state_br_mg,base.br
+city_3144508,Nazareno,3144508,base.state_br_mg,base.br
+city_3144607,Nepomuceno,3144607,base.state_br_mg,base.br
+city_3144656,Ninheira,3144656,base.state_br_mg,base.br
+city_3144672,Nova Belém,3144672,base.state_br_mg,base.br
+city_3144706,Nova Era,3144706,base.state_br_mg,base.br
+city_3144805,Nova Lima,3144805,base.state_br_mg,base.br
+city_3144904,Nova Módica,3144904,base.state_br_mg,base.br
+city_3145000,Nova Ponte,3145000,base.state_br_mg,base.br
+city_3145059,Nova Porteirinha,3145059,base.state_br_mg,base.br
+city_3145109,Nova Resende,3145109,base.state_br_mg,base.br
+city_3145208,Nova Serrana,3145208,base.state_br_mg,base.br
+city_3136603,Nova União,3136603,base.state_br_mg,base.br
+city_3145307,Novo Cruzeiro,3145307,base.state_br_mg,base.br
+city_3145356,Novo Oriente de Minas,3145356,base.state_br_mg,base.br
+city_3145372,Novorizonte,3145372,base.state_br_mg,base.br
+city_3145406,Olaria,3145406,base.state_br_mg,base.br
+city_3145455,Olhos-d'Água,3145455,base.state_br_mg,base.br
+city_3145505,Olímpio Noronha,3145505,base.state_br_mg,base.br
+city_3145604,Oliveira,3145604,base.state_br_mg,base.br
+city_3145703,Oliveira Fortes,3145703,base.state_br_mg,base.br
+city_3145802,Onça de Pitangui,3145802,base.state_br_mg,base.br
+city_3145851,Oratórios,3145851,base.state_br_mg,base.br
+city_3145877,Orizânia,3145877,base.state_br_mg,base.br
+city_3145901,Ouro Branco,3145901,base.state_br_mg,base.br
+city_3146008,Ouro Fino,3146008,base.state_br_mg,base.br
+city_3146107,Ouro Preto,3146107,base.state_br_mg,base.br
+city_3146206,Ouro Verde de Minas,3146206,base.state_br_mg,base.br
+city_3146255,Padre Carvalho,3146255,base.state_br_mg,base.br
+city_3146305,Padre Paraíso,3146305,base.state_br_mg,base.br
+city_3146552,Pai Pedro,3146552,base.state_br_mg,base.br
+city_3146404,Paineiras,3146404,base.state_br_mg,base.br
+city_3146503,Pains,3146503,base.state_br_mg,base.br
+city_3146602,Paiva,3146602,base.state_br_mg,base.br
+city_3146701,Palma,3146701,base.state_br_mg,base.br
+city_3146750,Palmópolis,3146750,base.state_br_mg,base.br
+city_3146909,Papagaios,3146909,base.state_br_mg,base.br
+city_3147105,Pará de Minas,3147105,base.state_br_mg,base.br
+city_3147006,Paracatu,3147006,base.state_br_mg,base.br
+city_3147204,Paraguaçu,3147204,base.state_br_mg,base.br
+city_3147303,Paraisópolis,3147303,base.state_br_mg,base.br
+city_3147402,Paraopeba,3147402,base.state_br_mg,base.br
+city_3147600,Passa Quatro,3147600,base.state_br_mg,base.br
+city_3147709,Passa Tempo,3147709,base.state_br_mg,base.br
+city_3147808,Passa Vinte,3147808,base.state_br_mg,base.br
+city_3147501,Passabém,3147501,base.state_br_mg,base.br
+city_3147907,Passos,3147907,base.state_br_mg,base.br
+city_3147956,Patis,3147956,base.state_br_mg,base.br
+city_3148004,Patos de Minas,3148004,base.state_br_mg,base.br
+city_3148103,Patrocínio,3148103,base.state_br_mg,base.br
+city_3148202,Patrocínio do Muriaé,3148202,base.state_br_mg,base.br
+city_3148301,Paula Cândido,3148301,base.state_br_mg,base.br
+city_3148400,Paulistas,3148400,base.state_br_mg,base.br
+city_3148509,Pavão,3148509,base.state_br_mg,base.br
+city_3148608,Peçanha,3148608,base.state_br_mg,base.br
+city_3148707,Pedra Azul,3148707,base.state_br_mg,base.br
+city_3148756,Pedra Bonita,3148756,base.state_br_mg,base.br
+city_3148806,Pedra do Anta,3148806,base.state_br_mg,base.br
+city_3148905,Pedra do Indaiá,3148905,base.state_br_mg,base.br
+city_3149002,Pedra Dourada,3149002,base.state_br_mg,base.br
+city_3149101,Pedralva,3149101,base.state_br_mg,base.br
+city_3149150,Pedras de Maria da Cruz,3149150,base.state_br_mg,base.br
+city_3149200,Pedrinópolis,3149200,base.state_br_mg,base.br
+city_3149309,Pedro Leopoldo,3149309,base.state_br_mg,base.br
+city_3149408,Pedro Teixeira,3149408,base.state_br_mg,base.br
+city_3149507,Pequeri,3149507,base.state_br_mg,base.br
+city_3149606,Pequi,3149606,base.state_br_mg,base.br
+city_3149705,Perdigão,3149705,base.state_br_mg,base.br
+city_3149804,Perdizes,3149804,base.state_br_mg,base.br
+city_3149903,Perdões,3149903,base.state_br_mg,base.br
+city_3149952,Periquito,3149952,base.state_br_mg,base.br
+city_3150000,Pescador,3150000,base.state_br_mg,base.br
+city_3150109,Piau,3150109,base.state_br_mg,base.br
+city_3150158,Piedade de Caratinga,3150158,base.state_br_mg,base.br
+city_3150208,Piedade de Ponte Nova,3150208,base.state_br_mg,base.br
+city_3150307,Piedade do Rio Grande,3150307,base.state_br_mg,base.br
+city_3150406,Piedade dos Gerais,3150406,base.state_br_mg,base.br
+city_3150505,Pimenta,3150505,base.state_br_mg,base.br
+city_3150539,Pingo-d'Água,3150539,base.state_br_mg,base.br
+city_3150570,Pintópolis,3150570,base.state_br_mg,base.br
+city_3150604,Piracema,3150604,base.state_br_mg,base.br
+city_3150703,Pirajuba,3150703,base.state_br_mg,base.br
+city_3150802,Piranga,3150802,base.state_br_mg,base.br
+city_3150901,Piranguçu,3150901,base.state_br_mg,base.br
+city_3151008,Piranguinho,3151008,base.state_br_mg,base.br
+city_3151107,Pirapetinga,3151107,base.state_br_mg,base.br
+city_3151206,Pirapora,3151206,base.state_br_mg,base.br
+city_3151305,Piraúba,3151305,base.state_br_mg,base.br
+city_3151404,Pitangui,3151404,base.state_br_mg,base.br
+city_3151503,Piumhi,3151503,base.state_br_mg,base.br
+city_3151602,Planura,3151602,base.state_br_mg,base.br
+city_3151701,Poço Fundo,3151701,base.state_br_mg,base.br
+city_3151800,Poços de Caldas,3151800,base.state_br_mg,base.br
+city_3151909,Pocrane,3151909,base.state_br_mg,base.br
+city_3152006,Pompéu,3152006,base.state_br_mg,base.br
+city_3152105,Ponte Nova,3152105,base.state_br_mg,base.br
+city_3152131,Ponto Chique,3152131,base.state_br_mg,base.br
+city_3152170,Ponto dos Volantes,3152170,base.state_br_mg,base.br
+city_3152204,Porteirinha,3152204,base.state_br_mg,base.br
+city_3152303,Porto Firme,3152303,base.state_br_mg,base.br
+city_3152402,Poté,3152402,base.state_br_mg,base.br
+city_3152501,Pouso Alegre,3152501,base.state_br_mg,base.br
+city_3152600,Pouso Alto,3152600,base.state_br_mg,base.br
+city_3152709,Prados,3152709,base.state_br_mg,base.br
+city_3152808,Prata,3152808,base.state_br_mg,base.br
+city_3152907,Pratápolis,3152907,base.state_br_mg,base.br
+city_3153004,Pratinha,3153004,base.state_br_mg,base.br
+city_3153103,Presidente Bernardes,3153103,base.state_br_mg,base.br
+city_3153202,Presidente Juscelino,3153202,base.state_br_mg,base.br
+city_3153301,Presidente Kubitschek,3153301,base.state_br_mg,base.br
+city_3153400,Presidente Olegário,3153400,base.state_br_mg,base.br
+city_3153608,Prudente de Morais,3153608,base.state_br_mg,base.br
+city_3153707,Quartel Geral,3153707,base.state_br_mg,base.br
+city_3153806,Queluzito,3153806,base.state_br_mg,base.br
+city_3153905,Raposos,3153905,base.state_br_mg,base.br
+city_3154002,Raul Soares,3154002,base.state_br_mg,base.br
+city_3154101,Recreio,3154101,base.state_br_mg,base.br
+city_3154150,Reduto,3154150,base.state_br_mg,base.br
+city_3154200,Resende Costa,3154200,base.state_br_mg,base.br
+city_3154309,Resplendor,3154309,base.state_br_mg,base.br
+city_3154408,Ressaquinha,3154408,base.state_br_mg,base.br
+city_3154457,Riachinho,3154457,base.state_br_mg,base.br
+city_3154507,Riacho dos Machados,3154507,base.state_br_mg,base.br
+city_3154606,Ribeirão das Neves,3154606,base.state_br_mg,base.br
+city_3154705,Ribeirão Vermelho,3154705,base.state_br_mg,base.br
+city_3154804,Rio Acima,3154804,base.state_br_mg,base.br
+city_3154903,Rio Casca,3154903,base.state_br_mg,base.br
+city_3155108,Rio do Prado,3155108,base.state_br_mg,base.br
+city_3155009,Rio Doce,3155009,base.state_br_mg,base.br
+city_3155207,Rio Espera,3155207,base.state_br_mg,base.br
+city_3155306,Rio Manso,3155306,base.state_br_mg,base.br
+city_3155405,Rio Novo,3155405,base.state_br_mg,base.br
+city_3155504,Rio Paranaíba,3155504,base.state_br_mg,base.br
+city_3155603,Rio Pardo de Minas,3155603,base.state_br_mg,base.br
+city_3155702,Rio Piracicaba,3155702,base.state_br_mg,base.br
+city_3155801,Rio Pomba,3155801,base.state_br_mg,base.br
+city_3155900,Rio Preto,3155900,base.state_br_mg,base.br
+city_3156007,Rio Vermelho,3156007,base.state_br_mg,base.br
+city_3156106,Ritápolis,3156106,base.state_br_mg,base.br
+city_3156205,Rochedo de Minas,3156205,base.state_br_mg,base.br
+city_3156304,Rodeiro,3156304,base.state_br_mg,base.br
+city_3156403,Romaria,3156403,base.state_br_mg,base.br
+city_3156452,Rosário da Limeira,3156452,base.state_br_mg,base.br
+city_3156502,Rubelita,3156502,base.state_br_mg,base.br
+city_3156601,Rubim,3156601,base.state_br_mg,base.br
+city_3156700,Sabará,3156700,base.state_br_mg,base.br
+city_3156809,Sabinópolis,3156809,base.state_br_mg,base.br
+city_3156908,Sacramento,3156908,base.state_br_mg,base.br
+city_3157005,Salinas,3157005,base.state_br_mg,base.br
+city_3157104,Salto da Divisa,3157104,base.state_br_mg,base.br
+city_3157203,Santa Bárbara,3157203,base.state_br_mg,base.br
+city_3157252,Santa Bárbara do Leste,3157252,base.state_br_mg,base.br
+city_3157278,Santa Bárbara do Monte Verde,3157278,base.state_br_mg,base.br
+city_3157302,Santa Bárbara do Tugúrio,3157302,base.state_br_mg,base.br
+city_3157336,Santa Cruz de Minas,3157336,base.state_br_mg,base.br
+city_3157377,Santa Cruz de Salinas,3157377,base.state_br_mg,base.br
+city_3157401,Santa Cruz do Escalvado,3157401,base.state_br_mg,base.br
+city_3157500,Santa Efigênia de Minas,3157500,base.state_br_mg,base.br
+city_3157609,Santa Fé de Minas,3157609,base.state_br_mg,base.br
+city_3157658,Santa Helena de Minas,3157658,base.state_br_mg,base.br
+city_3157708,Santa Juliana,3157708,base.state_br_mg,base.br
+city_3157807,Santa Luzia,3157807,base.state_br_mg,base.br
+city_3157906,Santa Margarida,3157906,base.state_br_mg,base.br
+city_3158003,Santa Maria de Itabira,3158003,base.state_br_mg,base.br
+city_3158102,Santa Maria do Salto,3158102,base.state_br_mg,base.br
+city_3158201,Santa Maria do Suaçuí,3158201,base.state_br_mg,base.br
+city_3159209,Santa Rita de Caldas,3159209,base.state_br_mg,base.br
+city_3159407,Santa Rita de Ibitipoca,3159407,base.state_br_mg,base.br
+city_3159308,Santa Rita de Jacutinga,3159308,base.state_br_mg,base.br
+city_3159357,Santa Rita de Minas,3159357,base.state_br_mg,base.br
+city_3159506,Santa Rita do Itueto,3159506,base.state_br_mg,base.br
+city_3159605,Santa Rita do Sapucaí,3159605,base.state_br_mg,base.br
+city_3159704,Santa Rosa da Serra,3159704,base.state_br_mg,base.br
+city_3159803,Santa Vitória,3159803,base.state_br_mg,base.br
+city_3158300,Santana da Vargem,3158300,base.state_br_mg,base.br
+city_3158409,Santana de Cataguases,3158409,base.state_br_mg,base.br
+city_3158508,Santana de Pirapama,3158508,base.state_br_mg,base.br
+city_3158607,Santana do Deserto,3158607,base.state_br_mg,base.br
+city_3158706,Santana do Garambéu,3158706,base.state_br_mg,base.br
+city_3158805,Santana do Jacaré,3158805,base.state_br_mg,base.br
+city_3158904,Santana do Manhuaçu,3158904,base.state_br_mg,base.br
+city_3158953,Santana do Paraíso,3158953,base.state_br_mg,base.br
+city_3159001,Santana do Riacho,3159001,base.state_br_mg,base.br
+city_3159100,Santana dos Montes,3159100,base.state_br_mg,base.br
+city_3159902,Santo Antônio do Amparo,3159902,base.state_br_mg,base.br
+city_3160009,Santo Antônio do Aventureiro,3160009,base.state_br_mg,base.br
+city_3160108,Santo Antônio do Grama,3160108,base.state_br_mg,base.br
+city_3160207,Santo Antônio do Itambé,3160207,base.state_br_mg,base.br
+city_3160306,Santo Antônio do Jacinto,3160306,base.state_br_mg,base.br
+city_3160405,Santo Antônio do Monte,3160405,base.state_br_mg,base.br
+city_3160454,Santo Antônio do Retiro,3160454,base.state_br_mg,base.br
+city_3160504,Santo Antônio do Rio Abaixo,3160504,base.state_br_mg,base.br
+city_3160603,Santo Hipólito,3160603,base.state_br_mg,base.br
+city_3160702,Santos Dumont,3160702,base.state_br_mg,base.br
+city_3160801,São Bento Abade,3160801,base.state_br_mg,base.br
+city_3160900,São Brás do Suaçuí,3160900,base.state_br_mg,base.br
+city_3160959,São Domingos das Dores,3160959,base.state_br_mg,base.br
+city_3161007,São Domingos do Prata,3161007,base.state_br_mg,base.br
+city_3161056,São Félix de Minas,3161056,base.state_br_mg,base.br
+city_3161106,São Francisco,3161106,base.state_br_mg,base.br
+city_3161205,São Francisco de Paula,3161205,base.state_br_mg,base.br
+city_3161304,São Francisco de Sales,3161304,base.state_br_mg,base.br
+city_3161403,São Francisco do Glória,3161403,base.state_br_mg,base.br
+city_3161502,São Geraldo,3161502,base.state_br_mg,base.br
+city_3161601,São Geraldo da Piedade,3161601,base.state_br_mg,base.br
+city_3161650,São Geraldo do Baixio,3161650,base.state_br_mg,base.br
+city_3161700,São Gonçalo do Abaeté,3161700,base.state_br_mg,base.br
+city_3161809,São Gonçalo do Pará,3161809,base.state_br_mg,base.br
+city_3161908,São Gonçalo do Rio Abaixo,3161908,base.state_br_mg,base.br
+city_3125507,São Gonçalo do Rio Preto,3125507,base.state_br_mg,base.br
+city_3162005,São Gonçalo do Sapucaí,3162005,base.state_br_mg,base.br
+city_3162104,São Gotardo,3162104,base.state_br_mg,base.br
+city_3162203,São João Batista do Glória,3162203,base.state_br_mg,base.br
+city_3162252,São João da Lagoa,3162252,base.state_br_mg,base.br
+city_3162302,São João da Mata,3162302,base.state_br_mg,base.br
+city_3162401,São João da Ponte,3162401,base.state_br_mg,base.br
+city_3162450,São João das Missões,3162450,base.state_br_mg,base.br
+city_3162500,São João del Rei,3162500,base.state_br_mg,base.br
+city_3162559,São João do Manhuaçu,3162559,base.state_br_mg,base.br
+city_3162575,São João do Manteninha,3162575,base.state_br_mg,base.br
+city_3162609,São João do Oriente,3162609,base.state_br_mg,base.br
+city_3162658,São João do Pacuí,3162658,base.state_br_mg,base.br
+city_3162708,São João do Paraíso,3162708,base.state_br_mg,base.br
+city_3162807,São João Evangelista,3162807,base.state_br_mg,base.br
+city_3162906,São João Nepomuceno,3162906,base.state_br_mg,base.br
+city_3162922,São Joaquim de Bicas,3162922,base.state_br_mg,base.br
+city_3162948,São José da Barra,3162948,base.state_br_mg,base.br
+city_3162955,São José da Lapa,3162955,base.state_br_mg,base.br
+city_3163003,São José da Safira,3163003,base.state_br_mg,base.br
+city_3163102,São José da Varginha,3163102,base.state_br_mg,base.br
+city_3163201,São José do Alegre,3163201,base.state_br_mg,base.br
+city_3163300,São José do Divino,3163300,base.state_br_mg,base.br
+city_3163409,São José do Goiabal,3163409,base.state_br_mg,base.br
+city_3163508,São José do Jacuri,3163508,base.state_br_mg,base.br
+city_3163607,São José do Mantimento,3163607,base.state_br_mg,base.br
+city_3163706,São Lourenço,3163706,base.state_br_mg,base.br
+city_3163805,São Miguel do Anta,3163805,base.state_br_mg,base.br
+city_3163904,São Pedro da União,3163904,base.state_br_mg,base.br
+city_3164100,São Pedro do Suaçuí,3164100,base.state_br_mg,base.br
+city_3164001,São Pedro dos Ferros,3164001,base.state_br_mg,base.br
+city_3164209,São Romão,3164209,base.state_br_mg,base.br
+city_3164308,São Roque de Minas,3164308,base.state_br_mg,base.br
+city_3164407,São Sebastião da Bela Vista,3164407,base.state_br_mg,base.br
+city_3164431,São Sebastião da Vargem Alegre,3164431,base.state_br_mg,base.br
+city_3164472,São Sebastião do Anta,3164472,base.state_br_mg,base.br
+city_3164506,São Sebastião do Maranhão,3164506,base.state_br_mg,base.br
+city_3164605,São Sebastião do Oeste,3164605,base.state_br_mg,base.br
+city_3164704,São Sebastião do Paraíso,3164704,base.state_br_mg,base.br
+city_3164803,São Sebastião do Rio Preto,3164803,base.state_br_mg,base.br
+city_3164902,São Sebastião do Rio Verde,3164902,base.state_br_mg,base.br
+city_3165008,São Tiago,3165008,base.state_br_mg,base.br
+city_3165107,São Tomás de Aquino,3165107,base.state_br_mg,base.br
+city_3165206,São Tomé das Letras,3165206,base.state_br_mg,base.br
+city_3165305,São Vicente de Minas,3165305,base.state_br_mg,base.br
+city_3165404,Sapucaí-Mirim,3165404,base.state_br_mg,base.br
+city_3165503,Sardoá,3165503,base.state_br_mg,base.br
+city_3165537,Sarzedo,3165537,base.state_br_mg,base.br
+city_3165560,Sem-Peixe,3165560,base.state_br_mg,base.br
+city_3165578,Senador Amaral,3165578,base.state_br_mg,base.br
+city_3165602,Senador Cortes,3165602,base.state_br_mg,base.br
+city_3165701,Senador Firmino,3165701,base.state_br_mg,base.br
+city_3165800,Senador José Bento,3165800,base.state_br_mg,base.br
+city_3165909,Senador Modestino Gonçalves,3165909,base.state_br_mg,base.br
+city_3166006,Senhora de Oliveira,3166006,base.state_br_mg,base.br
+city_3166105,Senhora do Porto,3166105,base.state_br_mg,base.br
+city_3166204,Senhora dos Remédios,3166204,base.state_br_mg,base.br
+city_3166303,Sericita,3166303,base.state_br_mg,base.br
+city_3166402,Seritinga,3166402,base.state_br_mg,base.br
+city_3166501,Serra Azul de Minas,3166501,base.state_br_mg,base.br
+city_3166600,Serra da Saudade,3166600,base.state_br_mg,base.br
+city_3166808,Serra do Salitre,3166808,base.state_br_mg,base.br
+city_3166709,Serra dos Aimorés,3166709,base.state_br_mg,base.br
+city_3166907,Serrania,3166907,base.state_br_mg,base.br
+city_3166956,Serranópolis de Minas,3166956,base.state_br_mg,base.br
+city_3167004,Serranos,3167004,base.state_br_mg,base.br
+city_3167103,Serro,3167103,base.state_br_mg,base.br
+city_3167202,Sete Lagoas,3167202,base.state_br_mg,base.br
+city_3165552,Setubinha,3165552,base.state_br_mg,base.br
+city_3167301,Silveirânia,3167301,base.state_br_mg,base.br
+city_3167400,Silvianópolis,3167400,base.state_br_mg,base.br
+city_3167509,Simão Pereira,3167509,base.state_br_mg,base.br
+city_3167608,Simonésia,3167608,base.state_br_mg,base.br
+city_3167707,Sobrália,3167707,base.state_br_mg,base.br
+city_3167806,Soledade de Minas,3167806,base.state_br_mg,base.br
+city_3167905,Tabuleiro,3167905,base.state_br_mg,base.br
+city_3168002,Taiobeiras,3168002,base.state_br_mg,base.br
+city_3168051,Taparuba,3168051,base.state_br_mg,base.br
+city_3168101,Tapira,3168101,base.state_br_mg,base.br
+city_3168200,Tapiraí,3168200,base.state_br_mg,base.br
+city_3168309,Taquaraçu de Minas,3168309,base.state_br_mg,base.br
+city_3168408,Tarumirim,3168408,base.state_br_mg,base.br
+city_3168507,Teixeiras,3168507,base.state_br_mg,base.br
+city_3168606,Teófilo Otoni,3168606,base.state_br_mg,base.br
+city_3168705,Timóteo,3168705,base.state_br_mg,base.br
+city_3168804,Tiradentes,3168804,base.state_br_mg,base.br
+city_3168903,Tiros,3168903,base.state_br_mg,base.br
+city_3169000,Tocantins,3169000,base.state_br_mg,base.br
+city_3169059,Tocos do Moji,3169059,base.state_br_mg,base.br
+city_3169109,Toledo,3169109,base.state_br_mg,base.br
+city_3169208,Tombos,3169208,base.state_br_mg,base.br
+city_3169307,Três Corações,3169307,base.state_br_mg,base.br
+city_3169356,Três Marias,3169356,base.state_br_mg,base.br
+city_3169406,Três Pontas,3169406,base.state_br_mg,base.br
+city_3169505,Tumiritinga,3169505,base.state_br_mg,base.br
+city_3169604,Tupaciguara,3169604,base.state_br_mg,base.br
+city_3169703,Turmalina,3169703,base.state_br_mg,base.br
+city_3169802,Turvolândia,3169802,base.state_br_mg,base.br
+city_3169901,Ubá,3169901,base.state_br_mg,base.br
+city_3170008,Ubaí,3170008,base.state_br_mg,base.br
+city_3170057,Ubaporanga,3170057,base.state_br_mg,base.br
+city_3170107,Uberaba,3170107,base.state_br_mg,base.br
+city_3170206,Uberlândia,3170206,base.state_br_mg,base.br
+city_3170305,Umburatiba,3170305,base.state_br_mg,base.br
+city_3170404,Unaí,3170404,base.state_br_mg,base.br
+city_3170438,União de Minas,3170438,base.state_br_mg,base.br
+city_3170479,Uruana de Minas,3170479,base.state_br_mg,base.br
+city_3170503,Urucânia,3170503,base.state_br_mg,base.br
+city_3170529,Urucuia,3170529,base.state_br_mg,base.br
+city_3170578,Vargem Alegre,3170578,base.state_br_mg,base.br
+city_3170602,Vargem Bonita,3170602,base.state_br_mg,base.br
+city_3170651,Vargem Grande do Rio Pardo,3170651,base.state_br_mg,base.br
+city_3170701,Varginha,3170701,base.state_br_mg,base.br
+city_3170750,Varjão de Minas,3170750,base.state_br_mg,base.br
+city_3170800,Várzea da Palma,3170800,base.state_br_mg,base.br
+city_3170909,Varzelândia,3170909,base.state_br_mg,base.br
+city_3171006,Vazante,3171006,base.state_br_mg,base.br
+city_3171030,Verdelândia,3171030,base.state_br_mg,base.br
+city_3171071,Veredinha,3171071,base.state_br_mg,base.br
+city_3171105,Veríssimo,3171105,base.state_br_mg,base.br
+city_3171154,Vermelho Novo,3171154,base.state_br_mg,base.br
+city_3171204,Vespasiano,3171204,base.state_br_mg,base.br
+city_3171303,Viçosa,3171303,base.state_br_mg,base.br
+city_3171402,Vieiras,3171402,base.state_br_mg,base.br
+city_3171600,Virgem da Lapa,3171600,base.state_br_mg,base.br
+city_3171709,Virgínia,3171709,base.state_br_mg,base.br
+city_3171808,Virginópolis,3171808,base.state_br_mg,base.br
+city_3171907,Virgolândia,3171907,base.state_br_mg,base.br
+city_3172004,Visconde do Rio Branco,3172004,base.state_br_mg,base.br
+city_3172103,Volta Grande,3172103,base.state_br_mg,base.br
+city_3172202,Wenceslau Braz,3172202,base.state_br_mg,base.br
+city_3200102,Afonso Cláudio,3200102,base.state_br_es,base.br
+city_3200169,Água Doce do Norte,3200169,base.state_br_es,base.br
+city_3200136,Águia Branca,3200136,base.state_br_es,base.br
+city_3200201,Alegre,3200201,base.state_br_es,base.br
+city_3200300,Alfredo Chaves,3200300,base.state_br_es,base.br
+city_3200359,Alto Rio Novo,3200359,base.state_br_es,base.br
+city_3200409,Anchieta,3200409,base.state_br_es,base.br
+city_3200508,Apiacá,3200508,base.state_br_es,base.br
+city_3200607,Aracruz,3200607,base.state_br_es,base.br
+city_3200706,Atílio Vivácqua,3200706,base.state_br_es,base.br
+city_3200805,Baixo Guandu,3200805,base.state_br_es,base.br
+city_3200904,Barra de São Francisco,3200904,base.state_br_es,base.br
+city_3201001,Boa Esperança,3201001,base.state_br_es,base.br
+city_3201100,Bom Jesus do Norte,3201100,base.state_br_es,base.br
+city_3201159,Brejetuba,3201159,base.state_br_es,base.br
+city_3201209,Cachoeiro de Itapemirim,3201209,base.state_br_es,base.br
+city_3201308,Cariacica,3201308,base.state_br_es,base.br
+city_3201407,Castelo,3201407,base.state_br_es,base.br
+city_3201506,Colatina,3201506,base.state_br_es,base.br
+city_3201605,Conceição da Barra,3201605,base.state_br_es,base.br
+city_3201704,Conceição do Castelo,3201704,base.state_br_es,base.br
+city_3201803,Divino de São Lourenço,3201803,base.state_br_es,base.br
+city_3201902,Domingos Martins,3201902,base.state_br_es,base.br
+city_3202009,Dores do Rio Preto,3202009,base.state_br_es,base.br
+city_3202108,Ecoporanga,3202108,base.state_br_es,base.br
+city_3202207,Fundão,3202207,base.state_br_es,base.br
+city_3202256,Governador Lindenberg,3202256,base.state_br_es,base.br
+city_3202306,Guaçuí,3202306,base.state_br_es,base.br
+city_3202405,Guarapari,3202405,base.state_br_es,base.br
+city_3202454,Ibatiba,3202454,base.state_br_es,base.br
+city_3202504,Ibiraçu,3202504,base.state_br_es,base.br
+city_3202553,Ibitirama,3202553,base.state_br_es,base.br
+city_3202603,Iconha,3202603,base.state_br_es,base.br
+city_3202652,Irupi,3202652,base.state_br_es,base.br
+city_3202702,Itaguaçu,3202702,base.state_br_es,base.br
+city_3202801,Itapemirim,3202801,base.state_br_es,base.br
+city_3202900,Itarana,3202900,base.state_br_es,base.br
+city_3203007,Iúna,3203007,base.state_br_es,base.br
+city_3203056,Jaguaré,3203056,base.state_br_es,base.br
+city_3203106,Jerônimo Monteiro,3203106,base.state_br_es,base.br
+city_3203130,João Neiva,3203130,base.state_br_es,base.br
+city_3203163,Laranja da Terra,3203163,base.state_br_es,base.br
+city_3203205,Linhares,3203205,base.state_br_es,base.br
+city_3203304,Mantenópolis,3203304,base.state_br_es,base.br
+city_3203320,Marataízes,3203320,base.state_br_es,base.br
+city_3203346,Marechal Floriano,3203346,base.state_br_es,base.br
+city_3203353,Marilândia,3203353,base.state_br_es,base.br
+city_3203403,Mimoso do Sul,3203403,base.state_br_es,base.br
+city_3203502,Montanha,3203502,base.state_br_es,base.br
+city_3203601,Mucurici,3203601,base.state_br_es,base.br
+city_3203700,Muniz Freire,3203700,base.state_br_es,base.br
+city_3203809,Muqui,3203809,base.state_br_es,base.br
+city_3203908,Nova Venécia,3203908,base.state_br_es,base.br
+city_3204005,Pancas,3204005,base.state_br_es,base.br
+city_3204054,Pedro Canário,3204054,base.state_br_es,base.br
+city_3204104,Pinheiros,3204104,base.state_br_es,base.br
+city_3204203,Piúma,3204203,base.state_br_es,base.br
+city_3204252,Ponto Belo,3204252,base.state_br_es,base.br
+city_3204302,Presidente Kennedy,3204302,base.state_br_es,base.br
+city_3204351,Rio Bananal,3204351,base.state_br_es,base.br
+city_3204401,Rio Novo do Sul,3204401,base.state_br_es,base.br
+city_3204500,Santa Leopoldina,3204500,base.state_br_es,base.br
+city_3204559,Santa Maria de Jetibá,3204559,base.state_br_es,base.br
+city_3204609,Santa Teresa,3204609,base.state_br_es,base.br
+city_3204658,São Domingos do Norte,3204658,base.state_br_es,base.br
+city_3204708,São Gabriel da Palha,3204708,base.state_br_es,base.br
+city_3204807,São José do Calçado,3204807,base.state_br_es,base.br
+city_3204906,São Mateus,3204906,base.state_br_es,base.br
+city_3204955,São Roque do Canaã,3204955,base.state_br_es,base.br
+city_3205002,Serra,3205002,base.state_br_es,base.br
+city_3205010,Sooretama,3205010,base.state_br_es,base.br
+city_3205036,Vargem Alta,3205036,base.state_br_es,base.br
+city_3205069,Venda Nova do Imigrante,3205069,base.state_br_es,base.br
+city_3205101,Viana,3205101,base.state_br_es,base.br
+city_3205150,Vila Pavão,3205150,base.state_br_es,base.br
+city_3205176,Vila Valério,3205176,base.state_br_es,base.br
+city_3205200,Vila Velha,3205200,base.state_br_es,base.br
+city_3205309,Vitória,3205309,base.state_br_es,base.br
+city_3300100,Angra dos Reis,3300100,base.state_br_rj,base.br
+city_3300159,Aperibé,3300159,base.state_br_rj,base.br
+city_3300209,Araruama,3300209,base.state_br_rj,base.br
+city_3300225,Areal,3300225,base.state_br_rj,base.br
+city_3300233,Armação dos Búzios,3300233,base.state_br_rj,base.br
+city_3300258,Arraial do Cabo,3300258,base.state_br_rj,base.br
+city_3300308,Barra do Piraí,3300308,base.state_br_rj,base.br
+city_3300407,Barra Mansa,3300407,base.state_br_rj,base.br
+city_3300456,Belford Roxo,3300456,base.state_br_rj,base.br
+city_3300506,Bom Jardim,3300506,base.state_br_rj,base.br
+city_3300605,Bom Jesus do Itabapoana,3300605,base.state_br_rj,base.br
+city_3300704,Cabo Frio,3300704,base.state_br_rj,base.br
+city_3300803,Cachoeiras de Macacu,3300803,base.state_br_rj,base.br
+city_3300902,Cambuci,3300902,base.state_br_rj,base.br
+city_3301009,Campos dos Goytacazes,3301009,base.state_br_rj,base.br
+city_3301108,Cantagalo,3301108,base.state_br_rj,base.br
+city_3300936,Carapebus,3300936,base.state_br_rj,base.br
+city_3301157,Cardoso Moreira,3301157,base.state_br_rj,base.br
+city_3301207,Carmo,3301207,base.state_br_rj,base.br
+city_3301306,Casimiro de Abreu,3301306,base.state_br_rj,base.br
+city_3300951,Comendador Levy Gasparian,3300951,base.state_br_rj,base.br
+city_3301405,Conceição de Macabu,3301405,base.state_br_rj,base.br
+city_3301504,Cordeiro,3301504,base.state_br_rj,base.br
+city_3301603,Duas Barras,3301603,base.state_br_rj,base.br
+city_3301702,Duque de Caxias,3301702,base.state_br_rj,base.br
+city_3301801,Engenheiro Paulo de Frontin,3301801,base.state_br_rj,base.br
+city_3301850,Guapimirim,3301850,base.state_br_rj,base.br
+city_3301876,Iguaba Grande,3301876,base.state_br_rj,base.br
+city_3301900,Itaboraí,3301900,base.state_br_rj,base.br
+city_3302007,Itaguaí,3302007,base.state_br_rj,base.br
+city_3302056,Italva,3302056,base.state_br_rj,base.br
+city_3302106,Itaocara,3302106,base.state_br_rj,base.br
+city_3302205,Itaperuna,3302205,base.state_br_rj,base.br
+city_3302254,Itatiaia,3302254,base.state_br_rj,base.br
+city_3302270,Japeri,3302270,base.state_br_rj,base.br
+city_3302304,Laje do Muriaé,3302304,base.state_br_rj,base.br
+city_3302403,Macaé,3302403,base.state_br_rj,base.br
+city_3302452,Macuco,3302452,base.state_br_rj,base.br
+city_3302502,Magé,3302502,base.state_br_rj,base.br
+city_3302601,Mangaratiba,3302601,base.state_br_rj,base.br
+city_3302700,Maricá,3302700,base.state_br_rj,base.br
+city_3302809,Mendes,3302809,base.state_br_rj,base.br
+city_3302858,Mesquita,3302858,base.state_br_rj,base.br
+city_3302908,Miguel Pereira,3302908,base.state_br_rj,base.br
+city_3303005,Miracema,3303005,base.state_br_rj,base.br
+city_3303104,Natividade,3303104,base.state_br_rj,base.br
+city_3303203,Nilópolis,3303203,base.state_br_rj,base.br
+city_3303302,Niterói,3303302,base.state_br_rj,base.br
+city_3303401,Nova Friburgo,3303401,base.state_br_rj,base.br
+city_3303500,Nova Iguaçu,3303500,base.state_br_rj,base.br
+city_3303609,Paracambi,3303609,base.state_br_rj,base.br
+city_3303708,Paraíba do Sul,3303708,base.state_br_rj,base.br
+city_3303807,Paraty,3303807,base.state_br_rj,base.br
+city_3303856,Paty do Alferes,3303856,base.state_br_rj,base.br
+city_3303906,Petrópolis,3303906,base.state_br_rj,base.br
+city_3303955,Pinheiral,3303955,base.state_br_rj,base.br
+city_3304003,Piraí,3304003,base.state_br_rj,base.br
+city_3304102,Porciúncula,3304102,base.state_br_rj,base.br
+city_3304110,Porto Real,3304110,base.state_br_rj,base.br
+city_3304128,Quatis,3304128,base.state_br_rj,base.br
+city_3304144,Queimados,3304144,base.state_br_rj,base.br
+city_3304151,Quissamã,3304151,base.state_br_rj,base.br
+city_3304201,Resende,3304201,base.state_br_rj,base.br
+city_3304300,Rio Bonito,3304300,base.state_br_rj,base.br
+city_3304409,Rio Claro,3304409,base.state_br_rj,base.br
+city_3304508,Rio das Flores,3304508,base.state_br_rj,base.br
+city_3304524,Rio das Ostras,3304524,base.state_br_rj,base.br
+city_3304557,Rio de Janeiro,3304557,base.state_br_rj,base.br
+city_3304607,Santa Maria Madalena,3304607,base.state_br_rj,base.br
+city_3304706,Santo Antônio de Pádua,3304706,base.state_br_rj,base.br
+city_3304805,São Fidélis,3304805,base.state_br_rj,base.br
+city_3304755,São Francisco de Itabapoana,3304755,base.state_br_rj,base.br
+city_3304904,São Gonçalo,3304904,base.state_br_rj,base.br
+city_3305000,São João da Barra,3305000,base.state_br_rj,base.br
+city_3305109,São João de Meriti,3305109,base.state_br_rj,base.br
+city_3305133,São José de Ubá,3305133,base.state_br_rj,base.br
+city_3305158,São José do Vale do Rio Preto,3305158,base.state_br_rj,base.br
+city_3305208,São Pedro da Aldeia,3305208,base.state_br_rj,base.br
+city_3305307,São Sebastião do Alto,3305307,base.state_br_rj,base.br
+city_3305406,Sapucaia,3305406,base.state_br_rj,base.br
+city_3305505,Saquarema,3305505,base.state_br_rj,base.br
+city_3305554,Seropédica,3305554,base.state_br_rj,base.br
+city_3305604,Silva Jardim,3305604,base.state_br_rj,base.br
+city_3305703,Sumidouro,3305703,base.state_br_rj,base.br
+city_3305752,Tanguá,3305752,base.state_br_rj,base.br
+city_3305802,Teresópolis,3305802,base.state_br_rj,base.br
+city_3305901,Trajano de Moraes,3305901,base.state_br_rj,base.br
+city_3306008,Três Rios,3306008,base.state_br_rj,base.br
+city_3306107,Valença,3306107,base.state_br_rj,base.br
+city_3306156,Varre-Sai,3306156,base.state_br_rj,base.br
+city_3306206,Vassouras,3306206,base.state_br_rj,base.br
+city_3306305,Volta Redonda,3306305,base.state_br_rj,base.br
+city_3500105,Adamantina,3500105,base.state_br_sp,base.br
+city_3500204,Adolfo,3500204,base.state_br_sp,base.br
+city_3500303,Aguaí,3500303,base.state_br_sp,base.br
+city_3500402,Águas da Prata,3500402,base.state_br_sp,base.br
+city_3500501,Águas de Lindóia,3500501,base.state_br_sp,base.br
+city_3500550,Águas de Santa Bárbara,3500550,base.state_br_sp,base.br
+city_3500600,Águas de São Pedro,3500600,base.state_br_sp,base.br
+city_3500709,Agudos,3500709,base.state_br_sp,base.br
+city_3500758,Alambari,3500758,base.state_br_sp,base.br
+city_3500808,Alfredo Marcondes,3500808,base.state_br_sp,base.br
+city_3500907,Altair,3500907,base.state_br_sp,base.br
+city_3501004,Altinópolis,3501004,base.state_br_sp,base.br
+city_3501103,Alto Alegre,3501103,base.state_br_sp,base.br
+city_3501152,Alumínio,3501152,base.state_br_sp,base.br
+city_3501202,Álvares Florence,3501202,base.state_br_sp,base.br
+city_3501301,Álvares Machado,3501301,base.state_br_sp,base.br
+city_3501400,Álvaro de Carvalho,3501400,base.state_br_sp,base.br
+city_3501509,Alvinlândia,3501509,base.state_br_sp,base.br
+city_3501608,Americana,3501608,base.state_br_sp,base.br
+city_3501707,Américo Brasiliense,3501707,base.state_br_sp,base.br
+city_3501806,Américo de Campos,3501806,base.state_br_sp,base.br
+city_3501905,Amparo,3501905,base.state_br_sp,base.br
+city_3502002,Analândia,3502002,base.state_br_sp,base.br
+city_3502101,Andradina,3502101,base.state_br_sp,base.br
+city_3502200,Angatuba,3502200,base.state_br_sp,base.br
+city_3502309,Anhembi,3502309,base.state_br_sp,base.br
+city_3502408,Anhumas,3502408,base.state_br_sp,base.br
+city_3502507,Aparecida,3502507,base.state_br_sp,base.br
+city_3502606,Aparecida d'Oeste,3502606,base.state_br_sp,base.br
+city_3502705,Apiaí,3502705,base.state_br_sp,base.br
+city_3502754,Araçariguama,3502754,base.state_br_sp,base.br
+city_3502804,Araçatuba,3502804,base.state_br_sp,base.br
+city_3502903,Araçoiaba da Serra,3502903,base.state_br_sp,base.br
+city_3503000,Aramina,3503000,base.state_br_sp,base.br
+city_3503109,Arandu,3503109,base.state_br_sp,base.br
+city_3503158,Arapeí,3503158,base.state_br_sp,base.br
+city_3503208,Araraquara,3503208,base.state_br_sp,base.br
+city_3503307,Araras,3503307,base.state_br_sp,base.br
+city_3503356,Arco-Íris,3503356,base.state_br_sp,base.br
+city_3503406,Arealva,3503406,base.state_br_sp,base.br
+city_3503505,Areias,3503505,base.state_br_sp,base.br
+city_3503604,Areiópolis,3503604,base.state_br_sp,base.br
+city_3503703,Ariranha,3503703,base.state_br_sp,base.br
+city_3503802,Artur Nogueira,3503802,base.state_br_sp,base.br
+city_3503901,Arujá,3503901,base.state_br_sp,base.br
+city_3503950,Aspásia,3503950,base.state_br_sp,base.br
+city_3504008,Assis,3504008,base.state_br_sp,base.br
+city_3504107,Atibaia,3504107,base.state_br_sp,base.br
+city_3504206,Auriflama,3504206,base.state_br_sp,base.br
+city_3504305,Avaí,3504305,base.state_br_sp,base.br
+city_3504404,Avanhandava,3504404,base.state_br_sp,base.br
+city_3504503,Avaré,3504503,base.state_br_sp,base.br
+city_3504602,Bady Bassitt,3504602,base.state_br_sp,base.br
+city_3504701,Balbinos,3504701,base.state_br_sp,base.br
+city_3504800,Bálsamo,3504800,base.state_br_sp,base.br
+city_3504909,Bananal,3504909,base.state_br_sp,base.br
+city_3505005,Barão de Antonina,3505005,base.state_br_sp,base.br
+city_3505104,Barbosa,3505104,base.state_br_sp,base.br
+city_3505203,Bariri,3505203,base.state_br_sp,base.br
+city_3505302,Barra Bonita,3505302,base.state_br_sp,base.br
+city_3505351,Barra do Chapéu,3505351,base.state_br_sp,base.br
+city_3505401,Barra do Turvo,3505401,base.state_br_sp,base.br
+city_3505500,Barretos,3505500,base.state_br_sp,base.br
+city_3505609,Barrinha,3505609,base.state_br_sp,base.br
+city_3505708,Barueri,3505708,base.state_br_sp,base.br
+city_3505807,Bastos,3505807,base.state_br_sp,base.br
+city_3505906,Batatais,3505906,base.state_br_sp,base.br
+city_3506003,Bauru,3506003,base.state_br_sp,base.br
+city_3506102,Bebedouro,3506102,base.state_br_sp,base.br
+city_3506201,Bento de Abreu,3506201,base.state_br_sp,base.br
+city_3506300,Bernardino de Campos,3506300,base.state_br_sp,base.br
+city_3506359,Bertioga,3506359,base.state_br_sp,base.br
+city_3506409,Bilac,3506409,base.state_br_sp,base.br
+city_3506508,Birigui,3506508,base.state_br_sp,base.br
+city_3506607,Biritiba Mirim,3506607,base.state_br_sp,base.br
+city_3506706,Boa Esperança do Sul,3506706,base.state_br_sp,base.br
+city_3506805,Bocaina,3506805,base.state_br_sp,base.br
+city_3506904,Bofete,3506904,base.state_br_sp,base.br
+city_3507001,Boituva,3507001,base.state_br_sp,base.br
+city_3507100,Bom Jesus dos Perdões,3507100,base.state_br_sp,base.br
+city_3507159,Bom Sucesso de Itararé,3507159,base.state_br_sp,base.br
+city_3507209,Borá,3507209,base.state_br_sp,base.br
+city_3507308,Boracéia,3507308,base.state_br_sp,base.br
+city_3507407,Borborema,3507407,base.state_br_sp,base.br
+city_3507456,Borebi,3507456,base.state_br_sp,base.br
+city_3507506,Botucatu,3507506,base.state_br_sp,base.br
+city_3507605,Bragança Paulista,3507605,base.state_br_sp,base.br
+city_3507704,Braúna,3507704,base.state_br_sp,base.br
+city_3507753,Brejo Alegre,3507753,base.state_br_sp,base.br
+city_3507803,Brodowski,3507803,base.state_br_sp,base.br
+city_3507902,Brotas,3507902,base.state_br_sp,base.br
+city_3508009,Buri,3508009,base.state_br_sp,base.br
+city_3508108,Buritama,3508108,base.state_br_sp,base.br
+city_3508207,Buritizal,3508207,base.state_br_sp,base.br
+city_3508306,Cabrália Paulista,3508306,base.state_br_sp,base.br
+city_3508405,Cabreúva,3508405,base.state_br_sp,base.br
+city_3508504,Caçapava,3508504,base.state_br_sp,base.br
+city_3508603,Cachoeira Paulista,3508603,base.state_br_sp,base.br
+city_3508702,Caconde,3508702,base.state_br_sp,base.br
+city_3508801,Cafelândia,3508801,base.state_br_sp,base.br
+city_3508900,Caiabu,3508900,base.state_br_sp,base.br
+city_3509007,Caieiras,3509007,base.state_br_sp,base.br
+city_3509106,Caiuá,3509106,base.state_br_sp,base.br
+city_3509205,Cajamar,3509205,base.state_br_sp,base.br
+city_3509254,Cajati,3509254,base.state_br_sp,base.br
+city_3509304,Cajobi,3509304,base.state_br_sp,base.br
+city_3509403,Cajuru,3509403,base.state_br_sp,base.br
+city_3509452,Campina do Monte Alegre,3509452,base.state_br_sp,base.br
+city_3509502,Campinas,3509502,base.state_br_sp,base.br
+city_3509601,Campo Limpo Paulista,3509601,base.state_br_sp,base.br
+city_3509700,Campos do Jordão,3509700,base.state_br_sp,base.br
+city_3509809,Campos Novos Paulista,3509809,base.state_br_sp,base.br
+city_3509908,Cananéia,3509908,base.state_br_sp,base.br
+city_3509957,Canas,3509957,base.state_br_sp,base.br
+city_3510005,Cândido Mota,3510005,base.state_br_sp,base.br
+city_3510104,Cândido Rodrigues,3510104,base.state_br_sp,base.br
+city_3510153,Canitar,3510153,base.state_br_sp,base.br
+city_3510203,Capão Bonito,3510203,base.state_br_sp,base.br
+city_3510302,Capela do Alto,3510302,base.state_br_sp,base.br
+city_3510401,Capivari,3510401,base.state_br_sp,base.br
+city_3510500,Caraguatatuba,3510500,base.state_br_sp,base.br
+city_3510609,Carapicuíba,3510609,base.state_br_sp,base.br
+city_3510708,Cardoso,3510708,base.state_br_sp,base.br
+city_3510807,Casa Branca,3510807,base.state_br_sp,base.br
+city_3510906,Cássia dos Coqueiros,3510906,base.state_br_sp,base.br
+city_3511003,Castilho,3511003,base.state_br_sp,base.br
+city_3511102,Catanduva,3511102,base.state_br_sp,base.br
+city_3511201,Catiguá,3511201,base.state_br_sp,base.br
+city_3511300,Cedral,3511300,base.state_br_sp,base.br
+city_3511409,Cerqueira César,3511409,base.state_br_sp,base.br
+city_3511508,Cerquilho,3511508,base.state_br_sp,base.br
+city_3511607,Cesário Lange,3511607,base.state_br_sp,base.br
+city_3511706,Charqueada,3511706,base.state_br_sp,base.br
+city_3557204,Chavantes,3557204,base.state_br_sp,base.br
+city_3511904,Clementina,3511904,base.state_br_sp,base.br
+city_3512001,Colina,3512001,base.state_br_sp,base.br
+city_3512100,Colômbia,3512100,base.state_br_sp,base.br
+city_3512209,Conchal,3512209,base.state_br_sp,base.br
+city_3512308,Conchas,3512308,base.state_br_sp,base.br
+city_3512407,Cordeirópolis,3512407,base.state_br_sp,base.br
+city_3512506,Coroados,3512506,base.state_br_sp,base.br
+city_3512605,Coronel Macedo,3512605,base.state_br_sp,base.br
+city_3512704,Corumbataí,3512704,base.state_br_sp,base.br
+city_3512803,Cosmópolis,3512803,base.state_br_sp,base.br
+city_3512902,Cosmorama,3512902,base.state_br_sp,base.br
+city_3513009,Cotia,3513009,base.state_br_sp,base.br
+city_3513108,Cravinhos,3513108,base.state_br_sp,base.br
+city_3513207,Cristais Paulista,3513207,base.state_br_sp,base.br
+city_3513306,Cruzália,3513306,base.state_br_sp,base.br
+city_3513405,Cruzeiro,3513405,base.state_br_sp,base.br
+city_3513504,Cubatão,3513504,base.state_br_sp,base.br
+city_3513603,Cunha,3513603,base.state_br_sp,base.br
+city_3513702,Descalvado,3513702,base.state_br_sp,base.br
+city_3513801,Diadema,3513801,base.state_br_sp,base.br
+city_3513850,Dirce Reis,3513850,base.state_br_sp,base.br
+city_3513900,Divinolândia,3513900,base.state_br_sp,base.br
+city_3514007,Dobrada,3514007,base.state_br_sp,base.br
+city_3514106,Dois Córregos,3514106,base.state_br_sp,base.br
+city_3514205,Dolcinópolis,3514205,base.state_br_sp,base.br
+city_3514304,Dourado,3514304,base.state_br_sp,base.br
+city_3514403,Dracena,3514403,base.state_br_sp,base.br
+city_3514502,Duartina,3514502,base.state_br_sp,base.br
+city_3514601,Dumont,3514601,base.state_br_sp,base.br
+city_3514700,Echaporã,3514700,base.state_br_sp,base.br
+city_3514809,Eldorado,3514809,base.state_br_sp,base.br
+city_3514908,Elias Fausto,3514908,base.state_br_sp,base.br
+city_3514924,Elisiário,3514924,base.state_br_sp,base.br
+city_3514957,Embaúba,3514957,base.state_br_sp,base.br
+city_3515004,Embu das Artes,3515004,base.state_br_sp,base.br
+city_3515103,Embu-Guaçu,3515103,base.state_br_sp,base.br
+city_3515129,Emilianópolis,3515129,base.state_br_sp,base.br
+city_3515152,Engenheiro Coelho,3515152,base.state_br_sp,base.br
+city_3515186,Espírito Santo do Pinhal,3515186,base.state_br_sp,base.br
+city_3515194,Espírito Santo do Turvo,3515194,base.state_br_sp,base.br
+city_3557303,Estiva Gerbi,3557303,base.state_br_sp,base.br
+city_3515301,Estrela do Norte,3515301,base.state_br_sp,base.br
+city_3515202,Estrela d'Oeste,3515202,base.state_br_sp,base.br
+city_3515350,Euclides da Cunha Paulista,3515350,base.state_br_sp,base.br
+city_3515400,Fartura,3515400,base.state_br_sp,base.br
+city_3515608,Fernando Prestes,3515608,base.state_br_sp,base.br
+city_3515509,Fernandópolis,3515509,base.state_br_sp,base.br
+city_3515657,Fernão,3515657,base.state_br_sp,base.br
+city_3515707,Ferraz de Vasconcelos,3515707,base.state_br_sp,base.br
+city_3515806,Flora Rica,3515806,base.state_br_sp,base.br
+city_3515905,Floreal,3515905,base.state_br_sp,base.br
+city_3516002,Flórida Paulista,3516002,base.state_br_sp,base.br
+city_3516101,Florínea,3516101,base.state_br_sp,base.br
+city_3516200,Franca,3516200,base.state_br_sp,base.br
+city_3516309,Francisco Morato,3516309,base.state_br_sp,base.br
+city_3516408,Franco da Rocha,3516408,base.state_br_sp,base.br
+city_3516507,Gabriel Monteiro,3516507,base.state_br_sp,base.br
+city_3516606,Gália,3516606,base.state_br_sp,base.br
+city_3516705,Garça,3516705,base.state_br_sp,base.br
+city_3516804,Gastão Vidigal,3516804,base.state_br_sp,base.br
+city_3516853,Gavião Peixoto,3516853,base.state_br_sp,base.br
+city_3516903,General Salgado,3516903,base.state_br_sp,base.br
+city_3517000,Getulina,3517000,base.state_br_sp,base.br
+city_3517109,Glicério,3517109,base.state_br_sp,base.br
+city_3517208,Guaiçara,3517208,base.state_br_sp,base.br
+city_3517307,Guaimbê,3517307,base.state_br_sp,base.br
+city_3517406,Guaíra,3517406,base.state_br_sp,base.br
+city_3517505,Guapiaçu,3517505,base.state_br_sp,base.br
+city_3517604,Guapiara,3517604,base.state_br_sp,base.br
+city_3517703,Guará,3517703,base.state_br_sp,base.br
+city_3517802,Guaraçaí,3517802,base.state_br_sp,base.br
+city_3517901,Guaraci,3517901,base.state_br_sp,base.br
+city_3518008,Guarani d'Oeste,3518008,base.state_br_sp,base.br
+city_3518107,Guarantã,3518107,base.state_br_sp,base.br
+city_3518206,Guararapes,3518206,base.state_br_sp,base.br
+city_3518305,Guararema,3518305,base.state_br_sp,base.br
+city_3518404,Guaratinguetá,3518404,base.state_br_sp,base.br
+city_3518503,Guareí,3518503,base.state_br_sp,base.br
+city_3518602,Guariba,3518602,base.state_br_sp,base.br
+city_3518701,Guarujá,3518701,base.state_br_sp,base.br
+city_3518800,Guarulhos,3518800,base.state_br_sp,base.br
+city_3518859,Guatapará,3518859,base.state_br_sp,base.br
+city_3518909,Guzolândia,3518909,base.state_br_sp,base.br
+city_3519006,Herculândia,3519006,base.state_br_sp,base.br
+city_3519055,Holambra,3519055,base.state_br_sp,base.br
+city_3519071,Hortolândia,3519071,base.state_br_sp,base.br
+city_3519105,Iacanga,3519105,base.state_br_sp,base.br
+city_3519204,Iacri,3519204,base.state_br_sp,base.br
+city_3519253,Iaras,3519253,base.state_br_sp,base.br
+city_3519303,Ibaté,3519303,base.state_br_sp,base.br
+city_3519402,Ibirá,3519402,base.state_br_sp,base.br
+city_3519501,Ibirarema,3519501,base.state_br_sp,base.br
+city_3519600,Ibitinga,3519600,base.state_br_sp,base.br
+city_3519709,Ibiúna,3519709,base.state_br_sp,base.br
+city_3519808,Icém,3519808,base.state_br_sp,base.br
+city_3519907,Iepê,3519907,base.state_br_sp,base.br
+city_3520004,Igaraçu do Tietê,3520004,base.state_br_sp,base.br
+city_3520103,Igarapava,3520103,base.state_br_sp,base.br
+city_3520202,Igaratá,3520202,base.state_br_sp,base.br
+city_3520301,Iguape,3520301,base.state_br_sp,base.br
+city_3520426,Ilha Comprida,3520426,base.state_br_sp,base.br
+city_3520442,Ilha Solteira,3520442,base.state_br_sp,base.br
+city_3520400,Ilhabela,3520400,base.state_br_sp,base.br
+city_3520509,Indaiatuba,3520509,base.state_br_sp,base.br
+city_3520608,Indiana,3520608,base.state_br_sp,base.br
+city_3520707,Indiaporã,3520707,base.state_br_sp,base.br
+city_3520806,Inúbia Paulista,3520806,base.state_br_sp,base.br
+city_3520905,Ipaussu,3520905,base.state_br_sp,base.br
+city_3521002,Iperó,3521002,base.state_br_sp,base.br
+city_3521101,Ipeúna,3521101,base.state_br_sp,base.br
+city_3521150,Ipiguá,3521150,base.state_br_sp,base.br
+city_3521200,Iporanga,3521200,base.state_br_sp,base.br
+city_3521309,Ipuã,3521309,base.state_br_sp,base.br
+city_3521408,Iracemápolis,3521408,base.state_br_sp,base.br
+city_3521507,Irapuã,3521507,base.state_br_sp,base.br
+city_3521606,Irapuru,3521606,base.state_br_sp,base.br
+city_3521705,Itaberá,3521705,base.state_br_sp,base.br
+city_3521804,Itaí,3521804,base.state_br_sp,base.br
+city_3521903,Itajobi,3521903,base.state_br_sp,base.br
+city_3522000,Itaju,3522000,base.state_br_sp,base.br
+city_3522109,Itanhaém,3522109,base.state_br_sp,base.br
+city_3522158,Itaoca,3522158,base.state_br_sp,base.br
+city_3522208,Itapecerica da Serra,3522208,base.state_br_sp,base.br
+city_3522307,Itapetininga,3522307,base.state_br_sp,base.br
+city_3522406,Itapeva,3522406,base.state_br_sp,base.br
+city_3522505,Itapevi,3522505,base.state_br_sp,base.br
+city_3522604,Itapira,3522604,base.state_br_sp,base.br
+city_3522653,Itapirapuã Paulista,3522653,base.state_br_sp,base.br
+city_3522703,Itápolis,3522703,base.state_br_sp,base.br
+city_3522802,Itaporanga,3522802,base.state_br_sp,base.br
+city_3522901,Itapuí,3522901,base.state_br_sp,base.br
+city_3523008,Itapura,3523008,base.state_br_sp,base.br
+city_3523107,Itaquaquecetuba,3523107,base.state_br_sp,base.br
+city_3523206,Itararé,3523206,base.state_br_sp,base.br
+city_3523305,Itariri,3523305,base.state_br_sp,base.br
+city_3523404,Itatiba,3523404,base.state_br_sp,base.br
+city_3523503,Itatinga,3523503,base.state_br_sp,base.br
+city_3523602,Itirapina,3523602,base.state_br_sp,base.br
+city_3523701,Itirapuã,3523701,base.state_br_sp,base.br
+city_3523800,Itobi,3523800,base.state_br_sp,base.br
+city_3523909,Itu,3523909,base.state_br_sp,base.br
+city_3524006,Itupeva,3524006,base.state_br_sp,base.br
+city_3524105,Ituverava,3524105,base.state_br_sp,base.br
+city_3524204,Jaborandi,3524204,base.state_br_sp,base.br
+city_3524303,Jaboticabal,3524303,base.state_br_sp,base.br
+city_3524402,Jacareí,3524402,base.state_br_sp,base.br
+city_3524501,Jaci,3524501,base.state_br_sp,base.br
+city_3524600,Jacupiranga,3524600,base.state_br_sp,base.br
+city_3524709,Jaguariúna,3524709,base.state_br_sp,base.br
+city_3524808,Jales,3524808,base.state_br_sp,base.br
+city_3524907,Jambeiro,3524907,base.state_br_sp,base.br
+city_3525003,Jandira,3525003,base.state_br_sp,base.br
+city_3525102,Jardinópolis,3525102,base.state_br_sp,base.br
+city_3525201,Jarinu,3525201,base.state_br_sp,base.br
+city_3525300,Jaú,3525300,base.state_br_sp,base.br
+city_3525409,Jeriquara,3525409,base.state_br_sp,base.br
+city_3525508,Joanópolis,3525508,base.state_br_sp,base.br
+city_3525607,João Ramalho,3525607,base.state_br_sp,base.br
+city_3525706,José Bonifácio,3525706,base.state_br_sp,base.br
+city_3525805,Júlio Mesquita,3525805,base.state_br_sp,base.br
+city_3525854,Jumirim,3525854,base.state_br_sp,base.br
+city_3525904,Jundiaí,3525904,base.state_br_sp,base.br
+city_3526001,Junqueirópolis,3526001,base.state_br_sp,base.br
+city_3526100,Juquiá,3526100,base.state_br_sp,base.br
+city_3526209,Juquitiba,3526209,base.state_br_sp,base.br
+city_3526308,Lagoinha,3526308,base.state_br_sp,base.br
+city_3526407,Laranjal Paulista,3526407,base.state_br_sp,base.br
+city_3526506,Lavínia,3526506,base.state_br_sp,base.br
+city_3526605,Lavrinhas,3526605,base.state_br_sp,base.br
+city_3526704,Leme,3526704,base.state_br_sp,base.br
+city_3526803,Lençóis Paulista,3526803,base.state_br_sp,base.br
+city_3526902,Limeira,3526902,base.state_br_sp,base.br
+city_3527009,Lindóia,3527009,base.state_br_sp,base.br
+city_3527108,Lins,3527108,base.state_br_sp,base.br
+city_3527207,Lorena,3527207,base.state_br_sp,base.br
+city_3527256,Lourdes,3527256,base.state_br_sp,base.br
+city_3527306,Louveira,3527306,base.state_br_sp,base.br
+city_3527405,Lucélia,3527405,base.state_br_sp,base.br
+city_3527504,Lucianópolis,3527504,base.state_br_sp,base.br
+city_3527603,Luís Antônio,3527603,base.state_br_sp,base.br
+city_3527702,Luiziânia,3527702,base.state_br_sp,base.br
+city_3527801,Lupércio,3527801,base.state_br_sp,base.br
+city_3527900,Lutécia,3527900,base.state_br_sp,base.br
+city_3528007,Macatuba,3528007,base.state_br_sp,base.br
+city_3528106,Macaubal,3528106,base.state_br_sp,base.br
+city_3528205,Macedônia,3528205,base.state_br_sp,base.br
+city_3528304,Magda,3528304,base.state_br_sp,base.br
+city_3528403,Mairinque,3528403,base.state_br_sp,base.br
+city_3528502,Mairiporã,3528502,base.state_br_sp,base.br
+city_3528601,Manduri,3528601,base.state_br_sp,base.br
+city_3528700,Marabá Paulista,3528700,base.state_br_sp,base.br
+city_3528809,Maracaí,3528809,base.state_br_sp,base.br
+city_3528858,Marapoama,3528858,base.state_br_sp,base.br
+city_3528908,Mariápolis,3528908,base.state_br_sp,base.br
+city_3529005,Marília,3529005,base.state_br_sp,base.br
+city_3529104,Marinópolis,3529104,base.state_br_sp,base.br
+city_3529203,Martinópolis,3529203,base.state_br_sp,base.br
+city_3529302,Matão,3529302,base.state_br_sp,base.br
+city_3529401,Mauá,3529401,base.state_br_sp,base.br
+city_3529500,Mendonça,3529500,base.state_br_sp,base.br
+city_3529609,Meridiano,3529609,base.state_br_sp,base.br
+city_3529658,Mesópolis,3529658,base.state_br_sp,base.br
+city_3529708,Miguelópolis,3529708,base.state_br_sp,base.br
+city_3529807,Mineiros do Tietê,3529807,base.state_br_sp,base.br
+city_3530003,Mira Estrela,3530003,base.state_br_sp,base.br
+city_3529906,Miracatu,3529906,base.state_br_sp,base.br
+city_3530102,Mirandópolis,3530102,base.state_br_sp,base.br
+city_3530201,Mirante do Paranapanema,3530201,base.state_br_sp,base.br
+city_3530300,Mirassol,3530300,base.state_br_sp,base.br
+city_3530409,Mirassolândia,3530409,base.state_br_sp,base.br
+city_3530508,Mococa,3530508,base.state_br_sp,base.br
+city_3530607,Mogi das Cruzes,3530607,base.state_br_sp,base.br
+city_3530706,Mogi Guaçu,3530706,base.state_br_sp,base.br
+city_3530805,Mogi Mirim,3530805,base.state_br_sp,base.br
+city_3530904,Mombuca,3530904,base.state_br_sp,base.br
+city_3531001,Monções,3531001,base.state_br_sp,base.br
+city_3531100,Mongaguá,3531100,base.state_br_sp,base.br
+city_3531209,Monte Alegre do Sul,3531209,base.state_br_sp,base.br
+city_3531308,Monte Alto,3531308,base.state_br_sp,base.br
+city_3531407,Monte Aprazível,3531407,base.state_br_sp,base.br
+city_3531506,Monte Azul Paulista,3531506,base.state_br_sp,base.br
+city_3531605,Monte Castelo,3531605,base.state_br_sp,base.br
+city_3531803,Monte Mor,3531803,base.state_br_sp,base.br
+city_3531704,Monteiro Lobato,3531704,base.state_br_sp,base.br
+city_3531902,Morro Agudo,3531902,base.state_br_sp,base.br
+city_3532009,Morungaba,3532009,base.state_br_sp,base.br
+city_3532058,Motuca,3532058,base.state_br_sp,base.br
+city_3532108,Murutinga do Sul,3532108,base.state_br_sp,base.br
+city_3532157,Nantes,3532157,base.state_br_sp,base.br
+city_3532207,Narandiba,3532207,base.state_br_sp,base.br
+city_3532306,Natividade da Serra,3532306,base.state_br_sp,base.br
+city_3532405,Nazaré Paulista,3532405,base.state_br_sp,base.br
+city_3532504,Neves Paulista,3532504,base.state_br_sp,base.br
+city_3532603,Nhandeara,3532603,base.state_br_sp,base.br
+city_3532702,Nipoã,3532702,base.state_br_sp,base.br
+city_3532801,Nova Aliança,3532801,base.state_br_sp,base.br
+city_3532827,Nova Campina,3532827,base.state_br_sp,base.br
+city_3532843,Nova Canaã Paulista,3532843,base.state_br_sp,base.br
+city_3532868,Nova Castilho,3532868,base.state_br_sp,base.br
+city_3532900,Nova Europa,3532900,base.state_br_sp,base.br
+city_3533007,Nova Granada,3533007,base.state_br_sp,base.br
+city_3533106,Nova Guataporanga,3533106,base.state_br_sp,base.br
+city_3533205,Nova Independência,3533205,base.state_br_sp,base.br
+city_3533304,Nova Luzitânia,3533304,base.state_br_sp,base.br
+city_3533403,Nova Odessa,3533403,base.state_br_sp,base.br
+city_3533254,Novais,3533254,base.state_br_sp,base.br
+city_3533502,Novo Horizonte,3533502,base.state_br_sp,base.br
+city_3533601,Nuporanga,3533601,base.state_br_sp,base.br
+city_3533700,Ocauçu,3533700,base.state_br_sp,base.br
+city_3533809,Óleo,3533809,base.state_br_sp,base.br
+city_3533908,Olímpia,3533908,base.state_br_sp,base.br
+city_3534005,Onda Verde,3534005,base.state_br_sp,base.br
+city_3534104,Oriente,3534104,base.state_br_sp,base.br
+city_3534203,Orindiúva,3534203,base.state_br_sp,base.br
+city_3534302,Orlândia,3534302,base.state_br_sp,base.br
+city_3534401,Osasco,3534401,base.state_br_sp,base.br
+city_3534500,Oscar Bressane,3534500,base.state_br_sp,base.br
+city_3534609,Osvaldo Cruz,3534609,base.state_br_sp,base.br
+city_3534708,Ourinhos,3534708,base.state_br_sp,base.br
+city_3534807,Ouro Verde,3534807,base.state_br_sp,base.br
+city_3534757,Ouroeste,3534757,base.state_br_sp,base.br
+city_3534906,Pacaembu,3534906,base.state_br_sp,base.br
+city_3535002,Palestina,3535002,base.state_br_sp,base.br
+city_3535101,Palmares Paulista,3535101,base.state_br_sp,base.br
+city_3535200,Palmeira d'Oeste,3535200,base.state_br_sp,base.br
+city_3535309,Palmital,3535309,base.state_br_sp,base.br
+city_3535408,Panorama,3535408,base.state_br_sp,base.br
+city_3535507,Paraguaçu Paulista,3535507,base.state_br_sp,base.br
+city_3535606,Paraibuna,3535606,base.state_br_sp,base.br
+city_3535705,Paraíso,3535705,base.state_br_sp,base.br
+city_3535804,Paranapanema,3535804,base.state_br_sp,base.br
+city_3535903,Paranapuã,3535903,base.state_br_sp,base.br
+city_3536000,Parapuã,3536000,base.state_br_sp,base.br
+city_3536109,Pardinho,3536109,base.state_br_sp,base.br
+city_3536208,Pariquera-Açu,3536208,base.state_br_sp,base.br
+city_3536257,Parisi,3536257,base.state_br_sp,base.br
+city_3536307,Patrocínio Paulista,3536307,base.state_br_sp,base.br
+city_3536406,Paulicéia,3536406,base.state_br_sp,base.br
+city_3536505,Paulínia,3536505,base.state_br_sp,base.br
+city_3536570,Paulistânia,3536570,base.state_br_sp,base.br
+city_3536604,Paulo de Faria,3536604,base.state_br_sp,base.br
+city_3536703,Pederneiras,3536703,base.state_br_sp,base.br
+city_3536802,Pedra Bela,3536802,base.state_br_sp,base.br
+city_3536901,Pedranópolis,3536901,base.state_br_sp,base.br
+city_3537008,Pedregulho,3537008,base.state_br_sp,base.br
+city_3537107,Pedreira,3537107,base.state_br_sp,base.br
+city_3537156,Pedrinhas Paulista,3537156,base.state_br_sp,base.br
+city_3537206,Pedro de Toledo,3537206,base.state_br_sp,base.br
+city_3537305,Penápolis,3537305,base.state_br_sp,base.br
+city_3537404,Pereira Barreto,3537404,base.state_br_sp,base.br
+city_3537503,Pereiras,3537503,base.state_br_sp,base.br
+city_3537602,Peruíbe,3537602,base.state_br_sp,base.br
+city_3537701,Piacatu,3537701,base.state_br_sp,base.br
+city_3537800,Piedade,3537800,base.state_br_sp,base.br
+city_3537909,Pilar do Sul,3537909,base.state_br_sp,base.br
+city_3538006,Pindamonhangaba,3538006,base.state_br_sp,base.br
+city_3538105,Pindorama,3538105,base.state_br_sp,base.br
+city_3538204,Pinhalzinho,3538204,base.state_br_sp,base.br
+city_3538303,Piquerobi,3538303,base.state_br_sp,base.br
+city_3538501,Piquete,3538501,base.state_br_sp,base.br
+city_3538600,Piracaia,3538600,base.state_br_sp,base.br
+city_3538709,Piracicaba,3538709,base.state_br_sp,base.br
+city_3538808,Piraju,3538808,base.state_br_sp,base.br
+city_3538907,Pirajuí,3538907,base.state_br_sp,base.br
+city_3539004,Pirangi,3539004,base.state_br_sp,base.br
+city_3539103,Pirapora do Bom Jesus,3539103,base.state_br_sp,base.br
+city_3539202,Pirapozinho,3539202,base.state_br_sp,base.br
+city_3539301,Pirassununga,3539301,base.state_br_sp,base.br
+city_3539400,Piratininga,3539400,base.state_br_sp,base.br
+city_3539509,Pitangueiras,3539509,base.state_br_sp,base.br
+city_3539608,Planalto,3539608,base.state_br_sp,base.br
+city_3539707,Platina,3539707,base.state_br_sp,base.br
+city_3539806,Poá,3539806,base.state_br_sp,base.br
+city_3539905,Poloni,3539905,base.state_br_sp,base.br
+city_3540002,Pompéia,3540002,base.state_br_sp,base.br
+city_3540101,Pongaí,3540101,base.state_br_sp,base.br
+city_3540200,Pontal,3540200,base.state_br_sp,base.br
+city_3540259,Pontalinda,3540259,base.state_br_sp,base.br
+city_3540309,Pontes Gestal,3540309,base.state_br_sp,base.br
+city_3540408,Populina,3540408,base.state_br_sp,base.br
+city_3540507,Porangaba,3540507,base.state_br_sp,base.br
+city_3540606,Porto Feliz,3540606,base.state_br_sp,base.br
+city_3540705,Porto Ferreira,3540705,base.state_br_sp,base.br
+city_3540754,Potim,3540754,base.state_br_sp,base.br
+city_3540804,Potirendaba,3540804,base.state_br_sp,base.br
+city_3540853,Pracinha,3540853,base.state_br_sp,base.br
+city_3540903,Pradópolis,3540903,base.state_br_sp,base.br
+city_3541000,Praia Grande,3541000,base.state_br_sp,base.br
+city_3541059,Pratânia,3541059,base.state_br_sp,base.br
+city_3541109,Presidente Alves,3541109,base.state_br_sp,base.br
+city_3541208,Presidente Bernardes,3541208,base.state_br_sp,base.br
+city_3541307,Presidente Epitácio,3541307,base.state_br_sp,base.br
+city_3541406,Presidente Prudente,3541406,base.state_br_sp,base.br
+city_3541505,Presidente Venceslau,3541505,base.state_br_sp,base.br
+city_3541604,Promissão,3541604,base.state_br_sp,base.br
+city_3541653,Quadra,3541653,base.state_br_sp,base.br
+city_3541703,Quatá,3541703,base.state_br_sp,base.br
+city_3541802,Queiroz,3541802,base.state_br_sp,base.br
+city_3541901,Queluz,3541901,base.state_br_sp,base.br
+city_3542008,Quintana,3542008,base.state_br_sp,base.br
+city_3542107,Rafard,3542107,base.state_br_sp,base.br
+city_3542206,Rancharia,3542206,base.state_br_sp,base.br
+city_3542305,Redenção da Serra,3542305,base.state_br_sp,base.br
+city_3542404,Regente Feijó,3542404,base.state_br_sp,base.br
+city_3542503,Reginópolis,3542503,base.state_br_sp,base.br
+city_3542602,Registro,3542602,base.state_br_sp,base.br
+city_3542701,Restinga,3542701,base.state_br_sp,base.br
+city_3542800,Ribeira,3542800,base.state_br_sp,base.br
+city_3542909,Ribeirão Bonito,3542909,base.state_br_sp,base.br
+city_3543006,Ribeirão Branco,3543006,base.state_br_sp,base.br
+city_3543105,Ribeirão Corrente,3543105,base.state_br_sp,base.br
+city_3543204,Ribeirão do Sul,3543204,base.state_br_sp,base.br
+city_3543238,Ribeirão dos Índios,3543238,base.state_br_sp,base.br
+city_3543253,Ribeirão Grande,3543253,base.state_br_sp,base.br
+city_3543303,Ribeirão Pires,3543303,base.state_br_sp,base.br
+city_3543402,Ribeirão Preto,3543402,base.state_br_sp,base.br
+city_3543600,Rifaina,3543600,base.state_br_sp,base.br
+city_3543709,Rincão,3543709,base.state_br_sp,base.br
+city_3543808,Rinópolis,3543808,base.state_br_sp,base.br
+city_3543907,Rio Claro,3543907,base.state_br_sp,base.br
+city_3544004,Rio das Pedras,3544004,base.state_br_sp,base.br
+city_3544103,Rio Grande da Serra,3544103,base.state_br_sp,base.br
+city_3544202,Riolândia,3544202,base.state_br_sp,base.br
+city_3543501,Riversul,3543501,base.state_br_sp,base.br
+city_3544251,Rosana,3544251,base.state_br_sp,base.br
+city_3544301,Roseira,3544301,base.state_br_sp,base.br
+city_3544400,Rubiácea,3544400,base.state_br_sp,base.br
+city_3544509,Rubinéia,3544509,base.state_br_sp,base.br
+city_3544608,Sabino,3544608,base.state_br_sp,base.br
+city_3544707,Sagres,3544707,base.state_br_sp,base.br
+city_3544806,Sales,3544806,base.state_br_sp,base.br
+city_3544905,Sales Oliveira,3544905,base.state_br_sp,base.br
+city_3545001,Salesópolis,3545001,base.state_br_sp,base.br
+city_3545100,Salmourão,3545100,base.state_br_sp,base.br
+city_3545159,Saltinho,3545159,base.state_br_sp,base.br
+city_3545209,Salto,3545209,base.state_br_sp,base.br
+city_3545308,Salto de Pirapora,3545308,base.state_br_sp,base.br
+city_3545407,Salto Grande,3545407,base.state_br_sp,base.br
+city_3545506,Sandovalina,3545506,base.state_br_sp,base.br
+city_3545605,Santa Adélia,3545605,base.state_br_sp,base.br
+city_3545704,Santa Albertina,3545704,base.state_br_sp,base.br
+city_3545803,Santa Bárbara d'Oeste,3545803,base.state_br_sp,base.br
+city_3546009,Santa Branca,3546009,base.state_br_sp,base.br
+city_3546108,Santa Clara d'Oeste,3546108,base.state_br_sp,base.br
+city_3546207,Santa Cruz da Conceição,3546207,base.state_br_sp,base.br
+city_3546256,Santa Cruz da Esperança,3546256,base.state_br_sp,base.br
+city_3546306,Santa Cruz das Palmeiras,3546306,base.state_br_sp,base.br
+city_3546405,Santa Cruz do Rio Pardo,3546405,base.state_br_sp,base.br
+city_3546504,Santa Ernestina,3546504,base.state_br_sp,base.br
+city_3546603,Santa Fé do Sul,3546603,base.state_br_sp,base.br
+city_3546702,Santa Gertrudes,3546702,base.state_br_sp,base.br
+city_3546801,Santa Isabel,3546801,base.state_br_sp,base.br
+city_3546900,Santa Lúcia,3546900,base.state_br_sp,base.br
+city_3547007,Santa Maria da Serra,3547007,base.state_br_sp,base.br
+city_3547106,Santa Mercedes,3547106,base.state_br_sp,base.br
+city_3547502,Santa Rita do Passa Quatro,3547502,base.state_br_sp,base.br
+city_3547403,Santa Rita d'Oeste,3547403,base.state_br_sp,base.br
+city_3547601,Santa Rosa de Viterbo,3547601,base.state_br_sp,base.br
+city_3547650,Santa Salete,3547650,base.state_br_sp,base.br
+city_3547205,Santana da Ponte Pensa,3547205,base.state_br_sp,base.br
+city_3547304,Santana de Parnaíba,3547304,base.state_br_sp,base.br
+city_3547700,Santo Anastácio,3547700,base.state_br_sp,base.br
+city_3547809,Santo André,3547809,base.state_br_sp,base.br
+city_3547908,Santo Antônio da Alegria,3547908,base.state_br_sp,base.br
+city_3548005,Santo Antônio de Posse,3548005,base.state_br_sp,base.br
+city_3548054,Santo Antônio do Aracanguá,3548054,base.state_br_sp,base.br
+city_3548104,Santo Antônio do Jardim,3548104,base.state_br_sp,base.br
+city_3548203,Santo Antônio do Pinhal,3548203,base.state_br_sp,base.br
+city_3548302,Santo Expedito,3548302,base.state_br_sp,base.br
+city_3548401,Santópolis do Aguapeí,3548401,base.state_br_sp,base.br
+city_3548500,Santos,3548500,base.state_br_sp,base.br
+city_3548609,São Bento do Sapucaí,3548609,base.state_br_sp,base.br
+city_3548708,São Bernardo do Campo,3548708,base.state_br_sp,base.br
+city_3548807,São Caetano do Sul,3548807,base.state_br_sp,base.br
+city_3548906,São Carlos,3548906,base.state_br_sp,base.br
+city_3549003,São Francisco,3549003,base.state_br_sp,base.br
+city_3549102,São João da Boa Vista,3549102,base.state_br_sp,base.br
+city_3549201,São João das Duas Pontes,3549201,base.state_br_sp,base.br
+city_3549250,São João de Iracema,3549250,base.state_br_sp,base.br
+city_3549300,São João do Pau d'Alho,3549300,base.state_br_sp,base.br
+city_3549409,São Joaquim da Barra,3549409,base.state_br_sp,base.br
+city_3549508,São José da Bela Vista,3549508,base.state_br_sp,base.br
+city_3549607,São José do Barreiro,3549607,base.state_br_sp,base.br
+city_3549706,São José do Rio Pardo,3549706,base.state_br_sp,base.br
+city_3549805,São José do Rio Preto,3549805,base.state_br_sp,base.br
+city_3549904,São José dos Campos,3549904,base.state_br_sp,base.br
+city_3549953,São Lourenço da Serra,3549953,base.state_br_sp,base.br
+city_3550001,São Luiz do Paraitinga,3550001,base.state_br_sp,base.br
+city_3550100,São Manuel,3550100,base.state_br_sp,base.br
+city_3550209,São Miguel Arcanjo,3550209,base.state_br_sp,base.br
+city_3550308,São Paulo,3550308,base.state_br_sp,base.br
+city_3550407,São Pedro,3550407,base.state_br_sp,base.br
+city_3550506,São Pedro do Turvo,3550506,base.state_br_sp,base.br
+city_3550605,São Roque,3550605,base.state_br_sp,base.br
+city_3550704,São Sebastião,3550704,base.state_br_sp,base.br
+city_3550803,São Sebastião da Grama,3550803,base.state_br_sp,base.br
+city_3550902,São Simão,3550902,base.state_br_sp,base.br
+city_3551009,São Vicente,3551009,base.state_br_sp,base.br
+city_3551108,Sarapuí,3551108,base.state_br_sp,base.br
+city_3551207,Sarutaiá,3551207,base.state_br_sp,base.br
+city_3551306,Sebastianópolis do Sul,3551306,base.state_br_sp,base.br
+city_3551405,Serra Azul,3551405,base.state_br_sp,base.br
+city_3551603,Serra Negra,3551603,base.state_br_sp,base.br
+city_3551504,Serrana,3551504,base.state_br_sp,base.br
+city_3551702,Sertãozinho,3551702,base.state_br_sp,base.br
+city_3551801,Sete Barras,3551801,base.state_br_sp,base.br
+city_3551900,Severínia,3551900,base.state_br_sp,base.br
+city_3552007,Silveiras,3552007,base.state_br_sp,base.br
+city_3552106,Socorro,3552106,base.state_br_sp,base.br
+city_3552205,Sorocaba,3552205,base.state_br_sp,base.br
+city_3552304,Sud Mennucci,3552304,base.state_br_sp,base.br
+city_3552403,Sumaré,3552403,base.state_br_sp,base.br
+city_3552551,Suzanápolis,3552551,base.state_br_sp,base.br
+city_3552502,Suzano,3552502,base.state_br_sp,base.br
+city_3552601,Tabapuã,3552601,base.state_br_sp,base.br
+city_3552700,Tabatinga,3552700,base.state_br_sp,base.br
+city_3552809,Taboão da Serra,3552809,base.state_br_sp,base.br
+city_3552908,Taciba,3552908,base.state_br_sp,base.br
+city_3553005,Taguaí,3553005,base.state_br_sp,base.br
+city_3553104,Taiaçu,3553104,base.state_br_sp,base.br
+city_3553203,Taiúva,3553203,base.state_br_sp,base.br
+city_3553302,Tambaú,3553302,base.state_br_sp,base.br
+city_3553401,Tanabi,3553401,base.state_br_sp,base.br
+city_3553500,Tapiraí,3553500,base.state_br_sp,base.br
+city_3553609,Tapiratiba,3553609,base.state_br_sp,base.br
+city_3553658,Taquaral,3553658,base.state_br_sp,base.br
+city_3553708,Taquaritinga,3553708,base.state_br_sp,base.br
+city_3553807,Taquarituba,3553807,base.state_br_sp,base.br
+city_3553856,Taquarivaí,3553856,base.state_br_sp,base.br
+city_3553906,Tarabai,3553906,base.state_br_sp,base.br
+city_3553955,Tarumã,3553955,base.state_br_sp,base.br
+city_3554003,Tatuí,3554003,base.state_br_sp,base.br
+city_3554102,Taubaté,3554102,base.state_br_sp,base.br
+city_3554201,Tejupá,3554201,base.state_br_sp,base.br
+city_3554300,Teodoro Sampaio,3554300,base.state_br_sp,base.br
+city_3554409,Terra Roxa,3554409,base.state_br_sp,base.br
+city_3554508,Tietê,3554508,base.state_br_sp,base.br
+city_3554607,Timburi,3554607,base.state_br_sp,base.br
+city_3554656,Torre de Pedra,3554656,base.state_br_sp,base.br
+city_3554706,Torrinha,3554706,base.state_br_sp,base.br
+city_3554755,Trabiju,3554755,base.state_br_sp,base.br
+city_3554805,Tremembé,3554805,base.state_br_sp,base.br
+city_3554904,Três Fronteiras,3554904,base.state_br_sp,base.br
+city_3554953,Tuiuti,3554953,base.state_br_sp,base.br
+city_3555000,Tupã,3555000,base.state_br_sp,base.br
+city_3555109,Tupi Paulista,3555109,base.state_br_sp,base.br
+city_3555208,Turiúba,3555208,base.state_br_sp,base.br
+city_3555307,Turmalina,3555307,base.state_br_sp,base.br
+city_3555356,Ubarana,3555356,base.state_br_sp,base.br
+city_3555406,Ubatuba,3555406,base.state_br_sp,base.br
+city_3555505,Ubirajara,3555505,base.state_br_sp,base.br
+city_3555604,Uchoa,3555604,base.state_br_sp,base.br
+city_3555703,União Paulista,3555703,base.state_br_sp,base.br
+city_3555802,Urânia,3555802,base.state_br_sp,base.br
+city_3555901,Uru,3555901,base.state_br_sp,base.br
+city_3556008,Urupês,3556008,base.state_br_sp,base.br
+city_3556107,Valentim Gentil,3556107,base.state_br_sp,base.br
+city_3556206,Valinhos,3556206,base.state_br_sp,base.br
+city_3556305,Valparaíso,3556305,base.state_br_sp,base.br
+city_3556354,Vargem,3556354,base.state_br_sp,base.br
+city_3556404,Vargem Grande do Sul,3556404,base.state_br_sp,base.br
+city_3556453,Vargem Grande Paulista,3556453,base.state_br_sp,base.br
+city_3556503,Várzea Paulista,3556503,base.state_br_sp,base.br
+city_3556602,Vera Cruz,3556602,base.state_br_sp,base.br
+city_3556701,Vinhedo,3556701,base.state_br_sp,base.br
+city_3556800,Viradouro,3556800,base.state_br_sp,base.br
+city_3556909,Vista Alegre do Alto,3556909,base.state_br_sp,base.br
+city_3556958,Vitória Brasil,3556958,base.state_br_sp,base.br
+city_3557006,Votorantim,3557006,base.state_br_sp,base.br
+city_3557105,Votuporanga,3557105,base.state_br_sp,base.br
+city_3557154,Zacarias,3557154,base.state_br_sp,base.br
+city_4100103,Abatiá,4100103,base.state_br_pr,base.br
+city_4100202,Adrianópolis,4100202,base.state_br_pr,base.br
+city_4100301,Agudos do Sul,4100301,base.state_br_pr,base.br
+city_4100400,Almirante Tamandaré,4100400,base.state_br_pr,base.br
+city_4100459,Altamira do Paraná,4100459,base.state_br_pr,base.br
+city_4128625,Alto Paraíso,4128625,base.state_br_pr,base.br
+city_4100608,Alto Paraná,4100608,base.state_br_pr,base.br
+city_4100707,Alto Piquiri,4100707,base.state_br_pr,base.br
+city_4100509,Altônia,4100509,base.state_br_pr,base.br
+city_4100806,Alvorada do Sul,4100806,base.state_br_pr,base.br
+city_4100905,Amaporã,4100905,base.state_br_pr,base.br
+city_4101002,Ampére,4101002,base.state_br_pr,base.br
+city_4101051,Anahy,4101051,base.state_br_pr,base.br
+city_4101101,Andirá,4101101,base.state_br_pr,base.br
+city_4101150,Ângulo,4101150,base.state_br_pr,base.br
+city_4101200,Antonina,4101200,base.state_br_pr,base.br
+city_4101309,Antônio Olinto,4101309,base.state_br_pr,base.br
+city_4101408,Apucarana,4101408,base.state_br_pr,base.br
+city_4101507,Arapongas,4101507,base.state_br_pr,base.br
+city_4101606,Arapoti,4101606,base.state_br_pr,base.br
+city_4101655,Arapuã,4101655,base.state_br_pr,base.br
+city_4101705,Araruna,4101705,base.state_br_pr,base.br
+city_4101804,Araucária,4101804,base.state_br_pr,base.br
+city_4101853,Ariranha do Ivaí,4101853,base.state_br_pr,base.br
+city_4101903,Assaí,4101903,base.state_br_pr,base.br
+city_4102000,Assis Chateaubriand,4102000,base.state_br_pr,base.br
+city_4102109,Astorga,4102109,base.state_br_pr,base.br
+city_4102208,Atalaia,4102208,base.state_br_pr,base.br
+city_4102307,Balsa Nova,4102307,base.state_br_pr,base.br
+city_4102406,Bandeirantes,4102406,base.state_br_pr,base.br
+city_4102505,Barbosa Ferraz,4102505,base.state_br_pr,base.br
+city_4102703,Barra do Jacaré,4102703,base.state_br_pr,base.br
+city_4102604,Barracão,4102604,base.state_br_pr,base.br
+city_4102752,Bela Vista da Caroba,4102752,base.state_br_pr,base.br
+city_4102802,Bela Vista do Paraíso,4102802,base.state_br_pr,base.br
+city_4102901,Bituruna,4102901,base.state_br_pr,base.br
+city_4103008,Boa Esperança,4103008,base.state_br_pr,base.br
+city_4103024,Boa Esperança do Iguaçu,4103024,base.state_br_pr,base.br
+city_4103040,Boa Ventura de São Roque,4103040,base.state_br_pr,base.br
+city_4103057,Boa Vista da Aparecida,4103057,base.state_br_pr,base.br
+city_4103107,Bocaiúva do Sul,4103107,base.state_br_pr,base.br
+city_4103156,Bom Jesus do Sul,4103156,base.state_br_pr,base.br
+city_4103206,Bom Sucesso,4103206,base.state_br_pr,base.br
+city_4103222,Bom Sucesso do Sul,4103222,base.state_br_pr,base.br
+city_4103305,Borrazópolis,4103305,base.state_br_pr,base.br
+city_4103354,Braganey,4103354,base.state_br_pr,base.br
+city_4103370,Brasilândia do Sul,4103370,base.state_br_pr,base.br
+city_4103404,Cafeara,4103404,base.state_br_pr,base.br
+city_4103453,Cafelândia,4103453,base.state_br_pr,base.br
+city_4103479,Cafezal do Sul,4103479,base.state_br_pr,base.br
+city_4103503,Califórnia,4103503,base.state_br_pr,base.br
+city_4103602,Cambará,4103602,base.state_br_pr,base.br
+city_4103701,Cambé,4103701,base.state_br_pr,base.br
+city_4103800,Cambira,4103800,base.state_br_pr,base.br
+city_4103909,Campina da Lagoa,4103909,base.state_br_pr,base.br
+city_4103958,Campina do Simão,4103958,base.state_br_pr,base.br
+city_4104006,Campina Grande do Sul,4104006,base.state_br_pr,base.br
+city_4104055,Campo Bonito,4104055,base.state_br_pr,base.br
+city_4104105,Campo do Tenente,4104105,base.state_br_pr,base.br
+city_4104204,Campo Largo,4104204,base.state_br_pr,base.br
+city_4104253,Campo Magro,4104253,base.state_br_pr,base.br
+city_4104303,Campo Mourão,4104303,base.state_br_pr,base.br
+city_4104402,Cândido de Abreu,4104402,base.state_br_pr,base.br
+city_4104428,Candói,4104428,base.state_br_pr,base.br
+city_4104451,Cantagalo,4104451,base.state_br_pr,base.br
+city_4104501,Capanema,4104501,base.state_br_pr,base.br
+city_4104600,Capitão Leônidas Marques,4104600,base.state_br_pr,base.br
+city_4104659,Carambeí,4104659,base.state_br_pr,base.br
+city_4104709,Carlópolis,4104709,base.state_br_pr,base.br
+city_4104808,Cascavel,4104808,base.state_br_pr,base.br
+city_4104907,Castro,4104907,base.state_br_pr,base.br
+city_4105003,Catanduvas,4105003,base.state_br_pr,base.br
+city_4105102,Centenário do Sul,4105102,base.state_br_pr,base.br
+city_4105201,Cerro Azul,4105201,base.state_br_pr,base.br
+city_4105300,Céu Azul,4105300,base.state_br_pr,base.br
+city_4105409,Chopinzinho,4105409,base.state_br_pr,base.br
+city_4105508,Cianorte,4105508,base.state_br_pr,base.br
+city_4105607,Cidade Gaúcha,4105607,base.state_br_pr,base.br
+city_4105706,Clevelândia,4105706,base.state_br_pr,base.br
+city_4105805,Colombo,4105805,base.state_br_pr,base.br
+city_4105904,Colorado,4105904,base.state_br_pr,base.br
+city_4106001,Congonhinhas,4106001,base.state_br_pr,base.br
+city_4106100,Conselheiro Mairinck,4106100,base.state_br_pr,base.br
+city_4106209,Contenda,4106209,base.state_br_pr,base.br
+city_4106308,Corbélia,4106308,base.state_br_pr,base.br
+city_4106407,Cornélio Procópio,4106407,base.state_br_pr,base.br
+city_4106456,Coronel Domingos Soares,4106456,base.state_br_pr,base.br
+city_4106506,Coronel Vivida,4106506,base.state_br_pr,base.br
+city_4106555,Corumbataí do Sul,4106555,base.state_br_pr,base.br
+city_4106803,Cruz Machado,4106803,base.state_br_pr,base.br
+city_4106571,Cruzeiro do Iguaçu,4106571,base.state_br_pr,base.br
+city_4106605,Cruzeiro do Oeste,4106605,base.state_br_pr,base.br
+city_4106704,Cruzeiro do Sul,4106704,base.state_br_pr,base.br
+city_4106852,Cruzmaltina,4106852,base.state_br_pr,base.br
+city_4106902,Curitiba,4106902,base.state_br_pr,base.br
+city_4107009,Curiúva,4107009,base.state_br_pr,base.br
+city_4107108,Diamante do Norte,4107108,base.state_br_pr,base.br
+city_4107124,Diamante do Sul,4107124,base.state_br_pr,base.br
+city_4107157,Diamante D'Oeste,4107157,base.state_br_pr,base.br
+city_4107207,Dois Vizinhos,4107207,base.state_br_pr,base.br
+city_4107256,Douradina,4107256,base.state_br_pr,base.br
+city_4107306,Doutor Camargo,4107306,base.state_br_pr,base.br
+city_4128633,Doutor Ulysses,4128633,base.state_br_pr,base.br
+city_4107405,Enéas Marques,4107405,base.state_br_pr,base.br
+city_4107504,Engenheiro Beltrão,4107504,base.state_br_pr,base.br
+city_4107538,Entre Rios do Oeste,4107538,base.state_br_pr,base.br
+city_4107520,Esperança Nova,4107520,base.state_br_pr,base.br
+city_4107546,Espigão Alto do Iguaçu,4107546,base.state_br_pr,base.br
+city_4107553,Farol,4107553,base.state_br_pr,base.br
+city_4107603,Faxinal,4107603,base.state_br_pr,base.br
+city_4107652,Fazenda Rio Grande,4107652,base.state_br_pr,base.br
+city_4107702,Fênix,4107702,base.state_br_pr,base.br
+city_4107736,Fernandes Pinheiro,4107736,base.state_br_pr,base.br
+city_4107751,Figueira,4107751,base.state_br_pr,base.br
+city_4107850,Flor da Serra do Sul,4107850,base.state_br_pr,base.br
+city_4107801,Floraí,4107801,base.state_br_pr,base.br
+city_4107900,Floresta,4107900,base.state_br_pr,base.br
+city_4108007,Florestópolis,4108007,base.state_br_pr,base.br
+city_4108106,Flórida,4108106,base.state_br_pr,base.br
+city_4108205,Formosa do Oeste,4108205,base.state_br_pr,base.br
+city_4108304,Foz do Iguaçu,4108304,base.state_br_pr,base.br
+city_4108452,Foz do Jordão,4108452,base.state_br_pr,base.br
+city_4108320,Francisco Alves,4108320,base.state_br_pr,base.br
+city_4108403,Francisco Beltrão,4108403,base.state_br_pr,base.br
+city_4108502,General Carneiro,4108502,base.state_br_pr,base.br
+city_4108551,Godoy Moreira,4108551,base.state_br_pr,base.br
+city_4108601,Goioerê,4108601,base.state_br_pr,base.br
+city_4108650,Goioxim,4108650,base.state_br_pr,base.br
+city_4108700,Grandes Rios,4108700,base.state_br_pr,base.br
+city_4108809,Guaíra,4108809,base.state_br_pr,base.br
+city_4108908,Guairaçá,4108908,base.state_br_pr,base.br
+city_4108957,Guamiranga,4108957,base.state_br_pr,base.br
+city_4109005,Guapirama,4109005,base.state_br_pr,base.br
+city_4109104,Guaporema,4109104,base.state_br_pr,base.br
+city_4109203,Guaraci,4109203,base.state_br_pr,base.br
+city_4109302,Guaraniaçu,4109302,base.state_br_pr,base.br
+city_4109401,Guarapuava,4109401,base.state_br_pr,base.br
+city_4109500,Guaraqueçaba,4109500,base.state_br_pr,base.br
+city_4109609,Guaratuba,4109609,base.state_br_pr,base.br
+city_4109658,Honório Serpa,4109658,base.state_br_pr,base.br
+city_4109708,Ibaiti,4109708,base.state_br_pr,base.br
+city_4109757,Ibema,4109757,base.state_br_pr,base.br
+city_4109807,Ibiporã,4109807,base.state_br_pr,base.br
+city_4109906,Icaraíma,4109906,base.state_br_pr,base.br
+city_4110003,Iguaraçu,4110003,base.state_br_pr,base.br
+city_4110052,Iguatu,4110052,base.state_br_pr,base.br
+city_4110078,Imbaú,4110078,base.state_br_pr,base.br
+city_4110102,Imbituva,4110102,base.state_br_pr,base.br
+city_4110201,Inácio Martins,4110201,base.state_br_pr,base.br
+city_4110300,Inajá,4110300,base.state_br_pr,base.br
+city_4110409,Indianópolis,4110409,base.state_br_pr,base.br
+city_4110508,Ipiranga,4110508,base.state_br_pr,base.br
+city_4110607,Iporã,4110607,base.state_br_pr,base.br
+city_4110656,Iracema do Oeste,4110656,base.state_br_pr,base.br
+city_4110706,Irati,4110706,base.state_br_pr,base.br
+city_4110805,Iretama,4110805,base.state_br_pr,base.br
+city_4110904,Itaguajé,4110904,base.state_br_pr,base.br
+city_4110953,Itaipulândia,4110953,base.state_br_pr,base.br
+city_4111001,Itambaracá,4111001,base.state_br_pr,base.br
+city_4111100,Itambé,4111100,base.state_br_pr,base.br
+city_4111209,Itapejara d'Oeste,4111209,base.state_br_pr,base.br
+city_4111258,Itaperuçu,4111258,base.state_br_pr,base.br
+city_4111308,Itaúna do Sul,4111308,base.state_br_pr,base.br
+city_4111407,Ivaí,4111407,base.state_br_pr,base.br
+city_4111506,Ivaiporã,4111506,base.state_br_pr,base.br
+city_4111555,Ivaté,4111555,base.state_br_pr,base.br
+city_4111605,Ivatuba,4111605,base.state_br_pr,base.br
+city_4111704,Jaboti,4111704,base.state_br_pr,base.br
+city_4111803,Jacarezinho,4111803,base.state_br_pr,base.br
+city_4111902,Jaguapitã,4111902,base.state_br_pr,base.br
+city_4112009,Jaguariaíva,4112009,base.state_br_pr,base.br
+city_4112108,Jandaia do Sul,4112108,base.state_br_pr,base.br
+city_4112207,Janiópolis,4112207,base.state_br_pr,base.br
+city_4112306,Japira,4112306,base.state_br_pr,base.br
+city_4112405,Japurá,4112405,base.state_br_pr,base.br
+city_4112504,Jardim Alegre,4112504,base.state_br_pr,base.br
+city_4112603,Jardim Olinda,4112603,base.state_br_pr,base.br
+city_4112702,Jataizinho,4112702,base.state_br_pr,base.br
+city_4112751,Jesuítas,4112751,base.state_br_pr,base.br
+city_4112801,Joaquim Távora,4112801,base.state_br_pr,base.br
+city_4112900,Jundiaí do Sul,4112900,base.state_br_pr,base.br
+city_4112959,Juranda,4112959,base.state_br_pr,base.br
+city_4113007,Jussara,4113007,base.state_br_pr,base.br
+city_4113106,Kaloré,4113106,base.state_br_pr,base.br
+city_4113205,Lapa,4113205,base.state_br_pr,base.br
+city_4113254,Laranjal,4113254,base.state_br_pr,base.br
+city_4113304,Laranjeiras do Sul,4113304,base.state_br_pr,base.br
+city_4113403,Leópolis,4113403,base.state_br_pr,base.br
+city_4113429,Lidianópolis,4113429,base.state_br_pr,base.br
+city_4113452,Lindoeste,4113452,base.state_br_pr,base.br
+city_4113502,Loanda,4113502,base.state_br_pr,base.br
+city_4113601,Lobato,4113601,base.state_br_pr,base.br
+city_4113700,Londrina,4113700,base.state_br_pr,base.br
+city_4113734,Luiziana,4113734,base.state_br_pr,base.br
+city_4113759,Lunardelli,4113759,base.state_br_pr,base.br
+city_4113809,Lupionópolis,4113809,base.state_br_pr,base.br
+city_4113908,Mallet,4113908,base.state_br_pr,base.br
+city_4114005,Mamborê,4114005,base.state_br_pr,base.br
+city_4114104,Mandaguaçu,4114104,base.state_br_pr,base.br
+city_4114203,Mandaguari,4114203,base.state_br_pr,base.br
+city_4114302,Mandirituba,4114302,base.state_br_pr,base.br
+city_4114351,Manfrinópolis,4114351,base.state_br_pr,base.br
+city_4114401,Mangueirinha,4114401,base.state_br_pr,base.br
+city_4114500,Manoel Ribas,4114500,base.state_br_pr,base.br
+city_4114609,Marechal Cândido Rondon,4114609,base.state_br_pr,base.br
+city_4114708,Maria Helena,4114708,base.state_br_pr,base.br
+city_4114807,Marialva,4114807,base.state_br_pr,base.br
+city_4114906,Marilândia do Sul,4114906,base.state_br_pr,base.br
+city_4115002,Marilena,4115002,base.state_br_pr,base.br
+city_4115101,Mariluz,4115101,base.state_br_pr,base.br
+city_4115200,Maringá,4115200,base.state_br_pr,base.br
+city_4115309,Mariópolis,4115309,base.state_br_pr,base.br
+city_4115358,Maripá,4115358,base.state_br_pr,base.br
+city_4115408,Marmeleiro,4115408,base.state_br_pr,base.br
+city_4115457,Marquinho,4115457,base.state_br_pr,base.br
+city_4115507,Marumbi,4115507,base.state_br_pr,base.br
+city_4115606,Matelândia,4115606,base.state_br_pr,base.br
+city_4115705,Matinhos,4115705,base.state_br_pr,base.br
+city_4115739,Mato Rico,4115739,base.state_br_pr,base.br
+city_4115754,Mauá da Serra,4115754,base.state_br_pr,base.br
+city_4115804,Medianeira,4115804,base.state_br_pr,base.br
+city_4115853,Mercedes,4115853,base.state_br_pr,base.br
+city_4115903,Mirador,4115903,base.state_br_pr,base.br
+city_4116000,Miraselva,4116000,base.state_br_pr,base.br
+city_4116059,Missal,4116059,base.state_br_pr,base.br
+city_4116109,Moreira Sales,4116109,base.state_br_pr,base.br
+city_4116208,Morretes,4116208,base.state_br_pr,base.br
+city_4116307,Munhoz de Melo,4116307,base.state_br_pr,base.br
+city_4116406,Nossa Senhora das Graças,4116406,base.state_br_pr,base.br
+city_4116505,Nova Aliança do Ivaí,4116505,base.state_br_pr,base.br
+city_4116604,Nova América da Colina,4116604,base.state_br_pr,base.br
+city_4116703,Nova Aurora,4116703,base.state_br_pr,base.br
+city_4116802,Nova Cantu,4116802,base.state_br_pr,base.br
+city_4116901,Nova Esperança,4116901,base.state_br_pr,base.br
+city_4116950,Nova Esperança do Sudoeste,4116950,base.state_br_pr,base.br
+city_4117008,Nova Fátima,4117008,base.state_br_pr,base.br
+city_4117057,Nova Laranjeiras,4117057,base.state_br_pr,base.br
+city_4117107,Nova Londrina,4117107,base.state_br_pr,base.br
+city_4117206,Nova Olímpia,4117206,base.state_br_pr,base.br
+city_4117255,Nova Prata do Iguaçu,4117255,base.state_br_pr,base.br
+city_4117214,Nova Santa Bárbara,4117214,base.state_br_pr,base.br
+city_4117222,Nova Santa Rosa,4117222,base.state_br_pr,base.br
+city_4117271,Nova Tebas,4117271,base.state_br_pr,base.br
+city_4117297,Novo Itacolomi,4117297,base.state_br_pr,base.br
+city_4117305,Ortigueira,4117305,base.state_br_pr,base.br
+city_4117404,Ourizona,4117404,base.state_br_pr,base.br
+city_4117453,Ouro Verde do Oeste,4117453,base.state_br_pr,base.br
+city_4117503,Paiçandu,4117503,base.state_br_pr,base.br
+city_4117602,Palmas,4117602,base.state_br_pr,base.br
+city_4117701,Palmeira,4117701,base.state_br_pr,base.br
+city_4117800,Palmital,4117800,base.state_br_pr,base.br
+city_4117909,Palotina,4117909,base.state_br_pr,base.br
+city_4118006,Paraíso do Norte,4118006,base.state_br_pr,base.br
+city_4118105,Paranacity,4118105,base.state_br_pr,base.br
+city_4118204,Paranaguá,4118204,base.state_br_pr,base.br
+city_4118303,Paranapoema,4118303,base.state_br_pr,base.br
+city_4118402,Paranavaí,4118402,base.state_br_pr,base.br
+city_4118451,Pato Bragado,4118451,base.state_br_pr,base.br
+city_4118501,Pato Branco,4118501,base.state_br_pr,base.br
+city_4118600,Paula Freitas,4118600,base.state_br_pr,base.br
+city_4118709,Paulo Frontin,4118709,base.state_br_pr,base.br
+city_4118808,Peabiru,4118808,base.state_br_pr,base.br
+city_4118857,Perobal,4118857,base.state_br_pr,base.br
+city_4118907,Pérola,4118907,base.state_br_pr,base.br
+city_4119004,Pérola d'Oeste,4119004,base.state_br_pr,base.br
+city_4119103,Piên,4119103,base.state_br_pr,base.br
+city_4119152,Pinhais,4119152,base.state_br_pr,base.br
+city_4119251,Pinhal de São Bento,4119251,base.state_br_pr,base.br
+city_4119202,Pinhalão,4119202,base.state_br_pr,base.br
+city_4119301,Pinhão,4119301,base.state_br_pr,base.br
+city_4119400,Piraí do Sul,4119400,base.state_br_pr,base.br
+city_4119509,Piraquara,4119509,base.state_br_pr,base.br
+city_4119608,Pitanga,4119608,base.state_br_pr,base.br
+city_4119657,Pitangueiras,4119657,base.state_br_pr,base.br
+city_4119707,Planaltina do Paraná,4119707,base.state_br_pr,base.br
+city_4119806,Planalto,4119806,base.state_br_pr,base.br
+city_4119905,Ponta Grossa,4119905,base.state_br_pr,base.br
+city_4119954,Pontal do Paraná,4119954,base.state_br_pr,base.br
+city_4120002,Porecatu,4120002,base.state_br_pr,base.br
+city_4120101,Porto Amazonas,4120101,base.state_br_pr,base.br
+city_4120150,Porto Barreiro,4120150,base.state_br_pr,base.br
+city_4120200,Porto Rico,4120200,base.state_br_pr,base.br
+city_4120309,Porto Vitória,4120309,base.state_br_pr,base.br
+city_4120333,Prado Ferreira,4120333,base.state_br_pr,base.br
+city_4120358,Pranchita,4120358,base.state_br_pr,base.br
+city_4120408,Presidente Castelo Branco,4120408,base.state_br_pr,base.br
+city_4120507,Primeiro de Maio,4120507,base.state_br_pr,base.br
+city_4120606,Prudentópolis,4120606,base.state_br_pr,base.br
+city_4120655,Quarto Centenário,4120655,base.state_br_pr,base.br
+city_4120705,Quatiguá,4120705,base.state_br_pr,base.br
+city_4120804,Quatro Barras,4120804,base.state_br_pr,base.br
+city_4120853,Quatro Pontes,4120853,base.state_br_pr,base.br
+city_4120903,Quedas do Iguaçu,4120903,base.state_br_pr,base.br
+city_4121000,Querência do Norte,4121000,base.state_br_pr,base.br
+city_4121109,Quinta do Sol,4121109,base.state_br_pr,base.br
+city_4121208,Quitandinha,4121208,base.state_br_pr,base.br
+city_4121257,Ramilândia,4121257,base.state_br_pr,base.br
+city_4121307,Rancho Alegre,4121307,base.state_br_pr,base.br
+city_4121356,Rancho Alegre D'Oeste,4121356,base.state_br_pr,base.br
+city_4121406,Realeza,4121406,base.state_br_pr,base.br
+city_4121505,Rebouças,4121505,base.state_br_pr,base.br
+city_4121604,Renascença,4121604,base.state_br_pr,base.br
+city_4121703,Reserva,4121703,base.state_br_pr,base.br
+city_4121752,Reserva do Iguaçu,4121752,base.state_br_pr,base.br
+city_4121802,Ribeirão Claro,4121802,base.state_br_pr,base.br
+city_4121901,Ribeirão do Pinhal,4121901,base.state_br_pr,base.br
+city_4122008,Rio Azul,4122008,base.state_br_pr,base.br
+city_4122107,Rio Bom,4122107,base.state_br_pr,base.br
+city_4122156,Rio Bonito do Iguaçu,4122156,base.state_br_pr,base.br
+city_4122172,Rio Branco do Ivaí,4122172,base.state_br_pr,base.br
+city_4122206,Rio Branco do Sul,4122206,base.state_br_pr,base.br
+city_4122305,Rio Negro,4122305,base.state_br_pr,base.br
+city_4122404,Rolândia,4122404,base.state_br_pr,base.br
+city_4122503,Roncador,4122503,base.state_br_pr,base.br
+city_4122602,Rondon,4122602,base.state_br_pr,base.br
+city_4122651,Rosário do Ivaí,4122651,base.state_br_pr,base.br
+city_4122701,Sabáudia,4122701,base.state_br_pr,base.br
+city_4122800,Salgado Filho,4122800,base.state_br_pr,base.br
+city_4122909,Salto do Itararé,4122909,base.state_br_pr,base.br
+city_4123006,Salto do Lontra,4123006,base.state_br_pr,base.br
+city_4123105,Santa Amélia,4123105,base.state_br_pr,base.br
+city_4123204,Santa Cecília do Pavão,4123204,base.state_br_pr,base.br
+city_4123303,Santa Cruz de Monte Castelo,4123303,base.state_br_pr,base.br
+city_4123402,Santa Fé,4123402,base.state_br_pr,base.br
+city_4123501,Santa Helena,4123501,base.state_br_pr,base.br
+city_4123600,Santa Inês,4123600,base.state_br_pr,base.br
+city_4123709,Santa Isabel do Ivaí,4123709,base.state_br_pr,base.br
+city_4123808,Santa Izabel do Oeste,4123808,base.state_br_pr,base.br
+city_4123824,Santa Lúcia,4123824,base.state_br_pr,base.br
+city_4123857,Santa Maria do Oeste,4123857,base.state_br_pr,base.br
+city_4123907,Santa Mariana,4123907,base.state_br_pr,base.br
+city_4123956,Santa Mônica,4123956,base.state_br_pr,base.br
+city_4124020,Santa Tereza do Oeste,4124020,base.state_br_pr,base.br
+city_4124053,Santa Terezinha de Itaipu,4124053,base.state_br_pr,base.br
+city_4124004,Santana do Itararé,4124004,base.state_br_pr,base.br
+city_4124103,Santo Antônio da Platina,4124103,base.state_br_pr,base.br
+city_4124202,Santo Antônio do Caiuá,4124202,base.state_br_pr,base.br
+city_4124301,Santo Antônio do Paraíso,4124301,base.state_br_pr,base.br
+city_4124400,Santo Antônio do Sudoeste,4124400,base.state_br_pr,base.br
+city_4124509,Santo Inácio,4124509,base.state_br_pr,base.br
+city_4124608,São Carlos do Ivaí,4124608,base.state_br_pr,base.br
+city_4124707,São Jerônimo da Serra,4124707,base.state_br_pr,base.br
+city_4124806,São João,4124806,base.state_br_pr,base.br
+city_4124905,São João do Caiuá,4124905,base.state_br_pr,base.br
+city_4125001,São João do Ivaí,4125001,base.state_br_pr,base.br
+city_4125100,São João do Triunfo,4125100,base.state_br_pr,base.br
+city_4125308,São Jorge do Ivaí,4125308,base.state_br_pr,base.br
+city_4125357,São Jorge do Patrocínio,4125357,base.state_br_pr,base.br
+city_4125209,São Jorge d'Oeste,4125209,base.state_br_pr,base.br
+city_4125407,São José da Boa Vista,4125407,base.state_br_pr,base.br
+city_4125456,São José das Palmeiras,4125456,base.state_br_pr,base.br
+city_4125506,São José dos Pinhais,4125506,base.state_br_pr,base.br
+city_4125555,São Manoel do Paraná,4125555,base.state_br_pr,base.br
+city_4125605,São Mateus do Sul,4125605,base.state_br_pr,base.br
+city_4125704,São Miguel do Iguaçu,4125704,base.state_br_pr,base.br
+city_4125753,São Pedro do Iguaçu,4125753,base.state_br_pr,base.br
+city_4125803,São Pedro do Ivaí,4125803,base.state_br_pr,base.br
+city_4125902,São Pedro do Paraná,4125902,base.state_br_pr,base.br
+city_4126009,São Sebastião da Amoreira,4126009,base.state_br_pr,base.br
+city_4126108,São Tomé,4126108,base.state_br_pr,base.br
+city_4126207,Sapopema,4126207,base.state_br_pr,base.br
+city_4126256,Sarandi,4126256,base.state_br_pr,base.br
+city_4126272,Saudade do Iguaçu,4126272,base.state_br_pr,base.br
+city_4126306,Sengés,4126306,base.state_br_pr,base.br
+city_4126355,Serranópolis do Iguaçu,4126355,base.state_br_pr,base.br
+city_4126405,Sertaneja,4126405,base.state_br_pr,base.br
+city_4126504,Sertanópolis,4126504,base.state_br_pr,base.br
+city_4126603,Siqueira Campos,4126603,base.state_br_pr,base.br
+city_4126652,Sulina,4126652,base.state_br_pr,base.br
+city_4126678,Tamarana,4126678,base.state_br_pr,base.br
+city_4126702,Tamboara,4126702,base.state_br_pr,base.br
+city_4126801,Tapejara,4126801,base.state_br_pr,base.br
+city_4126900,Tapira,4126900,base.state_br_pr,base.br
+city_4127007,Teixeira Soares,4127007,base.state_br_pr,base.br
+city_4127106,Telêmaco Borba,4127106,base.state_br_pr,base.br
+city_4127205,Terra Boa,4127205,base.state_br_pr,base.br
+city_4127304,Terra Rica,4127304,base.state_br_pr,base.br
+city_4127403,Terra Roxa,4127403,base.state_br_pr,base.br
+city_4127502,Tibagi,4127502,base.state_br_pr,base.br
+city_4127601,Tijucas do Sul,4127601,base.state_br_pr,base.br
+city_4127700,Toledo,4127700,base.state_br_pr,base.br
+city_4127809,Tomazina,4127809,base.state_br_pr,base.br
+city_4127858,Três Barras do Paraná,4127858,base.state_br_pr,base.br
+city_4127882,Tunas do Paraná,4127882,base.state_br_pr,base.br
+city_4127908,Tuneiras do Oeste,4127908,base.state_br_pr,base.br
+city_4127957,Tupãssi,4127957,base.state_br_pr,base.br
+city_4127965,Turvo,4127965,base.state_br_pr,base.br
+city_4128005,Ubiratã,4128005,base.state_br_pr,base.br
+city_4128104,Umuarama,4128104,base.state_br_pr,base.br
+city_4128203,União da Vitória,4128203,base.state_br_pr,base.br
+city_4128302,Uniflor,4128302,base.state_br_pr,base.br
+city_4128401,Uraí,4128401,base.state_br_pr,base.br
+city_4128534,Ventania,4128534,base.state_br_pr,base.br
+city_4128559,Vera Cruz do Oeste,4128559,base.state_br_pr,base.br
+city_4128609,Verê,4128609,base.state_br_pr,base.br
+city_4128658,Virmond,4128658,base.state_br_pr,base.br
+city_4128708,Vitorino,4128708,base.state_br_pr,base.br
+city_4128500,Wenceslau Braz,4128500,base.state_br_pr,base.br
+city_4128807,Xambrê,4128807,base.state_br_pr,base.br
+city_4200051,Abdon Batista,4200051,base.state_br_sc,base.br
+city_4200101,Abelardo Luz,4200101,base.state_br_sc,base.br
+city_4200200,Agrolândia,4200200,base.state_br_sc,base.br
+city_4200309,Agronômica,4200309,base.state_br_sc,base.br
+city_4200408,Água Doce,4200408,base.state_br_sc,base.br
+city_4200507,Águas de Chapecó,4200507,base.state_br_sc,base.br
+city_4200556,Águas Frias,4200556,base.state_br_sc,base.br
+city_4200606,Águas Mornas,4200606,base.state_br_sc,base.br
+city_4200705,Alfredo Wagner,4200705,base.state_br_sc,base.br
+city_4200754,Alto Bela Vista,4200754,base.state_br_sc,base.br
+city_4200804,Anchieta,4200804,base.state_br_sc,base.br
+city_4200903,Angelina,4200903,base.state_br_sc,base.br
+city_4201000,Anita Garibaldi,4201000,base.state_br_sc,base.br
+city_4201109,Anitápolis,4201109,base.state_br_sc,base.br
+city_4201208,Antônio Carlos,4201208,base.state_br_sc,base.br
+city_4201257,Apiúna,4201257,base.state_br_sc,base.br
+city_4201273,Arabutã,4201273,base.state_br_sc,base.br
+city_4201307,Araquari,4201307,base.state_br_sc,base.br
+city_4201406,Araranguá,4201406,base.state_br_sc,base.br
+city_4201505,Armazém,4201505,base.state_br_sc,base.br
+city_4201604,Arroio Trinta,4201604,base.state_br_sc,base.br
+city_4201653,Arvoredo,4201653,base.state_br_sc,base.br
+city_4201703,Ascurra,4201703,base.state_br_sc,base.br
+city_4201802,Atalanta,4201802,base.state_br_sc,base.br
+city_4201901,Aurora,4201901,base.state_br_sc,base.br
+city_4201950,Balneário Arroio do Silva,4201950,base.state_br_sc,base.br
+city_4202057,Balneário Barra do Sul,4202057,base.state_br_sc,base.br
+city_4202008,Balneário Camboriú,4202008,base.state_br_sc,base.br
+city_4202073,Balneário Gaivota,4202073,base.state_br_sc,base.br
+city_4212809,Balneário Piçarras,4212809,base.state_br_sc,base.br
+city_4220000,Balneário Rincão,4220000,base.state_br_sc,base.br
+city_4202081,Bandeirante,4202081,base.state_br_sc,base.br
+city_4202099,Barra Bonita,4202099,base.state_br_sc,base.br
+city_4202107,Barra Velha,4202107,base.state_br_sc,base.br
+city_4202131,Bela Vista do Toldo,4202131,base.state_br_sc,base.br
+city_4202156,Belmonte,4202156,base.state_br_sc,base.br
+city_4202206,Benedito Novo,4202206,base.state_br_sc,base.br
+city_4202305,Biguaçu,4202305,base.state_br_sc,base.br
+city_4202404,Blumenau,4202404,base.state_br_sc,base.br
+city_4202438,Bocaina do Sul,4202438,base.state_br_sc,base.br
+city_4202503,Bom Jardim da Serra,4202503,base.state_br_sc,base.br
+city_4202537,Bom Jesus,4202537,base.state_br_sc,base.br
+city_4202578,Bom Jesus do Oeste,4202578,base.state_br_sc,base.br
+city_4202602,Bom Retiro,4202602,base.state_br_sc,base.br
+city_4202453,Bombinhas,4202453,base.state_br_sc,base.br
+city_4202701,Botuverá,4202701,base.state_br_sc,base.br
+city_4202800,Braço do Norte,4202800,base.state_br_sc,base.br
+city_4202859,Braço do Trombudo,4202859,base.state_br_sc,base.br
+city_4202875,Brunópolis,4202875,base.state_br_sc,base.br
+city_4202909,Brusque,4202909,base.state_br_sc,base.br
+city_4203006,Caçador,4203006,base.state_br_sc,base.br
+city_4203105,Caibi,4203105,base.state_br_sc,base.br
+city_4203154,Calmon,4203154,base.state_br_sc,base.br
+city_4203204,Camboriú,4203204,base.state_br_sc,base.br
+city_4203303,Campo Alegre,4203303,base.state_br_sc,base.br
+city_4203402,Campo Belo do Sul,4203402,base.state_br_sc,base.br
+city_4203501,Campo Erê,4203501,base.state_br_sc,base.br
+city_4203600,Campos Novos,4203600,base.state_br_sc,base.br
+city_4203709,Canelinha,4203709,base.state_br_sc,base.br
+city_4203808,Canoinhas,4203808,base.state_br_sc,base.br
+city_4203253,Capão Alto,4203253,base.state_br_sc,base.br
+city_4203907,Capinzal,4203907,base.state_br_sc,base.br
+city_4203956,Capivari de Baixo,4203956,base.state_br_sc,base.br
+city_4204004,Catanduvas,4204004,base.state_br_sc,base.br
+city_4204103,Caxambu do Sul,4204103,base.state_br_sc,base.br
+city_4204152,Celso Ramos,4204152,base.state_br_sc,base.br
+city_4204178,Cerro Negro,4204178,base.state_br_sc,base.br
+city_4204194,Chapadão do Lageado,4204194,base.state_br_sc,base.br
+city_4204202,Chapecó,4204202,base.state_br_sc,base.br
+city_4204251,Cocal do Sul,4204251,base.state_br_sc,base.br
+city_4204301,Concórdia,4204301,base.state_br_sc,base.br
+city_4204350,Cordilheira Alta,4204350,base.state_br_sc,base.br
+city_4204400,Coronel Freitas,4204400,base.state_br_sc,base.br
+city_4204459,Coronel Martins,4204459,base.state_br_sc,base.br
+city_4204558,Correia Pinto,4204558,base.state_br_sc,base.br
+city_4204509,Corupá,4204509,base.state_br_sc,base.br
+city_4204608,Criciúma,4204608,base.state_br_sc,base.br
+city_4204707,Cunha Porã,4204707,base.state_br_sc,base.br
+city_4204756,Cunhataí,4204756,base.state_br_sc,base.br
+city_4204806,Curitibanos,4204806,base.state_br_sc,base.br
+city_4204905,Descanso,4204905,base.state_br_sc,base.br
+city_4205001,Dionísio Cerqueira,4205001,base.state_br_sc,base.br
+city_4205100,Dona Emma,4205100,base.state_br_sc,base.br
+city_4205159,Doutor Pedrinho,4205159,base.state_br_sc,base.br
+city_4205175,Entre Rios,4205175,base.state_br_sc,base.br
+city_4205191,Ermo,4205191,base.state_br_sc,base.br
+city_4205209,Erval Velho,4205209,base.state_br_sc,base.br
+city_4205308,Faxinal dos Guedes,4205308,base.state_br_sc,base.br
+city_4205357,Flor do Sertão,4205357,base.state_br_sc,base.br
+city_4205407,Florianópolis,4205407,base.state_br_sc,base.br
+city_4205431,Formosa do Sul,4205431,base.state_br_sc,base.br
+city_4205456,Forquilhinha,4205456,base.state_br_sc,base.br
+city_4205506,Fraiburgo,4205506,base.state_br_sc,base.br
+city_4205555,Frei Rogério,4205555,base.state_br_sc,base.br
+city_4205605,Galvão,4205605,base.state_br_sc,base.br
+city_4205704,Garopaba,4205704,base.state_br_sc,base.br
+city_4205803,Garuva,4205803,base.state_br_sc,base.br
+city_4205902,Gaspar,4205902,base.state_br_sc,base.br
+city_4206009,Governador Celso Ramos,4206009,base.state_br_sc,base.br
+city_4206108,Grão-Pará,4206108,base.state_br_sc,base.br
+city_4206207,Gravatal,4206207,base.state_br_sc,base.br
+city_4206306,Guabiruba,4206306,base.state_br_sc,base.br
+city_4206405,Guaraciaba,4206405,base.state_br_sc,base.br
+city_4206504,Guaramirim,4206504,base.state_br_sc,base.br
+city_4206603,Guarujá do Sul,4206603,base.state_br_sc,base.br
+city_4206652,Guatambú,4206652,base.state_br_sc,base.br
+city_4206702,Herval d'Oeste,4206702,base.state_br_sc,base.br
+city_4206751,Ibiam,4206751,base.state_br_sc,base.br
+city_4206801,Ibicaré,4206801,base.state_br_sc,base.br
+city_4206900,Ibirama,4206900,base.state_br_sc,base.br
+city_4207007,Içara,4207007,base.state_br_sc,base.br
+city_4207106,Ilhota,4207106,base.state_br_sc,base.br
+city_4207205,Imaruí,4207205,base.state_br_sc,base.br
+city_4207304,Imbituba,4207304,base.state_br_sc,base.br
+city_4207403,Imbuia,4207403,base.state_br_sc,base.br
+city_4207502,Indaial,4207502,base.state_br_sc,base.br
+city_4207577,Iomerê,4207577,base.state_br_sc,base.br
+city_4207601,Ipira,4207601,base.state_br_sc,base.br
+city_4207650,Iporã do Oeste,4207650,base.state_br_sc,base.br
+city_4207684,Ipuaçu,4207684,base.state_br_sc,base.br
+city_4207700,Ipumirim,4207700,base.state_br_sc,base.br
+city_4207759,Iraceminha,4207759,base.state_br_sc,base.br
+city_4207809,Irani,4207809,base.state_br_sc,base.br
+city_4207858,Irati,4207858,base.state_br_sc,base.br
+city_4207908,Irineópolis,4207908,base.state_br_sc,base.br
+city_4208005,Itá,4208005,base.state_br_sc,base.br
+city_4208104,Itaiópolis,4208104,base.state_br_sc,base.br
+city_4208203,Itajaí,4208203,base.state_br_sc,base.br
+city_4208302,Itapema,4208302,base.state_br_sc,base.br
+city_4208401,Itapiranga,4208401,base.state_br_sc,base.br
+city_4208450,Itapoá,4208450,base.state_br_sc,base.br
+city_4208500,Ituporanga,4208500,base.state_br_sc,base.br
+city_4208609,Jaborá,4208609,base.state_br_sc,base.br
+city_4208708,Jacinto Machado,4208708,base.state_br_sc,base.br
+city_4208807,Jaguaruna,4208807,base.state_br_sc,base.br
+city_4208906,Jaraguá do Sul,4208906,base.state_br_sc,base.br
+city_4208955,Jardinópolis,4208955,base.state_br_sc,base.br
+city_4209003,Joaçaba,4209003,base.state_br_sc,base.br
+city_4209102,Joinville,4209102,base.state_br_sc,base.br
+city_4209151,José Boiteux,4209151,base.state_br_sc,base.br
+city_4209177,Jupiá,4209177,base.state_br_sc,base.br
+city_4209201,Lacerdópolis,4209201,base.state_br_sc,base.br
+city_4209300,Lages,4209300,base.state_br_sc,base.br
+city_4209409,Laguna,4209409,base.state_br_sc,base.br
+city_4209458,Lajeado Grande,4209458,base.state_br_sc,base.br
+city_4209508,Laurentino,4209508,base.state_br_sc,base.br
+city_4209607,Lauro Müller,4209607,base.state_br_sc,base.br
+city_4209706,Lebon Régis,4209706,base.state_br_sc,base.br
+city_4209805,Leoberto Leal,4209805,base.state_br_sc,base.br
+city_4209854,Lindóia do Sul,4209854,base.state_br_sc,base.br
+city_4209904,Lontras,4209904,base.state_br_sc,base.br
+city_4210001,Luiz Alves,4210001,base.state_br_sc,base.br
+city_4210035,Luzerna,4210035,base.state_br_sc,base.br
+city_4210050,Macieira,4210050,base.state_br_sc,base.br
+city_4210100,Mafra,4210100,base.state_br_sc,base.br
+city_4210209,Major Gercino,4210209,base.state_br_sc,base.br
+city_4210308,Major Vieira,4210308,base.state_br_sc,base.br
+city_4210407,Maracajá,4210407,base.state_br_sc,base.br
+city_4210506,Maravilha,4210506,base.state_br_sc,base.br
+city_4210555,Marema,4210555,base.state_br_sc,base.br
+city_4210605,Massaranduba,4210605,base.state_br_sc,base.br
+city_4210704,Matos Costa,4210704,base.state_br_sc,base.br
+city_4210803,Meleiro,4210803,base.state_br_sc,base.br
+city_4210852,Mirim Doce,4210852,base.state_br_sc,base.br
+city_4210902,Modelo,4210902,base.state_br_sc,base.br
+city_4211009,Mondaí,4211009,base.state_br_sc,base.br
+city_4211058,Monte Carlo,4211058,base.state_br_sc,base.br
+city_4211108,Monte Castelo,4211108,base.state_br_sc,base.br
+city_4211207,Morro da Fumaça,4211207,base.state_br_sc,base.br
+city_4211256,Morro Grande,4211256,base.state_br_sc,base.br
+city_4211306,Navegantes,4211306,base.state_br_sc,base.br
+city_4211405,Nova Erechim,4211405,base.state_br_sc,base.br
+city_4211454,Nova Itaberaba,4211454,base.state_br_sc,base.br
+city_4211504,Nova Trento,4211504,base.state_br_sc,base.br
+city_4211603,Nova Veneza,4211603,base.state_br_sc,base.br
+city_4211652,Novo Horizonte,4211652,base.state_br_sc,base.br
+city_4211702,Orleans,4211702,base.state_br_sc,base.br
+city_4211751,Otacílio Costa,4211751,base.state_br_sc,base.br
+city_4211801,Ouro,4211801,base.state_br_sc,base.br
+city_4211850,Ouro Verde,4211850,base.state_br_sc,base.br
+city_4211876,Paial,4211876,base.state_br_sc,base.br
+city_4211892,Painel,4211892,base.state_br_sc,base.br
+city_4211900,Palhoça,4211900,base.state_br_sc,base.br
+city_4212007,Palma Sola,4212007,base.state_br_sc,base.br
+city_4212056,Palmeira,4212056,base.state_br_sc,base.br
+city_4212106,Palmitos,4212106,base.state_br_sc,base.br
+city_4212205,Papanduva,4212205,base.state_br_sc,base.br
+city_4212239,Paraíso,4212239,base.state_br_sc,base.br
+city_4212254,Passo de Torres,4212254,base.state_br_sc,base.br
+city_4212270,Passos Maia,4212270,base.state_br_sc,base.br
+city_4212304,Paulo Lopes,4212304,base.state_br_sc,base.br
+city_4212403,Pedras Grandes,4212403,base.state_br_sc,base.br
+city_4212502,Penha,4212502,base.state_br_sc,base.br
+city_4212601,Peritiba,4212601,base.state_br_sc,base.br
+city_4212650,Pescaria Brava,4212650,base.state_br_sc,base.br
+city_4212700,Petrolândia,4212700,base.state_br_sc,base.br
+city_4212908,Pinhalzinho,4212908,base.state_br_sc,base.br
+city_4213005,Pinheiro Preto,4213005,base.state_br_sc,base.br
+city_4213104,Piratuba,4213104,base.state_br_sc,base.br
+city_4213153,Planalto Alegre,4213153,base.state_br_sc,base.br
+city_4213203,Pomerode,4213203,base.state_br_sc,base.br
+city_4213302,Ponte Alta,4213302,base.state_br_sc,base.br
+city_4213351,Ponte Alta do Norte,4213351,base.state_br_sc,base.br
+city_4213401,Ponte Serrada,4213401,base.state_br_sc,base.br
+city_4213500,Porto Belo,4213500,base.state_br_sc,base.br
+city_4213609,Porto União,4213609,base.state_br_sc,base.br
+city_4213708,Pouso Redondo,4213708,base.state_br_sc,base.br
+city_4213807,Praia Grande,4213807,base.state_br_sc,base.br
+city_4213906,Presidente Castello Branco,4213906,base.state_br_sc,base.br
+city_4214003,Presidente Getúlio,4214003,base.state_br_sc,base.br
+city_4214102,Presidente Nereu,4214102,base.state_br_sc,base.br
+city_4214151,Princesa,4214151,base.state_br_sc,base.br
+city_4214201,Quilombo,4214201,base.state_br_sc,base.br
+city_4214300,Rancho Queimado,4214300,base.state_br_sc,base.br
+city_4214409,Rio das Antas,4214409,base.state_br_sc,base.br
+city_4214508,Rio do Campo,4214508,base.state_br_sc,base.br
+city_4214607,Rio do Oeste,4214607,base.state_br_sc,base.br
+city_4214805,Rio do Sul,4214805,base.state_br_sc,base.br
+city_4214706,Rio dos Cedros,4214706,base.state_br_sc,base.br
+city_4214904,Rio Fortuna,4214904,base.state_br_sc,base.br
+city_4215000,Rio Negrinho,4215000,base.state_br_sc,base.br
+city_4215059,Rio Rufino,4215059,base.state_br_sc,base.br
+city_4215075,Riqueza,4215075,base.state_br_sc,base.br
+city_4215109,Rodeio,4215109,base.state_br_sc,base.br
+city_4215208,Romelândia,4215208,base.state_br_sc,base.br
+city_4215307,Salete,4215307,base.state_br_sc,base.br
+city_4215356,Saltinho,4215356,base.state_br_sc,base.br
+city_4215406,Salto Veloso,4215406,base.state_br_sc,base.br
+city_4215455,Sangão,4215455,base.state_br_sc,base.br
+city_4215505,Santa Cecília,4215505,base.state_br_sc,base.br
+city_4215554,Santa Helena,4215554,base.state_br_sc,base.br
+city_4215604,Santa Rosa de Lima,4215604,base.state_br_sc,base.br
+city_4215653,Santa Rosa do Sul,4215653,base.state_br_sc,base.br
+city_4215679,Santa Terezinha,4215679,base.state_br_sc,base.br
+city_4215687,Santa Terezinha do Progresso,4215687,base.state_br_sc,base.br
+city_4215695,Santiago do Sul,4215695,base.state_br_sc,base.br
+city_4215703,Santo Amaro da Imperatriz,4215703,base.state_br_sc,base.br
+city_4215802,São Bento do Sul,4215802,base.state_br_sc,base.br
+city_4215752,São Bernardino,4215752,base.state_br_sc,base.br
+city_4215901,São Bonifácio,4215901,base.state_br_sc,base.br
+city_4216008,São Carlos,4216008,base.state_br_sc,base.br
+city_4216057,São Cristóvão do Sul,4216057,base.state_br_sc,base.br
+city_4216107,São Domingos,4216107,base.state_br_sc,base.br
+city_4216206,São Francisco do Sul,4216206,base.state_br_sc,base.br
+city_4216305,São João Batista,4216305,base.state_br_sc,base.br
+city_4216354,São João do Itaperiú,4216354,base.state_br_sc,base.br
+city_4216255,São João do Oeste,4216255,base.state_br_sc,base.br
+city_4216404,São João do Sul,4216404,base.state_br_sc,base.br
+city_4216503,São Joaquim,4216503,base.state_br_sc,base.br
+city_4216602,São José,4216602,base.state_br_sc,base.br
+city_4216701,São José do Cedro,4216701,base.state_br_sc,base.br
+city_4216800,São José do Cerrito,4216800,base.state_br_sc,base.br
+city_4216909,São Lourenço do Oeste,4216909,base.state_br_sc,base.br
+city_4217006,São Ludgero,4217006,base.state_br_sc,base.br
+city_4217105,São Martinho,4217105,base.state_br_sc,base.br
+city_4217154,São Miguel da Boa Vista,4217154,base.state_br_sc,base.br
+city_4217204,São Miguel do Oeste,4217204,base.state_br_sc,base.br
+city_4217253,São Pedro de Alcântara,4217253,base.state_br_sc,base.br
+city_4217303,Saudades,4217303,base.state_br_sc,base.br
+city_4217402,Schroeder,4217402,base.state_br_sc,base.br
+city_4217501,Seara,4217501,base.state_br_sc,base.br
+city_4217550,Serra Alta,4217550,base.state_br_sc,base.br
+city_4217600,Siderópolis,4217600,base.state_br_sc,base.br
+city_4217709,Sombrio,4217709,base.state_br_sc,base.br
+city_4217758,Sul Brasil,4217758,base.state_br_sc,base.br
+city_4217808,Taió,4217808,base.state_br_sc,base.br
+city_4217907,Tangará,4217907,base.state_br_sc,base.br
+city_4217956,Tigrinhos,4217956,base.state_br_sc,base.br
+city_4218004,Tijucas,4218004,base.state_br_sc,base.br
+city_4218103,Timbé do Sul,4218103,base.state_br_sc,base.br
+city_4218202,Timbó,4218202,base.state_br_sc,base.br
+city_4218251,Timbó Grande,4218251,base.state_br_sc,base.br
+city_4218301,Três Barras,4218301,base.state_br_sc,base.br
+city_4218350,Treviso,4218350,base.state_br_sc,base.br
+city_4218400,Treze de Maio,4218400,base.state_br_sc,base.br
+city_4218509,Treze Tílias,4218509,base.state_br_sc,base.br
+city_4218608,Trombudo Central,4218608,base.state_br_sc,base.br
+city_4218707,Tubarão,4218707,base.state_br_sc,base.br
+city_4218756,Tunápolis,4218756,base.state_br_sc,base.br
+city_4218806,Turvo,4218806,base.state_br_sc,base.br
+city_4218855,União do Oeste,4218855,base.state_br_sc,base.br
+city_4218905,Urubici,4218905,base.state_br_sc,base.br
+city_4218954,Urupema,4218954,base.state_br_sc,base.br
+city_4219002,Urussanga,4219002,base.state_br_sc,base.br
+city_4219101,Vargeão,4219101,base.state_br_sc,base.br
+city_4219150,Vargem,4219150,base.state_br_sc,base.br
+city_4219176,Vargem Bonita,4219176,base.state_br_sc,base.br
+city_4219200,Vidal Ramos,4219200,base.state_br_sc,base.br
+city_4219309,Videira,4219309,base.state_br_sc,base.br
+city_4219358,Vitor Meireles,4219358,base.state_br_sc,base.br
+city_4219408,Witmarsum,4219408,base.state_br_sc,base.br
+city_4219507,Xanxerê,4219507,base.state_br_sc,base.br
+city_4219606,Xavantina,4219606,base.state_br_sc,base.br
+city_4219705,Xaxim,4219705,base.state_br_sc,base.br
+city_4219853,Zortéa,4219853,base.state_br_sc,base.br
+city_4300034,Aceguá,4300034,base.state_br_rs,base.br
+city_4300059,Água Santa,4300059,base.state_br_rs,base.br
+city_4300109,Agudo,4300109,base.state_br_rs,base.br
+city_4300208,Ajuricaba,4300208,base.state_br_rs,base.br
+city_4300307,Alecrim,4300307,base.state_br_rs,base.br
+city_4300406,Alegrete,4300406,base.state_br_rs,base.br
+city_4300455,Alegria,4300455,base.state_br_rs,base.br
+city_4300471,Almirante Tamandaré do Sul,4300471,base.state_br_rs,base.br
+city_4300505,Alpestre,4300505,base.state_br_rs,base.br
+city_4300554,Alto Alegre,4300554,base.state_br_rs,base.br
+city_4300570,Alto Feliz,4300570,base.state_br_rs,base.br
+city_4300604,Alvorada,4300604,base.state_br_rs,base.br
+city_4300638,Amaral Ferrador,4300638,base.state_br_rs,base.br
+city_4300646,Ametista do Sul,4300646,base.state_br_rs,base.br
+city_4300661,André da Rocha,4300661,base.state_br_rs,base.br
+city_4300703,Anta Gorda,4300703,base.state_br_rs,base.br
+city_4300802,Antônio Prado,4300802,base.state_br_rs,base.br
+city_4300851,Arambaré,4300851,base.state_br_rs,base.br
+city_4300877,Araricá,4300877,base.state_br_rs,base.br
+city_4300901,Aratiba,4300901,base.state_br_rs,base.br
+city_4301008,Arroio do Meio,4301008,base.state_br_rs,base.br
+city_4301073,Arroio do Padre,4301073,base.state_br_rs,base.br
+city_4301057,Arroio do Sal,4301057,base.state_br_rs,base.br
+city_4301206,Arroio do Tigre,4301206,base.state_br_rs,base.br
+city_4301107,Arroio dos Ratos,4301107,base.state_br_rs,base.br
+city_4301305,Arroio Grande,4301305,base.state_br_rs,base.br
+city_4301404,Arvorezinha,4301404,base.state_br_rs,base.br
+city_4301503,Augusto Pestana,4301503,base.state_br_rs,base.br
+city_4301552,Áurea,4301552,base.state_br_rs,base.br
+city_4301602,Bagé,4301602,base.state_br_rs,base.br
+city_4301636,Balneário Pinhal,4301636,base.state_br_rs,base.br
+city_4301651,Barão,4301651,base.state_br_rs,base.br
+city_4301701,Barão de Cotegipe,4301701,base.state_br_rs,base.br
+city_4301750,Barão do Triunfo,4301750,base.state_br_rs,base.br
+city_4301859,Barra do Guarita,4301859,base.state_br_rs,base.br
+city_4301875,Barra do Quaraí,4301875,base.state_br_rs,base.br
+city_4301909,Barra do Ribeiro,4301909,base.state_br_rs,base.br
+city_4301925,Barra do Rio Azul,4301925,base.state_br_rs,base.br
+city_4301958,Barra Funda,4301958,base.state_br_rs,base.br
+city_4301800,Barracão,4301800,base.state_br_rs,base.br
+city_4302006,Barros Cassal,4302006,base.state_br_rs,base.br
+city_4302055,Benjamin Constant do Sul,4302055,base.state_br_rs,base.br
+city_4302105,Bento Gonçalves,4302105,base.state_br_rs,base.br
+city_4302154,Boa Vista das Missões,4302154,base.state_br_rs,base.br
+city_4302204,Boa Vista do Buricá,4302204,base.state_br_rs,base.br
+city_4302220,Boa Vista do Cadeado,4302220,base.state_br_rs,base.br
+city_4302238,Boa Vista do Incra,4302238,base.state_br_rs,base.br
+city_4302253,Boa Vista do Sul,4302253,base.state_br_rs,base.br
+city_4302303,Bom Jesus,4302303,base.state_br_rs,base.br
+city_4302352,Bom Princípio,4302352,base.state_br_rs,base.br
+city_4302378,Bom Progresso,4302378,base.state_br_rs,base.br
+city_4302402,Bom Retiro do Sul,4302402,base.state_br_rs,base.br
+city_4302451,Boqueirão do Leão,4302451,base.state_br_rs,base.br
+city_4302501,Bossoroca,4302501,base.state_br_rs,base.br
+city_4302584,Bozano,4302584,base.state_br_rs,base.br
+city_4302600,Braga,4302600,base.state_br_rs,base.br
+city_4302659,Brochier,4302659,base.state_br_rs,base.br
+city_4302709,Butiá,4302709,base.state_br_rs,base.br
+city_4302808,Caçapava do Sul,4302808,base.state_br_rs,base.br
+city_4302907,Cacequi,4302907,base.state_br_rs,base.br
+city_4303004,Cachoeira do Sul,4303004,base.state_br_rs,base.br
+city_4303103,Cachoeirinha,4303103,base.state_br_rs,base.br
+city_4303202,Cacique Doble,4303202,base.state_br_rs,base.br
+city_4303301,Caibaté,4303301,base.state_br_rs,base.br
+city_4303400,Caiçara,4303400,base.state_br_rs,base.br
+city_4303509,Camaquã,4303509,base.state_br_rs,base.br
+city_4303558,Camargo,4303558,base.state_br_rs,base.br
+city_4303608,Cambará do Sul,4303608,base.state_br_rs,base.br
+city_4303673,Campestre da Serra,4303673,base.state_br_rs,base.br
+city_4303707,Campina das Missões,4303707,base.state_br_rs,base.br
+city_4303806,Campinas do Sul,4303806,base.state_br_rs,base.br
+city_4303905,Campo Bom,4303905,base.state_br_rs,base.br
+city_4304002,Campo Novo,4304002,base.state_br_rs,base.br
+city_4304101,Campos Borges,4304101,base.state_br_rs,base.br
+city_4304200,Candelária,4304200,base.state_br_rs,base.br
+city_4304309,Cândido Godói,4304309,base.state_br_rs,base.br
+city_4304358,Candiota,4304358,base.state_br_rs,base.br
+city_4304408,Canela,4304408,base.state_br_rs,base.br
+city_4304507,Canguçu,4304507,base.state_br_rs,base.br
+city_4304606,Canoas,4304606,base.state_br_rs,base.br
+city_4304614,Canudos do Vale,4304614,base.state_br_rs,base.br
+city_4304622,Capão Bonito do Sul,4304622,base.state_br_rs,base.br
+city_4304630,Capão da Canoa,4304630,base.state_br_rs,base.br
+city_4304655,Capão do Cipó,4304655,base.state_br_rs,base.br
+city_4304663,Capão do Leão,4304663,base.state_br_rs,base.br
+city_4304689,Capela de Santana,4304689,base.state_br_rs,base.br
+city_4304697,Capitão,4304697,base.state_br_rs,base.br
+city_4304671,Capivari do Sul,4304671,base.state_br_rs,base.br
+city_4304713,Caraá,4304713,base.state_br_rs,base.br
+city_4304705,Carazinho,4304705,base.state_br_rs,base.br
+city_4304804,Carlos Barbosa,4304804,base.state_br_rs,base.br
+city_4304853,Carlos Gomes,4304853,base.state_br_rs,base.br
+city_4304903,Casca,4304903,base.state_br_rs,base.br
+city_4304952,Caseiros,4304952,base.state_br_rs,base.br
+city_4305009,Catuípe,4305009,base.state_br_rs,base.br
+city_4305108,Caxias do Sul,4305108,base.state_br_rs,base.br
+city_4305116,Centenário,4305116,base.state_br_rs,base.br
+city_4305124,Cerrito,4305124,base.state_br_rs,base.br
+city_4305132,Cerro Branco,4305132,base.state_br_rs,base.br
+city_4305157,Cerro Grande,4305157,base.state_br_rs,base.br
+city_4305173,Cerro Grande do Sul,4305173,base.state_br_rs,base.br
+city_4305207,Cerro Largo,4305207,base.state_br_rs,base.br
+city_4305306,Chapada,4305306,base.state_br_rs,base.br
+city_4305355,Charqueadas,4305355,base.state_br_rs,base.br
+city_4305371,Charrua,4305371,base.state_br_rs,base.br
+city_4305405,Chiapetta,4305405,base.state_br_rs,base.br
+city_4305439,Chuí,4305439,base.state_br_rs,base.br
+city_4305447,Chuvisca,4305447,base.state_br_rs,base.br
+city_4305454,Cidreira,4305454,base.state_br_rs,base.br
+city_4305504,Ciríaco,4305504,base.state_br_rs,base.br
+city_4305587,Colinas,4305587,base.state_br_rs,base.br
+city_4305603,Colorado,4305603,base.state_br_rs,base.br
+city_4305702,Condor,4305702,base.state_br_rs,base.br
+city_4305801,Constantina,4305801,base.state_br_rs,base.br
+city_4305835,Coqueiro Baixo,4305835,base.state_br_rs,base.br
+city_4305850,Coqueiros do Sul,4305850,base.state_br_rs,base.br
+city_4305871,Coronel Barros,4305871,base.state_br_rs,base.br
+city_4305900,Coronel Bicaco,4305900,base.state_br_rs,base.br
+city_4305934,Coronel Pilar,4305934,base.state_br_rs,base.br
+city_4305959,Cotiporã,4305959,base.state_br_rs,base.br
+city_4305975,Coxilha,4305975,base.state_br_rs,base.br
+city_4306007,Crissiumal,4306007,base.state_br_rs,base.br
+city_4306056,Cristal,4306056,base.state_br_rs,base.br
+city_4306072,Cristal do Sul,4306072,base.state_br_rs,base.br
+city_4306106,Cruz Alta,4306106,base.state_br_rs,base.br
+city_4306130,Cruzaltense,4306130,base.state_br_rs,base.br
+city_4306205,Cruzeiro do Sul,4306205,base.state_br_rs,base.br
+city_4306304,David Canabarro,4306304,base.state_br_rs,base.br
+city_4306320,Derrubadas,4306320,base.state_br_rs,base.br
+city_4306353,Dezesseis de Novembro,4306353,base.state_br_rs,base.br
+city_4306379,Dilermando de Aguiar,4306379,base.state_br_rs,base.br
+city_4306403,Dois Irmãos,4306403,base.state_br_rs,base.br
+city_4306429,Dois Irmãos das Missões,4306429,base.state_br_rs,base.br
+city_4306452,Dois Lajeados,4306452,base.state_br_rs,base.br
+city_4306502,Dom Feliciano,4306502,base.state_br_rs,base.br
+city_4306601,Dom Pedrito,4306601,base.state_br_rs,base.br
+city_4306551,Dom Pedro de Alcântara,4306551,base.state_br_rs,base.br
+city_4306700,Dona Francisca,4306700,base.state_br_rs,base.br
+city_4306734,Doutor Maurício Cardoso,4306734,base.state_br_rs,base.br
+city_4306759,Doutor Ricardo,4306759,base.state_br_rs,base.br
+city_4306767,Eldorado do Sul,4306767,base.state_br_rs,base.br
+city_4306809,Encantado,4306809,base.state_br_rs,base.br
+city_4306908,Encruzilhada do Sul,4306908,base.state_br_rs,base.br
+city_4306924,Engenho Velho,4306924,base.state_br_rs,base.br
+city_4306957,Entre Rios do Sul,4306957,base.state_br_rs,base.br
+city_4306932,Entre-Ijuís,4306932,base.state_br_rs,base.br
+city_4306973,Erebango,4306973,base.state_br_rs,base.br
+city_4307005,Erechim,4307005,base.state_br_rs,base.br
+city_4307054,Ernestina,4307054,base.state_br_rs,base.br
+city_4307203,Erval Grande,4307203,base.state_br_rs,base.br
+city_4307302,Erval Seco,4307302,base.state_br_rs,base.br
+city_4307401,Esmeralda,4307401,base.state_br_rs,base.br
+city_4307450,Esperança do Sul,4307450,base.state_br_rs,base.br
+city_4307500,Espumoso,4307500,base.state_br_rs,base.br
+city_4307559,Estação,4307559,base.state_br_rs,base.br
+city_4307609,Estância Velha,4307609,base.state_br_rs,base.br
+city_4307708,Esteio,4307708,base.state_br_rs,base.br
+city_4307807,Estrela,4307807,base.state_br_rs,base.br
+city_4307815,Estrela Velha,4307815,base.state_br_rs,base.br
+city_4307831,Eugênio de Castro,4307831,base.state_br_rs,base.br
+city_4307864,Fagundes Varela,4307864,base.state_br_rs,base.br
+city_4307906,Farroupilha,4307906,base.state_br_rs,base.br
+city_4308003,Faxinal do Soturno,4308003,base.state_br_rs,base.br
+city_4308052,Faxinalzinho,4308052,base.state_br_rs,base.br
+city_4308078,Fazenda Vilanova,4308078,base.state_br_rs,base.br
+city_4308102,Feliz,4308102,base.state_br_rs,base.br
+city_4308201,Flores da Cunha,4308201,base.state_br_rs,base.br
+city_4308250,Floriano Peixoto,4308250,base.state_br_rs,base.br
+city_4308300,Fontoura Xavier,4308300,base.state_br_rs,base.br
+city_4308409,Formigueiro,4308409,base.state_br_rs,base.br
+city_4308433,Forquetinha,4308433,base.state_br_rs,base.br
+city_4308458,Fortaleza dos Valos,4308458,base.state_br_rs,base.br
+city_4308508,Frederico Westphalen,4308508,base.state_br_rs,base.br
+city_4308607,Garibaldi,4308607,base.state_br_rs,base.br
+city_4308656,Garruchos,4308656,base.state_br_rs,base.br
+city_4308706,Gaurama,4308706,base.state_br_rs,base.br
+city_4308805,General Câmara,4308805,base.state_br_rs,base.br
+city_4308854,Gentil,4308854,base.state_br_rs,base.br
+city_4308904,Getúlio Vargas,4308904,base.state_br_rs,base.br
+city_4309001,Giruá,4309001,base.state_br_rs,base.br
+city_4309050,Glorinha,4309050,base.state_br_rs,base.br
+city_4309100,Gramado,4309100,base.state_br_rs,base.br
+city_4309126,Gramado dos Loureiros,4309126,base.state_br_rs,base.br
+city_4309159,Gramado Xavier,4309159,base.state_br_rs,base.br
+city_4309209,Gravataí,4309209,base.state_br_rs,base.br
+city_4309258,Guabiju,4309258,base.state_br_rs,base.br
+city_4309308,Guaíba,4309308,base.state_br_rs,base.br
+city_4309407,Guaporé,4309407,base.state_br_rs,base.br
+city_4309506,Guarani das Missões,4309506,base.state_br_rs,base.br
+city_4309555,Harmonia,4309555,base.state_br_rs,base.br
+city_4307104,Herval,4307104,base.state_br_rs,base.br
+city_4309571,Herveiras,4309571,base.state_br_rs,base.br
+city_4309605,Horizontina,4309605,base.state_br_rs,base.br
+city_4309654,Hulha Negra,4309654,base.state_br_rs,base.br
+city_4309704,Humaitá,4309704,base.state_br_rs,base.br
+city_4309753,Ibarama,4309753,base.state_br_rs,base.br
+city_4309803,Ibiaçá,4309803,base.state_br_rs,base.br
+city_4309902,Ibiraiaras,4309902,base.state_br_rs,base.br
+city_4309951,Ibirapuitã,4309951,base.state_br_rs,base.br
+city_4310009,Ibirubá,4310009,base.state_br_rs,base.br
+city_4310108,Igrejinha,4310108,base.state_br_rs,base.br
+city_4310207,Ijuí,4310207,base.state_br_rs,base.br
+city_4310306,Ilópolis,4310306,base.state_br_rs,base.br
+city_4310330,Imbé,4310330,base.state_br_rs,base.br
+city_4310363,Imigrante,4310363,base.state_br_rs,base.br
+city_4310405,Independência,4310405,base.state_br_rs,base.br
+city_4310413,Inhacorá,4310413,base.state_br_rs,base.br
+city_4310439,Ipê,4310439,base.state_br_rs,base.br
+city_4310462,Ipiranga do Sul,4310462,base.state_br_rs,base.br
+city_4310504,Iraí,4310504,base.state_br_rs,base.br
+city_4310538,Itaara,4310538,base.state_br_rs,base.br
+city_4310553,Itacurubi,4310553,base.state_br_rs,base.br
+city_4310579,Itapuca,4310579,base.state_br_rs,base.br
+city_4310603,Itaqui,4310603,base.state_br_rs,base.br
+city_4310652,Itati,4310652,base.state_br_rs,base.br
+city_4310702,Itatiba do Sul,4310702,base.state_br_rs,base.br
+city_4310751,Ivorá,4310751,base.state_br_rs,base.br
+city_4310801,Ivoti,4310801,base.state_br_rs,base.br
+city_4310850,Jaboticaba,4310850,base.state_br_rs,base.br
+city_4310876,Jacuizinho,4310876,base.state_br_rs,base.br
+city_4310900,Jacutinga,4310900,base.state_br_rs,base.br
+city_4311007,Jaguarão,4311007,base.state_br_rs,base.br
+city_4311106,Jaguari,4311106,base.state_br_rs,base.br
+city_4311122,Jaquirana,4311122,base.state_br_rs,base.br
+city_4311130,Jari,4311130,base.state_br_rs,base.br
+city_4311155,Jóia,4311155,base.state_br_rs,base.br
+city_4311205,Júlio de Castilhos,4311205,base.state_br_rs,base.br
+city_4311239,Lagoa Bonita do Sul,4311239,base.state_br_rs,base.br
+city_4311270,Lagoa dos Três Cantos,4311270,base.state_br_rs,base.br
+city_4311304,Lagoa Vermelha,4311304,base.state_br_rs,base.br
+city_4311254,Lagoão,4311254,base.state_br_rs,base.br
+city_4311403,Lajeado,4311403,base.state_br_rs,base.br
+city_4311429,Lajeado do Bugre,4311429,base.state_br_rs,base.br
+city_4311502,Lavras do Sul,4311502,base.state_br_rs,base.br
+city_4311601,Liberato Salzano,4311601,base.state_br_rs,base.br
+city_4311627,Lindolfo Collor,4311627,base.state_br_rs,base.br
+city_4311643,Linha Nova,4311643,base.state_br_rs,base.br
+city_4311718,Maçambará,4311718,base.state_br_rs,base.br
+city_4311700,Machadinho,4311700,base.state_br_rs,base.br
+city_4311734,Mampituba,4311734,base.state_br_rs,base.br
+city_4311759,Manoel Viana,4311759,base.state_br_rs,base.br
+city_4311775,Maquiné,4311775,base.state_br_rs,base.br
+city_4311791,Maratá,4311791,base.state_br_rs,base.br
+city_4311809,Marau,4311809,base.state_br_rs,base.br
+city_4311908,Marcelino Ramos,4311908,base.state_br_rs,base.br
+city_4311981,Mariana Pimentel,4311981,base.state_br_rs,base.br
+city_4312005,Mariano Moro,4312005,base.state_br_rs,base.br
+city_4312054,Marques de Souza,4312054,base.state_br_rs,base.br
+city_4312104,Mata,4312104,base.state_br_rs,base.br
+city_4312138,Mato Castelhano,4312138,base.state_br_rs,base.br
+city_4312153,Mato Leitão,4312153,base.state_br_rs,base.br
+city_4312179,Mato Queimado,4312179,base.state_br_rs,base.br
+city_4312203,Maximiliano de Almeida,4312203,base.state_br_rs,base.br
+city_4312252,Minas do Leão,4312252,base.state_br_rs,base.br
+city_4312302,Miraguaí,4312302,base.state_br_rs,base.br
+city_4312351,Montauri,4312351,base.state_br_rs,base.br
+city_4312377,Monte Alegre dos Campos,4312377,base.state_br_rs,base.br
+city_4312385,Monte Belo do Sul,4312385,base.state_br_rs,base.br
+city_4312401,Montenegro,4312401,base.state_br_rs,base.br
+city_4312427,Mormaço,4312427,base.state_br_rs,base.br
+city_4312443,Morrinhos do Sul,4312443,base.state_br_rs,base.br
+city_4312450,Morro Redondo,4312450,base.state_br_rs,base.br
+city_4312476,Morro Reuter,4312476,base.state_br_rs,base.br
+city_4312500,Mostardas,4312500,base.state_br_rs,base.br
+city_4312609,Muçum,4312609,base.state_br_rs,base.br
+city_4312617,Muitos Capões,4312617,base.state_br_rs,base.br
+city_4312625,Muliterno,4312625,base.state_br_rs,base.br
+city_4312658,Não-Me-Toque,4312658,base.state_br_rs,base.br
+city_4312674,Nicolau Vergueiro,4312674,base.state_br_rs,base.br
+city_4312708,Nonoai,4312708,base.state_br_rs,base.br
+city_4312757,Nova Alvorada,4312757,base.state_br_rs,base.br
+city_4312807,Nova Araçá,4312807,base.state_br_rs,base.br
+city_4312906,Nova Bassano,4312906,base.state_br_rs,base.br
+city_4312955,Nova Boa Vista,4312955,base.state_br_rs,base.br
+city_4313003,Nova Bréscia,4313003,base.state_br_rs,base.br
+city_4313011,Nova Candelária,4313011,base.state_br_rs,base.br
+city_4313037,Nova Esperança do Sul,4313037,base.state_br_rs,base.br
+city_4313060,Nova Hartz,4313060,base.state_br_rs,base.br
+city_4313086,Nova Pádua,4313086,base.state_br_rs,base.br
+city_4313102,Nova Palma,4313102,base.state_br_rs,base.br
+city_4313201,Nova Petrópolis,4313201,base.state_br_rs,base.br
+city_4313300,Nova Prata,4313300,base.state_br_rs,base.br
+city_4313334,Nova Ramada,4313334,base.state_br_rs,base.br
+city_4313359,Nova Roma do Sul,4313359,base.state_br_rs,base.br
+city_4313375,Nova Santa Rita,4313375,base.state_br_rs,base.br
+city_4313490,Novo Barreiro,4313490,base.state_br_rs,base.br
+city_4313391,Novo Cabrais,4313391,base.state_br_rs,base.br
+city_4313409,Novo Hamburgo,4313409,base.state_br_rs,base.br
+city_4313425,Novo Machado,4313425,base.state_br_rs,base.br
+city_4313441,Novo Tiradentes,4313441,base.state_br_rs,base.br
+city_4313466,Novo Xingu,4313466,base.state_br_rs,base.br
+city_4313508,Osório,4313508,base.state_br_rs,base.br
+city_4313607,Paim Filho,4313607,base.state_br_rs,base.br
+city_4313656,Palmares do Sul,4313656,base.state_br_rs,base.br
+city_4313706,Palmeira das Missões,4313706,base.state_br_rs,base.br
+city_4313805,Palmitinho,4313805,base.state_br_rs,base.br
+city_4313904,Panambi,4313904,base.state_br_rs,base.br
+city_4313953,Pantano Grande,4313953,base.state_br_rs,base.br
+city_4314001,Paraí,4314001,base.state_br_rs,base.br
+city_4314027,Paraíso do Sul,4314027,base.state_br_rs,base.br
+city_4314035,Pareci Novo,4314035,base.state_br_rs,base.br
+city_4314050,Parobé,4314050,base.state_br_rs,base.br
+city_4314068,Passa Sete,4314068,base.state_br_rs,base.br
+city_4314076,Passo do Sobrado,4314076,base.state_br_rs,base.br
+city_4314100,Passo Fundo,4314100,base.state_br_rs,base.br
+city_4314134,Paulo Bento,4314134,base.state_br_rs,base.br
+city_4314159,Paverama,4314159,base.state_br_rs,base.br
+city_4314175,Pedras Altas,4314175,base.state_br_rs,base.br
+city_4314209,Pedro Osório,4314209,base.state_br_rs,base.br
+city_4314308,Pejuçara,4314308,base.state_br_rs,base.br
+city_4314407,Pelotas,4314407,base.state_br_rs,base.br
+city_4314423,Picada Café,4314423,base.state_br_rs,base.br
+city_4314456,Pinhal,4314456,base.state_br_rs,base.br
+city_4314464,Pinhal da Serra,4314464,base.state_br_rs,base.br
+city_4314472,Pinhal Grande,4314472,base.state_br_rs,base.br
+city_4314498,Pinheirinho do Vale,4314498,base.state_br_rs,base.br
+city_4314506,Pinheiro Machado,4314506,base.state_br_rs,base.br
+city_4314548,Pinto Bandeira,4314548,base.state_br_rs,base.br
+city_4314555,Pirapó,4314555,base.state_br_rs,base.br
+city_4314605,Piratini,4314605,base.state_br_rs,base.br
+city_4314704,Planalto,4314704,base.state_br_rs,base.br
+city_4314753,Poço das Antas,4314753,base.state_br_rs,base.br
+city_4314779,Pontão,4314779,base.state_br_rs,base.br
+city_4314787,Ponte Preta,4314787,base.state_br_rs,base.br
+city_4314803,Portão,4314803,base.state_br_rs,base.br
+city_4314902,Porto Alegre,4314902,base.state_br_rs,base.br
+city_4315008,Porto Lucena,4315008,base.state_br_rs,base.br
+city_4315057,Porto Mauá,4315057,base.state_br_rs,base.br
+city_4315073,Porto Vera Cruz,4315073,base.state_br_rs,base.br
+city_4315107,Porto Xavier,4315107,base.state_br_rs,base.br
+city_4315131,Pouso Novo,4315131,base.state_br_rs,base.br
+city_4315149,Presidente Lucena,4315149,base.state_br_rs,base.br
+city_4315156,Progresso,4315156,base.state_br_rs,base.br
+city_4315172,Protásio Alves,4315172,base.state_br_rs,base.br
+city_4315206,Putinga,4315206,base.state_br_rs,base.br
+city_4315305,Quaraí,4315305,base.state_br_rs,base.br
+city_4315313,Quatro Irmãos,4315313,base.state_br_rs,base.br
+city_4315321,Quevedos,4315321,base.state_br_rs,base.br
+city_4315354,Quinze de Novembro,4315354,base.state_br_rs,base.br
+city_4315404,Redentora,4315404,base.state_br_rs,base.br
+city_4315453,Relvado,4315453,base.state_br_rs,base.br
+city_4315503,Restinga Sêca,4315503,base.state_br_rs,base.br
+city_4315552,Rio dos Índios,4315552,base.state_br_rs,base.br
+city_4315602,Rio Grande,4315602,base.state_br_rs,base.br
+city_4315701,Rio Pardo,4315701,base.state_br_rs,base.br
+city_4315750,Riozinho,4315750,base.state_br_rs,base.br
+city_4315800,Roca Sales,4315800,base.state_br_rs,base.br
+city_4315909,Rodeio Bonito,4315909,base.state_br_rs,base.br
+city_4315958,Rolador,4315958,base.state_br_rs,base.br
+city_4316006,Rolante,4316006,base.state_br_rs,base.br
+city_4316105,Ronda Alta,4316105,base.state_br_rs,base.br
+city_4316204,Rondinha,4316204,base.state_br_rs,base.br
+city_4316303,Roque Gonzales,4316303,base.state_br_rs,base.br
+city_4316402,Rosário do Sul,4316402,base.state_br_rs,base.br
+city_4316428,Sagrada Família,4316428,base.state_br_rs,base.br
+city_4316436,Saldanha Marinho,4316436,base.state_br_rs,base.br
+city_4316451,Salto do Jacuí,4316451,base.state_br_rs,base.br
+city_4316477,Salvador das Missões,4316477,base.state_br_rs,base.br
+city_4316501,Salvador do Sul,4316501,base.state_br_rs,base.br
+city_4316600,Sananduva,4316600,base.state_br_rs,base.br
+city_4316709,Santa Bárbara do Sul,4316709,base.state_br_rs,base.br
+city_4316733,Santa Cecília do Sul,4316733,base.state_br_rs,base.br
+city_4316758,Santa Clara do Sul,4316758,base.state_br_rs,base.br
+city_4316808,Santa Cruz do Sul,4316808,base.state_br_rs,base.br
+city_4316972,Santa Margarida do Sul,4316972,base.state_br_rs,base.br
+city_4316907,Santa Maria,4316907,base.state_br_rs,base.br
+city_4316956,Santa Maria do Herval,4316956,base.state_br_rs,base.br
+city_4317202,Santa Rosa,4317202,base.state_br_rs,base.br
+city_4317251,Santa Tereza,4317251,base.state_br_rs,base.br
+city_4317301,Santa Vitória do Palmar,4317301,base.state_br_rs,base.br
+city_4317004,Santana da Boa Vista,4317004,base.state_br_rs,base.br
+city_4317103,Sant'Ana do Livramento,4317103,base.state_br_rs,base.br
+city_4317400,Santiago,4317400,base.state_br_rs,base.br
+city_4317509,Santo Ângelo,4317509,base.state_br_rs,base.br
+city_4317608,Santo Antônio da Patrulha,4317608,base.state_br_rs,base.br
+city_4317707,Santo Antônio das Missões,4317707,base.state_br_rs,base.br
+city_4317558,Santo Antônio do Palma,4317558,base.state_br_rs,base.br
+city_4317756,Santo Antônio do Planalto,4317756,base.state_br_rs,base.br
+city_4317806,Santo Augusto,4317806,base.state_br_rs,base.br
+city_4317905,Santo Cristo,4317905,base.state_br_rs,base.br
+city_4317954,Santo Expedito do Sul,4317954,base.state_br_rs,base.br
+city_4318002,São Borja,4318002,base.state_br_rs,base.br
+city_4318051,São Domingos do Sul,4318051,base.state_br_rs,base.br
+city_4318101,São Francisco de Assis,4318101,base.state_br_rs,base.br
+city_4318200,São Francisco de Paula,4318200,base.state_br_rs,base.br
+city_4318309,São Gabriel,4318309,base.state_br_rs,base.br
+city_4318408,São Jerônimo,4318408,base.state_br_rs,base.br
+city_4318424,São João da Urtiga,4318424,base.state_br_rs,base.br
+city_4318432,São João do Polêsine,4318432,base.state_br_rs,base.br
+city_4318440,São Jorge,4318440,base.state_br_rs,base.br
+city_4318457,São José das Missões,4318457,base.state_br_rs,base.br
+city_4318465,São José do Herval,4318465,base.state_br_rs,base.br
+city_4318481,São José do Hortêncio,4318481,base.state_br_rs,base.br
+city_4318499,São José do Inhacorá,4318499,base.state_br_rs,base.br
+city_4318507,São José do Norte,4318507,base.state_br_rs,base.br
+city_4318606,São José do Ouro,4318606,base.state_br_rs,base.br
+city_4318614,São José do Sul,4318614,base.state_br_rs,base.br
+city_4318622,São José dos Ausentes,4318622,base.state_br_rs,base.br
+city_4318705,São Leopoldo,4318705,base.state_br_rs,base.br
+city_4318804,São Lourenço do Sul,4318804,base.state_br_rs,base.br
+city_4318903,São Luiz Gonzaga,4318903,base.state_br_rs,base.br
+city_4319000,São Marcos,4319000,base.state_br_rs,base.br
+city_4319109,São Martinho,4319109,base.state_br_rs,base.br
+city_4319125,São Martinho da Serra,4319125,base.state_br_rs,base.br
+city_4319158,São Miguel das Missões,4319158,base.state_br_rs,base.br
+city_4319208,São Nicolau,4319208,base.state_br_rs,base.br
+city_4319307,São Paulo das Missões,4319307,base.state_br_rs,base.br
+city_4319356,São Pedro da Serra,4319356,base.state_br_rs,base.br
+city_4319364,São Pedro das Missões,4319364,base.state_br_rs,base.br
+city_4319372,São Pedro do Butiá,4319372,base.state_br_rs,base.br
+city_4319406,São Pedro do Sul,4319406,base.state_br_rs,base.br
+city_4319505,São Sebastião do Caí,4319505,base.state_br_rs,base.br
+city_4319604,São Sepé,4319604,base.state_br_rs,base.br
+city_4319703,São Valentim,4319703,base.state_br_rs,base.br
+city_4319711,São Valentim do Sul,4319711,base.state_br_rs,base.br
+city_4319737,São Valério do Sul,4319737,base.state_br_rs,base.br
+city_4319752,São Vendelino,4319752,base.state_br_rs,base.br
+city_4319802,São Vicente do Sul,4319802,base.state_br_rs,base.br
+city_4319901,Sapiranga,4319901,base.state_br_rs,base.br
+city_4320008,Sapucaia do Sul,4320008,base.state_br_rs,base.br
+city_4320107,Sarandi,4320107,base.state_br_rs,base.br
+city_4320206,Seberi,4320206,base.state_br_rs,base.br
+city_4320230,Sede Nova,4320230,base.state_br_rs,base.br
+city_4320263,Segredo,4320263,base.state_br_rs,base.br
+city_4320305,Selbach,4320305,base.state_br_rs,base.br
+city_4320321,Senador Salgado Filho,4320321,base.state_br_rs,base.br
+city_4320354,Sentinela do Sul,4320354,base.state_br_rs,base.br
+city_4320404,Serafina Corrêa,4320404,base.state_br_rs,base.br
+city_4320453,Sério,4320453,base.state_br_rs,base.br
+city_4320503,Sertão,4320503,base.state_br_rs,base.br
+city_4320552,Sertão Santana,4320552,base.state_br_rs,base.br
+city_4320578,Sete de Setembro,4320578,base.state_br_rs,base.br
+city_4320602,Severiano de Almeida,4320602,base.state_br_rs,base.br
+city_4320651,Silveira Martins,4320651,base.state_br_rs,base.br
+city_4320677,Sinimbu,4320677,base.state_br_rs,base.br
+city_4320701,Sobradinho,4320701,base.state_br_rs,base.br
+city_4320800,Soledade,4320800,base.state_br_rs,base.br
+city_4320859,Tabaí,4320859,base.state_br_rs,base.br
+city_4320909,Tapejara,4320909,base.state_br_rs,base.br
+city_4321006,Tapera,4321006,base.state_br_rs,base.br
+city_4321105,Tapes,4321105,base.state_br_rs,base.br
+city_4321204,Taquara,4321204,base.state_br_rs,base.br
+city_4321303,Taquari,4321303,base.state_br_rs,base.br
+city_4321329,Taquaruçu do Sul,4321329,base.state_br_rs,base.br
+city_4321352,Tavares,4321352,base.state_br_rs,base.br
+city_4321402,Tenente Portela,4321402,base.state_br_rs,base.br
+city_4321436,Terra de Areia,4321436,base.state_br_rs,base.br
+city_4321451,Teutônia,4321451,base.state_br_rs,base.br
+city_4321469,Tio Hugo,4321469,base.state_br_rs,base.br
+city_4321477,Tiradentes do Sul,4321477,base.state_br_rs,base.br
+city_4321493,Toropi,4321493,base.state_br_rs,base.br
+city_4321501,Torres,4321501,base.state_br_rs,base.br
+city_4321600,Tramandaí,4321600,base.state_br_rs,base.br
+city_4321626,Travesseiro,4321626,base.state_br_rs,base.br
+city_4321634,Três Arroios,4321634,base.state_br_rs,base.br
+city_4321667,Três Cachoeiras,4321667,base.state_br_rs,base.br
+city_4321709,Três Coroas,4321709,base.state_br_rs,base.br
+city_4321808,Três de Maio,4321808,base.state_br_rs,base.br
+city_4321832,Três Forquilhas,4321832,base.state_br_rs,base.br
+city_4321857,Três Palmeiras,4321857,base.state_br_rs,base.br
+city_4321907,Três Passos,4321907,base.state_br_rs,base.br
+city_4321956,Trindade do Sul,4321956,base.state_br_rs,base.br
+city_4322004,Triunfo,4322004,base.state_br_rs,base.br
+city_4322103,Tucunduva,4322103,base.state_br_rs,base.br
+city_4322152,Tunas,4322152,base.state_br_rs,base.br
+city_4322186,Tupanci do Sul,4322186,base.state_br_rs,base.br
+city_4322202,Tupanciretã,4322202,base.state_br_rs,base.br
+city_4322251,Tupandi,4322251,base.state_br_rs,base.br
+city_4322301,Tuparendi,4322301,base.state_br_rs,base.br
+city_4322327,Turuçu,4322327,base.state_br_rs,base.br
+city_4322343,Ubiretama,4322343,base.state_br_rs,base.br
+city_4322350,União da Serra,4322350,base.state_br_rs,base.br
+city_4322376,Unistalda,4322376,base.state_br_rs,base.br
+city_4322400,Uruguaiana,4322400,base.state_br_rs,base.br
+city_4322509,Vacaria,4322509,base.state_br_rs,base.br
+city_4322533,Vale do Sol,4322533,base.state_br_rs,base.br
+city_4322541,Vale Real,4322541,base.state_br_rs,base.br
+city_4322525,Vale Verde,4322525,base.state_br_rs,base.br
+city_4322558,Vanini,4322558,base.state_br_rs,base.br
+city_4322608,Venâncio Aires,4322608,base.state_br_rs,base.br
+city_4322707,Vera Cruz,4322707,base.state_br_rs,base.br
+city_4322806,Veranópolis,4322806,base.state_br_rs,base.br
+city_4322855,Vespasiano Corrêa,4322855,base.state_br_rs,base.br
+city_4322905,Viadutos,4322905,base.state_br_rs,base.br
+city_4323002,Viamão,4323002,base.state_br_rs,base.br
+city_4323101,Vicente Dutra,4323101,base.state_br_rs,base.br
+city_4323200,Victor Graeff,4323200,base.state_br_rs,base.br
+city_4323309,Vila Flores,4323309,base.state_br_rs,base.br
+city_4323358,Vila Lângaro,4323358,base.state_br_rs,base.br
+city_4323408,Vila Maria,4323408,base.state_br_rs,base.br
+city_4323457,Vila Nova do Sul,4323457,base.state_br_rs,base.br
+city_4323507,Vista Alegre,4323507,base.state_br_rs,base.br
+city_4323606,Vista Alegre do Prata,4323606,base.state_br_rs,base.br
+city_4323705,Vista Gaúcha,4323705,base.state_br_rs,base.br
+city_4323754,Vitória das Missões,4323754,base.state_br_rs,base.br
+city_4323770,Westfália,4323770,base.state_br_rs,base.br
+city_4323804,Xangri-lá,4323804,base.state_br_rs,base.br
+city_5000203,Água Clara,5000203,base.state_br_ms,base.br
+city_5000252,Alcinópolis,5000252,base.state_br_ms,base.br
+city_5000609,Amambai,5000609,base.state_br_ms,base.br
+city_5000708,Anastácio,5000708,base.state_br_ms,base.br
+city_5000807,Anaurilândia,5000807,base.state_br_ms,base.br
+city_5000856,Angélica,5000856,base.state_br_ms,base.br
+city_5000906,Antônio João,5000906,base.state_br_ms,base.br
+city_5001003,Aparecida do Taboado,5001003,base.state_br_ms,base.br
+city_5001102,Aquidauana,5001102,base.state_br_ms,base.br
+city_5001243,Aral Moreira,5001243,base.state_br_ms,base.br
+city_5001508,Bandeirantes,5001508,base.state_br_ms,base.br
+city_5001904,Bataguassu,5001904,base.state_br_ms,base.br
+city_5002001,Batayporã,5002001,base.state_br_ms,base.br
+city_5002100,Bela Vista,5002100,base.state_br_ms,base.br
+city_5002159,Bodoquena,5002159,base.state_br_ms,base.br
+city_5002209,Bonito,5002209,base.state_br_ms,base.br
+city_5002308,Brasilândia,5002308,base.state_br_ms,base.br
+city_5002407,Caarapó,5002407,base.state_br_ms,base.br
+city_5002605,Camapuã,5002605,base.state_br_ms,base.br
+city_5002704,Campo Grande,5002704,base.state_br_ms,base.br
+city_5002803,Caracol,5002803,base.state_br_ms,base.br
+city_5002902,Cassilândia,5002902,base.state_br_ms,base.br
+city_5002951,Chapadão do Sul,5002951,base.state_br_ms,base.br
+city_5003108,Corguinho,5003108,base.state_br_ms,base.br
+city_5003157,Coronel Sapucaia,5003157,base.state_br_ms,base.br
+city_5003207,Corumbá,5003207,base.state_br_ms,base.br
+city_5003256,Costa Rica,5003256,base.state_br_ms,base.br
+city_5003306,Coxim,5003306,base.state_br_ms,base.br
+city_5003454,Deodápolis,5003454,base.state_br_ms,base.br
+city_5003488,Dois Irmãos do Buriti,5003488,base.state_br_ms,base.br
+city_5003504,Douradina,5003504,base.state_br_ms,base.br
+city_5003702,Dourados,5003702,base.state_br_ms,base.br
+city_5003751,Eldorado,5003751,base.state_br_ms,base.br
+city_5003801,Fátima do Sul,5003801,base.state_br_ms,base.br
+city_5003900,Figueirão,5003900,base.state_br_ms,base.br
+city_5004007,Glória de Dourados,5004007,base.state_br_ms,base.br
+city_5004106,Guia Lopes da Laguna,5004106,base.state_br_ms,base.br
+city_5004304,Iguatemi,5004304,base.state_br_ms,base.br
+city_5004403,Inocência,5004403,base.state_br_ms,base.br
+city_5004502,Itaporã,5004502,base.state_br_ms,base.br
+city_5004601,Itaquiraí,5004601,base.state_br_ms,base.br
+city_5004700,Ivinhema,5004700,base.state_br_ms,base.br
+city_5004809,Japorã,5004809,base.state_br_ms,base.br
+city_5004908,Jaraguari,5004908,base.state_br_ms,base.br
+city_5005004,Jardim,5005004,base.state_br_ms,base.br
+city_5005103,Jateí,5005103,base.state_br_ms,base.br
+city_5005152,Juti,5005152,base.state_br_ms,base.br
+city_5005202,Ladário,5005202,base.state_br_ms,base.br
+city_5005251,Laguna Carapã,5005251,base.state_br_ms,base.br
+city_5005400,Maracaju,5005400,base.state_br_ms,base.br
+city_5005608,Miranda,5005608,base.state_br_ms,base.br
+city_5005681,Mundo Novo,5005681,base.state_br_ms,base.br
+city_5005707,Naviraí,5005707,base.state_br_ms,base.br
+city_5005806,Nioaque,5005806,base.state_br_ms,base.br
+city_5006002,Nova Alvorada do Sul,5006002,base.state_br_ms,base.br
+city_5006200,Nova Andradina,5006200,base.state_br_ms,base.br
+city_5006259,Novo Horizonte do Sul,5006259,base.state_br_ms,base.br
+city_5006275,Paraíso das Águas,5006275,base.state_br_ms,base.br
+city_5006309,Paranaíba,5006309,base.state_br_ms,base.br
+city_5006358,Paranhos,5006358,base.state_br_ms,base.br
+city_5006408,Pedro Gomes,5006408,base.state_br_ms,base.br
+city_5006606,Ponta Porã,5006606,base.state_br_ms,base.br
+city_5006903,Porto Murtinho,5006903,base.state_br_ms,base.br
+city_5007109,Ribas do Rio Pardo,5007109,base.state_br_ms,base.br
+city_5007208,Rio Brilhante,5007208,base.state_br_ms,base.br
+city_5007307,Rio Negro,5007307,base.state_br_ms,base.br
+city_5007406,Rio Verde de Mato Grosso,5007406,base.state_br_ms,base.br
+city_5007505,Rochedo,5007505,base.state_br_ms,base.br
+city_5007554,Santa Rita do Pardo,5007554,base.state_br_ms,base.br
+city_5007695,São Gabriel do Oeste,5007695,base.state_br_ms,base.br
+city_5007802,Selvíria,5007802,base.state_br_ms,base.br
+city_5007703,Sete Quedas,5007703,base.state_br_ms,base.br
+city_5007901,Sidrolândia,5007901,base.state_br_ms,base.br
+city_5007935,Sonora,5007935,base.state_br_ms,base.br
+city_5007950,Tacuru,5007950,base.state_br_ms,base.br
+city_5007976,Taquarussu,5007976,base.state_br_ms,base.br
+city_5008008,Terenos,5008008,base.state_br_ms,base.br
+city_5008305,Três Lagoas,5008305,base.state_br_ms,base.br
+city_5008404,Vicentina,5008404,base.state_br_ms,base.br
+city_5100102,Acorizal,5100102,base.state_br_mt,base.br
+city_5100201,Água Boa,5100201,base.state_br_mt,base.br
+city_5100250,Alta Floresta,5100250,base.state_br_mt,base.br
+city_5100300,Alto Araguaia,5100300,base.state_br_mt,base.br
+city_5100359,Alto Boa Vista,5100359,base.state_br_mt,base.br
+city_5100409,Alto Garças,5100409,base.state_br_mt,base.br
+city_5100508,Alto Paraguai,5100508,base.state_br_mt,base.br
+city_5100607,Alto Taquari,5100607,base.state_br_mt,base.br
+city_5100805,Apiacás,5100805,base.state_br_mt,base.br
+city_5101001,Araguaiana,5101001,base.state_br_mt,base.br
+city_5101209,Araguainha,5101209,base.state_br_mt,base.br
+city_5101258,Araputanga,5101258,base.state_br_mt,base.br
+city_5101308,Arenápolis,5101308,base.state_br_mt,base.br
+city_5101407,Aripuanã,5101407,base.state_br_mt,base.br
+city_5101605,Barão de Melgaço,5101605,base.state_br_mt,base.br
+city_5101704,Barra do Bugres,5101704,base.state_br_mt,base.br
+city_5101803,Barra do Garças,5101803,base.state_br_mt,base.br
+city_5101852,Bom Jesus do Araguaia,5101852,base.state_br_mt,base.br
+city_5101902,Brasnorte,5101902,base.state_br_mt,base.br
+city_5102504,Cáceres,5102504,base.state_br_mt,base.br
+city_5102603,Campinápolis,5102603,base.state_br_mt,base.br
+city_5102637,Campo Novo do Parecis,5102637,base.state_br_mt,base.br
+city_5102678,Campo Verde,5102678,base.state_br_mt,base.br
+city_5102686,Campos de Júlio,5102686,base.state_br_mt,base.br
+city_5102694,Canabrava do Norte,5102694,base.state_br_mt,base.br
+city_5102702,Canarana,5102702,base.state_br_mt,base.br
+city_5102793,Carlinda,5102793,base.state_br_mt,base.br
+city_5102850,Castanheira,5102850,base.state_br_mt,base.br
+city_5103007,Chapada dos Guimarães,5103007,base.state_br_mt,base.br
+city_5103056,Cláudia,5103056,base.state_br_mt,base.br
+city_5103106,Cocalinho,5103106,base.state_br_mt,base.br
+city_5103205,Colíder,5103205,base.state_br_mt,base.br
+city_5103254,Colniza,5103254,base.state_br_mt,base.br
+city_5103304,Comodoro,5103304,base.state_br_mt,base.br
+city_5103353,Confresa,5103353,base.state_br_mt,base.br
+city_5103361,Conquista D'Oeste,5103361,base.state_br_mt,base.br
+city_5103379,Cotriguaçu,5103379,base.state_br_mt,base.br
+city_5103403,Cuiabá,5103403,base.state_br_mt,base.br
+city_5103437,Curvelândia,5103437,base.state_br_mt,base.br
+city_5103452,Denise,5103452,base.state_br_mt,base.br
+city_5103502,Diamantino,5103502,base.state_br_mt,base.br
+city_5103601,Dom Aquino,5103601,base.state_br_mt,base.br
+city_5103700,Feliz Natal,5103700,base.state_br_mt,base.br
+city_5103809,Figueirópolis D'Oeste,5103809,base.state_br_mt,base.br
+city_5103858,Gaúcha do Norte,5103858,base.state_br_mt,base.br
+city_5103908,General Carneiro,5103908,base.state_br_mt,base.br
+city_5103957,Glória D'Oeste,5103957,base.state_br_mt,base.br
+city_5104104,Guarantã do Norte,5104104,base.state_br_mt,base.br
+city_5104203,Guiratinga,5104203,base.state_br_mt,base.br
+city_5104500,Indiavaí,5104500,base.state_br_mt,base.br
+city_5104526,Ipiranga do Norte,5104526,base.state_br_mt,base.br
+city_5104542,Itanhangá,5104542,base.state_br_mt,base.br
+city_5104559,Itaúba,5104559,base.state_br_mt,base.br
+city_5104609,Itiquira,5104609,base.state_br_mt,base.br
+city_5104807,Jaciara,5104807,base.state_br_mt,base.br
+city_5104906,Jangada,5104906,base.state_br_mt,base.br
+city_5105002,Jauru,5105002,base.state_br_mt,base.br
+city_5105101,Juara,5105101,base.state_br_mt,base.br
+city_5105150,Juína,5105150,base.state_br_mt,base.br
+city_5105176,Juruena,5105176,base.state_br_mt,base.br
+city_5105200,Juscimeira,5105200,base.state_br_mt,base.br
+city_5105234,Lambari D'Oeste,5105234,base.state_br_mt,base.br
+city_5105259,Lucas do Rio Verde,5105259,base.state_br_mt,base.br
+city_5105309,Luciara,5105309,base.state_br_mt,base.br
+city_5105580,Marcelândia,5105580,base.state_br_mt,base.br
+city_5105606,Matupá,5105606,base.state_br_mt,base.br
+city_5105622,Mirassol d'Oeste,5105622,base.state_br_mt,base.br
+city_5105903,Nobres,5105903,base.state_br_mt,base.br
+city_5106000,Nortelândia,5106000,base.state_br_mt,base.br
+city_5106109,Nossa Senhora do Livramento,5106109,base.state_br_mt,base.br
+city_5106158,Nova Bandeirantes,5106158,base.state_br_mt,base.br
+city_5106208,Nova Brasilândia,5106208,base.state_br_mt,base.br
+city_5106216,Nova Canaã do Norte,5106216,base.state_br_mt,base.br
+city_5108808,Nova Guarita,5108808,base.state_br_mt,base.br
+city_5106182,Nova Lacerda,5106182,base.state_br_mt,base.br
+city_5108857,Nova Marilândia,5108857,base.state_br_mt,base.br
+city_5108907,Nova Maringá,5108907,base.state_br_mt,base.br
+city_5108956,Nova Monte Verde,5108956,base.state_br_mt,base.br
+city_5106224,Nova Mutum,5106224,base.state_br_mt,base.br
+city_5106174,Nova Nazaré,5106174,base.state_br_mt,base.br
+city_5106232,Nova Olímpia,5106232,base.state_br_mt,base.br
+city_5106190,Nova Santa Helena,5106190,base.state_br_mt,base.br
+city_5106240,Nova Ubiratã,5106240,base.state_br_mt,base.br
+city_5106257,Nova Xavantina,5106257,base.state_br_mt,base.br
+city_5106273,Novo Horizonte do Norte,5106273,base.state_br_mt,base.br
+city_5106265,Novo Mundo,5106265,base.state_br_mt,base.br
+city_5106315,Novo Santo Antônio,5106315,base.state_br_mt,base.br
+city_5106281,Novo São Joaquim,5106281,base.state_br_mt,base.br
+city_5106299,Paranaíta,5106299,base.state_br_mt,base.br
+city_5106307,Paranatinga,5106307,base.state_br_mt,base.br
+city_5106372,Pedra Preta,5106372,base.state_br_mt,base.br
+city_5106422,Peixoto de Azevedo,5106422,base.state_br_mt,base.br
+city_5106455,Planalto da Serra,5106455,base.state_br_mt,base.br
+city_5106505,Poconé,5106505,base.state_br_mt,base.br
+city_5106653,Pontal do Araguaia,5106653,base.state_br_mt,base.br
+city_5106703,Ponte Branca,5106703,base.state_br_mt,base.br
+city_5106752,Pontes e Lacerda,5106752,base.state_br_mt,base.br
+city_5106778,Porto Alegre do Norte,5106778,base.state_br_mt,base.br
+city_5106802,Porto dos Gaúchos,5106802,base.state_br_mt,base.br
+city_5106828,Porto Esperidião,5106828,base.state_br_mt,base.br
+city_5106851,Porto Estrela,5106851,base.state_br_mt,base.br
+city_5107008,Poxoréu,5107008,base.state_br_mt,base.br
+city_5107040,Primavera do Leste,5107040,base.state_br_mt,base.br
+city_5107065,Querência,5107065,base.state_br_mt,base.br
+city_5107156,Reserva do Cabaçal,5107156,base.state_br_mt,base.br
+city_5107180,Ribeirão Cascalheira,5107180,base.state_br_mt,base.br
+city_5107198,Ribeirãozinho,5107198,base.state_br_mt,base.br
+city_5107206,Rio Branco,5107206,base.state_br_mt,base.br
+city_5107578,Rondolândia,5107578,base.state_br_mt,base.br
+city_5107602,Rondonópolis,5107602,base.state_br_mt,base.br
+city_5107701,Rosário Oeste,5107701,base.state_br_mt,base.br
+city_5107750,Salto do Céu,5107750,base.state_br_mt,base.br
+city_5107248,Santa Carmem,5107248,base.state_br_mt,base.br
+city_5107743,Santa Cruz do Xingu,5107743,base.state_br_mt,base.br
+city_5107768,Santa Rita do Trivelato,5107768,base.state_br_mt,base.br
+city_5107776,Santa Terezinha,5107776,base.state_br_mt,base.br
+city_5107263,Santo Afonso,5107263,base.state_br_mt,base.br
+city_5107800,Santo Antônio de Leverger,5107800,base.state_br_mt,base.br
+city_5107792,Santo Antônio do Leste,5107792,base.state_br_mt,base.br
+city_5107859,São Félix do Araguaia,5107859,base.state_br_mt,base.br
+city_5107297,São José do Povo,5107297,base.state_br_mt,base.br
+city_5107305,São José do Rio Claro,5107305,base.state_br_mt,base.br
+city_5107354,São José do Xingu,5107354,base.state_br_mt,base.br
+city_5107107,São José dos Quatro Marcos,5107107,base.state_br_mt,base.br
+city_5107404,São Pedro da Cipa,5107404,base.state_br_mt,base.br
+city_5107875,Sapezal,5107875,base.state_br_mt,base.br
+city_5107883,Serra Nova Dourada,5107883,base.state_br_mt,base.br
+city_5107909,Sinop,5107909,base.state_br_mt,base.br
+city_5107925,Sorriso,5107925,base.state_br_mt,base.br
+city_5107941,Tabaporã,5107941,base.state_br_mt,base.br
+city_5107958,Tangará da Serra,5107958,base.state_br_mt,base.br
+city_5108006,Tapurah,5108006,base.state_br_mt,base.br
+city_5108055,Terra Nova do Norte,5108055,base.state_br_mt,base.br
+city_5108105,Tesouro,5108105,base.state_br_mt,base.br
+city_5108204,Torixoréu,5108204,base.state_br_mt,base.br
+city_5108303,União do Sul,5108303,base.state_br_mt,base.br
+city_5108352,Vale de São Domingos,5108352,base.state_br_mt,base.br
+city_5108402,Várzea Grande,5108402,base.state_br_mt,base.br
+city_5108501,Vera,5108501,base.state_br_mt,base.br
+city_5105507,Vila Bela da Santíssima Trindade,5105507,base.state_br_mt,base.br
+city_5108600,Vila Rica,5108600,base.state_br_mt,base.br
+city_5200050,Abadia de Goiás,5200050,base.state_br_go,base.br
+city_5200100,Abadiânia,5200100,base.state_br_go,base.br
+city_5200134,Acreúna,5200134,base.state_br_go,base.br
+city_5200159,Adelândia,5200159,base.state_br_go,base.br
+city_5200175,Água Fria de Goiás,5200175,base.state_br_go,base.br
+city_5200209,Água Limpa,5200209,base.state_br_go,base.br
+city_5200258,Águas Lindas de Goiás,5200258,base.state_br_go,base.br
+city_5200308,Alexânia,5200308,base.state_br_go,base.br
+city_5200506,Aloândia,5200506,base.state_br_go,base.br
+city_5200555,Alto Horizonte,5200555,base.state_br_go,base.br
+city_5200605,Alto Paraíso de Goiás,5200605,base.state_br_go,base.br
+city_5200803,Alvorada do Norte,5200803,base.state_br_go,base.br
+city_5200829,Amaralina,5200829,base.state_br_go,base.br
+city_5200852,Americano do Brasil,5200852,base.state_br_go,base.br
+city_5200902,Amorinópolis,5200902,base.state_br_go,base.br
+city_5201108,Anápolis,5201108,base.state_br_go,base.br
+city_5201207,Anhanguera,5201207,base.state_br_go,base.br
+city_5201306,Anicuns,5201306,base.state_br_go,base.br
+city_5201405,Aparecida de Goiânia,5201405,base.state_br_go,base.br
+city_5201454,Aparecida do Rio Doce,5201454,base.state_br_go,base.br
+city_5201504,Aporé,5201504,base.state_br_go,base.br
+city_5201603,Araçu,5201603,base.state_br_go,base.br
+city_5201702,Aragarças,5201702,base.state_br_go,base.br
+city_5201801,Aragoiânia,5201801,base.state_br_go,base.br
+city_5202155,Araguapaz,5202155,base.state_br_go,base.br
+city_5202353,Arenópolis,5202353,base.state_br_go,base.br
+city_5202502,Aruanã,5202502,base.state_br_go,base.br
+city_5202601,Aurilândia,5202601,base.state_br_go,base.br
+city_5202809,Avelinópolis,5202809,base.state_br_go,base.br
+city_5203104,Baliza,5203104,base.state_br_go,base.br
+city_5203203,Barro Alto,5203203,base.state_br_go,base.br
+city_5203302,Bela Vista de Goiás,5203302,base.state_br_go,base.br
+city_5203401,Bom Jardim de Goiás,5203401,base.state_br_go,base.br
+city_5203500,Bom Jesus de Goiás,5203500,base.state_br_go,base.br
+city_5203559,Bonfinópolis,5203559,base.state_br_go,base.br
+city_5203575,Bonópolis,5203575,base.state_br_go,base.br
+city_5203609,Brazabrantes,5203609,base.state_br_go,base.br
+city_5203807,Britânia,5203807,base.state_br_go,base.br
+city_5203906,Buriti Alegre,5203906,base.state_br_go,base.br
+city_5203939,Buriti de Goiás,5203939,base.state_br_go,base.br
+city_5203962,Buritinópolis,5203962,base.state_br_go,base.br
+city_5204003,Cabeceiras,5204003,base.state_br_go,base.br
+city_5204102,Cachoeira Alta,5204102,base.state_br_go,base.br
+city_5204201,Cachoeira de Goiás,5204201,base.state_br_go,base.br
+city_5204250,Cachoeira Dourada,5204250,base.state_br_go,base.br
+city_5204300,Caçu,5204300,base.state_br_go,base.br
+city_5204409,Caiapônia,5204409,base.state_br_go,base.br
+city_5204508,Caldas Novas,5204508,base.state_br_go,base.br
+city_5204557,Caldazinha,5204557,base.state_br_go,base.br
+city_5204607,Campestre de Goiás,5204607,base.state_br_go,base.br
+city_5204656,Campinaçu,5204656,base.state_br_go,base.br
+city_5204706,Campinorte,5204706,base.state_br_go,base.br
+city_5204805,Campo Alegre de Goiás,5204805,base.state_br_go,base.br
+city_5204854,Campo Limpo de Goiás,5204854,base.state_br_go,base.br
+city_5204904,Campos Belos,5204904,base.state_br_go,base.br
+city_5204953,Campos Verdes,5204953,base.state_br_go,base.br
+city_5205000,Carmo do Rio Verde,5205000,base.state_br_go,base.br
+city_5205059,Castelândia,5205059,base.state_br_go,base.br
+city_5205109,Catalão,5205109,base.state_br_go,base.br
+city_5205208,Caturaí,5205208,base.state_br_go,base.br
+city_5205307,Cavalcante,5205307,base.state_br_go,base.br
+city_5205406,Ceres,5205406,base.state_br_go,base.br
+city_5205455,Cezarina,5205455,base.state_br_go,base.br
+city_5205471,Chapadão do Céu,5205471,base.state_br_go,base.br
+city_5205497,Cidade Ocidental,5205497,base.state_br_go,base.br
+city_5205513,Cocalzinho de Goiás,5205513,base.state_br_go,base.br
+city_5205521,Colinas do Sul,5205521,base.state_br_go,base.br
+city_5205703,Córrego do Ouro,5205703,base.state_br_go,base.br
+city_5205802,Corumbá de Goiás,5205802,base.state_br_go,base.br
+city_5205901,Corumbaíba,5205901,base.state_br_go,base.br
+city_5206206,Cristalina,5206206,base.state_br_go,base.br
+city_5206305,Cristianópolis,5206305,base.state_br_go,base.br
+city_5206404,Crixás,5206404,base.state_br_go,base.br
+city_5206503,Cromínia,5206503,base.state_br_go,base.br
+city_5206602,Cumari,5206602,base.state_br_go,base.br
+city_5206701,Damianópolis,5206701,base.state_br_go,base.br
+city_5206800,Damolândia,5206800,base.state_br_go,base.br
+city_5206909,Davinópolis,5206909,base.state_br_go,base.br
+city_5207105,Diorama,5207105,base.state_br_go,base.br
+city_5208301,Divinópolis de Goiás,5208301,base.state_br_go,base.br
+city_5207253,Doverlândia,5207253,base.state_br_go,base.br
+city_5207352,Edealina,5207352,base.state_br_go,base.br
+city_5207402,Edéia,5207402,base.state_br_go,base.br
+city_5207501,Estrela do Norte,5207501,base.state_br_go,base.br
+city_5207535,Faina,5207535,base.state_br_go,base.br
+city_5207600,Fazenda Nova,5207600,base.state_br_go,base.br
+city_5207808,Firminópolis,5207808,base.state_br_go,base.br
+city_5207907,Flores de Goiás,5207907,base.state_br_go,base.br
+city_5208004,Formosa,5208004,base.state_br_go,base.br
+city_5208103,Formoso,5208103,base.state_br_go,base.br
+city_5208152,Gameleira de Goiás,5208152,base.state_br_go,base.br
+city_5208400,Goianápolis,5208400,base.state_br_go,base.br
+city_5208509,Goiandira,5208509,base.state_br_go,base.br
+city_5208608,Goianésia,5208608,base.state_br_go,base.br
+city_5208707,Goiânia,5208707,base.state_br_go,base.br
+city_5208806,Goianira,5208806,base.state_br_go,base.br
+city_5208905,Goiás,5208905,base.state_br_go,base.br
+city_5209101,Goiatuba,5209101,base.state_br_go,base.br
+city_5209150,Gouvelândia,5209150,base.state_br_go,base.br
+city_5209200,Guapó,5209200,base.state_br_go,base.br
+city_5209291,Guaraíta,5209291,base.state_br_go,base.br
+city_5209408,Guarani de Goiás,5209408,base.state_br_go,base.br
+city_5209457,Guarinos,5209457,base.state_br_go,base.br
+city_5209606,Heitoraí,5209606,base.state_br_go,base.br
+city_5209705,Hidrolândia,5209705,base.state_br_go,base.br
+city_5209804,Hidrolina,5209804,base.state_br_go,base.br
+city_5209903,Iaciara,5209903,base.state_br_go,base.br
+city_5209937,Inaciolândia,5209937,base.state_br_go,base.br
+city_5209952,Indiara,5209952,base.state_br_go,base.br
+city_5210000,Inhumas,5210000,base.state_br_go,base.br
+city_5210109,Ipameri,5210109,base.state_br_go,base.br
+city_5210158,Ipiranga de Goiás,5210158,base.state_br_go,base.br
+city_5210208,Iporá,5210208,base.state_br_go,base.br
+city_5210307,Israelândia,5210307,base.state_br_go,base.br
+city_5210406,Itaberaí,5210406,base.state_br_go,base.br
+city_5210562,Itaguari,5210562,base.state_br_go,base.br
+city_5210604,Itaguaru,5210604,base.state_br_go,base.br
+city_5210802,Itajá,5210802,base.state_br_go,base.br
+city_5210901,Itapaci,5210901,base.state_br_go,base.br
+city_5211008,Itapirapuã,5211008,base.state_br_go,base.br
+city_5211206,Itapuranga,5211206,base.state_br_go,base.br
+city_5211305,Itarumã,5211305,base.state_br_go,base.br
+city_5211404,Itauçu,5211404,base.state_br_go,base.br
+city_5211503,Itumbiara,5211503,base.state_br_go,base.br
+city_5211602,Ivolândia,5211602,base.state_br_go,base.br
+city_5211701,Jandaia,5211701,base.state_br_go,base.br
+city_5211800,Jaraguá,5211800,base.state_br_go,base.br
+city_5211909,Jataí,5211909,base.state_br_go,base.br
+city_5212006,Jaupaci,5212006,base.state_br_go,base.br
+city_5212055,Jesúpolis,5212055,base.state_br_go,base.br
+city_5212105,Joviânia,5212105,base.state_br_go,base.br
+city_5212204,Jussara,5212204,base.state_br_go,base.br
+city_5212253,Lagoa Santa,5212253,base.state_br_go,base.br
+city_5212303,Leopoldo de Bulhões,5212303,base.state_br_go,base.br
+city_5212501,Luziânia,5212501,base.state_br_go,base.br
+city_5212600,Mairipotaba,5212600,base.state_br_go,base.br
+city_5212709,Mambaí,5212709,base.state_br_go,base.br
+city_5212808,Mara Rosa,5212808,base.state_br_go,base.br
+city_5212907,Marzagão,5212907,base.state_br_go,base.br
+city_5212956,Matrinchã,5212956,base.state_br_go,base.br
+city_5213004,Maurilândia,5213004,base.state_br_go,base.br
+city_5213053,Mimoso de Goiás,5213053,base.state_br_go,base.br
+city_5213087,Minaçu,5213087,base.state_br_go,base.br
+city_5213103,Mineiros,5213103,base.state_br_go,base.br
+city_5213400,Moiporá,5213400,base.state_br_go,base.br
+city_5213509,Monte Alegre de Goiás,5213509,base.state_br_go,base.br
+city_5213707,Montes Claros de Goiás,5213707,base.state_br_go,base.br
+city_5213756,Montividiu,5213756,base.state_br_go,base.br
+city_5213772,Montividiu do Norte,5213772,base.state_br_go,base.br
+city_5213806,Morrinhos,5213806,base.state_br_go,base.br
+city_5213855,Morro Agudo de Goiás,5213855,base.state_br_go,base.br
+city_5213905,Mossâmedes,5213905,base.state_br_go,base.br
+city_5214002,Mozarlândia,5214002,base.state_br_go,base.br
+city_5214051,Mundo Novo,5214051,base.state_br_go,base.br
+city_5214101,Mutunópolis,5214101,base.state_br_go,base.br
+city_5214408,Nazário,5214408,base.state_br_go,base.br
+city_5214507,Nerópolis,5214507,base.state_br_go,base.br
+city_5214606,Niquelândia,5214606,base.state_br_go,base.br
+city_5214705,Nova América,5214705,base.state_br_go,base.br
+city_5214804,Nova Aurora,5214804,base.state_br_go,base.br
+city_5214838,Nova Crixás,5214838,base.state_br_go,base.br
+city_5214861,Nova Glória,5214861,base.state_br_go,base.br
+city_5214879,Nova Iguaçu de Goiás,5214879,base.state_br_go,base.br
+city_5214903,Nova Roma,5214903,base.state_br_go,base.br
+city_5215009,Nova Veneza,5215009,base.state_br_go,base.br
+city_5215207,Novo Brasil,5215207,base.state_br_go,base.br
+city_5215231,Novo Gama,5215231,base.state_br_go,base.br
+city_5215256,Novo Planalto,5215256,base.state_br_go,base.br
+city_5215306,Orizona,5215306,base.state_br_go,base.br
+city_5215405,Ouro Verde de Goiás,5215405,base.state_br_go,base.br
+city_5215504,Ouvidor,5215504,base.state_br_go,base.br
+city_5215603,Padre Bernardo,5215603,base.state_br_go,base.br
+city_5215652,Palestina de Goiás,5215652,base.state_br_go,base.br
+city_5215702,Palmeiras de Goiás,5215702,base.state_br_go,base.br
+city_5215801,Palmelo,5215801,base.state_br_go,base.br
+city_5215900,Palminópolis,5215900,base.state_br_go,base.br
+city_5216007,Panamá,5216007,base.state_br_go,base.br
+city_5216304,Paranaiguara,5216304,base.state_br_go,base.br
+city_5216403,Paraúna,5216403,base.state_br_go,base.br
+city_5216452,Perolândia,5216452,base.state_br_go,base.br
+city_5216809,Petrolina de Goiás,5216809,base.state_br_go,base.br
+city_5216908,Pilar de Goiás,5216908,base.state_br_go,base.br
+city_5217104,Piracanjuba,5217104,base.state_br_go,base.br
+city_5217203,Piranhas,5217203,base.state_br_go,base.br
+city_5217302,Pirenópolis,5217302,base.state_br_go,base.br
+city_5217401,Pires do Rio,5217401,base.state_br_go,base.br
+city_5217609,Planaltina,5217609,base.state_br_go,base.br
+city_5217708,Pontalina,5217708,base.state_br_go,base.br
+city_5218003,Porangatu,5218003,base.state_br_go,base.br
+city_5218052,Porteirão,5218052,base.state_br_go,base.br
+city_5218102,Portelândia,5218102,base.state_br_go,base.br
+city_5218300,Posse,5218300,base.state_br_go,base.br
+city_5218391,Professor Jamil,5218391,base.state_br_go,base.br
+city_5218508,Quirinópolis,5218508,base.state_br_go,base.br
+city_5218607,Rialma,5218607,base.state_br_go,base.br
+city_5218706,Rianápolis,5218706,base.state_br_go,base.br
+city_5218789,Rio Quente,5218789,base.state_br_go,base.br
+city_5218805,Rio Verde,5218805,base.state_br_go,base.br
+city_5218904,Rubiataba,5218904,base.state_br_go,base.br
+city_5219001,Sanclerlândia,5219001,base.state_br_go,base.br
+city_5219100,Santa Bárbara de Goiás,5219100,base.state_br_go,base.br
+city_5219209,Santa Cruz de Goiás,5219209,base.state_br_go,base.br
+city_5219258,Santa Fé de Goiás,5219258,base.state_br_go,base.br
+city_5219308,Santa Helena de Goiás,5219308,base.state_br_go,base.br
+city_5219357,Santa Isabel,5219357,base.state_br_go,base.br
+city_5219407,Santa Rita do Araguaia,5219407,base.state_br_go,base.br
+city_5219456,Santa Rita do Novo Destino,5219456,base.state_br_go,base.br
+city_5219506,Santa Rosa de Goiás,5219506,base.state_br_go,base.br
+city_5219605,Santa Tereza de Goiás,5219605,base.state_br_go,base.br
+city_5219704,Santa Terezinha de Goiás,5219704,base.state_br_go,base.br
+city_5219712,Santo Antônio da Barra,5219712,base.state_br_go,base.br
+city_5219738,Santo Antônio de Goiás,5219738,base.state_br_go,base.br
+city_5219753,Santo Antônio do Descoberto,5219753,base.state_br_go,base.br
+city_5219803,São Domingos,5219803,base.state_br_go,base.br
+city_5219902,São Francisco de Goiás,5219902,base.state_br_go,base.br
+city_5220058,São João da Paraúna,5220058,base.state_br_go,base.br
+city_5220009,São João d'Aliança,5220009,base.state_br_go,base.br
+city_5220108,São Luís de Montes Belos,5220108,base.state_br_go,base.br
+city_5220157,São Luiz do Norte,5220157,base.state_br_go,base.br
+city_5220207,São Miguel do Araguaia,5220207,base.state_br_go,base.br
+city_5220264,São Miguel do Passa Quatro,5220264,base.state_br_go,base.br
+city_5220280,São Patrício,5220280,base.state_br_go,base.br
+city_5220405,São Simão,5220405,base.state_br_go,base.br
+city_5220454,Senador Canedo,5220454,base.state_br_go,base.br
+city_5220504,Serranópolis,5220504,base.state_br_go,base.br
+city_5220603,Silvânia,5220603,base.state_br_go,base.br
+city_5220686,Simolândia,5220686,base.state_br_go,base.br
+city_5220702,Sítio d'Abadia,5220702,base.state_br_go,base.br
+city_5221007,Taquaral de Goiás,5221007,base.state_br_go,base.br
+city_5221080,Teresina de Goiás,5221080,base.state_br_go,base.br
+city_5221197,Terezópolis de Goiás,5221197,base.state_br_go,base.br
+city_5221304,Três Ranchos,5221304,base.state_br_go,base.br
+city_5221403,Trindade,5221403,base.state_br_go,base.br
+city_5221452,Trombas,5221452,base.state_br_go,base.br
+city_5221502,Turvânia,5221502,base.state_br_go,base.br
+city_5221551,Turvelândia,5221551,base.state_br_go,base.br
+city_5221577,Uirapuru,5221577,base.state_br_go,base.br
+city_5221601,Uruaçu,5221601,base.state_br_go,base.br
+city_5221700,Uruana,5221700,base.state_br_go,base.br
+city_5221809,Urutaí,5221809,base.state_br_go,base.br
+city_5221858,Valparaíso de Goiás,5221858,base.state_br_go,base.br
+city_5221908,Varjão,5221908,base.state_br_go,base.br
+city_5222005,Vianópolis,5222005,base.state_br_go,base.br
+city_5222054,Vicentinópolis,5222054,base.state_br_go,base.br
+city_5222203,Vila Boa,5222203,base.state_br_go,base.br
+city_5222302,Vila Propício,5222302,base.state_br_go,base.br
+city_5300108,Brasília,5300108,base.state_br_df,base.br

--- a/l10n_br_base/security/ir.model.access.csv
+++ b/l10n_br_base/security/ir.model.access.csv
@@ -1,5 +1,5 @@
-"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
-"state_tax_numbers_user","State Tax Numbers for User","model_state_tax_numbers","base.group_user",1,0,0,0
-"state_tax_numbers_manager","State Tax Numbers for Manager","model_state_tax_numbers","base.group_system",1,1,1,1
-"res_partner_pix_user","Partner PIX for User","model_res_partner_pix","base.group_user",1,0,0,0
-"res_partner_pix_manager","Partner PIX for Partner Manager","model_res_partner_pix","base.group_partner_manager",1,1,1,1
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+state_tax_numbers_user,State Tax Numbers for User,model_state_tax_numbers,base.group_user,1,0,0,0
+state_tax_numbers_manager,State Tax Numbers for Manager,model_state_tax_numbers,base.group_system,1,1,1,1
+res_partner_pix_user,Partner PIX for User,model_res_partner_pix,base.group_user,1,0,0,0
+res_partner_pix_manager,Partner PIX for Partner Manager,model_res_partner_pix,base.group_partner_manager,1,1,1,1


### PR DESCRIPTION
Unnecessary Quotes in CSV file.

Removendo aspas "", quando possível, dos arquivos CSV, com o objetivo de padronizar e remover o que é desnecessário.

Esse PR é até simples, os arquivos CSV podem ou não ter os valores entre aspas, o arquivo sem as aspas fica mais "limpo", dependendo do Editor ou IDE usado isso nem aparece mas em Editores onde é mostrado o arquivo "puro", por exemplo:

**Hoje**
```bash
"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
"state_tax_numbers_user","State Tax Numbers for User","model_state_tax_numbers","base.group_user",1,0,0,0
"state_tax_numbers_manager","State Tax Numbers for Manager","model_state_tax_numbers","base.group_system",1,1,1,1
"res_partner_pix_user","Partner PIX for User","model_res_partner_pix","base.group_user",1,0,0,0
"res_partner_pix_manager","Partner PIX for Partner Manager","model_res_partner_pix","base.group_partner_manager",1,1,1,1
```

```bash
"id","name","ibge_code","state_id:id","country_id:id"
"city_1100015","Alta Floresta D'Oeste","1100015","base.state_br_ro","base.br"
"city_1100379","Alto Alegre dos Parecis","1100379","base.state_br_ro","base.br"
"city_1100403","Alto Paraíso","1100403","base.state_br_ro","base.br"
"city_1100346","Alvorada D'Oeste","1100346","base.state_br_ro","base.br"
"city_1100023","Ariquemes","1100023","base.state_br_ro","base.br"
"city_1100452","Buritis","1100452","base.state_br_ro","base.br"
```

**Com esse PR**
```bash
id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
state_tax_numbers_user,State Tax Numbers for User,model_state_tax_numbers,base.group_user,1,0,0,0
state_tax_numbers_manager,State Tax Numbers for Manager,model_state_tax_numbers,base.group_system,1,1,1,1
res_partner_pix_user,Partner PIX for User,model_res_partner_pix,base.group_user,1,0,0,0
res_partner_pix_manager,Partner PIX for Partner Manager,model_res_partner_pix,base.group_partner_manager,1,1,1,1
```
```bash
id,name,ibge_code,state_id:id,country_id:id
city_1100015,Alta Floresta D'Oeste,1100015,base.state_br_ro,base.br
city_1100379,Alto Alegre dos Parecis,1100379,base.state_br_ro,base.br
city_1100403,Alto Paraíso,1100403,base.state_br_ro,base.br
city_1100346,Alvorada D'Oeste,1100346,base.state_br_ro,base.br
city_1100023,Ariquemes,1100023,base.state_br_ro,base.br
city_1100452,Buritis,1100452,base.state_br_ro,base.br
```

Não é possível remover as aspas nos casos onde dentro do valores informados tem vírgula "," nesse caso do **l10n_br_base** o arquivo https://github.com/OCA/l10n-brazil/blob/18.0/l10n_br_base/data/res.bank.csv

<img width="942" height="460" alt="image" src="https://github.com/user-attachments/assets/f4bb70c2-b385-4c49-b2b0-9c1e8060cbae" />

Seguem telas para mostrar que a alteração não deve afetar o que já existe hoje:

<img width="1324" height="229" alt="image" src="https://github.com/user-attachments/assets/97df36bc-9feb-42e5-99fb-56162d3a7384" />


<img width="1317" height="344" alt="image" src="https://github.com/user-attachments/assets/86a90fc4-b10d-4e44-9608-dcf547dc6226" />



cc @OCA/local-brazil-maintainers 