### PR TITLE
[16.0][IMP] l10n_br_account: reorder NCM/CFOP fields

### DIFF
--- a/l10n_br_account/views/account_move_view.xml
+++ b/l10n_br_account/views/account_move_view.xml
@@ -397,11 +397,11 @@
                     attrs="{'invisible': [('document_type_id', '=', False)], 'required': [('document_type_id', '!=', False)]}"
                 />
                 <field
-                    name="cfop_id"
+                    name="ncm_id"
                     attrs="{'invisible': ['|', ('document_type_id', '=', False), ('tax_icms_or_issqn', '=', 'issqn')], 'required': [('document_type_id', '!=', False), ('tax_icms_or_issqn', '=', 'icms')]}"
                 />
                 <field
-                    name="ncm_id"
+                    name="cfop_id"
                     attrs="{'invisible': ['|', ('document_type_id', '=', False), ('tax_icms_or_issqn', '=', 'issqn')], 'required': [('document_type_id', '!=', False), ('tax_icms_or_issqn', '=', 'icms')]}"
                 />
                 <field


### PR DESCRIPTION
Esta PR altera a ordem dos campos NCM e CFOP na visão da fatura, fazendo com que o NCM seja informado antes do CFOP.

Como o valor do CFOP depende do NCM, uma alteração no NCM após o preenchimento do CFOP pode levar à sua recomputação ou invalidar o valor já definido. Ao posicionar o NCM antes do CFOP, incentivamos a ordem correta de preenchimento e reduzimos o risco de inconsistências fiscais.
