### PR TITLE
[16.0][FIX] l10n_br_fiscal: ind_final selection warning

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -82,6 +82,13 @@ class AccountMove(models.Model):
         for line in self:
             line.proxy_user_id = line.user_id
 
+    @api.onchange("ind_final")
+    def _onchange_ind_final(self):
+        for move in self:
+            for line in move.invoice_line_ids:
+                if line.ind_final != move.ind_final:
+                    line.ind_final = move.ind_final
+
     @api.constrains("fiscal_document_id", "document_type_id")
     def _check_fiscal_document_type(self):
         for rec in self:

--- a/l10n_br_contract/models/contract_line.py
+++ b/l10n_br_contract/models/contract_line.py
@@ -29,7 +29,10 @@ class ContractLine(models.Model):
         string="Partner",
     )
 
-    ind_final = fields.Selection(related="contract_id.ind_final")
+    document_id = fields.Many2one(
+        comodel_name="contract.contract",
+        related="contract_id",
+    )
 
     comment_ids = fields.Many2many(
         comodel_name="l10n_br_fiscal.comment",

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -499,6 +499,10 @@ class Document(models.Model):
         # see https://github.com/OCA/l10n-brazil/pull/3272
         pass
 
+    def _is_imported(self):
+        # Mixin method override
+        return self.document_id.imported_document
+
     @api.depends("fiscal_operation_id")
     def _compute_edoc_purpose(self):
         for record in self:

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -864,10 +864,8 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         return ["icms_relief_value"]
 
     def _is_imported(self):
-        # When the mixin is used for instance
-        # in a PO line or SO line, there is no document_id
-        # and we consider the document is not imported
-        return hasattr(self, "document_id") and self.document_id.imported_document
+        # Override this method in inherited models if needed
+        return False
 
     currency_id = fields.Many2one(
         comodel_name="res.currency",

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -521,10 +521,6 @@ class FiscalDocumentLineMixin(models.AbstractModel):
                 "cost_price": line.product_id.standard_price,
             }.get(line.fiscal_operation_id.default_price_unit, 0)
 
-    def _get_document(self):
-        self.ensure_one()
-        return self.document_id
-
     def _get_fiscal_partner(self):
         """
         Meant to be overriden when the l10n_br_fiscal.document partner_id should not
@@ -873,6 +869,11 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         compute="_compute_currency_id",
     )
 
+    document_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.document.mixin",
+        string="Fiscal Document",
+    )
+
     product_id = fields.Many2one(
         comodel_name="product.product",
         string="Product",
@@ -910,17 +911,8 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     ind_final = fields.Selection(
         selection=FINAL_CUSTOMER,
         string="Consumidor final",
-        compute="_compute_ind_final",
-        store=True,
-        precompute=True,
-        readonly=False,
+        related="document_id.ind_final",
     )
-
-    def _compute_ind_final(self):
-        for line in self:
-            doc = line._get_document()
-            if line.ind_final != doc.ind_final:
-                line.ind_final = doc.ind_final
 
     partner_company_type = fields.Selection(related="partner_id.company_type")
 

--- a/l10n_br_purchase/models/purchase_order_line.py
+++ b/l10n_br_purchase/models/purchase_order_line.py
@@ -61,7 +61,10 @@ class PurchaseOrderLine(models.Model):
         string="Comments",
     )
 
-    ind_final = fields.Selection(related="order_id.ind_final")
+    document_id = fields.Many2one(
+        comodel_name="purchase.order",
+        related="order_id",
+    )
 
     # Usado para tornar Somente Leitura os campos totais dos custos
     # de entrega quando a definição for por Linha

--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -98,7 +98,10 @@ class SaleOrderLine(models.Model):
         precompute=True,
     )
 
-    ind_final = fields.Selection(related="order_id.ind_final")
+    document_id = fields.Many2one(
+        comodel_name="sale.order",
+        related="order_id",
+    )
 
     # Usado para tornar Somente Leitura os campos dos custos
     # de entrega quando a definição for por Total

--- a/l10n_br_sale_blanket_order/models/sale_blanket_order_line.py
+++ b/l10n_br_sale_blanket_order/models/sale_blanket_order_line.py
@@ -75,12 +75,15 @@ class SaleBlanketOrderLine(models.Model):
         string="Comments",
     )
 
-    ind_final = fields.Selection(related="order_id.ind_final")
-
     # Fields compute need parameter compute_sudo
     price_subtotal = fields.Monetary(compute_sudo=True)
     price_tax = fields.Monetary(compute_sudo=True)
     price_total = fields.Monetary(compute_sudo=True)
+
+    document_id = fields.Many2one(
+        comodel_name="sale.blanket.order",
+        related="order_id",
+    )
 
     @api.model
     def _cnae_domain(self):

--- a/l10n_br_sale_stock/tests/test_sale_stock.py
+++ b/l10n_br_sale_stock/tests/test_sale_stock.py
@@ -75,11 +75,7 @@ class TestSaleStock(TestBrPickingInvoicingCommon):
         sm_fields = [key for key in self.env["stock.move"]._fields.keys()]
         sol_fields = [key for key in self.env["sale.order.line"]._fields.keys()]
 
-        skipped_fields = [
-            "id",
-            "display_name",
-            "state",
-        ]
+        skipped_fields = ["id", "display_name", "state", "document_id"]
         common_fields = list(set(sm_fields) & set(sol_fields) - set(skipped_fields))
 
         for field in common_fields:
@@ -216,6 +212,7 @@ class TestSaleStock(TestBrPickingInvoicingCommon):
             # In the sale.orde.line display_type has only line_section
             # and line_note, the acccount.move.line has more options
             "display_type",
+            "document_id",
         ]
 
         common_fields = list(set(acl_fields) & set(sol_fields) - set(skipped_fields))

--- a/l10n_br_stock_account/models/stock_move.py
+++ b/l10n_br_stock_account/models/stock_move.py
@@ -71,7 +71,10 @@ class StockMove(models.Model):
     # A Fatura é criada com os dois valores positivos.
     fiscal_price = fields.Float(compute="_compute_fiscal_price")
 
-    ind_final = fields.Selection(related="picking_id.ind_final")
+    document_id = fields.Many2one(
+        comodel_name="stock.picking",
+        related="picking_id",
+    )
 
     # Usado para tornar Somente Leitura os campos totais dos custos
     # de entrega quando a definição for por Linha

--- a/l10n_br_stock_account/views/stock_picking.xml
+++ b/l10n_br_stock_account/views/stock_picking.xml
@@ -26,9 +26,19 @@
                 <attribute name="force_save">1</attribute>
             </field>
             <field name="move_ids_without_package" position="attributes">
-                <attribute
-                    name="context"
-                >{'default_invoice_state': invoice_state, 'address_in_id': partner_id, 'default_picking_type_id': picking_type_id, 'default_picking_id': id, 'default_location_id': location_id, 'default_location_dest_id': location_dest_id, 'default_fiscal_operation_id': fiscal_operation_id, 'default_company_id': company_id, 'default_partner_id': partner_id, 'picking_type_code': picking_type_code}</attribute>
+                <attribute name="context">{
+                    'default_invoice_state': invoice_state,
+                    'address_in_id': partner_id,
+                    'default_picking_type_id': picking_type_id,
+                    'default_picking_id': id,
+                    'default_location_id': location_id,
+                    'default_location_dest_id': location_dest_id,
+                    'default_fiscal_operation_id': fiscal_operation_id,
+                    'default_ind_final': ind_final,
+                    'default_company_id': company_id,
+                    'default_partner_id': partner_id,
+                    'picking_type_code': picking_type_code
+                }</attribute>
             </field>
             <xpath
                 expr="//field[@name='move_ids_without_package']//tree/field[@name='product_id']"


### PR DESCRIPTION
Resolve os WARNING:

```
WARNING odoo odoo.fields: stock.move.ind_final: selection attribute will be ignored as the field is related 
WARNING odoo odoo.fields: contract.line.ind_final: selection attribute will be ignored as the field is related
WARNING odoo odoo.fields: purchase.order.line.ind_final: selection attribute will be ignored as the field is related
WARNING odoo odoo.fields: sale.order.line.ind_final: selection attribute will be ignored as the field is related
```