### PR TITLE
[16.0][FIX] l10n_br_nfse_focus: error http 422

### DIFF
--- a/l10n_br_nfse_focus/models/document.py
+++ b/l10n_br_nfse_focus/models/document.py
@@ -76,6 +76,10 @@ class FocusnfeNfse(models.AbstractModel):
                 params=params,
                 auth=auth,
             )
+            if response.status_code == 422:
+                payload = response.json()
+                msg = payload.get("mensagem") or ""
+                raise UserError(f"Error communicating with NFSe service: {msg}")
             response.raise_for_status()  # Raises an error for 4xx/5xx responses
             return response
         except requests.HTTPError as e:

--- a/l10n_br_nfse_focus/tests/test_l10n_br_nfse_focus.py
+++ b/l10n_br_nfse_focus/tests/test_l10n_br_nfse_focus.py
@@ -313,6 +313,23 @@ class TestL10nBrNfseFocus(common.TransactionCase):
 
         self.assertEqual(result.status_code, 204)  # Asserting status code 204
 
+    @patch("odoo.addons.l10n_br_nfse_focus.models.document.requests.request")
+    def test_make_focus_nfse_http_request_422(self, mock_request):
+        """Tests handling of HTTP 422 with Focus NFSe error message."""
+        mock_request.return_value.status_code = 422
+        mock_request.return_value.json.return_value = {
+            "mensagem": "CNPJ do emitente não autorizado."
+        }
+
+        with self.assertRaises(UserError) as e:
+            self.nfse_focus._make_focus_nfse_http_request(
+                "POST", "https://api.focusnfe.com.br/v2/nfse", self.token, PAYLOAD
+            )
+        self.assertIn(
+            "Error communicating with NFSe service: CNPJ do emitente não autorizado.",
+            str(e.exception),
+        )
+
     def test_make_focus_nfse_pdf(self):
         """Tests generation of NFSe PDF."""
         record = self.nfse_demo


### PR DESCRIPTION
## Objetivo da PR

Esta PR adiciona o tratamento específico para respostas HTTP 422 (Unprocessable Entity) retornadas pelo serviço da Focus NFS-e, exibindo mensagens de erro mais informativas ao usuário.

Anteriormente, quando o serviço retornava 422, o Odoo levantava uma exceção genérica via requests.raise_for_status(), o que dificultava a identificação da causa exata da falha.

<img width="978" height="190" alt="image" src="https://github.com/user-attachments/assets/ff737cb7-1317-4ab5-a756-f12841e91d1a" />

Exemplo de retorno 422:
<img width="864" height="508" alt="image" src="https://github.com/user-attachments/assets/2b61dc4a-0e05-43f5-b8a0-b9c96d136824" />

cc @WesleyOliveira98 @kaynnan @marcelsavegnago 


