### PR TITLE
[18.0][FIX] l10n_br_base: Método _fields_view_get agora é _get_view

### DIFF
--- a/l10n_br_base/models/res_company.py
+++ b/l10n_br_base/models/res_company.py
@@ -133,13 +133,11 @@ class Company(models.Model):
     )
 
     @api.model
-    def _fields_view_get(
-        self, view_id=None, view_type="form", toolbar=False, submenu=False
-    ):
-        res = super()._fields_view_get(view_id, view_type, toolbar, submenu)
+    def _get_view(self, view_id=None, view_type="form", **options):
+        arch, view = super()._get_view(view_id, view_type, **options)
         if view_type == "form":
-            res["arch"] = self._view_get_address(res["arch"])
-        return res
+            arch = self._view_get_address(arch)
+        return arch, view
 
     def write(self, values):
         """


### PR DESCRIPTION
Método **_fields_view_get** agora é **_get_view**, PR simples na v16 já havia um alerta sobre o método se tornar obsoleto

https://github.com/odoo/odoo/blob/16.0/odoo/addons/base/models/ir_ui_view.py#L2763

```bash
    def _fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
        warnings.warn(
            'Method `_fields_view_get` is deprecated, use `_get_view` instead',
            DeprecationWarning, stacklevel=2,
        )
```

Mas tem um outro ponto aqui, que é a real necessidade disso, alguém sabe dizer?

Porque mesmo removendo o método já atualizado não parece ter afetado a tela, talvez esteja relacionado ao Issue

* https://github.com/OCA/l10n-brazil/issues/4328

cc @OCA/local-brazil-maintainers 