### PR TITLE
[16.0][IMP] l10n_br_cnab_structure: Domain in Payment Way

### DIFF
--- a/l10n_br_cnab_structure/models/account_payment_mode.py
+++ b/l10n_br_cnab_structure/models/account_payment_mode.py
@@ -19,6 +19,7 @@ class AccountPaymentMode(models.Model):
         comodel_name="cnab.payment.way",
         relation="payment_mode_cnab_payment_way_rel",
         string="CNAB Payment Ways",
+        domain="[('cnab_structure_id', '=', cnab_structure_id)]",
     )
 
     cnab_structure_ok = fields.Boolean(


### PR DESCRIPTION
cc @marcelsavegnago @WesleyOliveira98 @CristianoMafraJunior 

Melhoria implementada com o objetivo de impedir que os campos do `cnab_payment_way_ids` sejam carregados a partir de outras estruturas, que não a especificamente selecionada.

Antes:

<img width="1870" height="655" alt="image" src="https://github.com/user-attachments/assets/a9483c1c-f954-45b8-8525-39d6cd2767ff" />

Depois:

<img width="1870" height="655" alt="image" src="https://github.com/user-attachments/assets/f4272bbd-936a-4fdc-8204-20ae99f8ea85" />
