### PR TITLE
[16.0][FIX] l10n_br_fiscal: add space in dashboard links

### DIFF
--- a/l10n_br_fiscal/views/operation_dashboard_view.xml
+++ b/l10n_br_fiscal/views/operation_dashboard_view.xml
@@ -76,7 +76,7 @@
                                                         <span title="A enviar">
                                                         <t
                                                                 t-esc="dashboard.number_2confirm"
-                                                            />A enviar</span>
+                                                            /> A enviar</span>
                                                     </a>
                                                 </div>
                                             </div>
@@ -90,7 +90,7 @@
                                                     >
                                                     <t
                                                             t-esc="dashboard.number_authorized"
-                                                        />Autorizados</a>
+                                                        /> Autorizados</a>
                                                 </div>
                                             </div>
                                             <div class="row">
@@ -105,7 +105,7 @@
                                                         >
                                                         <t
                                                                 t-esc="dashboard.number_cancelled"
-                                                            />Cancelados</span>
+                                                            /> Cancelados</span>
                                                     </a>
                                                 </div>
                                             </div>


### PR DESCRIPTION
Estava faltando um espaço no link dos documentos no dashboard do fiscal:

<img width="673" height="342" alt="image" src="https://github.com/user-attachments/assets/ddac855a-d35c-42a3-893a-1f28a556072e" />



