### PR TITLE
[16.0][IMP] l10n_br_account: remove proxy_product_id

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -29,7 +29,7 @@ from .constants import (
 class AccountMove(models.Model):
     _name = "account.move"
     _fiscal_decorator_model = "l10n_br_fiscal.document"
-    _fiscal_decorator_compute_blacklist = ["_compute_fiscal_amount"]
+    # _fiscal_decorator_compute_blacklist = ["_compute_fiscal_amount"]
     _inherit = [
         _name,
         "l10n_br_fiscal.document.mixin.methods",

--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -11,7 +11,7 @@ from odoo.tools import frozendict
 class AccountMoveLine(models.Model):
     _name = "account.move.line"
     _fiscal_decorator_model = "l10n_br_fiscal.document.line"
-    _fiscal_decorator_compute_blacklist = ["_compute_fiscal_amounts"]
+    # _fiscal_decorator_compute_blacklist = ["_compute_fiscal_amounts"]
     _inherit = [
         _name,
         "l10n_br_fiscal.document.line.mixin.methods",

--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -56,14 +56,6 @@ class AccountMoveLine(models.Model):
     price_unit = fields.Float(inverse="_inverse_price_unit")
     product_uom_id = fields.Many2one(inverse="_inverse_product_uom_id")
 
-    @api.onchange("product_id")
-    def _inverse_product_id(self):
-        for line in self:
-            # we use proxy_product_id to avoid triggering _compute_product_fiscal_fields
-            # which would erase custom values such as custom ncm_id
-            line.proxy_product_id = line.product_id
-        return super()._inverse_product_id()
-
     @api.onchange("name")
     def _inverse_name(self):
         for line in self:

--- a/l10n_br_account/models/document_line.py
+++ b/l10n_br_account/models/document_line.py
@@ -19,15 +19,7 @@ class FiscalDocumentLine(models.Model):
     # SHADOWED FIELDS SYNC
     # -------------------------------------------------------------------------
 
-    proxy_product_id = fields.Many2one(
-        comodel_name="product.product",
-        string="Product (proxy)",
-        help="Technical Field.",
-        readonly=False,
-    )
-
     product_id = fields.Many2one(
-        related="proxy_product_id",
         comodel_name="product.product",
         string="Product",
         store=True,

--- a/l10n_br_account/models/document_line.py
+++ b/l10n_br_account/models/document_line.py
@@ -32,13 +32,6 @@ class FiscalDocumentLine(models.Model):
     price_unit = fields.Float(inverse="_inverse_price_unit")
     uom_id = fields.Many2one(inverse="_inverse_uom_id")
 
-    @api.onchange("product_id")
-    def _inverse_product_id(self):
-        for line in self:
-            for aml in line.account_line_ids:
-                if aml.product_id != line.product_id:
-                    aml.product_id = line.product_id.id
-
     @api.onchange("name")
     def _inverse_name(self):
         for line in self:

--- a/l10n_br_account/views/account_move_view.xml
+++ b/l10n_br_account/views/account_move_view.xml
@@ -154,7 +154,6 @@
                     domain here that is checked before the dynamic fiscal
                     placeholders kick in.
                 -->
-                <field name="proxy_product_id" invisible="1" />
                 <field name="fiscal_operation_id" invisible="1" />
                 <field name="document_type_id" invisible="1" />
                 <field name="fiscal_operation_type" invisible="1" />
@@ -289,7 +288,6 @@
                     name="fiscal_price"
                     attrs="{'invisible': [('document_type_id', '=', False)]}"
                 />
-                <field name="proxy_product_id" invisible="1" />
                 <field name="amount_currency" invisible="1" />
                 <field name="date" invisible="1" />
                 <field name="date_maturity" invisible="1" />


### PR DESCRIPTION
This pull request removes the use of the `proxy_product_id` field from the Brazilian localization accounting module. The changes simplify how product information is handled in both the model definitions and the user interface, eliminating technical indirection and unused code.

**Model cleanup and simplification:**

* Removed the `proxy_product_id` field from the `FiscalDocumentLine` model and updated the `product_id` field to no longer be related to `proxy_product_id`, making `product_id` a direct reference to the product.
* Deleted the `_inverse_product_id` method from the `AccountMoveLine` model, which previously used `proxy_product_id` to avoid triggering fiscal field computations.

**User interface updates:**

* Removed all references to `proxy_product_id` from the `account_move_view.xml` view, ensuring the technical field is no longer present or invisible in the UI. [[1]](diffhunk://#diff-beb5cd2b481034453b306f8119d7ecfee6921ac2a48d2c950f0ecb53b085829dL157) [[2]](diffhunk://#diff-beb5cd2b481034453b306f8119d7ecfee6921ac2a48d2c950f0ecb53b085829dL292)