### PR TITLE
[18.0][REF] l10n_br_crm: Alteração para usar o Env Translation

### DIFF
--- a/l10n_br_crm/models/crm_lead.py
+++ b/l10n_br_crm/models/crm_lead.py
@@ -4,7 +4,7 @@
 from erpbrasil.base import misc
 from erpbrasil.base.fiscal import cnpj_cpf
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 from odoo.exceptions import UserError
 
 from odoo.addons.l10n_br_base.tools import check_cnpj_cpf, check_ie
@@ -198,10 +198,10 @@ class Lead(models.Model):
     def action_open_cnpj_search_wizard(self):
         """Override to use cnpj field instead of vat for crm.lead."""
         if not self.cnpj:
-            raise UserError(_("Please enter your CNPJ"))
+            raise UserError(self.env._("Please enter your CNPJ"))
         if self.cnpj_validation_disabled():
             raise UserError(
-                _(
+                self.env._(
                     "It is necessary to activate the option to validate de CNPJ to use"
                     " this functionality."
                 )


### PR DESCRIPTION
Use env for translatiosns.

PR simples com uma alteração:

* atualização na forma definir os textos que deverão ser traduzidos, a partir da v18.0 foi adicionada essa nova forma, ao invés do **_(........)** passou para **self.env._(........)**

Mais referências sobre isso no PR:

* https://github.com/OCA/l10n-brazil/pull/4408

cc @OCA/local-brazil-maintainers 