### PR TITLE
[14.0][IMP] l10n_br_fiscal: Base Simples do ICMS Difal para não contribuintes

### DIFF
--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -24,7 +24,6 @@ from ..constants.icms import (
     ICMS_CST_RELIEF,
     ICMS_DIFAL_DOUBLE_BASE,
     ICMS_DIFAL_PARTITION,
-    ICMS_DIFAL_UNIQUE_BASE,
     ICMS_ORIGIN_TAX_IMPORTED,
     ICMS_SN_CST_WITH_CREDIT,
     ICMS_ST_BASE_TYPE,
@@ -389,8 +388,8 @@ class Tax(models.Model):
         # and operation_line.ind_final == FINAL_CUSTOMER_YES):
         if (
             cfop
+            and company.icms_regulation_id
             and cfop.destination == CFOP_DESTINATION_EXTERNAL
-            and partner.ind_ie_dest == NFE_IND_IE_DEST_9
             and tax_dict.get("tax_value")
             and (
                 operation_line.fiscal_operation_type == FISCAL_OUT
@@ -423,15 +422,15 @@ class Tax(models.Model):
 
             # Difal - Base
             icms_base = tax_dict.get("base")
-            difal_icms_base = 0.00
+            difal_icms_base = icms_base
 
             # Difal - ICMS Dest Value
             icms_dest_value = currency.round(icms_base * (icms_dest_perc / 100))
 
-            if partner.state_id.code in ICMS_DIFAL_UNIQUE_BASE:
-                difal_icms_base = icms_base
-
-            if partner.state_id.code in ICMS_DIFAL_DOUBLE_BASE:
+            if (
+                partner.state_id.code in ICMS_DIFAL_DOUBLE_BASE
+                and partner.ind_ie_dest != NFE_IND_IE_DEST_9
+            ):
                 difal_icms_base = currency.round(
                     (icms_base - icms_origin_value)
                     / (1 - ((icms_dest_perc + icmsfcp_perc) / 100))


### PR DESCRIPTION
Define como base simples o ICMS Difal para parceiros não contribuintes, mesmo que o estado do mesmo faça parte da lista de estados com base dupla

@Escodoo HT01854

cc: @marcelsavegnago @CristianoMafraJunior @kaynnan