### PR TITLE
[16.0][FIX] l10n_br_sale: product template invisible in sale line form

### DIFF
--- a/l10n_br_sale/views/sale_view.xml
+++ b/l10n_br_sale/views/sale_view.xml
@@ -201,7 +201,7 @@
             </xpath>
             <!-- order lines form view extensions:  -->
             <xpath expr="//field[@name='order_line']/form" position="inside">
-                <field name="product_template_id" />
+                <field name="product_template_id" invisible="1" />
                 <group name="fiscal_fields" invisible="1">
                     <!-- this is a dynamic fiscal fields placeholder-->
                     <!-- required because of cfop_id default domain: -->


### PR DESCRIPTION
Erro bobo da view... 
<img width="1574" height="777" alt="image" src="https://github.com/user-attachments/assets/cb7a72dd-5d43-4154-92a1-38234b2b3bd7" />
