### PR TITLE
[14.0][REM] l10n_br_hr_contract: remove _rec_names_search

### DIFF
--- a/l10n_br_hr_contract/models/hr_data_abstract.py
+++ b/l10n_br_hr_contract/models/hr_data_abstract.py
@@ -7,7 +7,6 @@ from odoo import fields, models
 class HrDataAbstract(models.AbstractModel):
     _name = "l10n_br_hr_contract.data.abstract"
     _description = "HR Data Base Abstract"
-    _rec_names_search = ["code", "name"]
 
     code = fields.Char(required=True, index=True)
 


### PR DESCRIPTION
### PR Trivial 
apenas para fazer remoção do _rec_names_search, como esse modulo foi feito o backport a partir da 16.0 acabou ficando essa questão.

cc @kaynnan @rvalyi @antoniospneto @marcelsavegnago 