### PR TITLE
[16.0][REF] l10n_br_account: clean account move constants

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -21,33 +21,9 @@ from odoo.addons.l10n_br_fiscal.constants.fiscal import (
     SITUACAO_EDOC_EM_DIGITACAO,
 )
 
-MOVE_TO_OPERATION = {
-    "out_invoice": "out",
-    "in_invoice": "in",
-    "out_refund": "in",
-    "in_refund": "out",
-    "out_receipt": "out",
-    "in_receipt": "in",
-}
-
-REFUND_TO_OPERATION = {
-    "out_invoice": "in",
-    "in_invoice": "out",
-    "out_refund": "out",
-    "in_refund": "in",
-}
-
-FISCAL_TYPE_REFUND = {
-    "out": ["purchase_refund", "in_return"],
-    "in": ["sale_refund", "out_return"],
-}
-
-MOVE_TAX_USER_TYPE = {
-    "out_invoice": "sale",
-    "in_invoice": "purchase",
-    "out_refund": "sale",
-    "in_refund": "purchase",
-}
+from .constants import (
+    MOVE_TO_OPERATION,
+)
 
 
 class AccountMove(models.Model):

--- a/l10n_br_account/models/constants.py
+++ b/l10n_br_account/models/constants.py
@@ -1,0 +1,8 @@
+MOVE_TO_OPERATION = {
+    "out_invoice": "out",
+    "in_invoice": "in",
+    "out_refund": "in",
+    "in_refund": "out",
+    "out_receipt": "out",
+    "in_receipt": "in",
+}


### PR DESCRIPTION
Remova as constantes não utilizadas do módulo `l10n_br_account` e mova as restantes para um arquivo próprio.