### PR TITLE
[16.0][FIX] l10n_br_fiscal, l10n_br_account: propaga ind_final para linhas ao trocar partner

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -119,7 +119,10 @@ class AccountMove(models.Model):
 
     def write(self, vals):
         self._sync_proxy_fields_vals(vals)
-        return super().write(vals)
+        res = super().write(vals)
+        if "partner_id" in vals:
+            self._onchange_ind_final()
+        return res
 
     @api.constrains("fiscal_document_id", "document_type_id")
     def _check_fiscal_document_type(self):
@@ -157,6 +160,22 @@ class AccountMove(models.Model):
     @api.model
     def _get_fiscal_lines_field_name(self):
         return "invoice_line_ids"
+
+    @api.onchange("ind_final")
+    def _onchange_ind_final(self):
+        """Propagate ind_final from the invoice header to its lines.
+
+        The document mixin defines the same onchange on
+        l10n_br_fiscal.document, but account.move uses _inherits (not
+        _inherit) to delegate to the fiscal document, so the mixin's
+        @api.onchange never fires in the account.move Form context.
+        We must re-declare it here so the Form triggers it when
+        ind_final changes (e.g. after a partner_id change that
+        recomputes ind_final via _compute_ind_final).
+        """
+        for line in self.invoice_line_ids:
+            if line.ind_final != self.ind_final:
+                line.ind_final = self.ind_final
 
     def ensure_one_doc(self):
         self.ensure_one()

--- a/l10n_br_account/tests/test_move_edition.py
+++ b/l10n_br_account/tests/test_move_edition.py
@@ -572,3 +572,102 @@ class TestMoveEdition(TransactionCase):
             move_after_total_update.fiscal_amount_total, 2776.48, places=2
         )
         self.assertAlmostEqual(move_after_total_update.amount_total, 2776.48, places=2)
+
+    def _setup_fiscal_user(self):
+        """Grant fiscal groups needed for invoice tests with fiscal documents."""
+        self.user.groups_id += self.env.ref("l10n_br_fiscal.group_user")
+        nfe_user_group = self.env.ref(
+            "l10n_br_nfe.group_user", raise_if_not_found=False
+        )
+        if nfe_user_group:
+            self.user.groups_id += nfe_user_group
+
+    def _create_fiscal_invoice_form(self, partner):
+        """Create a fiscal invoice Form pre-filled with the given partner."""
+        move_form = Form(
+            self.env["account.move"].with_context(
+                default_move_type="out_invoice",
+            )
+        )
+        move_form.partner_id = partner
+        move_form.document_type_id = self.env.ref("l10n_br_fiscal.document_55")
+        move_form.document_serie_id = self.env.ref(
+            "l10n_br_fiscal.empresa_lc_document_55_serie_1"
+        )
+        move_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
+        return move_form
+
+    def test_ind_final_propagation_on_manual_change(self):
+        """Changing ind_final directly on a saved invoice must propagate
+        to the fiscal document lines."""
+        self._setup_fiscal_user()
+        partner = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner.ind_final = "1"
+
+        move_form = self._create_fiscal_invoice_form(partner)
+        with move_form.invoice_line_ids.new() as line_form:
+            line_form.product_id = self.product_id
+            line_form.price_unit = 100.0
+            line_form.quantity = 1.0
+
+        move = move_form.save()
+        fiscal_line = move.fiscal_line_ids[0]
+        self.assertEqual(move.ind_final, "1")
+        self.assertEqual(fiscal_line.ind_final, "1")
+
+        # Manually change ind_final on the invoice
+        move.write({"ind_final": "0"})
+        self.assertEqual(move.ind_final, "0")
+        self.assertEqual(fiscal_line.ind_final, "0")
+
+    def test_ind_final_propagation_on_partner_change(self):
+        """Changing partner_id on a saved invoice must propagate ind_final
+        to the fiscal document lines when the new partner differs."""
+        self._setup_fiscal_user()
+        partner_final = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner_final.ind_final = "1"
+        partner_not_final = self.env.ref("l10n_br_base.res_partner_cliente5_pe")
+        partner_not_final.ind_final = "0"
+
+        move_form = self._create_fiscal_invoice_form(partner_final)
+        with move_form.invoice_line_ids.new() as line_form:
+            line_form.product_id = self.product_id
+            line_form.price_unit = 100.0
+            line_form.quantity = 1.0
+
+        move = move_form.save()
+        fiscal_line = move.fiscal_line_ids[0]
+        self.assertEqual(move.ind_final, "1")
+        self.assertEqual(fiscal_line.ind_final, "1")
+
+        # Change to a partner with ind_final="0"
+        move.write({"partner_id": partner_not_final.id})
+        self.assertEqual(move.ind_final, "0")
+        self.assertEqual(fiscal_line.ind_final, "0")
+
+    def test_ind_final_propagation_on_form_partner_change(self):
+        """Changing partner_id on an unsaved invoice form must propagate
+        ind_final to existing lines both in the form and after saving."""
+        self._setup_fiscal_user()
+        partner_final = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner_final.ind_final = "1"
+        partner_not_final = self.env.ref("l10n_br_base.res_partner_cliente5_pe")
+        partner_not_final.ind_final = "0"
+
+        move_form = self._create_fiscal_invoice_form(partner_final)
+        with move_form.invoice_line_ids.new() as line_form:
+            line_form.product_id = self.product_id
+            line_form.price_unit = 100.0
+            line_form.quantity = 1.0
+
+        self.assertEqual(move_form.ind_final, "1")
+
+        # Change partner without saving
+        move_form.partner_id = partner_not_final
+        self.assertEqual(move_form.ind_final, "0")
+
+        # Verify after saving
+        move = move_form.save()
+        fiscal_line = move.fiscal_line_ids[0]
+        self.assertEqual(move.ind_final, "0")
+        self.assertEqual(fiscal_line.ind_final, "0")

--- a/l10n_br_fiscal/models/document_mixin.py
+++ b/l10n_br_fiscal/models/document_mixin.py
@@ -217,6 +217,12 @@ class FiscalDocumentMixin(models.AbstractModel):
                 if line.ind_final != doc.ind_final:
                     line.ind_final = doc.ind_final
 
+    def write(self, vals):
+        res = super().write(vals)
+        if "partner_id" in vals:
+            self._inverse_ind_final()
+        return res
+
     @api.depends("fiscal_operation_id")
     def _compute_operation_name(self):
         for doc in self:

--- a/l10n_br_fiscal/tests/test_document_edition.py
+++ b/l10n_br_fiscal/tests/test_document_edition.py
@@ -346,6 +346,102 @@ class TestDocumentEdition(TransactionCase):
         # fiscal_amount_untaxed = (2000+40+20+8) + (500+10+5+2) = 2585
         self.assertAlmostEqual(doc.fiscal_amount_untaxed, 2585.0)
 
+    def test_ind_final_propagation_on_manual_change(self):
+        """Changing ind_final on a saved document must propagate to lines."""
+        partner = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner.ind_final = "1"
+        doc_form = Form(
+            self.env["l10n_br_fiscal.document"].with_context(
+                default_fiscal_operation_type="out",
+            )
+        )
+        doc_form.company_id = self.company
+        doc_form.partner_id = partner
+        doc_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
+
+        product = self.env.ref("product.product_product_6")
+        with doc_form.fiscal_line_ids.new() as line_form:
+            line_form.product_id = product
+            line_form.price_unit = 100.0
+            line_form.quantity = 1.0
+
+        doc = doc_form.save()
+        line = doc.fiscal_line_ids[0]
+        self.assertEqual(doc.ind_final, "1")
+        self.assertEqual(line.ind_final, "1")
+
+        # Manually change ind_final on the document
+        doc.write({"ind_final": "0"})
+        self.assertEqual(doc.ind_final, "0")
+        self.assertEqual(line.ind_final, "0")
+
+    def test_ind_final_propagation_on_partner_change(self):
+        """Changing partner_id on a saved document must propagate ind_final
+        to lines when the new partner has a different ind_final."""
+        partner_final = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner_final.ind_final = "1"
+        partner_not_final = self.env.ref("l10n_br_base.res_partner_cliente5_pe")
+        partner_not_final.ind_final = "0"
+
+        doc_form = Form(
+            self.env["l10n_br_fiscal.document"].with_context(
+                default_fiscal_operation_type="out",
+            )
+        )
+        doc_form.company_id = self.company
+        doc_form.partner_id = partner_final
+        doc_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
+
+        product = self.env.ref("product.product_product_6")
+        with doc_form.fiscal_line_ids.new() as line_form:
+            line_form.product_id = product
+            line_form.price_unit = 100.0
+            line_form.quantity = 1.0
+
+        doc = doc_form.save()
+        line = doc.fiscal_line_ids[0]
+        self.assertEqual(doc.ind_final, "1")
+        self.assertEqual(line.ind_final, "1")
+
+        # Change to a partner with ind_final="0"
+        doc.write({"partner_id": partner_not_final.id})
+        self.assertEqual(doc.ind_final, "0")
+        self.assertEqual(line.ind_final, "0")
+
+    def test_ind_final_propagation_on_form_partner_change(self):
+        """Changing partner_id on a form before saving must propagate
+        ind_final to lines when saved."""
+        partner_final = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner_final.ind_final = "1"
+        partner_not_final = self.env.ref("l10n_br_base.res_partner_cliente5_pe")
+        partner_not_final.ind_final = "0"
+
+        doc_form = Form(
+            self.env["l10n_br_fiscal.document"].with_context(
+                default_fiscal_operation_type="out",
+            )
+        )
+        doc_form.company_id = self.company
+        doc_form.partner_id = partner_final
+        doc_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
+
+        product = self.env.ref("product.product_product_6")
+        with doc_form.fiscal_line_ids.new() as line_form:
+            line_form.product_id = product
+            line_form.price_unit = 100.0
+            line_form.quantity = 1.0
+
+        self.assertEqual(doc_form.ind_final, "1")
+
+        # Change partner before saving
+        doc_form.partner_id = partner_not_final
+        self.assertEqual(doc_form.ind_final, "0")
+
+        doc = doc_form.save()
+        line = doc.fiscal_line_ids[0]
+        self.assertEqual(doc.ind_final, "0")
+        self.assertEqual(line.ind_final, "0")
+
     def test_difal_calculation(self):
         partner = self.env.ref("l10n_br_base.res_partner_cliente5_pe")
         partner.ind_ie_dest = "9"

--- a/l10n_br_sale/tests/__init__.py
+++ b/l10n_br_sale/tests/__init__.py
@@ -5,3 +5,4 @@ from . import test_l10n_br_sale_discount
 from . import test_l10n_br_sale_sn
 from . import test_l10n_br_sale_pricelist
 from . import test_sale_order_report
+from . import test_sale_order_ind_final

--- a/l10n_br_sale/tests/test_sale_order_ind_final.py
+++ b/l10n_br_sale/tests/test_sale_order_ind_final.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Engenere
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests import TransactionCase
+from odoo.tests.common import Form, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSaleOrderIndFinal(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.company = cls.env.ref("l10n_br_base.empresa_lucro_presumido")
+        cls.user = cls.env.user
+        cls.user.company_ids |= cls.company
+        cls.user.company_id = cls.company.id
+        cls.product = cls.env.ref("product.product_product_6")
+
+    def _create_sale_order_form(self, partner):
+        """Create a sale order Form pre-filled with the given partner."""
+        so_form = Form(self.env["sale.order"])
+        so_form.company_id = self.company
+        so_form.partner_id = partner
+        so_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
+        return so_form
+
+    def test_ind_final_propagation_on_manual_change(self):
+        """Changing ind_final on a saved sale order must propagate to lines."""
+        partner = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner.ind_final = "1"
+
+        so_form = self._create_sale_order_form(partner)
+        with so_form.order_line.new() as line_form:
+            line_form.product_id = self.product
+            line_form.product_uom_qty = 1.0
+
+        so = so_form.save()
+        line = so.order_line.filtered(lambda line: not line.display_type)[0]
+        self.assertEqual(so.ind_final, "1")
+        self.assertEqual(line.ind_final, "1")
+
+        # Manually change ind_final on the order
+        so.write({"ind_final": "0"})
+        self.assertEqual(so.ind_final, "0")
+        self.assertEqual(line.ind_final, "0")
+
+    def test_ind_final_propagation_on_partner_change(self):
+        """Changing partner_id on a saved sale order must propagate ind_final
+        to lines when the new partner has a different ind_final."""
+        partner_final = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner_final.ind_final = "1"
+        partner_not_final = self.env.ref("l10n_br_base.res_partner_cliente5_pe")
+        partner_not_final.ind_final = "0"
+
+        so_form = self._create_sale_order_form(partner_final)
+        with so_form.order_line.new() as line_form:
+            line_form.product_id = self.product
+            line_form.product_uom_qty = 1.0
+
+        so = so_form.save()
+        line = so.order_line.filtered(lambda line: not line.display_type)[0]
+        self.assertEqual(so.ind_final, "1")
+        self.assertEqual(line.ind_final, "1")
+
+        # Change to a partner with ind_final="0"
+        so.write({"partner_id": partner_not_final.id})
+        self.assertEqual(so.ind_final, "0")
+        self.assertEqual(line.ind_final, "0")
+
+    def test_ind_final_propagation_on_form_partner_change(self):
+        """Changing partner_id on a form before saving must propagate
+        ind_final to lines when saved."""
+        partner_final = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner_final.ind_final = "1"
+        partner_not_final = self.env.ref("l10n_br_base.res_partner_cliente5_pe")
+        partner_not_final.ind_final = "0"
+
+        so_form = self._create_sale_order_form(partner_final)
+        with so_form.order_line.new() as line_form:
+            line_form.product_id = self.product
+            line_form.product_uom_qty = 1.0
+
+        self.assertEqual(so_form.ind_final, "1")
+
+        # Change partner before saving
+        so_form.partner_id = partner_not_final
+        self.assertEqual(so_form.ind_final, "0")
+
+        so = so_form.save()
+        line = so.order_line.filtered(lambda line: not line.display_type)[0]
+        self.assertEqual(so.ind_final, "0")
+        self.assertEqual(line.ind_final, "0")


### PR DESCRIPTION
Substituí a PR #4392 

## Problema

Quando o `partner_id` é alterado em um documento fiscal — seja via `write()` no código Python ou via troca de parceiro no formulário — o campo `ind_final` do **cabeçalho** é recomputado corretamente pelo `_compute_ind_final` (que tem `@api.depends("partner_id")`), mas o `ind_final` das **linhas** não é atualizado.

Isso causa mapeamento incorreto de impostos, pois `_compute_fiscal_tax_ids` e `_compute_tax_fields` dependem de `line.ind_final` para determinar alíquotas, CSTs e CFOPs.

## Causa raiz

A propagação de `ind_final` do documento para as linhas depende do método `_inverse_ind_final`. No ORM do Odoo, a inverse de um campo computed é chamada em dois cenários:

| Cenário | A inverse dispara? |
|---|---|
| `doc.write({"ind_final": "0"})` — write explícito no campo computed | **Sim** ✓ |
| `doc.write({"partner_id": X})` → `_compute_ind_final` roda e seta `ind_final` | **Não** ✗ |

Esse é o comportamento padrão do ORM: **compute e inverse são caminhos mutuamente exclusivos**. A inverse só roda quando o valor é escrito explicitamente no campo computed, nunca quando o compute recalcula o valor via trigger de dependência.

Portanto, quando `partner_id` muda → `_compute_ind_final` atualiza `doc.ind_final` → mas `_inverse_ind_final` **não é chamada** → `line.ind_final` fica desatualizado.

Além disso, no `account.move`, o `_inherits` agrega campos do `l10n_br_fiscal.document` mas **não herda métodos** como `@api.onchange`. Então o `_inverse_ind_final` do mixin (que também é `@api.onchange("ind_final")`) nunca disparava no formulário de `account.move`, nem na troca de partner via onchange nem no write.

## Solução

Propagação explícita de `ind_final` no `write()` quando `partner_id` muda:

### `document_mixin.write()` (l10n_br_fiscal)
```python
def write(self, vals):
    res = super().write(vals)
    if "partner_id" in vals:
        self._inverse_ind_final()
    return res
```
Chamado para modelos que herdam o mixin via `_inherit`: `l10n_br_fiscal.document`, `sale.order`, etc.

### `account.move.write()` (l10n_br_account)
```python
def write(self, vals):
    self._sync_proxy_fields_vals(vals)
    res = super().write(vals)
    if "partner_id" in vals:
        self._onchange_ind_final()
    return res
```
Necessário porque `account.move` usa `_inherits` (delegação), não `_inherit`. O ORM **não** chama o `write()` do modelo delegado — escreve via `_write()` interno. Então o `write()` do mixin nunca é executado nesse caminho.

### `account.move._onchange_ind_final` (l10n_br_account)
```python
@api.onchange("ind_final")
def _onchange_ind_final(self):
    for line in self.invoice_line_ids:
        if line.ind_final != self.ind_final:
            line.ind_final = self.ind_final
```
Re-declara o onchange do mixin para o contexto do Form de `account.move`. Sem isso, trocar o parceiro no formulário da fatura não propagava `ind_final` para as `invoice_line_ids` (o `_inherits` não herda `@api.onchange`). Isso é o mesmo padrão usado pelo Odoo nativo para `partner_id` no `account.move` (que tem `_inverse_partner_id` com `@api.onchange` declarado diretamente).

## Alternativas descartadas

### 1. `related("document_id.ind_final")` na linha

Parece a solução "correta" do ponto de vista ORM, mas cria triggers implícitos que causam cascatas destrutivas:

- Quando `document_id` é atribuído na `account.move.line.create()` (necessário para o `_inherits` funcionar), o ORM detecta que o campo related mudou
- Isso dispara `_compute_fiscal_tax_ids` (que depende de `ind_final`)
- O compute **sobrescreve impostos que o usuário definiu manualmente** na linha

O `partner_id` na `document_line_mixin` já usa o mesmo padrão defensivo: compute sem `@api.depends` com comentário "Do not depend on document_id.partner_id" — exatamente para evitar esse tipo de cascade.

### 2. `@api.depends("document_id.ind_final")` no compute da linha

Mesmo problema que o `related` — cria o trigger implícito que causa a mesma cascata destrutiva de recompute de impostos durante `create()`.

### 3. Não fazer nada (manter onchange apenas)

A propagação via `@api.onchange` funciona no formulário, mas **não funciona via `write()` no código Python** — importações, APIs, scripts, testes automatizados, etc. Cenário real: integração que altera o parceiro de um pedido via `write()` não atualizaria o `ind_final` das linhas.

## Consequências da solução

- **Dupla execução no Form**: no UI, `@api.onchange` já propaga, e o `save()` chama `write()` que propaga de novo. Mas o guard `if line.ind_final != doc.ind_final` garante que a segunda chamada é no-op.
- **Cascade de impostos**: quando `line.ind_final` é atualizado, isso pode disparar `_compute_fiscal_tax_ids`. Esse é o comportamento **correto** — mudou o parceiro, os impostos precisam ser recalculados.
- **Performance**: a inverse itera as linhas do documento, mas é o mesmo custo que já existe no onchange.
- **Sem risco de recursão**: a inverse escreve nas linhas, não de volta no documento.

## Testes

Cada cenário de propagação é coberto em 3 módulos:

| Teste | l10n_br_fiscal | l10n_br_account | l10n_br_sale |
|---|---|---|---|
| `write({"ind_final": "0"})` — write direto | ✓ | ✓ | ✓ |
| `write({"partner_id": X})` — troca de parceiro via código | ✓ | ✓ | ✓ |
| Form: troca de parceiro antes de salvar | ✓ | ✓ | ✓ |