### PR TITLE
[16.0][FIX] l10n_br_fiscal: fix DIFAL calculation for return operations

### DIFF
--- a/l10n_br_fiscal/models/icms_regulation.py
+++ b/l10n_br_fiscal/models/icms_regulation.py
@@ -2101,7 +2101,7 @@ class ICMSRegulation(models.Model):
             company.state_id != partner.state_id
             and partner.ind_ie_dest == NFE_IND_IE_DEST_9
             and operation_line.fiscal_operation_type == FISCAL_OUT
-            or operation_line.fiscal_operation_id.fiscal_type == "return_in"
+            or operation_line.fiscal_operation_id.fiscal_type != "return_in"
             and operation_line.fiscal_operation_type == FISCAL_IN
         ):
             domain = self._build_map_tax_def_domain(

--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -450,9 +450,13 @@ class Tax(models.Model):
             and cfop.destination == CFOP_DESTINATION_EXTERNAL
             and partner.ind_ie_dest == NFE_IND_IE_DEST_9
             and tax_dict.get("tax_value")
-            and operation_line.fiscal_operation_type == FISCAL_OUT
-            or operation_line.fiscal_operation_id.fiscal_type == "return_in"
-            and operation_line.fiscal_operation_type == FISCAL_IN
+            and (
+                operation_line.fiscal_operation_type == FISCAL_OUT
+                or (
+                    operation_line.fiscal_operation_type == FISCAL_IN
+                    and operation_line.fiscal_operation_id.fiscal_type != "return_in"
+                )
+            )
         ):
             icms_tax_difal, _ = company.icms_regulation_id.map_tax_def_icms_difal(
                 company, partner, product, ncm, nbm, cest, operation_line, ind_final

--- a/l10n_br_fiscal/tests/test_document_edition.py
+++ b/l10n_br_fiscal/tests/test_document_edition.py
@@ -276,3 +276,28 @@ class TestDocumentEdition(TransactionCase):
         self.assertAlmostEqual(
             doc_after_total_update.fiscal_amount_total, 2776.48, places=2
         )
+
+    def test_difal_calculation(self):
+        partner = self.env.ref("l10n_br_base.res_partner_cliente5_pe")
+        partner.ind_ie_dest = "9"
+        doc_form = Form(
+            self.env["l10n_br_fiscal.document"].with_context(
+                default_fiscal_operation_type="out",
+            )
+        )
+        doc_form.company_id = self.company
+        doc_form.partner_id = partner
+        doc_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
+
+        product = self.env.ref("product.product_product_6")
+        with doc_form.fiscal_line_ids.new() as line_form:
+            line_form.product_id = product
+            line_form.price_unit = 100.0
+            line_form.quantity = 1.0
+
+        doc = doc_form.save()
+        line = doc.fiscal_line_ids[0]
+        self.assertEqual(line.icms_destination_base, 100.0)
+        self.assertEqual(line.icms_origin_percent, 7.0)
+        self.assertEqual(line.icms_destination_percent, 20.5)
+        self.assertEqual(line.icms_destination_value, 13.5)

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -344,16 +344,17 @@ class NFeLine(spec_models.StackedModel):
 
         if (
             not self.icms_value
+            or self.icms_value <= 0
             or self.partner_id.ind_ie_dest != "9"
             or self.partner_id.state_id == self.company_id.state_id
             or self.partner_id.country_id != self.company_id.country_id
         ):
             xsd_fields.remove("nfe40_ICMSUFDest")
 
-        if not self.pisst_value:
+        if not self.pisst_value or self.pisst_value <= 0:
             xsd_fields.remove("nfe40_PISST")
 
-        if not self.cofinsst_value:
+        if not self.cofinsst_value or self.cofinsst_value <= 0:
             xsd_fields.remove("nfe40_COFINSST")
 
         if not self.cfop_id.is_import and "nfe40_II" in xsd_fields:


### PR DESCRIPTION
## Objetivo da PR

Calcular o Difal para nota de devolução de venda aqui nessa issue relata o problema #3716

Superseed https://github.com/OCA/l10n-brazil/pull/3686

cc @marcelsavegnago @kaynnan @WesleyOliveira98 @corredato 