### PR TITLE
[16.0][FIX] l10n_br_account: force_fiscal_amount_recompute fix

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -192,7 +192,7 @@ class AccountMove(models.Model):
                 # fiscal documents for instance. It should be used
                 # exceptionnaly as it breaks the dependency chain and
                 # can leave fields such as payment_state inconsistent.
-                move._compute_fiscal_amount()
+                move.fiscal_document_id._compute_fiscal_amount()
 
         result = super()._compute_amount()
         for move in self.filtered(lambda m: m.fiscal_operation_id):


### PR DESCRIPTION
Na hora do merge de #4072 teve uma regressão: o método `_compute_fiscal_amount` não esta mais sendo herdado e precisa ser acessado através do fiscal_document_id