### PR TITLE
[16.0][IMP] l10n_br_nfse, l10n_br_nfse_focus: add percentual_total_tributos

### DIFF
--- a/l10n_br_nfse/models/document.py
+++ b/l10n_br_nfse/models/document.py
@@ -208,6 +208,21 @@ class Document(models.Model):
                 result_line.get("tipo_retencao_pis_cofins") or "2"
             )
 
+        state_id = (
+            self.fiscal_line_ids[0].issqn_fg_city_id.state_id
+            or self.company_id.partner_id.state_id
+        )
+        nbs_id = self.fiscal_line_ids[0].nbs_id
+        tax_estimate = nbs_id.tax_estimate_ids.filtered(
+            lambda x: x.state_id == state_id
+        )
+
+        percentual_total_tributos_federais = tax_estimate.federal_taxes_national
+        if self.partner_id.country_id.code != "BR":
+            percentual_total_tributos_federais = tax_estimate.federal_taxes_import
+        percentual_total_tributos_estaduais = tax_estimate.state_taxes
+        percentual_total_tributos_municipais = tax_estimate.municipal_taxes
+
         result = {
             "valor_servicos": valor_servicos,
             "valor_deducoes": valor_deducoes,
@@ -272,6 +287,11 @@ class Document(models.Model):
             "codigo_tributacao_iss": ISSQN_TO_TRIBUTACAO_ISS[
                 self.fiscal_line_ids[0].issqn_eligibility
             ],
+            "percentual_total_tributos_federais": percentual_total_tributos_federais,
+            "percentual_total_tributos_estaduais": percentual_total_tributos_estaduais,
+            "percentual_total_tributos_municipais": (
+                percentual_total_tributos_municipais
+            ),
         }
 
         result.update(self.company_id._prepare_company_service())

--- a/l10n_br_nfse/tests/test_fiscal_document_nfse_common.py
+++ b/l10n_br_nfse/tests/test_fiscal_document_nfse_common.py
@@ -30,6 +30,22 @@ class TestFiscalDocumentNFSeCommon(TransactionCase):
         ).id
         cls.company.document_type_id = cls.env.ref("l10n_br_fiscal.document_SE")
         cls.nfse_same_state.company_id = cls.company.id
+        cls.nbs_id = cls.env["l10n_br_fiscal.nbs"].create(
+            {
+                "code": "0101",
+                "name": "Desenvolvimento de Software",
+            }
+        )
+        cls.tax_estimate = cls.env["l10n_br_fiscal.tax.estimate"].create(
+            {
+                "nbs_id": cls.nbs_id.id,
+                "state_id": cls.company.partner_id.state_id.id,
+                "federal_taxes_national": 13.45,
+                "federal_taxes_import": 18.20,
+                "state_taxes": 0.0,
+                "municipal_taxes": 2.90,
+            }
+        )
 
     def test_certified_nfse_same_state_(self):
         """Test Certified NFSe same state."""
@@ -150,3 +166,63 @@ class TestFiscalDocumentNFSeCommon(TransactionCase):
                 "Error to mappping Fiscal Deductions Value 10.0"
                 " for Venda de Serviço de Contribuinte Dentro do Estado.",
             )
+
+    def test_tax_estimate_by_nbs(self):
+        """Test tax estimate tags for national and foreign partners based on NBS."""
+
+        fiscal_document = self.nfse_same_state
+        service_data = fiscal_document._prepare_dados_servico()
+
+        self.assertFalse(
+            service_data["percentual_total_tributos_federais"],
+            "Should be False when no NBS is defined",
+        )
+        self.assertFalse(
+            service_data["percentual_total_tributos_estaduais"],
+            "Should be False when no NBS is defined",
+        )
+        self.assertFalse(
+            service_data["percentual_total_tributos_municipais"],
+            "Should be False when no NBS is defined",
+        )
+
+        fiscal_line = fiscal_document.fiscal_line_ids[0]
+        fiscal_line.nbs_id = self.nbs_id
+        fiscal_line.issqn_fg_city_id = self.company.partner_id.city_id
+        service_data = fiscal_document._prepare_dados_servico()
+
+        self.assertEqual(
+            self.tax_estimate.federal_taxes_national,
+            service_data["percentual_total_tributos_federais"],
+            "Should be the same as tax_estimate.federal_taxes_national",
+        )
+        self.assertEqual(
+            self.tax_estimate.state_taxes,
+            service_data["percentual_total_tributos_estaduais"],
+            "Should be the same as tax_estimate.state_taxes",
+        )
+        self.assertEqual(
+            self.tax_estimate.municipal_taxes,
+            service_data["percentual_total_tributos_municipais"],
+            "Should be the same as tax_estimate.municipal_taxes",
+        )
+
+        fiscal_document.partner_id = self.env.ref("l10n_br_base.res_partner_exterior")
+        fiscal_line.issqn_fg_city_id = False
+        service_data = fiscal_document._prepare_dados_servico()
+
+        self.assertEqual(
+            self.tax_estimate.federal_taxes_import,
+            service_data["percentual_total_tributos_federais"],
+            "Should be the same as tax_estimate.federal_taxes_import",
+        )
+        self.assertEqual(
+            self.tax_estimate.state_taxes,
+            service_data["percentual_total_tributos_estaduais"],
+            "Should be the same as tax_estimate.state_taxes",
+        )
+        self.assertEqual(
+            self.tax_estimate.municipal_taxes,
+            service_data["percentual_total_tributos_municipais"],
+            "Should be the same as tax_estimate.municipal_taxes",
+        )

--- a/l10n_br_nfse_focus/models/nfse_nacional.py
+++ b/l10n_br_nfse_focus/models/nfse_nacional.py
@@ -177,6 +177,16 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
         # TODO: improve logic to get ISS retention code
         tipo_retencao_iss = "2" if service_info.get("iss_retido") == "1" else "1"
 
+        percentual_total_tributos_federais = service_info.get(
+            "percentual_total_tributos_federais", 0.0
+        )
+        percentual_total_tributos_estaduais = service_info.get(
+            "percentual_total_tributos_estaduais", 0.0
+        )
+        percentual_total_tributos_municipais = service_info.get(
+            "percentual_total_tributos_municipais", 0.0
+        )
+
         return {
             "codigo_municipio_prestacao": str(codigo_municipio_prestacao),
             "codigo_tributacao_nacional": codigo_tributacao_nacional,
@@ -185,6 +195,11 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
             "valor": round(service_info.get("valor_servicos", 0), 2),
             "tributacao_iss": str(tributacao_iss),
             "tipo_retencao_iss": str(tipo_retencao_iss),
+            "percentual_total_tributos_federais": percentual_total_tributos_federais,
+            "percentual_total_tributos_estaduais": percentual_total_tributos_estaduais,
+            "percentual_total_tributos_municipais": (
+                percentual_total_tributos_municipais
+            ),
         }
 
     def _prepare_tax_data_nacional(self, service_info, valor_servico):
@@ -318,6 +333,21 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
             "valor_servico": service_basic["valor"],
             "tributacao_iss": service_basic["tributacao_iss"],
             "tipo_retencao_iss": service_basic["tipo_retencao_iss"],
+            **(
+                {
+                    "percentual_total_tributos_federais": service_basic[
+                        "percentual_total_tributos_federais"
+                    ],
+                    "percentual_total_tributos_estaduais": service_basic[
+                        "percentual_total_tributos_estaduais"
+                    ],
+                    "percentual_total_tributos_municipais": service_basic[
+                        "percentual_total_tributos_municipais"
+                    ],
+                }
+                if provider_data["codigo_opcao_simples_nacional"] == "1"
+                else {}
+            ),
             **tax_data,
         }
 


### PR DESCRIPTION
@Escodoo HT01812

Essa PR propõe adicionar as tags de percentual do total de tributos federais (`pTotTribFed`), estaduais (`pTotTribEst`) e municipais (`pTotTribMun`), baseado na configuração no NBS (`tax_estimate_ids` que é relacionado a tabela `l10n_br_fiscal.tax.estimate`) que agora é exigido para as notas do padrão nacional para não optantes do simples nacional.

cc: @marcelsavegnago @CristianoMafraJunior @kaynnan 