### PR TITLE
Fix invalid broken symlink

### DIFF
--- a/setup/l10n_br_sped_ecd/odoo/addons/l10n_br_sped_ecd
+++ b/setup/l10n_br_sped_ecd/odoo/addons/l10n_br_sped_ecd
@@ -1,1 +1,1 @@
-../../../l10n_br_sped_ecd
+../../../../l10n_br_sped_ecd


### PR DESCRIPTION
@rvalyi @renatonlima The symlink is broken and this block the oca module parsing.

Thanks for merging it