### PR TITLE
[16.0][FIX] l10n_br_stock_account: Prevent unintended recomputation

### DIFF
--- a/l10n_br_stock_account/models/stock_move.py
+++ b/l10n_br_stock_account/models/stock_move.py
@@ -234,6 +234,12 @@ class StockMove(models.Model):
         for record in self:
             record.fiscal_price = record.price_unit
 
+    @api.depends("product_id", "state")
+    def _compute_product_fiscal_fields(self):
+        # Skip compute for "done" records
+        moves = self.filtered(lambda m: m.state != "done")
+        return super(StockMove, moves)._compute_product_fiscal_fields()
+
     def _get_taxes(self, fiscal_position, inv_type):
         """
         Map product taxes based on given fiscal position


### PR DESCRIPTION
Extraido de #4072 

Sobreescrita no compute herdado do fiscal para evitar recomputação acidentais sobre documento já confirmado.