### PR TITLE
[16.0][IMP] l10n_br_cnab_structure: Enhance CNAB field error handling with detailed ValidationError

### DIFF
--- a/l10n_br_cnab_structure/models/cnab_line_field.py
+++ b/l10n_br_cnab_structure/models/cnab_line_field.py
@@ -3,6 +3,7 @@
 # @author Felipe Motter Pereira <felipe@engenere.one>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+import inspect
 import operator
 import re
 from datetime import datetime
@@ -10,7 +11,7 @@ from datetime import datetime
 from unidecode import unidecode
 
 from odoo import _, api, fields, models
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 from odoo.tools.safe_eval import safe_eval, time
 
 
@@ -196,6 +197,28 @@ class CNABField(models.Model):
         for rec in self:
             value = rec.default_value or ""
             if rec.content_source_field and resource_ref:
+                if not hasattr(resource_ref, rec.content_source_field):
+                    raise ValidationError(
+                        _(
+                            "CNAB Field Error:\n"
+                            "- Field: '%(field_name)s' (ID: %(field_id)s)\n"
+                            "- Attempted Attribute: '%(attr)s'\n"
+                            "- Resource Type: '%(res_type)s' (ID: %(res_id)s)\n"
+                            "- Issue: Attribute does not exist\n"
+                            "- Suggestion: Please check the mapping in the CSV data\n"
+                            "- File: %(file)s\n"
+                            "- Line: %(line)s"
+                        )
+                        % {
+                            "field_name": rec.name,
+                            "field_id": rec.id,
+                            "attr": rec.content_source_field,
+                            "res_type": type(resource_ref).__name__,
+                            "res_id": getattr(resource_ref, "id", "N/A"),
+                            "file": __file__,
+                            "line": inspect.currentframe().f_lineno + 1,
+                        }
+                    )
                 value = (
                     operator.attrgetter(rec.content_source_field)(resource_ref) or ""
                 )


### PR DESCRIPTION
cc @marcelsavegnago @CristianoMafraJunior @WesleyOliveira98 @rvalyi 

Esta PR aprimora o método output na classe CNABField adicionando uma verificação para garantir que o atributo especificado exista no objeto de recurso antes de tentar acessá-lo. Se o atributo não existir, uma ValidationError é lançada com informações detalhadas, incluindo nome do campo, ID, atributo tentado, tipo e ID do recurso, caminho do arquivo e número da linha. Isso facilita a depuração de problemas de mapeamento em estruturas CNAB.

Antes:

<img width="1920" height="968" alt="image" src="https://github.com/user-attachments/assets/042ce792-b0a0-4018-a4b4-259c6ee103c5" />

Depois:

<img width="1920" height="968" alt="image" src="https://github.com/user-attachments/assets/e12f7b3f-ddde-457f-bce2-4eb0fd300f64" />
