### PR TITLE
[14.0][FIX] l10n_br_cte: field cte40_vTotDFe

### DIFF
--- a/l10n_br_cte/models/document.py
+++ b/l10n_br_cte/models/document.py
@@ -771,8 +771,14 @@ class CTe(spec_models.StackedModel):
         digits=(3, 2),
         compute="_compute_cte40_ibscbs_fields",
     )
+    cte40_vTotDFe = fields.Monetary(
+        string="Valor total do documento fiscal",
+        compute="_compute_cte40_ibscbs_fields",
+        currency_field="brl_currency_id",
+    )
 
     @api.depends(
+        "amount_total",
         "fiscal_line_ids.ibs_base",
         "fiscal_line_ids.cbs_base",
         "fiscal_line_ids.price_gross",
@@ -794,6 +800,7 @@ class CTe(spec_models.StackedModel):
                 record.cte40_pIBSUF = 0.0
                 record.cte40_pIBSMun = 0.0
                 record.cte40_pCBS = 0.0
+                record.cte40_vTotDFe = 0.0
                 continue
 
             first = lines[0]
@@ -821,6 +828,20 @@ class CTe(spec_models.StackedModel):
             record.cte40_pIBSUF = p_ibs_uf
             record.cte40_pIBSMun = p_ibs_mun
             record.cte40_pCBS = p_cbs
+
+            year = datetime.now().year
+            if record.cte40_vIBS or record.cte40_vCBS:
+                if year <= 2026:
+                    # Exceção: em 2026 não soma IBS e CBS
+                    record.cte40_vTotDFe = record.amount_total or 0.0
+                else:
+                    record.cte40_vTotDFe = (
+                        (record.amount_total or 0.0)
+                        + record.cte40_vIBS
+                        + record.cte40_vCBS
+                    )
+            else:
+                record.cte40_vTotDFe = 0.0
 
     # ##########################
     # # CT-e tag: ICMSUFFim


### PR DESCRIPTION
Fix #4485

## Objetivo da PR 

[CTe_Nota_Tecnica_2025_001_RTC_v1.14a.pdf](https://github.com/user-attachments/files/26707904/CTe_Nota_Tecnica_2025_001_RTC_v1.14a.pdf)

Segundo documentação Tecnica:
**Exceção: Em 2026 não somar IBS e CBS, usando a fórmula:**
`vTotDFe = vPrest/vTPrest`

<img width="792" height="358" alt="image" src="https://github.com/user-attachments/assets/e464d2fd-5cd5-4eca-a20b-68a1b5f4afb8" />

CT-E testado em Homologação com a reforma tributaria e autorizado
cc @antoniospneto @marcelsavegnago @rvalyi  @WesleyOliveira98 @kaynnan 