### PR TITLE
[16.0][FIX] l10n_br_fiscal_edi: prevent recursive loop in action_document_confirm

### DIFF
--- a/l10n_br_account/tests/test_account_move_lc.py
+++ b/l10n_br_account/tests/test_account_move_lc.py
@@ -2159,3 +2159,37 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
         self.assertEqual(self.move_out_venda.state, "draft")
         document_id.exec_after_SITUACAO_EDOC_DENEGADA("em_digitacao", "denegada")
         self.assertEqual(self.move_out_venda.state, "cancel")
+
+    def test_in_invoice_confirm_from_fiscal_document(self):
+        """
+        Test that confirming an incoming invoice (issuer=partner) from
+        the fiscal document view works correctly without causing a
+        recursive loop error.
+
+        This test was added to prevent regression of a bug where
+        action_document_confirm() called from the fiscal document view
+        would trigger _post() on the invoice, which in turn would call
+        action_document_confirm() again, causing a "transition not allowed:
+        autorizada -> autorizada" error.
+        """
+        fiscal_edi = self.env["ir.module.module"].search(
+            [("name", "=", "l10n_br_fiscal_edi")]
+        )
+        if not (fiscal_edi and fiscal_edi.state == "installed"):
+            return
+
+        move = self.move_in_compra_para_revenda
+        document_id = move.fiscal_document_id
+
+        # Verify initial state
+        self.assertEqual(move.state, "draft")
+        self.assertEqual(document_id.state_edoc, "em_digitacao")
+        self.assertEqual(document_id.issuer, "partner")
+
+        # Confirm from fiscal document view (this used to fail with loop error)
+        document_id.action_document_confirm()
+
+        # Verify final state - document should be authorized (issuer=partner)
+        # and invoice should be posted
+        self.assertEqual(document_id.state_edoc, "autorizada")
+        self.assertEqual(move.state, "posted")

--- a/l10n_br_account/tests/test_move_workflow.py
+++ b/l10n_br_account/tests/test_move_workflow.py
@@ -22,6 +22,19 @@ class TestMoveWorkflow(AccountMoveBRCommon):
             fiscal_operation_lines=[cls.env.ref("l10n_br_fiscal.fo_venda_venda")],
         )
 
+        cls.env.ref("l10n_br_fiscal.fo_compras").deductible_taxes = True
+        cls.move_in_compra_para_revenda = cls.init_invoice(
+            "in_invoice",
+            products=[cls.product_a],
+            document_type=cls.env.ref("l10n_br_fiscal.document_55"),
+            fiscal_operation=cls.env.ref("l10n_br_fiscal.fo_compras"),
+            fiscal_operation_lines=[
+                cls.env.ref("l10n_br_fiscal.fo_compras_compras_comercializacao")
+            ],
+            document_serie="1",
+            document_number="42",
+        )
+
     def test_change_states(self):
         document_id = self.move_out_venda.fiscal_document_id
         self.assertEqual(self.move_out_venda.state, "draft")
@@ -48,3 +61,16 @@ class TestMoveWorkflow(AccountMoveBRCommon):
         self.assertEqual(self.move_out_venda.state, "draft")
         document_id.exec_after_SITUACAO_EDOC_DENEGADA("em_digitacao", "denegada")
         self.assertEqual(self.move_out_venda.state, "cancel")
+
+    def test_in_invoice_confirm_from_fiscal_document(self):
+        document_id = self.move_in_compra_para_revenda.fiscal_document_id
+        self.assertEqual(self.move_in_compra_para_revenda.state, "draft")
+        self.assertEqual(document_id.state, "em_digitacao")
+        fiscal_edi = self.env["ir.module.module"].search(
+            [("name", "=", "l10n_br_fiscal_edi")]
+        )
+        if fiscal_edi and fiscal_edi.state == "installed":
+            self.assertEqual(document_id.issuer, "partner")
+            document_id.action_document_confirm()
+            self.assertEqual(document_id.state, "autorizada")
+            self.assertEqual(self.move_in_compra_para_revenda.state, "posted")

--- a/l10n_br_fiscal_edi/models/document_workflow.py
+++ b/l10n_br_fiscal_edi/models/document_workflow.py
@@ -299,7 +299,9 @@ class DocumentWorkflow(models.AbstractModel):
             self._change_state(SITUACAO_EDOC_AUTORIZADA)
 
     def _document_confirm_to_send(self):
-        to_confirm = self.filtered(lambda inv: inv.state_edoc != SITUACAO_EDOC_A_ENVIAR)
+        to_confirm = self.filtered(
+            lambda inv: inv.state_edoc == SITUACAO_EDOC_EM_DIGITACAO
+        )
         if to_confirm:
             to_confirm._document_confirm()
 

--- a/l10n_br_fiscal_edi/tests/test_workflow.py
+++ b/l10n_br_fiscal_edi/tests/test_workflow.py
@@ -117,3 +117,35 @@ class TestWorkflow(TransactionCase):
         assert (
             self.fiscal_document.state_edoc == SITUACAO_EDOC_EM_DIGITACAO
         ), "Error with document workflow, state 'SITUACAO_EDOC_A_ENVIAR' "
+
+    def test_partner_issuer_confirm_idempotent(self):
+        """
+        Test that confirming a document with issuer='partner' multiple times
+        does not raise an error. This is a regression test for a bug where
+        action_document_confirm() would fail on the second call because
+        the document was already in 'autorizada' state.
+
+        The fix ensures _document_confirm_to_send() only processes documents
+        in 'em_digitacao' state, making it safe to call multiple times.
+        """
+        self.fiscal_document.document_electronic = True
+        self.fiscal_document.issuer = "partner"
+
+        assert (
+            self.fiscal_document.state_edoc == SITUACAO_EDOC_EM_DIGITACAO
+        ), "Document should start in em_digitacao"
+
+        # First confirm - should go directly to autorizada (issuer=partner)
+        self.fiscal_document.action_document_confirm()
+        assert (
+            self.fiscal_document.state_edoc == SITUACAO_EDOC_AUTORIZADA
+        ), "Document should be autorizada after first confirm"
+
+        # Second confirm - should NOT raise error (idempotent behavior)
+        # Before the fix, this would raise:
+        # "Não é possível realizar esta operação, esta transição não é permitida:
+        # De: autorizada Para: autorizada"
+        self.fiscal_document.action_document_confirm()
+        assert (
+            self.fiscal_document.state_edoc == SITUACAO_EDOC_AUTORIZADA
+        ), "Document should still be autorizada after second confirm"


### PR DESCRIPTION
## Resumo

Corrige um bug onde confirmar uma fatura de entrada (issuer=partner) pela view do documento fiscal falhava com o erro:

> Não é possível realizar esta operação, esta transição não é permitida:
> De: autorizada
> Para: autorizada

## Como reproduzir

1. Criar uma fatura de entrada (`in_invoice`) com um tipo de documento fiscal (ex: NF-e)
2. Certificar que o documento fiscal tem `issuer=partner` (padrão para faturas de entrada)
3. Navegar até a view do documento fiscal vinculado (`l10n_br_fiscal.document`)
4. Clicar no botão "Confirmar"
5. **Antes do fix:** Erro "transição não permitida: autorizada -> autorizada"
6. **Após o fix:** Documento é autorizado e fatura é postada corretamente

## Causa raiz

Ao confirmar pela view do documento fiscal:

1. `action_document_confirm()` é chamado → documento vai para `autorizada` (quando issuer=partner)
2. Isso dispara `move_ids._post()` para postar a fatura vinculada
3. `_post()` chama `action_document_confirm()` novamente no documento fiscal
4. A segunda chamada tenta fazer transição de `autorizada` para `autorizada` → erro

## Solução

Alterado o filtro em `_document_confirm_to_send()` para processar apenas documentos no estado `em_digitacao`, tornando o método idempotente e seguro para ser chamado múltiplas vezes.

Obs: Confirmar pela view da fatura (`account.move`) funciona corretamente porque a flag de contexto `skip_post` previne a chamada recursiva.