### PR TITLE
[16.0][FIX] l10n_br_account: filter fiscal operations by type in invoice views

### DIFF
--- a/l10n_br_account/views/account_move_view.xml
+++ b/l10n_br_account/views/account_move_view.xml
@@ -91,6 +91,7 @@
                 <field
                     name="fiscal_operation_id"
                     attrs="{'invisible': [('document_type_id', '=', False)], 'required': [('document_type_id', '!=', False)], 'readonly': [('state', '!=', 'draft')]}"
+                    domain="[('state', '=', 'approved'), ('fiscal_operation_type', '=', fiscal_operation_type)]"
                 />
                 <field
                     name="ind_final"
@@ -188,7 +189,11 @@
                 />
                 <field name="fiscal_document_line_id" invisible="1" />
                 <field name="document_type_id" invisible="1" />
-                <field name="fiscal_operation_id" optional="hide" />
+                <field
+                    name="fiscal_operation_id"
+                    optional="hide"
+                    domain="[('state', '=', 'approved'), ('fiscal_operation_type', '=', fiscal_operation_type)]"
+                />
                 <field name="cfop_id" optional="hide" />
                 <field name="tax_classification_id" optional="hide" />
                 <field name="city_taxation_code_id" optional="hide" />
@@ -392,7 +397,7 @@
                 <field
                     name="fiscal_operation_id"
                     attrs="{'invisible': [('document_type_id', '=', False)], 'required': [('document_type_id', '!=', False)]}"
-                    domain="[('state', '=', 'approved')]"
+                    domain="[('state', '=', 'approved'), ('fiscal_operation_type', '=', fiscal_operation_type)]"
                 />
                 <field
                     name="fiscal_operation_line_id"


### PR DESCRIPTION
## Resumo

O campo `fiscal_operation_id` nas views de `account.move` não filtrava operações por `fiscal_operation_type`, permitindo selecionar operações de compra em faturas de venda e vice-versa.

## Como reproduzir

1. Abrir uma fatura de venda (Faturamento > Faturas de Cliente)
2. Clicar no campo "Operação Fiscal"
3. Observar que operações de compra (tipo "in") aparecem na lista

- **Antes do fix:** todas as operações aprovadas aparecem, independente do tipo
- **Após o fix:** apenas operações compatíveis com o tipo da fatura (e tipo "all")

## Causa raiz

A PR #3925 simplificou o domínio estático de `fiscal_operation_id` em `l10n_br_fiscal.document` (removendo o filtro por `fiscal_operation_type`) para corrigir a criação direta de documentos fiscais onde `fiscal_operation_type` começa `False`. A solução substituiu o domínio estático por um `@api.onchange`, que não funciona de forma confiável no contexto de `account.move` porque `fiscal_operation_type` é um campo computed (não editável pelo usuário).

## Solução

Adicionar o filtro por `fiscal_operation_type` no domínio a nível de view em `account_move_view.xml` (header, tree das linhas, e form das linhas), restaurando o filtro que existia na v14 via domínio Python. Isso não afeta o fluxo de criação direta de documentos fiscais, que continua usando o onchange.