### PR TITLE
[16.0][REF] l10n_br_account_withholding: invalidate_cache warning

### DIFF
--- a/l10n_br_account_withholding/models/account_move.py
+++ b/l10n_br_account_withholding/models/account_move.py
@@ -182,7 +182,6 @@ class AccountMove(models.Model):
             wh_invoices.filtered(lambda i: i.state == "posted").button_draft()
             wh_invoices.filtered(lambda i: i.state == "draft").button_cancel()
             wh_invoices.line_ids.wh_move_line_id = False
-            wh_invoices.invalidate_cache()
 
     def button_draft(self):
         res = super().button_draft()


### PR DESCRIPTION
Resolve o warning:

> DeprecationWarning: Deprecated method invalidate_cache(), use invalidate_model(), invalidate_recordset() or env.invalidate_all() instead

Optei por remover a chamada de vez, pois não me parece necessário o uso. Não está sendo feita nenhuma alteração fora da ORM que justificasse manter esse método.

Mas @marcelsavegnago, se alguém da sua equipe puder testar melhor, agradeço!