### PR TITLE
[16.0] l10n_br_account, l10n_br_purchase_stock: stock_picking_bill_matching compat

### DIFF
--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -43,6 +43,16 @@ class AccountMoveLine(models.Model):
         " and '3-3' for the last installment.",
     )
 
+    # forcing store=True for these fields makes it easier to plug in SQL bill
+    # reconciliation and makes it compatible with the
+    # stock_picking_bill_matching module for instance.
+    partner_order = fields.Char(
+        related="fiscal_document_line_id.partner_order", store=True
+    )
+    partner_order_line = fields.Char(
+        related="fiscal_document_line_id.partner_order_line", store=True
+    )
+
     # -------------------------------------------------------------------------
     # SHADOWED FIELDS SYNC
     # These fields have the same name in account.move.line

--- a/l10n_br_purchase_stock/models/__init__.py
+++ b/l10n_br_purchase_stock/models/__init__.py
@@ -4,3 +4,4 @@ from . import purchase_order_line
 from . import res_config_settings
 from . import stock_move
 from . import stock_picking
+from . import account_move_line

--- a/l10n_br_purchase_stock/models/account_move_line.py
+++ b/l10n_br_purchase_stock/models/account_move_line.py
@@ -1,0 +1,19 @@
+# Copyright (C) 2026  Raphaël Valyi - Akretion
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import api, models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    @api.model
+    def _get_bill_matching_reference_sql(self, alias):
+        """
+        Duck-typing hook picked up dynamically by `stock_picking_bill_matching`.
+        The `alias` argument (e.g., 'aml' or 'sm') is passed by the SQL view builder.
+        """
+        return (
+            f"NULLIF(COALESCE({alias}.partner_order, '') || '-' "
+            f"|| COALESCE({alias}.partner_order_line, ''), '-')"
+        )

--- a/l10n_br_purchase_stock/models/stock_move.py
+++ b/l10n_br_purchase_stock/models/stock_move.py
@@ -2,7 +2,7 @@
 #   Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import models
+from odoo import api, models
 
 
 class StockMove(models.Model):
@@ -18,3 +18,14 @@ class StockMove(models.Model):
                 result = self.purchase_line_id.price_unit
 
         return result
+
+    @api.model
+    def _get_bill_matching_reference_sql(self, alias):
+        """
+        Duck-typing hook picked up dynamically by `stock_picking_bill_matching`.
+        The `alias` argument (e.g., 'aml' or 'sm') is passed by the SQL view builder.
+        """
+        return (
+            f"NULLIF(COALESCE({alias}.partner_order, '') || '-' "
+            f"|| COALESCE({alias}.partner_order_line, ''), '-')"
+        )


### PR DESCRIPTION
compatibilidade da localização com o modulo stock_picking_bill_matching aqui https://github.com/OCA/stock-logistics-workflow/pull/2310  
Em especial essa mudança aqui faz aparecer os campos xPed e nItemPed vindo do pedido de compra e da NFe importada na coluna Matching Ref. da tela de conciliação para facilitar a conciliação.