### PR TITLE
[14.0][IMP] l10n_br_cte: display_ibs_cbs brazilfiscalreport

### DIFF
--- a/l10n_br_cte/models/res_company.py
+++ b/l10n_br_cte/models/res_company.py
@@ -118,6 +118,12 @@ class ResCompany(spec_models.SpecModel):
         default=5, help="Left margin in mm for the DACTE layout."
     )
 
+    dacte_display_ibs_cbs = fields.Boolean(
+        string="IBS/CBS",
+        default=False,
+        help="Select to display the IBS and CBS fields in the generated DACTE.",
+    )
+
     def _compute_cte_data(self):
         # compute because a simple related field makes the match_record fail
         for rec in self:

--- a/l10n_br_cte/report/ir_actions_report.py
+++ b/l10n_br_cte/report/ir_actions_report.py
@@ -78,4 +78,6 @@ class IrActionsReport(models.Model):
             "logo": tmpLogo,
             "margins": margins,
         }
+        if company.dacte_display_ibs_cbs:
+            dacte_config["display_ibs_cbs"] = True
         return DacteConfig(**dacte_config)

--- a/l10n_br_cte/views/res_company.xml
+++ b/l10n_br_cte/views/res_company.xml
@@ -26,6 +26,10 @@
                             <field name="dacte_margin_right" string="Margin Right" />
                             <field name="dacte_margin_bottom" string="Margin Bottom" />
                             <field name="dacte_margin_left" string="Margin Left" />
+                            <field
+                                name="dacte_display_ibs_cbs"
+                                string="Display IBS/CBS"
+                            />
                         </group>
                     </group>
                 </page>


### PR DESCRIPTION
@Escodoo HT01544
Depende #4374
## Objetivo da PR 
Estou propondo aqui na Localização opção de imprimir IBS/CBS no Dacte.
Configuração:
<img width="1149" height="745" alt="pin232" src="https://github.com/user-attachments/assets/261e6975-d876-4418-8e56-b1bb8e3fc9ba" />

<img width="1727" height="546" alt="print_022" src="https://github.com/user-attachments/assets/1307905b-c1a0-4e5d-8e4c-5ad30c43c263" />

PDF -  [35240781583054000129570010000057511040645897.pdf](https://github.com/user-attachments/files/26148465/35240781583054000129570010000057511040645897.pdf)

REF https://github.com/Engenere/BrazilFiscalReport/pull/134

