### PR TITLE
[18.0][PERF] l10n_br_fiscal_dfe: fix N+1 query in _records_to_attachments

### DIFF
--- a/l10n_br_fiscal_dfe/models/attachment.py
+++ b/l10n_br_fiscal_dfe/models/attachment.py
@@ -100,9 +100,11 @@ class Attachment(models.TransientModel):
             attachment_ids = attachs
 
         if attachment_ids._name != "ir.attachment":
-            ids = attachment_obj
-            for record in attachment_ids:
-                ids += attachment_obj.search([("res_id", "=", record.id)])
-            attachment_ids = ids
+            attachment_ids = attachment_obj.search(
+                [
+                    ("res_model", "=", attachment_ids._name),
+                    ("res_id", "in", attachment_ids.ids),
+                ]
+            )
 
         return attachment_ids


### PR DESCRIPTION
## Problem

`_records_to_attachments()` issued one `SELECT` per record to collect
`ir.attachment` rows:

```python
for record in attachment_ids:
    ids += attachment_obj.search([('res_id', '=', record.id)])
```

With N fiscal documents selected for batch download, this produced N
sequential round-trips to PostgreSQL. On a typical monthly closing with
200+ documents the overhead is measurable and load scales linearly with
batch size.

Additionally, the original query filtered only by `res_id` without
`res_model`, meaning it could inadvertently return attachments from
unrelated models that share the same integer ID.

## Fix

Replace the loop with a single batched query:

```python
attachment_ids = attachment_obj.search([
    ('res_model', '=', attachment_ids._name),
    ('res_id', 'in', attachment_ids.ids),
])
```

## Impact

| | Before | After |
|---|---|---|
| Queries | N (one per record) | 1 |
| `res_model` filter | missing | added |

## Testing

Tested with `l10n_br_nfe` MDE batch download selecting multiple
records — behavior unchanged, single query confirmed via PostgreSQL logs.