### PR TITLE
[18.0][REF] l10n_br_fiscal: Alteração para usar o Env Translation

### DIFF
--- a/l10n_br_fiscal/models/data_abstract.py
+++ b/l10n_br_fiscal/models/data_abstract.py
@@ -6,7 +6,7 @@ import json
 from erpbrasil.base import misc
 from lxml import etree
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 from odoo.exceptions import AccessError
 
 
@@ -44,12 +44,16 @@ class DataAbstract(models.AbstractModel):
 
     def action_archive(self):
         if not self.env.user.has_group("l10n_br_fiscal.group_manager"):
-            raise AccessError(_("You don't have permission to archive records."))
+            raise AccessError(
+                self.env._("You don't have permission to archive records.")
+            )
         return super().action_archive()
 
     def action_unarchive(self):
         if not self.env.user.has_group("l10n_br_fiscal.group_manager"):
-            raise AccessError(_("You don't have permission to unarchive records."))
+            raise AccessError(
+                self.env._("You don't have permission to unarchive records.")
+            )
         return super().action_unarchive()
 
     @api.depends("code")

--- a/l10n_br_fiscal/models/data_ncm_nbs_abstract.py
+++ b/l10n_br_fiscal/models/data_ncm_nbs_abstract.py
@@ -8,7 +8,7 @@ from datetime import timedelta
 from erpbrasil.base import misc
 from lxml import etree
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 from odoo.tools import config as odooconfig
 
 from .ibpt import DeOlhoNoImposto
@@ -113,13 +113,19 @@ class DataNcmNbsAbstract(models.AbstractModel):
                     self.env["l10n_br_fiscal.tax.estimate"].create(values)
 
                     record.message_post(
-                        body=_("{} Tax Estimate Updated").format(object_name),
-                        subject=_("{} Tax Estimate Updated").format(object_name),
+                        body=self.env._(
+                            "%(name)s Tax Estimate Updated",
+                            name=object_name,
+                        ),
+                        subject=self.env._(
+                            "%(name)s Tax Estimate Updated",
+                            name=object_name,
+                        ),
                     )
 
             except Exception as e:
                 _logger.warning(
-                    _(
+                    self.env._(
                         "%(name)s Tax Estimate Failure: %(error)s",
                         name=object_name,
                         error=e,
@@ -127,7 +133,9 @@ class DataNcmNbsAbstract(models.AbstractModel):
                 )
                 record.message_post(
                     body=str(e),
-                    subject=_("%(name)s Tax Estimate Failure", name=object_name),
+                    subject=self.env._(
+                        "%(name)s Tax Estimate Failure", name=object_name
+                    ),
                 )
                 continue
 
@@ -135,7 +143,9 @@ class DataNcmNbsAbstract(models.AbstractModel):
     def _scheduled_update(self):
         object_name = OBJECT_NAMES.get(self._name)
 
-        _logger.info(_("Scheduled {} estimate taxes update...").format(object_name))
+        _logger.info(
+            self.env._("Scheduled %(name)s estimate taxes update...", name=object_name)
+        )
 
         config_date = self.env.company.ibpt_update_days
         today = fields.date.today()
@@ -176,7 +186,10 @@ class DataNcmNbsAbstract(models.AbstractModel):
                 continue
 
         _logger.info(
-            _("Scheduled {} estimate taxes update complete.").format(object_name)
+            self.env._(
+                "Scheduled %(name)s estimate taxes update complete.",
+                name=object_name,
+            )
         )
 
     @api.model

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -6,7 +6,7 @@ from ast import literal_eval
 
 from erpbrasil.base.fiscal.edoc import ChaveEdoc
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 from odoo.exceptions import ValidationError
 
 from ..constants.fiscal import (
@@ -295,8 +295,9 @@ class Document(models.Model):
 
             if documents:
                 raise ValidationError(
-                    _("There is already a fiscal document with this key: {} !").format(
-                        record.document_key
+                    self.env._(
+                        "There is already a fiscal document with this key: %(doc_key)s",
+                        doc_key=record.document_key,
                     )
                 )
             else:
@@ -330,7 +331,7 @@ class Document(models.Model):
 
             if documents or invalid_number:
                 raise ValidationError(
-                    _(
+                    self.env._(
                         "There is already a fiscal document with this "
                         "Serie: %(serie)s, Number: %(number)s!",
                         serie=record.document_serie,
@@ -371,7 +372,7 @@ class Document(models.Model):
             if self.document_date:
                 name += " - " + self.document_date.strftime("%d/%m/%Y")
             if not self.partner_id.vat:
-                name += " - " + _("Unidentified Consumer")
+                name += " - " + self.env._("Unidentified Consumer")
             elif self.partner_id.legal_name:
                 name += " - " + self.partner_id.legal_name
                 name += " - " + self.partner_id.vat
@@ -418,7 +419,7 @@ class Document(models.Model):
 
         for record in self.filtered(lambda d: d.state_edoc in forbidden_states_unlink):
             raise ValidationError(
-                _(
+                self.env._(
                     "You cannot delete fiscal document number %(number)s with "
                     "the status: %(state)s!",
                     number=record.document_number,
@@ -434,9 +435,11 @@ class Document(models.Model):
             fsc_op = record.fiscal_operation_id.return_fiscal_operation_id
             if not fsc_op:
                 raise ValidationError(
-                    _(
-                        "The fiscal operation {} has no return Fiscal Operation defined"
-                    ).format(record.fiscal_operation_id)
+                    self.env._(
+                        "The fiscal operation %(fiscal_op)s has no"
+                        " return Fiscal Operation defined",
+                        fiscal_op=record.fiscal_operation_id,
+                    )
                 )
 
             new_doc = record.copy()
@@ -446,7 +449,7 @@ class Document(models.Model):
                 fsc_op_line = line.fiscal_operation_id.return_fiscal_operation_id
                 if not fsc_op_line:
                     raise ValidationError(
-                        _(
+                        self.env._(
                             "The fiscal operation {} has no return Fiscal "
                             "Operation defined"
                         ).format(line.fiscal_operation_id)

--- a/l10n_br_fiscal/models/document_serie.py
+++ b/l10n_br_fiscal/models/document_serie.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2014  KMEE - www.kmee.com.br
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 from odoo.exceptions import ValidationError
 
 from ..constants.fiscal import (
@@ -70,7 +70,7 @@ class DocumentSerie(models.Model):
         """Create new no_gap entry sequence for every
         new document serie"""
         sequence = {
-            "name": values.get("name", _("Document Serie Sequence")),
+            "name": values.get("name", self.env._("Document Serie Sequence")),
             "implementation": "no_gap",
             "padding": 1,
             "number_increment": 1,
@@ -95,7 +95,9 @@ class DocumentSerie(models.Model):
 
     def write(self, vals):
         if "internal_sequence_id" in vals:
-            raise ValidationError(_("You cannot change the internal sequence."))
+            raise ValidationError(
+                self.env._("You cannot change the internal sequence.")
+            )
         if "code" in vals:
             for serie in self:
                 if serie.code == vals["code"]:
@@ -108,7 +110,7 @@ class DocumentSerie(models.Model):
                     limit=1,
                 ):
                     raise ValidationError(
-                        _(
+                        self.env._(
                             "You cannot change the code of a document "
                             "serie %(name)s that is already in use.",
                             name=serie.name,

--- a/l10n_br_fiscal/models/ibpt.py
+++ b/l10n_br_fiscal/models/ibpt.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 
 import requests
 
-from odoo import _
+import odoo
 from odoo.exceptions import UserError
 
 WS_SERVICOS = 0
@@ -33,7 +33,7 @@ def _request(ws_url, params, ibpt_request_timeout=30):
             )
         elif response.status_code == requests.codes.forbidden:
             raise UserError(
-                _(
+                odoo.api.Environment._(
                     "IBPT Forbidden - token=%(token)s, cnpj=%(cnpj)s, UF=%(uf)s",
                     token=params.get("token"),
                     cnpj=params.get("cnpj"),
@@ -41,11 +41,25 @@ def _request(ws_url, params, ibpt_request_timeout=30):
                 )
             )
         elif response.status_code == requests.codes.not_found:
-            raise UserError(_("IBPT URL not found - {!r}").format(ws_url))
+            raise UserError(
+                odoo.api.Environment._(
+                    "IBPT URL not found - %(url)s",
+                    url=ws_url,
+                )
+            )
         elif response.status_code == requests.codes.service_unavailable:
-            raise UserError(_("IBPT Service Unavailable - {!r}").format(ws_url))
-    except Exception as e:
-        raise UserError(f"Error in the request: {e}") from e
+            raise UserError(
+                odoo.api.Environment._(
+                    "IBPT Service Unavailable - %s(url)s", url=ws_url
+                )
+            )
+    except Exception as err:
+        raise UserError(
+            odoo.api.Environment._(
+                "Error in the request: %(error)s",
+                error=str(err),
+            )
+        ) from err
 
 
 def get_ibpt_product(

--- a/l10n_br_fiscal/models/invalidate_number.py
+++ b/l10n_br_fiscal/models/invalidate_number.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2014  KMEE - www.kmee.com.br
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 from odoo.exceptions import UserError, ValidationError
 
 from ..constants.fiscal import SITUACAO_EDOC_INUTILIZADA
@@ -93,7 +93,9 @@ class InvalidateNumber(models.Model):
                 ]
 
                 if self.search_count(domain):
-                    raise ValidationError(_("Number range overlap is not allowed."))
+                    raise ValidationError(
+                        self.env._("Number range overlap is not allowed.")
+                    )
         return True
 
     @api.depends("document_type_id", "document_serie_id", "number_start", "number_end")
@@ -107,7 +109,9 @@ class InvalidateNumber(models.Model):
 
     def unlink(self):
         if self.filtered(lambda n: not n.state == "draft"):
-            raise UserError(_("You can delete only draft Invalidate Number Range !"))
+            raise UserError(
+                self.env._("You can delete only draft Invalidate Number Range !")
+            )
         return super().unlink()
 
     def action_invalidate(self):

--- a/l10n_br_fiscal/models/operation.py
+++ b/l10n_br_fiscal/models/operation.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2013  Renato Lima - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import _, fields, models
+from odoo import fields, models
 from odoo.exceptions import UserError
 
 from ..constants.fiscal import (
@@ -192,7 +192,9 @@ class Operation(models.Model):
     def unlink(self):
         operations = self.filtered(lambda line: line.state == "approved")
         if operations:
-            raise UserError(_("You cannot delete an Operation which is not draft !"))
+            raise UserError(
+                self.env._("You cannot delete an Operation which is not draft !")
+            )
         return super().unlink()
 
     def get_document_serie(self, company, document_type):
@@ -302,7 +304,7 @@ class Operation(models.Model):
         if default is None:
             default = {}
         if self.code:
-            default["code"] = self.code + _(" (Copy)")
+            default["code"] = self.code + self.env._(" (Copy)")
 
         res = super().copy(default)
         return res

--- a/l10n_br_fiscal/models/operation_dashboard.py
+++ b/l10n_br_fiscal/models/operation_dashboard.py
@@ -3,7 +3,7 @@
 
 import json
 
-from odoo import _, fields, models
+from odoo import fields, models
 
 from ..constants.fiscal import (
     SITUACAO_EDOC_A_ENVIAR,
@@ -53,9 +53,9 @@ class Operation(models.Model):
         title = ""
         if self.fiscal_type in ("sale", "purchase"):
             title = (
-                _("Bills to pay")
+                self.env._("Bills to pay")
                 if self.fiscal_type == "purchase"
-                else _("Invoices owed to you")
+                else self.env._("Invoices owed to you")
             )
 
         number_2confirm = self._get_number_2confirm_documents()
@@ -117,7 +117,7 @@ class Operation(models.Model):
                 }
             )
         return {
-            "name": _("Create invoice/bill"),
+            "name": self.env._("Create invoice/bill"),
             "type": "ir.actions.act_window",
             "view_type": "form",
             "view_mode": "form",

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2019  Renato Lima - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 from odoo.exceptions import UserError
 
 from ..constants.fiscal import (
@@ -155,7 +155,9 @@ class OperationLine(models.Model):
         else:
             if not company.document_type_id:
                 raise UserError(
-                    _("You need to set a default fiscal document in your company!")
+                    self.env._(
+                        "You need to set a default fiscal document in your company!"
+                    )
                 )
 
             document_type = company.document_type_id
@@ -402,7 +404,7 @@ class OperationLine(models.Model):
         lines = self.filtered(lambda line: line.state == "approved")
         if lines:
             raise UserError(
-                _("You cannot delete an Operation Line which is not draft !")
+                self.env._("You cannot delete an Operation Line which is not draft !")
             )
         return super().unlink()
 
@@ -410,7 +412,7 @@ class OperationLine(models.Model):
     def _onchange_fiscal_operation_id(self):
         if not self.fiscal_operation_id.fiscal_operation_type:
             warning = {
-                "title": _("Warning!"),
-                "message": _("You must first select a operation type."),
+                "title": self.env._("Warning!"),
+                "message": self.env._("You must first select a operation type."),
             }
             return {"warning": warning}

--- a/l10n_br_fiscal/models/partner_profile.py
+++ b/l10n_br_fiscal/models/partner_profile.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2014  KMEE - www.kmee.com.br
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 from odoo.exceptions import ValidationError
 
 from ..constants.fiscal import (
@@ -101,9 +101,9 @@ class PartnerProfile(models.Model):
                 > 1
             ):
                 raise ValidationError(
-                    _(
-                        "Mantenha apenas um tipo fiscal padrão"
-                        " para Pessoa Física ou para Pessoa Jurídica!"
+                    self.env._(
+                        "Maintain only one standard tax type for"
+                        " Individuals or for Legal Entities!"
                     )
                 )
             return True

--- a/l10n_br_fiscal/models/tax_definition.py
+++ b/l10n_br_fiscal/models/tax_definition.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2013  Renato Lima - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 from odoo.exceptions import UserError, ValidationError
 
 from .. import tools
@@ -319,7 +319,7 @@ class TaxDefinition(models.Model):
         operations = self.filtered(lambda line: line.state == "approved")
         if operations:
             raise UserError(
-                _("You cannot delete an Tax Definition which is not draft !")
+                self.env._("You cannot delete an Tax Definition which is not draft !")
             )
         return super().unlink()
 
@@ -537,7 +537,7 @@ class TaxDefinition(models.Model):
 
                 if record.env["l10n_br_fiscal.tax.definition"].search_count(domain):
                     raise ValidationError(
-                        _(
+                        self.env._(
                             "Tax Definition already exists "
                             "for this Partner Profile and Tax Group !"
                         )
@@ -560,7 +560,7 @@ class TaxDefinition(models.Model):
 
                 if record.env["l10n_br_fiscal.tax.definition"].search_count(domain):
                     raise ValidationError(
-                        _(
+                        self.env._(
                             "Tax Definition already exists "
                             "for this Operation Line and Tax Group !"
                         )
@@ -573,7 +573,7 @@ class TaxDefinition(models.Model):
                 domain = self._get_search_domain(record)
                 if record.env["l10n_br_fiscal.tax.definition"].search_count(domain):
                     raise ValidationError(
-                        _(
+                        self.env._(
                             "Tax Definition already exists "
                             "for this ICMS and Tax Group !"
                         )
@@ -592,7 +592,7 @@ class TaxDefinition(models.Model):
 
                 if record.env["l10n_br_fiscal.tax.definition"].search_count(domain):
                     raise ValidationError(
-                        _(
+                        self.env._(
                             "Tax Definition already exists "
                             "for this Company and Tax Group !"
                         )
@@ -611,7 +611,7 @@ class TaxDefinition(models.Model):
 
                 if record.env["l10n_br_fiscal.tax.definition"].search_count(domain):
                     raise ValidationError(
-                        _(
+                        self.env._(
                             "Tax Definition already exists "
                             "for this CFOP and Tax Group !"
                         )
@@ -624,17 +624,19 @@ class TaxDefinition(models.Model):
                 if record.code:
                     if len(record.code) != 8:
                         raise ValidationError(
-                            _("Tax benefit code must be 8 characters!")
+                            self.env._("Tax benefit code must be 8 characters!")
                         )
 
                     if record.code[:2].upper() != record.state_from_id.code.upper():
                         raise ValidationError(
-                            _("Tax benefit code must be start with state code!")
+                            self.env._(
+                                "Tax benefit code must be start with state code!"
+                            )
                         )
 
                     if record.code[3:4] != record.benefit_type:
                         raise ValidationError(
-                            _(
+                            self.env._(
                                 "The tax benefit code must contain "
                                 "the type of benefit!"
                             )


### PR DESCRIPTION
Use env for translatiosns.

PR simples com três alterações:

* atualização na forma definir os textos que deverão ser traduzidos, a partir da v18.0 foi adicionada essa nova forma, ao invés do **_(........)** passou para **self.env._(........)**

* Alteração na forma de incluir variáveis no texto, de acordo com a recomendação da Documentação da OCA
https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#33idioms

<img width="1047" height="241" alt="image" src="https://github.com/user-attachments/assets/0ded0949-dee5-4a3f-be09-8f1974d53caa" />

* Passando textos que estão em Português para Inglês para facilitar a tradução para outras línguas e manter um padrão.

Mais referências sobre isso no PR:

* https://github.com/OCA/l10n-brazil/pull/4408

cc @OCA/local-brazil-maintainers 