### PR TITLE
[18.0][REF] l10n_br_base: Usando o método do tools para validar Chaves PIX tipo CNPJ

### DIFF
--- a/l10n_br_base/models/res_partner_pix.py
+++ b/l10n_br_base/models/res_partner_pix.py
@@ -4,10 +4,11 @@
 
 import phonenumbers
 from email_validator import EmailSyntaxError, validate_email
-from erpbrasil.base.fiscal import cnpj_cpf
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+
+from ..tools import check_cnpj_cpf
 
 
 class PartnerPix(models.Model):
@@ -91,18 +92,8 @@ class PartnerPix(models.Model):
         return phone
 
     def _normalize_cnpj_cpf(self, doc_number):
-        doc_number = "".join(char for char in doc_number if char.isdigit())
-        if not 11 <= len(doc_number) <= 14:
-            raise ValidationError(
-                _(
-                    f"Invalid Document Number {doc_number}: "
-                    f"\nThe CPF must have 11 digits and the CNPJ 14 digits."
-                )
-            )
-        is_valid = cnpj_cpf.validar(doc_number)
-        if not is_valid:
-            raise ValidationError(_(f"Invalid Document Number: {doc_number}"))
-        return doc_number
+        check_cnpj_cpf(self.env, doc_number, self.env.ref("base.br"), True)
+        return "".join(char for char in doc_number if char.isdigit())
 
     def _normalize_evp(self, key):
         # EVP: Endereço Virtual de Pagamento (chave aleatória)

--- a/l10n_br_base/tests/test_valid_pix.py
+++ b/l10n_br_base/tests/test_valid_pix.py
@@ -35,6 +35,12 @@ class ValidCreatePIXTest(TransactionCase):
         self.check_validation_error_on_create(pix_vals)
 
     def test_invalid_pix_cnpj_wrong_value(self):
+        # Desabilitando a Validação do CPF_CNPJ porque mesmo
+        # nesse caso a validação da Chave PIX deve ser feita.
+        self.env["ir.config_parameter"].set_param(
+            "l10n_br_base.disable_cpf_cnpj_validation", True
+        )
+
         pix_vals = {
             "partner_id": self.partner_id.id,
             "key_type": "cnpj_cpf",

--- a/l10n_br_base/tools.py
+++ b/l10n_br_base/tools.py
@@ -47,7 +47,7 @@ def check_ie(env, l10n_br_ie_code, state, country):
             )
 
 
-def check_cnpj_cpf(env, cnpj_cpf_value, country):
+def check_cnpj_cpf(env, cnpj_cpf_value, country, force_validation=False):
     """
     Check CNPJ or CPF is valid using erpbrasil library
     :param env:
@@ -61,24 +61,34 @@ def check_cnpj_cpf(env, cnpj_cpf_value, country):
                 "l10n_br_base.disable_cpf_cnpj_validation", default=False
             ) or env.context.get("disable_cpf_cnpj_validation")
 
-            if not disable_cpf_cnpj_validation:
-                if not cnpj_cpf.validar(cnpj_cpf_value):
-                    # Removendo . / - para diferenciar o CNPJ do CPF
-                    # 62.228.384/0001-51 -CNPJ
-                    # 62228384000151 - CNPJ
-                    # 765.865.078-12 - CPF
-                    # 76586507812 - CPF
-                    document = "CPF"
-                    if (
-                        len("".join(char for char in cnpj_cpf_value if char.isdigit()))
-                        == 14
-                    ):
-                        document = "CNPJ"
-
-                    raise ValidationError(
-                        env._(
-                            "%(d_type)s %(d_id)s is invalid!",
-                            d_type=document,
-                            d_id=cnpj_cpf_value,
-                        )
+            if not disable_cpf_cnpj_validation or force_validation:
+                # Removendo . / - para diferenciar o CNPJ do CPF
+                # 62.228.384/0001-51 -CNPJ
+                # 62228384000151 - CNPJ
+                # 765.865.078-12 - CPF
+                # 76586507812 - CPF
+                clean_cnpj_cpf_value = "".join(
+                    char for char in cnpj_cpf_value if char.isdigit()
+                )
+                error_msg = False
+                if len(clean_cnpj_cpf_value) not in (11, 14):
+                    error_msg = env._(
+                        "The size of CPF must have 11 and the CNPJ 14 digits "
+                        "without dot, dash and slash; in this case:\n\n"
+                        "CPF or CNPJ: %(d_clean_id)s\n"
+                        "Size: %(d_size_id)s",
+                        d_clean_id=clean_cnpj_cpf_value,
+                        d_size_id=len(clean_cnpj_cpf_value),
                     )
+                elif not cnpj_cpf.validar(cnpj_cpf_value):
+                    document = "CPF"
+                    if len(clean_cnpj_cpf_value) == 14:
+                        document = "CNPJ"
+                    error_msg = env._(
+                        "%(d_type)s %(d_id)s is invalid!",
+                        d_type=document,
+                        d_id=cnpj_cpf_value,
+                    )
+
+                if error_msg:
+                    raise ValidationError(error_msg)


### PR DESCRIPTION
Common method check CNPJ PIX Key.

Usando o método do tools para validar Chaves PIX tipo CNPJ.

Existe um método no arquivo tools https://github.com/OCA/l10n-brazil/blob/18.0/l10n_br_base/tools.py#L50 que busca unificar, padronizar e reduzir código em duplicidade para a Validação de CNPJ, no caso da Chave PIX do Tipo CNPJ não estava sendo usado, talvez o motivo era que existem os Casos de Uso onde a Validação pode ser Desabilitada mas que no caso da Chave PIX isso não se aplica, então para ter certeza que a validação será feita mesmo nesses casos foi incluído no teste esse caso e assim ter certeza que a validação será feita.

Como essa alteração deixaria o método **_normalize_cnpj_cpf**  com apenas com 3 linhas

```bash
def _normalize_cnpj_cpf(self, doc_number):
    check_cnpj_cpf(self.env, doc_number, self.env.ref("base.br"), True)
    return "".join(char for char in doc_number if char.isdigit())
```

Achei melhor remover esse método e fazer a validação e formatação direto no método **_normalize_evp** o que é feito com 2 linhas, mas se acreditarem se melhor vejo de voltar o método **_normalize_cnpj_cpf** e fazer a validação dentro dele.

cc @OCA/local-brazil-maintainers 
