### PR TITLE
[16.0][REF] l10n_br_fiscal: move additional data

### DIFF
--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -10,6 +10,8 @@ from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 
 from ..constants.fiscal import (
+    COMMENT_TYPE_COMMERCIAL,
+    COMMENT_TYPE_FISCAL,
     DOCUMENT_ISSUER_COMPANY,
     DOCUMENT_ISSUER_DICT,
     DOCUMENT_ISSUER_PARTNER,
@@ -235,6 +237,10 @@ class Document(models.Model):
     company_l10n_br_ie_code_st = fields.Char(
         string="Company ST State Tax Number",
     )
+
+    fiscal_additional_data = fields.Text()
+
+    customer_additional_data = fields.Text()
 
     @api.constrains("document_key")
     def _check_key(self):
@@ -478,3 +484,27 @@ class Document(models.Model):
     def _compute_edoc_purpose(self):
         for record in self:
             record.edoc_purpose = record.fiscal_operation_id.edoc_purpose
+
+    def __document_comment_vals(self):
+        return {
+            "user": self.env.user,
+            "ctx": self._context,
+            "doc": self,
+        }
+
+    def _document_comment(self):
+        for d in self:
+            # Fiscal Comments
+            d.fiscal_additional_data = d.comment_ids.filtered(
+                lambda c: c.comment_type == COMMENT_TYPE_FISCAL
+            ).compute_message(
+                d.__document_comment_vals(), d.manual_fiscal_additional_data
+            )
+
+            # Commercial Comments
+            d.customer_additional_data = d.comment_ids.filtered(
+                lambda c: c.comment_type == COMMENT_TYPE_COMMERCIAL
+            ).compute_message(
+                d.__document_comment_vals(), d.manual_customer_additional_data
+            )
+            d.fiscal_line_ids._document_comment()

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -67,3 +67,20 @@ class DocumentLine(models.Model):
     edoc_purpose = fields.Selection(
         related="document_id.edoc_purpose",
     )
+
+    additional_data = fields.Text()
+
+    def __document_comment_vals(self):
+        self.ensure_one()
+        return {
+            "user": self.env.user,
+            "ctx": self._context,
+            "doc": self.document_id if hasattr(self, "document_id") else None,
+            "item": self,
+        }
+
+    def _document_comment(self):
+        for d in self:
+            d.additional_data = d.comment_ids.compute_message(
+                d.__document_comment_vals(), d.manual_additional_data
+            )

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -1626,8 +1626,6 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         readonly=False,
     )
 
-    additional_data = fields.Text()
-
     manual_additional_data = fields.Text(
         help="Additional data manually entered by user"
     )

--- a/l10n_br_fiscal/models/document_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_line_mixin_methods.py
@@ -454,21 +454,6 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 "cost_price": line.product_id.standard_price,
             }.get(line.fiscal_operation_id.default_price_unit, 0)
 
-    def __document_comment_vals(self):
-        self.ensure_one()
-        return {
-            "user": self.env.user,
-            "ctx": self._context,
-            "doc": self.document_id if hasattr(self, "document_id") else None,
-            "item": self,
-        }
-
-    def _document_comment(self):
-        for d in self:
-            d.additional_data = d.comment_ids.compute_message(
-                d.__document_comment_vals(), d.manual_additional_data
-            )
-
     def _get_fiscal_partner(self):
         """
         Meant to be overriden when the l10n_br_fiscal.document partner_id should not

--- a/l10n_br_fiscal/models/document_mixin.py
+++ b/l10n_br_fiscal/models/document_mixin.py
@@ -100,13 +100,9 @@ class FiscalDocumentMixin(models.AbstractModel):
         store=True,
     )
 
-    fiscal_additional_data = fields.Text()
-
     manual_fiscal_additional_data = fields.Text(
         help="Fiscal Additional data manually entered by user",
     )
-
-    customer_additional_data = fields.Text()
 
     manual_customer_additional_data = fields.Text(
         help="Customer Additional data manually entered by user",

--- a/l10n_br_fiscal/models/document_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_mixin_methods.py
@@ -4,8 +4,6 @@
 from odoo import api, models
 
 from ..constants.fiscal import (
-    COMMENT_TYPE_COMMERCIAL,
-    COMMENT_TYPE_FISCAL,
     DOCUMENT_ISSUER_COMPANY,
 )
 
@@ -158,30 +156,6 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
                 values["amount_other_value"] = doc.amount_other_value
 
             doc.update(values)
-
-    def __document_comment_vals(self):
-        return {
-            "user": self.env.user,
-            "ctx": self._context,
-            "doc": self,
-        }
-
-    def _document_comment(self):
-        for d in self:
-            # Fiscal Comments
-            d.fiscal_additional_data = d.comment_ids.filtered(
-                lambda c: c.comment_type == COMMENT_TYPE_FISCAL
-            ).compute_message(
-                d.__document_comment_vals(), d.manual_fiscal_additional_data
-            )
-
-            # Commercial Comments
-            d.customer_additional_data = d.comment_ids.filtered(
-                lambda c: c.comment_type == COMMENT_TYPE_COMMERCIAL
-            ).compute_message(
-                d.__document_comment_vals(), d.manual_customer_additional_data
-            )
-            d.fiscal_line_ids._document_comment()
 
     def _get_fiscal_partner(self):
         """

--- a/l10n_br_fiscal/views/document_line_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_line_mixin_view.xml
@@ -1051,7 +1051,6 @@
                         <group>
                             <field name="comment_ids" widget="many2many_tags" />
                             <field name="manual_additional_data" />
-                            <field name="additional_data" readonly="1" />
                         </group>
                     </page>
                 </notebook>

--- a/l10n_br_fiscal/views/document_line_view.xml
+++ b/l10n_br_fiscal/views/document_line_view.xml
@@ -114,7 +114,9 @@
                             </group>
                         </group>
                     </page>
-                    <page name="fiscal_line_extra_info" string="Extra Info" />
+                    <page name="fiscal_line_extra_info" string="Extra Info">
+                        <field name="additional_data" readonly="1" />
+                    </page>
                 </notebook>
             </form>
         </field>


### PR DESCRIPTION
Os campos e métodos a baixo foram movidas do mixin diretamente para a classe concreta do documento e linha do documento fiscal, pois não são utilizadas em outros modelos que herdam o mixin.

Movido do `document_mixin` para `document`:

```
fiscal_additional_data
customer_additional_data
__document_comment_vals
_document_comment
```


Movido do `document_line_mixin` para `document_line`

```
additional_data
__document_comment_vals()
_document_comment()
```

Obs: os mixins ainda continuam com o campo manual_additional_data e comment_ids que é o onde o usuário tem acesso, esses campos que movi, são computado apenas no fim da emissão da NFe.