### PR TITLE
[18.0][REF] l10n_br_coa: Alteração para usar o Env Translation

### DIFF
--- a/l10n_br_coa/models/template_br_oca.py
+++ b/l10n_br_coa/models/template_br_oca.py
@@ -6,7 +6,7 @@
 import csv
 import logging
 
-from odoo import Command, _, api, models
+from odoo import Command, api, models
 from odoo.tools.misc import file_open
 
 from odoo.addons.account.models.chart_template import template
@@ -44,7 +44,7 @@ class AccountChartTemplate(models.AbstractModel):
     @template("br_oca")
     def _get_br_oca_template_data(self):
         return {
-            "name": _("Plano de Contas Base"),
+            "name": self.env._("Basic Chart of Accounts"),
             "visible": True,  # TODO
             "code_digits": "2",
             "use_anglo_saxon": True,
@@ -269,7 +269,7 @@ class AccountChartTemplate(models.AbstractModel):
         company.account_purchase_tax_id = None
 
         _logger.info(
-            _(
+            self.env._(
                 "Company %(company_name)s: created tax accounts: %(refs)s",
                 company_name=company.name,
                 refs=created_accounts_refs,


### PR DESCRIPTION
Use env for translatiosns.

PR simples com duas alterações:

* atualização na forma definir os textos que deverão ser traduzidos, a partir da v18.0 foi adicionada essa nova forma, ao invés do **_(........)** passou para **self.env._(........)**

* Passando textos que estão em Português para Inglês para facilitar a tradução para outras línguas e manter um padrão.

Mais referências sobre isso no PR:

* https://github.com/OCA/l10n-brazil/pull/4408

cc @OCA/local-brazil-maintainers 