### PR TITLE
[16.0] Substituído pylint por oca-hooks

### DIFF
--- a/l10n_br_account/report/account_invoice_report_view.xml
+++ b/l10n_br_account/report/account_invoice_report_view.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!-- pylint:disable=file-not-used -->
+<!-- oca-hooks:disable=file-not-used -->
 <odoo>
 
     <record

--- a/l10n_br_coa_generic/data/l10n_br_coa_generic_template_post.xml
+++ b/l10n_br_coa_generic/data/l10n_br_coa_generic_template_post.xml
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!-- TODO: A linha pylint é necessária na versão 7.0.2
-      na versão v9.0.0 pode ser removida -->
-<!-- pylint:disable=duplicate-xml-record-id -->
 <!-- oca-hooks:disable=xml-duplicate-record-id -->
 <odoo>
 

--- a/l10n_br_coa_generic/demo/account_journal.xml
+++ b/l10n_br_coa_generic/demo/account_journal.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!-- pylint:disable=file-not-used -->
+<!-- oca-hooks:disable=file-not-used -->
 <odoo>
 
     <!-- Account Journal xml ref -->

--- a/l10n_br_coa_simple/demo/account_journal.xml
+++ b/l10n_br_coa_simple/demo/account_journal.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!-- pylint:disable=file-not-used -->
+<!-- oca-hooks:disable=file-not-used -->
 <odoo>
 
     <!-- Account Journal xml ref -->

--- a/l10n_br_fiscal/data/operation_data.xml
+++ b/l10n_br_fiscal/data/operation_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!-- pylint:disable=xml-duplicate-record-id -->
+<!-- oca-hooks:disable=xml-duplicate-record-id -->
 <odoo noupdate="1">
 
     <record id="document_55_serie_1" model="l10n_br_fiscal.document.serie">

--- a/l10n_br_fiscal/demo/fiscal_document_demo.xml
+++ b/l10n_br_fiscal/demo/fiscal_document_demo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!-- pylint:disable=xml-duplicate-record-id -->
+<!-- oca-hooks:disable=xml-duplicate-record-id -->
 <odoo noupdate="1">
 
     <record id="dummy_file_1" model="ir.attachment">

--- a/l10n_br_purchase/reports/purchase_order_templates.xml
+++ b/l10n_br_purchase/reports/purchase_order_templates.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!-- pylint:disable=file-not-used -->
+<!-- oca-hooks:disable=file-not-used -->
 <odoo>
 
     <template

--- a/l10n_br_sale/report/sale_report_templates.xml
+++ b/l10n_br_sale/report/sale_report_templates.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!-- pylint:disable=file-not-used -->
+<!-- oca-hooks:disable=file-not-used -->
 <odoo>
 
     <template


### PR DESCRIPTION
PR para resolver as mensagens WARNING durante o pre-commit substitui os pylint:disable por oca-hooks:disable

```
l10n_br_fiscal/data/operation_data.xml:2 WARNING. DEPRECATED. Use oca-disable instead.
l10n_br_fiscal/demo/fiscal_document_demo.xml:2 WARNING. DEPRECATED. Use oca-disable instead.
l10n-brazil/l10n_br_sale/report/sale_report_templates.xml:2 WARNING. DEPRECATED. Use oca-disable instead.
```