### PR TITLE
[16.0][IMP] l10n_br_fiscal: prod fields required if sale_ok+cleanup

### DIFF
--- a/l10n_br_fiscal/views/product_product_view.xml
+++ b/l10n_br_fiscal/views/product_product_view.xml
@@ -58,16 +58,28 @@
                 >
                     <group>
                         <group>
-                            <field name="fiscal_type" required="1" />
+                            <field
+                                name="fiscal_type"
+                                required="1"
+                                attrs="{'required': [('sale_ok', '=', True)]}"
+                            />
                             <field
                                 name="icms_origin"
-                                attrs="{'required': [('fiscal_type', '!=', '09')], 'invisible': [('fiscal_type', '=', '09')]}"
+                                attrs="{'required': ['&amp;', ('fiscal_type', '!=', '09'), '|', ('sale_ok', '=', True), ('purchase_ok', '=', True)], 'invisible': [('fiscal_type', '=', '09')]}"
                             />
-                            <field name="ncm_id" required="1" />
-                            <field name="tax_icms_or_issqn" required="1" />
+                            <field
+                                name="ncm_id"
+                                attrs="{'required': ['|', ('sale_ok', '=', True), ('purchase_ok', '=', True)]}"
+                                options="{'no_create': True, 'no_create_edit': True}"
+                            />
+                            <field
+                                name="tax_icms_or_issqn"
+                                attrs="{'required': ['|', ('sale_ok', '=', True), ('purchase_ok', '=', True)]}"
+                            />
                             <field
                                 name="service_type_id"
                                 attrs="{'invisible': [('fiscal_type', '!=', '09')]}"
+                                options="{'no_create': True, 'no_create_edit': True}"
                             />
                             <field
                                 name="city_taxation_code_ids"
@@ -84,22 +96,35 @@
                             </field>
                         </group>
                         <group>
-                            <field name="fiscal_genre_id" required="1" />
+                            <field
+                                name="fiscal_genre_id"
+                                attrs="{'required': [('sale_ok', '=', True)]}"
+                                options="{'no_create': True, 'no_create_edit': True}"
+                            />
                             <field
                                 name="cest_id"
                                 attrs="{'invisible': [('fiscal_type', '=', '09')]}"
+                                options="{'no_create': True, 'no_create_edit': True}"
+                            />
+                            <field
+                                name="nbm_id"
+                                attrs="{'invisible': [('fiscal_type', '=', '09')]}"
+                                options="{'no_create': True, 'no_create_edit': True}"
                             />
                             <field
                                 name="nbs_id"
                                 attrs="{'invisible': [('fiscal_type', '!=', '09')]}"
+                                options="{'no_create': True, 'no_create_edit': True}"
                             />
                             <field
                                 name="ipi_guideline_class_id"
                                 attrs="{'invisible': [('fiscal_type', '=', '09')]}"
+                                options="{'no_create': True, 'no_create_edit': True}"
                             />
                             <field
                                 name="ipi_control_seal_id"
                                 attrs="{'invisible': [('fiscal_type', '=', '09')]}"
+                                options="{'no_create': True, 'no_create_edit': True}"
                             />
                         </group>
                         <group string="Tax UOM">

--- a/l10n_br_fiscal/views/product_template_view.xml
+++ b/l10n_br_fiscal/views/product_template_view.xml
@@ -59,17 +59,24 @@
                 <page name="fiscal" string="Fiscal" groups="l10n_br_fiscal.group_user">
                     <group>
                         <group>
-                            <field name="fiscal_type" required="1" />
+                            <field
+                                name="fiscal_type"
+                                required="1"
+                                attrs="{'required': [('sale_ok', '=', True)]}"
+                            />
                             <field
                                 name="icms_origin"
-                                attrs="{'required': [('fiscal_type', '!=', '09')], 'invisible': [('fiscal_type', '=', '09')]}"
+                                attrs="{'required': ['&amp;', ('fiscal_type', '!=', '09'), '|', ('sale_ok', '=', True), ('purchase_ok', '=', True)], 'invisible': [('fiscal_type', '=', '09')]}"
                             />
                             <field
                                 name="ncm_id"
-                                required="1"
+                                attrs="{'required': ['|', ('sale_ok', '=', True), ('purchase_ok', '=', True)]}"
                                 options="{'no_create': True, 'no_create_edit': True}"
                             />
-                            <field name="tax_icms_or_issqn" required="1" />
+                            <field
+                                name="tax_icms_or_issqn"
+                                attrs="{'required': ['|', ('sale_ok', '=', True), ('purchase_ok', '=', True)]}"
+                            />
                             <field
                                 name="service_type_id"
                                 attrs="{'invisible': [('fiscal_type', '!=', '09')]}"
@@ -104,7 +111,7 @@
                         <group>
                             <field
                                 name="fiscal_genre_id"
-                                required="1"
+                                attrs="{'required': [('sale_ok', '=', True)]}"
                                 options="{'no_create': True, 'no_create_edit': True}"
                             />
                             <field
@@ -120,6 +127,16 @@
                             <field
                                 name="nbs_id"
                                 attrs="{'invisible': [('fiscal_type', '!=', '09')]}"
+                                options="{'no_create': True, 'no_create_edit': True}"
+                            />
+                            <field
+                                name="ipi_guideline_class_id"
+                                attrs="{'invisible': [('fiscal_type', '=', '09')]}"
+                                options="{'no_create': True, 'no_create_edit': True}"
+                            />
+                            <field
+                                name="ipi_control_seal_id"
+                                attrs="{'invisible': [('fiscal_type', '=', '09')]}"
                                 options="{'no_create': True, 'no_create_edit': True}"
                             />
                         </group>


### PR DESCRIPTION
vários ajustes nas abas fiscais do template e da variante de produto.

1. A visão **variante** tinha os campos ipi_guideline_class_id e ipi_control_seal e a visão de **template** não tinha -> adicionei. Veja:
<img width="1542" height="945" alt="2025-11-01_01-34" src="https://github.com/user-attachments/assets/4e780584-d0f6-4812-bc4e-c76932a5a218" />
<img width="1214" height="760" alt="2025-11-01_01-35" src="https://github.com/user-attachments/assets/550206c8-fc52-45b7-97b4-6446fd7d2c59" />

2. Ajustei as opções  "{'no_create': True, 'no_create_edit': True}" onde faltava

3. Por fim eu tirei o required dos campos fiscais que impactam apenas as NFe e deixei obrigatório apenas se tiver sale_ok True. Pros campos ncm_id e tax_icms_or_issqn e icms_origin eu deixei obrigatorio se tiver sale_ok ou purchase_ok ja que esses campos impactam o tax_engine até em compras. Ainda teria o caso do produto que não pode ser nem vendido e nem comprado mas precisa ir numa nota de simples remessa. Mas eu acho que esse caso é raro suficente para deixar isso pro customização ou sem required até a nota. Pois pelo contrario, o que é chato hoje é que vc pode ter um montão de produtos intermediários ou para os quais vc ainda não quer implantar venda ou compras e que o usuario fica blocado para editar qualquer coisa se ele for usuario fiscal. Essa mudança alivia um pouco aqui.
