### PR TITLE
[16.0][FIX] l10n_br_sale: discount in sale order line

### DIFF
--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -88,12 +88,14 @@ class SaleOrderLine(models.Model):
 
     discount = fields.Float(
         compute="_compute_discounts",
+        inverse="_inverse_discount",
         store=True,
         precompute=True,
     )
 
     discount_value = fields.Monetary(
         compute="_compute_discounts",
+        inverse="_inverse_discount_value",
         store=True,
         precompute=True,
     )
@@ -245,6 +247,18 @@ class SaleOrderLine(models.Model):
                 line.discount_value = (line.product_uom_qty * line.price_unit) * (
                     line.discount / 100
                 )
+
+    def _inverse_discount(self):
+        for line in self:
+            line.discount_value = (line.product_uom_qty * line.price_unit) * (
+                line.discount / 100
+            )
+
+    def _inverse_discount_value(self):
+        for line in self:
+            line.discount = (line.discount_value * 100) / (
+                line.product_uom_qty * line.price_unit or 1
+            )
 
     def _compute_price_unit_fiscal(self):
         for line in self:


### PR DESCRIPTION
@Escodoo [HT01551]

Atualmente, ao se criar uma Venda e aplicar um Desconto Fixo pela primeira vez, o processo de `precompute`, no momento de salvar, está ocasionando a perda do valor do desconto `discount_value`. Consequentemente, o valor só é registrado se o usuário acessar novamente a linha  e aplicar o desconto uma segunda vez.

<img width="1866" height="697" alt="image" src="https://github.com/user-attachments/assets/12846995-452e-49c3-b2c4-893ec99b61cb" />

cc @marcelsavegnago @douglascstd @WesleyOliveira98 @CristianoMafraJunior 