### PR TITLE
[18.0][FIX] l10n_br_fiscal: fix N+1 query in _compute_fiscal_genre_id

### DIFF
--- a/l10n_br_fiscal/models/product_mixin.py
+++ b/l10n_br_fiscal/models/product_mixin.py
@@ -28,11 +28,19 @@ class ProductMixin(models.AbstractModel):
 
     @api.depends("ncm_id")
     def _compute_fiscal_genre_id(self):
+        # the genre table is the 100 NCM chapters, read it once for the whole
+        # batch instead of searching it again for every product
+        genre_id_by_code = {
+            genre["code"]: genre["id"]
+            for genre in self.env["l10n_br_fiscal.product.genre"].search_read(
+                [], ["code"]
+            )
+        }
         for product in self:
             if product.ncm_id:
-                product.fiscal_genre_id = self.env[
-                    "l10n_br_fiscal.product.genre"
-                ].search([("code", "=", product.ncm_id.code[0:2])])
+                product.fiscal_genre_id = genre_id_by_code.get(
+                    product.ncm_id.code[0:2], False
+                )
 
     @api.depends("fiscal_type")
     def _compute_tax_icms_or_issqn(self):


### PR DESCRIPTION
## Problem

`_compute_fiscal_genre_id()` issued one `SELECT` per product to resolve
the fiscal genre from `product.genre`:

```python
for product in self:
    if product.ncm_id:
        product.fiscal_genre_id = self.env[
            'l10n_br_fiscal.product.genre'
        ].search([('code', '=', product.ncm_id.code[0:2])])
```

With N products being computed (e.g. on import or NCM update), this
produced N sequential round-trips to PostgreSQL — all querying the same
static table of 100 rows (NCM chapter codes 00-99) that never changes
at runtime.

## Fix

Load all 100 genre records once before the loop and resolve via
in-memory dict lookup:

```python
genres = self.env['l10n_br_fiscal.product.genre'].search([])
genre_by_code = {g.code: g for g in genres}
for product in self:
    if product.ncm_id:
        product.fiscal_genre_id = genre_by_code.get(
            product.ncm_id.code[0:2], False
        )
```

## Impact

| | Before | After |
|---|---|---|
| Queries | N (one per product) | 1 |
| Typical import (500 products) | 500 queries | 1 query |

The `product.genre` table has exactly 100 rows (NCM chapter codes
00-99) and is static — loading it once per compute batch costs nothing
and eliminates all per-product round-trips.