### PR TITLE
[14.0] Erro de validação no campo computado "Name" em Email de Documentos Fiscais

### DIFF
--- a/l10n_br_fiscal/models/document_email.py
+++ b/l10n_br_fiscal/models/document_email.py
@@ -56,14 +56,20 @@ class DocumentEmail(models.Model):
         "this document state change.",
     )
 
-    @api.depends("document_type_id", "state_edoc")
+    @api.depends("document_type_id", "state_edoc", "company_id")
     def _compute_name(self):
         for record in self:
             document_type = record.document_type_id.name
             if not document_type:
                 document_type = "Others Document Types"
-            if record.state_edoc:
-                record.name = document_type + " - " + record.state_edoc
+            if record.state_edoc and record.company_id:
+                record.name = (
+                    document_type
+                    + " - "
+                    + record.state_edoc
+                    + " - "
+                    + record.company_id.name
+                )
 
     _sql_constraints = [
         (

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -16,4 +16,5 @@ from . import (
     test_subsequent_operation,
     test_uom_uom,
     test_operation,
+    test_document_email,
 )

--- a/l10n_br_fiscal/tests/test_document_email.py
+++ b/l10n_br_fiscal/tests/test_document_email.py
@@ -1,0 +1,99 @@
+# Mauricio-ATS
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import logging
+
+from odoo.tests.common import TransactionCase
+
+_logger = logging.getLogger(__name__)
+
+
+class TestDocumentEmail(TransactionCase):
+    def test_compute_name_with_company(self):
+        company = self.env.company
+
+        document_type = self.env["l10n_br_fiscal.document.type"].create(
+            {
+                "name": "NFe",
+                "code": "55",
+                "type": "icms",
+            }
+        )
+
+        mail_template = self.env["mail.template"].create(
+            {
+                "name": "NFe",
+                "model_id": self.env.ref(
+                    "l10n_br_fiscal.model_l10n_br_fiscal_document_email"
+                ).id,
+                "subject": "NFe - {{ object.name }}",
+                "body_html": "<p>Esta é uma mensagem automática.</p>",
+            }
+        )
+
+        record = self.env["l10n_br_fiscal.document.email"].create(
+            {
+                "document_type_id": document_type.id,
+                "issuer": "company",
+                "state_edoc": "autorizada",
+                "email_template_id": mail_template.id,
+                "company_id": company.id,
+            }
+        )
+
+        expected = "NFe - autorizada - " + company.name
+        self.assertEqual(record.name, expected)
+
+    def test_no_duplicate_with_different_company(self):
+        _logger.info(
+            "Testando o método _compute_name do modelo l10n_br_fiscal.document.email"
+            " em duas empresas diferentes"
+        )
+        company1 = self.env.company
+        company2 = self.env["res.company"].create(
+            {
+                "name": "Outra Empresa",
+            }
+        )
+
+        document_type = self.env["l10n_br_fiscal.document.type"].create(
+            {
+                "name": "NFe",
+                "code": "55",
+                "type": "icms",
+            }
+        )
+
+        mail_template = self.env["mail.template"].create(
+            {
+                "name": "NFe",
+                "model_id": self.env.ref(
+                    "l10n_br_fiscal.model_l10n_br_fiscal_document_email"
+                ).id,
+                "subject": "NFe",
+                "body_html": "<p>Mensagem</p>",
+            }
+        )
+
+        vals = {
+            "document_type_id": document_type.id,
+            "issuer": "company",
+            "state_edoc": "autorizada",
+            "email_template_id": mail_template.id,
+        }
+
+        rec1 = self.env["l10n_br_fiscal.document.email"].create(
+            {
+                **vals,
+                "company_id": company1.id,
+            }
+        )
+
+        rec2 = self.env["l10n_br_fiscal.document.email"].create(
+            {
+                **vals,
+                "company_id": company2.id,
+            }
+        )
+
+        self.assertNotEqual(rec1.name, rec2.name)


### PR DESCRIPTION
Este erro surge ao tentar criar um novo **Email de Documentos Fiscais**.

Em **l10n_br_fiscal/models/document_email.py**, há a função **_compute_name**:

```
@api.depends("document_type_id", "state_edoc")
def _compute_name(self):
    for record in self:
        document_type = record.document_type_id.name
        if not document_type:
            document_type = "Others Document Types"
        if record.state_edoc:
            record.name = document_type + " - " + record.state_edoc

    _sql_constraints = [
        (
            "name_company_unique",
            "unique(name)",
            "This name is already used by another email definition !",
        )
    ]
```

Essa forma de atribuir valor ao campo **name** acaba gerando erro, principalmente em ambientes multiempresa, visto que, se o tipo de documento e o status forem iguais, os nomes também serão iguais, violando o **_sql_constraints**.

Proponho, não como solução definitiva, mas como melhoria parcial, o acréscimo do nome da empresa nesse **compute**, como no exemplo a seguir:

```
-  @api.depends("document_type_id", "state_edoc")
+  @api.depends("document_type_id", "state_edoc", "company_id")
    def _compute_name(self):
        for record in self:
            document_type = record.document_type_id.name
            if not document_type:
                document_type = "Others Document Types"
-           if record.state_edoc:
-               record.name = document_type + " - " + record.state_edoc
+           if record.state_edoc and record.company_id:
+               record.name = document_type + " - " + record.state_edoc + " - " + record.company_id.name
```

Fico aberto a outras sugestões de melhoria...

Odoo Versão 14. A versão do Python é indiferente.