### PR TITLE
[16.0][REF] l10n_br_fiscal: rename _sql_constraints

### DIFF
--- a/l10n_br_fiscal/models/tax_pis_cofins_base.py
+++ b/l10n_br_fiscal/models/tax_pis_cofins_base.py
@@ -13,7 +13,7 @@ class TaxPisCofinsBase(models.Model):
 
     _sql_constraints = [
         (
-            "l10n_br_fiscal_tax_pis_cofins_base_uniq",
+            "code_unique",
             "unique (code)",
             _("Already exists with this code !"),
         )

--- a/l10n_br_fiscal/models/tax_pis_cofins_credit.py
+++ b/l10n_br_fiscal/models/tax_pis_cofins_credit.py
@@ -13,7 +13,7 @@ class TaxPisCofinsCredit(models.Model):
 
     _sql_constraints = [
         (
-            "l10n_br_fiscal_tax_pis_cofins_code_uniq",
+            "code_unique",
             "unique (code)",
             _("Already exists with this code !"),
         )


### PR DESCRIPTION
Não é necessário colocar prefixo com o nome do módulo e do modelo no nome da _constraint_, pois isso já é aplicado automaticamente.

Resolve os _warnings_:

> Constraint name 'l10n_br_fiscal_tax_pis_cofins_base_l10n_br_fiscal_tax_pis_cofins_base_uniq' has more than 63 characters
Constraint name 'l10n_br_fiscal_tax_pis_cofins_credit_l10n_br_fiscal_tax_pis_cofins_code_uniq' has more than 63 characters