### PR TITLE
[14.0][FIX] spec_driven_model: fix TransactionCase

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 # vcrpy  # Needed by payment_pagseguro
-odoo-test-helper  # Needed by spec_driven_model
+odoo-test-helper==2.1.1  # Needed by spec_driven_model
 pyopenssl==22.1.0
 signxml<3.1.0
 xmldiff


### PR DESCRIPTION
FIX #4406

Relacioando esse commit aqui -> https://github.com/OCA/odoo-test-helper/commit/e40eaef9b78e65fed58046ce48085f1584d2513b

A solução que tive foi chumbar o `odoo-test-helper==2.1.1` para assim não quebra CI dos testes, queria saber opinião de vocês se podemos seguir assim na V14.0?

cc @marcelsavegnago @antoniospneto @rvalyi @WesleyOliveira98 