### PR TITLE
[16.0][FIX] l10n_br_base: field bra_number

### DIFF
--- a/l10n_br_base/models/res_partner_bank.py
+++ b/l10n_br_base/models/res_partner_bank.py
@@ -84,10 +84,9 @@ class ResPartnerBank(models.Model):
 
     @api.constrains("bra_number")
     def _check_bra_number(self):
-        for b in self:
-            if b.bank_id.code_bc:
-                if len(b.bra_number) > 4:
-                    raise UserError(_("Bank branch code must be four characters."))
+        for bank in self:
+            if bank.bank_id.code_bc and bank.bra_number and len(bank.bra_number) > 4:
+                raise UserError(_("Bank branch code must be four characters."))
 
     @api.constrains(
         "transactional_acc_type",

--- a/l10n_br_base/tests/test_partner_bank.py
+++ b/l10n_br_base/tests/test_partner_bank.py
@@ -39,3 +39,13 @@ class PartnerBankTest(TransactionCase):
             self.partner_bank_model.with_context(tracking_disable=True).create(
                 wrong_bank_vals
             )
+
+    def test_bra_number_empty_does_not_raise(self):
+        bank_vals = {
+            "partner_id": self.partner_id.id,
+            "bank_id": self.bank_id.id,
+        }
+        bank = self.partner_bank_model.with_context(tracking_disable=True).create(
+            bank_vals
+        )
+        self.assertTrue(bank.exists())


### PR DESCRIPTION
## Objetivo da PR

Correção de validação: ajusta a constraint de bra_number em res.partner.bank para não chamar len() quando o campo estiver vazio, evitando o TypeError e garantindo que o erro de negócio só seja disparado quando o código da agência tiver mais de quatro caracteres.

Antes lançava esse erro quando deixa o campo `bra_number` vazio

```
RPC_ERROR
Odoo Server Error
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 1846, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/opt/odoo/custom/src/odoo/odoo/service/model.py", line 153, in retrying
    result = func()
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 1874, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 2078, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 761, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/opt/odoo/auto/addons/web/controllers/dataset.py", line 43, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/opt/odoo/auto/addons/web/controllers/dataset.py", line 34, in _call_kw
    return call_kw(Model, method, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 484, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 469, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/auto/addons/account/models/res_partner_bank.py", line 197, in write
    res = super().write(vals)
  File "/opt/odoo/auto/addons/mail/models/mail_thread.py", line 315, in write
    result = super(MailThread, self).write(values)
  File "/opt/odoo/auto/addons/mail/models/mail_activity_mixin.py", line 241, in write
    return super(MailActivityMixin, self).write(vals)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3842, in write
    real_recs._validate_fields(vals, inverse_fields)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 1373, in _validate_fields
    check(self)
  File "/opt/odoo/auto/addons/l10n_br_base/models/res_partner_bank.py", line 89, in _check_bra_number
    if len(b.bra_number) > 4:
TypeError: object of type 'bool' has no len()

The above server error caused the following client error:
null
```
cc @rvalyi @antoniospneto @marcelsavegnago @WesleyOliveira98 