### PR TITLE
[16.0][FIX] l10n_br_sale: fix fiscal_quantity on partial invoices

### DIFF
--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -194,10 +194,8 @@ class SaleOrderLine(models.Model):
         self.ensure_one()
         result = {}
         if not self.display_type and self.fiscal_operation_id:
-            # O caso Brasil se caracteriza por ter a Operação Fiscal
             result = self._prepare_br_fiscal_dict()
-            if self.product_id and self.product_id.invoice_policy == "delivery":
-                result["fiscal_quantity"] = self.qty_to_invoice
+            result.pop("fiscal_quantity", None)
         result.update(super()._prepare_invoice_line(**optional_values))
         return result
 

--- a/l10n_br_sale/tests/test_l10n_br_sale_lp.py
+++ b/l10n_br_sale/tests/test_l10n_br_sale_lp.py
@@ -10,3 +10,59 @@ class TestL10nBrSale(L10nBrSaleBaseTest, TransactionCase):
     so_products_ref = "l10n_br_sale.lc_so_only_products"
     so_services_ref = "l10n_br_sale.lc_so_only_services"
     so_product_service_ref = "l10n_br_sale.lc_so_product_service"
+
+    def test_partial_invoice_fiscal_quantity(self):
+        """Test fiscal_quantity on partial invoices with delivery policy."""
+        self._change_user_company(self.company)
+        self._run_sale_order_onchanges(self.so_products)
+        so_lines = self.so_products.order_line.filtered(
+            lambda line: not line.display_type
+        )
+        self.assertTrue(so_lines, "SO must have product lines")
+        for line in so_lines:
+            self._run_sale_line_onchanges(line)
+            line.product_id.invoice_policy = "delivery"
+
+        self.so_products.action_confirm()
+
+        # First delivery: half
+        for line in so_lines:
+            line.qty_delivered = line.product_uom_qty / 2.0
+
+        # First invoice
+        self.so_products._create_invoices()
+        first_invoice = self.so_products.invoice_ids[0]
+        inv_lines = first_invoice.invoice_line_ids.filtered(
+            lambda line: line.display_type == "product"
+        )
+        self.assertTrue(inv_lines, "Invoice must have product lines")
+        for inv_line in inv_lines:
+            so_line = inv_line.sale_line_ids[0]
+            uot_factor = so_line.product_id.uot_factor or 1.0
+            expected_qty = so_line.product_uom_qty / 2.0
+            expected_fiscal_qty = expected_qty * uot_factor
+            self.assertAlmostEqual(inv_line.quantity, expected_qty, 2)
+            self.assertAlmostEqual(inv_line.fiscal_quantity, expected_fiscal_qty, 2)
+
+        first_invoice.action_post()
+
+        # Second delivery: remaining half
+        for line in so_lines:
+            line.qty_delivered = line.product_uom_qty
+
+        # Second invoice
+        self.so_products._create_invoices()
+        second_invoice = self.so_products.invoice_ids.filtered(
+            lambda inv: inv.id != first_invoice.id
+        )[0]
+        inv_lines = second_invoice.invoice_line_ids.filtered(
+            lambda line: line.display_type == "product"
+        )
+        self.assertTrue(inv_lines, "Second invoice must have product lines")
+        for inv_line in inv_lines:
+            so_line = inv_line.sale_line_ids[0]
+            uot_factor = so_line.product_id.uot_factor or 1.0
+            expected_qty = so_line.product_uom_qty / 2.0
+            expected_fiscal_qty = expected_qty * uot_factor
+            self.assertAlmostEqual(inv_line.quantity, expected_qty, 2)
+            self.assertAlmostEqual(inv_line.fiscal_quantity, expected_fiscal_qty, 2)


### PR DESCRIPTION
## Resumo

Ao criar uma fatura parcial a partir de um pedido de venda, o `fiscal_quantity` na linha da fatura ficava com a quantidade total do pedido em vez da quantidade efetivamente faturada (`qty_to_invoice`).

O problema ocorria para produtos com política de faturamento "Quantidades pedidas" (`invoice_policy = "order"`). Para "Quantidades entregues" (`invoice_policy = "delivery"`) já havia um tratamento, porém sem considerar o `uot_factor`.

## Como reproduzir

1. Criar pedido de venda com 100 unidades (produto com política "Quantidades pedidas")
2. Faturar 50 unidades (fatura parcial)
3. Criar nova fatura para as 50 restantes

- **Antes do fix:** `quantity = 50` (correto), `fiscal_quantity = 100` (errado)
- **Após o fix:** `quantity = 50`, `fiscal_quantity = 50` (ambos corretos, considerando `uot_factor`)

## Causa raiz

O método `_prepare_invoice_line` chamava `_prepare_br_fiscal_dict()` que copia todos os campos fiscais da linha do pedido, incluindo `fiscal_quantity` com o valor total. Anteriormente, apenas linhas com `invoice_policy == "delivery"` tinham o `fiscal_quantity` corrigido — e sem considerar o `uot_factor`.

## Solução

Remover `fiscal_quantity` do dict preparado (`result.pop("fiscal_quantity", None)`) para que o compute `_compute_fiscal_quantity` recalcule corretamente baseado no `quantity` real da fatura, aplicando o `uot_factor` automaticamente.

Testes adicionados para faturamento parcial com delivery policy (entrega parcial única e duas entregas sequenciais).