### PR TITLE
[16.0][FIX] spec_driven_model, l10n_br_cte, l10n_br_mdfe: polymorphic spec import

### DIFF
--- a/l10n_br_cte/hooks.py
+++ b/l10n_br_cte/hooks.py
@@ -4,8 +4,6 @@
 import logging
 
 import pkg_resources
-
-# from nfelib.cte.bindings.v4_0.cte_tipos_basico_v4_00 import Tcte
 from nfelib.cte.bindings.v4_0.cte_v4_00 import Tcte
 
 from odoo import SUPERUSER_ID, api
@@ -19,9 +17,7 @@ _logger = logging.getLogger(__name__)
 
 def post_init_hook(cr, registry):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    cr.execute("select demo from ir_module_module where name='l10n_br_cte';")
-    is_demo = cr.fetchone()[0]
-    if is_demo:
+    if env.ref("base.module_l10n_br_cte").demo:
         res_items = (
             "tests",
             "cte",
@@ -39,11 +35,8 @@ def post_init_hook(cr, registry):
         )
         try:
             existing_docs.unlink()
-            cte = (
-                env["cte.40.tcte_infcte"]
-                .with_context(tracking_disable=True, edoc_type="in")
-                .build_from_binding("cte", "40", binding.infCte)
+            env["l10n_br_fiscal.document"].import_binding_cte(
+                binding, edoc_type="in", dry_run=False
             )
-            _logger.info(cte.cte40_emit.cte40_CNPJ)
         except ValidationError:
             _logger.info(f"CTE-e already {document_number} imported by hooks")

--- a/l10n_br_cte/models/document.py
+++ b/l10n_br_cte/models/document.py
@@ -9,7 +9,6 @@ import re
 import string
 import sys
 from datetime import datetime
-from enum import Enum
 
 from erpbrasil.base.fiscal import cnpj_cpf
 from erpbrasil.base.fiscal.edoc import ChaveEdoc
@@ -23,7 +22,7 @@ from nfelib.cte.bindings.v4_0.proc_cte_v4_00 import CteProc
 # from nfelib.nfe.ws.edoc_legacy import CTeAdapter as edoc_cte
 from xsdata.formats.dataclass.parsers import XmlParser
 
-from odoo import _, api, fields
+from odoo import Command, _, api, fields
 from odoo.exceptions import UserError, ValidationError
 
 from odoo.addons.l10n_br_cte_spec.models.v4_0.cte_modal_ferroviario_v4_00 import (
@@ -79,6 +78,16 @@ from ..constants.cte import (
 from ..constants.modal import CTE_MODAL_VERSION_DEFAULT
 
 CTE_XML_NAMESPACE = {"cte": "http://www.portalfiscal.inf.br/cte"}
+
+ICMS_SUB_TAGS = [
+    "ICMS00",
+    "ICMS20",
+    "ICMS45",
+    "ICMS60",
+    "ICMS90",
+    "ICMSOutraUF",
+    "ICMSSN",
+]
 
 
 _logger = logging.getLogger(__name__)
@@ -1259,36 +1268,15 @@ class CTe(spec_models.StackedModel):
     def _prepare_import_dict(
         self, values, model=None, parent_dict=None, defaults_model=None
     ):
-        return {
-            **super()._prepare_import_dict(values, model, parent_dict, defaults_model),
-            "imported_document": True,
-        }
-
-    def _build_attr(self, node, fields, vals, path, attr):
-        key = f"cte40_{attr[0]}"  # TODO schema wise
-        value = getattr(node, attr[0])
-
-        # if attr[0] == "any_element":  # build modal
-        #     modal_id = self._get_modal_to_build(node.any_element.__module__)
-        #     if modal_id is False:
-        #         return
-
-        #     modal_attrs = modal_id.build_attrs(value, path=path)
-        #     for chave, valor in modal_attrs.items():
-        #         vals[chave] = valor
-        #     return
-
-        if key == "cte40_mod":
-            if isinstance(value, Enum):
-                value = value.value
-
-            vals["document_type_id"] = (
+        res = super()._prepare_import_dict(values, model, parent_dict, defaults_model)
+        res["imported_document"] = True
+        if "cte40_mod" in values:
+            res["document_type_id"] = (
                 self.env["l10n_br_fiscal.document.type"]
-                .search([("code", "=", value)], limit=1)
+                .search([("code", "=", values["cte40_mod"])], limit=1)
                 .id
             )
-
-        return super()._build_attr(node, fields, vals, path, attr)
+        return res
 
     def _build_many2one(self, comodel, vals, new_value, key, value, path):
         if key == "cte40_emit" and self.env.context.get("edoc_type") == "in":
@@ -1704,18 +1692,72 @@ class CTe(spec_models.StackedModel):
 
         return proc_xml
 
-    def import_binding_cte(self, binding, edoc_type="out"):
+    def import_binding_cte(self, binding, edoc_type="in", dry_run=False):
+        if hasattr(binding, "CTe"):
+            binding = binding.CTe
         document = (
             self.env["cte.40.tcte_infcte"]
-            .with_context(tracking_disable=True, edoc_type=edoc_type, dry_run=False)
-            .build_from_binding("cte", "40", binding.CTe.infCte)
+            .with_context(tracking_disable=True, edoc_type=edoc_type)
+            .build_from_binding("cte", "40", binding.infCte, dry_run=dry_run)
         )
 
         if edoc_type == "in" and document.company_id.cnpj_cpf != cnpj_cpf.formata(
-            binding.CTe.infCte.emit.CNPJ
+            binding.infCte.emit.CNPJ
         ):
             document.fiscal_operation_type = "in"
             document.issuer = "partner"
+
+            icms = None
+            for icms_tag in ICMS_SUB_TAGS:
+                icms = getattr(binding.infCte.imp.ICMS, icms_tag)
+                if icms:
+                    break
+            if icms:
+                cst = icms.CST.value
+                percent = icms.pICMS if hasattr(icms, "pICMS") else None
+                base = icms.vBC if hasattr(icms, "vBC") else 0.0
+                value = icms.vICMS if hasattr(icms, "vICMS") else 0.0
+                cst_id = self.env.ref(f"l10n_br_fiscal.cst_icms_{cst}").id
+                tax_group_id = self.env.ref("l10n_br_fiscal.tax_group_icms").id
+                tax_domain = [("tax_group_id", "=", tax_group_id)]
+                if percent:
+                    tax_domain.append(("percent_amount", "=", percent))
+                tax_domain_with_cst = None
+                cst_kind = "cst_{}_id".format(self.env.context.get("edoc_type", "in"))
+                tax_domain_with_cst = tax_domain + [(cst_kind, "=", cst_id)]
+                # TODO deal with pRed like in l10n_br_nfe _import tax_attrs?
+                icms_tax_id = self.env["l10n_br_fiscal.tax"].search(
+                    tax_domain_with_cst,
+                    limit=1,
+                )
+
+                line_attrs = {
+                    "name": "Frete",  # TODO improve
+                    "price_unit": binding.infCte.vPrest.vTPrest,
+                    "quantity": 1,
+                    "fiscal_tax_ids": [Command.link(icms_tax_id.id)],
+                    "icms_cst_id": cst_id,
+                    "icms_tax_id": icms_tax_id.id,
+                    "icms_base": base,
+                    "icms_percent": percent,
+                    "icms_value": value,
+                }
+                if binding.infCte.ide.CFOP:
+                    line_attrs["cfop_id"] = (
+                        self.env["l10n_br_fiscal.cfop"]
+                        .search([("code", "=", binding.infCte.ide.CFOP)], limit=1)
+                        .id
+                    )
+
+                for comp in binding.infCte.vPrest.comp or [None]:
+                    if comp is not None:
+                        line_attrs.update(
+                            {
+                                "name": comp.xNome,
+                                "price_unit": comp.vComp,
+                            }
+                        )
+                    document.fiscal_line_ids = [Command.create(line_attrs)]
 
         return document
 

--- a/l10n_br_cte/tests/test_cte_import.py
+++ b/l10n_br_cte/tests/test_cte_import.py
@@ -1,6 +1,6 @@
 # Copyright 2024 - TODAY, Marcel Savegnago <marcel.savegnago@escodoo.com.br>
+# Copyright 2025 - TODAY Akretion - Raphael Valyi <raphael.valyi@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-import logging
 
 import pkg_resources
 from nfelib.cte.bindings.v4_0.cte_v4_00 import Tcte
@@ -10,8 +10,6 @@ from odoo.tests import TransactionCase
 
 from odoo.addons import l10n_br_cte
 
-_logger = logging.getLogger(__name__)
-
 
 class CTeImportTest(TransactionCase):
     def test_import_in_cte_dry_run(self):
@@ -20,16 +18,17 @@ class CTeImportTest(TransactionCase):
             "cte",
             "v4_00",
             "leiauteCTe",
-            "CTe51160824686092000173570010000000031000000024.xml",
+            "CTe51160724686092000173570010000000031000000024.xml",
         )
 
         resource_path = "/".join(res_items)
         cte_stream = pkg_resources.resource_stream(l10n_br_cte.__name__, resource_path)
         binding = Tcte.from_xml(cte_stream.read().decode())
-        cte = (
-            self.env["cte.40.tcte_infcte"]
-            .with_context(tracking_disable=True, edoc_type="in")
-            .build_from_binding("cte", "40", binding.infCte, dry_run=True)
+        self.env["l10n_br_fiscal.document"].search(
+            [("document_number", "=", 571)]
+        ).unlink()
+        cte = self.env["l10n_br_fiscal.document"].import_binding_cte(
+            binding, edoc_type="in", dry_run=True
         )
         assert isinstance(cte.id, NewId)
         self._check_cte(cte)
@@ -46,10 +45,11 @@ class CTeImportTest(TransactionCase):
         resource_path = "/".join(res_items)
         cte_stream = pkg_resources.resource_stream(l10n_br_cte.__name__, resource_path)
         binding = Tcte.from_xml(cte_stream.read().decode())
-        cte = (
-            self.env["cte.40.tcte_infcte"]
-            .with_context(tracking_disable=True, edoc_type="in")
-            .build_from_binding("cte", "40", binding.infCte, dry_run=False)
+        self.env["l10n_br_fiscal.document"].search(
+            [("document_number", "=", 571)]
+        ).unlink()
+        cte = self.env["l10n_br_fiscal.document"].import_binding_cte(
+            binding, edoc_type="in", dry_run=False
         )
 
         assert isinstance(cte.id, int)
@@ -57,11 +57,37 @@ class CTeImportTest(TransactionCase):
 
     def _check_cte(self, cte):
         self.assertEqual(type(cte)._name, "l10n_br_fiscal.document")
+        self.assertEqual(
+            cte.document_type_id, self.env.ref("l10n_br_fiscal.document_57")
+        )
+        self.assertEqual(cte.document_number, "571")
 
         self.assertEqual(cte.cte40_UFIni, "MT")
         self.assertEqual(cte.cte40_UFFim, "MT")
+        self.assertEqual(cte.cte40_modal, "01")
+        self.assertEqual(cte.cte40_vCarga, 79400)
+        self.assertEqual(cte.cte40_proPred, "GADO")
+
+        self.assertEqual(cte.partner_id.name, "P J TOSTA TRANSPORTES ME")
+        if isinstance(cte.id, int):
+            self.assertTrue(
+                cte.partner_id.vat in ("24.686.092/0001-73", "24686092000173")
+            )
+            self.assertEqual(cte.partner_id.legal_name, "P J TOSTA TRANSPORTES ME")
+            self.assertEqual(cte.partner_id.street_name, "RUA RENATO JOSE DOS SANTOS")
+            self.assertEqual(cte.partner_id.zip, "78132-712")
+            self.assertEqual(cte.partner_id.cte40_CEP, "78132712")
+            self.assertEqual(cte.partner_id.city_id.name, "Várzea Grande")
+
+        # now we check that company_id is unchanged
+        self.assertEqual(cte.company_id, self.env.ref("base.main_company"))
 
         self.assertEqual(cte.cte40_verProc, "2.0.1")
+
+        # lines data
+        self.assertEqual(len(cte.fiscal_line_ids), 1)
+        self.assertEqual(cte.fiscal_line_ids[0].quantity, 1)
+        self.assertEqual(cte.fiscal_line_ids[0].price_unit, 4000.0)
 
     def test_import_out_cte(self):
         "(can be useful after an ERP migration)"

--- a/l10n_br_mdfe/hooks.py
+++ b/l10n_br_mdfe/hooks.py
@@ -14,9 +14,7 @@ _logger = logging.getLogger(__name__)
 
 def post_init_hook(cr, registry):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    cr.execute("select demo from ir_module_module where name='l10n_br_mdfe';")
-    is_demo = cr.fetchone()[0]
-    if is_demo:
+    if env.ref("base.module_l10n_br_mdfe").demo:
         res_items = (
             "mdfe",
             "samples",
@@ -32,11 +30,8 @@ def post_init_hook(cr, registry):
         )
         try:
             existing_docs.unlink()
-            doc = (
-                env["mdfe.30.tmdfe_infmdfe"]
-                .with_context(tracking_disable=True, edoc_type="in")
-                .build_from_binding("mdfe", "30", binding.infMDFe)
+            env["l10n_br_fiscal.document"].import_binding_mdfe(
+                binding, edoc_type="in", dry_run=False
             )
-            _logger.info(doc.mdfe30_emit.mdfe30_CNPJ)
         except ValidationError:
             _logger.info(f"MDF-e already {document_number} imported by hooks")

--- a/l10n_br_mdfe/models/__init__.py
+++ b/l10n_br_mdfe/models/__init__.py
@@ -1,5 +1,6 @@
 from . import transporte
 from . import res_company
+from . import res_country_state
 from . import document
 from . import document_related
 from . import res_partner

--- a/l10n_br_mdfe/models/document.py
+++ b/l10n_br_mdfe/models/document.py
@@ -4,9 +4,9 @@
 import base64
 import re
 import string
-from enum import Enum
 from unicodedata import normalize
 
+from erpbrasil.base.fiscal import cnpj_cpf
 from erpbrasil.base.fiscal.edoc import ChaveEdoc
 from erpbrasil.base.misc import punctuation_rm
 from erpbrasil.transmissao import TransmissaoSOAP
@@ -681,15 +681,25 @@ class MDFe(spec_models.StackedModel):
     # NF-e tag: tot
     ##########################
 
-    mdfe30_qCTe = fields.Char(compute="_compute_mdfe30_tot")
+    mdfe30_qCTe = fields.Integer(
+        compute="_compute_mdfe30_tot", store=True, readonly=False
+    )
 
-    mdfe30_qNFe = fields.Char(compute="_compute_mdfe30_tot")
+    mdfe30_qNFe = fields.Integer(
+        compute="_compute_mdfe30_tot", store=True, readonly=False
+    )
 
-    mdfe30_qMDFe = fields.Char(compute="_compute_mdfe30_tot")
+    mdfe30_qMDFe = fields.Integer(
+        compute="_compute_mdfe30_tot", store=True, readonly=False
+    )
 
-    mdfe30_qCarga = fields.Float(compute="_compute_mdfe30_tot")
+    mdfe30_qCarga = fields.Float(
+        compute="_compute_mdfe30_tot", store=True, readonly=False
+    )
 
-    mdfe30_vCarga = fields.Float(compute="_compute_mdfe30_tot")
+    mdfe30_vCarga = fields.Float(
+        compute="_compute_mdfe30_tot", store=True, readonly=False
+    )
 
     mdfe30_cUnid = fields.Selection(default="01")
 
@@ -833,31 +843,18 @@ class MDFe(spec_models.StackedModel):
 
         return super()._export_many2one(field_name, xsd_required, class_obj)
 
-    def _build_attr(self, node, fields, vals, path, attr):
-        key = f"mdfe30_{attr[0]}"
-        value = getattr(node, attr[0])
-
-        # if attr[0] == "any_element":  # build modal
-        #     modal_id = self._get_mdfe_modal_to_build(node.any_element.__module__)
-        #     if modal_id is False:
-        #         return
-
-        #     modal_attrs = modal_id.build_attrs(value, path=path)
-        #     for chave, valor in modal_attrs.items():
-        #         vals[chave] = valor
-        #     return
-
-        if key == "mdfe30_mod":
-            if isinstance(value, Enum):
-                value = value.value
-
-            vals["document_type_id"] = (
+    def _prepare_import_dict(
+        self, values, model=None, parent_dict=None, defaults_model=None
+    ):
+        res = super()._prepare_import_dict(values, model, parent_dict, defaults_model)
+        res["imported_document"] = True
+        if "mdfe30_mod" in values:
+            res["document_type_id"] = (
                 self.env["l10n_br_fiscal.document.type"]
-                .search([("code", "=", value)], limit=1)
+                .search([("code", "=", values["mdfe30_mod"])], limit=1)
                 .id
             )
-
-        return super()._build_attr(node, fields, vals, path, attr)
+        return res
 
     def _get_mdfe_modal_to_build(self, module):
         modal_by_binding_module = {
@@ -907,6 +904,22 @@ class MDFe(spec_models.StackedModel):
             if match:
                 return match.id
         return False
+
+    def import_binding_mdfe(self, binding, edoc_type="in", dry_run=False):
+        if hasattr(binding, "MDFe"):
+            binding = binding.MDFe
+        document = (
+            self.env["mdfe.30.tmdfe_infmdfe"]
+            .with_context(tracking_disable=True, edoc_type=edoc_type)
+            .build_from_binding("mdfe", "30", binding.infMDFe, dry_run=dry_run)
+        )
+
+        if edoc_type == "in" and document.company_id.vat != cnpj_cpf.formata(
+            binding.infMDFe.emit.CNPJ
+        ):
+            document.fiscal_operation_type = "in"
+            document.issuer = "partner"
+        return document
 
     ################################
     # Business Model Methods

--- a/l10n_br_mdfe/models/document_info.py
+++ b/l10n_br_mdfe/models/document_info.py
@@ -13,9 +13,9 @@ class MDFeMunicipioDescarga(spec_models.SpecModel):
 
     document_id = fields.Many2one(comodel_name="l10n_br_fiscal.document")
 
-    mdfe30_cMunDescarga = fields.Char(compute="_compute_city_data")
+    mdfe30_cMunDescarga = fields.Char(related="city_id.ibge_code")
 
-    mdfe30_xMunDescarga = fields.Char(compute="_compute_city_data")
+    mdfe30_xMunDescarga = fields.Char(related="city_id.name")
 
     mdfe30_infCTe = fields.One2many(compute="_compute_document_data")
 
@@ -32,7 +32,7 @@ class MDFeMunicipioDescarga(spec_models.SpecModel):
         comodel_name="res.country.state",
         string="State",
         domain="[('country_id', '=', country_id)]",
-        required=True,
+        compute="_compute_state_id",
     )
 
     city_id = fields.Many2one(
@@ -67,12 +67,6 @@ class MDFeMunicipioDescarga(spec_models.SpecModel):
         relation="mdfe_related_mdfe_carregamento_rel",
     )
 
-    @api.depends("city_id")
-    def _compute_city_data(self):
-        for record in self:
-            record.mdfe30_cMunDescarga = record.city_id.ibge_code
-            record.mdfe30_xMunDescarga = record.city_id.name
-
     @api.depends("document_type", "nfe_ids", "cte_ids")
     def _compute_document_data(self):
         for record in self:
@@ -95,3 +89,9 @@ class MDFeMunicipioDescarga(spec_models.SpecModel):
                     Command.create({"mdfe30_chMDFe": mdfe.mdfe30_chMDFe})
                     for mdfe in record.mdfe_ids
                 ]
+
+    @api.depends("city_id")
+    def _compute_state_id(self):
+        for record in self:
+            if record.city_id:
+                record.state_id = record.city_id.state_id.id

--- a/l10n_br_mdfe/models/res_country_state.py
+++ b/l10n_br_mdfe/models/res_country_state.py
@@ -1,0 +1,20 @@
+# Copyright 2025 Akretion (Raphaël Valyi <raphael.valyi@akretion.com>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class ResCountryState(models.Model):
+    _inherit = "res.country.state"
+    _mdfe_search_keys = ["ibge_code", "code"]
+    _mdfe_extra_domain = [("ibge_code", "!=", False)]
+
+    @api.model
+    def match_or_create_m2o(self, rec_dict, parent_dict, model=None):
+        """If state not found, break hard, don't create it"""
+        if rec_dict.get("ibge_code"):
+            domain = [("ibge_code", "=", rec_dict.get("ibge_code"))]
+            match = self.search(domain, limit=1)
+            if match:
+                return match.id
+        return False

--- a/l10n_br_mdfe/tests/test_mdfe_import.py
+++ b/l10n_br_mdfe/tests/test_mdfe_import.py
@@ -1,6 +1,6 @@
 # @ 2020 KMEE INFORMATICA LTDA - www.kmee.com.br -
+# Copyright 2025 - TODAY Akretion - Raphael Valyi <raphael.valyi@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-import logging
 
 import nfelib
 import pkg_resources
@@ -8,8 +8,6 @@ from nfelib.mdfe.bindings.v3_0.mdfe_v3_00 import Tmdfe
 
 from odoo.models import NewId
 from odoo.tests import TransactionCase
-
-_logger = logging.getLogger(__name__)
 
 
 class MDFeImportTest(TransactionCase):
@@ -24,11 +22,8 @@ class MDFeImportTest(TransactionCase):
         resource_path = "/".join(res_items)
         mdfe_stream = pkg_resources.resource_stream(nfelib.__name__, resource_path)
         binding = Tmdfe.from_xml(mdfe_stream.read().decode())
-
-        mdfe = (
-            self.env["mdfe.30.tmdfe_infmdfe"]
-            .with_context(tracking_disable=True, edoc_type="in")
-            .build_from_binding("mdfe", "30", binding.infMDFe, dry_run=True)
+        mdfe = self.env["l10n_br_fiscal.document"].import_binding_mdfe(
+            binding, edoc_type="in", dry_run=True
         )
         assert isinstance(mdfe.id, NewId)
         self._check_mdfe(mdfe)
@@ -43,25 +38,42 @@ class MDFeImportTest(TransactionCase):
         resource_path = "/".join(res_items)
         mdfe_stream = pkg_resources.resource_stream(nfelib.__name__, resource_path)
         binding = Tmdfe.from_xml(mdfe_stream.read().decode())
-        mdfe = (
-            self.env["mdfe.30.tmdfe_infmdfe"]
-            .with_context(tracking_disable=True, edoc_type="in")
-            .build_from_binding("mdfe", "30", binding.infMDFe, dry_run=False)
+        for item in binding.infMDFe.infDoc.infMunDescarga:
+            # complete sample data to avoid empty state_id error:
+            item.cMunDescarga = "1200013"
+        mdfe = self.env["l10n_br_fiscal.document"].import_binding_mdfe(
+            binding, edoc_type="in", dry_run=False
         )
-
         assert isinstance(mdfe.id, int)
         self._check_mdfe(mdfe)
 
     def _check_mdfe(self, mdfe):
         self.assertEqual(type(mdfe)._name, "l10n_br_fiscal.document")
-
+        self.assertEqual(
+            mdfe.document_type_id, self.env.ref("l10n_br_fiscal.document_58")
+        )
+        self.assertEqual(mdfe.document_number, "1131")
         # ide
         self.assertEqual(mdfe.mdfe30_cMDF, "42103956")
         self.assertEqual(mdfe.mdfe30_infMunCarrega[0].mdfe30_xMunCarrega, "IVINHEMA")
         self.assertEqual(mdfe.mdfe30_UFIni, "MS")
         self.assertEqual(mdfe.mdfe30_UFFim, "PR")
+        self.assertEqual(mdfe.mdfe30_modal, "1")
+        self.assertEqual(mdfe.mdfe30_qNFe, 2)
+        self.assertEqual(mdfe.mdfe30_vCarga, 96800.0)
+        self.assertEqual(mdfe.mdfe30_qCarga, 44264.0)
+        self.assertEqual(mdfe.mdfe30_cUnid, "01")
 
-        # # modal
+        self.assertEqual(len(mdfe.mdfe30_infMunCarrega), 1)
+        self.assertEqual(mdfe.mdfe30_infMunCarrega[0].mdfe30_xMunCarrega, "IVINHEMA")
+        self.assertEqual(len(mdfe.mdfe30_infMunDescarga), 1)
+        if isinstance(mdfe.id, int):
+            self.assertEqual(
+                mdfe.mdfe30_infMunDescarga[0].city_id,
+                self.env.ref("l10n_br_base.city_1200013"),
+            )
+
+        # modal  # TODO implement modal mapping
         # self.assertEqual(mdfe.mdfe30_placa, "XXX1228")
         # self.assertEqual(mdfe.mdfe30_tara, "0")
         # self.assertEqual(mdfe.mdfe30_condutor[0].mdfe30_xNome, "TESTE")

--- a/l10n_br_nfe/hooks.py
+++ b/l10n_br_nfe/hooks.py
@@ -14,9 +14,7 @@ _logger = logging.getLogger(__name__)
 
 def post_init_hook(cr, registry):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    cr.execute("select demo from ir_module_module where name='l10n_br_nfe';")
-    is_demo = cr.fetchone()[0]
-    if is_demo:
+    if env.ref("base.module_l10n_br_nfe").demo:
         res_items = (
             "nfe",
             "samples",
@@ -33,11 +31,8 @@ def post_init_hook(cr, registry):
         )
         try:
             existing_nfes.unlink()
-            nfe = (
-                env["nfe.40.infnfe"]
-                .with_context(tracking_disable=True, edoc_type="in")
-                .build_from_binding("nfe", "40", binding.NFe.infNFe)
+            env["l10n_br_fiscal.document"].import_binding_nfe(
+                binding, edoc_type="in", dry_run=False
             )
-            _logger.info(nfe.nfe40_emit.nfe40_CNPJ)
         except ValidationError:
             _logger.info(f"NF-e already {document_number} imported by hooks")

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -727,23 +727,15 @@ class NFe(spec_models.StackedModel):
     def _prepare_import_dict(
         self, values, model=None, parent_dict=None, defaults_model=None
     ):
-        return {
-            **super()._prepare_import_dict(values, model, parent_dict, defaults_model),
-            "imported_document": True,
-        }
-
-    def _build_attr(self, node, fields, vals, path, attr):
-        key = f"nfe40_{attr[0]}"  # TODO schema wise
-        value = getattr(node, attr[0])
-
-        if key == "nfe40_mod":
-            vals["document_type_id"] = (
+        res = super()._prepare_import_dict(values, model, parent_dict, defaults_model)
+        res["imported_document"] = True
+        if "nfe40_mod" in values:
+            res["document_type_id"] = (
                 self.env["l10n_br_fiscal.document.type"]
-                .search([("code", "=", value)], limit=1)
+                .search([("code", "=", values["nfe40_mod"])], limit=1)
                 .id
             )
-
-        return super()._build_attr(node, fields, vals, path, attr)
+        return res
 
     def _build_many2one(self, comodel, vals, new_value, key, value, path):
         if key == "nfe40_entrega" and self.env.context.get("edoc_type") == "in":
@@ -1375,15 +1367,17 @@ class NFe(spec_models.StackedModel):
 
         self.file_report_id = self.env["ir.attachment"].create(attachment_data)
 
-    def import_binding_nfe(self, binding, edoc_type="out"):
+    def import_binding_nfe(self, binding, edoc_type="in", dry_run=False):
+        if hasattr(binding, "NFe"):
+            binding = binding.NFe
         document = (
             self.env["nfe.40.infnfe"]
-            .with_context(tracking_disable=True, edoc_type=edoc_type, dry_run=False)
-            .build_from_binding("nfe", "40", binding.NFe.infNFe)
+            .with_context(tracking_disable=True, edoc_type=edoc_type)
+            .build_from_binding("nfe", "40", binding.infNFe, dry_run=dry_run)
         )
 
         if edoc_type == "in" and document.company_id.cnpj_cpf != cnpj_cpf.formata(
-            binding.NFe.infNFe.emit.CNPJ
+            binding.infNFe.emit.CNPJ
         ):
             document.fiscal_operation_type = "in"
             document.issuer = "partner"

--- a/l10n_br_nfe/tests/test_nfe_import.py
+++ b/l10n_br_nfe/tests/test_nfe_import.py
@@ -1,4 +1,5 @@
-import logging
+# Copyright 2021 - TODAY Akretion - Raphael Valyi <raphael.valyi@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import nfelib
 import pkg_resources
@@ -6,8 +7,6 @@ from nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00 import TnfeProc
 
 from odoo.models import NewId
 from odoo.tests import TransactionCase
-
-_logger = logging.getLogger(__name__)
 
 
 class NFeImportTest(TransactionCase):
@@ -23,11 +22,8 @@ class NFeImportTest(TransactionCase):
         resource_path = "/".join(res_items)
         nfe_stream = pkg_resources.resource_stream(nfelib.__name__, resource_path)
         binding = TnfeProc.from_xml(nfe_stream.read().decode())
-
-        nfe = (
-            self.env["nfe.40.infnfe"]
-            .with_context(tracking_disable=True, edoc_type="in")
-            .build_from_binding("nfe", "40", binding.NFe.infNFe, dry_run=True)
+        nfe = self.env["l10n_br_fiscal.document"].import_binding_nfe(
+            binding, edoc_type="in", dry_run=True
         )
         assert isinstance(nfe.id, NewId)
         self._check_nfe(nfe)
@@ -43,10 +39,8 @@ class NFeImportTest(TransactionCase):
         resource_path = "/".join(res_items)
         nfe_stream = pkg_resources.resource_stream(nfelib.__name__, resource_path)
         binding = TnfeProc.from_xml(nfe_stream.read().decode())
-        nfe = (
-            self.env["nfe.40.infnfe"]
-            .with_context(tracking_disable=True, edoc_type="in")
-            .build_from_binding("nfe", "40", binding.NFe.infNFe, dry_run=False)
+        nfe = self.env["l10n_br_fiscal.document"].import_binding_nfe(
+            binding, edoc_type="in", dry_run=False
         )
 
         assert isinstance(nfe.id, int)
@@ -54,6 +48,10 @@ class NFeImportTest(TransactionCase):
 
     def _check_nfe(self, nfe):
         self.assertEqual(type(nfe)._name, "l10n_br_fiscal.document")
+        self.assertEqual(
+            nfe.document_type_id, self.env.ref("l10n_br_fiscal.document_55")
+        )
+        self.assertEqual(nfe.document_number, "47428")
 
         # here we check that emit and enderEmit
         # are now the supplier data (partner_id)

--- a/spec_driven_model/models/spec_import.py
+++ b/spec_driven_model/models/spec_import.py
@@ -3,6 +3,7 @@
 
 import dataclasses
 import inspect
+import itertools
 import logging
 import re
 from datetime import datetime
@@ -27,7 +28,7 @@ class SpecMixinImport(models.AbstractModel):
     """
 
     @api.model
-    def build_from_binding(self, spec_schema, spec_version, node, dry_run=False):
+    def build_from_binding(self, spec_schema, spec_version, binding, dry_run=False):
         """
         Build an instance of an Odoo Model from a pre-populated
         Python binding object. Binding object such as the ones generated using
@@ -47,7 +48,7 @@ class SpecMixinImport(models.AbstractModel):
         )
         self._register_hook()
         model = self._get_concrete_model(self._name)
-        attrs = model.build_attrs(node)
+        attrs = model.build_attrs(binding)
         if dry_run:
             return model.new(attrs)
         else:
@@ -117,17 +118,13 @@ class SpecMixinImport(models.AbstractModel):
                 else:
                     key = fields[key].related
                 comodel_name = fields[key].comodel_name
+                comodel = self._get_concrete_model(comodel_name)
             else:
-                clean_type = binding_type.lower()
-                comodel_name = "{}.{}.{}".format(
-                    self._context["spec_schema"],
-                    self._context["spec_version"].replace(".", "")[0:2],
-                    clean_type.split(".")[-1],
-                )
+                comodel = self._comodel_from_binding_type(binding_type)
 
-            comodel = self._get_concrete_model(comodel_name)
             if comodel is None:  # example skip ICMS100 class
                 return
+
             if str(attr[1].type).startswith("typing.List"):
                 # o2m
                 lines = []
@@ -146,6 +143,54 @@ class SpecMixinImport(models.AbstractModel):
                 self._build_many2one(
                     comodel, vals, comodel_vals, key, value, child_path
                 )
+
+    @api.model
+    def _comodel_from_binding_type(self, binding_type):
+        """
+        The binding_type is a full binding name. But it can be too long.
+        So in xsdata-odoo, when generating the corresponding abstract models,
+        we figure out the a minimal subset of the full binding_type name that is
+        both minimal and unique. For polymorphic schemas like Brazilian CT-e or MDF-e,
+        this minimal Odoo abstract unique model is not trivial and for a given binding,
+        we can try different combo of binding_type subsets until we eventually find the
+        Odoo model where it is mapped. This is what this method does.
+        """
+
+        def _comodel_from_model_suffix(model_suffix):
+            comodel_name = "{}.{}.{}".format(
+                self._context["spec_schema"],
+                self._context["spec_version"].replace(".", "")[0:2],
+                model_suffix,
+            )
+            return self._get_concrete_model(comodel_name)
+
+        clean_type = binding_type.lower()
+        parts = clean_type.split(".")
+        if len(parts) <= 1:
+            return _comodel_from_model_suffix(clean_type)
+
+        first = parts[0]
+        last = parts[-1]
+        middle = parts[1:-1]
+
+        all_combos = []
+
+        # Loop through all possible lengths for the middle part combinations
+        # (from 0 to all of them)
+        for i in range(len(middle) + 1):
+            # Get all combinations of the middle parts for a given length
+            for combo in itertools.combinations(middle, i):
+                # Create the new string by joining the first part,
+                # the current combination, and the last part
+                new_string = "_".join([first] + list(combo) + [last])
+                all_combos.append(new_string)
+
+        all_combos.append(last)
+        for model_suffix in all_combos:
+            comodel = _comodel_from_model_suffix(model_suffix)
+            if comodel is not None:
+                return comodel
+        return None
 
     @api.model
     def _build_many2one(self, comodel, vals, comodel_vals, key, value, path):

--- a/spec_driven_model/tests/test_spec_model.py
+++ b/spec_driven_model/tests/test_spec_model.py
@@ -1,6 +1,8 @@
 # Copyright 2021 Akretion - Raphael Valyi <raphael.valyi@akretion.com>
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
 
+from unittest.mock import patch
+
 from odoo_test_helper import FakeModelLoader
 
 from odoo.models import NewId
@@ -94,11 +96,7 @@ class TestSpecModel(TransactionCase, FakeModelLoader):
     def test_stacked_model(self):
         po_fields_or_stacking = set(self.env["fake.purchase.order"]._fields.keys())
         po_fields_or_stacking.update(
-            set(
-                self.env["fake.purchase.order"]
-                ._poxsd10_stacking_points
-                .keys()
-            )
+            set(self.env["fake.purchase.order"]._poxsd10_stacking_points.keys())
         )
         self.assertTrue(
             po_fields_or_stacking.issuperset(
@@ -106,11 +104,7 @@ class TestSpecModel(TransactionCase, FakeModelLoader):
             )
         )
         self.assertEqual(
-            list(
-                self.env["fake.purchase.order"]
-                ._poxsd10_stacking_points
-                .keys()
-            ),
+            list(self.env["fake.purchase.order"]._poxsd10_stacking_points.keys()),
             ["poxsd10_items"],
         )
 
@@ -130,7 +124,6 @@ class TestSpecModel(TransactionCase, FakeModelLoader):
         )
 
     def test_create_export_import(self):
-
         # 1st we create an Odoo PO:
         po = self.env["fake.purchase.order"].create(
             {
@@ -214,3 +207,36 @@ class TestSpecModel(TransactionCase, FakeModelLoader):
             imported_po.partner_id.id, self.env.ref("base.res_partner_1").id
         )
         self.assertEqual(imported_po.order_line[0].name, "Some product desc")
+
+    def test_polymorphic_comodel_from_binding_type(self):
+        binding_type = "Cte.Tcte.Ide"
+        expected_model_name = "cte.40.ide"
+        # in the l10n_br_cte module tcte_ide is actually expected
+        # but expecting the last combo here allows us to check the iterations/combos
+        available_models = {expected_model_name: "Found Fallback Model"}
+
+        method_path = (
+            "odoo.addons.spec_driven_model.models.spec_mixin."
+            "SpecMixin._get_concrete_model"
+        )
+        with patch(method_path) as mock_get_concrete_model:
+            mock_get_concrete_model.side_effect = lambda name: available_models.get(
+                name
+            )
+            model_instance = self.env["spec.mixin"].with_context(
+                spec_schema="cte", spec_version="40"
+            )
+            result = model_instance._comodel_from_binding_type(binding_type)
+
+        assert result == "Found Fallback Model"
+
+        # Check the full sequence of calls.
+        actual_calls = [c.args[0] for c in mock_get_concrete_model.call_args_list]
+        expected_model_suffixes = [
+            "cte.40.cte_ide",
+            "cte.40.cte_tcte_ide",
+            "cte.40.ide",  # This is the one that should be found (in this test)
+        ]
+
+        assert actual_calls == expected_model_suffixes
+        assert mock_get_concrete_model.call_count == len(expected_model_suffixes)


### PR DESCRIPTION
extraído de #4157 para facilitar a revisão

Eu comecei a testar de importar arquivos de CT-e e de MDF-e então e vi que faltava importar muita informação do proprio l10n_br_fiscal.document porque as no _spec_import.py, o _get_concrete_model("cte.40.ide") e de outros modelos retornava None. Isso porque ao montar os objetos "stacked" de CTe ou de MDFe, o polimorfismo faz que esses modelos abstract entravam no SPEC_MIXIN_MAPPINGS com um prefixo para evitar as colisões, como "cte.40.tcte_ide" em vez de "cte.40.ide" (para evitar colisão com CTe-OS por exemplo).

Por exemplo para a tag "Ide" da CTe, temos essas 4 variações e por isso o modelo abstrato veio com prefixo e não apenas como "cte.40.ide" (sem prefixo como fizemos com o l10n_br_nfe_spec).

- https://github.com/OCA/l10n-brazil/blob/18.0/l10n_br_cte_spec/models/v4_0/cte_tipos_basico_v4_00.py#L1192
- https://github.com/OCA/l10n-brazil/blob/18.0/l10n_br_cte_spec/models/v4_0/cte_tipos_basico_v4_00.py#L2344
- https://github.com/OCA/l10n-brazil/blob/18.0/l10n_br_cte_spec/models/v4_0/cte_tipos_basico_v4_00.py#L3459
- https://github.com/OCA/l10n-brazil/blob/18.0/l10n_br_cte_spec/models/v4_0/cte_tipos_basico_v4_00.py#L5750

A criação desse _name mínimo mas único pros bindings polimórficos pelo xsdata-odoo pode ser visto aqui e foi preciso pros modulos de CTe e MDfe não ter colisão de nomes:
https://github.com/akretion/xsdata-odoo/blob/master/xsdata_odoo/generator.py#L71

Esse PR soluciona isso procurando no SPEX_MIXIN_MAPPINGS com os vários combo de nomes que podem ser criados a partir de um binding XML (exemplo Cte.Tcte.Ide) que vai ser registrado no SPEX_MIXIN_MAPPINGS como cte.40.tctc_ide e não apenas como "cte.40.ide" como seria com os binding de NFe não não tem colisão nomes e que os nomes são minimalistas (antes desse fix o spec_driven_model usava somente o ultimo pedaço binding_type.split(".")[-1].

Finalmente, com o fix no spec_driven_model, mais coisas passaram as ser importadas para a MDF-e tambem. Em especial ele começou a importar as informações de descargas. E ele dava erro com state_id NULL ao tentar os registros de l10n_br_mdfe.municipio.descarga e é por isso que eu fiz o ultimo commit no l10n_br_mdfe

OBS: Eu movi o calculo do document_type_id do _build_attr pro _prepare_import a gente tb evita bugs estranhos onde os hooks que importavam documentos fiscais de demo acabavam tentando criar registros l10n_br_fiscal.document.type que criavam erros de integridade por conta de unicidade do code. Isso acontecia qdo mudava a ordem de instalação ou repetia os testes porque o _build_attr rodava antes do framework tentar deduiz um valor a partir do code mapeado em related com mdef30_mod ou cte40_mod.