### PR TITLE
[16.0][IMP] l10n_br_mdfe: Melhorias na informações de pagamento - Modal Rodoviário 

### DIFF
--- a/l10n_br_mdfe/models/modal_rodoviario.py
+++ b/l10n_br_mdfe/models/modal_rodoviario.py
@@ -156,7 +156,10 @@ class MDFeModalRodoviarioPagamento(spec_models.StackedModel):
         comodel_name="l10n_br_mdfe.modal.rodoviario.pagamento.prazo"
     )
 
-    mdfe30_vContrato = fields.Monetary(required=True)
+    mdfe30_vContrato = fields.Monetary(
+        required=True,
+        compute="_compute_vcontrato",
+    )
 
     mdfe30_indPag = fields.Selection(required=True)
 
@@ -203,6 +206,11 @@ class MDFeModalRodoviarioPagamento(spec_models.StackedModel):
                     rec.mdfe30_choice_tresponsible = "mdfe30_CPF"
             else:
                 rec.mdfe30_choice_tresponsible = False
+
+    @api.depends("mdfe30_comp.mdfe30_vComp")
+    def _compute_vcontrato(self):
+        for rec in self:
+            rec.mdfe30_vContrato = sum(rec.mdfe30_comp.mapped("mdfe30_vComp"))
 
 
 class MDFeModalRodoviarioPagamentoFrete(spec_models.SpecModel):

--- a/l10n_br_mdfe/views/modal/modal_rodoviario.xml
+++ b/l10n_br_mdfe/views/modal/modal_rodoviario.xml
@@ -198,7 +198,10 @@
                         </group>
                         <group>
                             <field name="mdfe30_vContrato" />
-                            <field name="mdfe30_vAdiant" />
+                            <field
+                                name="mdfe30_vAdiant"
+                                attrs="{'invisible': [('mdfe30_indPag', '=', '0')]}"
+                            />
                         </group>
                         <group>
                             <field name="payment_type" />


### PR DESCRIPTION
Objetivo da PR

O campo VContrato ele tem que ser calculado a partir do Comp/VComp conforme a documentação

<img width="719" height="84" alt="image" src="https://github.com/user-attachments/assets/f559bba1-ad0f-4c40-b507-6d2052bd876b" />

Essa PR cria um compute para fazer o calculo desse campo, outra coisa é que o campo vAdiant só pode ser informado quando for a prazo então ele só fica visível quando tipo de pagamento for a prazo
<img width="730" height="80" alt="image" src="https://github.com/user-attachments/assets/14086c7e-c8ba-4e59-b5f6-1d669cd75cb5" />


relacionado #4111

cc @WesleyOliveira98 @marcelsavegnago @kaynnan 

