### PR TITLE
[16.0][FIX] l10n_br_fiscal: base wizard ->AbstractModel

### DIFF
--- a/l10n_br_fiscal/security/ir.model.access.csv
+++ b/l10n_br_fiscal/security/ir.model.access.csv
@@ -94,6 +94,5 @@
 "l10n_br_fiscal_invalidate_number_manager","manager_l10n_br_fiscal_invalidate_number","model_l10n_br_fiscal_invalidate_number","l10n_br_fiscal.group_manager",1,1,1,1
 "l10n_br_fiscal_city_taxation_code_user","Fiscal City Taxation Code for User","model_l10n_br_fiscal_city_taxation_code","l10n_br_fiscal.group_user",1,1,1,0
 "l10n_br_fiscal_city_taxation_code_manager","Fiscal City Taxation Code for Manager","model_l10n_br_fiscal_city_taxation_code","l10n_br_fiscal.group_user",1,1,1,1
-"l10n_br_fiscal_base_wizard_mixin_user",l10n_br_fiscal_base_wizard_mixin,model_l10n_br_fiscal_base_wizard_mixin,base.group_user,1,1,1,1
 "l10n_br_fiscal_document_status_wizard_user",l10n_br_fiscal_document_status_wizard,model_l10n_br_fiscal_document_status_wizard,base.group_user,1,1,1,1
 "l10n_br_fiscal_document_import_wizard_mixin_user",l10n_br_fiscal_document_import_wizard_mixin_user,model_l10n_br_fiscal_document_import_wizard_mixin,base.group_user,1,1,1,1

--- a/l10n_br_fiscal/wizards/base_wizard_mixin.py
+++ b/l10n_br_fiscal/wizards/base_wizard_mixin.py
@@ -5,7 +5,7 @@
 from odoo import api, fields, models
 
 
-class BaseWizardMixin(models.TransientModel):
+class BaseWizardMixin(models.AbstractModel):
     _name = "l10n_br_fiscal.base.wizard.mixin"
     _description = "Fiscal Base Wizard Mixin"
 

--- a/l10n_br_fiscal_edi/wizards/base_wizard_mixin.py
+++ b/l10n_br_fiscal_edi/wizards/base_wizard_mixin.py
@@ -4,7 +4,7 @@
 from odoo import fields, models
 
 
-class BaseWizardMixin(models.TransientModel):
+class BaseWizardMixin(models.AbstractModel):
     _inherit = "l10n_br_fiscal.base.wizard.mixin"
 
     event_id = fields.Many2one(


### PR DESCRIPTION
o l10n_br_fiscal.base.wizard.mixin é feito para ser herdado em TransientModel wizards, mas ele mesmo deve ser um AbstractModel apenas.