### PR TITLE
[16.0][IMP] l10n_br_focus: add tax reform fields

### DIFF
--- a/l10n_br_nfse/models/document.py
+++ b/l10n_br_nfse/models/document.py
@@ -163,6 +163,10 @@ class Document(models.Model):
         valor_liquido_nfse = 0
         valor_desconto_incondicionado = 0
         ibs_cbs_base_calculo = 0
+        ibs_uf_aliquota = 0
+        cbs_aliquota = 0
+        ibs_uf_valor = 0
+        cbs_valor = 0
 
         for line in lines:
             result_line.update(line._prepare_line_service())
@@ -187,6 +191,10 @@ class Document(models.Model):
                 "valor_desconto_incondicionado"
             )
             ibs_cbs_base_calculo += result_line.get("ibs_cbs_base_calculo")
+            ibs_uf_aliquota += result_line.get("ibs_uf_aliquota") or 0
+            cbs_aliquota += result_line.get("cbs_aliquota") or 0
+            ibs_uf_valor += result_line.get("ibs_uf_valor") or 0
+            cbs_valor += result_line.get("cbs_valor") or 0
 
         result = {
             "valor_servicos": valor_servicos,
@@ -232,6 +240,12 @@ class Document(models.Model):
             ].tax_classification_id.code,
             "codigo_situacao_tributaria": self.fiscal_line_ids[0].cbs_cst_code,
             "ibs_cbs_base_calculo": ibs_cbs_base_calculo,
+            "ibs_uf_aliquota": ibs_uf_aliquota if ibs_uf_aliquota else None,
+            "ibs_mun_aliquota": 0.0,
+            "cbs_aliquota": cbs_aliquota if cbs_aliquota else None,
+            "ibs_uf_valor": ibs_uf_valor if ibs_uf_valor else None,
+            "ibs_mun_valor": 0.0,
+            "cbs_valor": cbs_valor if cbs_valor else None,
         }
 
         result.update(self.company_id._prepare_company_service())

--- a/l10n_br_nfse/models/document_line.py
+++ b/l10n_br_nfse/models/document_line.py
@@ -103,4 +103,10 @@ class DocumentLine(models.Model):
             "codigo_situacao_tributaria": self.ibs_cst_code or "000",
             "ibs_cbs_base_calculo": round(self.issqn_base, 2),
             "valor_desconto_incondicionado": round(self.discount_value, 2),
+            "ibs_uf_aliquota": round(self.ibs_percent, 2) if self.ibs_percent else None,
+            "ibs_mun_aliquota": 0.0,
+            "cbs_aliquota": round(self.cbs_percent, 2) if self.cbs_percent else None,
+            "ibs_uf_valor": round(self.ibs_value, 2) if self.ibs_value else None,
+            "ibs_mun_valor": 0.0,
+            "cbs_valor": round(self.cbs_value, 2) if self.cbs_value else None,
         }

--- a/l10n_br_nfse_focus/models/document.py
+++ b/l10n_br_nfse_focus/models/document.py
@@ -227,6 +227,20 @@ class FocusnfeNfse(models.AbstractModel):
             ),
             "codigo_situacao_tributaria": service.get("codigo_situacao_tributaria"),
             "ibs_cbs_base_calculo": service.get("ibs_cbs_base_calculo"),
+            "ibs_uf_aliquota": round(service.get("ibs_uf_aliquota", 0), 2)
+            if service.get("ibs_uf_aliquota")
+            else None,
+            "ibs_mun_aliquota": 0.0,
+            "cbs_aliquota": round(service.get("cbs_aliquota", 0), 2)
+            if service.get("cbs_aliquota")
+            else None,
+            "ibs_uf_valor": round(service.get("ibs_uf_valor", 0), 2)
+            if service.get("ibs_uf_valor")
+            else None,
+            "ibs_mun_valor": 0.0,
+            "cbs_valor": round(service.get("cbs_valor", 0), 2)
+            if service.get("cbs_valor")
+            else None,
         }
 
     def _prepare_recipient_data(self, recipient, identification, company):


### PR DESCRIPTION
This pull request enhances the handling of tax-related fields for service documents in the NFSe module. It introduces new fields for IBS and CBS tax rates and values at both the line and document levels, ensuring these values are calculated, aggregated, and included in the resulting data structures used for electronic invoicing.

**Tax calculation and aggregation improvements:**

* Added new fields (`ibs_uf_aliquota`, `ibs_mun_aliquota`, `cbs_aliquota`, `ibs_uf_valor`, `ibs_mun_valor`, `cbs_valor`) to the output of `_prepare_line_service` in `document_line.py`, calculating and rounding them as appropriate.
* Updated `_prepare_dados_servico` in `document.py` to initialize, aggregate, and include the new IBS/CBS fields at the document level, ensuring they are summed across all lines and set in the result dictionary. [[1]](diffhunk://#diff-32b1e0c1baa158d8aa4f5ff3d815669955cbc722eebb0f18514953c2288003e9R166-R169) [[2]](diffhunk://#diff-32b1e0c1baa158d8aa4f5ff3d815669955cbc722eebb0f18514953c2288003e9R194-R197) [[3]](diffhunk://#diff-32b1e0c1baa158d8aa4f5ff3d815669955cbc722eebb0f18514953c2288003e9R243-R248)

**Integration with focus NFSe provider:**

* Modified `_prepare_service_data` in `l10n_br_nfse_focus/models/document.py` to extract, round, and include the new IBS/CBS fields from the service data, ensuring correct formatting for integration with the Focus provider.