### PR TITLE
[16.0][FIX] l10n_br_purchase: do not copy fiscal_quantity from PO to invoice

### DIFF
--- a/l10n_br_purchase/models/purchase_order_line.py
+++ b/l10n_br_purchase/models/purchase_order_line.py
@@ -123,6 +123,11 @@ class PurchaseOrderLine(models.Model):
             if line.fiscal_operation_id:
                 # O caso Brasil se caracteriza por ter a Operação Fiscal
                 fiscal_values = line._prepare_br_fiscal_dict()
+                # fiscal_quantity must not be copied from PO line because
+                # the invoice quantity may differ (e.g. partial receipt).
+                # Let _compute_fiscal_quantity recompute it from the
+                # invoice line quantity, same approach as l10n_br_sale.
+                fiscal_values.pop("fiscal_quantity", None)
                 fiscal_values.update(values)
                 values.update(fiscal_values)
 

--- a/l10n_br_purchase/tests/test_l10n_br_purchase.py
+++ b/l10n_br_purchase/tests/test_l10n_br_purchase.py
@@ -284,6 +284,66 @@ class L10nBrPurchaseBaseTest(TransactionCase):
             "Error opening invoice !",
         )
 
+    def test_invoice_fiscal_quantity_not_from_po(self):
+        """Test that fiscal_quantity on invoice is computed from invoice qty,
+        not copied from PO line.
+
+        When the received/invoiced quantity differs from the ordered quantity
+        (e.g. weight adjustment on bulk products), fiscal_quantity must match
+        the invoice line quantity, not the PO line quantity.
+        """
+        self._change_user_company(self.company)
+        self._run_purchase_order_onchanges(self.po_products)
+        for line in self.po_products.order_line:
+            self._run_purchase_line_onchanges(line)
+
+        self.po_products.with_context(tracking_disable=True).button_confirm()
+
+        # 1) _prepare_account_move_line must NOT contain fiscal_quantity
+        for po_line in self.po_products.order_line:
+            vals = po_line._prepare_account_move_line(False)
+            self.assertNotIn(
+                "fiscal_quantity",
+                vals,
+                "fiscal_quantity should not be in the prepared invoice line "
+                "values — it must be recomputed from the invoice quantity.",
+            )
+
+        # 2) Create the invoice the same way the existing helper does
+        self._invoice_purchase_order(self.po_products)
+
+        product_lines = self.invoice.invoice_line_ids.filtered(
+            lambda line: line.display_type == "product"
+        )
+        self.assertTrue(product_lines, "Invoice must have product lines")
+
+        for inv_line in product_lines:
+            uot_factor = inv_line.product_id.uot_factor or 1.0
+            expected_fiscal_qty = inv_line.quantity * uot_factor
+            self.assertAlmostEqual(
+                inv_line.fiscal_quantity,
+                expected_fiscal_qty,
+                2,
+                "fiscal_quantity must equal quantity * uot_factor, "
+                "not the PO line fiscal_quantity.",
+            )
+
+        # 3) Simulate a weight adjustment: change invoice qty and verify
+        #    fiscal_quantity follows
+        first_line = product_lines[0]
+        original_qty = first_line.quantity
+        adjusted_qty = original_qty + 1.0
+        first_line.quantity = adjusted_qty
+
+        uot_factor = first_line.product_id.uot_factor or 1.0
+        self.assertAlmostEqual(
+            first_line.fiscal_quantity,
+            adjusted_qty * uot_factor,
+            2,
+            "After quantity adjustment, fiscal_quantity must recompute "
+            "to the new quantity * uot_factor.",
+        )
+
     def test_l10n_br_purchase_products(self):
         """Test brazilian Purchase Order with only Products."""
         self._change_user_company(self.company)


### PR DESCRIPTION
## Resumo

Ao criar uma fatura a partir de um pedido de compra, o método `_prepare_account_move_line` copia todos os campos fiscais do PO para a fatura via `_prepare_br_fiscal_dict`, incluindo `fiscal_quantity`. Isso faz com que a quantidade fiscal fique congelada no valor do pedido, mesmo quando a quantidade real da fatura difere (ex: recebimento parcial, ajuste de peso em produtos a granel).

Este é o mesmo problema corrigido no módulo de vendas em #4371, mas aplicado ao fluxo de compras.

## Como reproduzir

1. Criar um pedido de compra com produto vendido a granel (KG), quantidade 28.000 KG
2. Configurar a política de faturamento com **quantidades entregues**
3. Receber 28.050 KG (quantidade real pesada/ajustada no recebimento)
4. Criar a fatura a partir do PO
5. A `quantity` na `account.move.line` é 28.050 (correta, bate com a DANFE), mas a `fiscal_quantity` na `l10n_br_fiscal.document.line` permanece 28.000 (do PO)

- **Antes do fix:** `fiscal_quantity` = 28.000 (valor do PO)
- **Após o fix:** `fiscal_quantity` = 28.050 (recomputada a partir da quantidade da fatura)

## Causa raiz

O `_prepare_br_fiscal_dict()` retorna todos os campos do mixin fiscal, incluindo `fiscal_quantity`. No módulo de vendas (`l10n_br_sale`), esse campo já é removido do dict com `result.pop("fiscal_quantity", None)` (ver #4371), mas no módulo de compras (`l10n_br_purchase`) essa remoção não existia.

## Solução

Adicionar `fiscal_values.pop("fiscal_quantity", None)` em `_prepare_account_move_line` do `purchase.order.line`, seguindo o mesmo padrão já utilizado em `l10n_br_sale`.