### PR TITLE
[16.0][FIX] l10n_br_fiscal: CBENEF remove check

### DIFF
--- a/l10n_br_fiscal/models/tax_definition.py
+++ b/l10n_br_fiscal/models/tax_definition.py
@@ -664,11 +664,3 @@ class TaxDefinition(models.Model):
                         raise ValidationError(
                             _("Tax benefit code must be start with state code!")
                         )
-
-                    if record.code[3:4] != record.benefit_type:
-                        raise ValidationError(
-                            _(
-                                "The tax benefit code must contain "
-                                "the type of benefit!"
-                            )
-                        )

--- a/l10n_br_fiscal/views/document_line_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_line_mixin_view.xml
@@ -307,6 +307,7 @@
                                         attrs="{'readonly': ['|', ('icms_tax_id', '!=', False), ('icmssn_tax_id', '!=', False)]}"
                                     />
                                     <field name="icms_tax_benefit_id" force_save="1" />
+                                    <field name="icms_tax_benefit_code" />
                                 </group>
                                 <group>
                                     <group>


### PR DESCRIPTION
## Objetivo da PR 
#### O que foi alterado
Removida a validação rígida que comparava code[3:4] com benefit_type em tax_definition.
Colocado o Código do CBENEF na view

**Códigos:** 
![WhatsApp Image 2026-03-26 at 16 34 17](https://github.com/user-attachments/assets/0039c008-6692-414d-af47-6b09b92a4ba3)
**Documentação:** [NT2022.002v1.30a - Equiparação Exportação e outras alterações-2.pdf](https://github.com/user-attachments/files/26351146/NT2022.002v1.30a.-.Equiparacao.Exportacao.e.outras.alteracoes-2.pdf)

Related #4476

cc @marcelsavegnago @rvalyi @antoniospneto 