### PR TITLE
[16.0][FIX] l10n_br_nfse_focus: limit informacoes_adicionais_contribuinte

### DIFF
--- a/l10n_br_nfse_focus/models/document.py
+++ b/l10n_br_nfse_focus/models/document.py
@@ -146,8 +146,10 @@ class FocusnfeNfse(models.AbstractModel):
             "natureza_operacao": rps_info.get("natureza_operacao"),
             "optante_simples_nacional": rps_info.get("optante_simples_nacional", False),
             "status": rps_info.get("status"),
-            "informacoes_adicionais_contribuinte": rps_info.get(
-                "customer_additional_data", False
+            "informacoes_adicionais_contribuinte": (
+                rps_info.get("customer_additional_data", False)[:256]
+                if rps_info.get("customer_additional_data")
+                else False
             ),
         }
         codigo_obra = rps_info.get("codigo_obra", False)


### PR DESCRIPTION
## Objetivo da PR

Fazer limitação de 256 caracteres do informações adicionais do contribuente

Conforme suporte da Focus o campo informações adicionais do contribuente aceita somente 256 caracteres isso esta retornando um 422 ficando um pouco complicado de fazer a motivação do erro.

Estou trabalhando na PR #4146 para melhorar essa questão da mensagem do erro.
<img width="993" height="419" alt="image" src="https://github.com/user-attachments/assets/196723a9-8e2e-4498-bea7-0fcb0e1fe27b" />
