### PR TITLE
[16.0][REF] l10n_br_nfse: hide meths from RPC (security)

### DIFF
--- a/l10n_br_nfse/models/document.py
+++ b/l10n_br_nfse/models/document.py
@@ -164,7 +164,7 @@ class Document(models.Model):
         valor_desconto_incondicionado = 0
 
         for line in lines:
-            result_line.update(line.prepare_line_servico())
+            result_line.update(line._prepare_line_service())
             valor_servicos += result_line.get("valor_servicos")
             valor_deducoes += result_line.get("valor_deducoes")
             valor_pis += result_line.get("valor_pis")
@@ -223,12 +223,14 @@ class Document(models.Model):
             "valor_desconto_incondicionado": valor_desconto_incondicionado,
         }
 
-        result.update(self.company_id.prepare_company_servico())
+        result.update(self.company_id._prepare_company_service())
 
         return result
 
     def _prepare_dados_tomador(self):
-        result = self.partner_id.prepare_partner_tomador(self.company_id.country_id.id)
+        result = self.partner_id._prepare_service_provider(
+            self.company_id.country_id.id
+        )
 
         result.update({"complemento": self.partner_shipping_id.street2 or None})
 
@@ -270,12 +272,12 @@ class Document(models.Model):
             "fiscal_additional_data": self.fiscal_additional_data,
         }
 
-    def convert_type_nfselib(self, class_object, object_filed, value):
+    def _convert_binding_value_to_odoo(self, binding_type, object_filed, value):
         if value is None:
             return value
 
         value_type = ""
-        for field in class_object().member_data_items_:
+        for field in binding_type().member_data_items_:
             if field.name == object_filed:
                 value_type = field.child_attrs.get("type", "").replace("xsd:", "")
                 break

--- a/l10n_br_nfse/models/document_line.py
+++ b/l10n_br_nfse/models/document_line.py
@@ -66,7 +66,7 @@ class DocumentLine(models.Model):
         model_view["fields"] = xfields
         return model_view
 
-    def prepare_line_servico(self):
+    def _prepare_line_service(self):
         return {
             "valor_servicos": round(self.price_gross, 2),
             "valor_deducoes": round(self.fiscal_deductions_value, 2),

--- a/l10n_br_nfse/models/res_company.py
+++ b/l10n_br_nfse/models/res_company.py
@@ -33,7 +33,7 @@ class ResCompany(models.Model):
         default=False,
     )
 
-    def prepare_company_servico(self):
+    def _prepare_company_service(self):
         return {
             "codigo_municipio": int(self.partner_id.city_id.ibge_code) or None,
         }

--- a/l10n_br_nfse/models/res_partner.py
+++ b/l10n_br_nfse/models/res_partner.py
@@ -9,7 +9,7 @@ from odoo import models
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
-    def prepare_partner_tomador(self, country_id):
+    def _prepare_service_provider(self, country_id):
         if self.is_company:
             tomador_cnpj = misc.punctuation_rm(self.cnpj_cpf or "")
             tomador_cpf = None

--- a/l10n_br_nfse/tests/test_fiscal_document_nfse_common.py
+++ b/l10n_br_nfse/tests/test_fiscal_document_nfse_common.py
@@ -67,7 +67,7 @@ class TestFiscalDocumentNFSeCommon(TransactionCase):
 
         # IBGE Code
         self.assertEqual(
-            str(self.company.prepare_company_servico().get("codigo_municipio")),
+            str(self.company._prepare_company_service().get("codigo_municipio")),
             "3132404",
             "Error to mappping IBGE Code 3132404"
             " for Venda de Serviço de Contribuinte Dentro do Estado.",
@@ -96,10 +96,9 @@ class TestFiscalDocumentNFSeCommon(TransactionCase):
         self.company.processador_edoc = PROCESSADOR_NENHUM
         self.assertFalse(filter_processador_edoc_nfse(self.nfse_same_state))
 
-        # Test res.partner.prepare_partner_tomador
         self.assertEqual(
             str(
-                self.nfse_same_state.partner_id.prepare_partner_tomador(
+                self.nfse_same_state.partner_id._prepare_service_provider(
                     self.company.country_id.id
                 ).get("codigo_municipio")
             ),
@@ -108,10 +107,9 @@ class TestFiscalDocumentNFSeCommon(TransactionCase):
             " for Venda de Serviço de Contribuinte Dentro do Estado.",
         )
 
-        # Test res.partner.prepare_partner_tomador (Exterior)
         self.assertEqual(
             str(
-                self.nfse_same_state.partner_id.prepare_partner_tomador(1).get(
+                self.nfse_same_state.partner_id._prepare_service_provider(1).get(
                     "codigo_municipio"
                 )
             ),
@@ -125,9 +123,8 @@ class TestFiscalDocumentNFSeCommon(TransactionCase):
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_taxes()
 
-            # prepare_line_servico()
             self.assertEqual(
-                line.prepare_line_servico().get("codigo_tributacao_municipio"),
+                line._prepare_line_service().get("codigo_tributacao_municipio"),
                 "6311900",
                 "Error to mappping City Taxation Code 6311900"
                 " for Venda de Serviço de Contribuinte Dentro do Estado.",


### PR DESCRIPTION
recentemente eu migrei o modulo l10n_br_nfse para 17.0 e 18.0 e eu vi que tinham vários métodos expostos no RPC que poderiam até representar uma falha se segurança. Nisso botei _ na frente para não expor mais. Eu tb aproveitei para botar um nome em inglês nestes casos.