### PR TITLE
[16.0][FIX] l10n_br_sale: add skip_compute_fiscal_tax_ids=true on create_invoice method

### DIFF
--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -135,7 +135,9 @@ class SaleOrder(models.Model):
 
         moves = self.env["account.move"]
         for document_type in document_types:
-            self = self.with_context(document_type_id=document_type.id)
+            self = self.with_context(
+                document_type_id=document_type.id, skip_compute_fiscal_tax_ids=True
+            )
             try:
                 moves |= super()._create_invoices(
                     grouped=grouped, final=final, date=date


### PR DESCRIPTION
https://github.com/OCA/l10n-brazil/issues/4080#issuecomment-3298743726