### PR TITLE
[16.0][IMP] l10n_br_fiscal: doc line improvements

### DIFF
--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2013  Renato Lima - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class DocumentLine(models.Model):
@@ -30,7 +30,12 @@ class DocumentLine(models.Model):
         ondelete="cascade",
     )
 
-    name = fields.Char()
+    name = fields.Char(
+        compute="_compute_name",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
 
     company_id = fields.Many2one(
         comodel_name="res.company",
@@ -52,7 +57,11 @@ class DocumentLine(models.Model):
 
     quantity = fields.Float(default=1.0)
 
-    ind_final = fields.Selection(related="document_id.ind_final")
+    ind_final = fields.Selection(
+        related="document_id.ind_final",
+        store=True,
+        precompute=True,
+    )
 
     # Usado para tornar Somente Leitura os campos dos custos
     # de entrega quando a definição for por Total
@@ -66,9 +75,19 @@ class DocumentLine(models.Model):
 
     edoc_purpose = fields.Selection(
         related="document_id.edoc_purpose",
+        store=True,
+        precompute=True,
     )
 
     additional_data = fields.Text()
+
+    @api.depends("product_id")
+    def _compute_name(self):
+        for line in self:
+            if line.product_id:
+                line.name = line.product_id.display_name
+            else:
+                line.name = False
 
     def __document_comment_vals(self):
         self.ensure_one()

--- a/l10n_br_fiscal/models/document_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_line_mixin_methods.py
@@ -474,7 +474,6 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         if not self.fiscal_operation_id:
             return
         if self.product_id:
-            self.name = self.product_id.display_name
             self.fiscal_type = self.product_id.fiscal_type
             self.uom_id = self.product_id.uom_id
             self.ncm_id = self.product_id.ncm_id
@@ -495,7 +494,6 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                     self.city_taxation_code_id = city_id
                     self.issqn_fg_city_id = company_city_id
         else:
-            self.name = False
             self.fiscal_type = False
             self.uom_id = False
             self.ncm_id = False


### PR DESCRIPTION
@antoniospneto eu extrai isso do seu PR #4072

No caso do name com compute eu acho tranquilo botar esse compute e tirar do onchange.

porem até nisso eu fico com pé atrás: aqui os campos `ind_final`, `edoc_purpose` que antes eram um dado normalizado related agora viram store=True. Sendo que nas versões superiores do Odoo, eu o ORM permite ate de usar campos related nos search sem ter que botar store=True. Ai eu me pergunto se essa denormalização dos dados vai no bom caminho (sei que ja tivemos que fazer em varios lugares, mas idealmente a gente limita esse problema).

@antoniospneto  vc poderia explicar porque isso foi necessário? Bom eu fico com pé atrás mas tb não é nada demais de se fazer, se isso for bem justificado...