### PR TITLE
[18.0][FIX] l10n_br_fiscal: fix tax_framework synchronization with partner

### DIFF
--- a/l10n_br_base/models/res_company.py
+++ b/l10n_br_base/models/res_company.py
@@ -23,6 +23,7 @@ class Company(models.Model):
             "state_tax_number_ids",
             "street_number",
             "street_name",
+            "street_number2",
         ]
 
     def _inverse_legal_name(self):
@@ -40,6 +41,10 @@ class Company(models.Model):
     def _inverse_street_number(self):
         for company in self:
             company.partner_id.street_number = company.street_number
+
+    def _inverse_street_number2(self):
+        for company in self:
+            company.partner_id.street_number2 = company.street_number2
 
     def _inverse_cnpj_cpf(self):
         for company in self:
@@ -81,6 +86,10 @@ class Company(models.Model):
         inverse="_inverse_legal_name",
     )
 
+    country_enforce_cities = fields.Boolean(
+        related="partner_id.country_id.enforce_cities", readonly=True
+    )
+
     district = fields.Char(
         compute="_compute_address",
         inverse="_inverse_district",
@@ -94,6 +103,10 @@ class Company(models.Model):
     street_number = fields.Char(
         compute="_compute_address",
         inverse="_inverse_street_number",
+    )
+
+    street_number2 = fields.Char(
+        compute="_compute_address", inverse="_inverse_street_number2"
     )
 
     city_id = fields.Many2one(

--- a/l10n_br_fiscal/models/res_company.py
+++ b/l10n_br_fiscal/models/res_company.py
@@ -43,11 +43,7 @@ class ResCompany(models.Model):
 
     def _get_company_address_field_names(self):
         partner_fields = super()._get_company_address_field_names()
-        return partner_fields + [
-            "tax_framework",
-            "legal_nature_id",
-            "cnae_main_id",
-        ]
+        return partner_fields + ["tax_framework", "legal_nature_id", "cnae_main_id"]
 
     def _inverse_legal_nature_id(self):
         """Write the l10n_br specific functional fields."""
@@ -63,6 +59,49 @@ class ResCompany(models.Model):
         """Write the l10n_br specific functional fields."""
         for c in self:
             c.partner_id.tax_framework = c.tax_framework
+
+    @api.depends("tax_framework")
+    def _compute_tax_domains(self):
+        try:
+            simples_piscofins = self.env.ref(
+                "l10n_br_fiscal.tax_pis_cofins_simples_nacional"
+            ).id
+            ipi_outros = self.env.ref("l10n_br_fiscal.tax_ipi_outros").id
+            group_ipi = self.env.ref("l10n_br_fiscal.tax_group_ipi").id
+            group_icms = self.env.ref("l10n_br_fiscal.tax_group_icms").id
+            group_icmssn = self.env.ref("l10n_br_fiscal.tax_group_icmssn").id
+        except ValueError:
+            simples_piscofins = ipi_outros = group_ipi = False
+            group_icms = group_icmssn = False
+
+        for rec in self:
+            # PIS/COFINS
+            if rec.tax_framework == "3":
+                ps_dom = [
+                    ("piscofins_type", "=", "company"),
+                    ("id", "!=", simples_piscofins),
+                ]
+            else:
+                ps_dom = [
+                    ("piscofins_type", "=", "company"),
+                    ("id", "=", simples_piscofins),
+                ]
+
+            # IPI
+            if rec.tax_framework == "3":
+                ipi_dom = [("tax_group_id", "=", group_ipi), ("id", "!=", ipi_outros)]
+            else:
+                ipi_dom = [("id", "=", ipi_outros)]
+
+            # ICMS
+            if rec.tax_framework == "3":
+                icms_dom = [("tax_group_id", "=", group_icms)]
+            else:
+                icms_dom = [("tax_group_id", "=", group_icmssn)]
+
+            rec.piscofins_domain = str(ps_dom)
+            rec.ipi_domain = str(ipi_dom)
+            rec.icms_domain = str(icms_dom)
 
     @api.depends("cnae_main_id", "annual_revenue", "payroll_amount")
     def _compute_simplified_tax(self):
@@ -111,6 +150,10 @@ class ResCompany(models.Model):
                         record.currency_id.decimal_places,
                     )
 
+    piscofins_domain = fields.Char(compute="_compute_tax_domains")
+    ipi_domain = fields.Char(compute="_compute_tax_domains")
+    icms_domain = fields.Char(compute="_compute_tax_domains")
+
     legal_nature_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.legal.nature",
         string="Legal Nature",
@@ -129,7 +172,7 @@ class ResCompany(models.Model):
 
     cnae_secondary_ids = fields.Many2many(
         comodel_name="l10n_br_fiscal.cnae",
-        domain="[('internal_type', '=', 'normal'), " "('id', '!=', cnae_main_id)]",
+        domain="[('internal_type', '=', 'normal'), ('id', '!=', cnae_main_id)]",
         string="Secondary CNAE",
     )
 

--- a/l10n_br_fiscal/views/res_company_view.xml
+++ b/l10n_br_fiscal/views/res_company_view.xml
@@ -82,11 +82,12 @@
                         <page name="taxes" string="Taxes">
                             <group name="normal_taxes" string="Default Taxes">
                                 <group name="piscofins_taxes" string="PIS/COFINS">
+                                    <field name="piscofins_domain" invisible="1" />
                                     <field
                                         name="piscofins_id"
                                         required="1"
-                                        domain="[ ('piscofins_type', '=', 'company'), '|', '&amp;', ('parent.tax_framework', '=', 3), ('id', '!=', %(l10n_br_fiscal.tax_pis_cofins_simples_nacional)d), '&amp;', ('parent.tax_framework', '!=', 3), ('id', '=', %(l10n_br_fiscal.tax_pis_cofins_simples_nacional)d) ]"
                                         options="{'no_create': True, 'no_create_edit': True}"
+                                        domain="piscofins_domain"
                                     />
                                     <field name="tax_pis_wh_id" />
                                     <field name="tax_cofins_wh_id" />
@@ -96,11 +97,12 @@
                                         name="ripi"
                                         invisible="tax_framework != '3'"
                                     />
+                                    <field name="ipi_domain" invisible="1" />
                                     <field
                                         name="tax_ipi_id"
                                         invisible="tax_framework == '3' and ripi"
                                         required="tax_framework != '3'"
-                                        domain="['|', '&amp;', ('parent.tax_framework', '=', 3), '&amp;', ('id', '!=', %(l10n_br_fiscal.tax_ipi_outros)d), ('tax_group_id', '=', %(l10n_br_fiscal.tax_group_ipi)d), '&amp;', ('parent.tax_framework', '!=', 3), ('id', '=', %(l10n_br_fiscal.tax_ipi_outros)d) ]"
+                                        domain="ipi_domain"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
                                     <div
@@ -110,11 +112,12 @@
                                     >IPI tax will be calculed by Product NCM and Fiscal Operation.</div>
                                 </group>
                                 <group name="icms_taxes" string="ICMS">
+                                    <field name="icms_domain" invisible="1" />
                                     <field
                                         name="tax_icms_id"
                                         invisible="tax_framework == '3'"
                                         required="tax_framework in ('1', '2')"
-                                        domain="['|', '&amp;', ('parent.tax_framework', '=', 3), ('tax_group_id', '=', %(l10n_br_fiscal.tax_group_icms)d), '&amp;', ('parent.tax_framework', '!=', 3), ('tax_group_id', '=', %(l10n_br_fiscal.tax_group_icmssn)d) ]"
+                                        domain="icms_domain"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
                                     <field


### PR DESCRIPTION
Correção das issues #4213 e #4328.
- #4328 Alguns campos do addon nativo do odoo `base_address_extended` não estavam sendo tratados no `res_company.py` do módulo `l10n_br_base`.
- #4213 O _domain_ de _field's_ que faziam um filtro antes de mostrar os regimes disponíveis de acordo com a Estrutura Tributária selecionada gerava erros por causa do `parent.tax_framework` que não encontrava o verdadeiro campo na tabela `res_partner`. Foram criadas variáveis simples para computar no Python ao invés do XML qual vai ser a estrutura do _domain_ para fazer o filtro. Assim foi possível obter acesso ao valor de `tax_framework` e poder fazer o filtro do domain corretamente no XML inserindo a variável com o _domain_ pronto.



