### PR TITLE
[16.0][REF] l10n_br_fiscal: rename city_taxation_code

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -10,7 +10,7 @@
     "maintainers": ["renatonlima", "rvalyi"],
     "website": "https://github.com/OCA/l10n-brazil",
     "development_status": "Production/Stable",
-    "version": "16.0.12.5.0",
+    "version": "16.0.13.0.0",
     "depends": [
         "product",
         "uom_alias",

--- a/l10n_br_fiscal/migrations/16.0.13.0.0/pre-migration.py
+++ b/l10n_br_fiscal/migrations/16.0.13.0.0/pre-migration.py
@@ -1,0 +1,25 @@
+# Copyright (C) 2025 - Engenere (<https://engenere.one>).
+# @author Antônio S. Pereira Neto <neto@engenere.one>
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """Rename product.template M2M field to the new pluralized name.
+
+    The underlying Many2many relation table remains the same because
+    Odoo derives it from model table names, not the field name. This
+    rename keeps references (e.g., stored views/filters) consistent.
+    """
+    openupgrade.rename_fields(
+        env,
+        [
+            (
+                "product.template",
+                "product.template",
+                "city_taxation_code_id",
+                "city_taxation_code_ids",
+            ),
+        ],
+    )

--- a/l10n_br_fiscal/models/document_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_line_mixin_methods.py
@@ -497,9 +497,9 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             self.fiscal_genre_id = self.product_id.fiscal_genre_id
             self.service_type_id = self.product_id.service_type_id
             self.uot_id = self.product_id.uot_id or self.product_id.uom_id
-            if self.product_id.city_taxation_code_id:
+            if self.product_id.city_taxation_code_ids:
                 company_city_id = self.company_id.city_id
-                city_id = self.product_id.city_taxation_code_id.filtered(
+                city_id = self.product_id.city_taxation_code_ids.filtered(
                     lambda r: r.city_id == company_city_id
                 )
                 if city_id:

--- a/l10n_br_fiscal/models/product_template.py
+++ b/l10n_br_fiscal/models/product_template.py
@@ -83,7 +83,7 @@ class ProductTemplate(models.Model):
         domain="[('internal_type', '=', 'normal')]",
     )
 
-    city_taxation_code_id = fields.Many2many(
+    city_taxation_code_ids = fields.Many2many(
         comodel_name="l10n_br_fiscal.city.taxation.code", string="City Taxation Code"
     )
 

--- a/l10n_br_fiscal/views/product_product_view.xml
+++ b/l10n_br_fiscal/views/product_product_view.xml
@@ -70,7 +70,7 @@
                                 attrs="{'invisible': [('fiscal_type', '!=', '09')]}"
                             />
                             <field
-                                name="city_taxation_code_id"
+                                name="city_taxation_code_ids"
                                 attrs="{'invisible': [('fiscal_type', '!=', '09')]}"
                                 context="{'default_service_type_id': service_type_id}"
                             >

--- a/l10n_br_fiscal/views/product_template_view.xml
+++ b/l10n_br_fiscal/views/product_template_view.xml
@@ -75,7 +75,7 @@
                                 attrs="{'invisible': [('fiscal_type', '!=', '09')]}"
                             />
                             <field
-                                name="city_taxation_code_id"
+                                name="city_taxation_code_ids"
                                 attrs="{'invisible': [('fiscal_type', '!=', '09')]}"
                                 context="{'default_service_type_id': service_type_id}"
                             >

--- a/l10n_br_nfse/__manifest__.py
+++ b/l10n_br_nfse/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "NFS-e",
     "summary": "Root electronic invoice for service / NFS-e module",
-    "version": "16.0.4.4.0",
+    "version": "16.0.4.4.1",
     "license": "AGPL-3",
     "author": "KMEE, Odoo Community Association (OCA)",
     "maintainers": ["mileo", "luismalta", "marcelsavegnago"],

--- a/l10n_br_nfse/demo/product_demo.xml
+++ b/l10n_br_nfse/demo/product_demo.xml
@@ -5,7 +5,6 @@
 
     <record id="l10n_br_fiscal.customized_development_sale" model="product.product">
         <field name="fiscal_deductions_value">0.0</field>
-<!--        <field name="city_taxation_code_id" ref="l10n_br_fiscal.city_taxation_code_itajuba"/>-->
     </record>
 
 </odoo>

--- a/l10n_br_nfse/models/res_company.py
+++ b/l10n_br_nfse/models/res_company.py
@@ -32,9 +32,6 @@ class ResCompany(models.Model):
         string="NFSe SSL Verify",
         default=False,
     )
-    city_taxation_code_id = fields.Many2many(
-        comodel_name="l10n_br_fiscal.city.taxation.code", string="City Taxation Code"
-    )
 
     def prepare_company_servico(self):
         return {

--- a/l10n_br_nfse/tests/test_fiscal_document_nfse_common.py
+++ b/l10n_br_nfse/tests/test_fiscal_document_nfse_common.py
@@ -28,9 +28,6 @@ class TestFiscalDocumentNFSeCommon(TransactionCase):
         cls.company.icms_regulation_id = cls.env.ref(
             "l10n_br_fiscal.tax_icms_regulation"
         ).id
-        cls.company.city_taxation_code_id = cls.env.ref(
-            "l10n_br_fiscal.city_taxation_code_itajuba"
-        )
         cls.company.document_type_id = cls.env.ref("l10n_br_fiscal.document_SE")
         cls.nfse_same_state.company_id = cls.company.id
 


### PR DESCRIPTION
Renomeia o campo do produto `city_taxation_code_id` para `city_taxation_code_ids` no plural, já que o campo é many2many.