### PR TITLE
[16.0][FIX] l10n_br_fiscal: action_name

### DIFF
--- a/l10n_br_fiscal/models/operation_dashboard.py
+++ b/l10n_br_fiscal/models/operation_dashboard.py
@@ -127,7 +127,7 @@ class Operation(models.Model):
         }
 
     def open_action(self):
-        """return action based on type for related journals"""
+        """Return action based on type for related journals"""
 
         _fiscal_type_map = {
             "purchase": "in",
@@ -157,7 +157,8 @@ class Operation(models.Model):
             }
         )
 
-        [action] = self.env.ref("l10n_br_fiscal.{action_name}").read()
+        xmlid = f"l10n_br_fiscal.{action_name}"
+        [action] = self.env.ref(xmlid).read()
         action["context"] = ctx
         action["domain"] = self._context.get("use_domain", [])
         action["domain"] += [


### PR DESCRIPTION
Relacionado issue #4191

Explicando a alteração o código novo usa f-string para montar corretamente o XML ID, antes o Odoo lia literalmente {action_name} com chaves agora substitui pela variável