### PR TITLE
[18.0][UPD] l10n_br_nfe: Setuptools 82.0.0 deprecated pkg_resources

### DIFF
--- a/l10n_br_nfe/hooks.py
+++ b/l10n_br_nfe/hooks.py
@@ -1,9 +1,9 @@
 # Copyright (C) 2019-2020 - Raphael Valyi Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+import importlib
 import logging
 
 import nfelib
-import pkg_resources
 from nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00 import TnfeProc
 
 from odoo.exceptions import ValidationError
@@ -21,8 +21,9 @@ def post_init_hook(env):
             "35180834128745000152550010000474491454651420-nfe.xml",
         )
         resource_path = "/".join(res_items)
-        nfe_stream = pkg_resources.resource_stream(nfelib.__name__, resource_path)
-        binding = TnfeProc.from_xml(nfe_stream.read().decode())
+        nfe_stream = importlib.resources.files(nfelib.__name__).joinpath(resource_path)
+        with nfe_stream.open("rb") as fp:
+            binding = TnfeProc.from_xml(fp.read().decode())
         document_number = binding.NFe.infNFe.ide.nNF
         existing_nfes = env["l10n_br_fiscal.document"].search(
             [("document_number", "=", document_number)]

--- a/l10n_br_nfe/tests/test_nfe_import.py
+++ b/l10n_br_nfe/tests/test_nfe_import.py
@@ -1,8 +1,9 @@
 # Copyright 2021 - TODAY Akretion - Raphael Valyi <raphael.valyi@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+import importlib
+
 import nfelib
-import pkg_resources
 from nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00 import TnfeProc
 
 from odoo.models import NewId
@@ -20,8 +21,9 @@ class NFeImportTest(TransactionCase):
         )
 
         resource_path = "/".join(res_items)
-        nfe_stream = pkg_resources.resource_stream(nfelib.__name__, resource_path)
-        binding = TnfeProc.from_xml(nfe_stream.read().decode())
+        nfe_stream = importlib.resources.files(nfelib.__name__).joinpath(resource_path)
+        with nfe_stream.open("rb") as fp:
+            binding = TnfeProc.from_xml(fp.read().decode())
         nfe = self.env["l10n_br_fiscal.document"].import_binding_nfe(
             binding, edoc_type="in", dry_run=True
         )
@@ -37,8 +39,9 @@ class NFeImportTest(TransactionCase):
             "35180834128745000152550010000474281920007498-nfe.xml",
         )
         resource_path = "/".join(res_items)
-        nfe_stream = pkg_resources.resource_stream(nfelib.__name__, resource_path)
-        binding = TnfeProc.from_xml(nfe_stream.read().decode())
+        nfe_stream = importlib.resources.files(nfelib.__name__).joinpath(resource_path)
+        with nfe_stream.open("rb") as fp:
+            binding = TnfeProc.from_xml(fp.read().decode())
         nfe = self.env["l10n_br_fiscal.document"].import_binding_nfe(
             binding, edoc_type="in", dry_run=False
         )


### PR DESCRIPTION
Setuptools **82.0.0** deprecated pkg_resources.

* https://github.com/pypa/setuptools/issues/3085

https://setuptools.pypa.io/en/latest/history.html#v82-0-0

<img width="1120" height="235" alt="image" src="https://github.com/user-attachments/assets/60381311-82f6-421f-97e9-23e33215efd1" />

Atualização necessária para adaptar o código a mudança no SetupTools, sem isso ocorre o erro:

```bash
2026-03-27 21:37:51,417 15 CRITICAL odoo odoo.service.server: Failed to initialize database `odoo`. 
Traceback (most recent call last):
  File "/opt/venv/lib/python3.12/site-packages/odoo/service/server.py", line 1366, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

...

  File "/home/odoo/app/external-src/l10n-brazil/l10n_br_nfe/__init__.py", line 3, in <module>
    from .hooks import post_init_hook
  File "/home/odoo/app/external-src/l10n-brazil/l10n_br_nfe/hooks.py", line 6, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```
Usei para a atualização como referencia:

https://docs.python.org/3/library/importlib.resources.html

https://importlib-resources.readthedocs.io/en/latest/migration.html

<img width="750" height="312" alt="image" src="https://github.com/user-attachments/assets/e08a1cbc-307b-443f-9323-258ef885a739" />

cc @OCA/local-brazil-maintainers 