### PR TITLE
[16.0][IMP] l10n_br_fiscal: inject missing computed fields

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -208,7 +208,8 @@ class AccountMove(models.Model):
         arch, view = super()._get_view(view_id, view_type, **options)
         if self.env.company.country_id.code != "BR" or view_type != "form":
             return arch, view
-        arch = self.env["account.move.line"].inject_fiscal_fields(arch)
+        if view_type == "form" and self.env.company.country_id.code == "BR":
+            arch = self.env["account.move.line"].inject_fiscal_fields(arch)
 
         for tax_totals_node in arch.xpath(
             "//field[@name='tax_totals'][@widget='account-tax-totals-field']"

--- a/l10n_br_fiscal/models/document_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_line_mixin_methods.py
@@ -4,6 +4,7 @@
 from copy import deepcopy
 
 from lxml import etree
+from lxml.builder import E
 
 from odoo import Command, api, models
 
@@ -85,6 +86,23 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
         Inject common fiscal fields into view placeholder elements.
         Used for invoice line, sale order line, purchase order line...
         """
+
+        # the list of computed fields we will add to the view when missing
+        missing_line_fields = set(
+            [
+                fname
+                for fname, _field in filter(
+                    lambda item: item[1].compute
+                    in (
+                        "_compute_tax_fields",
+                        "_compute_fiscal_tax_ids",
+                        "_compute_product_fiscal_fields",
+                    ),
+                    self.env["l10n_br_fiscal.document.line.mixin"]._fields.items(),
+                )
+            ]
+        )
+
         fiscal_view = self.env.ref(
             "l10n_br_fiscal.document_fiscal_line_mixin_form"
         ).sudo()
@@ -133,13 +151,19 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                         e.attrib["name"] for e in target_node if e.tag == "field"
                     ]
                     for fiscal_node in fiscal_nodes:
+                        if fiscal_node.attrib["name"] in missing_line_fields:
+                            missing_line_fields.remove(fiscal_node.attrib["name"])
                         if fiscal_node.attrib["name"] in existing_fields:
                             continue
                         field = deepcopy(fiscal_node)
                         if not field.attrib.get("optional"):
-                            field.attrib["invisible"] = "0"
                             field.attrib["optional"] = "hide"
                         target_node.append(field)
+                    for fname in missing_line_fields:
+                        if fname not in existing_fields:
+                            target_node.append(
+                                E.field(name=fname, string=fname, optional="hide")
+                            )
         return doc
 
     @api.model

--- a/l10n_br_purchase/models/purchase_order.py
+++ b/l10n_br_purchase/models/purchase_order.py
@@ -55,7 +55,8 @@ class PurchaseOrder(models.Model):
             "//field[@name='tax_totals'][@widget='account-tax-totals-field']"
         ):
             tax_totals_node.set("attrs", "{'invisible': True}")
-        arch = self.env["purchase.order.line"].inject_fiscal_fields(arch)
+        if view_type == "form" and self.env.company.country_id.code == "BR":
+            arch = self.env["purchase.order.line"].inject_fiscal_fields(arch)
 
         if view_type == "form" and (
             self.user_has_groups("l10n_br_purchase.group_line_fiscal_detail")

--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -75,7 +75,8 @@ class SaleOrder(models.Model):
         arch, view = super()._get_view(view_id, view_type, **options)
         if self.env.company.country_id.code != "BR":
             return arch, view
-        arch = self.env["sale.order.line"].inject_fiscal_fields(arch)
+        if view_type == "form" and self.env.company.country_id.code == "BR":
+            arch = self.env["sale.order.line"].inject_fiscal_fields(arch)
         for tax_totals_node in arch.xpath(
             "//field[@name='tax_totals'][@widget='account-tax-totals-field']"
         ):

--- a/l10n_br_stock_account/models/stock_picking.py
+++ b/l10n_br_stock_account/models/stock_picking.py
@@ -48,7 +48,7 @@ class StockPicking(models.Model):
     @api.model
     def _get_view(self, view_id=None, view_type="form", **options):
         arch, view = super()._get_view(view_id, view_type, **options)
-        if self.env.company.country_id.code == "BR":
+        if view_type == "form" and self.env.company.country_id.code == "BR":
             arch = self.env["stock.move"].inject_fiscal_fields(arch)
 
         return arch, view


### PR DESCRIPTION
This ensures _compute methods like _compute_tax_fields won't override custom editable fields just because some some fields was not sent from the client to the server.

Isso foi extraido de #4181.
@antoniospneto eu acredito que mesmo se a gente for partir para sua solução de matar o fiscal_decorator_mixin, isso sempre vai ser útil. Ai por exemplo na sua branch, depois de mesclar isso vc poderia adicionar uma so vez a lista de proxy_fields no inicio do método inject_fiscal_fields e assim a gente reduz o diff.
