### PR TITLE
[16.0][FIX] l10n_br_account_payment_order: Correção da alteração de vencimento

### DIFF
--- a/l10n_br_account_payment_order/models/l10n_br_cnab_change_methods.py
+++ b/l10n_br_account_payment_order/models/l10n_br_cnab_change_methods.py
@@ -205,13 +205,13 @@ class L10nBrCNABChangeMethods(models.Model):
         :return: deveria retornar algo ? Uma mensagem de confirmação talvez ?
         """
 
-        if new_date == self.date:
+        if new_date == self.date_maturity:
             raise UserError(
                 _(
                     "New Date Maturity %(new_date)s is equal to actual Date "
                     "Maturity %(date_maturity)s",
                     new_date=new_date,
-                    date_maturity=self.date,
+                    date_maturity=self.date_maturity,
                 )
             )
 
@@ -220,7 +220,7 @@ class L10nBrCNABChangeMethods(models.Model):
         if not cnab_config.change_maturity_date_code_id:
             self._msg_error_cnab_missing(self.payment_mode_id, "Date Maturity Code")
 
-        self.date = new_date
+        self.date_maturity = new_date
 
         return cnab_config.change_maturity_date_code_id
 

--- a/l10n_br_account_payment_order/tests/common.py
+++ b/l10n_br_account_payment_order/tests/common.py
@@ -868,7 +868,7 @@ class CNABTestCommon(AccountTestInvoicingCommon):
             if code_to_send == "change_date_maturity":
                 new_date = date.today() + relativedelta(years=1)
                 self.assertEqual(
-                    aml_to_change.date,
+                    aml_to_change.date_maturity,
                     new_date,
                     "Data não alterada",
                 )


### PR DESCRIPTION
No método que cria a instrução de alteração de vencimento esta alterando o campo date ao invés de alterar o campo date_maturity.