### PR TITLE
[17.0][FIX] l10n_br_fiscal_edi: fix migr to 17

### DIFF
--- a/l10n_br_fiscal_edi/views/invalidate_number_view.xml
+++ b/l10n_br_fiscal_edi/views/invalidate_number_view.xml
@@ -8,7 +8,7 @@
             <xpath expr="//group[@name='invalidation']" position="after">
                 <notebook>
                     <page string="Events">
-                        <field name="event_ids" />
+                        <field name="event_ids" readonly="state != 'draft'" />
                     </page>
                 </notebook>
             </xpath>


### PR DESCRIPTION
tava faltando isso qdo migrei para a 17.0 e que tirei o `states=` do invalidate_number.py:
https://github.com/OCA/l10n-brazil/pull/3967/commits/82125b3728820824b03109cba2e8271a253281f2