### PR TITLE
[16.0][REF] l10n_br_purchase: Campos precompute herdados do fiscal

### DIFF
--- a/l10n_br_contract/models/contract_line.py
+++ b/l10n_br_contract/models/contract_line.py
@@ -41,11 +41,6 @@ class ContractLine(models.Model):
 
     line_recurrence = fields.Boolean(related="contract_id.line_recurrence")
 
-    def _get_fiscal_tax_ids_dependencies(self):
-        fields = super()._get_fiscal_tax_ids_dependencies()
-        fields.remove("company_id")
-        return fields
-
     def _prepare_invoice_line(self):
         self.ensure_one()
 

--- a/l10n_br_fiscal/models/document_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_line_mixin_methods.py
@@ -274,25 +274,18 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 product=self.product_id,
             )
 
-    def _get_fiscal_tax_ids_dependencies(self):
-        """
-        Dynamically get the list of fields dependencies, overriden in l10n_br_purchase.
-        """
-        return [
-            "company_id",
-            "partner_id",
-            "fiscal_operation_line_id",
-            "product_id",
-            "ncm_id",
-            "nbs_id",
-            "nbm_id",
-            "cest_id",
-            "city_taxation_code_id",
-            "service_type_id",
-            "ind_final",
-        ]
-
-    @api.depends(lambda self: self._get_fiscal_tax_ids_dependencies())
+    @api.depends(
+        "partner_id",
+        "fiscal_operation_line_id",
+        "product_id",
+        "ncm_id",
+        "nbs_id",
+        "nbm_id",
+        "cest_id",
+        "city_taxation_code_id",
+        "service_type_id",
+        "ind_final",
+    )
     def _compute_fiscal_tax_ids(self):
         """
         Use fiscal_operation_line_id to map and compute the applicable Brazilian taxes.
@@ -363,34 +356,26 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             mask_dict[fiscal_tax_field] = False
         return mask_dict
 
-    def _get_tax_fields_dependencies(self):
-        """
-        Dynamically get the list of fields dependencies, overriden in l10n_br_purchase.
-        """
-        # IMPORTANT NOTE: as _compute_fiscal_tax_ids triggers _compute_tax_fields,
-        # we don't put fields that trigger _compute_fiscal_tax_ids as dependencies here.
-        return [
-            "price_unit",
-            "quantity",
-            "uom_id",
-            "fiscal_price",
-            "fiscal_quantity",
-            "uot_id",
-            "discount_value",
-            "insurance_value",
-            "ii_customhouse_charges",
-            "ii_iof_value",
-            "other_value",
-            "freight_value",
-            "cfop_id",
-            "icmssn_range_id",
-            "icms_origin",
-            "icms_cst_id",
-            "icms_relief_id",
-            "fiscal_tax_ids",
-        ]
-
-    @api.depends(lambda self: self._get_tax_fields_dependencies())
+    @api.depends(
+        "price_unit",
+        "quantity",
+        "uom_id",
+        "fiscal_price",
+        "fiscal_quantity",
+        "uot_id",
+        "discount_value",
+        "insurance_value",
+        "ii_customhouse_charges",
+        "ii_iof_value",
+        "other_value",
+        "freight_value",
+        "cfop_id",
+        "icmssn_range_id",
+        "icms_origin",
+        "icms_cst_id",
+        "icms_relief_id",
+        "fiscal_tax_ids",
+    )
     def _compute_tax_fields(self):
         """
         Compute base, percent, value... tax fields for ICMS, IPI, PIS, COFINS... taxes.

--- a/l10n_br_purchase/models/purchase_order_line.py
+++ b/l10n_br_purchase/models/purchase_order_line.py
@@ -38,16 +38,6 @@ class PurchaseOrderLine(models.Model):
         "('state', '=', 'approved')]",
     )
 
-    # overriden to disable precompute as it depends on price_unit which is not
-    # precompute in the purchase module. We don't need precompute in purchase.
-    fiscal_price = fields.Float(
-        precompute=False,
-    )
-
-    price_unit = fields.Float(
-        precompute=False,
-    )
-
     quantity = fields.Float(
         string="Mixin Quantity",
         related="product_qty",
@@ -78,18 +68,6 @@ class PurchaseOrderLine(models.Model):
     delivery_costs = fields.Selection(
         related="company_id.delivery_costs",
     )
-
-    def _get_fiscal_tax_ids_dependencies(self):
-        fields = super()._get_fiscal_tax_ids_dependencies()
-        fields.remove("company_id")
-        fields.remove("partner_id")
-        return fields
-
-    def _get_tax_fields_dependencies(self):
-        fields = super()._get_tax_fields_dependencies()
-        fields.remove("price_unit")
-        fields.remove("fiscal_price")
-        return fields
 
     @api.depends(
         "product_uom_qty",
@@ -161,6 +139,30 @@ class PurchaseOrderLine(models.Model):
                 partner.address_get(["invoice"]).get("invoice")
             )
         return partner
+
+    def _setup_complete(self):
+        # /!\ LOW-LEVEL OVERRIDE (registry setup) /!\
+        # The BR fiscal mixin uses many fields with precompute=True,
+        # but purchase does not have all dependencies ready at create time.
+        # Since we have hundreds of fields, instead of overriding each one,
+        # we set precompute=False dynamically here.
+        res = super()._setup_complete()
+        mixin = self.env["l10n_br_fiscal.document.line.mixin"]
+        mixin_fields = mixin._fields
+        for name, field in self._fields.items():
+            mixin_field = mixin_fields.get(name)
+            if not mixin_field:
+                continue
+            if mixin_field.compute in (
+                "_compute_price_unit_fiscal",
+                "_compute_product_fiscal_fields",
+                "_compute_fiscal_quantity",
+                "_compute_fiscal_price",
+                "_compute_fiscal_tax_ids",
+                "_compute_tax_fields",
+            ) and getattr(mixin_field, "precompute", False):
+                field.precompute = False
+        return res
 
     @api.model
     def _get_total_for_tax_totals(self):


### PR DESCRIPTION
Extraido de #4072

Proposta diferente paral lidar com os campos precompute=True que são herdados do fiscal no módulo Purschase.

É feito um override no método _setup_complete para desativar o precompute dos campos herdados.