### PR TITLE
[16.0][REF] l10n_br_account: fix incoterm warning

### DIFF
--- a/l10n_br_account/models/document.py
+++ b/l10n_br_account/models/document.py
@@ -89,6 +89,7 @@ class FiscalDocument(models.Model):
     # For some reason, perhaps limitation of _inhertis,
     # the related directly in the account.move does not work correctly.
     incoterm_id = fields.Many2one(
+        comodel_name="account.incoterms",
         string="Fiscal Inconterm",
         compute="_compute_incoterm_id",
         inverse="_inverse_incoterm_id",


### PR DESCRIPTION
resolve esse warning (lembrando que depois na 18 os warning travam a CI então é preciso resolver mesmo):

<img width="1145" height="575" alt="2025-09-18_23-33" src="https://github.com/user-attachments/assets/4b73c765-d099-4b7e-bedf-e2a14636d2f8" />


