### PR TITLE
[14.0][FIX] l10n_br_fiscal: CBENEF remove check - BCK #4484

### DIFF
--- a/l10n_br_fiscal/models/tax_definition.py
+++ b/l10n_br_fiscal/models/tax_definition.py
@@ -615,11 +615,3 @@ class TaxDefinition(models.Model):
                         raise ValidationError(
                             _("Tax benefit code must be start with state code!")
                         )
-
-                    if record.code[3:4] != record.benefit_type:
-                        raise ValidationError(
-                            _(
-                                "The tax benefit code must contain "
-                                "the type of benefit!"
-                            )
-                        )

--- a/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
@@ -275,6 +275,7 @@
                                         attrs="{'readonly': ['|', ('icms_tax_id', '!=', False), ('icmssn_tax_id', '!=', False)]}"
                                     />
                     <field name="icms_tax_benefit_id" force_save="1" />
+                    <field name="icms_tax_benefit_code" />
                   </group>
                   <group>
                       <group>


### PR DESCRIPTION
@Escodoo HT01872
## Objetivo da PR 

#### O que foi alterado
Removida a validação rígida que comparava code[3:4] com benefit_type em tax_definition.
Mantidas as validações essenciais já existentes:
tamanho do código (8 caracteres),
UF inicial do código compatível com state_from_id.
#### Campo de benefício fiscal na linha fiscal da NF ajustado para permitir edição manual:
- icms_tax_benefit_code deixou de ser apenas related,
- inclusão do campo na tela fiscal de ICMS,
- preenchimento automático do código ao selecionar icms_tax_benefit_id, sem impedir ajuste manual pelo operador.
#### Motivo da alteração
- Adequar o sistema ao processo fiscal real da operação, onde o código CBENEF pode ser definido manualmente no momento da emissão, e evitar rejeição indevida de códigos válidos por uma regra de validação excessivamente restritiva.
#### Resultado esperado
- Operador consegue informar/ajustar CBENEF na emissão da nota quando necessário.
- Campo permanece opcional (não obrigatório).
- Códigos válidos de benefício deixam de ser rejeitados por vínculo forçado com benefit_type.

**Códigos:** 
![WhatsApp Image 2026-03-26 at 16 34 17](https://github.com/user-attachments/assets/0039c008-6692-414d-af47-6b09b92a4ba3)
**Documentação:** [NT2022.002v1.30a - Equiparação Exportação e outras alterações-2.pdf](https://github.com/user-attachments/files/26351146/NT2022.002v1.30a.-.Equiparacao.Exportacao.e.outras.alteracoes-2.pdf)


Relacionado issue #4433