### PR TITLE
[16.0] l10n_br_fiscal: Validações para a Serie de Documentos Fiscais

### DIFF
--- a/l10n_br_account/tests/common.py
+++ b/l10n_br_account/tests/common.py
@@ -266,6 +266,7 @@ class AccountMoveBRCommon(AccountTestInvoicingCommon):
                 "code": "1",
                 "name": "Série 1",
                 "document_type_id": cls.env.ref("l10n_br_fiscal.document_55").id,
+                "company_id": cls.company_data["company"].id,
                 "active": True,
             }
         )

--- a/l10n_br_account/tests/test_account_move_sn.py
+++ b/l10n_br_account/tests/test_account_move_sn.py
@@ -35,6 +35,7 @@ class AccountMoveSimpleNacional(AccountMoveBRCommon):
                 "code": "1",
                 "name": "Série 1",
                 "document_type_id": cls.env.ref("l10n_br_fiscal.document_55").id,
+                "company_id": cls.company_data["company"].id,
                 "active": True,
             }
         )

--- a/l10n_br_account/tests/test_invoice_refund.py
+++ b/l10n_br_account/tests/test_invoice_refund.py
@@ -13,6 +13,7 @@ class TestInvoiceRefund(AccountMoveBRCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.configure_normal_company_taxes()
         cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
 
         cls.sale_account = cls.env["account.account"].create(
@@ -55,9 +56,7 @@ class TestInvoiceRefund(AccountMoveBRCommon):
                 partner_id=cls.env.ref("l10n_br_base.res_partner_cliente1_sp").id,
                 journal_id=cls.refund_journal.id,
                 document_type_id=cls.env.ref("l10n_br_fiscal.document_55").id,
-                document_serie_id=cls.env.ref(
-                    "l10n_br_fiscal.empresa_lc_document_55_serie_1"
-                ).id,
+                document_serie_id=cls.empresa_lc_document_55_serie_1.id,
                 invoice_line_ids=[
                     (
                         0,

--- a/l10n_br_fiscal/models/document_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_mixin_methods.py
@@ -88,7 +88,11 @@ class FiscalDocumentMixinMethods(models.AbstractModel):
     @api.depends("document_type_id", "issuer")
     def _compute_document_serie_id(self):
         for doc in self:
-            if doc.document_type_id and doc.issuer == DOCUMENT_ISSUER_COMPANY:
+            if (
+                not doc.document_serie_id
+                and doc.document_type_id
+                and doc.issuer == DOCUMENT_ISSUER_COMPANY
+            ):
                 doc.document_serie_id = doc.document_type_id.get_document_serie(
                     doc.company_id, doc.fiscal_operation_id
                 )

--- a/l10n_br_fiscal/models/document_serie.py
+++ b/l10n_br_fiscal/models/document_serie.py
@@ -3,11 +3,13 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 from ..constants.fiscal import (
     DOCUMENT_ISSUER_COMPANY,
     FISCAL_IN_OUT,
     FISCAL_IN_OUT_DEFAULT,
+    SITUACAO_EDOC_EM_DIGITACAO,
 )
 
 
@@ -55,6 +57,14 @@ class DocumentSerie(models.Model):
         string="Invalidate Number Range",
     )
 
+    _sql_constraints = [
+        (
+            "document_serie_unique",
+            "unique(code, document_type_id, company_id)",
+            "A Fiscal Document Serie already exists for this document type.",
+        )
+    ]
+
     @api.model
     def _create_sequence(self, values):
         """Create new no_gap entry sequence for every
@@ -77,6 +87,29 @@ class DocumentSerie(models.Model):
             if not vals.get("internal_sequence_id"):
                 vals.update({"internal_sequence_id": self._create_sequence(vals)})
         return super().create(vals_list)
+
+    def write(self, vals):
+        if "internal_sequence_id" in vals:
+            raise ValidationError(_("You cannot change the internal sequence."))
+        if "code" in vals:
+            for serie in self:
+                if serie.code == vals["code"]:
+                    continue
+                if self.env["l10n_br_fiscal.document"].search_count(
+                    [
+                        ("document_serie_id", "=", serie.id),
+                        ("state_edoc", "not in", [SITUACAO_EDOC_EM_DIGITACAO]),
+                    ],
+                    limit=1,
+                ):
+                    raise ValidationError(
+                        _(
+                            "You cannot change the code of a document "
+                            "serie %(name)s that is already in use.",
+                            name=serie.name,
+                        )
+                    )
+        return super().write(vals)
 
     def name_get(self):
         return [(r.id, f"{r.name}") for r in self]

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -2,6 +2,7 @@
 
 from . import (
     test_cnae,
+    test_fiscal_document_serie,
     test_fiscal_document_generic,
     test_fiscal_document_nfse,
     test_fiscal_tax,

--- a/l10n_br_fiscal/tests/test_fiscal_document_serie.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_serie.py
@@ -1,0 +1,60 @@
+# Copyright (C) 2025  Renato Lima - Akretion <renato.lima@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from psycopg2 import IntegrityError
+
+from odoo.exceptions import ValidationError
+from odoo.tests import TransactionCase
+from odoo.tools import mute_logger
+
+
+class TestFiscalDocumentSerie(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+
+        # Company
+        cls.company_sn = cls.env.ref("l10n_br_base.empresa_simples_nacional")
+
+        # Fiscal Document Type
+        cls.document_type_nfe = cls.env.ref("l10n_br_fiscal.document_55")
+
+        cls.document_serie_nfe_5 = cls.env["l10n_br_fiscal.document.serie"].create(
+            {
+                "code": "5",
+                "name": "Serie 5",
+                "document_type_id": cls.document_type_nfe.id,
+                "company_id": cls.company_sn.id,
+            }
+        )
+
+        # Fiscal Document
+        cls.document = cls.env["l10n_br_fiscal.document"].create(
+            {
+                "company_id": cls.company_sn.id,
+                "document_type_id": cls.document_type_nfe.id,
+                "document_serie_id": cls.document_serie_nfe_5.id,
+                "partner_id": cls.env.ref("l10n_br_base.res_partner_cliente1_sp").id,
+                "state_edoc": "cancelada",
+            }
+        )
+
+    def test_document_serie_duplicated(self):
+        """Test document serie duplicate constraint."""
+        document_serie = self.env["l10n_br_fiscal.document.serie"]
+        document_serie_values = {
+            "code": "10",
+            "name": "Serie 10",
+            "document_type_id": self.document_type_nfe.id,
+            "company_id": self.company_sn.id,
+        }
+
+        with self.assertRaises(IntegrityError), mute_logger("odoo.sql_db"):
+            for _ in range(2):
+                document_serie.create(document_serie_values)
+
+    def test_document_serie_code_in_use(self):
+        """Test document serie code in use constraint."""
+        with self.assertRaises(ValidationError):
+            self.document_serie_nfe_5.write({"code": "7"})


### PR DESCRIPTION

- [x] Corrigido o método _compute_document_serie_id no documento fiscal para permitir criar documentos fiscais e especificar uma serie
- [x] Adicionada duas constraints:
    - [x] Restringir a criação de mais de uma série com o mesmo código, documento fiscal e empresa;
    - [x] Não permitir alterar o código da serie de documento fiscal se já existe documentos fiscais com status diferente de draft.
- [x] Adicionado testes para a serie de documento fiscal 