### PR TITLE
[16.0][FIX] l10n_br_base: stop mutating the parent _rec_names_search list

### DIFF
--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -19,8 +19,8 @@ class Partner(models.Model):
     @property
     def _rec_names_search(self):
         names = super()._rec_names_search
-        names += ["cnpj_cpf_stripped", "legal_name", "l10n_br_ie_code"]
-        return names
+        # not "names +=": that would extend the parent class attribute in place
+        return names + ["cnpj_cpf_stripped", "legal_name", "l10n_br_ie_code"]
 
     def _inverse_street_data(self):
         """In Brazil the address format is street_name, street_number


### PR DESCRIPTION
Série 16.0 do mesmo fix da #4482.

`res.partner._rec_names_search` is a plain class attribute list. In Odoo 16 the base declares:

```python
_rec_names_search = ['display_name', 'email', 'ref', 'vat', 'company_registry']
```

The property in `l10n_br_base` reads it through `super()` and extends it with `names +=`, which is `list.__iadd__` and therefore extends **that very list** in place instead of building a new one.

So every access to the property appends three more entries to the parent class attribute, permanently, and the list grows without bound:

| access | fields |
| --- | --- |
| 1 | 8 |
| 2 | 11 |
| 3 | 14 |
| n | 5 + 3n |

`BaseModel._name_search` builds an OR chain over those fields, so the SQL generated for a partner name search keeps growing until PostgreSQL gives up with:

```
ERROR: memory exhausted at or near "("
```

The fix returns a new list instead of extending the parent one in place.

Note that the Odoo base `res.partner` does **not** declare `cnpj_cpf_stripped`, `legal_name` or `l10n_br_ie_code` — neither in 16.0 nor in 18.0 — so there is no overlap with the core list and no deduplication is needed: with `+` instead of `+=` a field can never be added twice.

The mechanism reproduces without Odoo:

```python
class BasePartner:  # like res.partner in Odoo 16 core
    _rec_names_search = ["display_name", "email", "ref", "vat", "company_registry"]

class BrPartner(BasePartner):
    @property
    def _rec_names_search(self):
        names = super()._rec_names_search
        names += ["cnpj_cpf_stripped", "legal_name", "l10n_br_ie_code"]
        return names

p = BrPartner()
print([len(p._rec_names_search) for _ in range(6)])
# [8, 11, 14, 17, 20, 23]
print(len(BasePartner._rec_names_search))
# 23   <- the class attribute of the parent was mutated
```
