### PR TITLE
[14.0][FIX] l10n_br_fiscal: fix amount method name used by ibs/cbs amounts

### DIFF
--- a/l10n_br_fiscal/models/document_mixin.py
+++ b/l10n_br_fiscal/models/document_mixin.py
@@ -115,25 +115,25 @@ class FiscalDocumentMixinFields(models.AbstractModel):
 
     amount_ibs_base = fields.Monetary(
         string="IBS Base",
-        compute="_compute_fiscal_amount",
+        compute="_compute_amount",
         store=True,
     )
 
     amount_ibs_value = fields.Monetary(
         string="IBS Value",
-        compute="_compute_fiscal_amount",
+        compute="_compute_amount",
         store=True,
     )
 
     amount_cbs_base = fields.Monetary(
         string="CBS Base",
-        compute="_compute_fiscal_amount",
+        compute="_compute_amount",
         store=True,
     )
 
     amount_cbs_value = fields.Monetary(
         string="CBS Value",
-        compute="_compute_fiscal_amount",
+        compute="_compute_amount",
         store=True,
     )
 


### PR DESCRIPTION
This pull request updates the computation method used for several monetary fields in the `l10n_br_fiscal/models/document_mixin.py` file. The fields related to IBS and CBS calculations now use the `_compute_amount` method instead of `_compute_fiscal_amount`, ensuring consistency in how these values are computed.

Field computation updates:

* Changed the `compute` attribute for `amount_ibs_base`, `amount_ibs_value`, `amount_cbs_base`, and `amount_cbs_value` fields to use the `_compute_amount` method instead of `_compute_fiscal_amount` for more consistent calculation logic

Ref. https://github.com/OCA/l10n-brazil/pull/4298