### PR TITLE
[18.0] oca-port: blacklist PR(s) 4249 for l10n_br_base

### DIFF
--- a/.oca/oca-port/blacklist/l10n_br_base.json
+++ b/.oca/oca-port/blacklist/l10n_br_base.json
@@ -1,0 +1,5 @@
+{
+  "pull_requests": {
+    "OCA/l10n-brazil#4249": "no need to support Python 3.9 for 17.0"
+  }
+}


### PR DESCRIPTION
apenas faz o blacklist do port de https://github.com/OCA/l10n-brazil/pull/4249