### PR TITLE
[16.0][IMP] l10n_br_nfe, l10n_br_fiscal_dfe, l10n_br_mdfe , l10n_br_cte: use newest nfelib version

### DIFF
--- a/l10n_br_cte/__manifest__.py
+++ b/l10n_br_cte/__manifest__.py
@@ -45,7 +45,7 @@
     "auto_install": False,
     "external_dependencies": {
         "python": [
-            "nfelib<=2.0.7",
+            "nfelib",
             "erpbrasil.assinatura>=1.7.0",
             "erpbrasil.transmissao>=1.1.0",
             "erpbrasil.edoc>=2.5.2",

--- a/l10n_br_fiscal_dfe/__manifest__.py
+++ b/l10n_br_fiscal_dfe/__manifest__.py
@@ -20,7 +20,7 @@
         "python": [
             "erpbrasil.edoc>=2.5.2",
             "erpbrasil.transmissao>=1.1.0",
-            "nfelib<=2.0.7",
+            "nfelib",
         ],
     },
 }

--- a/l10n_br_fiscal_dfe/tests/test_dfe.py
+++ b/l10n_br_fiscal_dfe/tests/test_dfe.py
@@ -5,8 +5,8 @@
 from unittest import mock
 
 from erpbrasil.edoc.resposta import analisar_retorno_raw
+from erpbrasil.nfelib_legacy.v4_00 import retDistDFeInt
 from nfelib.nfe.ws.edoc_legacy import DocumentoElectronicoAdapter
-from nfelib.v4_00 import retDistDFeInt
 
 from odoo.tests.common import TransactionCase
 

--- a/l10n_br_mdfe/__manifest__.py
+++ b/l10n_br_mdfe/__manifest__.py
@@ -45,7 +45,7 @@
     "auto_install": False,
     "external_dependencies": {
         "python": [
-            "nfelib<=2.0.7",
+            "nfelib",
             "erpbrasil.transmissao>=1.1.0",
             "erpbrasil.edoc>=2.5.2",
         ]

--- a/l10n_br_nfe/__manifest__.py
+++ b/l10n_br_nfe/__manifest__.py
@@ -53,7 +53,7 @@
     "auto_install": False,
     "external_dependencies": {
         "python": [
-            "nfelib<=2.0.7",
+            "nfelib",
             "erpbrasil.assinatura>=1.7.0",
             "erpbrasil.transmissao>=1.1.0",
             "erpbrasil.edoc>=2.5.2",

--- a/l10n_br_nfe/tests/test_nfe_mde.py
+++ b/l10n_br_nfe/tests/test_nfe_mde.py
@@ -5,8 +5,8 @@
 from unittest import mock
 
 from erpbrasil.edoc.resposta import analisar_retorno_raw
+from erpbrasil.nfelib_legacy.v4_00 import retEnvEvento
 from nfelib.nfe.ws.edoc_legacy import DocumentoElectronicoAdapter
-from nfelib.v4_00 import retEnvEvento
 
 from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ erpbrasil.assinatura>=1.7.0
 erpbrasil.base>=2.3.0
 erpbrasil.edoc>=2.5.2
 erpbrasil.transmissao>=1.1.0
-nfelib<=2.0.7
+nfelib
 num2words
 phonenumbers
 pyyaml

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,4 @@
 # vcrpy  # Needed by payment_pagseguro
 odoo-test-helper  # Needed by spec_driven_model
 pyopenssl==22.1.0
-nfelib<=2.0.7
 xmldiff


### PR DESCRIPTION
depende de https://github.com/erpbrasil/erpbrasil.edoc/pull/92

Esse PR visa a demonstrar que é viável fazer o merge desse PR no erpbrasil.edoc https://github.com/erpbrasil/erpbrasil.edoc/pull/92 para poder usar versões mais recentes de nfelib.

Isso seria um primeiro passo para:

1. trabalhar com a nfelib para a reforma fiscal (IS/IBSCBS...)
2. se livrar da dependência erpbrasil.edoc no modulo l10n_br_fiscal_dfe com https://github.com/OCA/l10n-brazil/pull/4096
3. se livrar da dependência erpbrasil.edoc no modulo l10n_br_nfe com https://github.com/OCA/l10n-brazil/pull/4147

OBS: como eu tive o cuidado de testar a nfelib com Python 3.8, seria viavel fazer o backport disso para a branch 14.0 tb, para suportar a reforma tributaria por exemplo...