### PR TITLE
[18.0][IMP] l10n_br_base_l10n_br_compat: merge cities

### DIFF
--- a/l10n_br_base_l10n_br_compat/__init__.py
+++ b/l10n_br_base_l10n_br_compat/__init__.py
@@ -1,0 +1,1 @@
+from .hooks import post_init_hook

--- a/l10n_br_base_l10n_br_compat/__manifest__.py
+++ b/l10n_br_base_l10n_br_compat/__manifest__.py
@@ -15,5 +15,6 @@
         "views/res_partner_views.xml",
         "views/res_company_view.xml",
     ],
+    "post_init_hook": "post_init_hook",
     "auto_install": True,
 }

--- a/l10n_br_base_l10n_br_compat/hooks.py
+++ b/l10n_br_base_l10n_br_compat/hooks.py
@@ -1,0 +1,136 @@
+# Copyright (C) 2025 - TODAY Raphaël Valyi - Akretion
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+import logging
+import unicodedata
+
+_logger = logging.getLogger(__name__)
+
+
+def post_init_hook(env):
+    _merge_l10n_br_cities(env)
+
+
+def _normalize_name(name):
+    if not name:
+        return ""
+    return "".join(
+        c
+        for c in unicodedata.normalize("NFKD", name.lower())
+        if not unicodedata.combining(c)
+    ).strip()
+
+
+def _build_oca_city_map(env):
+    # We use a normalized key: (state_id, normalized_name)
+    # We prioritize cities that have an IBGE code (OCA cities)
+    oca_cities = (
+        env["res.city"]
+        .with_context(active_test=False)
+        .search([("state_id", "!=", False)])
+    )
+    oca_city_map = {}
+    for city in oca_cities:
+        key = (city.state_id.id, _normalize_name(city.name))
+        # In l10n_br_base, the field is 'ibge_code'
+        has_ibge = hasattr(city, "ibge_code") and city.ibge_code
+        if key not in oca_city_map or has_ibge:
+            oca_city_map[key] = city
+    return oca_city_map
+
+
+def _redirect_and_collect_duplicates(env, city_data, oca_city_map):
+    to_delete = env["res.city"]
+    merged_count = 0
+
+    for data in city_data:
+        core_city = env["res.city"].with_context(active_test=False).browse(data.res_id)
+        if not core_city.exists():
+            continue
+
+        key = (core_city.state_id.id, _normalize_name(core_city.name))
+        oca_city = oca_city_map.get(key)
+
+        if oca_city and oca_city.id != core_city.id:
+            # Update the external ID to point to the OCA city
+            data.write({"res_id": oca_city.id})
+            # Prepare to delete the duplicate core city
+            if core_city not in to_delete:
+                to_delete |= core_city
+            merged_count += 1
+    return to_delete, merged_count
+
+
+def _update_references(env, to_delete, oca_city_map):
+    # Update references in l10n_br.zip.range before deleting
+    zip_ranges = (
+        env["l10n_br.zip.range"]
+        .with_context(active_test=False)
+        .search([("city_id", "in", to_delete.ids)])
+    )
+    if zip_ranges:
+        _logger.info("Updating city_id for %d zip ranges", len(zip_ranges))
+        for zip_range in zip_ranges:
+            key = (
+                zip_range.city_id.state_id.id,
+                _normalize_name(zip_range.city_id.name),
+            )
+            oca_city = oca_city_map.get(key)
+            if oca_city:
+                zip_range.write({"city_id": oca_city.id})
+
+    # Update references in res.partner before deleting
+    partners = (
+        env["res.partner"]
+        .with_context(active_test=False)
+        .search([("city_id", "in", to_delete.ids)])
+    )
+    if partners:
+        _logger.info("Updating city_id for %d partners", len(partners))
+        for partner in partners:
+            key = (partner.city_id.state_id.id, _normalize_name(partner.city_id.name))
+            oca_city = oca_city_map.get(key)
+            if oca_city:
+                partner.write({"city_id": oca_city.id})
+
+
+def _delete_cities(env, to_delete):
+    _logger.info("Unlinking cities in batch...")
+    try:
+        to_delete.unlink()
+    except Exception as e:
+        _logger.warning(
+            "Batch unlink failed, falling back to individual unlink. Error: %s", e
+        )
+        for city in to_delete:
+            try:
+                with env.cr.savepoint():
+                    city.unlink()
+            except Exception:
+                _logger.warning(
+                    "Could not delete duplicate city %s (ID %s)", city.name, city.id
+                )
+
+
+def _merge_l10n_br_cities(env):
+    _logger.info("Merging l10n_br cities into l10n_br_base cities...")
+
+    city_data = env["ir.model.data"].search(
+        [("module", "=", "l10n_br"), ("model", "=", "res.city")]
+    )
+
+    if not city_data:
+        _logger.info("No cities from l10n_br found to merge.")
+        return
+
+    oca_city_map = _build_oca_city_map(env)
+    to_delete, merged_count = _redirect_and_collect_duplicates(
+        env, city_data, oca_city_map
+    )
+
+    if to_delete:
+        _logger.info("Deleting %d duplicate cities from l10n_br", len(to_delete))
+        _update_references(env, to_delete, oca_city_map)
+        _delete_cities(env, to_delete)
+
+    _logger.info("Successfully merged %d cities.", merged_count)

--- a/l10n_br_base_l10n_br_compat/readme/DESCRIPTION.md
+++ b/l10n_br_base_l10n_br_compat/readme/DESCRIPTION.md
@@ -1,17 +1,17 @@
 ## Compatibilidade entre a Localização Brasil OCA e o Módulo l10n_br "oficial"
 
-Este módulo atua como uma ponte de integração, harmonizando o módulo base da localização brasileira da OCA (`l10n_br_base`) com seu equivalente da Odoo Community (`l10n_br`). Sua finalidade é abrir o rico e maduro ecossistema open source da OCA para o ambiente mais limitado do Odoo Enterprise, compatibilizando ambos os mundos.
+Este módulo harmoniza o módulo base da localização brasileira da OCA, `l10n_br_base`, com o módulo `l10n_br`, módulo da Odoo Community que também serve como base para a localização Odoo Enterprise. Sua finalidade é abrir o rico e maduro ecossistema open source da OCA para o ambiente mais limitado do Odoo Enterprise, compatibilizando ambos os mundos.
 
 ### Benefícios e Funcionalidades:
 
-*   **Integração de Ecossistemas:** Conecta a abrangência e flexibilidade do desenvolvimento colaborativo da OCA com a base do Odoo Enterprise. Isso permite que os módulos Enterprise sejam enriquecidos com uma porção significativa das funcionalidades da localização OCA. Este módulo funciona porque foi previamente feito um trabalho de harmonização dos campos dos objetos `res.partner` e `res.company` na OCA com os novos nomes introduzidos pela Odoo a partir das versões 16.0/17.0/18.0.
-*   **Compatibilidade Estendida:** Ao resolver os conflitos entre `l10n_br_base` (e aproximadamente um terço dos módulos OCA que dependem dele) e o módulo `l10n_br`, este módulo desbloqueia uma compatibilidade que beneficia a quem pretende fazer uma transição do Odoo Enterprise para a OCA.
-*   **Prevenção de Conflitos:** Sua função é desativar as views conflitantes de `res.partner` e `res.company` do módulo `l10n_br`. Isso elimina a duplicação de campos na interface, priorizando as visões mais completas e robustas fornecidas pelo `l10n_br_base` da OCA.
+*   **Integração de Ecossistemas:** Conecta a abrangência e flexibilidade do desenvolvimento colaborativo da OCA com a base do Odoo Enterprise. Isso permite que os módulos Enterprise sejam enriquecidos com uma parcela significativa das funcionalidades da localização OCA. Este módulo funciona porque foi previamente feito um trabalho de harmonização dos campos dos objetos `res.partner` e `res.company` na OCA com os novos nomes introduzidos pela Odoo a partir das versões 16.0/17.0/18.0.
+*   **Compatibilidade Estendida:** Ao resolver os conflitos entre `l10n_br_base` (e aproximadamente um terço dos módulos OCA que dependem dele) e o módulo `l10n_br`, este módulo viabiliza o uso de aproximadamente um terço dos módulos da localização OCA com a localização fechada do Odoo Enterprise.
+*   **Prevenção de Conflitos:** Sua função é desativar as views conflitantes de `res.partner` e `res.company` do módulo `l10n_br`. Isso elimina a duplicação de campos na interface, priorizando as visões mais completas e robustas fornecidas pelo `l10n_br_base` da OCA. O módulo também evita a duplicação dos registros de cidades `res.city`.
 
-### Publico-Alvo e Recomendações:
+### Público-Alvo e Recomendações:
 
-*   **Para usuários do Odoo Enterprise:** Este módulo é ideal para uma **transição progressiva** ou para projetos que necessitam de funcionalidades de ambos os conjuntos de módulos.
-*   **Para usuários exclusivos da OCA:** Se você já utiliza apenas a localização open source OCA (**parabéns!**), a instalação deste módulo **não é recomendada**. Os módulos `l10n_br` e `l10n_br_base_l10n_compat` não agregam valor ao seu projeto e podem introduzir complexidade desnecessária.
+*   **Para usuários do Odoo Enterprise:** Este módulo é ideal para uma **transição progressiva para a OCA** ou para projetos que necessitam de funcionalidades de ambos os conjuntos de módulos.
+*   **Para usuários exclusivos da OCA:** Se você já utiliza apenas a localização open source OCA (**parabéns!**), a instalação deste módulo **não é recomendada**. Os módulos `l10n_br` e `l10n_br_base_l10n_br_compat` não agregam valor ao seu projeto e podem introduzir complexidade desnecessária.
 
 ### Nota Técnica Importante:
 A compatibilidade remove o campo `l10n_latam_identification_type_id`. Caso este campo seja essencial para a sua operação (ex.: em um contexto multi-empresa com outros países da América Latina), será necessário recriá-lo através de um módulo de customização específico.
@@ -20,7 +20,7 @@ A compatibilidade remove o campo `l10n_latam_identification_type_id`. Caso este 
 
 É fundamental entender as implicações das licenças envolvidas ao integrar módulos de ecossistemas diferentes:
 
-*   **Licença AGPL (Módulos OCA):** A licença AGPL-3, sob a qual a grande maioria dos módulos da OCA é publicada (e que era a licença original do Odoo), é uma licença de *copyleft* forte. Ela garante a liberdade de usar, modificar e redistribuir o software, mas **exige que qualquer trabalho derivado (módulo customizado que dependa de um módulo AGPL) seja também licenciado sob a AGPL** quando distribuído ou oferecido como serviço (SaaS). O objetivo é garantir que as melhorias feitas no software permaneçam livres e abertas para toda a comunidade.
+*   **Licença AGPL (Módulos OCA):** A licença AGPL-3, sob a qual a grande maioria dos módulos da OCA é publicada (e que era a licença original do Odoo), é uma licença de *copyleft* forte. Ela garante a sua liberdade de usar, modificar e redistribuir o software, mas **exige que qualquer trabalho derivado (módulo customizado que dependa de um módulo AGPL) seja também licenciado sob a AGPL** quando distribuído ou oferecido como serviço (SaaS). O objetivo é garantir que as melhorias feitas no software permaneçam livres e abertas para toda a comunidade.
 
 *   **Licença Proprietária (Odoo Enterprise):** A licença do Odoo Enterprise é restritiva e proprietária. Ela **não permite a redistribuição ou publicação do código-fonte** dos módulos Enterprise ou de trabalhos derivados deles.
 


### PR DESCRIPTION
add post_init_hook to merge cities

When both l10n_br_base and l10n_br are installed, duplicate cities are created. This commit adds a post_init_hook that:
1. Detects duplicate cities from l10n_br.
2. Redirects their external IDs to the corresponding l10n_br_base cities (matching by normalized name and state).
3. Deletes the duplicate l10n_br cities.
4. Updates partner references to point to the preserved cities.

This ensures that the OCA city data (with IBGE codes) prevails and prevents data duplication.