### PR TITLE
[16.0][REF] Renomeia campos fiscais que conflitam 

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -259,13 +259,14 @@ class AccountMove(models.Model):
                 lambda line: line.display_type == "product"
                 and (not line.cfop_id or line.cfop_id.finance_move)
             )
-            move.amount_untaxed = sum(inv_line_ids.mapped("amount_untaxed"))
-            move.amount_tax = sum(inv_line_ids.mapped("amount_tax"))
+            move.amount_untaxed = sum(inv_line_ids.mapped("fiscal_amount_untaxed"))
+            move.amount_tax = sum(inv_line_ids.mapped("fiscal_amount_tax"))
             move.amount_untaxed_signed = sign * sum(
-                inv_line_ids.mapped("amount_untaxed")
+                inv_line_ids.mapped("fiscal_amount_untaxed")
             )
-            move.amount_tax_signed = sign * sum(inv_line_ids.mapped("amount_tax"))
-
+            move.amount_tax_signed = sign * sum(
+                inv_line_ids.mapped("fiscal_amount_tax")
+            )
         return result
 
     def _compute_imported_terms(self):

--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -232,11 +232,11 @@ class AccountMoveLine(models.Model):
                     else:
                         if line.move_id.fiscal_operation_id.deductible_taxes:
                             unsigned_amount_currency = (
-                                line.amount_total + line.amount_tax_withholding
+                                line.fiscal_amount_total + line.amount_tax_withholding
                             )
                         else:
                             amount_total = (
-                                line.amount_total + line.amount_tax_withholding
+                                line.fiscal_amount_total + line.amount_tax_withholding
                             )
                             unsigned_amount_currency = line.currency_id.round(
                                 amount_total

--- a/l10n_br_account/views/account_move_view.xml
+++ b/l10n_br_account/views/account_move_view.xml
@@ -397,13 +397,13 @@
                     <page name="amounts" string="Amounts">
                         <group>
                             <group>
-                                <field name="amount_untaxed" />
+                                <field name="fiscal_amount_untaxed" />
                                 <field name="amount_fiscal" />
-                                <field name="amount_tax" />
+                                <field name="fiscal_amount_tax" />
                                 <field name="estimate_tax" />
                             </group>
                             <group>
-                                <field name="amount_total" />
+                                <field name="fiscal_amount_total" />
                                 <field name="amount_tax_withholding" />
                                 <field name="amount_taxed" />
                             </group>

--- a/l10n_br_account/views/fiscal_invoice_view.xml
+++ b/l10n_br_account/views/fiscal_invoice_view.xml
@@ -98,7 +98,7 @@
                         <field name="price_unit" />
                         <field name="quantity" />
                         <field name="fiscal_tax_ids" widget="many2many_tags" />
-                        <field name="amount_total" sum="Total" />
+                        <field name="fiscal_amount_total" sum="Total" />
                     </tree>
                 </field>
             </xpath>

--- a/l10n_br_contract/__manifest__.py
+++ b/l10n_br_contract/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Brazilian Localization Contract",
     "summary": """
         Customization of Contract module for implementations in Brazil.""",
-    "version": "16.0.4.1.0",
+    "version": "16.0.5.0.0",
     "license": "AGPL-3",
     "author": "KMEE,Odoo Community Association (OCA)",
     "maintainers": ["mileo", "marcelsavegnago"],

--- a/l10n_br_contract/migrations/16.0.5.0.0/pre-migration.py
+++ b/l10n_br_contract/migrations/16.0.5.0.0/pre-migration.py
@@ -1,0 +1,29 @@
+# Copyright (C) 2025 - Engenere (<https://engenere.one>).
+# @author Antônio S. Pereira Neto <neto@engenere.one>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    field_spec = [
+        (
+            "contract.contract",
+            "contract_contract",
+            "amount_untaxed",
+            "fiscal_amount_untaxed",
+        ),
+        (
+            "contract.contract",
+            "contract_contract",
+            "amount_tax",
+            "fiscal_amount_tax",
+        ),
+        (
+            "contract.contract",
+            "contract_contract",
+            "amount_total",
+            "fiscal_amount_total",
+        ),
+    ]
+    openupgrade.rename_fields(env, field_spec)

--- a/l10n_br_contract/views/contract_line.xml
+++ b/l10n_br_contract/views/contract_line.xml
@@ -70,13 +70,13 @@
                     >
                         <group>
                             <group>
-                                <field name="amount_untaxed" />
+                                <field name="fiscal_amount_untaxed" />
                                 <field name="amount_fiscal" />
-                                <field name="amount_tax" />
+                                <field name="fiscal_amount_tax" />
                                 <field name="estimate_tax" readonly="1" />
                             </group>
                             <group>
-                                <field name="amount_total" />
+                                <field name="fiscal_amount_total" />
                                 <field name="amount_tax_withholding" readonly="1" />
                                 <field name="amount_taxed" />
                             </group>

--- a/l10n_br_cte/models/document.py
+++ b/l10n_br_cte/models/document.py
@@ -587,7 +587,7 @@ class CTe(spec_models.StackedModel):
     # CT-e tag: vPrest
     ##########################
 
-    cte40_vTPrest = fields.Monetary(related="amount_total")
+    cte40_vTPrest = fields.Monetary(related="fiscal_amount_total")
 
     cte40_vRec = fields.Monetary(related="amount_price_gross")
 

--- a/l10n_br_cte/models/document_line.py
+++ b/l10n_br_cte/models/document_line.py
@@ -23,7 +23,7 @@ class CTeLine(spec_models.StackedModel):
 
     cte40_xNome = fields.Char(related="name")
 
-    cte40_vComp = fields.Monetary(related="amount_total")
+    cte40_vComp = fields.Monetary(related="fiscal_amount_total")
 
     # FIXME ORM/spec_model_driven workaround
     # see https://github.com/OCA/l10n-brazil/pull/3651#issuecomment-2729890350

--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -10,7 +10,7 @@
     "maintainers": ["renatonlima", "rvalyi"],
     "website": "https://github.com/OCA/l10n-brazil",
     "development_status": "Production/Stable",
-    "version": "16.0.13.1.0",
+    "version": "16.0.14.0.0",
     "depends": [
         "product",
         "uom_alias",

--- a/l10n_br_fiscal/migrations/16.0.14.0.0/pre-migration.py
+++ b/l10n_br_fiscal/migrations/16.0.14.0.0/pre-migration.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2025 - Engenere (<https://engenere.one>).
+# @author Antônio S. Pereira Neto <neto@engenere.one>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    field_spec = [
+        (
+            "l10n_br_fiscal.document",
+            "l10n_br_fiscal_document",
+            "amount_untaxed",
+            "fiscal_amount_untaxed",
+        ),
+        (
+            "l10n_br_fiscal.document",
+            "l10n_br_fiscal_document",
+            "amount_tax",
+            "fiscal_amount_tax",
+        ),
+        (
+            "l10n_br_fiscal.document",
+            "l10n_br_fiscal_document",
+            "amount_total",
+            "fiscal_amount_total",
+        ),
+    ]
+    openupgrade.rename_fields(env, field_spec)

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -258,11 +258,11 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         compute="_compute_fiscal_amounts",
     )
 
-    amount_untaxed = fields.Monetary(
+    fiscal_amount_untaxed = fields.Monetary(
         compute="_compute_fiscal_amounts",
     )
 
-    amount_tax = fields.Monetary(
+    fiscal_amount_tax = fields.Monetary(
         compute="_compute_fiscal_amounts",
     )
 
@@ -270,7 +270,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         compute="_compute_fiscal_amounts",
     )
 
-    amount_total = fields.Monetary(
+    fiscal_amount_total = fields.Monetary(
         compute="_compute_fiscal_amounts",
     )
 

--- a/l10n_br_fiscal/models/document_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_line_mixin_methods.py
@@ -171,11 +171,11 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             # Total value of products or services
             record.price_gross = round_curr.round(record.price_unit * record.quantity)
             record.amount_fiscal = record.price_gross - record.discount_value
-            record.amount_tax = record.amount_tax_not_included
+            record.fiscal_amount_tax = record.amount_tax_not_included
 
             add_to_amount = sum(record[a] for a in record._add_fields_to_amount())
             rm_to_amount = sum(record[r] for r in record._rm_fields_to_amount())
-            record.amount_untaxed = (
+            record.fiscal_amount_untaxed = (
                 record.price_gross
                 - record.discount_value
                 + add_to_amount
@@ -183,13 +183,17 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             )
 
             # Valor do documento (NF)
-            record.amount_total = record.amount_untaxed + record.amount_tax
+            record.fiscal_amount_total = (
+                record.fiscal_amount_untaxed + record.fiscal_amount_tax
+            )
 
             # Valor Liquido (TOTAL + IMPOSTOS - RETENÇÕES)
-            record.amount_taxed = record.amount_total - record.amount_tax_withholding
+            record.amount_taxed = (
+                record.fiscal_amount_total - record.amount_tax_withholding
+            )
 
             # Valor do documento (NF) - RETENÇÕES
-            record.amount_total = record.amount_taxed
+            record.fiscal_amount_total = record.amount_taxed
 
             # Valor financeiro
             if (

--- a/l10n_br_fiscal/models/document_mixin.py
+++ b/l10n_br_fiscal/models/document_mixin.py
@@ -126,7 +126,7 @@ class FiscalDocumentMixin(models.AbstractModel):
         help="Amount without discount.",
     )
 
-    amount_untaxed = fields.Monetary(
+    fiscal_amount_untaxed = fields.Monetary(
         compute="_compute_fiscal_amount",
         store=True,
     )
@@ -394,12 +394,12 @@ class FiscalDocumentMixin(models.AbstractModel):
         store=True,
     )
 
-    amount_tax = fields.Monetary(
+    fiscal_amount_tax = fields.Monetary(
         compute="_compute_fiscal_amount",
         store=True,
     )
 
-    amount_total = fields.Monetary(
+    fiscal_amount_total = fields.Monetary(
         compute="_compute_fiscal_amount",
         store=True,
     )

--- a/l10n_br_fiscal/models/document_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_mixin_methods.py
@@ -73,7 +73,8 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
     def _get_amount_fields(self):
         """Get all fields with 'amount_' prefix"""
         fields = self.env["l10n_br_fiscal.document.mixin"]._fields.keys()
-        amount_fields = [f for f in fields if f.startswith("amount_")]
+        prefixes = ("amount_", "fiscal_amount_")
+        amount_fields = [f for f in fields if f.startswith(prefixes)]
         return amount_fields
 
     @api.depends("document_serie_id", "issuer")
@@ -221,13 +222,13 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
                         )
                     )
                 else:
-                    amount_total = sum(
+                    fiscal_amount_total = sum(
                         record._get_product_amount_lines().mapped("price_gross")
                     )
                     for line in record._get_product_amount_lines()[:-1]:
-                        if line.price_gross and amount_total:
+                        if line.price_gross and fiscal_amount_total:
                             line.freight_value = amount_freight_value * (
-                                line.price_gross / amount_total
+                                line.price_gross / fiscal_amount_total
                             )
                     record._get_product_amount_lines()[-1].freight_value = (
                         amount_freight_value
@@ -238,7 +239,7 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
                     )
                 for line in record._get_product_amount_lines():
                     line._onchange_fiscal_taxes()
-                record._fields["amount_total"].compute_value(record)
+                record._fields["fiscal_amount_total"].compute_value(record)
                 record.write(
                     {
                         name: value
@@ -271,13 +272,13 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
                         )
                     )
                 else:
-                    amount_total = sum(
+                    fiscal_amount_total = sum(
                         record._get_product_amount_lines().mapped("price_gross")
                     )
                     for line in record._get_product_amount_lines()[:-1]:
-                        if line.price_gross and amount_total:
+                        if line.price_gross and fiscal_amount_total:
                             line.insurance_value = amount_insurance_value * (
-                                line.price_gross / amount_total
+                                line.price_gross / fiscal_amount_total
                             )
                     record._get_product_amount_lines()[-1].insurance_value = (
                         amount_insurance_value
@@ -288,7 +289,7 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
                     )
                 for line in record._get_product_amount_lines():
                     line._onchange_fiscal_taxes()
-                record._fields["amount_total"].compute_value(record)
+                record._fields["fiscal_amount_total"].compute_value(record)
                 record.write(
                     {
                         name: value
@@ -321,13 +322,13 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
                         )
                     )
                 else:
-                    amount_total = sum(
+                    fiscal_amount_total = sum(
                         record._get_product_amount_lines().mapped("price_gross")
                     )
                     for line in record._get_product_amount_lines()[:-1]:
-                        if line.price_gross and amount_total:
+                        if line.price_gross and fiscal_amount_total:
                             line.other_value = amount_other_value * (
-                                line.price_gross / amount_total
+                                line.price_gross / fiscal_amount_total
                             )
                     record._get_product_amount_lines()[-1].other_value = (
                         amount_other_value
@@ -338,7 +339,7 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
                     )
                 for line in record._get_product_amount_lines():
                     line._onchange_fiscal_taxes()
-                record._fields["amount_total"].compute_value(record)
+                record._fields["fiscal_amount_total"].compute_value(record)
                 record.write(
                     {
                         name: value

--- a/l10n_br_fiscal/models/document_related.py
+++ b/l10n_br_fiscal/models/document_related.py
@@ -104,7 +104,7 @@ class DocumentRelated(models.Model):
             return False
 
         self.document_type_id = related.document_type_id
-        self.document_total_amount = related.amount_total
+        self.document_total_amount = related.fiscal_amount_total
         self.document_total_weight = related.total_weight
 
         if related.document_type_id.electronic:

--- a/l10n_br_fiscal/views/document_line_view.xml
+++ b/l10n_br_fiscal/views/document_line_view.xml
@@ -102,13 +102,13 @@
                     <page name="amounts" string="Amounts">
                         <group>
                             <group>
-                                <field name="amount_untaxed" />
+                                <field name="fiscal_amount_untaxed" />
                                 <field name="amount_fiscal" />
-                                <field name="amount_tax" />
+                                <field name="fiscal_amount_tax" />
                                 <field name="estimate_tax" />
                             </group>
                             <group>
-                                <field name="amount_total" />
+                                <field name="fiscal_amount_total" />
                                 <field name="amount_tax_withholding" />
                                 <field name="amount_taxed" />
                             </group>

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -71,9 +71,9 @@
                 <field name="document_date" />
                 <field name="fiscal_operation_id" />
                 <field name="partner_id" />
-                <field name="amount_untaxed" />
-                <field name="amount_tax" />
-                <field name="amount_total" />
+                <field name="fiscal_amount_untaxed" />
+                <field name="fiscal_amount_tax" />
+                <field name="fiscal_amount_total" />
                 <field name="state" invisible="1" />
                 <field
                     name="state_edoc"
@@ -310,7 +310,7 @@
                                         name="fiscal_tax_ids"
                                         widget="many2many_tags"
                                     />
-                                    <field name="amount_total" sum="Total" />
+                                    <field name="fiscal_amount_total" sum="Total" />
                                 </tree>
                             </field>
                         </page>
@@ -408,8 +408,8 @@
                                             attrs="{'readonly': [('delivery_costs', '=', 'line'),('force_compute_delivery_costs_by_total', '=', False)]}"
                                         />
                                         <field name="amount_estimate_tax" />
-                                        <field name="amount_tax" />
-                                        <field name="amount_total" />
+                                        <field name="fiscal_amount_tax" />
+                                        <field name="fiscal_amount_total" />
                                         <field name="amount_tax_withholding" />
                                         <field name="amount_financial_total" />
                                         <field name="amount_financial_total_gross" />

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -547,7 +547,7 @@ class NFe(spec_models.StackedModel):
         related="amount_other_value",
     )
 
-    nfe40_vNF = fields.Monetary(related="amount_total")
+    nfe40_vNF = fields.Monetary(related="fiscal_amount_total")
 
     nfe40_vTotTrib = fields.Monetary(related="amount_estimate_tax")
 
@@ -1578,7 +1578,7 @@ class NFe(spec_models.StackedModel):
             "total_product_quantity": len(
                 self.fiscal_line_ids.filtered(lambda line: line.product_id)
             ),
-            "amount_total": self.amount_total,
+            "amount_total": self.fiscal_amount_total,
             "amount_discount_value": self.amount_discount_value,
             "amount_freight_value": self.amount_freight_value,
             "payments": self._prepare_nfce_danfe_payment_values(),

--- a/l10n_br_nfse/models/document.py
+++ b/l10n_br_nfse/models/document.py
@@ -263,7 +263,7 @@ class Document(models.Model):
             "intermediario_servico": None,
             "codigo_obra": self.civil_construction_code or "",
             "art": self.civil_construction_art or "",
-            "carga_tributaria": self.amount_tax,
+            "carga_tributaria": self.fiscal_amount_tax,
             "total_recebido": self.amount_price_gross,
             "carga_tributaria_estimada": self.amount_estimate_tax,
             "customer_additional_data": self.customer_additional_data,

--- a/l10n_br_purchase/__manifest__.py
+++ b/l10n_br_purchase/__manifest__.py
@@ -8,7 +8,7 @@
     "author": "Akretion, Odoo Community Association (OCA)",
     "maintainers": ["renatonlima", "rvalyi"],
     "website": "https://github.com/OCA/l10n-brazil",
-    "version": "16.0.4.1.0",
+    "version": "16.0.5.0.0",
     "depends": ["purchase", "l10n_br_account"],
     "data": [
         # Security

--- a/l10n_br_purchase/migrations/16.0.5.0.0/pre-migration.py
+++ b/l10n_br_purchase/migrations/16.0.5.0.0/pre-migration.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2025 - Engenere (<https://engenere.one>).
+# @author Antônio S. Pereira Neto <neto@engenere.one>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    field_spec = [
+        (
+            "purchase.order",
+            "purchase_order",
+            "amount_untaxed",
+            "fiscal_amount_untaxed",
+        ),
+        (
+            "purchase.order",
+            "purchase_order",
+            "amount_tax",
+            "fiscal_amount_tax",
+        ),
+        (
+            "purchase.order",
+            "purchase_order",
+            "amount_total",
+            "fiscal_amount_total",
+        ),
+    ]
+    openupgrade.rename_fields(env, field_spec)

--- a/l10n_br_purchase/models/purchase_order_line.py
+++ b/l10n_br_purchase/models/purchase_order_line.py
@@ -110,9 +110,9 @@ class PurchaseOrderLine(models.Model):
                 line._compute_tax_fields()  # TODO is it required?
                 line.update(
                     {
-                        "price_subtotal": line.amount_untaxed,
-                        "price_tax": line.amount_tax,
-                        "price_total": line.amount_total,
+                        "price_subtotal": line.fiscal_amount_untaxed,
+                        "price_tax": line.fiscal_amount_tax,
+                        "price_total": line.fiscal_amount_total,
                     }
                 )
         return result

--- a/l10n_br_sale/__manifest__.py
+++ b/l10n_br_sale/__manifest__.py
@@ -7,7 +7,7 @@
     "license": "AGPL-3",
     "author": "Akretion, " "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-brazil",
-    "version": "16.0.5.1.1",
+    "version": "16.0.6.0.0",
     "depends": ["sale_management", "l10n_br_account"],
     "data": [
         # Data

--- a/l10n_br_sale/migrations/16.0.6.0.0/pre-migration.py
+++ b/l10n_br_sale/migrations/16.0.6.0.0/pre-migration.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2025 - Engenere (<https://engenere.one>).
+# @author Antônio S. Pereira Neto <neto@engenere.one>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    field_spec = [
+        (
+            "sale.order",
+            "sale_order",
+            "amount_untaxed",
+            "fiscal_amount_untaxed",
+        ),
+        (
+            "sale.order",
+            "sale_order",
+            "amount_tax",
+            "fiscal_amount_tax",
+        ),
+        (
+            "sale.order",
+            "sale_order",
+            "amount_total",
+            "fiscal_amount_total",
+        ),
+    ]
+    openupgrade.rename_fields(env, field_spec)

--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -183,13 +183,15 @@ class SaleOrderLine(models.Model):
         """Compute the amounts of the SO line."""
         result = super()._compute_amount()
         for line in self:
-            line._compute_tax_fields()  # TODO is it required?
-            line.update(
-                {
-                    "price_tax": line.amount_tax,
-                    "price_total": line.amount_total,
-                }
-            )
+            if line.fiscal_operation_id:
+                line._compute_tax_fields()  # TODO is it required?
+                line.update(
+                    {
+                        "price_subtotal": line.fiscal_amount_untaxed,
+                        "price_tax": line.fiscal_amount_tax,
+                        "price_total": line.fiscal_amount_total,
+                    }
+                )
         return result
 
     def _prepare_invoice_line(self, **optional_values):

--- a/l10n_br_sale/views/sale_view.xml
+++ b/l10n_br_sale/views/sale_view.xml
@@ -350,13 +350,13 @@
                     <page name="amounts" string="Amounts">
                         <group>
                             <group>
-                                <field name="amount_untaxed" />
+                                <field name="fiscal_amount_untaxed" />
                                 <field name="amount_fiscal" />
-                                <field name="amount_tax" />
+                                <field name="fiscal_amount_tax" />
                                 <field name="estimate_tax" readonly="1" />
                             </group>
                             <group>
-                                <field name="amount_total" />
+                                <field name="fiscal_amount_total" />
                                 <field name="amount_tax_withholding" readonly="1" />
                                 <field name="amount_taxed" />
                             </group>

--- a/l10n_br_sale_stock/tests/test_sale_stock.py
+++ b/l10n_br_sale_stock/tests/test_sale_stock.py
@@ -112,8 +112,8 @@ class TestSaleStock(TestBrPickingInvoicingCommon):
             "fiscal_price",
             "amount_fiscal",
             "price_unit",
-            "amount_untaxed",
-            "amount_total",
+            "fiscal_amount_untaxed",
+            "fiscal_amount_total",
         ]
         skipped_fields[len(skipped_fields) :] = skipped_fields_after_confirm
 

--- a/l10n_br_sped_ecd/models/sped_ecd.py
+++ b/l10n_br_sped_ecd/models/sped_ecd.py
@@ -502,10 +502,11 @@ class RegistroI200(models.Model):
         return {
             "NUM_LCTO": record.name,  # Número ou Código de identificação
             "DT_LCTO": record.create_date,  # Data do lançamento.
-            "VL_LCTO": record.amount_total,  # Valor do lançamento.
+            "VL_LCTO": record.fiscal_amount_total,  # Valor do lançamento.
             "IND_LCTO": "N",
             "DT_LCTO_EXT": record.date,  # O Data de ocorrência dos fatos
-            "VL_LCTO_MF": record.amount_total,  # Valor do lançamento em moeda funcional
+            # Valor do lançamento em moeda funcional
+            "VL_LCTO_MF": record.fiscal_amount_total,
         }
 
 

--- a/l10n_br_stock_account/__manifest__.py
+++ b/l10n_br_stock_account/__manifest__.py
@@ -9,7 +9,7 @@
     "author": "Akretion, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-brazil",
     "maintainers": ["renatonlima", "mbcosta"],
-    "version": "16.0.2.4.1",
+    "version": "16.0.3.0.0",
     "depends": [
         "stock_account",
         "stock_picking_invoicing",

--- a/l10n_br_stock_account/migrations/16.0.3.0.0/pre-migration.py
+++ b/l10n_br_stock_account/migrations/16.0.3.0.0/pre-migration.py
@@ -1,0 +1,31 @@
+# Copyright (C) 2025 - Engenere (<https://engenere.one>).
+# @author Antônio S. Pereira Neto <neto@engenere.one>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    field_spec = [
+        (
+            "stock.picking",
+            "stock_picking",
+            "amount_untaxed",
+            "fiscal_amount_untaxed",
+        ),
+        (
+            "stock.picking",
+            "stock_picking",
+            "amount_tax",
+            "fiscal_amount_tax",
+        ),
+        (
+            "stock.picking",
+            "stock_picking",
+            "amount_total",
+            "fiscal_amount_total",
+        ),
+    ]
+
+    openupgrade.rename_fields(env, field_spec)

--- a/l10n_br_stock_account/views/stock_picking.xml
+++ b/l10n_br_stock_account/views/stock_picking.xml
@@ -185,13 +185,13 @@
                         <page name="amounts" string="Amounts">
                             <group>
                                 <group>
-                                    <field name="amount_untaxed" />
+                                    <field name="fiscal_amount_untaxed" />
                                     <field name="amount_fiscal" />
-                                    <field name="amount_tax" />
+                                    <field name="fiscal_amount_tax" />
                                     <field name="estimate_tax" />
                                 </group>
                                 <group>
-                                    <field name="amount_total" />
+                                    <field name="fiscal_amount_total" />
                                     <field name="amount_tax_withholding" />
                                     <field name="amount_taxed" />
                                     <field name="amount_tax_included" invisible="1" />


### PR DESCRIPTION
Alguns campos implementados no módulo fiscal entravam em conflito com campos de mesmo nome já existentes no módulo nativo account. Os campos afetados foram:

```
amount_untaxed
amount_tax
amount_total
```

Para evitar conflitos com o módulo nativo, os campos fiscais foram renomeados com o prefixo fiscal_:

```
fiscal_amount_untaxed
fiscal_amount_tax
fiscal_amount_total
```