### PR TITLE
[16.0] l10n_br_account: fix composite move importation

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -309,10 +309,6 @@ class AccountMove(models.Model):
                                 pass
                             else:
                                 untaxed_amount_currency += line.price_subtotal
-                                for tax_result in (line.compute_all_tax or {}).values():
-                                    tax_amount_currency += -sign * tax_result.get(
-                                        "amount_currency", 0.0
-                                    )
                         untaxed_amount = untaxed_amount_currency
                         tax_amount = tax_amount_currency
                     else:

--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -243,16 +243,13 @@ class AccountMove(models.Model):
         "line_ids.cfop_id",
     )
     def _compute_amount(self):
-        # TODO find another way to make test_composite_move work
-        # as compute in compute breaks payment_state
-        # for move in self.filtered(lambda m: m.fiscal_operation_id):
-        #     move._compute_fiscal_amount()  # breaks test_composite_move if removed
-        #     for line in move.line_ids:
-        #         if (
-        #             move.is_invoice(include_receipts=True)
-        #             and line.display_type == "product"
-        #         ):
-        #             line._compute_tax_fields()
+        if "force_fiscal_amount_recompute" in self._context:
+            for move in self.filtered(lambda m: m.fiscal_operation_id):
+                # this is a ugly hack required for importing composite
+                # fiscal documents for instance. It should be used
+                # exceptionnaly as it breaks the dependency chain and
+                # can leave fields such as payment_state inconsistent.
+                move._compute_fiscal_amount()
 
         result = super()._compute_amount()
         for move in self.filtered(lambda m: m.fiscal_operation_id):
@@ -672,6 +669,7 @@ class AccountMove(models.Model):
             move.with_context(
                 default_move_type=move_type,
                 account_predictive_bills_disable_prediction=True,
+                force_fiscal_amount_recompute=True,
             )
         )
         if not move_id or not move.fiscal_document_id:

--- a/l10n_br_account/tests/test_account_move_lc.py
+++ b/l10n_br_account/tests/test_account_move_lc.py
@@ -2046,7 +2046,7 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             move_vals,
         )
 
-    def TODO_test_composite_move(self):
+    def test_composite_move(self):
         # first we make a few assertions about an existing vendor bill:
         self.assertEqual(len(self.move_in_compra_para_revenda.invoice_line_ids), 1)
         self.assertEqual(len(self.move_in_compra_para_revenda.line_ids), 10)


### PR DESCRIPTION
Então isso resolve a importação dos move compostos de vários documentos fiscais, chamando o _compute_fiscal_amount() mas apenas se tiver uma chave de contexto especial. Procurei muito resolver de outra forma mas não vi nada mais simples. Usando de forma exceptional e com o warning nos comentários eu acho que ta de boa.

No segundo commit eu faço uma pequena optimizaçao que da para fazer no Brasil onde não precisa de taxas nos termos de pagamentos.