### PR TITLE
[16.0][FIX] l10n_br_fiscal,l10n_br_account: propaga ind_final para linhas ao alterar parceiro

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -380,6 +380,13 @@ class AccountMove(models.Model):
                 protected.update(self.pool.field_computed.get(field, [field]))
         return [(protected, rec) for rec in records] if protected else []
 
+    @api.onchange("ind_final")
+    def _onchange_ind_final(self):
+        for move in self:
+            for line in move.invoice_line_ids:
+                if line.ind_final != move.ind_final:
+                    line.ind_final = move.ind_final
+
     @contextmanager
     def _sync_dynamic_lines(self, container):
         with self._disable_recursion(container, "skip_invoice_sync") as disabled:

--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -387,6 +387,13 @@ class AccountMove(models.Model):
                 if line.ind_final != move.ind_final:
                     line.ind_final = move.ind_final
 
+    @api.onchange("ind_final")
+    def _onchange_ind_final(self):
+        for move in self:
+            for line in move.invoice_line_ids:
+                if line.ind_final != move.ind_final:
+                    line.ind_final = move.ind_final
+
     @contextmanager
     def _sync_dynamic_lines(self, container):
         with self._disable_recursion(container, "skip_invoice_sync") as disabled:

--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -387,13 +387,6 @@ class AccountMove(models.Model):
                 if line.ind_final != move.ind_final:
                     line.ind_final = move.ind_final
 
-    @api.onchange("ind_final")
-    def _onchange_ind_final(self):
-        for move in self:
-            for line in move.invoice_line_ids:
-                if line.ind_final != move.ind_final:
-                    line.ind_final = move.ind_final
-
     @contextmanager
     def _sync_dynamic_lines(self, container):
         with self._disable_recursion(container, "skip_invoice_sync") as disabled:

--- a/l10n_br_account/tests/test_move_edition.py
+++ b/l10n_br_account/tests/test_move_edition.py
@@ -572,3 +572,102 @@ class TestMoveEdition(TransactionCase):
             move_after_total_update.fiscal_amount_total, 2776.48, places=2
         )
         self.assertAlmostEqual(move_after_total_update.amount_total, 2776.48, places=2)
+
+    def _setup_fiscal_user(self):
+        """Grant fiscal groups needed for invoice tests with fiscal documents."""
+        self.user.groups_id += self.env.ref("l10n_br_fiscal.group_user")
+        nfe_user_group = self.env.ref(
+            "l10n_br_nfe.group_user", raise_if_not_found=False
+        )
+        if nfe_user_group:
+            self.user.groups_id += nfe_user_group
+
+    def _create_fiscal_invoice_form(self, partner):
+        """Create a fiscal invoice Form pre-filled with the given partner."""
+        move_form = Form(
+            self.env["account.move"].with_context(
+                default_move_type="out_invoice",
+            )
+        )
+        move_form.partner_id = partner
+        move_form.document_type_id = self.env.ref("l10n_br_fiscal.document_55")
+        move_form.document_serie_id = self.env.ref(
+            "l10n_br_fiscal.empresa_lc_document_55_serie_1"
+        )
+        move_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
+        return move_form
+
+    def test_ind_final_propagation_on_manual_change(self):
+        """Changing ind_final directly on a saved invoice must propagate
+        to the fiscal document lines."""
+        self._setup_fiscal_user()
+        partner = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner.ind_final = "1"
+
+        move_form = self._create_fiscal_invoice_form(partner)
+        with move_form.invoice_line_ids.new() as line_form:
+            line_form.product_id = self.product_id
+            line_form.price_unit = 100.0
+            line_form.quantity = 1.0
+
+        move = move_form.save()
+        fiscal_line = move.fiscal_line_ids[0]
+        self.assertEqual(move.ind_final, "1")
+        self.assertEqual(fiscal_line.ind_final, "1")
+
+        # Manually change ind_final on the invoice
+        move.write({"ind_final": "0"})
+        self.assertEqual(move.ind_final, "0")
+        self.assertEqual(fiscal_line.ind_final, "0")
+
+    def test_ind_final_propagation_on_partner_change(self):
+        """Changing partner_id on a saved invoice must propagate ind_final
+        to the fiscal document lines when the new partner differs."""
+        self._setup_fiscal_user()
+        partner_final = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner_final.ind_final = "1"
+        partner_not_final = self.env.ref("l10n_br_base.res_partner_cliente5_pe")
+        partner_not_final.ind_final = "0"
+
+        move_form = self._create_fiscal_invoice_form(partner_final)
+        with move_form.invoice_line_ids.new() as line_form:
+            line_form.product_id = self.product_id
+            line_form.price_unit = 100.0
+            line_form.quantity = 1.0
+
+        move = move_form.save()
+        fiscal_line = move.fiscal_line_ids[0]
+        self.assertEqual(move.ind_final, "1")
+        self.assertEqual(fiscal_line.ind_final, "1")
+
+        # Change to a partner with ind_final="0"
+        move.write({"partner_id": partner_not_final.id})
+        self.assertEqual(move.ind_final, "0")
+        self.assertEqual(fiscal_line.ind_final, "0")
+
+    def test_ind_final_propagation_on_form_partner_change(self):
+        """Changing partner_id on an unsaved invoice form must propagate
+        ind_final to existing lines both in the form and after saving."""
+        self._setup_fiscal_user()
+        partner_final = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner_final.ind_final = "1"
+        partner_not_final = self.env.ref("l10n_br_base.res_partner_cliente5_pe")
+        partner_not_final.ind_final = "0"
+
+        move_form = self._create_fiscal_invoice_form(partner_final)
+        with move_form.invoice_line_ids.new() as line_form:
+            line_form.product_id = self.product_id
+            line_form.price_unit = 100.0
+            line_form.quantity = 1.0
+
+        self.assertEqual(move_form.ind_final, "1")
+
+        # Change partner without saving
+        move_form.partner_id = partner_not_final
+        self.assertEqual(move_form.ind_final, "0")
+
+        # Verify after saving
+        move = move_form.save()
+        fiscal_line = move.fiscal_line_ids[0]
+        self.assertEqual(move.ind_final, "0")
+        self.assertEqual(fiscal_line.ind_final, "0")

--- a/l10n_br_fiscal/models/document_mixin.py
+++ b/l10n_br_fiscal/models/document_mixin.py
@@ -210,12 +210,21 @@ class FiscalDocumentMixin(models.AbstractModel):
                 # Default Value
                 doc.ind_final = "1"  # Yes
 
-    @api.onchange("ind_final")
-    def _inverse_ind_final(self):
+    def _propagate_ind_final_to_lines(self):
         for doc in self:
             for line in doc._get_amount_lines():
                 if line.ind_final != doc.ind_final:
                     line.ind_final = doc.ind_final
+
+    @api.onchange("ind_final")
+    def _inverse_ind_final(self):
+        self._propagate_ind_final_to_lines()
+
+    def write(self, vals):
+        result = super().write(vals)
+        if "partner_id" in vals or "ind_final" in vals:
+            self._propagate_ind_final_to_lines()
+        return result
 
     @api.depends("fiscal_operation_id")
     def _compute_operation_name(self):

--- a/l10n_br_fiscal/tests/test_document_edition.py
+++ b/l10n_br_fiscal/tests/test_document_edition.py
@@ -346,6 +346,102 @@ class TestDocumentEdition(TransactionCase):
         # fiscal_amount_untaxed = (2000+40+20+8) + (500+10+5+2) = 2585
         self.assertAlmostEqual(doc.fiscal_amount_untaxed, 2585.0)
 
+    def test_ind_final_propagation_on_manual_change(self):
+        """Changing ind_final on a saved document must propagate to lines."""
+        partner = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner.ind_final = "1"
+        doc_form = Form(
+            self.env["l10n_br_fiscal.document"].with_context(
+                default_fiscal_operation_type="out",
+            )
+        )
+        doc_form.company_id = self.company
+        doc_form.partner_id = partner
+        doc_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
+
+        product = self.env.ref("product.product_product_6")
+        with doc_form.fiscal_line_ids.new() as line_form:
+            line_form.product_id = product
+            line_form.price_unit = 100.0
+            line_form.quantity = 1.0
+
+        doc = doc_form.save()
+        line = doc.fiscal_line_ids[0]
+        self.assertEqual(doc.ind_final, "1")
+        self.assertEqual(line.ind_final, "1")
+
+        # Manually change ind_final on the document
+        doc.write({"ind_final": "0"})
+        self.assertEqual(doc.ind_final, "0")
+        self.assertEqual(line.ind_final, "0")
+
+    def test_ind_final_propagation_on_partner_change(self):
+        """Changing partner_id on a saved document must propagate ind_final
+        to lines when the new partner has a different ind_final."""
+        partner_final = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner_final.ind_final = "1"
+        partner_not_final = self.env.ref("l10n_br_base.res_partner_cliente5_pe")
+        partner_not_final.ind_final = "0"
+
+        doc_form = Form(
+            self.env["l10n_br_fiscal.document"].with_context(
+                default_fiscal_operation_type="out",
+            )
+        )
+        doc_form.company_id = self.company
+        doc_form.partner_id = partner_final
+        doc_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
+
+        product = self.env.ref("product.product_product_6")
+        with doc_form.fiscal_line_ids.new() as line_form:
+            line_form.product_id = product
+            line_form.price_unit = 100.0
+            line_form.quantity = 1.0
+
+        doc = doc_form.save()
+        line = doc.fiscal_line_ids[0]
+        self.assertEqual(doc.ind_final, "1")
+        self.assertEqual(line.ind_final, "1")
+
+        # Change to a partner with ind_final="0"
+        doc.write({"partner_id": partner_not_final.id})
+        self.assertEqual(doc.ind_final, "0")
+        self.assertEqual(line.ind_final, "0")
+
+    def test_ind_final_propagation_on_form_partner_change(self):
+        """Changing partner_id on a form before saving must propagate
+        ind_final to lines when saved."""
+        partner_final = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner_final.ind_final = "1"
+        partner_not_final = self.env.ref("l10n_br_base.res_partner_cliente5_pe")
+        partner_not_final.ind_final = "0"
+
+        doc_form = Form(
+            self.env["l10n_br_fiscal.document"].with_context(
+                default_fiscal_operation_type="out",
+            )
+        )
+        doc_form.company_id = self.company
+        doc_form.partner_id = partner_final
+        doc_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
+
+        product = self.env.ref("product.product_product_6")
+        with doc_form.fiscal_line_ids.new() as line_form:
+            line_form.product_id = product
+            line_form.price_unit = 100.0
+            line_form.quantity = 1.0
+
+        self.assertEqual(doc_form.ind_final, "1")
+
+        # Change partner before saving
+        doc_form.partner_id = partner_not_final
+        self.assertEqual(doc_form.ind_final, "0")
+
+        doc = doc_form.save()
+        line = doc.fiscal_line_ids[0]
+        self.assertEqual(doc.ind_final, "0")
+        self.assertEqual(line.ind_final, "0")
+
     def test_difal_calculation(self):
         partner = self.env.ref("l10n_br_base.res_partner_cliente5_pe")
         partner.ind_ie_dest = "9"

--- a/l10n_br_sale/tests/__init__.py
+++ b/l10n_br_sale/tests/__init__.py
@@ -5,3 +5,4 @@ from . import test_l10n_br_sale_discount
 from . import test_l10n_br_sale_sn
 from . import test_l10n_br_sale_pricelist
 from . import test_sale_order_report
+from . import test_sale_order_ind_final

--- a/l10n_br_sale/tests/test_sale_order_ind_final.py
+++ b/l10n_br_sale/tests/test_sale_order_ind_final.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Engenere
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests import TransactionCase
+from odoo.tests.common import Form, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSaleOrderIndFinal(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.company = cls.env.ref("l10n_br_base.empresa_lucro_presumido")
+        cls.user = cls.env.user
+        cls.user.company_ids |= cls.company
+        cls.user.company_id = cls.company.id
+        cls.product = cls.env.ref("product.product_product_6")
+
+    def _create_sale_order_form(self, partner):
+        """Create a sale order Form pre-filled with the given partner."""
+        so_form = Form(self.env["sale.order"])
+        so_form.company_id = self.company
+        so_form.partner_id = partner
+        so_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
+        return so_form
+
+    def test_ind_final_propagation_on_manual_change(self):
+        """Changing ind_final on a saved sale order must propagate to lines."""
+        partner = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner.ind_final = "1"
+
+        so_form = self._create_sale_order_form(partner)
+        with so_form.order_line.new() as line_form:
+            line_form.product_id = self.product
+            line_form.product_uom_qty = 1.0
+
+        so = so_form.save()
+        line = so.order_line.filtered(lambda line: not line.display_type)[0]
+        self.assertEqual(so.ind_final, "1")
+        self.assertEqual(line.ind_final, "1")
+
+        # Manually change ind_final on the order
+        so.write({"ind_final": "0"})
+        self.assertEqual(so.ind_final, "0")
+        self.assertEqual(line.ind_final, "0")
+
+    def test_ind_final_propagation_on_partner_change(self):
+        """Changing partner_id on a saved sale order must propagate ind_final
+        to lines when the new partner has a different ind_final."""
+        partner_final = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner_final.ind_final = "1"
+        partner_not_final = self.env.ref("l10n_br_base.res_partner_cliente5_pe")
+        partner_not_final.ind_final = "0"
+
+        so_form = self._create_sale_order_form(partner_final)
+        with so_form.order_line.new() as line_form:
+            line_form.product_id = self.product
+            line_form.product_uom_qty = 1.0
+
+        so = so_form.save()
+        line = so.order_line.filtered(lambda line: not line.display_type)[0]
+        self.assertEqual(so.ind_final, "1")
+        self.assertEqual(line.ind_final, "1")
+
+        # Change to a partner with ind_final="0"
+        so.write({"partner_id": partner_not_final.id})
+        self.assertEqual(so.ind_final, "0")
+        self.assertEqual(line.ind_final, "0")
+
+    def test_ind_final_propagation_on_form_partner_change(self):
+        """Changing partner_id on a form before saving must propagate
+        ind_final to lines when saved."""
+        partner_final = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner_final.ind_final = "1"
+        partner_not_final = self.env.ref("l10n_br_base.res_partner_cliente5_pe")
+        partner_not_final.ind_final = "0"
+
+        so_form = self._create_sale_order_form(partner_final)
+        with so_form.order_line.new() as line_form:
+            line_form.product_id = self.product
+            line_form.product_uom_qty = 1.0
+
+        self.assertEqual(so_form.ind_final, "1")
+
+        # Change partner before saving
+        so_form.partner_id = partner_not_final
+        self.assertEqual(so_form.ind_final, "0")
+
+        so = so_form.save()
+        line = so.order_line.filtered(lambda line: not line.display_type)[0]
+        self.assertEqual(so.ind_final, "0")
+        self.assertEqual(line.ind_final, "0")


### PR DESCRIPTION
## Problema

Ao alterar o parceiro em um documento fiscal ou fatura, o campo `ind_final` (consumidor final) atualiza no cabeçalho mas **não propaga para as linhas**.

A edição manual direta do `ind_final` já funciona (o inverse cuida da propagação). O problema ocorre quando `ind_final` muda **indiretamente**, via troca de parceiro.

Cenários que falham sem a correção:

| Cenário | l10n_br_fiscal | account.move | sale.order |
|---|---|---|---|
| Edição manual do ind_final | OK | OK | OK |
| Troca de parceiro (write) | **FALHA** | **FALHA** | OK |
| Troca de parceiro (form) | OK | **FALHA** | OK |

- `l10n_br_fiscal`: falha na troca de parceiro via `write()`. No form funciona porque o `@api.onchange("ind_final")` do mixin dispara.
- `account.move`: falha na troca de parceiro tanto via `write()` quanto no form, porque usa `_inherits` (delegação) — o `write()` e onchanges do mixin fiscal não são chamados.
- `sale.order`: não falha — `sale.order.line.ind_final` é `related`.

## Causa

O campo `ind_final` é computado a partir do parceiro, mas também é editável (possui inverse). Quando o parceiro muda e o compute recalcula `ind_final`, a ORM **não aciona o inverse** — e o valor nas linhas fica desatualizado.

No `account.move`, o problema é agravado porque `partner_id` é um campo "shadow" (existe no account.move e no fiscal document). A ORM não delega a escrita de shadow fields via `_inherits`, então o fiscal document não recebe a mudança de `partner_id` diretamente — esse problema é resolvido pelo padrão de proxy fields introduzido na #4394.

## Solução

- **l10n_br_fiscal**: Override de `write()` no `document_mixin` que detecta mudanças em `partner_id` ou `ind_final` e propaga para as linhas fiscais via `_propagate_ind_final_to_lines()`
- **l10n_br_account** (proxy → ind_final): Override de `write()` no fiscal document que detecta `proxy_partner_id` nos vals e propaga ind_final (necessário porque o mixin verifica `partner_id`, mas com proxy o fiscal doc recebe `proxy_partner_id`)
- **l10n_br_account** (form): `@api.onchange("ind_final")` no `account.move` para propagar no form (necessário porque `_inherits` não herda onchanges do mixin)
- **l10n_br_sale**: Não precisa de correção, mas testes foram adicionados para documentar o comportamento esperado

## Testes

9 testes adicionados (3 por módulo):
- Edição manual do `ind_final`
- Troca de parceiro via `write()`
- Troca de parceiro no form