### PR TITLE
[16.0][REF] l10n_br_fiscal: remove function to default operation unused

### DIFF
--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -79,10 +79,6 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     _description = "Document Fiscal Mixin"
 
     @api.model
-    def _default_operation(self):
-        return False
-
-    @api.model
     def _default_icmssn_range_id(self):
         company = self.env.company
         stax_range_id = self.env["l10n_br_fiscal.simplified.tax.range"]
@@ -173,7 +169,6 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         comodel_name="l10n_br_fiscal.operation",
         string="Operation",
         domain=lambda self: self._operation_domain(),
-        default=_default_operation,
     )
 
     fiscal_operation_type = fields.Selection(

--- a/l10n_br_fiscal/models/document_mixin.py
+++ b/l10n_br_fiscal/models/document_mixin.py
@@ -49,10 +49,6 @@ class FiscalDocumentMixin(models.AbstractModel):
         return fields.Datetime.now().strftime(DEFAULT_SERVER_DATETIME_FORMAT)
 
     @api.model
-    def _default_operation(self):
-        return False
-
-    @api.model
     def _operation_domain(self):
         domain = (
             "[('state', '=', 'approved'),"
@@ -66,7 +62,6 @@ class FiscalDocumentMixin(models.AbstractModel):
         comodel_name="l10n_br_fiscal.operation",
         string="Operation",
         domain=lambda self: self._operation_domain(),
-        default=_default_operation,
     )
 
     operation_name = fields.Char(


### PR DESCRIPTION
remove pequeno trecho de código morto, essa parte do código não está sendo utilizado, pelo que percebi é algo que veio de antes da migração para a v12