### PR TITLE
[18.0][l10n_br_base] don't mess with base.main_company country_id; avoid demo conflicts

### DIFF
--- a/l10n_br_base/demo/res_company_demo.xml
+++ b/l10n_br_base/demo/res_company_demo.xml
@@ -7,10 +7,7 @@
         <field name="street_name">Avenida Paulista</field>
         <field name="street_number">1</field>
         <field name="district">Bela Vista</field>
-        <field name="city_id" ref="l10n_br_base.city_3550308" />
         <field name="zip">01311-000</field>
-        <field name="country_id" ref="base.br" />
-        <field name='state_id' ref='base.state_br_sp' />
         <field name="phone">+55 11 9999-9999</field>
         <field name="email">info@suaempresa.com.br</field>
         <field name="website">www.example.com</field>

--- a/l10n_br_base/models/res_company.py
+++ b/l10n_br_base/models/res_company.py
@@ -144,25 +144,36 @@ class Company(models.Model):
     def write(self, values):
         """
         Overriden so we can change the currency_id of base.main_company
-        in l10n_br_base/demo/res_company_demo.xml (demo data)
+        and specific demo companies even if constraints would normally prevent it.
         """
         try:
-            result = super().write(values)
+            return super().write(values)
         except UserError as e:
-            demo_main_company = self.env.ref(
-                "base.main_company", raise_if_not_found=False
-            )
-            brl_currency = self.env.ref("base.BRL")
+            brl_currency = self.env.ref("base.BRL", raise_if_not_found=False)
+            usd_currency = self.env.ref("base.USD", raise_if_not_found=False)
             if (
-                demo_main_company
-                and self.ids == [demo_main_company.id]
-                and values.get("currency_id") == brl_currency.id
+                not brl_currency
+                or not usd_currency
+                or values.get("currency_id") not in (brl_currency.id, usd_currency.id)
             ):
-                result = models.Model.write(self, values)
-            else:
                 raise e
 
-        return result
+            demo_refs = [
+                "base.main_company",
+                "l10n_br_base.empresa_simples_nacional",
+                "l10n_br_base.empresa_lucro_presumido",
+            ]
+
+            allowed_companies = self.env["res.company"]
+            for ref in demo_refs:
+                company = self.env.ref(ref, raise_if_not_found=False)
+                if company:
+                    allowed_companies |= company
+
+            if allowed_companies and not (self - allowed_companies):
+                return super(models.Model, self).write(values)
+
+            raise e
 
     @api.onchange("state_id")
     def _onchange_state_id(self):

--- a/l10n_br_cnpj_search/tests/common.py
+++ b/l10n_br_cnpj_search/tests/common.py
@@ -8,6 +8,23 @@ class TestCnpjCommon(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+
+        # Create a Brazilian company and switch user to it
+        # This prevents tests from failing if main_company is not Brazilian
+        # (which causes VAT propagation to children, breaking the test)
+        cls.company_br = cls.env["res.company"].create(
+            {
+                "name": "Company BR",
+                "country_id": cls.env.ref("base.br").id,
+            }
+        )
+        cls.env.user.write(
+            {
+                "company_ids": [cls.company_br.id],
+                "company_id": cls.company_br.id,
+            }
+        )
+
         cls.model = cls.env["res.partner"]
         cls.mocked_response_ws_1 = {
             "nome": "Kilian Macedo Melcher 08777131460",


### PR DESCRIPTION
port de #4348 

isso é para facilitar o tipo de funcionalidade de desacoplagem dos testes com os dados de demo e da diminução dos conflitos com os dados de demo, ver aqui tb: #4326