### PR TITLE
[16.0] l10n_br_fiscal, l10n_br_cte: clean cte view

### DIFF
--- a/l10n_br_cte/views/document.xml
+++ b/l10n_br_cte/views/document.xml
@@ -9,16 +9,6 @@
         <field name="inherit_id" ref="l10n_br_fiscal.document_form" />
         <field name="priority">5</field>
         <field name="arch" type="xml">
-            <xpath expr="//group[@name='l10n_br_fiscal']" position="attributes">
-                <attribute
-                    name="invisible"
-                >[('document_type_id.code', 'in', ['57', '08', '09', '10', '11', '26', '67', '8B'])]</attribute>
-            </xpath>
-            <xpath expr="//group[@name='CT-e Info']" position="attributes">
-                <attribute
-                    name="invisible"
-                >[('document_type_id.code', 'in', ['57', '08', '09', '10', '11', '26', '67', '8B'])]</attribute>
-            </xpath>
             <field name="document_serie_id" position="after">
                 <field
                     name="service_provider"

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -234,7 +234,10 @@
                             />
                             <field name="partner_shipping_id" />
                         </group>
-                        <group name="l10n_br_fiscal" attrs="{'invisible': [('document_type', 'in', ['57', '08', '09', '10', '11', '26', '67', '8B'])]}">
+                        <group
+                            name="l10n_br_fiscal"
+                            attrs="{'invisible': [('document_type', 'in', ['57', '08', '09', '10', '11', '26', '67', '8B'])]}"
+                        >
                             <field
                                 name="fiscal_operation_id"
                                 options="{'no_create': True, 'no_create_edit': True}"

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -234,7 +234,7 @@
                             />
                             <field name="partner_shipping_id" />
                         </group>
-                        <group name="l10n_br_fiscal">
+                        <group name="l10n_br_fiscal" attrs="{'invisible': [('document_type', 'in', ['57', '08', '09', '10', '11', '26', '67', '8B'])]}">
                             <field
                                 name="fiscal_operation_id"
                                 options="{'no_create': True, 'no_create_edit': True}"
@@ -286,13 +286,6 @@
                                 groups="base.group_multi_company"
                             />
                             <field name="company_id" invisible="1" />
-                        </group>
-                        <group
-                            name="CT-e Info"
-                            invisible="[('document_type_id.code', 'in', ['57', '08', '09', '10', '11', '26', '67', '8B'])]"
-                        >
-                            <field name="transport_modal" />
-                            <field name="service_provider" />
                         </group>
                     </group>
                     <notebook>


### PR DESCRIPTION
a instalação do modulo l10n_br_cte escondia o campo fiscal_operation_id essencial para emitir documentos fiscais a partir do menu fiscal porque o domain com fiscal_type_id.code não funcionava, tinha que usar o fiscal_type.

Além disso removi os grupo CT-e Info do da view l10n_br_fiscal.document_form porque os campos transport_modal e service_provider são usados apenas no modulo l10n_br_cte e ja tinha campos na view de CTe. Não entendi porque tinha sido no l10n_br_fiscal.

cc @marcelsavegnago @mileo 