### PR TITLE
[16.0][FIX] l10n_br_nfe: small fixes backport

### DIFF
--- a/l10n_br_nfe/models/dfe.py
+++ b/l10n_br_nfe/models/dfe.py
@@ -41,7 +41,7 @@ class DFe(models.Model):
     @api.model
     def _create_mde_from_schema(self, schema, root):
         schema_type = schema.split("_")[0]
-        method = "_create_mde_from_%s" % schema_type
+        method = f"_create_mde_from_{schema_type}"
         if not hasattr(self, method):
             return
 

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -128,7 +128,9 @@ class NFeLine(spec_models.StackedModel):
     # Grupo I. Produtos e Serviços da NF-e
     ######################################
 
-    nfe40_det_infNFe_id = fields.Many2one(related="document_id")
+    nfe40_det_infNFe_id = fields.Many2one(
+        related="document_id", string="Fiscal Document"
+    )
 
     ######################################
     # NF-e tag: prod
@@ -145,7 +147,7 @@ class NFeLine(spec_models.StackedModel):
 
     # NVE TODO
 
-    nfe40_CEST = fields.Char(related="cest_id.code_unmasked")
+    nfe40_CEST = fields.Char(related="cest_id.code_unmasked", string="CEST code")
 
     # indEscala TODO
 
@@ -397,7 +399,7 @@ class NFeLine(spec_models.StackedModel):
     nfe40_vICMSST = fields.Monetary(related="icmsst_value")
 
     # ICMS FCP ST
-    nfe40_vFCPST = fields.Monetary(related="icmsfcpst_value")
+    nfe40_vFCPST = fields.Monetary(related="icmsfcpst_value", string="vFCPST")
 
     # COLOCAR NA ORDEM
     nfe40_pICMSST = fields.Float(related="icmsst_percent", string="pICMSST")
@@ -684,7 +686,7 @@ class NFeLine(spec_models.StackedModel):
 
     nfe40_vII = fields.Monetary(related="ii_value")
 
-    nfe40_vIOF = fields.Monetary(related="ii_iof_value")
+    nfe40_vIOF = fields.Monetary(related="ii_iof_value", string="vIOF")
 
     ###############
     # NF-e tag: PIS

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -448,39 +448,39 @@ class NFeLine(spec_models.StackedModel):
             "orig": self.nfe40_orig,
             "CST": self.icms_cst_id.code,
             "modBC": self.icms_base_type,
-            "vBC": str("%.02f" % self.icms_base),
-            "pRedBC": str("%.04f" % self.icms_reduction),
-            "pICMS": str("%.04f" % self.icms_percent),
-            "vICMS": str("%.02f" % self.icms_value),
-            "vICMSSubstituto": str("%.02f" % self.icms_substitute),
+            "vBC": f"{self.icms_base:.2f}",
+            "pRedBC": f"{self.icms_reduction:.4f}",
+            "pICMS": f"{self.icms_percent:.4f}",
+            "vICMS": f"{self.icms_value:.2f}",
+            "vICMSSubstituto": f"{self.icms_substitute:.2f}",
             # ICMS SUBSTITUIÇÃO TRIBUTÁRIA
             "modBCST": self.icmsst_base_type,
-            "pMVAST": str("%.04f" % self.icmsst_mva_percent),
-            "pRedBCST": str("%.04f" % self.icmsst_reduction),
-            "vBCST": str("%.02f" % self.icmsst_base),
-            "pICMSST": str("%.04f" % self.icmsst_percent),
-            "vICMSST": str("%.02f" % self.icmsst_value),
+            "pMVAST": f"{self.icmsst_mva_percent:.4f}",
+            "pRedBCST": f"{self.icmsst_reduction:.4f}",
+            "vBCST": f"{self.icmsst_base:.2f}",
+            "pICMSST": f"{self.icmsst_percent:.4f}",
+            "vICMSST": f"{self.icmsst_value:.2f}",
             "UFST": self.partner_id.state_id.code,
             # ICMS COBRADO ANTERIORMENTE POR SUBSTITUIÇÃO TRIBUTÁRIA
-            "vBCSTRet": str("%.02f" % self.icmsst_wh_base),
-            "pST": str("%.04f" % (self.icmsst_wh_percent + self.icmsfcp_wh_percent)),
-            "vICMSSTRet": str("%.02f" % self.icmsst_wh_value),
-            "pRedBCEfet": str("%.04f" % self.icms_effective_reduction),
-            "vBCEfet": str("%.02f" % self.icms_effective_base),
-            "pICMSEfet": str("%.04f" % self.icms_effective_percent),
-            "vICMSEfet": str("%.02f" % self.icms_effective_value),
+            "vBCSTRet": f"{self.icmsst_wh_base:.2f}",
+            "pST": f"{(self.icmsst_wh_percent + self.icmsfcp_wh_percent):.4f}",
+            "vICMSSTRet": f"{self.icmsst_wh_value:.2f}",
+            "pRedBCEfet": f"{self.icms_effective_reduction:.4f}",
+            "vBCEfet": f"{self.icms_effective_base:.2f}",
+            "pICMSEfet": f"{self.icms_effective_percent:.4f}",
+            "vICMSEfet": f"{self.icms_effective_value:.2f}",
             # ICMS SIMPLES NACIONAL
             "CSOSN": self.icms_cst_id.code,
-            "pCredSN": str("%.04f" % self.icmssn_percent),
-            "vCredICMSSN": str("%.02f" % self.icmssn_credit_value),
+            "pCredSN": f"{self.icmssn_percent:.4f}",
+            "vCredICMSSN": f"{self.icmssn_credit_value:.2f}",
         }
         if self.icmsfcp_wh_percent:
             icms.update(
                 {
                     # FUNDO DE COMBATE À POBREZA RETIDO
-                    "vBCFCPSTRet": str("%.02f" % self.icmsfcp_base_wh),
-                    "pFCPSTRet": str("%.04f" % self.icmsfcp_wh_percent),
-                    "vFCPSTRet": str("%.02f" % self.icmsfcp_value_wh),
+                    "vBCFCPSTRet": f"{self.icmsfcp_base_wh:.2f}",
+                    "pFCPSTRet": f"{self.icmsfcp_wh_percent:.4f}",
+                    "vFCPSTRet": f"{self.icmsfcp_value_wh:.2f}",
                 }
             )
         if (
@@ -491,25 +491,25 @@ class NFeLine(spec_models.StackedModel):
             icms.update(
                 {
                     # FUNDO DE COMBATE À POBREZA
-                    "vBCFCP": str("%.02f" % self.icmsfcp_base),
-                    "pFCP": str("%.04f" % self.icmsfcp_percent),
-                    "vFCP": str("%.02f" % self.icmsfcp_value),
+                    "vBCFCP": f"{self.icmsfcp_base:.2f}",
+                    "pFCP": f"{self.icmsfcp_percent:.4f}",
+                    "vFCP": f"{self.icmsfcp_value:.2f}",
                 }
             )
         if self.icmsfcpst_percent:
             icms.update(
                 {
                     # FUNDO DE COMBATE À POBREZA - COM ST
-                    "vBCFCPST": str("%.02f" % self.icmsfcpst_base),
-                    "pFCPST": str("%.04f" % self.icmsfcpst_percent),
-                    "vFCPST": str("%.02f" % self.icmsfcpst_value),
+                    "vBCFCPST": f"{self.icmsfcpst_base:.2f}",
+                    "pFCPST": f"{self.icmsfcpst_percent:.4f}",
+                    "vFCPST": f"{self.icmsfcpst_value:.2f}",
                 }
             )
         if self.icms_relief_id:
             icms.update(
                 {
                     # DESONERAÇÃO DO IMCS
-                    "vICMSDeson": str("%.02f" % self.icms_relief_value),
+                    "vICMSDeson": f"{self.icms_relief_value:.2f}",
                     "motDesICMS": self.icms_relief_id.code,
                 }
             )
@@ -580,7 +580,7 @@ class NFeLine(spec_models.StackedModel):
     def _compute_nfe40_ICMSUFDest(self):
         for record in self:
             if record.icms_origin_percent:
-                record.nfe40_pICMSInter = str("%.02f" % record.icms_origin_percent)
+                record.nfe40_pICMSInter = f"{record.icms_origin_percent:.2f}"
             else:
                 record.nfe40_pICMSInter = False
 
@@ -1080,7 +1080,7 @@ class NFeLine(spec_models.StackedModel):
         return values
 
     def _build_attr(self, node, fields, vals, path, attr):
-        key = "nfe40_%s" % (attr[0])
+        key = f"nfe40_{attr[0]}"
         value = getattr(node, attr[0])
         if key in ["nfe40_CST", "nfe40_modBC", "nfe40_CSOSN"]:
             return  # (dealt with in _build_many2one)

--- a/l10n_br_nfe/models/mde.py
+++ b/l10n_br_nfe/models/mde.py
@@ -213,7 +213,7 @@ class MDe(models.Model):
         )
 
     def create_xml_attachment(self, xml):
-        file_name = "NFe%s.xml" % self.dfe_id.last_nsu
+        file_name = f"NFe{self.dfe_id.last_nsu}.xml"
         self.attachment_id = self.env["ir.attachment"].create(
             {
                 "name": file_name,

--- a/l10n_br_nfe/models/res_company.py
+++ b/l10n_br_nfe/models/res_company.py
@@ -28,7 +28,7 @@ PROCESSADOR = [(PROCESSADOR_ERPBRASIL_EDOC, "erpbrasil.edoc")]
 class ResCompany(spec_models.SpecModel):
     _name = "res.company"
     _inherit = ["res.company", "nfe.40.emit"]
-    _nfe_search_keys = ["nfe40_CNPJ", "nfe40_xNome", "nfe40_xFant"]
+    _nfe_search_keys = ["vat", "nfe40_xNome", "nfe40_xFant"]
 
     nfe40_CNPJ = fields.Char(related="partner_id.nfe40_CNPJ")
     nfe40_CPF = fields.Char(related="partner_id.nfe40_CPF")

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -26,7 +26,7 @@ class ResPartner(spec_models.SpecModel):
         "nfe.40.transporta",
         "nfe.40.autxml",
     ]
-    _nfe_search_keys = ["nfe40_CNPJ", "nfe40_CPF", "nfe40_xNome"]
+    _nfe_search_keys = ["cnpj_cpf_stripped", "nfe40_xNome"]
 
     @api.model
     def _prepare_import_dict(
@@ -40,17 +40,14 @@ class ResPartner(spec_models.SpecModel):
         return values
 
     # nfe.40.tlocal / nfe.40.enderEmit / 'nfe.40.enderDest
-    # TODO: may be not store=True -> then override match
     nfe40_CNPJ = fields.Char(
         compute="_compute_nfe_data",
         inverse="_inverse_nfe40_CNPJ",
-        store=True,
         compute_sudo=True,
     )
     nfe40_CPF = fields.Char(
         compute="_compute_nfe_data",
         inverse="_inverse_nfe40_CPF",
-        store=True,
         compute_sudo=True,
     )
     nfe40_xLgr = fields.Char(
@@ -202,12 +199,11 @@ class ResPartner(spec_models.SpecModel):
         for rec in self:
             rec.nfe40_enderDest = rec.id
 
-    @api.depends("company_type", "l10n_br_ie_code", "cnpj_cpf", "country_id")
+    @api.depends("is_company", "l10n_br_ie_code", "vat", "country_id")
     def _compute_nfe_data(self):
         """Set schema data which are not just related fields"""
         for rec in self:
-            cnpj_cpf = punctuation_rm(rec.cnpj_cpf)
-            if cnpj_cpf:
+            if rec.cnpj_cpf_stripped:
                 if rec.country_id.code != "BR":
                     rec.nfe40_choice_dest = "nfe40_idEstrangeiro"
                     rec.nfe40_choice_tlocal = False
@@ -217,7 +213,7 @@ class ResPartner(spec_models.SpecModel):
                     rec.nfe40_choice_dest = "nfe40_CNPJ"
                     rec.nfe40_choice_autxml = "nfe40_CNPJ"
                     rec.nfe40_choice_transporta = "nfe40_CNPJ"
-                    rec.nfe40_CNPJ = cnpj_cpf
+                    rec.nfe40_CNPJ = rec.cnpj_cpf_stripped
                     rec.nfe40_CPF = None
                 else:
                     rec.nfe40_choice_tlocal = "nfe40_CPF"
@@ -225,7 +221,7 @@ class ResPartner(spec_models.SpecModel):
                     rec.nfe40_choice_dest = "nfe40_CPF"
                     rec.nfe40_choice_autxml = "nfe40_CPF"
                     rec.nfe40_choice_transporta = "nfe40_CPF"
-                    rec.nfe40_CPF = cnpj_cpf
+                    rec.nfe40_CPF = rec.cnpj_cpf_stripped
                     rec.nfe40_CNPJ = None
             else:
                 rec.nfe40_choice_tlocal = False

--- a/l10n_br_nfe/tests/test_nfe_import_wizard.py
+++ b/l10n_br_nfe/tests/test_nfe_import_wizard.py
@@ -119,7 +119,8 @@ class NFeImportWizardTest(TransactionCase):
         origin_company = self.wizard.company_id
 
         doc_company_id = self.env["res.company"].search(
-            [("nfe40_CNPJ", "=", re.sub("[^0-9]", "", doc.cnpj_cpf_emitente))], limit=1
+            [("cnpj_cpf_stripped", "=", re.sub("[^0-9]", "", doc.cnpj_cpf_emitente))],
+            limit=1,
         )
         self.wizard.company_id = doc_company_id
         self.wizard._set_fiscal_operation_type()

--- a/l10n_br_nfe/tests/test_nfe_xml_validation.py
+++ b/l10n_br_nfe/tests/test_nfe_xml_validation.py
@@ -41,7 +41,7 @@ class TestXMLValidation(TransactionCase):
         document.action_document_confirm()
         document.action_document_send()
         _logger.info(
-            "(Test Result) XML Validation Message: %s" % (document.xml_error_message)
+            f"(Test Result) XML Validation Message: {document.xml_error_message}"
         )
         self.assertTrue("CEP" in document.xml_error_message)
         self.assertEqual(document.state_edoc, SITUACAO_EDOC_A_ENVIAR)


### PR DESCRIPTION
migrando o modulo para as 17.0 e 18.0 eu resolvi alguns problemas.

o primeiro commit resolve esse warning do ORM (na 17 e 18):

`2025-09-10 22:02:26,878 17590 WARNING odoo17 py.warnings: /home/rvalyi/DEV/odoo17/odoo/src/odoo/modules/registry.py:372: UserWarning: res.partner: inconsistent 'store' for computed fields, accessing nfe40_IE, nfe40_fone, nfe40_CEP, nfe40_choice_emit, nfe40_choice_tlocal, nfe40_choice_dest, nfe40_choice_autxml, nfe40_choice_transporta may recompute and update nfe40_CNPJ, nfe40_CPF. Use distinct compute methods for stored and non-stored fields.`

o segundo commit resolve warnings do ORM porque alguns campos tinham o mesmo label.

o terceiro commit usa f-string em vez da antiga sintaxe %.