### PR TITLE
[18.0][REF] l10n_br_base: remove legacy cnpj_cpf, inscr_est, inscr_mun compatibility

### DIFF
--- a/l10n_br_base/models/party_mixin.py
+++ b/l10n_br_base/models/party_mixin.py
@@ -34,11 +34,6 @@ class PartyMixin(models.AbstractModel):
         size=17,
     )
 
-    # compat with legacy code:
-    inscr_est = fields.Char(
-        related="l10n_br_ie_code", string="State Tax Number alias", readonly=False
-    )
-
     state_tax_number_ids = fields.One2many(
         string="Others State Tax Number",
         comodel_name="state.tax.numbers",
@@ -48,11 +43,6 @@ class PartyMixin(models.AbstractModel):
     l10n_br_im_code = fields.Char(
         string="Municipal Tax Number",
         size=18,
-    )
-
-    # backward compat with v14:
-    inscr_mun = fields.Char(
-        related="l10n_br_im_code", string="Municipal Tax Number alias", readonly=False
     )
 
     l10n_br_isuf_code = fields.Char(

--- a/l10n_br_base/models/party_mixin.py
+++ b/l10n_br_base/models/party_mixin.py
@@ -13,13 +13,6 @@ class PartyMixin(models.AbstractModel):
     _description = "Brazilian partner and company data mixin"
 
     vat = fields.Char()  # mixin methods needs the vat field here
-    cnpj_cpf = fields.Char(  # alias for v14 backward compat
-        string="CNPJ/CPF",
-        # (for some reason related="vat" makes numerous tests fail)
-        inverse="_inverse_cnpj_cpf",
-        compute="_compute_cnpj_cpf",
-        copy=False,
-    )
 
     cnpj_cpf_stripped = fields.Char(
         string="CNPJ/CPF Stripped",
@@ -80,10 +73,6 @@ class PartyMixin(models.AbstractModel):
             else False
         )
 
-    def _inverse_cnpj_cpf(self):
-        for partner in self:
-            partner.vat = cnpj_cpf.formata(str(self.cnpj_cpf))
-
     @api.model
     def search(self, domain, offset=0, limit=None, order=None, count=False):
         """in the case of a simple search with only OR terms and a vat ilike condition,
@@ -104,20 +93,6 @@ class PartyMixin(models.AbstractModel):
                     )
                     break
         return super().search(domain, offset, limit, order)
-
-    @api.onchange("cnpj_cpf")
-    def _onchange_cnpj_cpf(self):  # TODO, see comment bellow
-        """
-        In the future we should simply put @api.onchange("cnpj_cpf")
-        on _inverse_cnpj_cpf and remove this method. But for now,
-        it's good to maintain backward compat with the v14 codebase with this.
-        """
-        return self._inverse_cnpj_cpf()
-
-    @api.depends("vat")
-    def _compute_cnpj_cpf(self):
-        for partner in self:
-            partner.cnpj_cpf = partner.vat
 
     @api.depends("vat")
     def _compute_cnpj_cpf_stripped(self):
@@ -145,3 +120,9 @@ class PartyMixin(models.AbstractModel):
     @api.onchange("city_id")
     def _onchange_city_id(self):
         self.city = self.city_id.name
+
+    @api.onchange("vat")
+    def _onchange_vat(self):
+        """Format the VAT field (CNPJ/CPF) with proper punctuation."""
+        if self.vat:
+            self.vat = cnpj_cpf.formata(str(self.vat))

--- a/l10n_br_base/models/res_company.py
+++ b/l10n_br_base/models/res_company.py
@@ -14,7 +14,6 @@ class Company(models.Model):
         partner_fields = super()._get_company_address_field_names()
         return partner_fields + [
             "legal_name",
-            "cnpj_cpf",
             "l10n_br_ie_code",
             "l10n_br_im_code",
             "district",
@@ -40,10 +39,6 @@ class Company(models.Model):
     def _inverse_street_number(self):
         for company in self:
             company.partner_id.street_number = company.street_number
-
-    def _inverse_cnpj_cpf(self):
-        for company in self:
-            company.partner_id.cnpj_cpf = company.cnpj_cpf
 
     def _inverse_l10n_br_ie_code(self):
         for company in self:
@@ -103,11 +98,6 @@ class Company(models.Model):
     )
 
     country_id = fields.Many2one(default=lambda self: self.env.ref("base.br"))
-
-    cnpj_cpf = fields.Char(
-        compute="_compute_address",
-        inverse="_inverse_cnpj_cpf",
-    )
 
     l10n_br_ie_code = fields.Char(
         compute="_compute_address",

--- a/l10n_br_base/tests/test_base_onchange.py
+++ b/l10n_br_base/tests/test_base_onchange.py
@@ -53,7 +53,7 @@ class L10nBrBaseOnchangeTest(TransactionCase):
         """
         Call all the onchange methods in l10n_br_base
         """
-        self.company_01._onchange_cnpj_cpf()
+        self.company_01._onchange_vat()
         self.company_01._onchange_city_id()
         self.company_01._onchange_zip()
         self.company_01._onchange_state()
@@ -63,7 +63,7 @@ class L10nBrBaseOnchangeTest(TransactionCase):
         #  chamado, por isso existe outro metodo com o final _id
         self.company_01._onchange_state_id()
 
-        self.partner_01._onchange_cnpj_cpf()
+        self.partner_01._onchange_vat()
         self.partner_01._onchange_city_id()
         self.partner_01._onchange_zip()
         self.partner_01._onchange_state()

--- a/l10n_br_cnpj_search/models/cnpj_webservice.py
+++ b/l10n_br_cnpj_search/models/cnpj_webservice.py
@@ -345,7 +345,7 @@ class CNPJWebservice(models.AbstractModel):
 
             if schema == "empresa":
                 partner_cpf = self.get_data(partner, "cpf")
-                values.update({"cnpj_cpf": partner_cpf})
+                values.update({"vat": partner_cpf})
 
             partner_id = self.env["res.partner"].create(values).id
             child_ids.append(partner_id)

--- a/l10n_br_cnpj_search/models/l10n_br_base_party_mixin.py
+++ b/l10n_br_cnpj_search/models/l10n_br_base_party_mixin.py
@@ -27,7 +27,7 @@ class PartyMixin(models.AbstractModel):
     )
 
     def action_open_cnpj_search_wizard(self):
-        if not self.cnpj_cpf:
+        if not self.vat:
             raise UserError(_("Please enter your CNPJ"))
         if self.cnpj_validation_disabled():
             raise UserError(

--- a/l10n_br_cnpj_search/tests/test_receitaws.py
+++ b/l10n_br_cnpj_search/tests/test_receitaws.py
@@ -22,7 +22,7 @@ class TestReceitaWS(TestCnpjCommon):
         kilian = self.model.create(
             {
                 "name": "Kilian",
-                "cnpj_cpf": "44.356.113/0001-08",
+                "vat": "44.356.113/0001-08",
             }
         )
 
@@ -58,10 +58,8 @@ class TestReceitaWS(TestCnpjCommon):
 
     def test_receita_ws_fail(self):
         with self.assertRaises(ValidationError):
-            invalido = self.model.create(
-                {"name": "invalido", "cnpj_cpf": "00000000000000"}
-            )
-            invalido._onchange_cnpj_cpf()
+            invalido = self.model.create({"name": "invalido", "vat": "00000000000000"})
+            invalido._onchange_vat()
             action_wizard = invalido.action_open_cnpj_search_wizard()
             wizard_context = action_wizard.get("context")
             wizard_context["active_model"] = "res.partner"
@@ -72,8 +70,8 @@ class TestReceitaWS(TestCnpjCommon):
             "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
             return_value=self.mocked_response_ws_2,
         ):
-            isla = self.model.create({"name": "Isla", "cnpj_cpf": "92.666.056/0001-06"})
-            isla._onchange_cnpj_cpf()
+            isla = self.model.create({"name": "Isla", "vat": "92.666.056/0001-06"})
+            isla._onchange_vat()
 
             action_wizard = isla.action_open_cnpj_search_wizard()
             wizard_context = action_wizard.get("context")

--- a/l10n_br_cnpj_search/tests/test_serpro.py
+++ b/l10n_br_cnpj_search/tests/test_serpro.py
@@ -30,9 +30,9 @@ class TestTestSerPro(TestCnpjCommon):
             return_value=self.mocked_response_serpro_1,
         ):
             dummy_basica = self.model.create(
-                {"name": "Dummy Basica", "cnpj_cpf": "34.238.864/0001-68"}
+                {"name": "Dummy Basica", "vat": "34.238.864/0001-68"}
             )
-            dummy_basica._onchange_cnpj_cpf()
+            dummy_basica._onchange_vat()
 
             action_wizard = dummy_basica.action_open_cnpj_search_wizard()
             wizard_context = action_wizard.get("context")
@@ -63,10 +63,8 @@ class TestTestSerPro(TestCnpjCommon):
 
     def test_serpro_not_found(self):
         # In the Trial version there are only a few registered CNPJ records
-        invalid = self.model.create(
-            {"name": "invalid", "cnpj_cpf": "44.356.113/0001-08"}
-        )
-        invalid._onchange_cnpj_cpf()
+        invalid = self.model.create({"name": "invalid", "vat": "44.356.113/0001-08"})
+        invalid._onchange_vat()
 
         with self.assertRaises(ValidationError):
             action_wizard = invalid.action_open_cnpj_search_wizard()
@@ -77,7 +75,7 @@ class TestTestSerPro(TestCnpjCommon):
     def assert_socios(self, partner, expected_cnpjs):
         socios = self.model.search_read(
             [("id", "in", partner.child_ids.ids)],
-            fields=["name", "cnpj_cpf", "company_type"],
+            fields=["name", "vat", "company_type"],
         )
 
         for s in socios:
@@ -86,27 +84,27 @@ class TestTestSerPro(TestCnpjCommon):
         expected_socios = [
             {
                 "name": "Joana Alves Mundim Pena",
-                "cnpj_cpf": expected_cnpjs["Joana"],
+                "vat": expected_cnpjs["Joana"],
                 "company_type": "person",
             },
             {
                 "name": "Luiza Aldenora",
-                "cnpj_cpf": expected_cnpjs["Aldenora"],
+                "vat": expected_cnpjs["Aldenora"],
                 "company_type": "person",
             },
             {
                 "name": "Luiza Araujo De Oliveira",
-                "cnpj_cpf": expected_cnpjs["Araujo"],
+                "vat": expected_cnpjs["Araujo"],
                 "company_type": "person",
             },
             {
                 "name": "Luiza Barbosa Bezerra",
-                "cnpj_cpf": expected_cnpjs["Barbosa"],
+                "vat": expected_cnpjs["Barbosa"],
                 "company_type": "person",
             },
             {
                 "name": "Marcelo Antonio Barros De Cicco",
-                "cnpj_cpf": expected_cnpjs["Marcelo"],
+                "vat": expected_cnpjs["Marcelo"],
                 "company_type": "person",
             },
         ]
@@ -124,10 +122,10 @@ class TestTestSerPro(TestCnpjCommon):
             self.set_param("serpro_schema", "empresa")
 
             dummy_empresa = self.model.create(
-                {"name": "Dummy Empresa", "cnpj_cpf": "34.238.864/0002-49"}
+                {"name": "Dummy Empresa", "vat": "34.238.864/0002-49"}
             )
 
-            dummy_empresa._onchange_cnpj_cpf()
+            dummy_empresa._onchange_vat()
             action_wizard = dummy_empresa.action_open_cnpj_search_wizard()
             wizard_context = action_wizard.get("context")
             wizard_context["active_model"] = "res.partner"
@@ -160,10 +158,10 @@ class TestTestSerPro(TestCnpjCommon):
             self.set_param("serpro_schema", "qsa")
 
             dummy_qsa = self.model.create(
-                {"name": "Dummy QSA", "cnpj_cpf": "34.238.864/0001-68"}
+                {"name": "Dummy QSA", "vat": "34.238.864/0001-68"}
             )
 
-            dummy_qsa._onchange_cnpj_cpf()
+            dummy_qsa._onchange_vat()
             action_wizard = dummy_qsa.action_open_cnpj_search_wizard()
             wizard_context = action_wizard.get("context")
             wizard_context["active_model"] = "res.partner"

--- a/l10n_br_cnpj_search/wizard/partner_cnpj_search_wizard.py
+++ b/l10n_br_cnpj_search/wizard/partner_cnpj_search_wizard.py
@@ -94,7 +94,7 @@ class PartnerCnpjSearchWizard(models.TransientModel):
             if partner_id:
                 partner_model = self.env["res.partner"]
                 partner = partner_model.browse(partner_id)
-                cnpj_cpf = punctuation_rm(partner.cnpj_cpf)
+                cnpj_cpf = punctuation_rm(partner.vat)
                 misc.punctuation_rm(self.zip)
                 values = self._get_partner_values(cnpj_cpf)
                 res.update(values)

--- a/l10n_br_crm/models/crm_lead.py
+++ b/l10n_br_crm/models/crm_lead.py
@@ -4,7 +4,8 @@
 from erpbrasil.base import misc
 from erpbrasil.base.fiscal import cnpj_cpf
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 from odoo.addons.l10n_br_base.tools import check_cnpj_cpf, check_ie
 
@@ -134,14 +135,14 @@ class Lead(models.Model):
             result["country_id"] = self.partner_id.country_id.id
             if self.partner_id.is_company:
                 result["legal_name"] = self.partner_id.legal_name
-                result["cnpj"] = self.partner_id.cnpj_cpf
+                result["cnpj"] = self.partner_id.vat
                 result["l10n_br_ie_code"] = self.partner_id.l10n_br_ie_code
                 result["l10n_br_im_code"] = self.partner_id.l10n_br_im_code
                 result["l10n_br_isuf_code"] = self.partner_id.l10n_br_isuf_code
             else:
                 result["partner_name"] = self.partner_id.parent_id.name or False
                 result["legal_name"] = self.partner_id.parent_id.legal_name or False
-                result["cnpj"] = self.partner_id.parent_id.cnpj_cpf or False
+                result["cnpj"] = self.partner_id.parent_id.vat or False
                 result["l10n_br_ie_code"] = (
                     self.partner_id.parent_id.l10n_br_ie_code or False
                 )
@@ -152,7 +153,7 @@ class Lead(models.Model):
                     self.partner_id.parent_id.l10n_br_isuf_code or False
                 )
                 result["website"] = self.partner_id.parent_id.website or False
-                result["cpf"] = self.partner_id.cnpj_cpf
+                result["cpf"] = self.partner_id.vat
                 result["l10n_br_rg_code"] = self.partner_id.l10n_br_rg_code
                 result["name_surname"] = self.partner_id.legal_name
         self.update(result)
@@ -178,7 +179,7 @@ class Lead(models.Model):
         if is_company:
             values.update(
                 {
-                    "cnpj_cpf": self.cnpj,
+                    "vat": self.cnpj,
                     "l10n_br_ie_code": self.l10n_br_ie_code,
                     "l10n_br_im_code": self.l10n_br_im_code,
                     "l10n_br_isuf_code": self.l10n_br_isuf_code,
@@ -187,9 +188,40 @@ class Lead(models.Model):
         else:
             values.update(
                 {
-                    "cnpj_cpf": self.cpf,
+                    "vat": self.cpf,
                     "l10n_br_ie_code": self.l10n_br_rg_code,
                     "l10n_br_rg_code": self.l10n_br_rg_code,
                 }
             )
         return values
+
+    def action_open_cnpj_search_wizard(self):
+        """Override to use cnpj field instead of vat for crm.lead."""
+        if not self.cnpj:
+            raise UserError(_("Please enter your CNPJ"))
+        if self.cnpj_validation_disabled():
+            raise UserError(
+                _(
+                    "It is necessary to activate the option to validate de CNPJ to use"
+                    " this functionality."
+                )
+            )
+        context = {
+            "active_model": self._name,
+        }
+        if self._name == "res.partner":
+            context["default_partner_id"] = self.id
+        elif self._name == "crm.lead":
+            context["default_lead_id"] = self.id
+        else:
+            context["default_partner_id"] = self.partner_id.id
+
+        return {
+            "name": "Search Data by CNPJ",
+            "type": "ir.actions.act_window",
+            "res_model": "partner.search.wizard",
+            "view_type": "form",
+            "view_mode": "form",
+            "context": context,
+            "target": "new",
+        }

--- a/l10n_br_crm/tests/test_crm_lead.py
+++ b/l10n_br_crm/tests/test_crm_lead.py
@@ -56,7 +56,7 @@ class CrmLeadTest(TransactionCase):
             {
                 "name": "Test Lead Partner",
                 "legal_name": "Test Lead Partner",
-                "cnpj_cpf": "22.898.817/0001-61",
+                "vat": "22.898.817/0001-61",
                 "l10n_br_ie_code": "041.092.540.590",
                 "l10n_br_im_code": "99999999",
                 "l10n_br_isuf_code": "99999999",
@@ -115,7 +115,7 @@ class CrmLeadTest(TransactionCase):
         self.assertTrue(
             self.obj_partner.legal_name, "The field Razão Social not was filled."
         )
-        self.assertTrue(self.obj_partner.cnpj_cpf, "The field CNPJ not was filled.")
+        self.assertTrue(self.obj_partner.vat, "The field CNPJ not was filled.")
         self.assertTrue(
             self.obj_partner.l10n_br_ie_code,
             "The field Inscrição Estadual not was filled",
@@ -171,7 +171,7 @@ class CrmLeadTest(TransactionCase):
         self.obj_partner = self.env["res.partner"].browse(self.partner_id.id)
 
         self.assertTrue(self.obj_partner.name, "The field Name was not filled.")
-        self.assertTrue(self.obj_partner.cnpj_cpf, "The field CNPJ was not filled.")
+        self.assertTrue(self.obj_partner.vat, "The field CNPJ was not filled.")
         self.assertTrue(self.obj_partner.l10n_br_ie_code, "The field RG was not filled")
 
     def test_lead_won_contact(self):
@@ -195,7 +195,7 @@ class CrmLeadTest(TransactionCase):
         self.assertTrue(
             self.obj_partner.legal_name, "The field Razão Social not was filled."
         )
-        self.assertTrue(self.obj_partner.cnpj_cpf, "The field CNPJ not was filled.")
+        self.assertTrue(self.obj_partner.vat, "The field CNPJ not was filled.")
         self.assertTrue(
             self.obj_partner.l10n_br_ie_code,
             "The field Inscrição Estadual not was filled",

--- a/l10n_br_crm_cnpj_search/models/crm_lead.py
+++ b/l10n_br_crm_cnpj_search/models/crm_lead.py
@@ -4,8 +4,6 @@ from odoo import Command, fields, models
 class Lead(models.Model):
     _inherit = "crm.lead"
 
-    cnpj_cpf = fields.Char(related="cnpj")
-
     cnae_secondary_ids = fields.Many2many(
         comodel_name="l10n_br_fiscal.cnae",
         relation="crm_lead_fiscal_cnae_rel",
@@ -28,7 +26,7 @@ class Lead(models.Model):
         if is_company:
             values.update(
                 {
-                    "cnpj_cpf": self.cnpj,
+                    "vat": self.cnpj,
                     "l10n_br_ie_code": self.l10n_br_ie_code,
                     "l10n_br_im_code": self.l10n_br_im_code,
                     "l10n_br_isuf_code": self.l10n_br_isuf_code,
@@ -41,7 +39,7 @@ class Lead(models.Model):
         else:
             values.update(
                 {
-                    "cnpj_cpf": self.cpf,
+                    "vat": self.cpf,
                     "l10n_br_ie_code": self.l10n_br_rg_code,
                     "l10n_br_rg_code": self.l10n_br_rg_code,
                 }

--- a/l10n_br_crm_cnpj_search/tests/test_receitaws.py
+++ b/l10n_br_crm_cnpj_search/tests/test_receitaws.py
@@ -48,7 +48,7 @@ class TestCRMReceitaws(TestCnpjCommon):
             "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
             return_value=mocked_response,
         ):
-            self.crm_lead_1.write({"cnpj_cpf": "31.954.065/0001-08"})
+            self.crm_lead_1.write({"cnpj": "31.954.065/0001-08"})
             action_wizard = self.crm_lead_1.action_open_cnpj_search_wizard()
             wizard_context = action_wizard.get("context")
             wizard = (

--- a/l10n_br_crm_cnpj_search/wizard/partner_cnpj_search_wizard.py
+++ b/l10n_br_crm_cnpj_search/wizard/partner_cnpj_search_wizard.py
@@ -14,7 +14,7 @@ class PartnerCnpjSearchWizard(models.TransientModel):
             if "currency_id" in res:
                 lead_model = self.env["crm.lead"]
                 lead = lead_model.browse(lead_id)
-                cnpj_cpf = punctuation_rm(lead.cnpj_cpf)
+                cnpj_cpf = punctuation_rm(lead.cnpj)
                 values = self._get_partner_values(cnpj_cpf)
                 res.update(values)
         return res
@@ -25,7 +25,7 @@ class PartnerCnpjSearchWizard(models.TransientModel):
         if active_model == "crm.lead":
             lead_model = self.env["crm.lead"]
             lead_id = lead_model.browse(lead_id)
-            lead_id.partner_id.cnpj_cpf = lead_id.cnpj
+            lead_id.partner_id.vat = lead_id.cnpj
             values_to_update = {
                 "partner_name": self.name,
                 "legal_name": self.legal_name,

--- a/l10n_br_fiscal_certificate/tests/test_certificate.py
+++ b/l10n_br_fiscal_certificate/tests/test_certificate.py
@@ -55,7 +55,7 @@ class TestCertificate(TransactionCase):
         company = cls.env["res.company"].create(
             {
                 "name": "Company Test Fiscal BR",
-                "cnpj_cpf": "42.245.642/0001-09",
+                "vat": "42.245.642/0001-09",
                 "country_id": cls.env.ref("base.br").id,
                 "state_id": cls.env.ref("base.state_br_sp").id,
             }

--- a/l10n_br_fiscal_dfe/models/dfe.py
+++ b/l10n_br_fiscal_dfe/models/dfe.py
@@ -95,7 +95,7 @@ class DFe(models.Model):
         while maxNSU != self.last_nsu:
             try:
                 result = self._get_processor().consultar_distribuicao(
-                    cnpj_cpf=re.sub("[^0-9]", "", self.company_id.cnpj_cpf),
+                    cnpj_cpf=re.sub("[^0-9]", "", self.company_id.vat),
                     ultimo_nsu=utils.format_nsu(self.last_nsu),
                 )
             except Exception as e:
@@ -136,7 +136,7 @@ class DFe(models.Model):
     def _download_document(self, nfe_key):
         try:
             result = self._get_processor().consultar_distribuicao(
-                chave=nfe_key, cnpj_cpf=re.sub("[^0-9]", "", self.company_id.cnpj_cpf)
+                chave=nfe_key, cnpj_cpf=re.sub("[^0-9]", "", self.company_id.vat)
             )
         except Exception as e:
             self.message_post(

--- a/l10n_br_hr_contract/models/hr_contract.py
+++ b/l10n_br_hr_contract/models/hr_contract.py
@@ -53,7 +53,7 @@ class HrContract(models.Model):
     )
 
     union_cnpj = fields.Char(
-        string="Union CNPJ", related="partner_union.cnpj_cpf", readonly=True
+        string="Union CNPJ", related="partner_union.vat", readonly=True
     )
 
     union_entity_code = fields.Char(

--- a/l10n_br_nfse/models/document.py
+++ b/l10n_br_nfse/models/document.py
@@ -105,7 +105,7 @@ class Document(models.Model):
             transmissao=transmissao,
             ambiente=self.nfse_environment,
             cidade_ibge=int(self.company_id.partner_id.city_id.ibge_code),
-            cnpj_prestador=misc.punctuation_rm(self.company_id.partner_id.cnpj_cpf),
+            cnpj_prestador=misc.punctuation_rm(self.company_id.partner_id.vat),
             im_prestador=misc.punctuation_rm(
                 self.company_id.partner_id.l10n_br_im_code or ""
             ),
@@ -250,7 +250,7 @@ class Document(models.Model):
     def _prepare_lote_rps(self):
         num_rps = self.rps_number
         return {
-            "cnpj": misc.punctuation_rm(self.company_id.partner_id.cnpj_cpf),
+            "cnpj": misc.punctuation_rm(self.company_id.partner_id.vat),
             "inscricao_municipal": misc.punctuation_rm(
                 self.company_id.partner_id.l10n_br_im_code or ""
             )

--- a/l10n_br_nfse/models/res_partner.py
+++ b/l10n_br_nfse/models/res_partner.py
@@ -11,11 +11,11 @@ class ResPartner(models.Model):
 
     def _prepare_service_provider(self, country_id):
         if self.is_company:
-            tomador_cnpj = misc.punctuation_rm(self.cnpj_cpf or "")
+            tomador_cnpj = misc.punctuation_rm(self.vat or "")
             tomador_cpf = None
         else:
             tomador_cnpj = None
-            tomador_cpf = misc.punctuation_rm(self.cnpj_cpf or "")
+            tomador_cpf = misc.punctuation_rm(self.vat or "")
         partner_cep = misc.punctuation_rm(self.zip)
 
         if self.country_id.id != country_id:


### PR DESCRIPTION
este PR remove completamente os alias legacy:

- inscr_est (agora l10n_br_ie_code)
- inscr_mun (agora l10n_br_im_code)
- cnpj_cpf (agora vat)

## Porque eu adicionei o metodo `action_open_cnpj_search_wizard` no `crm.lead:` O Problema
O método `action_open_cnpj_search_wizard` está definido no mixin `l10n_br_base.party.mixin` (em l10n_br_cnpj_search/models/l10n_br_base_party_mixin.py). Este mixin fornece a funcionalidade de buscar dados da empresa pelo CNPJ.

O método original verifica:
```
if not self.vat:
    raise UserError(_("Please enter your CNPJ"))
```

O problema: O modelo `crm.lead` não usa o campo `vat` - ele possui campos separados `cnpj` e `cpf`. Então, quando o teste chamou `action_open_cnpj_search_wizard() ` em um registro de `crm.lead` com o campo `cnpj` preenchido, falhou com "Please enter your CNPJ" porque `self.vat` estava vazio.

## A Solução
Eu sobrescrevi o método em l10n_br_crm/models/crm_lead.py para verificar o campo apropriado:
```
def action_open_cnpj_search_wizard(self):
    """Override to use cnpj field instead of vat for crm.lead."""
    if not self.cnpj:  # Alterado de self.vat
        raise UserError(_("Please enter your CNPJ"))
    # ... resto do método
```
Isso garante que:
1. Para res.partner e outros modelos usando o mixin → verifica o campo vat (comportamento padrão)
2. Para crm.lead → verifica o campo cnpj (sobrescrita no l10n_br_crm)

## Abordagens Alternativas
Eu também poderia ter:
1. Alterado o mixin para verificar ambos os campos - mas isso seria menos limpo e poderia causar problemas em outros lugares
2. Adicionado um campo computado vat ao `crm.lead` - mas no momento isso adiciona complexidade desnecessária. Na verdade no futuro poderia se cogitar de depender do modulo https://github.com/OCA/crm/tree/18.0/crm_lead_vat
