### PR TITLE
[16.0][FIX] l10n_br_purchase: Precompute WARNING

### DIFF
--- a/l10n_br_purchase/models/purchase_order_line.py
+++ b/l10n_br_purchase/models/purchase_order_line.py
@@ -159,6 +159,8 @@ class PurchaseOrderLine(models.Model):
                 "_compute_fiscal_price",
                 "_compute_fiscal_tax_ids",
                 "_compute_tax_fields",
+                "_compute_fiscal_operation_line_id",
+                "_compute_comment_ids",
             ) and getattr(mixin_field, "precompute", False):
                 field.precompute = False
         return res


### PR DESCRIPTION
No CI ainda estava aparecendo alguns WARNING em relação aos campos precompute do Purschase:

```
Field purchase.order.line.fiscal_operation_line_id cannot be precomputed as it depends on non-precomputed field purchase.order.line.partner_id

Field purchase.order.line.comment_ids cannot be precomputed as it depends on non-precomputed field purchase.order.line.fiscal_operation_line_id
```