### PR TITLE
[16.0][FIX] l10n_br_account: add sync_proxy_fields

### DIFF
--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -120,9 +120,20 @@ class AccountMoveLine(models.Model):
             return super()._compute_name()
         return True
 
+    @api.model
+    def _sync_proxy_fields_vals(self, vals):
+        if "proxy_product_id" not in vals and "product_id" in vals:
+            vals["proxy_product_id"] = vals["product_id"]
+
+    def write(self, values):
+        self._sync_proxy_fields_vals(values)
+        res = super().write(values)
+        return res
+
     @api.model_create_multi
     def create(self, vals_list):
         for values in vals_list:
+            self._sync_proxy_fields_vals(values)
             if values.get("fiscal_document_line_id"):
                 continue
 

--- a/l10n_br_contract/tests/test_l10n_br_contract.py
+++ b/l10n_br_contract/tests/test_l10n_br_contract.py
@@ -29,6 +29,7 @@ class TestL10nBrContract(TransactionCase):
                     "l10n_br_fiscal.customized_development_sale"
                 )
                 line.fiscal_operation_id = cls.env.ref("l10n_br_fiscal.fo_venda")
+                line.price_unit = 550.00
 
         # Create Invoice and Fiscal Documents related to the contract
         cls.contract_id.recurring_create_invoice()
@@ -74,6 +75,12 @@ class TestL10nBrContract(TransactionCase):
                     "The product of the Fiscal Document does not "
                     "correspond with the expected",
                 )
+                self.assertEqual(
+                    550.00,
+                    document_id.fiscal_line_ids[0].price_unit,
+                    "The price unit of the Fiscal Document does not "
+                    "correspond with the expected",
+                )
 
             else:
                 product_1_id = self.env.ref("product.product_delivery_01")
@@ -112,6 +119,13 @@ class TestL10nBrContract(TransactionCase):
                     service_product_id.id,
                     invoice.invoice_line_ids[0].product_id.id,
                     "The product of the Fiscal Document does not "
+                    "correspond with the expected",
+                )
+
+                self.assertEqual(
+                    550.00,
+                    invoice.invoice_line_ids[0].price_unit,
+                    "The price unit of the Invoice does not "
                     "correspond with the expected",
                 )
 


### PR DESCRIPTION
This pull request introduces a mechanism to synchronize the `proxy_product_id` field with the `product_id` field in `account_move_line` records, ensuring data consistency when creating or updating records. Additionally, the test suite for contracts has been enhanced to verify that the correct price unit is set for both invoices and fiscal documents.

**Proxy field synchronization:**

* Added the `_sync_proxy_fields_vals` method to `l10n_br_account/models/account_move_line.py` to automatically set `proxy_product_id` to the value of `product_id` if not already present when creating or updating records. This logic is now invoked in both the `write` and `create` methods to ensure consistency.

**Test improvements for contract pricing:**

* Set the `price_unit` to `550.00` in the contract test setup to establish a consistent test value for invoice and fiscal document lines.
* Added assertions in `test_created_fiscal_documents` to verify that the fiscal document line's `price_unit` matches the expected value of `550.00`.
* Added assertions in `test_created_invoices` to verify that the invoice line's `price_unit` matches the expected value of `550.00`.

Ref https://github.com/OCA/l10n-brazil/issues/4173