### PR TITLE
[16.0][FIX] l10n_br_purchase: readonly operation on purch line

### DIFF
--- a/l10n_br_purchase/models/purchase_order_line.py
+++ b/l10n_br_purchase/models/purchase_order_line.py
@@ -24,8 +24,6 @@ class PurchaseOrderLine(models.Model):
     # Adapt Mixin's fields
     fiscal_operation_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.operation",
-        readonly=True,
-        states={"draft": [("readonly", False)]},
         default=_default_fiscal_operation,
         domain=lambda self: self._fiscal_operation_domain(),
     )


### PR DESCRIPTION
Mesmo que a #2999, que apesar de nunca ter entrado ficou muito tempo em uma base em produção.