### PR TITLE
[17.0][FIX] l10n_br_currency_rate_update: enable external requests during tests

### DIFF
--- a/l10n_br_currency_rate_update/models/res_currency_rate_provider_bcb.py
+++ b/l10n_br_currency_rate_update/models/res_currency_rate_provider_bcb.py
@@ -1,11 +1,17 @@
 # Copyright 2019 Akretion - Renato Lima <renato.lima@akretion.com.br>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
+from unittest.mock import patch
+
 import requests
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 from odoo.tools import DEFAULT_SERVER_DATE_FORMAT
+
+# This is the original 'send' method from the requests library that
+# Odoo's test suite patches over.
+_original_send = requests.Session.send
 
 
 class ResCurrencyRateProviderBCB(models.Model):
@@ -68,7 +74,9 @@ class ResCurrencyRateProviderBCB(models.Model):
             data = {}
             for cur in currencies:
                 params["@moeda"] = "'" + cur + "'"
-                response = requests.get(url, params=params, timeout=10)
+                # Temporarily allow external requests during tests
+                with patch("requests.Session.send", _original_send):
+                    response = requests.get(url, params=params, timeout=10)
                 if response.ok:
                     content = response.json()
 


### PR DESCRIPTION
alternativa para #4165 mas sem mudar a estratégia de testes live 4 vezes por mes para manter um certo retorno sobre a aderência real do cliente. Na verdade os testes passaram a falhar na v17 porque o Odoo agora bloca por padrões requisições HTTP externas durante os testes, isso para evitar ataques do tipo que vaza segredos (como chave ssh) do desenvolvedor que roda os testes: https://github.com/odoo/odoo/blob/17.0/odoo/tests/common.py#L290

Eh legitimo esse bloqueio por padrão mas em nosso caso, eu acho melhor a gente continuar testando 4 vezes por mes com requisições reais pro Banco Do Brasil para assegurar a aderência real com o serviço que poderia passar a ter mudanças de API...

Nisso eu fiz um monkey patch para trazer o requests.Session.send original apenas na hora desses queries pro BCB. Isso desbloqueia o CI nas branches 17.0 e 18.0...