### PR TITLE
[16.0][FIX] l10n_br_fiscal: base.group_user can read partner profile

### DIFF
--- a/l10n_br_fiscal/security/ir.model.access.csv
+++ b/l10n_br_fiscal/security/ir.model.access.csv
@@ -67,7 +67,7 @@
 "l10n_br_fiscal_operation_line_manager","Fiscal Operation Line for Manager","model_l10n_br_fiscal_operation_line","l10n_br_fiscal.group_manager",1,1,1,1
 "l10n_br_fiscal_operation_document_type_user","Fiscal Operation Document Type for User","model_l10n_br_fiscal_operation_document_type","l10n_br_fiscal.group_user",1,0,0,0
 "l10n_br_fiscal_operation_document_type_manager","Fiscal Operation Document Type for Manager","model_l10n_br_fiscal_operation_document_type","l10n_br_fiscal.group_manager",1,1,1,1
-"l10n_br_fiscal_partner_profile_user","Fiscal Partner Profile for User","model_l10n_br_fiscal_partner_profile","l10n_br_fiscal.group_user",1,0,0,0
+"l10n_br_fiscal_partner_profile_user","Fiscal Partner Profile for User","model_l10n_br_fiscal_partner_profile","base.group_user",1,0,0,0
 "l10n_br_fiscal_partner_profile_manager","Fiscal Partner Profile for Manager","model_l10n_br_fiscal_partner_profile","l10n_br_fiscal.group_manager",1,1,1,1
 "l10n_br_fiscal_document_user","Fiscal Document for User","model_l10n_br_fiscal_document","l10n_br_fiscal.group_user",1,1,1,0
 "l10n_br_fiscal_document_manager","Fiscal Document for Manager","model_l10n_br_fiscal_document","l10n_br_fiscal.group_manager",1,1,1,1


### PR DESCRIPTION
alivia o acesso em leitura pro objeto `l10n_br_fiscal.partner.profile`, é algo que eu tive que fazer em 2 PRs pelo menos:

- #4074 
- #4075

