### PR TITLE
[18.0][REF] l10n_br_account_payment_order: Alteração para usar o Env Translation

### DIFF
--- a/l10n_br_account_payment_order/models/account_payment.py
+++ b/l10n_br_account_payment_order/models/account_payment.py
@@ -5,7 +5,7 @@
 # @author Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import _, models
+from odoo import models
 from odoo.exceptions import UserError
 
 from ..constants import BR_CODES_PAYMENT_ORDER
@@ -31,7 +31,7 @@ class AccountPayment(models.Model):
                 #  na tela.
                 #  Testar na migração.
                 raise UserError(
-                    _(
+                    self.env._(
                         "CNAB Payment Method can't be used to make"
                         " direct Payments, just used in Payment Orders,"
                         " choose another one."

--- a/l10n_br_account_payment_order/models/account_payment_line.py
+++ b/l10n_br_account_payment_order/models/account_payment_line.py
@@ -5,7 +5,7 @@
 
 from erpbrasil.base import misc
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 from odoo.exceptions import UserError
 
 from ..constants import (
@@ -244,10 +244,11 @@ class AccountPaymentLine(models.Model):
                 and not rec.partner_bank_id.transactional_acc_type
             ):
                 raise UserError(
-                    _(
-                        "When the payment method is pix transfer, a pix key must be "
-                        "informed, or the bank account with the type of account.\n"
-                        f"Payment Line: {rec.name}"
+                    self.env._(
+                        "When the payment method is pix transfer, a pix key must be"
+                        " informed, or the bank account with the type of account.\n"
+                        "Payment Line: %(rec_name)s",
+                        rec_name=rec.name,
                     )
                 )
 

--- a/l10n_br_account_payment_order/models/account_payment_mode.py
+++ b/l10n_br_account_payment_order/models/account_payment_mode.py
@@ -5,7 +5,7 @@
 # @author Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 from odoo.exceptions import ValidationError
 
 from ..constants import BR_CODES_PAYMENT_ORDER
@@ -79,7 +79,7 @@ class AccountPaymentMode(models.Model):
 
             for field in fields_forbidden_cnab:
                 raise ValidationError(
-                    _(
+                    self.env._(
                         "The Payment Mode can not be used for CNAB with the field"
                         " %s active. \n Please uncheck it to continue."
                     )

--- a/l10n_br_account_payment_order/models/account_payment_order.py
+++ b/l10n_br_account_payment_order/models/account_payment_order.py
@@ -10,7 +10,7 @@
 
 import logging
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 from odoo.exceptions import UserError
 
 from ..constants import (
@@ -97,19 +97,23 @@ class AccountPaymentOrder(models.Model):
 
             if not order.journal_id:
                 raise UserError(
-                    _("Missing Bank Journal on payment order %s.") % order.name
+                    self.env._("Missing Bank Journal on payment order %(name)s."),
+                    name=order.name,
                 )
             if (
                 order.payment_method_id.bank_account_required
                 and not order.journal_id.bank_account_id
             ):
                 raise UserError(
-                    _("Missing bank account on bank journal '%s'.")
-                    % order.journal_id.display_name
+                    self.env._("Missing bank account on bank journal '%(name)s'."),
+                    name=order.journal_id.display_name,
                 )
             if not order.payment_line_ids:
                 raise UserError(
-                    _("There are no transactions on payment order %s.") % order.name
+                    self.env._(
+                        "There are no transactions on payment order %(name)s.",
+                        name=order.name,
+                    )
                 )
             # Unreconcile, cancel and delete existing account payments
             order.payment_ids.action_draft()
@@ -137,7 +141,7 @@ class AccountPaymentOrder(models.Model):
                     and requested_date < payline.ml_maturity_date
                 ):
                     raise UserError(
-                        _(
+                        self.env._(
                             "The payment mode '%(payment_mode)s' has the option "
                             "'Disallow Debit Before Maturity Date'. The payment line "
                             "'%(payline)s' has a maturity date %(maturity_date)s which "
@@ -170,7 +174,7 @@ class AccountPaymentOrder(models.Model):
                 # Block if a bank payment line is <= 0
                 if paydict["total"] <= 0:
                     raise UserError(
-                        _(
+                        self.env._(
                             "The amount for Partner '%(name)s' "
                             "is negative "
                             "or null (%(total).2f) !",
@@ -191,7 +195,7 @@ class AccountPaymentOrder(models.Model):
                 order.payment_method_code in BR_CODES_PAYMENT_ORDER
                 and order.payment_mode_id.payment_method_id.payment_type == "inbound"
             ):
-                raise UserError(_("You cannot delete CNAB order."))
+                raise UserError(self.env._("You cannot delete CNAB order."))
 
     def action_done_cancel(self):
         for order in self:
@@ -201,7 +205,7 @@ class AccountPaymentOrder(models.Model):
                 order.payment_method_code in BR_CODES_PAYMENT_ORDER
                 and order.payment_mode_id.payment_method_id.payment_type == "inbound"
             ):
-                raise UserError(_("You cannot Cancel CNAB order."))
+                raise UserError(self.env._("You cannot Cancel CNAB order."))
         return super().unlink()
 
     def generate_payment_file(self):

--- a/l10n_br_account_payment_order/models/ir_attachment.py
+++ b/l10n_br_account_payment_order/models/ir_attachment.py
@@ -2,7 +2,7 @@
 # @author Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import SUPERUSER_ID, _, api, models
+from odoo import SUPERUSER_ID, api, models
 from odoo.exceptions import UserError
 
 
@@ -18,5 +18,5 @@ class IrAttachment(models.Model):
                 and self._uid != SUPERUSER_ID
             ):
                 raise UserError(
-                    _("Sorry, you are not allowed to delete the attachment.")
+                    self.env._("Sorry, you are not allowed to delete the attachment.")
                 )

--- a/l10n_br_account_payment_order/models/l10n_br_cnab_change_methods.py
+++ b/l10n_br_account_payment_order/models/l10n_br_cnab_change_methods.py
@@ -2,7 +2,7 @@
 # @author Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import _, fields, models
+from odoo import fields, models
 from odoo.exceptions import UserError
 
 
@@ -105,7 +105,7 @@ class L10nBrCNABChangeMethods(models.Model):
         )
         if payment_line_to_be_send:
             raise UserError(
-                _(
+                self.env._(
                     "There is a CNAB Payment Order %(order_name)s in status "
                     "%(order_state)s related to invoice %(invoice_name)s created, "
                     "the CNAB file should be sent to bank, because only after "
@@ -131,7 +131,7 @@ class L10nBrCNABChangeMethods(models.Model):
         )
         if new_payorder:
             self.move_id.message_post(
-                body=_(
+                body=self.env._(
                     "Payment line added to the the new draft payment "
                     "order %(order_name)s which has been automatically created,"
                     " to send CNAB Instruction %(instruction)s for OWN NUMBER "
@@ -144,7 +144,7 @@ class L10nBrCNABChangeMethods(models.Model):
             )
         else:
             self.move_id.message_post(
-                body=_(
+                body=self.env._(
                     "Payment line added to the existing draft "
                     "order %(order_name)s to send CNAB Instruction %(instruction)s "
                     "for OWN NUMBER %(own_number)s.\nJustification: %(reason)s",
@@ -163,7 +163,7 @@ class L10nBrCNABChangeMethods(models.Model):
         :return: Mensagem de Erro
         """
         raise UserError(
-            _(
+            self.env._(
                 "CNAB Config %(cnab_config_name)s in Payment Mode"
                 " %(payment_mode_name)s don't has %(missing)s for"
                 " making CNAB change, check if should have.",
@@ -207,7 +207,7 @@ class L10nBrCNABChangeMethods(models.Model):
 
         if new_date == self.date_maturity:
             raise UserError(
-                _(
+                self.env._(
                     "New Date Maturity %(new_date)s is equal to actual Date "
                     "Maturity %(date_maturity)s",
                     new_date=new_date,
@@ -233,7 +233,7 @@ class L10nBrCNABChangeMethods(models.Model):
 
         if new_date == self.date:
             raise UserError(
-                _(
+                self.env._(
                     "New Discount Date %(new_date)s is equal to current Discount "
                     "Date %(date_discount)s",
                     new_date=new_date,
@@ -344,7 +344,7 @@ class L10nBrCNABChangeMethods(models.Model):
         self.payment_situation = payment_situation
         # TODO criar um state removed ?
         self.cnab_state = "done"
-        self.move_id.message_post(body=_(reason))
+        self.move_id.message_post(body=self.env._(reason))
 
     def create_cnab_write_off(self, reason, payment_situation):
         """

--- a/l10n_br_account_payment_order/models/l10n_br_cnab_code.py
+++ b/l10n_br_account_payment_order/models/l10n_br_cnab_code.py
@@ -2,7 +2,7 @@
 # @author Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 from odoo.exceptions import ValidationError
 
 
@@ -102,7 +102,7 @@ class L10nBrCNABCode(models.Model):
                     code_already_exist.code + " - " + code_already_exist.name
                 )
                 raise ValidationError(
-                    _(
+                    self.env._(
                         "The Code %(code)s %(name)s already exists for Bank %(bank)s "
                         "and CNAB %(type_code)s type.",
                         code=record.code,
@@ -119,7 +119,7 @@ class L10nBrCNABCode(models.Model):
                 "return_move_code",
             ):
                 raise ValidationError(
-                    _(
+                    self.env._(
                         "The field Code in 'Instruction and Return Move Code'"
                         " should have two characters."
                     )

--- a/l10n_br_account_payment_order/models/l10n_br_cnab_config.py
+++ b/l10n_br_account_payment_order/models/l10n_br_cnab_config.py
@@ -2,7 +2,7 @@
 # @author Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 from odoo.exceptions import ValidationError
 
 from ..constants import BR_CODES_PAYMENT_ORDER, FORMA_LANCAMENTO, TIPO_SERVICO
@@ -112,14 +112,16 @@ class L10nBRCNABConfig(models.Model):
                 and self.payment_type == "inbound"
                 and not self.boleto_wallet
             ):
-                raise ValidationError(_("Carteira no banco Itaú é obrigatória"))
+                raise ValidationError(
+                    self.env._("The Wallet in Itaú Bank need to be informed.")
+                )
 
     @api.constrains("boleto_discount_perc")
     def _check_discount_perc(self):
         for record in self:
             if record.boleto_discount_perc > 100 or record.boleto_discount_perc < 0:
                 raise ValidationError(
-                    _("O percentual deve ser um valor entre 0 a 100.")
+                    self.env._("The percent value should be between 0 to 100.")
                 )
 
     def _check_sequence_already_in_use(self, field):
@@ -137,9 +139,10 @@ class L10nBRCNABConfig(models.Model):
                 )
                 if already_in_use:
                     raise ValidationError(
-                        _(
-                            f"Sequence {sequence.name} already in"
-                            f" use by {already_in_use.name}!",
+                        self.env._(
+                            "Sequence %s(seq_name) already in use by %(al_name)s!",
+                            seq_name=sequence.name,
+                            al_name=already_in_use.name,
                         )
                     )
 

--- a/l10n_br_account_payment_order/models/l10n_br_cnab_data_abstract.py
+++ b/l10n_br_account_payment_order/models/l10n_br_cnab_data_abstract.py
@@ -2,7 +2,7 @@
 # @author Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 from odoo.exceptions import ValidationError
 
 
@@ -44,7 +44,7 @@ class L10nBrCNABDataAbstract(models.AbstractModel):
                     code_already_exist.code + " - " + code_already_exist.name
                 )
                 raise ValidationError(
-                    _(
+                    self.env._(
                         "The Code %(code)s already exist %(code_name_exist)s for Bank "
                         "and CNAB type.",
                         code=record.code,


### PR DESCRIPTION
Use env for translatiosns.

PR simples com três alterações:

* atualização na forma definir os textos que deverão ser traduzidos, a partir da **v18.0** foi adicionada essa nova forma, ao invés do **_(........)** passou para **self.env._(........)**, 

* Alteração na forma de incluir variáveis no texto, de acordo com a recomendação da Documentação da OCA
https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#33idioms 

<img width="1047" height="241" alt="image" src="https://github.com/user-attachments/assets/a476c6b7-ad83-4d88-a8c2-6bfcb39eb002" />

* Passando textos que estão em Português para Inglês para facilitar a tradução para outras línguas e manter um padrão.

Mais referências sobre isso no PR:

* https://github.com/OCA/l10n-brazil/pull/4408

cc @OCA/local-brazil-maintainers 