### PR TITLE
[16.0][FIX] l10n_br_stock_account: fix adapt type error for company

### DIFF
--- a/l10n_br_stock_account/models/stock_rule.py
+++ b/l10n_br_stock_account/models/stock_rule.py
@@ -66,9 +66,11 @@ class StockRule(models.Model):
         easily add fields from procurement 'values' argument to move data.
         """
         custom_move_fields = super()._get_custom_move_fields()
+        # Keep only simple (non-relational) fields to avoid "can't adapt type" errors
+        # during move creation.
         custom_move_fields += [
             key
-            for key in self.env["l10n_br_fiscal.document.line.mixin"]._fields.keys()
-            if key != "product_id"
+            for key in self.env["l10n_br_fiscal.document.line.mixin"]._fields
+            if key not in {"product_id", "company_id"}
         ]
         return custom_move_fields


### PR DESCRIPTION
Ajuste para evitar o erro **“can’t adapt type”**: o método nativo não aceita campos relacionais (m2o/o2m/m2m) nesses valores; se algum for passado, estoura o erro.
Isso não ocorria antes porque `company_id` vinha vazio (False) por uma falha na sincronização dos shadow fields