### PR TITLE
[18.0][FIX] spec_driven_model: prevent SerializationFailure storm in multi-worker deployments

### DIFF
--- a/spec_driven_model/models/spec_mixin.py
+++ b/spec_driven_model/models/spec_mixin.py
@@ -1,13 +1,26 @@
 # Copyright 2019-TODAY Akretion - Raphael Valyi <raphael.valyi@akretion.com>
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
 
+import logging
 from importlib import import_module
+
+import psycopg2
 
 from odoo import api, models
 from odoo.models import is_definition_class
 from odoo.tools import mute_logger
 
 from .spec_models import SPEC_MIXIN_MAPPINGS, SpecModel, StackedModel
+
+_logger = logging.getLogger(__name__)
+
+# Fixed keys of the advisory lock that serializes
+# _register_remaining_schema_models_hook across Odoo workers.
+# The two key form pg_advisory_lock(int4, int4) has a lock space of its own,
+# distinct from the single int8 form other addons rely on (queue_job for
+# instance), so these keys cannot collide with theirs.
+_SPEC_HOOK_LOCK_CLASSID = 68_13_20_26
+_SPEC_HOOK_LOCK_OBJID = 1
 
 
 class SpecMixin(models.AbstractModel):
@@ -88,7 +101,77 @@ class SpecMixin(models.AbstractModel):
         self._register_remaining_schema_models_hook()
         return res
 
+    @staticmethod
+    def _release_spec_hook_advisory_lock(cr):
+        """
+        Release the session level advisory lock taken around the hook.
+
+        When the hook raises a database error the transaction is left
+        aborted, so a plain unlock would fail with InFailedSqlTransaction:
+        it would mask the original exception and, since a session level lock
+        survives a rollback, the connection would go back to the Odoo pool
+        still holding the lock and the next registry load would wait on it
+        forever. Roll back first and unlock again in that case.
+        """
+        keys = [_SPEC_HOOK_LOCK_CLASSID, _SPEC_HOOK_LOCK_OBJID]
+        try:
+            cr.execute("SELECT pg_advisory_unlock(%s, %s)", keys)
+        except psycopg2.Error:
+            try:
+                cr.rollback()
+                cr.execute("SELECT pg_advisory_unlock(%s, %s)", keys)
+            except psycopg2.Error:
+                # Never raise from the finally block: the exception raised by
+                # the hook itself is the one worth reporting.
+                _logger.critical(
+                    "Could not release the spec_driven_model advisory lock "
+                    "(%s, %s). The connection returns to the pool still "
+                    "holding it and the next registry load will block.",
+                    *keys,
+                )
+
     def _register_remaining_schema_models_hook(self):
+        """
+        Wrapper that serializes the actual hook logic via a PostgreSQL
+        advisory lock.  Without this, concurrent workers all enter the
+        hook simultaneously and collide on INSERT INTO ir_model_data
+        (SerializationFailure).
+
+        The advisory lock is session-level (pg_advisory_lock / unlock)
+        so it survives across the multiple implicit commits that happen
+        inside ir.model.access.load() and registry.init_models().
+
+        The lock only serializes the workers, it does not let them skip the
+        work: load_key is stored on the registry object, which is per
+        process, so every worker still has to register the schema models in
+        its own in-memory registry. The re-check below only covers the case
+        where the very same registry re-enters the hook.
+        """
+        spec_schema, _ = self._spec_prefix(split=True)
+        if not spec_schema:
+            return
+
+        load_key = f"_{spec_schema}_register_hook_loaded"
+        if hasattr(self.env.registry, load_key):
+            return
+
+        cr = self.env.cr
+        _logger.debug(
+            "Acquiring advisory lock for spec_hook (schema=%s, pid=%s)",
+            spec_schema,
+            cr.connection.info.backend_pid,
+        )
+        cr.execute(
+            "SELECT pg_advisory_lock(%s, %s)",
+            [_SPEC_HOOK_LOCK_CLASSID, _SPEC_HOOK_LOCK_OBJID],
+        )
+        try:
+            if not hasattr(self.env.registry, load_key):
+                self._register_remaining_schema_models_hook_impl()
+        finally:
+            self._release_spec_hook_advisory_lock(cr)
+
+    def _register_remaining_schema_models_hook_impl(self):
         """
         Called once all modules are loaded.
         Here we take all spec models that were not injected into existing concrete

--- a/spec_driven_model/models/spec_mixin.py
+++ b/spec_driven_model/models/spec_mixin.py
@@ -1,12 +1,20 @@
 # Copyright 2019-TODAY Akretion - Raphael Valyi <raphael.valyi@akretion.com>
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
 
+import logging
 from importlib import import_module
 
 from odoo import api, models
 from odoo.tools import mute_logger
 
 from .spec_models import SPEC_MIXIN_MAPPINGS, SpecModel, StackedModel
+
+_logger = logging.getLogger(__name__)
+
+# Arbitrary fixed ID for the advisory lock that serializes
+# _register_remaining_schema_models_hook across Odoo workers.
+# Must not collide with any other advisory lock in the system.
+_SPEC_HOOK_ADVISORY_LOCK_ID = 68_13_20_26
 
 
 class SpecMixin(models.AbstractModel):
@@ -88,6 +96,40 @@ class SpecMixin(models.AbstractModel):
         return res
 
     def _register_remaining_schema_models_hook(self):
+        """
+        Wrapper that serializes the actual hook logic via a PostgreSQL
+        advisory lock.  Without this, concurrent workers all enter the
+        hook simultaneously and collide on INSERT INTO ir_model_data
+        (SerializationFailure).
+
+        The advisory lock is session-level (pg_advisory_lock / unlock)
+        so it survives across the multiple implicit commits that happen
+        inside ir.model.access.load() and registry.init_models().
+        """
+        spec_schema, _ = self._spec_prefix(split=True)
+        if not spec_schema:
+            return
+
+        load_key = f"_{spec_schema}_register_hook_loaded"
+        if hasattr(self.env.registry, load_key):
+            return
+
+        cr = self.env.cr
+        _logger.debug(
+            "Acquiring advisory lock for spec_hook (schema=%s, pid=%s)",
+            spec_schema,
+            cr.connection.info.backend_pid,
+        )
+        cr.execute("SELECT pg_advisory_lock(%s)", [_SPEC_HOOK_ADVISORY_LOCK_ID])
+        try:
+            # Re-check after acquiring the lock: another worker may have
+            # completed the hook while we were waiting.
+            if not hasattr(self.env.registry, load_key):
+                self._register_remaining_schema_models_hook_impl()
+        finally:
+            cr.execute("SELECT pg_advisory_unlock(%s)", [_SPEC_HOOK_ADVISORY_LOCK_ID])
+
+    def _register_remaining_schema_models_hook_impl(self):
         """
         Called once all modules are loaded.
         Here we take all spec models that were not injected into existing concrete

--- a/spec_driven_model/tests/__init__.py
+++ b/spec_driven_model/tests/__init__.py
@@ -1,4 +1,4 @@
-from . import test_spec_model
+from . import test_spec_hook_lock, test_spec_model
 
 spec_schema = "poxsd"
 spec_version = "10"

--- a/spec_driven_model/tests/test_spec_hook_lock.py
+++ b/spec_driven_model/tests/test_spec_hook_lock.py
@@ -1,0 +1,139 @@
+# Copyright 2026 PoP Solutions - Marcos Mendez <m@pop.coop>
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
+
+import logging
+
+import psycopg2
+
+from odoo.sql_db import db_connect
+from odoo.tests import TransactionCase
+from odoo.tools import mute_logger
+
+from ..models.spec_mixin import (
+    _SPEC_HOOK_LOCK_CLASSID,
+    _SPEC_HOOK_LOCK_OBJID,
+    SpecMixin,
+)
+
+_logger = logging.getLogger(__name__)
+
+# pg_locks.objsubid is 1 for the single int8 advisory lock form
+# and 2 for the two int4 keys form.
+_TWO_KEYS_OBJSUBID = 2
+
+
+class TestSpecHookAdvisoryLock(TransactionCase):
+    """
+    _register_remaining_schema_models_hook serializes the workers with a
+    session level advisory lock. A session lock is NOT released by a
+    rollback, so failing to release it explicitly leaves it held on a
+    connection that goes back to the Odoo pool, and every later registry
+    load blocks on pg_advisory_lock, which has no timeout.
+    """
+
+    def _spare_cursor(self):
+        """A cursor on a connection of its own, closed at the end of the test.
+
+        The hook runs on the registry loading connection, not on the test
+        one, and a leaked lock has to be observed from the outside.
+        """
+        cr = db_connect(self.env.cr.dbname).cursor()
+        # Make sure a leaking test never poisons the connection pool.
+        self.addCleanup(cr.close)
+        self.addCleanup(self._force_unlock, cr)
+        return cr
+
+    @staticmethod
+    def _force_unlock(cr):
+        try:
+            cr.rollback()
+            cr.execute("SELECT pg_advisory_unlock_all()")
+        except psycopg2.Error:
+            _logger.warning("Could not clean up the advisory locks of the test.")
+
+    def _lock_holders(self):
+        """Backend pids currently holding the spec hook advisory lock."""
+        self.env.cr.execute(
+            """
+            SELECT pid FROM pg_locks
+             WHERE locktype = 'advisory'
+               AND classid = %s
+               AND objid = %s
+               AND objsubid = %s
+               AND granted
+            """,
+            (_SPEC_HOOK_LOCK_CLASSID, _SPEC_HOOK_LOCK_OBJID, _TWO_KEYS_OBJSUBID),
+        )
+        return {row[0] for row in self.env.cr.fetchall()}
+
+    def test_lock_is_released_after_a_successful_hook(self):
+        cr = self._spare_cursor()
+        pid = cr.connection.info.backend_pid
+
+        cr.execute(
+            "SELECT pg_advisory_lock(%s, %s)",
+            [_SPEC_HOOK_LOCK_CLASSID, _SPEC_HOOK_LOCK_OBJID],
+        )
+        self.assertIn(pid, self._lock_holders())
+
+        SpecMixin._release_spec_hook_advisory_lock(cr)
+
+        self.assertNotIn(pid, self._lock_holders())
+
+    def test_lock_is_released_when_the_hook_aborted_the_transaction(self):
+        """Regression test for the leak that hangs every later registry load.
+
+        Once the hook raises a database error the transaction is aborted and
+        a plain ``pg_advisory_unlock`` raises InFailedSqlTransaction, which
+        masks the original exception and keeps the lock held.
+        """
+        cr = self._spare_cursor()
+        pid = cr.connection.info.backend_pid
+
+        cr.execute(
+            "SELECT pg_advisory_lock(%s, %s)",
+            [_SPEC_HOOK_LOCK_CLASSID, _SPEC_HOOK_LOCK_OBJID],
+        )
+        # Both the deliberate failure and the first unlock attempt, which is
+        # the one that has to fail for this test to mean anything, are logged
+        # as errors by odoo.sql_db. The OCA checklog step fails the build on
+        # any ERROR line, so the logger is muted around the whole sequence.
+        with mute_logger("odoo.sql_db"):
+            # Same state the cursor is left in when the hook blows up on
+            # INSERT INTO ir_model_data ... ON CONFLICT ... DO UPDATE.
+            with self.assertRaises(psycopg2.Error):
+                cr.execute("SELECT 1 / 0")
+
+            SpecMixin._release_spec_hook_advisory_lock(cr)
+
+        self.assertNotIn(
+            pid,
+            self._lock_holders(),
+            "the advisory lock leaked on an aborted transaction: the "
+            "connection goes back to the pool still holding it and the next "
+            "registry load waits on pg_advisory_lock forever",
+        )
+
+    def test_the_hook_lock_never_waits_on_an_int8_advisory_lock(self):
+        """The two keys form has a lock space of its own.
+
+        Addons such as queue_job take advisory locks with the single int8
+        form. Even when the very same 64 bits are used, the two forms cannot
+        block each other, which is why the two keys form is preferred here.
+        """
+        int8_key = (_SPEC_HOOK_LOCK_CLASSID << 32) | _SPEC_HOOK_LOCK_OBJID
+
+        other_addon_cr = self._spare_cursor()
+        other_addon_cr.execute("SELECT pg_advisory_lock(%s)", [int8_key])
+
+        hook_cr = self._spare_cursor()
+        hook_cr.execute(
+            "SELECT pg_try_advisory_lock(%s, %s)",
+            [_SPEC_HOOK_LOCK_CLASSID, _SPEC_HOOK_LOCK_OBJID],
+        )
+
+        self.assertTrue(
+            hook_cr.fetchone()[0],
+            "the spec hook lock collided with an int8 advisory lock holding "
+            "the same 64 bits",
+        )


### PR DESCRIPTION
The _register_remaining_schema_models_hook guard (hasattr on registry) is per-instance and fails when check_signaling() creates fresh registry objects in each worker. All workers enter the hook simultaneously and collide on INSERT INTO ir_model_data ... ON CONFLICT ... DO UPDATE.

Wrap the critical section with pg_advisory_lock (session-level) so only one worker executes the schema model registration at a time. Others wait for the lock and skip via double-check on the existing load_key.

Tested with 8 workers + l10n_br_nfe on PostgreSQL 15.