### PR TITLE
[14.0][FIX] l10n_br_cte: required service_provider - BCK #4434

### DIFF
--- a/l10n_br_cte/views/document.xml
+++ b/l10n_br_cte/views/document.xml
@@ -23,7 +23,10 @@
             <field name="document_serie_id" position="after">
                 <field
                     name="service_provider"
-                    attrs="{'invisible': [('document_type', 'not in', ['57'])]}"
+                    attrs="{
+                        'invisible': [('document_type', 'not in', ['57'])],
+                        'required': [('document_type', 'in', ['57'])]
+                    }"
                 />
                 <field
                     name="cte40_tpServ"


### PR DESCRIPTION
BCK #4434

@Escodoo HT01544

cc @marcelsavegnago @WesleyOliveira98 @rvalyi 
É um campo obrigatorio o Tomador do Serviço
<img width="1123" height="756" alt="campo_obrigatorio" src="https://github.com/user-attachments/assets/11cba091-36bb-4973-9bb5-423950af9f4e" />