### PR TITLE
[18.0][REF] l10n_br_cnpj_search: Alteração para usar o Env Translation

### DIFF
--- a/l10n_br_cnpj_search/models/cnpj_webservice.py
+++ b/l10n_br_cnpj_search/models/cnpj_webservice.py
@@ -7,7 +7,7 @@ from os.path import dirname
 
 from erpbrasil.base.misc import punctuation_rm
 
-from odoo import Command, _, api, models
+from odoo import Command, api, models
 from odoo.exceptions import UserError, ValidationError
 
 _logger = logging.getLogger(__name__)
@@ -115,7 +115,7 @@ class CNPJWebservice(models.AbstractModel):
     @api.model
     def _validate(self, response):
         if response.status_code != 200:
-            raise ValidationError(_("%s") % response.reason)
+            raise ValidationError(self.env._("%(reason)s", reason=response.reason))
 
     @api.model
     def _get_legal_nature(self, raw_code):
@@ -160,7 +160,7 @@ class CNPJWebservice(models.AbstractModel):
         self._validate(response)
         data = response.json()
         if data.get("status") == "ERROR":
-            raise ValidationError(_(data.get("message")))
+            raise ValidationError(self.env._(data.get("message")))
 
         return data
 

--- a/l10n_br_cnpj_search/models/l10n_br_base_party_mixin.py
+++ b/l10n_br_cnpj_search/models/l10n_br_base_party_mixin.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2024-Today - Engenere (<https://engenere.one>).
 # @author Cristiano Mafra Junior
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 from odoo.exceptions import UserError
 
 
@@ -28,10 +28,10 @@ class PartyMixin(models.AbstractModel):
 
     def action_open_cnpj_search_wizard(self):
         if not self.vat:
-            raise UserError(_("Please enter your CNPJ"))
+            raise UserError(self.env._("Please enter your CNPJ"))
         if self.cnpj_validation_disabled():
             raise UserError(
-                _(
+                self.env._(
                     "It is necessary to activate the option to validate de CNPJ to use"
                     " this functionality."
                 )


### PR DESCRIPTION
Use env for translatiosns.

PR simples com duas alterações:

* atualização na forma definir os textos que deverão ser traduzidos, a partir da v18.0 foi adicionada essa nova forma, ao invés do **_(........)** passou para **self.env._(........)**

* Alteração na forma de incluir variáveis no texto, de acordo com a recomendação da Documentação da OCA
https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#33idioms

<img width="1047" height="241" alt="image" src="https://github.com/user-attachments/assets/59c9084b-25b9-4b35-8d25-324786589c6b" />

Mais referências sobre isso no PR:

* https://github.com/OCA/l10n-brazil/pull/4408

cc @OCA/local-brazil-maintainers 