### PR TITLE
[16.0][REF] l10n_br_account: Do not call inverse in tests

### DIFF
--- a/l10n_br_account/tests/test_move_document_discount.py
+++ b/l10n_br_account/tests/test_move_document_discount.py
@@ -107,7 +107,6 @@ class TestInvoiceDatesAndDiscount(TransactionCase):
         self.move_id.issuer = DOCUMENT_ISSUER_PARTNER
         new_date = datetime.now() - timedelta(days=2)
         self.move_id.fiscal_document_id.document_date = new_date
-        self.move_id.fiscal_document_id._inverse_document_date()
 
         self.assertEqual(
             self.move_id.invoice_date,


### PR DESCRIPTION
Trival.. não há necessidade chamar o inverse de forma explicita.