### PR TITLE
[16.0] l10n_br_base: compat with Python 3.9

### DIFF
--- a/l10n_br_base/models/party_mixin.py
+++ b/l10n_br_base/models/party_mixin.py
@@ -107,7 +107,7 @@ class PartyMixin(models.AbstractModel):
         ):
             for term in domain:
                 if (
-                    isinstance(term, list | tuple)
+                    isinstance(term, (list, tuple))  # noqa: UP038
                     and len(term) == 3
                     and term[0] == "vat"
                     and term[1] == "ilike"


### PR DESCRIPTION
This PR re-submits the fix requested in the previous PR, now following the correct workflow.

As asked in the review, I cleaned up the branch history, kept only the minimal required change in `l10n_br_base/models/party_mixin.py`, and squashed everything into a single commit.

The patch fixes a compatibility issue with Python 3.9, which is the version used by the official Odoo 16.0 Docker image. The previous implementation used a construct that is not supported in Python 3.9; this update replaces it with an equivalent 3.9-compatible expression.

No functional behavior change is introduced beyond restoring compatibility.

- [x] Code is compatible with Python 3.9
- [x] Patch limited to the minimal change required
- [x] Single commit as requested
- [x] No functional behavior changes

Thanks for the review and guidance