### PR TITLE
[18.0][REF] l10n_br_currency_rate_update: Alteração para usar o Env Translation

### DIFF
--- a/l10n_br_currency_rate_update/models/res_currency_rate_provider_bcb.py
+++ b/l10n_br_currency_rate_update/models/res_currency_rate_provider_bcb.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import requests
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 from odoo.exceptions import UserError
 from odoo.tools import DEFAULT_SERVER_DATE_FORMAT
 
@@ -50,7 +50,7 @@ class ResCurrencyRateProviderBCB(models.Model):
         if self.service == "BCB":
             if base_currency != "BRL":
                 raise UserError(
-                    _(
+                    self.env._(
                         "Brazilian Central Bank is suitable only for companies"
                         " with BRL as base currency!"
                     )


### PR DESCRIPTION
Use env for translatiosns.

PR simples com uma alteração:

* atualização na forma definir os textos que deverão ser traduzidos, a partir da v18.0 foi adicionada essa nova forma, ao invés do **_(........)** passou para **self.env._(........)**

Mais referências sobre isso no PR:

* https://github.com/OCA/l10n-brazil/pull/4408

cc @OCA/local-brazil-maintainers 