### PR TITLE
[17.0][FIX] l10n_br_fiscal, l10n_br_sped_base: missing readonly/invisible attrs

### DIFF
--- a/l10n_br_fiscal/models/tax_definition.py
+++ b/l10n_br_fiscal/models/tax_definition.py
@@ -65,11 +65,16 @@ class TaxDefinition(models.Model):
 
     code = fields.Char(
         size=8,
+        readonly=True,
     )
 
-    name = fields.Char()
+    name = fields.Char(
+        readonly=True,
+    )
 
-    description = fields.Text()
+    description = fields.Text(
+        readonly=True,
+    )
 
     type_in_out = fields.Selection(
         selection=FISCAL_IN_OUT,
@@ -136,12 +141,14 @@ class TaxDefinition(models.Model):
         comodel_name="res.country.state",
         string="From State",
         domain=[("country_id.code", "=", "BR")],
+        readonly=True,
     )
 
     state_to_ids = fields.Many2many(
         comodel_name="res.country.state",
         string="To States",
         domain=[("country_id.code", "=", "BR")],
+        readonly=True,
     )
 
     ncms = fields.Text(
@@ -265,6 +272,7 @@ class TaxDefinition(models.Model):
 
     benefit_type = fields.Selection(
         selection=ICMS_TAX_BENEFIT_TYPE,
+        readonly=True,
     )
 
     def _get_search_domain(self, tax_definition):

--- a/l10n_br_fiscal/views/operation_view.xml
+++ b/l10n_br_fiscal/views/operation_view.xml
@@ -148,7 +148,7 @@
                             </field>
                         </page>
                         <page name="notes" string="Notes">
-                            <field name="comment_ids" />
+                            <field name="comment_ids" readonly="state != 'draft'" />
                         </page>
                     </notebook>
                 </sheet>

--- a/l10n_br_fiscal/views/tax_definition_view.xml
+++ b/l10n_br_fiscal/views/tax_definition_view.xml
@@ -9,7 +9,7 @@
                 <field name="tax_group_id" readonly="state != 'draft'" />
                 <field name="is_taxed" readonly="state != 'draft'" />
                 <field name="tax_id" readonly="state != 'draft'" />
-                <field name="cst_code" />
+                <field name="cst_code" readonly="state != 'draft'" />
             </tree>
         </field>
     </record>
@@ -31,7 +31,7 @@
                 <field name="state_from_id" />
                 <field name="state_to_ids" />
                 <field name="tax_id" readonly="state != 'draft'" />
-                <field name="cst_code" />
+                <field name="cst_code" readonly="state != 'draft'" />
             </tree>
         </field>
     </record>
@@ -268,6 +268,7 @@
                                     force_save="1"
                                     nolabel="1"
                                     colspan="2"
+                                    readonly="state != 'draft'"
                                 />
                             </group>
                         </page>
@@ -295,7 +296,7 @@
                         </page>
                         <page name="fiscal_profile_page" string="Fiscal Profile">
                             <group name="fiscal_profile" string="Fiscal Profile">
-                                <field name="ind_final" />
+                                <field name="ind_final" readonly="state != 'draft'" />
                             </group>
                         </page>
                     </notebook>

--- a/l10n_br_sped_base/models/sped_declaration.py
+++ b/l10n_br_sped_base/models/sped_declaration.py
@@ -260,7 +260,7 @@ class SpedDeclaration(models.AbstractModel):
             E.button(
                 name="button_populate_sped_from_odoo",
                 type="object",
-                states="draft",
+                invisible="state != 'draft'",
                 string="Pull Registers from Odoo",
                 #            class="oe_highlight",
                 groups="l10n_br_fiscal.group_manager",
@@ -270,7 +270,7 @@ class SpedDeclaration(models.AbstractModel):
             E.button(
                 name="button_flush_registers",
                 type="object",
-                states="draft",
+                invisible="state != 'draft'",
                 string="Flush Registers",
                 #            class="oe_highlight",
                 groups="l10n_br_fiscal.group_manager",
@@ -280,7 +280,7 @@ class SpedDeclaration(models.AbstractModel):
             E.button(
                 name="button_done",
                 type="object",
-                states="draft",
+                invisible="state != 'draft'",
                 string="Set to Done",
                 #            class="oe_highlight",
                 groups="l10n_br_fiscal.group_manager",
@@ -290,7 +290,7 @@ class SpedDeclaration(models.AbstractModel):
             E.button(
                 name="button_draft",
                 type="object",
-                states="done",
+                invisible="state != 'done'",
                 string="Reset to Draft",
                 #            class="oe_highlight",
                 groups="l10n_br_fiscal.group_manager",
@@ -300,7 +300,7 @@ class SpedDeclaration(models.AbstractModel):
             E.button(
                 name="button_create_sped_files",
                 type="object",
-                states="done",
+                invisible="state != 'done'",
                 string="Generate SPED File",
                 #            class="oe_highlight",
                 groups="l10n_br_fiscal.group_manager",


### PR DESCRIPTION
Quando eu migrei esses 2 módulos para a v17 eu tirei os atributos `states` dos fields. Mas na verdade eu deveria ter adaptado para completar os atributos `readonly` de acordo nas views desses modelos/campos. Botei uma AI para faze-lo agora.