### PR TITLE
[14.0] Remove especificação da versão das dependências

### DIFF
--- a/l10n_br_cte/__manifest__.py
+++ b/l10n_br_cte/__manifest__.py
@@ -45,10 +45,10 @@
     "auto_install": False,
     "external_dependencies": {
         "python": [
-            "nfelib<=2.0.7",
+            "nfelib",
             "erpbrasil.assinatura",
-            "erpbrasil.transmissao>=1.1.0",
-            "erpbrasil.edoc>=2.5.2",
+            "erpbrasil.transmissao",
+            "erpbrasil.edoc",
         ],
     },
 }

--- a/l10n_br_fiscal_dfe/__manifest__.py
+++ b/l10n_br_fiscal_dfe/__manifest__.py
@@ -18,9 +18,9 @@
     ],
     "external_dependencies": {
         "python": [
-            "erpbrasil.edoc>=2.5.2",
-            "erpbrasil.transmissao>=1.1.0",
-            "nfelib<=2.0.7",
+            "erpbrasil.edoc",
+            "erpbrasil.transmissao",
+            "nfelib",
         ],
     },
 }

--- a/l10n_br_fiscal_dfe/tests/test_dfe.py
+++ b/l10n_br_fiscal_dfe/tests/test_dfe.py
@@ -5,8 +5,8 @@
 from unittest import mock
 
 from erpbrasil.edoc.resposta import analisar_retorno_raw
+from erpbrasil.nfelib_legacy.v4_00 import retDistDFeInt
 from nfelib.nfe.ws.edoc_legacy import DocumentoElectronicoAdapter
-from nfelib.v4_00 import retDistDFeInt
 
 from odoo.tests.common import SavepointCase
 

--- a/l10n_br_ie_search/__manifest__.py
+++ b/l10n_br_ie_search/__manifest__.py
@@ -14,9 +14,9 @@
     "external_dependencies": {
         "python": [
             "erpbrasil.base",
-            "erpbrasil.transmissao>=1.1.0",
+            "erpbrasil.transmissao",
             "erpbrasil.assinatura",
-            "erpbrasil.edoc>=2.5.2",
+            "erpbrasil.edoc",
         ]
     },
 }

--- a/l10n_br_mdfe/__manifest__.py
+++ b/l10n_br_mdfe/__manifest__.py
@@ -47,9 +47,9 @@
     "auto_install": False,
     "external_dependencies": {
         "python": [
-            "nfelib<=2.0.7",
-            "erpbrasil.transmissao>=1.1.0",
-            "erpbrasil.edoc>=2.5.2",
+            "nfelib",
+            "erpbrasil.transmissao",
+            "erpbrasil.edoc",
         ]
     },
 }

--- a/l10n_br_nfe/__manifest__.py
+++ b/l10n_br_nfe/__manifest__.py
@@ -53,10 +53,10 @@
     "auto_install": False,
     "external_dependencies": {
         "python": [
-            "nfelib<=2.0.7",
+            "nfelib",
             "erpbrasil.assinatura",
-            "erpbrasil.transmissao>=1.1.0",
-            "erpbrasil.edoc>=2.5.2",
+            "erpbrasil.transmissao",
+            "erpbrasil.edoc",
             "erpbrasil.edoc.pdf",
             "erpbrasil.base",
             "brazilfiscalreport",

--- a/l10n_br_nfe/tests/test_nfe_mde.py
+++ b/l10n_br_nfe/tests/test_nfe_mde.py
@@ -5,8 +5,8 @@
 from unittest import mock
 
 from erpbrasil.edoc.resposta import analisar_retorno_raw
+from erpbrasil.nfelib_legacy.v4_00 import retEnvEvento
 from nfelib.nfe.ws.edoc_legacy import DocumentoElectronicoAdapter
-from nfelib.v4_00 import retEnvEvento
 
 from odoo.exceptions import ValidationError
 from odoo.tests.common import SavepointCase

--- a/l10n_br_nfse/__manifest__.py
+++ b/l10n_br_nfse/__manifest__.py
@@ -11,8 +11,8 @@
     "website": "https://github.com/OCA/l10n-brazil",
     "external_dependencies": {
         "python": [
-            "erpbrasil.edoc>=2.5.2",
-            "erpbrasil.transmissao>=1.1.0",
+            "erpbrasil.edoc",
+            "erpbrasil.transmissao",
             "erpbrasil.base",
         ],
     },

--- a/l10n_br_nfse_barueri/__manifest__.py
+++ b/l10n_br_nfse_barueri/__manifest__.py
@@ -13,9 +13,9 @@
     "development_status": "Beta",
     "external_dependencies": {
         "python": [
-            "erpbrasil.edoc>=2.5.2",
+            "erpbrasil.edoc",
             "erpbrasil.assinatura",
-            "erpbrasil.transmissao>=1.1.0",
+            "erpbrasil.transmissao",
             "erpbrasil.base",
             "nfselib.barueri",
         ],

--- a/l10n_br_nfse_ginfes/__manifest__.py
+++ b/l10n_br_nfse_ginfes/__manifest__.py
@@ -13,9 +13,9 @@
     "development_status": "Beta",
     "external_dependencies": {
         "python": [
-            "erpbrasil.edoc>=2.5.2",
+            "erpbrasil.edoc",
             "erpbrasil.assinatura",
-            "erpbrasil.transmissao>=1.1.0",
+            "erpbrasil.transmissao",
             "erpbrasil.base",
             "nfselib.ginfes",
         ],

--- a/l10n_br_nfse_paulistana/__manifest__.py
+++ b/l10n_br_nfse_paulistana/__manifest__.py
@@ -13,9 +13,9 @@
     "website": "https://github.com/OCA/l10n-brazil",
     "external_dependencies": {
         "python": [
-            "erpbrasil.edoc>=2.5.2",
+            "erpbrasil.edoc",
             "erpbrasil.assinatura",
-            "erpbrasil.transmissao>=1.1.0",
+            "erpbrasil.transmissao",
             "erpbrasil.base",
             "nfselib.paulistana",
             "unidecode",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,10 @@ brazilfiscalreport
 email-validator
 erpbrasil.assinatura
 erpbrasil.base
+erpbrasil.edoc
 erpbrasil.edoc.pdf
-erpbrasil.edoc>=2.5.2
-erpbrasil.transmissao>=1.1.0
-nfelib<=2.0.7
+erpbrasil.transmissao
+nfelib
 nfselib.barueri
 nfselib.ginfes
 nfselib.paulistana


### PR DESCRIPTION
BCK - #4223

**OBS**: Acabei passando pelo erro do erpbrasil.edoc, acredito como foi colocado na v16 sem espeficicar versão podemos fazer na 14 também 

cc @rvalyi @antoniospneto @marcelsavegnago 