### PR TITLE
[16.0][FIX] l10n_br_nfse: fix cep length

### DIFF
--- a/l10n_br_nfse/models/res_partner.py
+++ b/l10n_br_nfse/models/res_partner.py
@@ -60,7 +60,7 @@ class ResPartner(models.Model):
             "descricao_municipio": address_invoice_city_description,
             "uf": address_invoice_state_code,
             "municipio": self.city or None,
-            "cep": int(partner_cep),
+            "cep": partner_cep.zfill(8),
             "nif": nif,
             "nif_motivo_ausencia": nif_motivo_ausencia,
         }


### PR DESCRIPTION
O campo CEP do tomador estava sendo convertido para inteiro (int), o que removia zeros à esquerda, ex: 04022020 → 4022020.