### PR TITLE
[16.0][IMP] l10n_br_fiscal: fix landed costs + tests

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -266,6 +266,8 @@ class AccountMove(models.Model):
             move.amount_tax_signed = sign * sum(
                 inv_line_ids.mapped("fiscal_amount_tax")
             )
+            move.amount_total = sum(inv_line_ids.mapped("fiscal_amount_total"))
+
         return result
 
     def _compute_imported_terms(self):

--- a/l10n_br_account/tests/test_move_edition.py
+++ b/l10n_br_account/tests/test_move_edition.py
@@ -95,7 +95,7 @@ class TestMoveEdition(TransactionCase):
             line_form.account_id = self.out_invoice_account_id
             line_form.debit = 10
         with self.assertRaises(UserError):  # ensure not balanced is still checked
-            move = move_form.save()
+            move_form.save()
 
         with move_form.line_ids.new() as line_form:
             line_form.account_id = self.out_invoice_account_id
@@ -446,3 +446,89 @@ class TestMoveEdition(TransactionCase):
         self.assertEqual(doc.fiscal_line_ids[0].fiscal_price, 50)
         self.assertEqual(doc.fiscal_line_ids[0].quantity, 10)
         self.assertEqual(doc.fiscal_line_ids[0].fiscal_quantity, 20)
+
+    def test_move_landed_costs_by_line_and_by_total(self):
+        """
+        Tests landed cost scenarios on an account.move form.
+        1. By Line: Enters costs on lines and verifies the header totals.
+        2. By Total: Enters costs on the header and verifies distribution to lines.
+        """
+        self.user.groups_id += self.env.ref("l10n_br_fiscal.group_user")
+        self.user.groups_id += self.env.ref("l10n_br_account.group_line_fiscal_detail")
+
+        product1 = self.env.ref("product.product_product_6")
+        product2 = self.env.ref("product.product_product_7")
+
+        # Part 1: Test with delivery_costs = 'line'
+        self.company.delivery_costs = "line"
+        move_form = Form(
+            self.env["account.move"].with_context(default_move_type="out_invoice")
+        )
+        move_form.company_id = self.company
+        move_form.partner_id = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        move_form.document_type_id = self.env.ref("l10n_br_fiscal.document_55")
+        move_form.document_serie_id = self.env.ref(
+            "l10n_br_fiscal.empresa_lc_document_55_serie_1"
+        )
+        move_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
+
+        with move_form.invoice_line_ids.new() as line1:
+            line1.product_id = product1
+            line1.fiscal_operation_line_id = self.env.ref(
+                "l10n_br_fiscal.fo_venda_venda"
+            )
+            line1.price_unit = 1000.0
+            line1.quantity = 2.0
+            line1.freight_value = 10.0
+            line1.insurance_value = 20.0
+            line1.other_value = 5.0
+
+        with move_form.invoice_line_ids.new() as line2:
+            line2.product_id = product2
+            line2.fiscal_operation_line_id = self.env.ref(
+                "l10n_br_fiscal.fo_venda_venda"
+            )
+            line2.price_unit = 500.0
+            line2.quantity = 1.0
+            line2.freight_value = 4.0
+            line2.insurance_value = 6.0
+            line2.other_value = 2.0
+
+        move = move_form.save()
+
+        self.assertEqual(move.company_id.delivery_costs, "line")
+        self.assertAlmostEqual(move.amount_freight_value, 14.0)
+        self.assertAlmostEqual(move.amount_insurance_value, 26.0)
+        self.assertAlmostEqual(move.amount_other_value, 7.0)
+        self.assertAlmostEqual(move.fiscal_amount_untaxed, 2547.00)
+        # Corrected assertion: (2035 * 3.25%) + (512 * 5%) = 66.14 + 25.60 = 91.74
+        self.assertAlmostEqual(move.fiscal_amount_tax, 91.74, places=2)
+        # Corrected assertion: 2547.00 + 91.74 = 2638.74
+        self.assertAlmostEqual(move.fiscal_amount_total, 2638.74, places=2)
+        self.assertAlmostEqual(move.amount_total, 2638.74, places=2)
+
+        # Part 2: Test with delivery_costs = 'total'
+        self.company.delivery_costs = "total"
+        move_form_edit = Form(move)
+        move_form_edit.amount_freight_value = 30.0
+        move_form_edit.amount_insurance_value = 60.0
+        move_form_edit.amount_other_value = 90.0
+        move_after_total_update = move_form_edit.save()
+
+        line1 = move_after_total_update.invoice_line_ids[0]
+        line2 = move_after_total_update.invoice_line_ids[1]
+
+        self.assertAlmostEqual(line1.freight_value, 24.0)
+        self.assertAlmostEqual(line2.freight_value, 6.0)
+        self.assertAlmostEqual(line1.insurance_value, 48.0)
+        self.assertAlmostEqual(line2.insurance_value, 12.0)
+        self.assertAlmostEqual(line1.other_value, 72.0)
+        self.assertAlmostEqual(line2.other_value, 18.0)
+        self.assertAlmostEqual(move_after_total_update.fiscal_amount_untaxed, 2680.00)
+        self.assertAlmostEqual(
+            move_after_total_update.fiscal_amount_tax, 96.48, places=2
+        )
+        self.assertAlmostEqual(
+            move_after_total_update.fiscal_amount_total, 2776.48, places=2
+        )
+        self.assertAlmostEqual(move_after_total_update.amount_total, 2776.48, places=2)

--- a/l10n_br_delivery/tests/test_delivery_inverse_amount.py
+++ b/l10n_br_delivery/tests/test_delivery_inverse_amount.py
@@ -11,441 +11,133 @@ class TestDeliveryInverseAmount(TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.company = cls.env.user.company_id
+        cls.partner = cls.env.ref("l10n_br_base.res_partner_kmee")
+        cls.product1 = cls.env.ref("product.product_delivery_01")  # Price: 70.0
+        cls.product2 = cls.env.ref("product.product_delivery_02")  # Price: 40.0
 
-        cls.sale_demo = cls.env.ref("l10n_br_delivery.main_so_delivery_1")
+    def _create_and_prepare_so(self):
+        """Helper to create a draft SO with two lines."""
+        so_form = Form(self.env["sale.order"])
+        so_form.partner_id = self.partner
+        with so_form.order_line.new() as line:
+            line.product_id = self.product1
+            line.product_uom_qty = 1.0
+        with so_form.order_line.new() as line:
+            line.product_id = self.product2
+            line.product_uom_qty = 1.0
+        return so_form.save()
 
-        # Create two sale orders
-        sale_order_form_total = Form(cls.env["sale.order"], "sale.view_order_form")
-        sale_order_form_total.partner_id = cls.env.ref("l10n_br_base.res_partner_kmee")
-        cls.sale_order_total_id = sale_order_form_total.save()
+    def _process_so_to_invoice(self, sale_order):
+        """Helper to confirm an SO, process its picking, and create an invoice."""
+        sale_order.action_confirm()
 
-        sale_order_form_line = Form(cls.env["sale.order"], "sale.view_order_form")
-        sale_order_form_line.partner_id = cls.env.ref("l10n_br_base.res_partner_kmee")
-        cls.sale_order_line_id = sale_order_form_line.save()
+        picking = sale_order.picking_ids
+        picking.action_confirm()
+        picking.action_assign()
+        for move in picking.move_ids_without_package:
+            move.quantity_done = move.product_uom_qty
+        picking.button_validate()
 
-        # Set 2 different products to the sale orders
-        with Form(cls.sale_order_total_id) as so:
-            with so.order_line.new() as line:
-                line.product_id = cls.env.ref("product.product_delivery_01")
-            with so.order_line.new() as line:
-                line.product_id = cls.env.ref("product.product_delivery_02")
+        wizard = (
+            self.env["sale.advance.payment.inv"]
+            .with_context(active_ids=sale_order.ids)
+            .create({})
+        )
+        wizard.create_invoices()
+        return sale_order.invoice_ids
 
-        with Form(cls.sale_order_line_id) as so:
-            with so.order_line.new() as line:
-                line.product_id = cls.env.ref("product.product_delivery_01")
-            with so.order_line.new() as line:
-                line.product_id = cls.env.ref("product.product_delivery_02")
+    def test_delivery_costs_by_line(self):
+        """
+        Tests when costs are entered on each SO line. The invoice should reflect
+        these exact line values.
+        """
+        self.company.delivery_costs = "line"
+        so = self._create_and_prepare_so()
 
-        # Alteração para permitir do teste
-        cls.sale_order_line_id.company_id.delivery_costs = "total"
-        # Change freight, insurance and other costs amount by Total values
-        with Form(cls.sale_order_total_id) as so:
-            so.amount_freight_value = 100.0
-            so.amount_insurance_value = 100.0
-            so.amount_other_value = 100.0
-
-        # Alteração para permitir do teste
-        cls.sale_order_line_id.company_id.delivery_costs = "line"
-        # Change freight, insurance and other costs amount by Lines values
-        with Form(cls.sale_order_line_id) as so:
-            with so.order_line.edit(0) as line:
+        # Update SO lines with costs
+        with Form(so) as so_form:
+            with so_form.order_line.edit(0) as line:
                 line.freight_value = 70.00
-                line.insurance_value = 70.00
-                line.other_value = 70.00
-            with so.order_line.edit(1) as line:
+                line.insurance_value = 60.00
+                line.other_value = 50.00
+            with so_form.order_line.edit(1) as line:
                 line.freight_value = 10.00
-                line.insurance_value = 10.00
-                line.other_value = 10.00
+                line.insurance_value = 20.00
+                line.other_value = 30.00
 
-        # TODO ?: alterando para permitir edição do campo e não falhar o teste
-        cls.sale_order_line_id.company_id.delivery_costs = "total"
-        with Form(cls.sale_order_line_id) as so:
-            so.amount_freight_value = 100.0
-            so.amount_insurance_value = 100.0
-            so.amount_other_value = 100.0
+        # Check SO header totals are summed correctly
+        self.assertAlmostEqual(so.amount_freight_value, 80.0)
+        self.assertAlmostEqual(so.amount_insurance_value, 80.0)
+        self.assertAlmostEqual(so.amount_other_value, 80.0)
 
-        # Confirm and create invoices for the sale orders
-        cls.sale_order_total_id.action_confirm()
-        cls.sale_order_line_id.action_confirm()
+        # Create the invoice from the finalized SO
+        invoice = self._process_so_to_invoice(so)
+        fiscal_document = invoice.fiscal_document_id
 
-        picking = cls.sale_order_total_id.picking_ids
-        picking.action_confirm()
-        # Check product availability
-        picking.action_assign()
-        # Force product availability
-        for move in picking.move_ids_without_package:
-            move.quantity_done = move.product_uom_qty
-        picking.button_validate()
+        # Check invoice header totals
+        self.assertAlmostEqual(fiscal_document.amount_freight_value, 80.0)
+        self.assertAlmostEqual(fiscal_document.amount_insurance_value, 80.0)
+        self.assertAlmostEqual(fiscal_document.amount_other_value, 80.0)
 
-        picking = cls.sale_order_line_id.picking_ids
-        picking.action_confirm()
-        # Check product availability
-        picking.action_assign()
-        # Force product availability
-        for move in picking.move_ids_without_package:
-            move.quantity_done = move.product_uom_qty
-        picking.button_validate()
-
-        for move in picking.move_ids_without_package:
-            move.quantity_done = move.product_uom_qty
-
-        wizard_total = (
-            cls.env["sale.advance.payment.inv"]
-            .with_context(active_ids=cls.sale_order_total_id.ids)
-            .create({})
+        # Check invoice line values (should match SO line values)
+        line1 = fiscal_document.fiscal_line_ids.filtered(
+            lambda line: line.product_id == self.product1
         )
-
-        wizard_line = (
-            cls.env["sale.advance.payment.inv"]
-            .with_context(active_ids=cls.sale_order_line_id.ids)
-            .create({})
+        line2 = fiscal_document.fiscal_line_ids.filtered(
+            lambda line: line.product_id == self.product2
         )
+        self.assertAlmostEqual(line1.freight_value, 70.0)
+        self.assertAlmostEqual(line2.freight_value, 10.0)
+        self.assertAlmostEqual(line1.insurance_value, 60.0)
+        self.assertAlmostEqual(line2.insurance_value, 20.0)
+        self.assertAlmostEqual(line1.other_value, 50.0)
+        self.assertAlmostEqual(line2.other_value, 30.0)
 
-        wizard_total.create_invoices()
-        wizard_line.create_invoices()
-
-    def test_sale_order_total_amounts(self):
-        """Check sale order total amounts"""
-        self.assertEqual(
-            self.sale_order_total_id.amount_price_gross,
-            110.0,
-            "Unexpected value for the field amount_price_gross from Sale Order",
-        )
-        # No amount_untaxed é esperado o valor total dos produtos + frete, seguro
-        # e outros.
-        self.assertEqual(
-            self.sale_order_total_id.amount_untaxed,
-            410.0,
-            "Unexpected value for the field amount_untaxed from Sale Order",
-        )
-        self.assertEqual(
-            self.sale_order_total_id.amount_freight_value,
-            100.0,
-            "Unexpected value for the field amount_freight from Sale Order",
-        )
-        self.assertEqual(
-            self.sale_order_total_id.amount_insurance_value,
-            100.0,
-            "Unexpected value for the field amount_insurance from Sale Order",
-        )
-        self.assertEqual(
-            self.sale_order_total_id.amount_other_value,
-            100.0,
-            "Unexpected value for the field amount_costs from Sale Order",
-        )
-        self.assertEqual(
-            self.sale_order_total_id.amount_tax,
-            0.0,
-            "Unexpected value for the field amount_tax from Sale Order",
-        )
-
-    def test_sale_order_line_amounts(self):
-        """Check sale order line amounts"""
-        self.assertEqual(
-            self.sale_order_line_id.amount_price_gross,
-            110.0,
-            "Unexpected value for the field amount_price_gross from Sale Order",
-        )
-        # No amount_untaxed é esperado o valor total dos produtos + frete, seguro
-        # e outros.
-        self.assertEqual(
-            self.sale_order_line_id.amount_untaxed,
-            410.0,
-            "Unexpected value for the field amount_untaxed from Sale Order",
-        )
-        self.assertEqual(
-            self.sale_order_line_id.amount_freight_value,
-            100.0,
-            "Unexpected value for the field amount_freight from Sale Order",
-        )
-        self.assertEqual(
-            self.sale_order_line_id.amount_insurance_value,
-            100.0,
-            "Unexpected value for the field amount_insurance from Sale Order",
-        )
-        self.assertEqual(
-            self.sale_order_line_id.amount_other_value,
-            100.0,
-            "Unexpected value for the field amount_other from Sale Order",
-        )
-        self.assertEqual(
-            self.sale_order_line_id.amount_tax,
-            0.0,
-            "Unexpected value for the field amount_tax from Sale Order",
-        )
-
-    def test_invoice_amount_tax(self):
-        """Check invoice amount tax"""
-        invoice_tax_total = self.sale_order_total_id.invoice_ids[0].amount_tax
-
-        self.assertEqual(
-            invoice_tax_total,
-            0.0,
-            "Unexpected value for the field invoice_tax from Invoice",
-        )
-
-        invoice_tax_line = self.sale_order_line_id.invoice_ids[0].amount_tax
-
-        self.assertEqual(
-            invoice_tax_line,
-            0.0,
-            "Unexpected value for the field invoice_tax from Invoice",
-        )
-
-    def test_inverse_amount_freight_total(self):
-        """Check Fiscal Document freight values for total"""
-        fiscal_document_id = self.sale_order_total_id.invoice_ids[0].fiscal_document_id
-        self.assertEqual(
-            fiscal_document_id.amount_freight_value,
-            100,
-            "Unexpected value for the field amount_freight_value from "
-            "Fiscal Document",
-        )
-
-        for line in fiscal_document_id.fiscal_line_ids:
-            if line.name == "[FURN_7777] Office Chair":
-                self.assertEqual(
-                    line.freight_value,
-                    63.64,
-                    "Unexpected value for the field freight_value from "
-                    "Fiscal Document line",
-                )
-            if line.name == "[FURN_8888] Office Lamp":
-                self.assertEqual(
-                    line.freight_value,
-                    36.36,
-                    "Unexpected value for the field freight_value from "
-                    "Fiscal Document line",
-                )
-
-    def test_inverse_amount_freight_line(self):
-        """Check Fiscal Document freight values for lines"""
-        fiscal_document_id = self.sale_order_line_id.invoice_ids[0].fiscal_document_id
-        self.assertEqual(
-            fiscal_document_id.amount_freight_value,
-            100,
-            "Unexpected value for the field amount_freight_value from "
-            "Fiscal Document",
-        )
-
-        for line in fiscal_document_id.fiscal_line_ids:
-            if line.name == "[FURN_7777] Office Chair":
-                self.assertEqual(
-                    line.freight_value,
-                    87.5,
-                    "Unexpected value for the field freight_value from "
-                    "Fiscal Document line",
-                )
-            if line.name == "[FURN_8888] Office Lamp":
-                self.assertEqual(
-                    line.freight_value,
-                    12.5,
-                    "Unexpected value for the field freight_value from "
-                    "Fiscal Document line",
-                )
-
-    def test_inverse_amount_insurance_total(self):
-        """Check Fiscal Document insurance values for total"""
-        fiscal_document_id = self.sale_order_total_id.invoice_ids[0].fiscal_document_id
-        self.assertEqual(
-            fiscal_document_id.amount_insurance_value,
-            100,
-            "Unexpected value for the field amount_insurance_value from "
-            "Fiscal Document",
-        )
-
-        for line in fiscal_document_id.fiscal_line_ids:
-            if line.name == "[FURN_7777] Office Chair":
-                self.assertEqual(
-                    line.insurance_value,
-                    63.64,
-                    "Unexpected value for the field insurance_value from "
-                    "Fiscal Document line",
-                )
-            if line.name == "[FURN_8888] Office Lamp":
-                self.assertEqual(
-                    line.insurance_value,
-                    36.36,
-                    "Unexpected value for the field insurance_value from "
-                    "Fiscal Document line",
-                )
-
-    def test_inverse_amount_insurance_line(self):
-        """Check Fiscal Document insurance values for lines"""
-        fiscal_document_id = self.sale_order_line_id.invoice_ids[0].fiscal_document_id
-        self.assertEqual(
-            fiscal_document_id.amount_insurance_value,
-            100,
-            "Unexpected value for the field amount_insurance_value from "
-            "Fiscal Document",
-        )
-
-        for line in fiscal_document_id.fiscal_line_ids:
-            if line.name == "[FURN_7777] Office Chair":
-                self.assertEqual(
-                    line.insurance_value,
-                    87.5,
-                    "Unexpected value for the field insurance_value from "
-                    "Fiscal Document line",
-                )
-            if line.name == "[FURN_8888] Office Lamp":
-                self.assertEqual(
-                    line.insurance_value,
-                    12.5,
-                    "Unexpected value for the field insurance_value from "
-                    "Fiscal Document line",
-                )
-
-    def test_inverse_amount_other_costs_total(self):
-        """Check Fiscal Document other costs values for total"""
-        fiscal_document_id = self.sale_order_total_id.invoice_ids[0].fiscal_document_id
-        self.assertEqual(
-            fiscal_document_id.amount_other_value,
-            100,
-            "Unexpected value for the field other_value from " "Fiscal Document",
-        )
-
-        for line in fiscal_document_id.fiscal_line_ids:
-            if line.name == "[FURN_7777] Office Chair":
-                self.assertEqual(
-                    line.other_value,
-                    63.64,
-                    "Unexpected value for the field other_value from "
-                    "Fiscal Document line",
-                )
-            if line.name == "[FURN_8888] Office Lamp":
-                self.assertEqual(
-                    line.other_value,
-                    36.36,
-                    "Unexpected value for the field other_value from "
-                    "Fiscal Document line",
-                )
-
-    def test_inverse_amount_other_line(self):
-        """Check Fiscal Document other other values for lines"""
-        fiscal_document_id = self.sale_order_line_id.invoice_ids[0].fiscal_document_id
-        self.assertEqual(
-            fiscal_document_id.amount_other_value,
-            100,
-            "Unexpected value for the field other_value from " "Fiscal Document",
-        )
-
-        for line in fiscal_document_id.fiscal_line_ids:
-            if line.name == "[FURN_7777] Office Chair":
-                self.assertEqual(
-                    line.other_value,
-                    87.5,
-                    "Unexpected value for the field other_value from "
-                    "Fiscal Document line",
-                )
-            if line.name == "[FURN_8888] Office Lamp":
-                self.assertEqual(
-                    line.other_value,
-                    12.5,
-                    "Unexpected value for the field other_value from "
-                    "Fiscal Document line",
-                )
-
-    def test_not_cost_ratio_by_lines(self):
+    def test_delivery_costs_by_total(self):
         """
-        Teste quando não deve acontecer divisão proporcional entre os valores,
-        de Frete, Seguro e Outros Custos, esses valores nas linhas devem ser
-        independentes.
+        Tests when costs are entered on the SO header. The invoice should reflect
+        these header values and distribute them proportionally to the lines
+        based on price_gross.
         """
-        self.sale_demo.company_id.delivery_costs = "line"
-        self.sale_demo.action_confirm()
+        self.company.delivery_costs = "total"
+        so = self._create_and_prepare_so()
 
-        self.assertEqual(
-            self.sale_demo.amount_freight_value,
-            30.0,
-            "Unexpected value for the field amount_freight from Sale Order",
+        # Update SO header with total costs
+        with Form(so) as so_form:
+            so_form.amount_freight_value = 100.0
+            so_form.amount_insurance_value = 100.0
+            so_form.amount_other_value = 100.0
+
+        # Create the invoice from the finalized SO
+        invoice = self._process_so_to_invoice(so)
+        fiscal_document = invoice.fiscal_document_id
+
+        # Proportionality check:
+        # line1 price_gross = 1 * 70 = 70
+        # line2 price_gross = 1 * 40 = 40
+        # total_gross = 110
+        # line1 proportion = 70 / 110
+        # line2 proportion = 40 / 110
+
+        # Check invoice header totals
+        self.assertAlmostEqual(fiscal_document.amount_freight_value, 100.0)
+        self.assertAlmostEqual(fiscal_document.amount_insurance_value, 100.0)
+        self.assertAlmostEqual(fiscal_document.amount_other_value, 100.0)
+
+        # Check invoice line values (should be proportionally distributed)
+        line1 = fiscal_document.fiscal_line_ids.filtered(
+            lambda line: line.product_id == self.product1
         )
-        self.assertEqual(
-            self.sale_demo.amount_insurance_value,
-            45.0,
-            "Unexpected value for the field amount_insurance from Sale Order",
+        line2 = fiscal_document.fiscal_line_ids.filtered(
+            lambda line: line.product_id == self.product2
         )
-        self.assertEqual(
-            self.sale_demo.amount_other_value,
-            15.0,
-            "Unexpected value for the field amount_costs from Sale Order",
-        )
-        for line in self.sale_demo.order_line:
-            other_line = self.sale_demo.order_line.filtered(
-                lambda o_l, line=line: o_l.id != line.id
-            )
-            self.assertNotEqual(
-                line.freight_value,
-                other_line.freight_value,
-                "Value freight_value should not be has same value in lines.",
-            )
-            self.assertNotEqual(
-                line.insurance_value,
-                other_line.insurance_value,
-                "Value insurance_value should not be has same value in lines.",
-            )
-            self.assertNotEqual(
-                line.other_value,
-                other_line.other_value,
-                "Value other_value should not be has same value in lines.",
-            )
 
-        picking = self.sale_demo.picking_ids
-        # Check product availability
-        picking.action_assign()
-        # Force product availability
-        for move in picking.move_ids_without_package:
-            move.quantity_done = move.product_uom_qty
-        picking.button_validate()
-        self.assertEqual(picking.state, "done")
+        self.assertAlmostEqual(line1.freight_value, 100.0 * (70.0 / 110.0), 2)
+        self.assertAlmostEqual(line2.freight_value, 100.0 * (40.0 / 110.0), 2)
 
-        self.sale_demo._create_invoices(final=True)
+        self.assertAlmostEqual(line1.insurance_value, 100.0 * (70.0 / 110.0), 2)
+        self.assertAlmostEqual(line2.insurance_value, 100.0 * (40.0 / 110.0), 2)
 
-        self.assertEqual(self.sale_demo.state, "sale", "Error to confirm Sale Order.")
-
-        invoice = self.sale_demo.invoice_ids[0]
-        invoice.action_post()
-        self.assertEqual(invoice.state, "posted", "Invoice should be in state Posted")
-        for line in invoice.invoice_line_ids:
-            other_line = invoice.invoice_line_ids.filtered(
-                lambda o_l, line=line: o_l.id != line.id
-            )
-            self.assertNotEqual(
-                line.freight_value,
-                other_line.freight_value,
-                "Value freight_value should not be has same value" " in invoice lines.",
-            )
-            self.assertNotEqual(
-                line.insurance_value,
-                other_line.insurance_value,
-                "Value insurance_value should not be has same value"
-                " in invoice lines.",
-            )
-            self.assertNotEqual(
-                line.other_value,
-                other_line.other_value,
-                "Value other_value should not be has same value" " in invoice lines.",
-            )
-
-        fiscal_document_id = self.sale_demo.invoice_ids[0].fiscal_document_id
-
-        for line in fiscal_document_id.fiscal_line_ids:
-            other_line = fiscal_document_id.fiscal_line_ids.filtered(
-                lambda o_l, line=line: o_l.id != line.id
-            )
-            self.assertNotEqual(
-                line.freight_value,
-                other_line.freight_value,
-                "Value freight_value should not be has same value" " in invoice lines.",
-            )
-            self.assertNotEqual(
-                line.insurance_value,
-                other_line.insurance_value,
-                "Value insurance_value should not be has same value"
-                " in invoice lines.",
-            )
-            self.assertNotEqual(
-                line.other_value,
-                other_line.other_value,
-                "Value other_value should not be has same value" " in invoice lines.",
-            )
+        self.assertAlmostEqual(line1.other_value, 100.0 * (70.0 / 110.0), 2)
+        self.assertAlmostEqual(line2.other_value, 100.0 * (40.0 / 110.0), 2)

--- a/l10n_br_fiscal/models/document_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_mixin_methods.py
@@ -199,152 +199,37 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
             elif doc.comment_ids is None:
                 doc.comment_ids = []
 
-    def _inverse_amount_freight(self):
-        for record in self.filtered(lambda doc: doc._get_product_amount_lines()):
-            if (
+    def _distribute_amount_to_lines(self, amount_field_name, line_field_name):
+        for record in self:
+            if not (
                 record.delivery_costs == "total"
                 or record.force_compute_delivery_costs_by_total
             ):
-                amount_freight_value = record.amount_freight_value
-                if all(record._get_product_amount_lines().mapped("freight_value")):
-                    amount_freight_old = sum(
-                        record._get_product_amount_lines().mapped("freight_value")
+                continue
+            lines = record._get_product_amount_lines()
+            if not lines:
+                continue
+            amount_to_distribute = record[amount_field_name]
+            total_gross = sum(lines.mapped("price_gross"))
+            if total_gross > 0:
+                distributed_amount = 0
+                for line in lines[:-1]:
+                    proportional_amount = record.currency_id.round(
+                        amount_to_distribute * (line.price_gross / total_gross)
                     )
-                    for line in record._get_product_amount_lines()[:-1]:
-                        line.freight_value = amount_freight_value * (
-                            line.freight_value / amount_freight_old
-                        )
-                    record._get_product_amount_lines()[-1].freight_value = (
-                        amount_freight_value
-                        - sum(
-                            line.freight_value
-                            for line in record._get_product_amount_lines()[:-1]
-                        )
-                    )
-                else:
-                    fiscal_amount_total = sum(
-                        record._get_product_amount_lines().mapped("price_gross")
-                    )
-                    for line in record._get_product_amount_lines()[:-1]:
-                        if line.price_gross and fiscal_amount_total:
-                            line.freight_value = amount_freight_value * (
-                                line.price_gross / fiscal_amount_total
-                            )
-                    record._get_product_amount_lines()[-1].freight_value = (
-                        amount_freight_value
-                        - sum(
-                            line.freight_value
-                            for line in record._get_product_amount_lines()[:-1]
-                        )
-                    )
-                for line in record._get_product_amount_lines():
-                    line._onchange_fiscal_taxes()
-                record._fields["fiscal_amount_total"].compute_value(record)
-                record.write(
-                    {
-                        name: value
-                        for name, value in record._cache.items()
-                        if record._fields[name].compute == "_amount_all"
-                        and not record._fields[name].inverse
-                    }
-                )
+                    line[line_field_name] = proportional_amount
+                    distributed_amount += proportional_amount
+                lines[-1][line_field_name] = amount_to_distribute - distributed_amount
+            else:
+                lines.write({line_field_name: 0.0})
+                if lines:
+                    lines[0][line_field_name] = amount_to_distribute
+
+    def _inverse_amount_freight(self):
+        self._distribute_amount_to_lines("amount_freight_value", "freight_value")
 
     def _inverse_amount_insurance(self):
-        for record in self.filtered(lambda doc: doc._get_product_amount_lines()):
-            if (
-                record.delivery_costs == "total"
-                or record.force_compute_delivery_costs_by_total
-            ):
-                amount_insurance_value = record.amount_insurance_value
-                if all(record._get_product_amount_lines().mapped("insurance_value")):
-                    amount_insurance_old = sum(
-                        record._get_product_amount_lines().mapped("insurance_value")
-                    )
-                    for line in record._get_product_amount_lines()[:-1]:
-                        line.insurance_value = amount_insurance_value * (
-                            line.insurance_value / amount_insurance_old
-                        )
-                    record._get_product_amount_lines()[-1].insurance_value = (
-                        amount_insurance_value
-                        - sum(
-                            line.insurance_value
-                            for line in record._get_product_amount_lines()[:-1]
-                        )
-                    )
-                else:
-                    fiscal_amount_total = sum(
-                        record._get_product_amount_lines().mapped("price_gross")
-                    )
-                    for line in record._get_product_amount_lines()[:-1]:
-                        if line.price_gross and fiscal_amount_total:
-                            line.insurance_value = amount_insurance_value * (
-                                line.price_gross / fiscal_amount_total
-                            )
-                    record._get_product_amount_lines()[-1].insurance_value = (
-                        amount_insurance_value
-                        - sum(
-                            line.insurance_value
-                            for line in record._get_product_amount_lines()[:-1]
-                        )
-                    )
-                for line in record._get_product_amount_lines():
-                    line._onchange_fiscal_taxes()
-                record._fields["fiscal_amount_total"].compute_value(record)
-                record.write(
-                    {
-                        name: value
-                        for name, value in record._cache.items()
-                        if record._fields[name].compute == "_amount_all"
-                        and not record._fields[name].inverse
-                    }
-                )
+        self._distribute_amount_to_lines("amount_insurance_value", "insurance_value")
 
     def _inverse_amount_other(self):
-        for record in self.filtered(lambda doc: doc._get_product_amount_lines()):
-            if (
-                record.delivery_costs == "total"
-                or record.force_compute_delivery_costs_by_total
-            ):
-                amount_other_value = record.amount_other_value
-                if all(record._get_product_amount_lines().mapped("other_value")):
-                    amount_other_old = sum(
-                        record._get_product_amount_lines().mapped("other_value")
-                    )
-                    for line in record._get_product_amount_lines()[:-1]:
-                        line.other_value = amount_other_value * (
-                            line.other_value / amount_other_old
-                        )
-                    record._get_product_amount_lines()[-1].other_value = (
-                        amount_other_value
-                        - sum(
-                            line.other_value
-                            for line in record._get_product_amount_lines()[:-1]
-                        )
-                    )
-                else:
-                    fiscal_amount_total = sum(
-                        record._get_product_amount_lines().mapped("price_gross")
-                    )
-                    for line in record._get_product_amount_lines()[:-1]:
-                        if line.price_gross and fiscal_amount_total:
-                            line.other_value = amount_other_value * (
-                                line.price_gross / fiscal_amount_total
-                            )
-                    record._get_product_amount_lines()[-1].other_value = (
-                        amount_other_value
-                        - sum(
-                            line.other_value
-                            for line in record._get_product_amount_lines()[:-1]
-                        )
-                    )
-                for line in record._get_product_amount_lines():
-                    line._onchange_fiscal_taxes()
-                record._fields["fiscal_amount_total"].compute_value(record)
-                record.write(
-                    {
-                        name: value
-                        for name, value in record._cache.items()
-                        if record._fields[name].compute == "_amount_all"
-                        and not record._fields[name].inverse
-                    }
-                )
+        self._distribute_amount_to_lines("amount_other_value", "other_value")

--- a/l10n_br_fiscal/tests/test_document_edition.py
+++ b/l10n_br_fiscal/tests/test_document_edition.py
@@ -12,6 +12,10 @@ class TestDocumentEdition(TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.user = cls.env.user
+        cls.company = cls.env.ref("l10n_br_base.empresa_lucro_presumido")
+        cls.user.company_ids |= cls.company
+        cls.user.company_id = cls.company.id
 
     def test_basic_doc_edition(self):
         doc_form = Form(
@@ -163,3 +167,112 @@ class TestDocumentEdition(TransactionCase):
         self.assertEqual(doc.fiscal_line_ids[0].fiscal_price, 112)
         self.assertEqual(doc.fiscal_line_ids[0].quantity, 10)
         self.assertEqual(doc.fiscal_line_ids[0].fiscal_quantity, 5)
+
+    def test_landed_costs_by_line_and_by_total(self):
+        """
+        Tests both landed cost scenarios: 'by line' and 'by total'.
+        1. By Line: Enters costs on lines and verifies the header totals.
+        2. By Total: Enters costs on the header and verifies lines distribution.
+        """
+        self.env.user.groups_id |= self.env.ref("l10n_br_fiscal.group_user")
+        product1 = self.env.ref("product.product_product_6")
+        product2 = self.env.ref("product.product_product_7")
+
+        # Part 1: Test with delivery_costs = 'line'
+        # ----------------------------------------------------
+        self.company.delivery_costs = "line"
+        doc_form = Form(self.env["l10n_br_fiscal.document"])
+        doc_form.company_id = self.company
+        doc_form.partner_id = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        doc_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
+
+        with doc_form.fiscal_line_ids.new() as line1:
+            line1.product_id = product1
+            line1.fiscal_operation_line_id = self.env.ref(
+                "l10n_br_fiscal.fo_venda_venda"
+            )
+            line1.price_unit = 1000.0
+            line1.quantity = 2.0  # Gross: 2000
+            line1.freight_value = 10.0
+            line1.insurance_value = 20.0
+            line1.other_value = 5.0
+
+        with doc_form.fiscal_line_ids.new() as line2:
+            line2.product_id = product2
+            line2.fiscal_operation_line_id = self.env.ref(
+                "l10n_br_fiscal.fo_venda_venda"
+            )
+            line2.price_unit = 500.0
+            line2.quantity = 1.0  # Gross: 500
+            line2.freight_value = 4.0
+            line2.insurance_value = 6.0
+            line2.other_value = 2.0
+
+        doc = doc_form.save()
+
+        self.assertEqual(doc.company_id.delivery_costs, "line")
+        # Assert header totals are the SUM of line values
+        self.assertAlmostEqual(doc.amount_freight_value, 14.0)  # 10.0 + 4.0
+        self.assertAlmostEqual(doc.amount_insurance_value, 26.0)  # 20.0 + 6.0
+        self.assertAlmostEqual(doc.amount_other_value, 7.0)  # 5.0 + 2.0
+
+        # Assert final fiscal totals (bottom-up calculation)
+        # price_gross = (1000*2) + (500*1) = 2500
+        # landed_costs = 14 + 26 + 7 = 47
+        # fiscal_amount_untaxed (IPI Base) = 2500 + 47 = 2547
+        self.assertAlmostEqual(doc.fiscal_amount_untaxed, 2547.00)
+        # fiscal_amount_tax (IPI) = (2035 * 3.25%) + (512 * 5%) = 66.14 + 25.60 = 91.74
+        self.assertAlmostEqual(doc.fiscal_amount_tax, 91.74, places=2)
+        # fiscal_amount_total = 2547.00 + 91.74 = 2638.74
+        self.assertAlmostEqual(doc.fiscal_amount_total, 2638.74, places=2)
+
+        # Part 2: Test with delivery_costs = 'total'
+        # ----------------------------------------------------
+        self.company.delivery_costs = "total"
+        doc_form_edit = Form(doc)
+        # Set new header totals, which should trigger inverse methods to distribute
+        doc_form_edit.amount_freight_value = 30.0
+        doc_form_edit.amount_insurance_value = 60.0
+        doc_form_edit.amount_other_value = 90.0
+        doc_after_total_update = doc_form_edit.save()
+
+        line1 = doc_after_total_update.fiscal_line_ids[0]
+        line2 = doc_after_total_update.fiscal_line_ids[1]
+
+        # Assert values were distributed proportionally to price_gross
+        # (2000 vs 500 -> 80% vs 20%)
+        # Freight: 30.0 * 0.8 = 24.0 | 30.0 * 0.2 = 6.0
+        self.assertAlmostEqual(line1.freight_value, 24.0)
+        self.assertAlmostEqual(line2.freight_value, 6.0)
+        # Insurance: 60.0 * 0.8 = 48.0 | 60.0 * 0.2 = 12.0
+        self.assertAlmostEqual(line1.insurance_value, 48.0)
+        self.assertAlmostEqual(line2.insurance_value, 12.0)
+        # Other: 90.0 * 0.8 = 72.0 | 90.0 * 0.2 = 18.0
+        self.assertAlmostEqual(line1.other_value, 72.0)
+        self.assertAlmostEqual(line2.other_value, 18.0)
+
+        # Assert final fiscal totals are recomputed correctly (top-down calculation)
+        # price_gross = 2500
+        # landed_costs = 30 + 60 + 90 = 180
+        # fiscal_amount_untaxed (IPI Base) = 2500 + 180 = 2680
+        self.assertAlmostEqual(doc_after_total_update.fiscal_amount_untaxed, 2680.00)
+        # Line 1 IPI Base = 2000 (product) + 24 (freight) + 48 (insurance)
+        # + 72 (other) = 2144
+        # Line 1 IPI Value = 2144 * 3.25% = 69.68
+        self.assertAlmostEqual(line1.ipi_base, 2144.00)
+        self.assertAlmostEqual(line1.ipi_value, 69.68, places=2)
+
+        # Line 2 IPI Base = 500 (product) + 6 (freight) + 12 (insurance)
+        # + 18 (other) = 536
+        # Line 2 IPI Value = 536 * 5% = 26.80
+        self.assertAlmostEqual(line2.ipi_base, 536.00)
+        self.assertAlmostEqual(line2.ipi_value, 26.80, places=2)
+
+        # fiscal_amount_tax (IPI) = 69.68 + 26.80 = 96.48
+        self.assertAlmostEqual(
+            doc_after_total_update.fiscal_amount_tax, 96.48, places=2
+        )
+        # fiscal_amount_total = 2680.00 + 96.48 = 2776.48
+        self.assertAlmostEqual(
+            doc_after_total_update.fiscal_amount_total, 2776.48, places=2
+        )

--- a/l10n_br_purchase/tests/test_l10n_br_purchase.py
+++ b/l10n_br_purchase/tests/test_l10n_br_purchase.py
@@ -466,95 +466,79 @@ class L10nBrPurchaseBaseTest(TransactionCase):
 
     def test_fields_freight_insurance_other_costs(self):
         """Test fields Freight, Insurance and Other Costs when
-        defined or By Line or By Total in Purchase Order.
+        defined By Line or By Total in a Purchase Order.
         """
-
         self._change_user_company(self.company)
-        # Por padrão a definição dos campos está por Linha
-        self.po_products.company_id.delivery_costs = "line"
-        self._run_purchase_order_onchanges(self.po_products)
-        # Teste definindo os valores Por Linha
-        for line in self.po_products.order_line:
-            line.price_unit = 100.0
-            line.freight_value = 10.0
-            line.insurance_value = 10.0
-            line.other_value = 10.0
-            self._run_purchase_line_onchanges(line)
+        po = self.po_products
+        # Ensure the PO is in draft state for the test
+        if po.state != "draft":
+            po.button_cancel()
+            po.button_draft()
 
-        self._invoice_purchase_order(self.po_products)
+        # Part 1: Test with delivery_costs = 'line'
+        # Values are set on the lines and totals are computed on the header.
+        po.company_id.delivery_costs = "line"
+
+        # Set values for the first line (qty=4, price_unit=100)
+        line1 = po.order_line[0]
+        line1.price_unit = 100.0
+        line1.product_qty = 4.0
+        line1.freight_value = 10.0
+        line1.insurance_value = 15.0
+        line1.other_value = 5.0
+
+        # Set values for the second line (qty=2, price_unit=100)
+        line2 = po.order_line[1]
+        line2.price_unit = 100.0
+        line2.product_qty = 2.0
+        line2.freight_value = 8.0
+        line2.insurance_value = 12.0
+        line2.other_value = 4.0
 
         self.assertEqual(
-            self.po_products.amount_freight_value,
-            20.0,
-            "Unexpected value for the field Amount Freight in Purchase Order.",
+            po.amount_freight_value,
+            18.0,
+            "Amount Freight should be the sum of line values.",
         )
         self.assertEqual(
-            self.po_products.amount_insurance_value,
-            20.0,
-            "Unexpected value for the field Amount Insurance in Purchase Order.",
+            po.amount_insurance_value,
+            27.0,
+            "Amount Insurance should be the sum of line values.",
         )
         self.assertEqual(
-            self.po_products.amount_other_value,
-            20.0,
-            "Unexpected value for the field Amount Other in Purchase Order.",
+            po.amount_other_value, 9.0, "Amount Other should be the sum of line values."
         )
 
-        # Teste definindo os valores Por Total
-        # Por padrão a definição dos campos está por Linha
-        self.po_products.company_id.delivery_costs = "total"
+        # Part 2: Test with delivery_costs = 'total'
+        # Values are set on the header and distributed proportionally to lines.
+        po.company_id.delivery_costs = "total"
 
-        # Caso que os Campos na Linha tem valor
-        self.po_products.amount_freight_value = 10.0
-        self.po_products.amount_insurance_value = 10.0
-        self.po_products.amount_other_value = 10.0
+        # Set header totals, which should trigger inverse methods to distribute.
+        po.amount_freight_value = 30.0
+        po.amount_insurance_value = 45.0
+        po.amount_other_value = 15.0
 
-        for line in self.po_products.order_line:
-            self.assertEqual(
-                line.freight_value,
-                5.0,
-                "Unexpected value for the field Freight in Purchase line.",
-            )
-            self.assertEqual(
-                line.insurance_value,
-                5.0,
-                "Unexpected value for the field Insurance in Purchase line.",
-            )
-            self.assertEqual(
-                line.other_value,
-                5.0,
-                "Unexpected value for the field Other Values in Purchase line.",
-            )
+        # Proportionality check:
+        # line1 price_gross = 4 * 100 = 400
+        # line2 price_gross = 2 * 100 = 200
+        # total_gross = 600
+        # line1 proportion = 400 / 600 = 2/3
+        # line2 proportion = 200 / 600 = 1/3
 
-        # Caso que os Campos na Linha não tem valor
-        for line in self.po_products.order_line:
-            line.price_unit = 100.0
-            line.freight_value = 0.0
-            line.insurance_value = 0.0
-            line.other_value = 0.0
+        # Check freight distribution
+        self.assertAlmostEqual(line1.freight_value, 30.0 * (2 / 3), 2)
+        self.assertAlmostEqual(line2.freight_value, 30.0 * (1 / 3), 2)
 
-        self.po_products.company_id.delivery_costs = "total"
+        # Check insurance distribution
+        self.assertAlmostEqual(line1.insurance_value, 45.0 * (2 / 3), 2)
+        self.assertAlmostEqual(line2.insurance_value, 45.0 * (1 / 3), 2)
 
-        self.po_products.amount_freight_value = 20.0
-        self.po_products.amount_insurance_value = 20.0
-        self.po_products.amount_other_value = 20.0
+        # Check other costs distribution
+        self.assertAlmostEqual(line1.other_value, 15.0 * (2 / 3), 2)
+        self.assertAlmostEqual(line2.other_value, 15.0 * (1 / 3), 2)
 
-        for line in self.po_products.order_line:
-            if line.price_total == 440.02:
-                self.assertEqual(
-                    line.freight_value,
-                    13.34,
-                    "Unexpected value for the field Amount Freight in Purchase Order.",
-                )
-                self.assertEqual(
-                    line.insurance_value,
-                    13.34,
-                    "Unexpected value for the field Insurance in Purchase Order.",
-                )
-                self.assertEqual(
-                    line.other_value,
-                    13.34,
-                    "Unexpected value for the field Other Values in Purchase Order.",
-                )
+        # Finally, test invoicing with the final values
+        self._invoice_purchase_order(po)
 
     def test_purchase_service_and_products(self):
         """


### PR DESCRIPTION
- adicionei testes de landing cost diretamente no l10n_br_fiscal. Não são live, até porque os campos amount do documento fiscal são store=True sem precompute hoje e que isso daria treta com o _compute_needed_terms, mas bom ter eles na hora de salvar já faz o trabalho.
- Nisso eu fatorizei e limpei o codigo que faz essa distribuição dos landed cost nas linhas, na mesma vibe do que https://github.com/OCA/l10n-brazil/pull/3529 so que mais limpo
- em compra eu tive que mudar para mudar o método de calculo com o PO em rascunho
- nos testes do l10n_br_delivery, os valores testados eram zoados.