### PR TITLE
[16.0][FIX] l10n_br_fiscal: compute price_unit only for standalone documents

### DIFF
--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -71,6 +71,14 @@ class DocumentLine(models.Model):
         precompute=True,
     )
 
+    price_unit = fields.Float(
+        digits="Product Price",
+        compute="_compute_price_unit_fiscal",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
+
     quantity = fields.Float(default=1.0)
 
     # Usado para tornar Somente Leitura os campos dos custos

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -125,10 +125,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
 
     price_unit = fields.Float(
         digits="Product Price",
-        compute="_compute_price_unit_fiscal",
         store=True,
-        precompute=True,
-        readonly=False,
     )
 
     partner_id = fields.Many2one(comodel_name="res.partner", string="Partner")


### PR DESCRIPTION
o price_unit já vem calculado em sale, purchase, l10n_br_stock_account e então o compute não precisa ficar no l10n_br_fiscal_document.mixin.methods, apenas no l10n_br_fiscal.document.line para não interferir.