### PR TITLE
[17.0][WIP] populate fiscal taxes and repartition lines from account and CO…

### DIFF
--- a/l10n_br_account/models/template_br_oca.py
+++ b/l10n_br_account/models/template_br_oca.py
@@ -1,0 +1,102 @@
+# Copyright 2019-TODAY Akretion - Renato Lima
+# Copyright 2025-TODAY Akretion - Raphael Valyi <raphael.valyi@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class AccountChartTemplate(models.AbstractModel):
+    _inherit = "account.chart.template"
+
+    def load_fiscal_taxes(self, companies=None):
+        """
+        Create missing account.tax for Brazil.
+        Add missing account.account for the Brazilian taxes.
+        Relate account taxes with fiscal taxes to enable the Brazilian
+        tax engine to kick in with the installed chart of account.
+        """
+        tax_group_data = self._parse_csv(
+            "br_oca", "account.tax.group", module="l10n_br_coa"
+        )
+        tax_group_data_rel = self._parse_csv(
+            "br_oca", "account.tax.group", module="l10n_br_account"
+        )
+        tax_data = self._parse_csv("br_oca", "account.tax", module="l10n_br_coa")
+
+        if companies is None:
+            companies = self.env["res.company"].search(
+                [("chart_template", "=", "br_oca")]
+            )
+
+        for company in companies:
+            for key, value in tax_group_data.items():
+                id_key = f"{company.id}_{key}"
+
+                # TODO: improve
+                model_key = "l10n_coa_" + company.chart_template.removeprefix("br_oca_")
+
+                existing_group = self.env.ref(
+                    f"account.{id_key}", raise_if_not_found=False
+                )
+                if existing_group:
+                    continue
+                else:
+                    group_vals = {
+                        "name": value["name"],
+                        "company_id": company.id,
+                    }
+                    if key in tax_group_data_rel:
+                        group_vals["fiscal_tax_group_id"] = self.env.ref(
+                            tax_group_data_rel[key]["fiscal_tax_group_id"]
+                        ).id
+
+                    tax_group = self.env["account.tax.group"].create(group_vals)
+                    self.env["ir.model.data"].create(
+                        {
+                            "name": id_key,
+                            "module": model_key,
+                            "model": "account.tax.group",
+                            "res_id": tax_group.id,
+                            "noupdate": True,
+                        }
+                    )
+            for key, value in tax_data.items():
+                id_key = f"{company.id}_{key}"
+                existing_tax = self.env.ref(
+                    f"account.{id_key}", raise_if_not_found=False
+                )
+                if existing_tax:  # TODO also check record/res_id
+                    continue
+                else:
+                    tax_vals = {
+                        "name": value["name"],
+                        "company_id": company.id,
+                        "tax_group_id": self.env.ref(
+                            f"{model_key}.{company.id}_{value['tax_group_id']}"
+                        ).id,
+                        "type_tax_use": value["type_tax_use"],
+                        "price_include": value["price_include"],
+                        "deductible": value["deductible"],
+                        "withholdable": value["withholdable"],
+                    }
+
+                    account_tax = self.env["account.tax"].create(tax_vals)
+                    self.env["ir.model.data"].create(
+                        {
+                            "name": id_key,
+                            "module": model_key,
+                            "model": "account.tax",
+                            "res_id": account_tax.id,
+                            "noupdate": True,
+                        }
+                    )
+
+            # TODO: improve
+            if company.chart_template == "br_oca_simple":
+                flavor_key = "itg"
+            else:
+                flavor_key = "cfc"
+
+            self.env["account.chart.template"]._populate_default_br_tax_accounts(
+                company, flavor=flavor_key, review_suffix=""
+            )

--- a/l10n_br_coa/models/template_br_oca.py
+++ b/l10n_br_coa/models/template_br_oca.py
@@ -256,9 +256,7 @@ class AccountChartTemplate(models.AbstractModel):
             tax_template_xmlid,
             acc_mapping_keys,
         ) in DEFAULT_TAX_TEMPLATES_ACCOUNTS.items():
-            tax_xmlid = (
-                f"{template_module}.{company.id}_{tax_template_xmlid.split('.')[1]}"
-            )
+            tax_xmlid = f"account.{company.id}_{tax_template_xmlid.split('.')[1]}"
             company_tax = self.env.ref(tax_xmlid, raise_if_not_found=False)
             if not company_tax:
                 _logger.warning(f"tax {tax_xmlid} not found! Skipping it...")


### PR DESCRIPTION
depends on #4339 

## PR para testar a migração das funcionalidades do coa_simple e coa_generic para l10n_br_coa e l10n_br_account

A ideia é que os repartition lines e os Brazilian Tax eram populados nos planos de contas simple e generic:
<img width="1282" height="832" alt="image" src="https://github.com/user-attachments/assets/f05870dd-6c39-47cb-bf48-2779d2c101c3" />


Mas isso mudou, agora essas linhas são preenchidas apenas na instalação do l10n_br_coa e l10n_br_account. Por isso tive que fazer duas coisas:

1. Remover os antigos trechos que populavam tax group no simple e generic
veja os commits WIP (⚠️ FAZER SQUASH DEPOIS DE TESTAR):
- https://github.com/OCA/l10n-brazil/pull/4370/changes/65fd558c1e7b2d12f2f096385d0b15f41d48c897
- https://github.com/OCA/l10n-brazil/pull/4367/changes/e4bdea732f1fb1b2bf033f35bd40917a8a0828cc

2. Ajustes no l10n_br_account e l10n_br_coa para popular as repartition lines
- FEITO NESSE PR

## STATUS

Com o código desses PRs consegui preencher os repartition lines porém ainda não consegui popular os fiscal taxes:

repartion_line_ids ✅
<img width="1335" height="895" alt="image" src="https://github.com/user-attachments/assets/bc616014-3705-42d2-8681-d288db99de1e" />

Relate account taxes with fiscal taxes  WIP‼️
<img width="1366" height="733" alt="image" src="https://github.com/user-attachments/assets/5810767f-dfc7-411d-8aeb-41b20f75b4b8" />


