### PR TITLE
[16.0][REF] Mover constante FISCAL_PAYMENT_MODE do módulo l10n_br_fiscal para o módulo l10n_br_nfe

### DIFF
--- a/l10n_br_account_nfe/models/account_payment_mode.py
+++ b/l10n_br_account_nfe/models/account_payment_mode.py
@@ -7,7 +7,7 @@
 
 from odoo import fields, models
 
-from odoo.addons.l10n_br_fiscal.constants.fiscal import FISCAL_PAYMENT_MODE
+from odoo.addons.l10n_br_nfe.constants.nfe import FISCAL_PAYMENT_MODE
 
 
 class AccountPaymentMode(models.Model):

--- a/l10n_br_fiscal/constants/fiscal.py
+++ b/l10n_br_fiscal/constants/fiscal.py
@@ -508,23 +508,3 @@ EVENT_ENVIRONMENT = [
     (EVENT_ENV_PROD, "Production"),
     (EVENT_ENV_HML, "Homologation"),
 ]
-
-FISCAL_PAYMENT_MODE = [
-    ("01", "01 - Dinheiro"),
-    ("02", "02 - Cheque"),
-    ("03", "03 - Cartão de Crédito"),
-    ("04", "04 - Cartão de Débito"),
-    ("05", "05 - Crédito de Loja"),
-    ("10", "10 - Vale Alimentação"),
-    ("11", "11 - Vale Refeição"),
-    ("12", "12 - Vale Presente"),
-    ("13", "13 - Vale Combustível"),
-    ("14", "14 - Duplicata Mercanti"),
-    ("15", "15 - Boleto Bancário"),
-    ("16", "16 - Depósito Bancário"),
-    ("17", "17 - Pagamento Instantâneo (PIX)"),
-    ("18", "18 - Transferência bancária, Carteira Digital"),
-    ("19", "19 - Programa de fidelidade, Cashback, Crédito Virtual"),
-    ("90", "90 - Sem Pagamento"),
-    ("99", "99 - Outros"),
-]

--- a/l10n_br_nfe/constants/nfe.py
+++ b/l10n_br_nfe/constants/nfe.py
@@ -52,3 +52,24 @@ NFCE_DANFE_LAYOUTS = [
 
 
 NFCE_DANFE_LAYOUT_DEFAULT = "4"
+
+
+FISCAL_PAYMENT_MODE = [
+    ("01", "01 - Dinheiro"),
+    ("02", "02 - Cheque"),
+    ("03", "03 - Cartão de Crédito"),
+    ("04", "04 - Cartão de Débito"),
+    ("05", "05 - Crédito de Loja"),
+    ("10", "10 - Vale Alimentação"),
+    ("11", "11 - Vale Refeição"),
+    ("12", "12 - Vale Presente"),
+    ("13", "13 - Vale Combustível"),
+    ("14", "14 - Duplicata Mercanti"),
+    ("15", "15 - Boleto Bancário"),
+    ("16", "16 - Depósito Bancário"),
+    ("17", "17 - Pagamento Instantâneo (PIX)"),
+    ("18", "18 - Transferência bancária, Carteira Digital"),
+    ("19", "19 - Programa de fidelidade, Cashback, Crédito Virtual"),
+    ("90", "90 - Sem Pagamento"),
+    ("99", "99 - Outros"),
+]

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -35,7 +35,6 @@ from odoo.addons.l10n_br_fiscal.constants.fiscal import (
     EVENT_ENV_HML,
     EVENT_ENV_PROD,
     EVENTO_RECEBIDO,
-    FISCAL_PAYMENT_MODE,
     LOTE_PROCESSADO,
     MODELO_FISCAL_NFCE,
     MODELO_FISCAL_NFE,
@@ -54,6 +53,7 @@ from odoo.addons.l10n_br_fiscal.tools import remove_non_ascii_characters
 from odoo.addons.spec_driven_model.models import spec_models
 
 from ..constants.nfe import (
+    FISCAL_PAYMENT_MODE,
     NFCE_DANFE_LAYOUTS,
     NFE_DANFE_LAYOUTS,
     NFE_ENVIRONMENTS,


### PR DESCRIPTION
A constate FISCAL_PAYMENT_MODE hoje contida no módulo l10n_br_fiscal foi criada para gerenciar o tipo de pagamento (tpag) da NFe/NFCe, e deveria ser movida para o módulo especifico l10n_br_nfe seguindo o plano descrito no issue #4124