### PR TITLE
[16.0][FIX+IMP] l10n_br_account_payment_order, l10n_br_account_payment_brcobranca: Corrigido processo de apagar um account.move e melhoria na cobertura de testes 

### DIFF
--- a/l10n_br_account_payment_brcobranca/tests/common.py
+++ b/l10n_br_account_payment_brcobranca/tests/common.py
@@ -6,6 +6,7 @@ import base64
 import logging
 import os
 
+from odoo import Command
 from odoo.modules import get_resource_path
 from odoo.tests import tagged
 
@@ -137,18 +138,6 @@ class TestBRCobrancaCommon(CNABTestCommon):
             },
         )
 
-        cls.bank_account_ailos = create_with_form_res_partner_bank(
-            cls.env,
-            {
-                "acc_number": "374",
-                "acc_number_dig": "0",
-                "bra_number": "1236",
-                "bra_number_dig": "1",
-                "bank_id": cls.env.ref("l10n_br_base.res_bank_085"),
-                "partner_id": cls.env.company.partner_id,
-            },
-        )
-
         cls.bank_account_nordeste = create_with_form_res_partner_bank(
             cls.env,
             {
@@ -272,24 +261,6 @@ class TestBRCobrancaCommon(CNABTestCommon):
             },
         )
 
-        cls.cnab_seq_ailos = create_with_form_ir_sequence(
-            cls.env,
-            cls.common_sequence_values
-            | {
-                "name": "Sequencia Arquivo CNAB - AILOS 240",
-                "code": "Sequencia Arquivo CNAB - AILOS 240",
-            },
-        )
-
-        cls.own_number_seq_ailos = create_with_form_ir_sequence(
-            cls.env,
-            cls.common_sequence_values
-            | {
-                "name": "Nosso número AILOS",
-                "code": "nosso.numero",
-            },
-        )
-
         cls.cnab_seq_nordeste = create_with_form_ir_sequence(
             cls.env,
             cls.common_sequence_values
@@ -312,6 +283,7 @@ class TestBRCobrancaCommon(CNABTestCommon):
         cls.cnab_config_cef.cnab_processor = "brcobranca"
         cls.cnab_config_itau_400.cnab_processor = "brcobranca"
         cls.cnab_config_itau_240.cnab_processor = "brcobranca"
+        cls.cnab_config_ailos_240.cnab_processor = "brcobranca"
 
         cls.common_cnab_config_values.update({"cnab_processor": "brcobranca"})
 
@@ -366,9 +338,7 @@ class TestBRCobrancaCommon(CNABTestCommon):
         cls.cnab_config_unicred.write(
             {
                 "liq_return_move_code_ids": [
-                    (
-                        6,
-                        0,
+                    Command.set(
                         [
                             cls.env.ref(
                                 "l10n_br_account_payment_order.unicred_240_400_return_01"
@@ -530,55 +500,6 @@ class TestBRCobrancaCommon(CNABTestCommon):
                     "l10n_br_account_payment_order.santander_240_instruction_02"
                 ),
             },
-        )
-
-        cls.cnab_config_ailos = create_with_form_l10n_br_cnab_config(
-            cls.env,
-            cls.common_cnab_config_values
-            | {
-                "name": "Banco AILOS - CNAB 240 (inbound)",
-                "bank_id": cls.env.ref("l10n_br_base.res_bank_085"),
-                "payment_method_id": cls.pay_method_type_240,
-                "boleto_wallet": "01",
-                "boleto_variation": "35",
-                "boleto_discount_code_id": cls.env.ref(
-                    "l10n_br_account_payment_order.ailos_240_boleto_discount_code_1"
-                ),
-                "boleto_interest_code": "2",
-                "cnab_sequence_id": cls.cnab_seq_ailos,
-                "own_number_sequence_id": cls.own_number_seq_ailos,
-                "cnab_company_bank_code": "101004",
-                "sending_code_id": cls.env.ref(
-                    "l10n_br_account_payment_order.ailos_instruction_01"
-                ),
-                "write_off_code_id": cls.env.ref(
-                    "l10n_br_account_payment_order.ailos_instruction_02"
-                ),
-                "boleto_fee_code_id": cls.env.ref(
-                    "l10n_br_account_payment_order.febrabam_240_boleto_fee_code_2"
-                ),
-            },
-        )
-        cls.cnab_config_ailos.write(
-            {
-                "liq_return_move_code_ids": [
-                    (
-                        6,
-                        0,
-                        [
-                            cls.env.ref(
-                                "l10n_br_account_payment_order.ailos_240_return_06"
-                            ).id,
-                            cls.env.ref(
-                                "l10n_br_account_payment_order.ailos_240_return_76"
-                            ).id,
-                            cls.env.ref(
-                                "l10n_br_account_payment_order.ailos_240_return_77"
-                            ).id,
-                        ],
-                    )
-                ],
-            }
         )
 
         cls.cnab_config_nordeste = create_with_form_l10n_br_cnab_config(
@@ -759,25 +680,6 @@ class TestBRCobrancaCommon(CNABTestCommon):
             }
         )
 
-        cls.journal_ailos = create_with_form_account_journal(
-            cls.env,
-            {
-                "name": "Banco AILOS",
-                "type": "bank",
-                "code": "BNC16",
-                "bank_account_id": cls.bank_account_ailos,
-                "edi_format_ids": False,
-                "used_for_import": True,
-                "import_type": "cnab240",
-                "return_auto_reconcile": True,
-            },
-            [
-                {
-                    "name": "AILOS CNAB 240",
-                    "payment_method_id": cls.pay_method_type_240,
-                }
-            ],
-        )
         cls.journal_ailos.write(
             {
                 "used_for_import": True,
@@ -886,18 +788,6 @@ class TestBRCobrancaCommon(CNABTestCommon):
             },
         )
 
-        cls.pay_mode_ailos = create_with_form_account_payment_mode(
-            cls.env,
-            cls.common_pay_mode_values
-            | {
-                "name": "Cobrança AILOS 240",
-                "bank_id": cls.env.ref("l10n_br_base.res_bank_085"),
-                "fixed_journal_id": cls.journal_ailos,
-                "payment_method_id": cls.pay_method_type_240,
-                "cnab_config_id": cls.cnab_config_ailos,
-            },
-        )
-
         cls.pay_mode_nordeste = create_with_form_account_payment_mode(
             cls.env,
             cls.common_pay_mode_values
@@ -996,19 +886,6 @@ class TestBRCobrancaCommon(CNABTestCommon):
             },
             cls.inv_line_common_values,
         )
-
-        cls.invoice_ailos_240 = create_with_form_account_move(
-            cls.env,
-            cls.inv_common_values
-            | {
-                "name": "AILOS CNAB 240",
-                "payment_mode_id": cls.pay_mode_ailos,
-            },
-            cls.inv_line_common_values,
-        )
-        # Altera o valor total para 1000
-        for line in cls.invoice_ailos_240.invoice_line_ids:
-            line.tax_ids = False
 
         cls.invoice_nordeste_400 = create_with_form_account_move(
             cls.env,

--- a/l10n_br_account_payment_brcobranca/tests/test_brcobranca.py
+++ b/l10n_br_account_payment_brcobranca/tests/test_brcobranca.py
@@ -223,6 +223,11 @@ class TestPaymentOrder(TestBRCobrancaCommon):
             )
             self.assertEqual("Retorno CNAB - Banco UNICRED - Conta 372", moves.ref)
             self.assertEqual(self.invoice_unicred_400_2.payment_state, "paid")
+            with self.assertRaises(UserError):
+                self._run_import_return_file(
+                    "CNAB400UNICRED_valor_maior_4.RET",
+                    self.journal_unicred,
+                )
 
     def test_3_ailos_cnab_240(self):
         """

--- a/l10n_br_account_payment_order/models/account_move.py
+++ b/l10n_br_account_payment_order/models/account_move.py
@@ -146,8 +146,7 @@ class AccountMove(models.Model):
 
         if cnab_already_start:
             # Solicitar a Baixa do CNAB
-            invoice = self.env["account.move"].search([("move_id", "=", self.id)])
-            for l_aml in invoice.mapped("due_line_ids"):
+            for l_aml in self.mapped("due_line_ids"):
                 l_aml.update_cnab_for_cancel_invoice()
 
         return super().unlink()

--- a/l10n_br_account_payment_order/tests/common.py
+++ b/l10n_br_account_payment_order/tests/common.py
@@ -8,6 +8,7 @@ from datetime import date
 
 from dateutil.relativedelta import relativedelta
 
+from odoo import Command
 from odoo.exceptions import UserError
 from odoo.fields import Date
 from odoo.tests import Form, tagged
@@ -135,6 +136,18 @@ class CNABTestCommon(AccountTestInvoicingCommon):
             },
         )
 
+        cls.bank_account_ailos = create_with_form_res_partner_bank(
+            cls.env,
+            {
+                "acc_number": "374",
+                "acc_number_dig": "0",
+                "bra_number": "1236",
+                "bra_number_dig": "1",
+                "bank_id": cls.env.ref("l10n_br_base.res_bank_085"),
+                "partner_id": cls.env.company.partner_id,
+            },
+        )
+
         # Sequencias
         cls.common_sequence_values = {
             "number_next_actual": "1",
@@ -196,6 +209,24 @@ class CNABTestCommon(AccountTestInvoicingCommon):
             },
         )
 
+        cls.cnab_seq_ailos = create_with_form_ir_sequence(
+            cls.env,
+            cls.common_sequence_values
+            | {
+                "name": "Sequencia Arquivo CNAB - AILOS 240",
+                "code": "Sequencia Arquivo CNAB - AILOS 240",
+            },
+        )
+
+        cls.own_number_seq_ailos = create_with_form_ir_sequence(
+            cls.env,
+            cls.common_sequence_values
+            | {
+                "name": "Nosso número AILOS",
+                "code": "nosso.numero",
+            },
+        )
+
         # Configurção do CNAB
         cls.common_cnab_config_values = {
             "instructions": "Pagavel em qualquer banco ate o vencimento",
@@ -211,6 +242,17 @@ class CNABTestCommon(AccountTestInvoicingCommon):
             "boleto_interest_perc": "2",
             "boleto_days_protest": "5",
             "boleto_fee_perc": "1",
+            "cnab_processor": False,
+            "change_title_value_code_id": False,
+            "change_maturity_date_code_id": False,
+            "change_discount_date_code_id": False,
+            "protest_title_code_id": False,
+            "suspend_protest_keep_wallet_code_id": False,
+            "grant_discount_code_id": False,
+            "cancel_discount_code_id": False,
+            "grant_rebate_code_id": False,
+            "boleto_byte_idt": False,
+            "boleto_fee_code_id": False,
         }
 
         cls.cnab_config_cef = create_with_form_l10n_br_cnab_config(
@@ -283,9 +325,7 @@ class CNABTestCommon(AccountTestInvoicingCommon):
         cls.cnab_config_cef.write(
             {
                 "liq_return_move_code_ids": [
-                    (
-                        6,
-                        0,
+                    Command.set(
                         [
                             cls.env.ref(
                                 "l10n_br_account_payment_order.cef_240_return_06"
@@ -349,6 +389,56 @@ class CNABTestCommon(AccountTestInvoicingCommon):
             },
         )
 
+        cls.cnab_config_ailos_240 = create_with_form_l10n_br_cnab_config(
+            cls.env,
+            cls.common_cnab_config_values
+            | {
+                "name": "Banco AILOS - CNAB 240 (inbound)",
+                "bank_id": cls.env.ref("l10n_br_base.res_bank_085"),
+                "payment_method_id": cls.pay_method_type_240,
+                "boleto_wallet": "01",
+                "boleto_variation": "35",
+                "boleto_discount_code_id": cls.env.ref(
+                    "l10n_br_account_payment_order.ailos_240_boleto_discount_code_1"
+                ),
+                "boleto_interest_code": "2",
+                "cnab_sequence_id": cls.cnab_seq_ailos,
+                "own_number_sequence_id": cls.own_number_seq_ailos,
+                "cnab_company_bank_code": "101004",
+                "sending_code_id": cls.env.ref(
+                    "l10n_br_account_payment_order.ailos_instruction_01"
+                ),
+                "write_off_code_id": cls.env.ref(
+                    "l10n_br_account_payment_order.ailos_instruction_02"
+                ),
+                "boleto_fee_code_id": cls.env.ref(
+                    "l10n_br_account_payment_order.febrabam_240_boleto_fee_code_2"
+                ),
+                "change_discount_date_code_id": cls.env.ref(
+                    "l10n_br_account_payment_order.ailos_instruction_16"
+                ),
+            },
+        )
+        cls.cnab_config_ailos_240.write(
+            {
+                "liq_return_move_code_ids": [
+                    Command.set(
+                        [
+                            cls.env.ref(
+                                "l10n_br_account_payment_order.ailos_240_return_06"
+                            ).id,
+                            cls.env.ref(
+                                "l10n_br_account_payment_order.ailos_240_return_76"
+                            ).id,
+                            cls.env.ref(
+                                "l10n_br_account_payment_order.ailos_240_return_77"
+                            ).id,
+                        ],
+                    )
+                ],
+            }
+        )
+
         # Diário
         cls.journal_cef = create_with_form_account_journal(
             cls.env,
@@ -401,6 +491,26 @@ class CNABTestCommon(AccountTestInvoicingCommon):
             ],
         )
 
+        cls.journal_ailos = create_with_form_account_journal(
+            cls.env,
+            {
+                "name": "Banco AILOS",
+                "type": "bank",
+                "code": "BNC16",
+                "bank_account_id": cls.bank_account_ailos,
+                "edi_format_ids": False,
+                "used_for_import": True,
+                "import_type": "cnab240",
+                "return_auto_reconcile": True,
+            },
+            [
+                {
+                    "name": "AILOS CNAB 240",
+                    "payment_method_id": cls.pay_method_type_240,
+                }
+            ],
+        )
+
         # Modo de Pagamento
         cls.common_pay_mode_values = {
             "bank_account_link": "fixed",
@@ -445,10 +555,23 @@ class CNABTestCommon(AccountTestInvoicingCommon):
             },
         )
 
+        cls.pay_mode_ailos = create_with_form_account_payment_mode(
+            cls.env,
+            cls.common_pay_mode_values
+            | {
+                "name": "Cobrança AILOS 240",
+                "bank_id": cls.env.ref("l10n_br_base.res_bank_085"),
+                "fixed_journal_id": cls.journal_ailos,
+                "payment_method_id": cls.pay_method_type_240,
+                "cnab_config_id": cls.cnab_config_ailos_240,
+            },
+        )
+
         # Fatura
         cls.inv_common_values = {
             "invoice_payment_term_id": cls.pay_terms_b,
             "partner_id": cls.partner_a,
+            "eval_payment_mode_instructions": "Teste Eval Payment Mode Instructions",
             "instructions": "TESTE Intruções Boleto",
         }
         cls.inv_line_common_values = {
@@ -490,6 +613,19 @@ class CNABTestCommon(AccountTestInvoicingCommon):
             },
             cls.inv_line_common_values,
         )
+
+        cls.invoice_ailos_240 = create_with_form_account_move(
+            cls.env,
+            cls.inv_common_values
+            | {
+                "name": "AILOS CNAB 240",
+                "payment_mode_id": cls.pay_mode_ailos,
+            },
+            cls.inv_line_common_values,
+        )
+        # Altera o valor total para 1000
+        for line in cls.invoice_ailos_240.invoice_line_ids:
+            line.tax_ids = False
 
         # Caso que não é um CNAB
         # Diário Cheque
@@ -682,7 +818,7 @@ class CNABTestCommon(AccountTestInvoicingCommon):
             ),
         ) as f:
             f.change_type = code_to_send
-            if code_to_send == "change_date_maturity":
+            if code_to_send in ("change_date_maturity", "change_discount_date"):
                 new_date = date.today() + relativedelta(years=1)
 
                 if warning_error and test_dates_are_equals:

--- a/l10n_br_account_payment_order/tests/test_payment_order_inbound.py
+++ b/l10n_br_account_payment_order/tests/test_payment_order_inbound.py
@@ -52,9 +52,9 @@ class TestPaymentOrderInbound(CNABTestCommon):
             assert (
                 line.own_number
             ), "own_number field is not filled in created Move Line."
-            assert line.instruction_move_code_id, (
-                "instruction_move_code_id field is not filled" " in created Move Line."
-            )
+            assert (
+                line.instruction_move_code_id
+            ), "instruction_move_code_id field is not filled in created Move Line."
             # testar com a parcela 700
             if line.debit == 700.0:
                 test_balance_value = line.get_balance()
@@ -62,6 +62,10 @@ class TestPaymentOrderInbound(CNABTestCommon):
         self.assertEqual(test_balance_value, 700.0, "Error with method get_balance()")
 
         payment_order = self._get_draft_payment_order(self.invoice_cef_240)
+        for pay_line in payment_order.payment_line_ids:
+            self.assertFalse(
+                pay_line.amount_interest, "Error with Amout Interest field"
+            )
 
         # Ordem de Pagto CNAB não pode ser apagada
         with self.assertRaises(UserError):
@@ -84,24 +88,63 @@ class TestPaymentOrderInbound(CNABTestCommon):
     def test_warning_when_cnab_config_dont_has_code(self):
         self._run_invoice_and_order_workflow(self.invoice_itau_400)
         aml_to_change = self.invoice_itau_400.due_line_ids[0]
-        self.changes_to_sending.append(
+        self.changes_to_sending += [
             {
                 "change_to_send": "change_date_maturity",
                 "test_dates_are_equals": True,
-            }
-        )
+            },
+            {
+                "change_to_send": "change_discount_date",
+                "test_dates_are_equals": True,
+            },
+            {
+                "change_to_send": "change_discount_date",
+            },
+            {"change_to_send": "suspend_protest_keep_wallet"},
+            {
+                "change_to_send": "not_payment",
+                "without_account": True,
+            },
+        ]
+
         for change in self.changes_to_sending:
             test_dates_are_equals = False
             if change.get("test_dates_are_equals"):
                 test_dates_are_equals = True
             # Caso not_payment não tem Warning
-            if change.get("change_to_send") != "not_payment":
-                self._send_new_cnab_code(
-                    aml_to_change,
-                    change.get("change_to_send"),
-                    warning_error=True,
-                    test_dates_are_equals=test_dates_are_equals,
-                )
+            if change.get("change_to_send") == "not_payment":
+                self.cnab_config_itau_400.write_off_code_id = False
+                if change.get("without_account"):
+                    self.cnab_config_itau_400.not_payment_account_id = False
+            self._send_new_cnab_code(
+                aml_to_change,
+                change.get("change_to_send"),
+                warning_error=True,
+                test_dates_are_equals=test_dates_are_equals,
+            )
+
+    def test_cnab_change_specific_cases(self):
+        self._run_invoice_and_order_workflow(self.invoice_ailos_240)
+        changes_to_sending = [
+            {
+                "change_to_send": "change_discount_date",
+                "test_dates_are_equals": True,
+                "warning_error": True,
+            },
+            {
+                "change_to_send": "change_discount_date",
+            },
+        ]
+        for change in changes_to_sending:
+            self._send_new_cnab_code(
+                self.invoice_ailos_240.due_line_ids[0],
+                change.get("change_to_send"),
+                change.get("warning_error"),
+                change.get("test_dates_are_equals"),
+            )
+            if not change.get("warning_error"):
+                pay_order = self._get_draft_payment_order(self.invoice_ailos_240)
+                self._run_payment_order_workflow(pay_order)
 
     def test_payment_outside_cnab_payment_order_draft(self):
         """
@@ -210,6 +253,9 @@ class TestPaymentOrderInbound(CNABTestCommon):
         self._run_invoice_and_order_workflow(self.invoice_cef_240)
         self.invoice_cef_240.button_cancel()
         self._check_order_with_write_off_code(self.invoice_cef_240)
+        pay_order = self._get_draft_payment_order(self.invoice_cef_240)
+        self._run_payment_order_workflow(pay_order)
+        self.invoice_cef_240.unlink()
 
     def test_cancel_invoice_no_payment_mode_pay(self):
         """Test Pay Invoice without payment mode in cash"""

--- a/l10n_br_account_payment_order/tests/tools.py
+++ b/l10n_br_account_payment_order/tests/tools.py
@@ -58,7 +58,7 @@ def create_with_form_account_journal(env, values, line_values=False):
     return journal.save()
 
 
-def create_with_form_l10n_br_cnab_config(env, values):  # noqa: C901
+def create_with_form_l10n_br_cnab_config(env, values):
     with Form(
         env["l10n_br_cnab.config"],
         "l10n_br_account_payment_order.l10n_br_cnab_config_form_view",
@@ -66,8 +66,7 @@ def create_with_form_l10n_br_cnab_config(env, values):  # noqa: C901
         cnab_config.name = values.get("name")
         cnab_config.bank_id = values.get("bank_id")
         cnab_config.payment_method_id = values.get("payment_method_id")
-        if values.get("cnab_processor"):
-            cnab_config.cnab_processor = values.get("cnab_processor")
+        cnab_config.cnab_processor = values.get("cnab_processor")
         cnab_config.cnab_company_bank_code = values.get("cnab_company_bank_code")
         if values.get("convention_code"):
             cnab_config.convention_code = values.get("convention_code")
@@ -77,8 +76,7 @@ def create_with_form_l10n_br_cnab_config(env, values):  # noqa: C901
         cnab_config.boleto_accept = values.get("boleto_accept")
         if values.get("boleto_protest_code_id"):
             cnab_config.boleto_protest_code_id = values.get("boleto_protest_code_id")
-        if values.get("boleto_discount_perc"):
-            cnab_config.boleto_discount_perc = values.get("boleto_discount_perc")
+        cnab_config.boleto_discount_perc = values.get("boleto_discount_perc")
         cnab_config.boleto_days_protest = values.get("boleto_days_protest")
         cnab_config.boleto_interest_code = values.get("boleto_interest_code")
         cnab_config.boleto_interest_perc = values.get("boleto_interest_perc")
@@ -117,7 +115,6 @@ def create_with_form_l10n_br_cnab_config(env, values):  # noqa: C901
         #     )
 
         if values.get("change_title_value_code_id"):
-            # UNICRED 400 não tem
             cnab_config.change_title_value_code_id = values.get(
                 "change_title_value_code_id"
             )
@@ -132,16 +129,13 @@ def create_with_form_l10n_br_cnab_config(env, values):  # noqa: C901
         if values.get("protest_title_code_id"):
             cnab_config.protest_title_code_id = values.get("protest_title_code_id")
         if values.get("suspend_protest_keep_wallet_code_id"):
-            # Itau 400 não tem
             cnab_config.suspend_protest_keep_wallet_code_id = values.get(
                 "suspend_protest_keep_wallet_code_id"
             )
-        if values.get("grant_discount_code_id"):
-            # Itau 400 não tem
+        if values.get("grant_rebate_code_id"):
             cnab_config.grant_rebate_code_id = values.get("grant_rebate_code_id")
             cnab_config.cancel_rebate_code_id = values.get("cancel_rebate_code_id")
         if values.get("grant_discount_code_id"):
-            # UNICRED 400 não tem
             cnab_config.grant_discount_code_id = values.get("grant_discount_code_id")
             cnab_config.cancel_discount_code_id = values.get("cancel_discount_code_id")
         if values.get("boleto_byte_idt"):
@@ -149,7 +143,6 @@ def create_with_form_l10n_br_cnab_config(env, values):  # noqa: C901
             cnab_config.boleto_post = values.get("boleto_post")
         if values.get("boleto_fee_code_id"):
             cnab_config.boleto_fee_code_id = values.get("boleto_fee_code_id")
-        if values.get("boleto_fee_perc"):
             cnab_config.boleto_fee_perc = values.get("boleto_fee_perc")
 
     return cnab_config.save()


### PR DESCRIPTION
FIX process to unlink account move an IMP cnab tests.

Corrigido processo de apagar um account.move e melhoria na cobertura de testes, segue detalhes:

**[FIX]**

* acredito que como o **l10n_br_fiscal** não permitia apagar o account.move isso não aparecia, mas ao incluir um teste foi possível ver que provavelmente deve ter ficado esse resquício de quando os objetos **account.invoice** foi unido ao **account.move** 

**[IMP]**

* Movi a criação dos Dados do **AILOS 240** do módulo **l10n_br_account_payment_brcobranca** para o **l10n_br_account_payment_order** para poder rodar o teste especifico para Alteração da Data de Desconto
https://github.com/OCA/l10n-brazil/pull/3957 , eu havia me comprometido de adaptar isso na v16

* Alterado os caso **[(6, 0, {** para usar o **Command.Set** na criação do Dados de Teste

* Resolvido o **noqa: C901**, excesso de IFs

* Incluído testes para outros casos de Alteração CNAB e de Linha já Reconciliada

cc @OCA/local-brazil-maintainers 