### PR TITLE
[16.0] l10n_br_sale_commission: stop conflicting with l10n_br_fiscal/l10n_br_account

### DIFF
--- a/l10n_br_account/tests/test_move_edition.py
+++ b/l10n_br_account/tests/test_move_edition.py
@@ -7,7 +7,7 @@ from unittest import mock
 from odoo import Command, fields
 from odoo.exceptions import UserError
 from odoo.tests import TransactionCase
-from odoo.tests.common import Form
+from odoo.tests.common import Form, tagged
 
 _logger = logging.getLogger(__name__)
 
@@ -25,6 +25,7 @@ class PatchedForm(Form):
             _logger.debug(f"ignoring error {e}")
 
 
+@tagged("post_install", "-at_install")
 class TestMoveEdition(TransactionCase):
     """
     Test basic invoicing scenarios through the user interface to ensure
@@ -258,7 +259,7 @@ class TestMoveEdition(TransactionCase):
         self.assertEqual(move.user_id, move.fiscal_document_id.user_id)
 
         # test "shadowed" line fields:
-        aml = move.line_ids[0]
+        aml = move.line_ids.filtered(lambda line: line.product_id)[0]
         fisc_line = move.fiscal_line_ids[0]
         self.assertEqual(aml.product_id, fisc_line.product_id)
         self.assertEqual(aml.name, fisc_line.name)
@@ -385,7 +386,7 @@ class TestMoveEdition(TransactionCase):
         self.assertEqual(move.user_id, move.fiscal_document_id.user_id)
 
         # test "shadowed" line fields:
-        aml = move.line_ids[0]
+        aml = move.line_ids.filtered(lambda line: line.product_id)[0]
         fisc_line = move.fiscal_line_ids[0]
         self.assertEqual(aml.product_id, fisc_line.product_id)
         self.assertEqual(aml.name, fisc_line.name)

--- a/l10n_br_sale_commission/models/account_move_line.py
+++ b/l10n_br_sale_commission/models/account_move_line.py
@@ -8,7 +8,7 @@ from odoo import api, models
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
-    @api.depends("move_id.partner_id", "cfop_id")
+    @api.depends("move_id.partner_id", "product_id", "fiscal_operation_line_id")
     def _compute_agent_ids(self):
         res = super()._compute_agent_ids()
         for record in self.filtered(lambda ln: ln.cfop_id):

--- a/l10n_br_sale_commission/models/sale_order_line.py
+++ b/l10n_br_sale_commission/models/sale_order_line.py
@@ -8,7 +8,11 @@ from odoo import api, models
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
-    @api.depends("order_id.partner_id", "cfop_id")
+    # NOTE: this compute cannot depend on cfop_id directly because
+    # _compute_fiscal_tax_ids would trigger it and it would somewho set
+    # _compute_tax_fields for recompute loosing possible custom tax values.
+    # See https://github.com/OCA/l10n-brazil/issues/4154
+    @api.depends("order_id.partner_id", "product_id", "fiscal_operation_line_id")
     def _compute_agent_ids(self):
         res = super()._compute_agent_ids()
         for record in self.filtered(lambda ln: ln.cfop_id):


### PR DESCRIPTION
resolve a parte critica de #4154

o modulo l10n_br_sale_commission interferia com o modulo l10n_br_account: o calculo do cfop_id pelo _compute_fiscal_tax_ids mandava recalcular o _compute_agent_ids (pelo api.depends) que por sua vez de algum maneira botava o _compute_tax_fields para recalcular no create do account.move e assim podiam se perder a seleção customizada de alguma alíquota de imposto e onde o campo voltava pro valor do tax engine.

OBS: o @tagged("post_install", "-at_install") no teste do l10n_br_account garante que o teste é executado depois do l10n_br_sale_comission instalado e pega o bug caso a gente não fizer essa mudança no l10n_br_sale_commission. Isso pode ser visto aqui por exemplo: https://github.com/OCA/l10n-brazil/actions/runs/18531720565/job/52816025413?pr=4158#step:9:5835 que rodou antes de solucionar o problema.

Não depender mais do cfop_id diretamente no _compute_agent_ids resolve o problema. Em vez disso dependemos de product_id a fiscal_operation_line_id que ja devem lidar bem com a atualização do compute_agent_ids que apenas trata de tirar o agent_ids para as linhas sem finance_move (as linhas de remessa).

cc @OCA/local-brazil-maintainers @felipemotter @crsilveira @mbcosta 