### PR TITLE
[18.0][FIX] l10n_br_base: stop mutating the parent _rec_names_search list

### DIFF
--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -19,8 +19,8 @@ class Partner(models.Model):
     @property
     def _rec_names_search(self):
         names = super()._rec_names_search
-        names += ["cnpj_cpf_stripped", "legal_name", "l10n_br_ie_code"]
-        return names
+        # not "names +=": that would extend the parent class attribute in place
+        return names + ["cnpj_cpf_stripped", "legal_name", "l10n_br_ie_code"]
 
     def _inverse_street_data(self):
         """In Brazil the address format is street_name, street_number

--- a/l10n_br_fiscal_closing/models/closing.py
+++ b/l10n_br_fiscal_closing/models/closing.py
@@ -271,6 +271,48 @@ class FiscalClosing(models.Model):
 
         return domain
 
+    def _prefetch_third_party_attachments(self, documents):
+        """Batch-fetch ir.attachment records for third-party documents.
+
+        Avoids N+1 queries: the original code issued one search() per
+        third-party document inside the _prepare_files loop.  Here we
+        collect all relevant IDs upfront and run at most two queries total.
+
+        Returns a dict mapping document.id -> ir.attachment recordset.
+        """
+        third_party_docs = documents.filtered(
+            lambda d: d.issuer != DOCUMENT_ISSUER_COMPANY
+        )
+        attaches_by_doc = {}
+        if not third_party_docs:
+            return attaches_by_doc
+
+        if hasattr(self.env["l10n_br_fiscal.document"], "move_ids"):
+            all_move_ids = third_party_docs.mapped("move_ids").ids
+            attaches_by_move = {}
+            if all_move_ids:
+                for att in self.env["ir.attachment"].search(
+                    [("res_model", "=", "account.move"), ("res_id", "in", all_move_ids)]
+                ):
+                    attaches_by_move.setdefault(att.res_id, []).append(att)
+            for doc in third_party_docs:
+                atts = self.env["ir.attachment"]
+                for move_id in doc.move_ids.ids:
+                    for att in attaches_by_move.get(move_id, []):
+                        atts |= att
+                attaches_by_doc[doc.id] = atts
+        else:
+            for att in self.env["ir.attachment"].search(
+                [
+                    ("res_model", "=", "l10n_br_fiscal.document"),
+                    ("res_id", "in", third_party_docs.ids),
+                ]
+            ):
+                attaches_by_doc.setdefault(att.res_id, self.env["ir.attachment"])
+                attaches_by_doc[att.res_id] |= att
+
+        return attaches_by_doc
+
     def _prepare_files(self, temp_dir):
         domain = self._document_domain()
         documents = self.env["l10n_br_fiscal.document"].search(domain)
@@ -298,6 +340,8 @@ class FiscalClosing(models.Model):
                     _("Error!"), _("Check write permissions in your system temp folder")
                 ) from e
 
+        attaches_by_doc = self._prefetch_third_party_attachments(documents)
+
         for document in documents:
             if document.issuer == DOCUMENT_ISSUER_COMPANY:
                 attachment_ids = document.authorization_event_id.mapped(
@@ -310,20 +354,9 @@ class FiscalClosing(models.Model):
                 if self.include_pdf_file:
                     attachment_ids |= document.file_report_id
             else:
-                if hasattr(document, "move_ids"):
-                    attachment_ids = self.env["ir.attachment"].search(
-                        [
-                            ("res_model", "=", "account.move"),
-                            ("res_id", "in", document.move_ids.ids),
-                        ]
-                    )
-                else:
-                    attachment_ids = self.env["ir.attachment"].search(
-                        [
-                            ("res_model", "=", "l10n_br_fiscal.document"),
-                            ("res_id", "=", document.id),
-                        ]
-                    )
+                attachment_ids = attaches_by_doc.get(
+                    document.id, self.env["ir.attachment"]
+                )
 
             if self.export_type == "period":
                 document.close_id = self.id


### PR DESCRIPTION
`res.partner._rec_names_search` is a plain class attribute list. The property in `l10n_br_base` reads it through `super()` and extends it with `names +=`, which is `list.__iadd__` and therefore extends **that very list** in place instead of building a new one.

So every access to the property appends three more entries to the parent class attribute, permanently, and the list grows without bound:

| access | fields |
| --- | --- |
| 1 | 8 |
| 2 | 11 |
| 3 | 14 |
| n | 5 + 3n |

`BaseModel._name_search` builds an OR chain over those fields, so the SQL generated for a partner name search keeps growing until PostgreSQL gives up with:

```
ERROR: memory exhausted at or near "("
```

The fix returns a new list instead of extending the parent one in place.

Note that the Odoo base `res.partner` does **not** declare `cnpj_cpf_stripped`, `legal_name` or `l10n_br_ie_code`, so there is no overlap with the core list and no deduplication is needed: with `+` instead of `+=` the field can never be added twice.

The mechanism reproduces without Odoo:

```python
class BasePartner:  # like res.partner in Odoo core
    _rec_names_search = ["complete_name", "email", "ref", "vat", "company_registry"]

class BrPartner(BasePartner):
    @property
    def _rec_names_search(self):
        names = super()._rec_names_search
        names += ["cnpj_cpf_stripped", "legal_name", "l10n_br_ie_code"]
        return names

p = BrPartner()
print([len(p._rec_names_search) for _ in range(6)])
# [8, 11, 14, 17, 20, 23]
print(len(BasePartner._rec_names_search))
# 23   <- the class attribute of the parent was mutated
```

Replacing `names +=` with `return names + [...]` gives `[8, 8, 8, 8, 8, 8]` and leaves the parent list at 5.
