### PR TITLE
[16.0][FIX] l10n_br_account: precompute journal_id account.move.reversal

### DIFF
--- a/l10n_br_account/tests/test_invoice_refund.py
+++ b/l10n_br_account/tests/test_invoice_refund.py
@@ -300,3 +300,19 @@ class TestInvoiceRefund(AccountMoveBRCommon):
             "Journal ID should remain unchanged when force_fiscal_operation_id\
                  is not set",
         )
+
+    def test_reversal_create_without_journal_id_uses_force_operation_journal(self):
+        fiscal_operation = self.env.ref("l10n_br_fiscal.fo_devolucao_venda")
+        fiscal_operation.with_company(self.env.company).journal_id = self.refund_journal
+
+        invoice = self._create_test_invoice(
+            "Test Refund Invoice without journal_id",
+            "Refund Test without journal_id",
+        )
+        move_reversal = self._create_move_reversal(
+            invoice,
+            force_fiscal_operation_id=fiscal_operation,
+            journal_id=None,
+        )
+
+        self.assertEqual(move_reversal.journal_id.id, self.refund_journal.id)

--- a/l10n_br_account/wizards/account_move_reversal.py
+++ b/l10n_br_account/wizards/account_move_reversal.py
@@ -9,6 +9,12 @@ from odoo import api, fields, models
 class AccountMoveReversal(models.TransientModel):
     _inherit = "account.move.reversal"
 
+    journal_id = fields.Many2one(
+        compute="_compute_journal_id",
+        store=True,
+        precompute=True,
+    )
+
     force_fiscal_operation_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.operation", string="Force Fiscal Operation"
     )


### PR DESCRIPTION
Erro ao forçar uma operação fiscal no wizard de devolução.

![WhatsApp Image 2025-12-18 at 10 09 12](https://github.com/user-attachments/assets/41c7254c-f333-42f7-b93b-6eb398e3513a)
![WhatsApp Image 2025-12-18 at 10 09 35](https://github.com/user-attachments/assets/b66f8f06-c204-4852-bf09-ae3b54945147)
![WhatsApp Image 2025-12-18 at 10 08 48](https://github.com/user-attachments/assets/d0099bb0-4307-4645-b831-1b47d453eb26)
