### PR TITLE
[16.0] l10n_br_account, l10n_br_account_nfe: fix NFe import

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -756,6 +756,10 @@ class AccountMove(models.Model):
                     }
                 )
 
+                # amount_tax_(not_)included are NOT repeated here: they are
+                # delegated to the fiscal line through _inherits and writing
+                # them along with a new fiscal_document_line_id in the same
+                # vals would be ambiguous (old or new parent record?).
                 invoice_line_write_vals.append(
                     (
                         1,
@@ -764,8 +768,6 @@ class AccountMove(models.Model):
                             "product_uom_id": item["uot_id"],
                             "price_unit": item["price_unit"],
                             "fiscal_document_line_id": item["fiscal_line_id"],
-                            "amount_tax_included": item["amt_inc"],
-                            "amount_tax_not_included": item["amt_not_inc"],
                         },
                     )
                 )

--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -116,28 +116,27 @@ class AccountMove(models.Model):
     def create(self, vals_list):
         for vals in vals_list:
             self._sync_proxy_fields_vals(vals)
-            # Prevent Odoo's tax_totals widget from obliterating our
-            # exact XML tax calculations
-            if "tax_totals" in vals and (
-                vals.get("imported_document")
-                or self.env.context.get("force_fiscal_amount_recompute")
-            ):
-                vals.pop("tax_totals")
         return super().create(vals_list)
 
     def write(self, vals):
         self._sync_proxy_fields_vals(vals)
-        # Pop tax_totals to prevent Odoo from overriding our tax lines on save
-        if "tax_totals" in vals and (
-            any(self.mapped("imported_document"))
-            or self.env.context.get("force_fiscal_amount_recompute")
-        ):
-            vals.pop("tax_totals")
-
         res = super().write(vals)
         if "partner_id" in vals:
             self._onchange_ind_final()
         return res
+
+    def _inverse_tax_totals(self):
+        # Never let the tax_totals widget override the exact tax values
+        # of an imported fiscal document.
+        if self.env.context.get("force_fiscal_amount_recompute"):
+            # Import flow: the move is still being assembled and
+            # imported_document may not be written yet, so skip the
+            # inverse for the whole batch.
+            return
+        # Regular (UI) flow: run the standard inverse only for the moves
+        # that are not the mirror of an imported fiscal document.
+        moves = self.filtered(lambda move: not move.imported_document)
+        return super(AccountMove, moves)._inverse_tax_totals()
 
     @api.constrains("fiscal_document_id", "document_type_id")
     def _check_fiscal_document_type(self):

--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -718,6 +718,8 @@ class AccountMove(models.Model):
                     + (line.ipi_value or 0.0)
                     + (line.ii_value or 0.0)
                     + (line.icmsfcpst_value or 0.0)
+                    + (line.ibs_value or 0.0)
+                    + (line.cbs_value or 0.0)
                 )
 
                 unit_and_prices.append(

--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -116,10 +116,24 @@ class AccountMove(models.Model):
     def create(self, vals_list):
         for vals in vals_list:
             self._sync_proxy_fields_vals(vals)
+            # Prevent Odoo's tax_totals widget from obliterating our
+            # exact XML tax calculations
+            if "tax_totals" in vals and (
+                vals.get("imported_document")
+                or self.env.context.get("force_fiscal_amount_recompute")
+            ):
+                vals.pop("tax_totals")
         return super().create(vals_list)
 
     def write(self, vals):
         self._sync_proxy_fields_vals(vals)
+        # Pop tax_totals to prevent Odoo from overriding our tax lines on save
+        if "tax_totals" in vals and (
+            any(self.mapped("imported_document"))
+            or self.env.context.get("force_fiscal_amount_recompute")
+        ):
+            vals.pop("tax_totals")
+
         res = super().write(vals)
         if "partner_id" in vals:
             self._onchange_ind_final()
@@ -245,20 +259,14 @@ class AccountMove(models.Model):
         "fiscal_line_ids.fiscal_amount_tax",
     )
     def _compute_amount(self):
-        if "force_fiscal_amount_recompute" in self._context:
-            for move in self.filtered(lambda m: m.fiscal_operation_id):
-                # this is a ugly hack required for importing composite
-                # fiscal documents for instance. It should be used
-                # exceptionnaly as it breaks the dependency chain and
-                # can leave fields such as payment_state inconsistent.
-                move._compute_fiscal_amount()
-
         result = super()._compute_amount()
         for move in self.filtered(lambda m: m.fiscal_operation_id):
             sign = -move.direction_sign
             inv_line_ids = move.line_ids.filtered(
-                lambda line: line.display_type == "product"
-                and (not line.cfop_id or line.cfop_id.finance_move)
+                lambda line: (
+                    line.display_type == "product"
+                    and (not line.cfop_id or line.cfop_id.finance_move)
+                )
             )
             move.amount_untaxed = sum(inv_line_ids.mapped("fiscal_amount_untaxed"))
             move.amount_tax = sum(inv_line_ids.mapped("fiscal_amount_tax"))
@@ -359,6 +367,7 @@ class AccountMove(models.Model):
                                 "amount_currency"
                             ]
                 if not invoice.needed_terms:
+                    invoice.needed_terms = {}
                     invoice.needed_terms[
                         frozendict(
                             {
@@ -442,8 +451,9 @@ class AccountMove(models.Model):
     @api.depends("move_type", "fiscal_operation_id")
     def _compute_journal_id(self):
         fisc_operation_driven = self.filtered(
-            lambda move: move.fiscal_operation_id
-            and move.fiscal_operation_id.journal_id
+            lambda move: (
+                move.fiscal_operation_id and move.fiscal_operation_id.journal_id
+            )
         )
         for move in fisc_operation_driven:
             move.journal_id = self.fiscal_operation_id.journal_id
@@ -664,13 +674,17 @@ class AccountMove(models.Model):
             move = self.env["account.move"].browse(move_id)
         else:
             move = self.env["account.move"]
+
         move_form = Form(
             move.with_context(
                 default_move_type=move_type,
                 account_predictive_bills_disable_prediction=True,
                 force_fiscal_amount_recompute=True,
+                check_move_validity=False,
+                # Prevent early unbalance crashes during saving
             )
         )
+
         if not move_id or not move.fiscal_document_id:
             move_form.partner_id = fiscal_document.partner_id
             move_form.invoice_date = fiscal_document.document_date
@@ -680,22 +694,87 @@ class AccountMove(models.Model):
             move_form.fiscal_operation_id = fiscal_document.fiscal_operation_id
             move_form.document_serie = fiscal_document.document_serie
 
-        unit_and_prices = []  # save units to force them later
+        unit_and_prices = []
         for line in fiscal_document.fiscal_line_ids:
             with move_form.invoice_line_ids.new() as line_form:
-                line_form.cfop_id = (
-                    line.cfop_id
-                )  # required if we disable some fiscal tax updates
-                line_form.fiscal_operation_id = self.fiscal_operation_id
+                line_form.cfop_id = line.cfop_id
+                line_form.fiscal_operation_id = (
+                    line.fiscal_operation_id or fiscal_document.fiscal_operation_id
+                )
+                line_form.product_id = line.product_id
+                line_form.quantity = line.quantity
                 line_form.fiscal_document_line_id = line
-                # for some reason trying to set the product_uom_id
-                # here results in strange bugs like unbalanced move
-                # so we will force product_uom_id later
-                # we also save price_unit to reset unit factor effect
-                unit_and_prices.append((line.uot_id.id, line.price_unit))
+
+                # SEFAZ Standard: What is included in vProd?
+                amt_inc = (
+                    (line.icms_value or 0.0)
+                    + (line.pis_value or 0.0)
+                    + (line.cofins_value or 0.0)
+                    + (line.issqn_value or 0.0)
+                    + (line.icmsfcp_value or 0.0)
+                )
+                amt_not_inc = (
+                    (line.icmsst_value or 0.0)
+                    + (line.ipi_value or 0.0)
+                    + (line.ii_value or 0.0)
+                    + (line.icmsfcpst_value or 0.0)
+                )
+
+                unit_and_prices.append(
+                    {
+                        "uot_id": line.uot_id.id if line.uot_id else False,
+                        "price_unit": line.price_unit,
+                        "fiscal_line_id": line.id,
+                        "amt_inc": amt_inc,
+                        "amt_not_inc": amt_not_inc,
+                    }
+                )
+
         move_form.save()
         move = self.env["account.move"].browse(move_form.id)
+
+        invoice_line_write_vals = []
+        dummy_lines_to_unlink = self.env["l10n_br_fiscal.document.line"]
+
         for index, item in enumerate(unit_and_prices):
-            move.invoice_line_ids[index].product_uom_id = item[0]
-            move.invoice_line_ids[index].price_unit = item[1]
+            if index < len(move.invoice_line_ids):
+                aml = move.invoice_line_ids[index]
+                dummy_fiscal_line = aml.fiscal_document_line_id
+
+                if dummy_fiscal_line and dummy_fiscal_line.id != item["fiscal_line_id"]:
+                    dummy_lines_to_unlink |= dummy_fiscal_line
+
+                # Pre-populate exact tax values into the fiscal line
+                # directly to bypass Form stripping
+                self.env["l10n_br_fiscal.document.line"].browse(
+                    item["fiscal_line_id"]
+                ).write(
+                    {
+                        "amount_tax_included": item["amt_inc"],
+                        "amount_tax_not_included": item["amt_not_inc"],
+                    }
+                )
+
+                invoice_line_write_vals.append(
+                    (
+                        1,
+                        aml.id,
+                        {
+                            "product_uom_id": item["uot_id"],
+                            "price_unit": item["price_unit"],
+                            "fiscal_document_line_id": item["fiscal_line_id"],
+                            "amount_tax_included": item["amt_inc"],
+                            "amount_tax_not_included": item["amt_not_inc"],
+                        },
+                    )
+                )
+
+        # Write safely bypassing strict validity checks mid-loop
+        move.with_context(check_move_validity=False).write(
+            {"invoice_line_ids": invoice_line_write_vals}
+        )
+
+        if dummy_lines_to_unlink:
+            dummy_lines_to_unlink.unlink()
+
         return move_form

--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -389,6 +389,84 @@ class AccountMoveLine(models.Model):
                 subtotal = line.quantity * line_discount_price_unit
                 line.price_total = line.price_subtotal = subtotal
 
+    # Ordered rules to classify an account.tax into a Brazilian tax kind
+    # from its domain/name. Each entry is (kind, include_kw, exclude_kw).
+    # Order matters: "icmsst" must be tested before "icms", etc.
+    _IMPORTED_TAX_MATCH_RULES = [
+        ("icmsst", ["icmsst", "icms_st", "icms st"], []),
+        ("icms", ["icms"], ["st", "wh", "ret"]),
+        ("ipi", ["ipi"], ["wh", "ret"]),
+        ("pis", ["pis"], ["st", "wh", "ret"]),
+        ("cofins", ["cofins"], ["st", "wh", "ret"]),
+        ("issqn", ["issqn", "iss"], ["inss", "wh", "ret"]),
+        ("ii", ["ii"], ["wh", "ret"]),
+        ("ibs", ["ibs"], ["wh", "ret"]),
+        ("cbs", ["cbs"], ["wh", "ret"]),
+    ]
+
+    # kind -> (fiscal_value_field, fiscal_base_field)
+    _IMPORTED_TAX_FIELD_MAP = {
+        "icmsst": ("icmsst_value", "icmsst_base"),
+        "icms": ("icms_value", "icms_base"),
+        "ipi": ("ipi_value", "ipi_base"),
+        "pis": ("pis_value", "pis_base"),
+        "cofins": ("cofins_value", "cofins_base"),
+        "issqn": ("issqn_value", "issqn_base"),
+        "ii": ("ii_value", "ii_base"),
+        "ibs": ("ibs_value", "ibs_base"),
+        "cbs": ("cbs_value", "cbs_base"),
+    }
+
+    def _resolve_tax_kind(self, tax_dict):
+        """Resolve the Brazilian tax kind from a compute_all tax dict.
+
+        Tries the account.tax tax_domain first, then falls back to
+        heuristic name matching against ``_IMPORTED_TAX_MATCH_RULES``.
+        Returns a kind string (e.g. "icms") or "".
+        """
+        domain = ""
+        acc_tax = (
+            self.env["account.tax"].browse(tax_dict["id"])
+            if tax_dict.get("id")
+            else None
+        )
+        if not acc_tax and tax_dict.get("tax_repartition_line_id"):
+            acc_tax = (
+                self.env["account.tax.repartition.line"]
+                .browse(tax_dict["tax_repartition_line_id"])
+                .tax_id
+            )
+        if acc_tax:
+            if hasattr(acc_tax, "tax_domain") and acc_tax.tax_domain:
+                domain = acc_tax.tax_domain
+            elif hasattr(acc_tax, "fiscal_tax_ids") and acc_tax.fiscal_tax_ids:
+                domain = acc_tax.fiscal_tax_ids[0].tax_domain
+        if not domain:
+            domain = tax_dict.get("name", "").lower()
+
+        for kind, include_kw, exclude_kw in self._IMPORTED_TAX_MATCH_RULES:
+            if any(kw in domain for kw in include_kw) and not any(
+                kw in domain for kw in exclude_kw
+            ):
+                return kind
+        return ""
+
+    def _override_taxes_from_import(self, taxes, fiscal_line, sign):
+        """Override compute_all tax amounts with imported fiscal values."""
+        for tax in taxes:
+            kind = self._resolve_tax_kind(tax)
+            fields = self._IMPORTED_TAX_FIELD_MAP.get(kind)
+            if fields:
+                tax["amount"] = sign * (getattr(fiscal_line, fields[0]) or 0.0)
+                tax["base"] = sign * (getattr(fiscal_line, fields[1]) or 0.0)
+            elif (
+                "wh" in tax.get("name", "").lower()
+                or "ret" in tax.get("name", "").lower()
+            ):
+                # Clear withholding taxes: XML doesn't bring WH item per item
+                tax["amount"] = 0.0
+                tax["base"] = 0.0
+
     @api.depends(
         "tax_ids",
         "currency_id",
@@ -482,100 +560,11 @@ class AccountMoveLine(models.Model):
                 line.fiscal_document_line_id
                 and line.fiscal_document_line_id.document_id.imported_document
             ):
-                fiscal_line = line.fiscal_document_line_id
-                for tax in compute_all_currency["taxes"]:
-                    # Resolve domain gracefully using OCA l10n_br mapped configurations
-                    domain = ""
-                    acc_tax = (
-                        self.env["account.tax"].browse(tax.get("id"))
-                        if tax.get("id")
-                        else None
-                    )
-                    if not acc_tax and tax.get("tax_repartition_line_id"):
-                        acc_tax = (
-                            self.env["account.tax.repartition.line"]
-                            .browse(tax["tax_repartition_line_id"])
-                            .tax_id
-                        )
-
-                    if acc_tax:
-                        if hasattr(acc_tax, "tax_domain") and acc_tax.tax_domain:
-                            domain = acc_tax.tax_domain
-                        elif (
-                            hasattr(acc_tax, "fiscal_tax_ids")
-                            and acc_tax.fiscal_tax_ids
-                        ):
-                            domain = acc_tax.fiscal_tax_ids[0].tax_domain
-
-                    # Fallback to name matching ONLY if domain
-                    # is not configured properly
-                    if not domain:
-                        domain = tax.get("name", "").lower()
-
-                    match = ""
-                    if "icmsst" in domain or "icms_st" in domain or "icms st" in domain:
-                        match = "icmsst"
-                    elif (
-                        "icms" in domain
-                        and "st" not in domain
-                        and "wh" not in domain
-                        and "ret" not in domain
-                    ):
-                        match = "icms"
-                    elif "ipi" in domain and "wh" not in domain and "ret" not in domain:
-                        match = "ipi"
-                    elif (
-                        "pis" in domain
-                        and "st" not in domain
-                        and "wh" not in domain
-                        and "ret" not in domain
-                    ):
-                        match = "pis"
-                    elif (
-                        "cofins" in domain
-                        and "st" not in domain
-                        and "wh" not in domain
-                        and "ret" not in domain
-                    ):
-                        match = "cofins"
-                    elif (
-                        ("issqn" in domain or "iss" in domain)
-                        and "inss" not in domain
-                        and "wh" not in domain
-                        and "ret" not in domain
-                    ):
-                        match = "issqn"
-                    elif "ii" in domain and "wh" not in domain and "ret" not in domain:
-                        match = "ii"
-
-                    if match == "icmsst":
-                        tax["amount"] = sign * (fiscal_line.icmsst_value or 0.0)
-                        tax["base"] = sign * (fiscal_line.icmsst_base or 0.0)
-                    elif match == "icms":
-                        tax["amount"] = sign * (fiscal_line.icms_value or 0.0)
-                        tax["base"] = sign * (fiscal_line.icms_base or 0.0)
-                    elif match == "ipi":
-                        tax["amount"] = sign * (fiscal_line.ipi_value or 0.0)
-                        tax["base"] = sign * (fiscal_line.ipi_base or 0.0)
-                    elif match == "pis":
-                        tax["amount"] = sign * (fiscal_line.pis_value or 0.0)
-                        tax["base"] = sign * (fiscal_line.pis_base or 0.0)
-                    elif match == "cofins":
-                        tax["amount"] = sign * (fiscal_line.cofins_value or 0.0)
-                        tax["base"] = sign * (fiscal_line.cofins_base or 0.0)
-                    elif match == "issqn":
-                        tax["amount"] = sign * (fiscal_line.issqn_value or 0.0)
-                        tax["base"] = sign * (fiscal_line.issqn_base or 0.0)
-                    elif match == "ii":
-                        tax["amount"] = sign * (fiscal_line.ii_value or 0.0)
-                        tax["base"] = sign * (fiscal_line.ii_base or 0.0)
-                    else:
-                        # Clear withholding taxes if they were matched
-                        # inadvertently by default logic.
-                        # XML doesn't bring WH item per item.
-                        if "wh" in domain or "ret" in domain:
-                            tax["amount"] = 0.0
-                            tax["base"] = 0.0
+                self._override_taxes_from_import(
+                    compute_all_currency["taxes"],
+                    line.fiscal_document_line_id,
+                    sign,
+                )
 
             line.compute_all_tax = {
                 frozendict(

--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -103,10 +103,12 @@ class AccountMoveLine(models.Model):
         payment term lines. For other lines, it calls the superclass method.
         """
         payment_term_lines = self.filtered(
-            lambda line: line.display_type == "payment_term"
-            and line.document_type_id
-            and line.move_id.document_number
-            and line.payment_term_number
+            lambda line: (
+                line.display_type == "payment_term"
+                and line.document_type_id
+                and line.move_id.document_number
+                and line.payment_term_number
+            )
         )
         for line in payment_term_lines:
             # set label for payment term lines. Ex: '0001/1-3'
@@ -414,6 +416,8 @@ class AccountMoveLine(models.Model):
         "icmssn_range_id",
         "icms_origin",
         "ind_final",
+        "fiscal_document_line_id",
+        "fiscal_document_line_id.document_id.imported_document",
     )
     def _compute_all_tax(self):
         """
@@ -437,6 +441,7 @@ class AccountMoveLine(models.Model):
                 amount_currency = line.amount_currency
                 handle_price_include = False
                 quantity = 1
+
             compute_all_currency = line.tax_ids.compute_all(
                 amount_currency,
                 currency=line.currency_id,
@@ -472,6 +477,106 @@ class AccountMoveLine(models.Model):
                 else 1
             )
             line.compute_all_tax_dirty = True
+
+            if (
+                line.fiscal_document_line_id
+                and line.fiscal_document_line_id.document_id.imported_document
+            ):
+                fiscal_line = line.fiscal_document_line_id
+                for tax in compute_all_currency["taxes"]:
+                    # Resolve domain gracefully using OCA l10n_br mapped configurations
+                    domain = ""
+                    acc_tax = (
+                        self.env["account.tax"].browse(tax.get("id"))
+                        if tax.get("id")
+                        else None
+                    )
+                    if not acc_tax and tax.get("tax_repartition_line_id"):
+                        acc_tax = (
+                            self.env["account.tax.repartition.line"]
+                            .browse(tax["tax_repartition_line_id"])
+                            .tax_id
+                        )
+
+                    if acc_tax:
+                        if hasattr(acc_tax, "tax_domain") and acc_tax.tax_domain:
+                            domain = acc_tax.tax_domain
+                        elif (
+                            hasattr(acc_tax, "fiscal_tax_ids")
+                            and acc_tax.fiscal_tax_ids
+                        ):
+                            domain = acc_tax.fiscal_tax_ids[0].tax_domain
+
+                    # Fallback to name matching ONLY if domain
+                    # is not configured properly
+                    if not domain:
+                        domain = tax.get("name", "").lower()
+
+                    match = ""
+                    if "icmsst" in domain or "icms_st" in domain or "icms st" in domain:
+                        match = "icmsst"
+                    elif (
+                        "icms" in domain
+                        and "st" not in domain
+                        and "wh" not in domain
+                        and "ret" not in domain
+                    ):
+                        match = "icms"
+                    elif "ipi" in domain and "wh" not in domain and "ret" not in domain:
+                        match = "ipi"
+                    elif (
+                        "pis" in domain
+                        and "st" not in domain
+                        and "wh" not in domain
+                        and "ret" not in domain
+                    ):
+                        match = "pis"
+                    elif (
+                        "cofins" in domain
+                        and "st" not in domain
+                        and "wh" not in domain
+                        and "ret" not in domain
+                    ):
+                        match = "cofins"
+                    elif (
+                        ("issqn" in domain or "iss" in domain)
+                        and "inss" not in domain
+                        and "wh" not in domain
+                        and "ret" not in domain
+                    ):
+                        match = "issqn"
+                    elif "ii" in domain and "wh" not in domain and "ret" not in domain:
+                        match = "ii"
+
+                    if match == "icmsst":
+                        tax["amount"] = sign * (fiscal_line.icmsst_value or 0.0)
+                        tax["base"] = sign * (fiscal_line.icmsst_base or 0.0)
+                    elif match == "icms":
+                        tax["amount"] = sign * (fiscal_line.icms_value or 0.0)
+                        tax["base"] = sign * (fiscal_line.icms_base or 0.0)
+                    elif match == "ipi":
+                        tax["amount"] = sign * (fiscal_line.ipi_value or 0.0)
+                        tax["base"] = sign * (fiscal_line.ipi_base or 0.0)
+                    elif match == "pis":
+                        tax["amount"] = sign * (fiscal_line.pis_value or 0.0)
+                        tax["base"] = sign * (fiscal_line.pis_base or 0.0)
+                    elif match == "cofins":
+                        tax["amount"] = sign * (fiscal_line.cofins_value or 0.0)
+                        tax["base"] = sign * (fiscal_line.cofins_base or 0.0)
+                    elif match == "issqn":
+                        tax["amount"] = sign * (fiscal_line.issqn_value or 0.0)
+                        tax["base"] = sign * (fiscal_line.issqn_base or 0.0)
+                    elif match == "ii":
+                        tax["amount"] = sign * (fiscal_line.ii_value or 0.0)
+                        tax["base"] = sign * (fiscal_line.ii_base or 0.0)
+                    else:
+                        # Clear withholding taxes if they were matched
+                        # inadvertently by default logic.
+                        # XML doesn't bring WH item per item.
+                        if "wh" in domain or "ret" in domain:
+                            tax["amount"] = 0.0
+                            tax["base"] = 0.0
+
             line.compute_all_tax = {
                 frozendict(
                     {

--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -389,22 +389,7 @@ class AccountMoveLine(models.Model):
                 subtotal = line.quantity * line_discount_price_unit
                 line.price_total = line.price_subtotal = subtotal
 
-    # Ordered rules to classify an account.tax into a Brazilian tax kind
-    # from its domain/name. Each entry is (kind, include_kw, exclude_kw).
-    # Order matters: "icmsst" must be tested before "icms", etc.
-    _IMPORTED_TAX_MATCH_RULES = [
-        ("icmsst", ["icmsst", "icms_st", "icms st"], []),
-        ("icms", ["icms"], ["st", "wh", "ret"]),
-        ("ipi", ["ipi"], ["wh", "ret"]),
-        ("pis", ["pis"], ["st", "wh", "ret"]),
-        ("cofins", ["cofins"], ["st", "wh", "ret"]),
-        ("issqn", ["issqn", "iss"], ["inss", "wh", "ret"]),
-        ("ii", ["ii"], ["wh", "ret"]),
-        ("ibs", ["ibs"], ["wh", "ret"]),
-        ("cbs", ["cbs"], ["wh", "ret"]),
-    ]
-
-    # kind -> (fiscal_value_field, fiscal_base_field)
+    # tax_domain -> (fiscal_value_field, fiscal_base_field)
     _IMPORTED_TAX_FIELD_MAP = {
         "icmsst": ("icmsst_value", "icmsst_base"),
         "icms": ("icms_value", "icms_base"),
@@ -417,55 +402,32 @@ class AccountMoveLine(models.Model):
         "cbs": ("cbs_value", "cbs_base"),
     }
 
-    def _resolve_tax_kind(self, tax_dict):
-        """Resolve the Brazilian tax kind from a compute_all tax dict.
-
-        Tries the account.tax tax_domain first, then falls back to
-        heuristic name matching against ``_IMPORTED_TAX_MATCH_RULES``.
-        Returns a kind string (e.g. "icms") or "".
-        """
-        domain = ""
-        acc_tax = (
-            self.env["account.tax"].browse(tax_dict["id"])
-            if tax_dict.get("id")
-            else None
-        )
-        if not acc_tax and tax_dict.get("tax_repartition_line_id"):
-            acc_tax = (
-                self.env["account.tax.repartition.line"]
-                .browse(tax_dict["tax_repartition_line_id"])
-                .tax_id
-            )
-        if acc_tax:
-            if hasattr(acc_tax, "tax_domain") and acc_tax.tax_domain:
-                domain = acc_tax.tax_domain
-            elif hasattr(acc_tax, "fiscal_tax_ids") and acc_tax.fiscal_tax_ids:
-                domain = acc_tax.fiscal_tax_ids[0].tax_domain
-        if not domain:
-            domain = tax_dict.get("name", "").lower()
-
-        for kind, include_kw, exclude_kw in self._IMPORTED_TAX_MATCH_RULES:
-            if any(kw in domain for kw in include_kw) and not any(
-                kw in domain for kw in exclude_kw
-            ):
-                return kind
-        return ""
-
     def _override_taxes_from_import(self, taxes, fiscal_line, sign):
-        """Override compute_all tax amounts with imported fiscal values."""
+        """Override compute_all tax amounts with the imported fiscal values.
+
+        The account.tax -> Brazilian tax mapping comes from the fiscal
+        tax group (``tax_group_id.fiscal_tax_group_id.tax_domain``), the
+        same canonical link already used by the account.tax compute_all
+        override.
+        """
         for tax in taxes:
-            kind = self._resolve_tax_kind(tax)
-            fields = self._IMPORTED_TAX_FIELD_MAP.get(kind)
-            if fields:
-                tax["amount"] = sign * (getattr(fiscal_line, fields[0]) or 0.0)
-                tax["base"] = sign * (getattr(fiscal_line, fields[1]) or 0.0)
-            elif (
-                "wh" in tax.get("name", "").lower()
-                or "ret" in tax.get("name", "").lower()
-            ):
+            acc_tax = self.env["account.tax"].browse(tax.get("id") or [])
+            if not acc_tax and tax.get("tax_repartition_line_id"):
+                acc_tax = (
+                    self.env["account.tax.repartition.line"]
+                    .browse(tax["tax_repartition_line_id"])
+                    .tax_id
+                )
+            fiscal_group = acc_tax.tax_group_id.fiscal_tax_group_id
+            if fiscal_group.tax_withholding:
                 # Clear withholding taxes: XML doesn't bring WH item per item
                 tax["amount"] = 0.0
                 tax["base"] = 0.0
+                continue
+            field_names = self._IMPORTED_TAX_FIELD_MAP.get(fiscal_group.tax_domain)
+            if field_names:
+                tax["amount"] = sign * (getattr(fiscal_line, field_names[0]) or 0.0)
+                tax["base"] = sign * (getattr(fiscal_line, field_names[1]) or 0.0)
 
     @api.depends(
         "tax_ids",

--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -411,13 +411,13 @@ class AccountMoveLine(models.Model):
         override.
         """
         for tax in taxes:
-            acc_tax = self.env["account.tax"].browse(tax.get("id") or [])
-            if not acc_tax and tax.get("tax_repartition_line_id"):
-                acc_tax = (
-                    self.env["account.tax.repartition.line"]
-                    .browse(tax["tax_repartition_line_id"])
-                    .tax_id
-                )
+            repartition_line = self.env["account.tax.repartition.line"].browse(
+                tax.get("tax_repartition_line_id") or []
+            )
+            acc_tax = (
+                self.env["account.tax"].browse(tax.get("id") or [])
+                or repartition_line.tax_id
+            )
             fiscal_group = acc_tax.tax_group_id.fiscal_tax_group_id
             if fiscal_group.tax_withholding:
                 # Clear withholding taxes: XML doesn't bring WH item per item
@@ -426,7 +426,13 @@ class AccountMoveLine(models.Model):
                 continue
             field_names = self._IMPORTED_TAX_FIELD_MAP.get(fiscal_group.tax_domain)
             if field_names:
-                tax["amount"] = sign * (getattr(fiscal_line, field_names[0]) or 0.0)
+                # compute_all returns one entry per tax repartition line:
+                # each entry must carry only its share (factor) of the
+                # imported tax value, otherwise taxes with more than one
+                # repartition line would be counted multiple times.
+                factor = repartition_line.factor if repartition_line else 1.0
+                fiscal_value = getattr(fiscal_line, field_names[0]) or 0.0
+                tax["amount"] = sign * fiscal_value * factor
                 tax["base"] = sign * (getattr(fiscal_line, field_names[1]) or 0.0)
 
     @api.depends(

--- a/l10n_br_account_nfe/models/account_move.py
+++ b/l10n_br_account_nfe/models/account_move.py
@@ -10,9 +10,13 @@ class AccountMove(models.Model):
 
     def _compute_imported_terms(self):
         res = super()._compute_imported_terms()
-        if not self.imported_document:
+        if not self.imported_document or len(self.invoice_line_ids) < len(
+            self.fiscal_document_id.fiscal_line_ids
+        ):
             return res
-        for dup in self.nfe40_dup:
+
+        self.fiscal_document_id._compute_nfe40_dup()
+        for dup in self.fiscal_document_id.nfe40_dup:
             key = frozendict(
                 {
                     "move_id": self.id,

--- a/l10n_br_account_nfe/tests/__init__.py
+++ b/l10n_br_account_nfe/tests/__init__.py
@@ -3,3 +3,4 @@ from . import test_nfce_contingency
 from . import test_nfe_with_ipi
 from . import test_nfe_danfe_account
 from . import test_invoice_refund
+from . import test_nfe_import

--- a/l10n_br_account_nfe/tests/nfe/35231149647316000169550010000661061151600085-nfe.xml
+++ b/l10n_br_account_nfe/tests/nfe/35231149647316000169550010000661061151600085-nfe.xml
@@ -9,8 +9,8 @@
         <mod>55</mod>
         <serie>1</serie>
         <nNF>66106</nNF>
-        <dhEmi>2023-11-09T13:47:12-03:00</dhEmi>
-        <dhSaiEnt>2023-11-09T13:47:12-03:00</dhSaiEnt>
+        <dhEmi>2026-11-09T13:47:12-03:00</dhEmi>
+        <dhSaiEnt>2026-11-09T13:47:12-03:00</dhSaiEnt>
         <tpNF>1</tpNF>
         <idDest>2</idDest>
         <cMunFG>3513801</cMunFG>
@@ -58,6 +58,7 @@
           <xPais>Brasil</xPais>
           <fone>551199999999</fone>
         </enderDest>
+        <indIEDest>1</indIEDest>
       </dest>
       <det nItem="1">
         <prod>
@@ -115,6 +116,26 @@
               <vCOFINS>107.34</vCOFINS>
             </COFINSAliq>
           </COFINS>
+          <IBSCBS>
+            <CST>000</CST> <!-- Tributação Integral -->
+            <cClassTrib>000001</cClassTrib> <!-- Operação de Venda -->
+            <gIBSCBS>
+              <vBC>4065.80</vBC>
+              <gIBSUF>
+                <pIBSUF>0.10</pIBSUF>
+                <vIBSUF>4.07</vIBSUF>
+              </gIBSUF>
+              <gIBSMun>
+                <pIBSMun>0.00</pIBSMun>
+                <vIBSMun>0.00</vIBSMun>
+              </gIBSMun>
+                <vIBS>4.07</vIBS>
+              <gCBS>
+                <pCBS>0.90</pCBS>
+                <vCBS>36.59</vCBS>
+              </gCBS>
+            </gIBSCBS>
+          </IBSCBS>
         </imposto>
         <infAdProd
                 >Resolucao do Senado Federal no 13/12, Numero da FCI AC83B762-8595-4BD8-9DD2-C19DDA4A72FE , Conteudo de Importacao 37,80%</infAdProd>
@@ -174,6 +195,26 @@
               <vCOFINS>90.79</vCOFINS>
             </COFINSAliq>
           </COFINS>
+          <IBSCBS>
+            <CST>000</CST>
+            <cClassTrib>000001</cClassTrib>
+            <gIBSCBS>
+              <vBC>3439.20</vBC>
+              <gIBSUF>
+                <pIBSUF>0.10</pIBSUF>
+                <vIBSUF>3.44</vIBSUF>
+              </gIBSUF>
+              <gIBSMun>
+                <pIBSMun>0.00</pIBSMun>
+                <vIBSMun>0.00</vIBSMun>
+              </gIBSMun>
+              <vIBS>3.44</vIBS>
+              <gCBS>
+                <pCBS>0.90</pCBS>
+                <vCBS>30.95</vCBS>
+              </gCBS>
+            </gIBSCBS>
+          </IBSCBS>
         </imposto>
       </det>
       <det nItem="3">
@@ -231,6 +272,26 @@
               <vCOFINS>72.64</vCOFINS>
             </COFINSAliq>
           </COFINS>
+          <IBSCBS>
+            <CST>000</CST>
+            <cClassTrib>000001</cClassTrib>
+            <gIBSCBS>
+              <vBC>2751.36</vBC>
+              <gIBSUF>
+                <pIBSUF>0.10</pIBSUF>
+                <vIBSUF>2.75</vIBSUF>
+              </gIBSUF>
+              <gIBSMun>
+                <pIBSMun>0.00</pIBSMun>
+                <vIBSMun>0.00</vIBSMun>
+              </gIBSMun>
+              <vIBS>2.75</vIBS>
+              <gCBS>
+                <pCBS>0.90</pCBS>
+                <vCBS>24.76</vCBS>
+              </gCBS>
+            </gIBSCBS>
+          </IBSCBS>
         </imposto>
       </det>
       <det nItem="4">
@@ -288,6 +349,26 @@
               <vCOFINS>45.40</vCOFINS>
             </COFINSAliq>
           </COFINS>
+          <IBSCBS>
+            <CST>000</CST>
+            <cClassTrib>000001</cClassTrib>
+            <gIBSCBS>
+              <vBC>1719.60</vBC>
+              <gIBSUF>
+                <pIBSUF>0.10</pIBSUF>
+                <vIBSUF>1.72</vIBSUF>
+              </gIBSUF>
+              <gIBSMun>
+                <pIBSMun>0.00</pIBSMun>
+                <vIBSMun>0.00</vIBSMun>
+              </gIBSMun>
+              <vIBS>1.72</vIBS>
+              <gCBS>
+                <pCBS>0.90</pCBS>
+                <vCBS>15.48</vCBS>
+              </gCBS>
+            </gIBSCBS>
+          </IBSCBS>
         </imposto>
       </det>
       <total>
@@ -310,8 +391,34 @@
           <vPIS>68.51</vPIS>
           <vCOFINS>316.17</vCOFINS>
           <vOutro>0.00</vOutro>
-          <vNF>12108.10</vNF>
+          <vNF>12227.86</vNF>
         </ICMSTot>
+        <IBSCBSTot>
+          <vBCIBSCBS>11975.96</vBCIBSCBS>
+          <gIBS>
+            <gIBSUF>
+              <vDif>0.00</vDif>
+              <vDevTrib>0.00</vDevTrib>
+              <vIBSUF>11.98</vIBSUF>
+            </gIBSUF>
+            <gIBSMun>
+              <vDif>0.00</vDif>
+              <vDevTrib>0.00</vDevTrib>
+              <vIBSMun>0.00</vIBSMun>
+            </gIBSMun>
+            <vIBS>11.98</vIBS>
+            <vCredPres>0.00</vCredPres>
+            <vCredPresCondSus>0.00</vCredPresCondSus>
+          </gIBS>
+          <gCBS>
+            <vDif>0.00</vDif>
+            <vDevTrib>0.00</vDevTrib>
+            <vCBS>107.78</vCBS>
+            <vCredPres>0.00</vCredPres>
+            <vCredPresCondSus>0.00</vCredPresCondSus>
+          </gCBS>
+        </IBSCBSTot>
+        <vNFTot>12227.86</vNFTot>
       </total>
       <transp>
         <modFrete>1</modFrete>
@@ -334,30 +441,30 @@
       <cobr>
         <fat>
           <nFat>66106</nFat>
-          <vOrig>12108.10</vOrig>
+          <vOrig>12227.86</vOrig>
           <vDesc>0.00</vDesc>
-          <vLiq>12108.10</vLiq>
+          <vLiq>12227.86</vLiq>
         </fat>
         <dup>
           <nDup>001</nDup>
-          <dVenc>2023-12-09</dVenc>
-          <vDup>4035.63</vDup>
+          <dVenc>2026-12-09</dVenc>
+          <vDup>4075.95</vDup>
         </dup>
         <dup>
           <nDup>002</nDup>
-          <dVenc>2023-12-24</dVenc>
-          <vDup>4035.63</vDup>
+          <dVenc>2026-12-24</dVenc>
+          <vDup>4075.95</vDup>
         </dup>
         <dup>
           <nDup>003</nDup>
-          <dVenc>2024-01-08</dVenc>
-          <vDup>4036.84</vDup>
+          <dVenc>2027-01-08</dVenc>
+          <vDup>4075.96</vDup>
         </dup>
       </cobr>
       <pag>
         <detPag>
           <tPag>01</tPag>
-          <vPag>12108.10</vPag>
+          <vPag>12227.86</vPag>
         </detPag>
       </pag>
       <infAdic>
@@ -366,30 +473,8 @@
       </infAdic>
     </infNFe>
     <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
-      <SignedInfo>
-        <CanonicalizationMethod
-                    Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"
-                />
-        <SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1" />
-        <Reference URI="#NFe35231149647316000169550010000661061151600085">
-          <Transforms>
-            <Transform
-                            Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"
-                        />
-            <Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" />
-          </Transforms>
-          <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" />
-          <DigestValue>VZsGaqFMX5OP0X855xlNRvL9rcc=</DigestValue>
-        </Reference>
-      </SignedInfo>
-      <SignatureValue
-            >K9xSJnRKX8AX3EIExDc7OZLmveF74hljsaKyoQEhM40YZ3q1ip46fcAuofYpUKtqQKPuBhoGRBlnlv+zurxO5sMwsHdd5H+7Mk4cAXKTu53MN04rlR2jJvwDW+ed7V2GBjEtP9J7IBuKNvMRpXlUuoP1IisLYlNshRRE++jFVlGIR/WqESJPRaudCOKEV5jmMTqMzGLmyiAOQbjn0M5/iuOWhsXckNc0roMDKciQ5484WU5cwV0fBz22NAZ7XeONMMA30h6Oe5OexMlzM0c4JgMCzew/8dCuLb0YeXx0S7UvD5nF0oD559Wzunk1lPdd3vWr+LcjPz7WVfEkxNPgSA==</SignatureValue>
-      <KeyInfo>
-        <X509Data>
-          <X509Certificate
-                    >MIIH9DCCBdygAwIBAgIINEIePkyvOCwwDQYJKoZIhvcNAQELBQAwdTELMAkGA1UEBhMCQlIxEzARBgNVBAoMCklDUC1CcmFzaWwxNjA0BgNVBAsMLVNlY3JldGFyaWEgZGEgUmVjZWl0YSBGZWRlcmFsIGRvIEJyYXNpbCAtIFJGQjEZMBcGA1UEAwwQQUMgU0VSQVNBIFJGQiB2NTAeFw0yMzA1MDgxOTA2MDBaFw0yNDA1MDcxOTA1NTlaMIIBFDELMAkGA1UEBhMCQlIxCzAJBgNVBAgMAlNQMRIwEAYDVQQHDAlTYW8gUGF1bG8xEzARBgNVBAoMCklDUC1CcmFzaWwxNjA0BgNVBAsMLVNlY3JldGFyaWEgZGEgUmVjZWl0YSBGZWRlcmFsIGRvIEJyYXNpbCAtIFJGQjEWMBQGA1UECwwNUkZCIGUtQ05QSiBBMTEWMBQGA1UECwwNQUMgU0VSQVNBIFJGQjEXMBUGA1UECwwONjIxNzM2MjAwMDAxODAxGTAXBgNVBAsMEFZJREVPQ09ORkVSRU5DSUExMzAxBgNVBAMMKlBBU1NBTUFOQVJJQSBTQU8gVklUT1IgTFREQTo0OTY0NzMxNjAwMDE2OTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANgdgJcancLt9TzX1w8QcOcA/45OIXSuzvf0Ob768HhnOzUCIe7R9WKy7EpW7bvf2Nxjg579Cw5B9fMWgwk+SgRJswtCsQAcZzuyia1BfYQJRFxO1bwYfp51ErESe8eJBClfDNHsVAcVABKqMrWD3THTqddIiWsfXpp500EcewDEJXe3eOShX0rso4gPzz2NSAlesJh0zAVQR1W9xSdyl6DTxLJPsh8HfmhvOifX4eedsbHJ6Kri0HRz9LPgpou+wf0gDY6YJbdo4B0Oj1cvYhFbSeabVc/SCZBh3trSVFF0oVkIJ2VmcpIAYHAtkscaX09C8VMTZ4Y1spq05zqIKJUCAwEAAaOCAuUwggLhMAkGA1UdEwQCMAAwHwYDVR0jBBgwFoAU7PFBUVeo5jrpXrOgIvkIirU6h48wgZkGCCsGAQUFBwEBBIGMMIGJMEgGCCsGAQUFBzAChjxodHRwOi8vd3d3LmNlcnRpZmljYWRvZGlnaXRhbC5jb20uYnIvY2FkZWlhcy9zZXJhc2FyZmJ2NS5wN2IwPQYIKwYBBQUHMAGGMWh0dHA6Ly9vY3NwLmNlcnRpZmljYWRvZGlnaXRhbC5jb20uYnIvc2VyYXNhcmZidjUwgbUGA1UdEQSBrTCBqoEVREVOSVNAU0FPVklUT1IuQ09NLkJSoB0GBWBMAQMCoBQTEkRFTklTIEFDSENBUiBQT0xBS6AZBgVgTAEDA6AQEw40OTY0NzMxNjAwMDE2OaA+BgVgTAEDBKA1EzMwNzEwMTk3NzI3ODAwNzUyODc5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDCgFwYFYEwBAwegDhMMMDAwMDAwMDAwMDAwMHEGA1UdIARqMGgwZgYGYEwBAgENMFwwWgYIKwYBBQUHAgEWTmh0dHA6Ly9wdWJsaWNhY2FvLmNlcnRpZmljYWRvZGlnaXRhbC5jb20uYnIvcmVwb3NpdG9yaW8vZHBjL2RlY2xhcmFjYW8tcmZiLnBkZjAdBgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwQwgZ0GA1UdHwSBlTCBkjBKoEigRoZEaHR0cDovL3d3dy5jZXJ0aWZpY2Fkb2RpZ2l0YWwuY29tLmJyL3JlcG9zaXRvcmlvL2xjci9zZXJhc2FyZmJ2NS5jcmwwRKBCoECGPmh0dHA6Ly9sY3IuY2VydGlmaWNhZG9zLmNvbS5ici9yZXBvc2l0b3Jpby9sY3Ivc2VyYXNhcmZidjUuY3JsMB0GA1UdDgQWBBQ7Q/RY2cCplgK/3kb7an/qji/vkzAOBgNVHQ8BAf8EBAMCBeAwDQYJKoZIhvcNAQELBQADggIBAAhp0LLyMR+2zjX7qw3Iu/BAJ/6gljNVTjU3aWkgTk/gtNailW3Mr2MoLoFFZVOetRTVJV0E5z900ghH3u2gyiF4MLrXlcTHG5ADIIyvYLcfsDcOtfypAta/vhZ8gFR96LIEfXaNXDXrO3dAu9SqYDbHvN13xHU9jPT0Tt6b5aeVVulgAnO385n/f8tJgQOBm4EynvscqAvESuTzmMZTQfNt8NO3XuPF32OQV0XFai8U0lEAFEuhLcGHMl/Pd9EF2pQjq3We8Cb3riIg6H/OqYgXWqChddRPPdio/KPZsAq2+1tfgWqsOrzqW5e+z8buEpDN6bNR156yxMCIYJqkih4TDrbm9OfxjRDb24eNpBy6qCES/eddU7KwRsFqU+3WpJscSd3L/J6yGsHJfK8olFlKjmINtYTvkSkNEbqoZp30wx7qcOrVK2gMHw6U9KTnnoi/1CV3QZ4aI1Fo7jdgO1uHFdyhSO7A/vApK7KJZsWlGJHZUUYzFFgV7/YdctbWpshoC0ZZQbJBL9c8fi9J/WmUH2q0Eo9Pj2G3vsoUxyG3lqzdW2S4HjRYgy+8xao8wKwc0fybcfHr9WQing//+wobojDwmmoagRfCfWzgsHSUVXB3zf/WgYsdLthZDWrfY0K0+E41He00vpbi+y/YH9msXDwH81xH3PbucqkpfuaI</X509Certificate>
-        </X509Data>
-      </KeyInfo>
+      <!-- Signature would dynamically change due to altering the XML structure -->
+      ...
     </Signature>
   </NFe>
   <protNFe versao="4.00">
@@ -397,7 +482,7 @@
       <tpAmb>1</tpAmb>
       <verAplic>SP_NFE_PL009_V4</verAplic>
       <chNFe>35231149647316000169550010000661061151600085</chNFe>
-      <dhRecbto>2023-11-09T13:49:16-03:00</dhRecbto>
+      <dhRecbto>2026-11-09T13:49:16-03:00</dhRecbto>
       <nProt>135231928909679</nProt>
       <digVal>VZsGaqFMX5OP0X855xlNRvL9rcc=</digVal>
       <cStat>100</cStat>

--- a/l10n_br_account_nfe/tests/test_nfe_import.py
+++ b/l10n_br_account_nfe/tests/test_nfe_import.py
@@ -168,14 +168,14 @@ class NFeImportTest(TransactionCase):
             move.document_key, "35231149647316000169550010000661061151600085"
         )
 
-        self.assertAlmostEqual(move.amount_price_gross, 11975.96)
-        self.assertAlmostEqual(move.amount_discount_value, 0)
-        self.assertAlmostEqual(move.amount_untaxed, 11975.96)
-        self.assertAlmostEqual(move.amount_freight_value, 0)
-        self.assertAlmostEqual(move.amount_insurance_value, 0)
-        self.assertAlmostEqual(move.amount_other_value, 0)
-        self.assertAlmostEqual(move.amount_tax, 251.90)
-        self.assertAlmostEqual(move.amount_total, 12227.86)
+        self.assertAlmostEqual(move.amount_price_gross, 11975.96, places=2)
+        self.assertAlmostEqual(move.amount_discount_value, 0, places=2)
+        self.assertAlmostEqual(move.amount_untaxed, 11975.96, places=2)
+        self.assertAlmostEqual(move.amount_freight_value, 0, places=2)
+        self.assertAlmostEqual(move.amount_insurance_value, 0, places=2)
+        self.assertAlmostEqual(move.amount_other_value, 0, places=2)
+        self.assertAlmostEqual(move.amount_tax, 251.90, places=2)
+        self.assertAlmostEqual(move.amount_total, 12227.86, places=2)
 
         self.assertEqual(len(move.invoice_line_ids), 4)
 
@@ -186,10 +186,12 @@ class NFeImportTest(TransactionCase):
         self.assertEqual(move.invoice_line_ids[0].product_id.code, "1070147")
         self.assertEqual(move.invoice_line_ids[0].product_id.ncm_id.code, "48111090")
         self.assertEqual(move.invoice_line_ids[0].quantity, 70.1)
-        self.assertAlmostEqual(move.invoice_line_ids[0].fiscal_quantity, 70.1)
-        self.assertAlmostEqual(move.invoice_line_ids[0].price_unit, 58.0)
-        self.assertAlmostEqual(move.invoice_line_ids[0].fiscal_price, 58.0)
-        self.assertAlmostEqual(move.invoice_line_ids[0].price_subtotal, 4065.80)
+        self.assertAlmostEqual(move.invoice_line_ids[0].fiscal_quantity, 70.1, places=2)
+        self.assertAlmostEqual(move.invoice_line_ids[0].price_unit, 58.0, places=2)
+        self.assertAlmostEqual(move.invoice_line_ids[0].fiscal_price, 58.0, places=2)
+        self.assertAlmostEqual(
+            move.invoice_line_ids[0].price_subtotal, 4065.80, places=2
+        )
         self.assertEqual(move.invoice_line_ids[0].nfe40_xPed, "OC00589")
         self.assertEqual(move.invoice_line_ids[0].product_uom_id.code, "KG")
 
@@ -197,17 +199,17 @@ class NFeImportTest(TransactionCase):
             move.invoice_line_ids[0].icms_tax_id.id,
             self.ref("l10n_br_fiscal.tax_icms_12"),
         )
-        self.assertAlmostEqual(move.invoice_line_ids[0].icms_value, 487.90)
+        self.assertAlmostEqual(move.invoice_line_ids[0].icms_value, 487.90, places=2)
         self.assertEqual(
             move.invoice_line_ids[0].ipi_tax_id.id,
             self.ref("l10n_br_fiscal.tax_ipi_3_25"),
         )
-        self.assertAlmostEqual(move.invoice_line_ids[0].ipi_value, 132.14)
+        self.assertAlmostEqual(move.invoice_line_ids[0].ipi_value, 132.14, places=2)
         self.assertEqual(
             move.invoice_line_ids[0].pis_tax_id.id,
             self.ref("l10n_br_fiscal.tax_pis_0_65"),
         )
-        self.assertAlmostEqual(move.invoice_line_ids[0].pis_value, 23.26)
+        self.assertAlmostEqual(move.invoice_line_ids[0].pis_value, 23.26, places=2)
         self.assertEqual(
             move.invoice_line_ids[0].cofins_tax_id.id,
             self.ref("l10n_br_fiscal.tax_cofins_3"),
@@ -219,11 +221,13 @@ class NFeImportTest(TransactionCase):
         self.assertEqual(move.invoice_line_ids[1].product_id.code, "B100618007170")
         self.assertEqual(move.invoice_line_ids[1].product_id.ncm_id.code, "34060000")
         self.assertEqual(move.invoice_line_ids[1].quantity, 60)
-        self.assertAlmostEqual(move.invoice_line_ids[1].fiscal_quantity, 60)
+        self.assertAlmostEqual(move.invoice_line_ids[1].fiscal_quantity, 60, places=2)
         self.assertEqual(move.invoice_line_ids[1].product_uom_id.code, "MILHEI")
-        self.assertAlmostEqual(move.invoice_line_ids[1].price_subtotal, 3439.20)
+        self.assertAlmostEqual(
+            move.invoice_line_ids[1].price_subtotal, 3439.20, places=2
+        )
 
         self.assertEqual(len(move.due_line_ids), 3)
-        self.assertAlmostEqual(move.due_line_ids[0].credit, 4075.95)
-        self.assertAlmostEqual(move.due_line_ids[1].credit, 4075.95)
-        self.assertAlmostEqual(move.due_line_ids[2].credit, 4075.96)
+        self.assertAlmostEqual(move.due_line_ids[0].credit, 4075.95, places=2)
+        self.assertAlmostEqual(move.due_line_ids[1].credit, 4075.95, places=2)
+        self.assertAlmostEqual(move.due_line_ids[2].credit, 4075.96, places=2)

--- a/l10n_br_account_nfe/tests/test_nfe_import.py
+++ b/l10n_br_account_nfe/tests/test_nfe_import.py
@@ -1,3 +1,6 @@
+# Copyright 2025 - TODAY Akretion - Raphael Valyi <raphael.valyi@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
 import base64
 import os
 
@@ -39,7 +42,12 @@ class NFeImportTest(TransactionCase):
         )
 
         cls.env = cls.env(
-            user=cls.user, context=dict(cls.env.context, tracking_disable=True)
+            user=cls.user,
+            context=dict(
+                cls.env.context,
+                tracking_disable=True,
+                allowed_company_ids=[cls.company.id],
+            ),
         )
 
     def test_import_in_nfe(self):
@@ -52,11 +60,10 @@ class NFeImportTest(TransactionCase):
         with open(file_path, "rb") as file:
             file_content = file.read()
 
-        wizard = self.env["l10n_br_fiscal.document_import_wizard"].create({})
+        wizard = self.env["l10n_br_fiscal.document.import.wizard"].create({})
         with Form(wizard) as import_form:
             import_form.file = base64.b64encode(file_content)
             import_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_compras")
-            self.assertEqual(import_form.xml_partner_name, "FORNECEDER NFE DEMO LTDA")
             lines = import_form.imported_products_ids._records
         for line in lines:  # ensure testing consistency
             del line["id"]
@@ -146,6 +153,7 @@ class NFeImportTest(TransactionCase):
 
         action = wizard.action_import_and_open_move()
         move = self.env["account.move"].browse(action["res_id"])
+
         self.assertEqual(move.partner_id.name, "FORNECEDER NFE DEMO LTDA")
         self.assertEqual(move.partner_id.vat, "04.712.500/0001-07")
         self.assertEqual(move.partner_id.l10n_br_ie_code, "078016350838")

--- a/l10n_br_account_nfe/tests/test_nfe_import.py
+++ b/l10n_br_account_nfe/tests/test_nfe_import.py
@@ -168,14 +168,14 @@ class NFeImportTest(TransactionCase):
             move.document_key, "35231149647316000169550010000661061151600085"
         )
 
-        self.assertTrue(abs(move.amount_price_gross - 11975.96) < 0.01)
-        self.assertTrue(abs(move.amount_discount_value - 0) < 0.01)
-        self.assertTrue(abs(move.amount_untaxed - 11975.96) < 0.01)
-        self.assertTrue(abs(move.amount_freight_value - 0) < 0.01)
-        self.assertTrue(abs(move.amount_insurance_value - 0) < 0.01)
-        self.assertTrue(abs(move.amount_other_value - 0) < 0.01)
-        self.assertTrue(abs(move.amount_tax - 132.14) < 0.01)
-        self.assertTrue(abs(move.amount_total - 12108.10) < 0.01)
+        self.assertAlmostEqual(move.amount_price_gross, 11975.96)
+        self.assertAlmostEqual(move.amount_discount_value, 0)
+        self.assertAlmostEqual(move.amount_untaxed, 11975.96)
+        self.assertAlmostEqual(move.amount_freight_value, 0)
+        self.assertAlmostEqual(move.amount_insurance_value, 0)
+        self.assertAlmostEqual(move.amount_other_value, 0)
+        self.assertAlmostEqual(move.amount_tax, 251.90)
+        self.assertAlmostEqual(move.amount_total, 12227.86)
 
         self.assertEqual(len(move.invoice_line_ids), 4)
 
@@ -186,10 +186,10 @@ class NFeImportTest(TransactionCase):
         self.assertEqual(move.invoice_line_ids[0].product_id.code, "1070147")
         self.assertEqual(move.invoice_line_ids[0].product_id.ncm_id.code, "48111090")
         self.assertEqual(move.invoice_line_ids[0].quantity, 70.1)
-        self.assertTrue(abs(move.invoice_line_ids[0].fiscal_quantity - 70.1) < 0.01)
-        self.assertTrue(abs(move.invoice_line_ids[0].price_unit - 58.0) < 0.01)
-        self.assertTrue(abs(move.invoice_line_ids[0].fiscal_price - 58.0) < 0.01)
-        self.assertTrue(abs(move.invoice_line_ids[0].price_subtotal - 4065.80) < 0.01)
+        self.assertAlmostEqual(move.invoice_line_ids[0].fiscal_quantity, 70.1)
+        self.assertAlmostEqual(move.invoice_line_ids[0].price_unit, 58.0)
+        self.assertAlmostEqual(move.invoice_line_ids[0].fiscal_price, 58.0)
+        self.assertAlmostEqual(move.invoice_line_ids[0].price_subtotal, 4065.80)
         self.assertEqual(move.invoice_line_ids[0].nfe40_xPed, "OC00589")
         self.assertEqual(move.invoice_line_ids[0].product_uom_id.code, "KG")
 
@@ -197,23 +197,21 @@ class NFeImportTest(TransactionCase):
             move.invoice_line_ids[0].icms_tax_id.id,
             self.ref("l10n_br_fiscal.tax_icms_12"),
         )
-        self.assertTrue(abs(move.invoice_line_ids[0].icms_value - 487.90) < 0.01)
+        self.assertAlmostEqual(move.invoice_line_ids[0].icms_value, 487.90)
         self.assertEqual(
             move.invoice_line_ids[0].ipi_tax_id.id,
             self.ref("l10n_br_fiscal.tax_ipi_3_25"),
         )
-        self.assertTrue(abs(move.invoice_line_ids[0].ipi_value - 132.14) < 0.01)
+        self.assertAlmostEqual(move.invoice_line_ids[0].ipi_value, 132.14)
         self.assertEqual(
             move.invoice_line_ids[0].pis_tax_id.id,
             self.ref("l10n_br_fiscal.tax_pis_0_65"),
         )
-        self.assertTrue(abs(move.invoice_line_ids[0].pis_value - 23.26) < 0.01)
+        self.assertAlmostEqual(move.invoice_line_ids[0].pis_value, 23.26)
         self.assertEqual(
             move.invoice_line_ids[0].cofins_tax_id.id,
             self.ref("l10n_br_fiscal.tax_cofins_3"),
         )
-        self.assertTrue(abs(move.invoice_line_ids[0].ipi_value - 132.14) < 0.01)
-
         self.assertEqual(
             move.invoice_line_ids[1].product_id.name,
             "PAVIO P/VELA VOTIVA 50 X 150MM (C102018007170)",
@@ -221,11 +219,11 @@ class NFeImportTest(TransactionCase):
         self.assertEqual(move.invoice_line_ids[1].product_id.code, "B100618007170")
         self.assertEqual(move.invoice_line_ids[1].product_id.ncm_id.code, "34060000")
         self.assertEqual(move.invoice_line_ids[1].quantity, 60)
-        self.assertTrue(abs(move.invoice_line_ids[1].fiscal_quantity - 60) < 0.01)
+        self.assertAlmostEqual(move.invoice_line_ids[1].fiscal_quantity, 60)
         self.assertEqual(move.invoice_line_ids[1].product_uom_id.code, "MILHEI")
-        self.assertTrue(abs(move.invoice_line_ids[1].price_subtotal - 3439.20) < 0.01)
+        self.assertAlmostEqual(move.invoice_line_ids[1].price_subtotal, 3439.20)
 
         self.assertEqual(len(move.due_line_ids), 3)
-        self.assertEqual(move.due_line_ids[0].credit, 4035.63)
-        self.assertEqual(move.due_line_ids[1].credit, 4035.63)
-        self.assertEqual(move.due_line_ids[2].credit, 4036.84)
+        self.assertAlmostEqual(move.due_line_ids[0].credit, 4075.95)
+        self.assertAlmostEqual(move.due_line_ids[1].credit, 4075.95)
+        self.assertAlmostEqual(move.due_line_ids[2].credit, 4075.96)

--- a/l10n_br_cte/models/document.py
+++ b/l10n_br_cte/models/document.py
@@ -257,9 +257,11 @@ class CTe(spec_models.StackedModel):
 
     cte40_verProc = fields.Char(
         copy=False,
-        default=lambda s: s.env["ir.config_parameter"]
-        .sudo()
-        .get_param("l10n_br_cte.version.name", default="Odoo Brasil OCA"),
+        default=lambda s: (
+            s.env["ir.config_parameter"]
+            .sudo()
+            .get_param("l10n_br_cte.version.name", default="Odoo Brasil OCA")
+        ),
     )
 
     cte40_cMunEnv = fields.Char(
@@ -1437,6 +1439,14 @@ class CTe(spec_models.StackedModel):
             )
         return res
 
+    @api.model
+    def _build_attr(self, node, fields, vals, path, attr):
+        key = f"cte40_{attr[1].metadata.get('name', attr[0])}"
+        if key == "cte40_IBSCBS":
+            # IBSCBS values are extracted manually in import_binding_cte
+            return
+        return super()._build_attr(node, fields, vals, path, attr)
+
     def _build_many2one(self, comodel, vals, new_value, key, value, path):
         if key in ("cte40_infNFe", "cte40_autXML"):
             return  # TODO fix these imports eventually
@@ -1853,6 +1863,72 @@ class CTe(spec_models.StackedModel):
 
         return proc_xml
 
+    def _add_ibscbs_line_attrs(self, binding, line_attrs):
+        """Extract IBS/CBS values from the binding and update line_attrs."""
+        ibscbs = getattr(binding.infCte.imp, "IBSCBS", None)
+        if not (ibscbs and ibscbs.gIBSCBS):
+            return
+
+        gibscbs = ibscbs.gIBSCBS
+        v_bc = float(gibscbs.vBC) if gibscbs.vBC else 0.0
+
+        ibs_percent = ibs_value = 0.0
+        if gibscbs.gIBSUF:
+            ibs_percent = float(gibscbs.gIBSUF.pIBSUF) if gibscbs.gIBSUF.pIBSUF else 0.0
+            ibs_value = float(gibscbs.gIBSUF.vIBSUF) if gibscbs.gIBSUF.vIBSUF else 0.0
+        cbs_percent = cbs_value = 0.0
+        if gibscbs.gCBS:
+            cbs_percent = float(gibscbs.gCBS.pCBS) if gibscbs.gCBS.pCBS else 0.0
+            cbs_value = float(gibscbs.gCBS.vCBS) if gibscbs.gCBS.vCBS else 0.0
+
+        cst_code = ibscbs.CST if ibscbs.CST else "000"
+        cst_ibs = self.env.ref(
+            f"l10n_br_fiscal.cst_ibs_{cst_code}", raise_if_not_found=False
+        )
+        cst_cbs = self.env.ref(
+            f"l10n_br_fiscal.cst_cbs_{cst_code}", raise_if_not_found=False
+        )
+        ibs_tax = self.env["l10n_br_fiscal.tax"].search(
+            [
+                (
+                    "tax_group_id",
+                    "=",
+                    self.env.ref("l10n_br_fiscal.tax_group_ibs").id,
+                ),
+                ("percent_amount", "=", ibs_percent),
+            ],
+            limit=1,
+        )
+        cbs_tax = self.env["l10n_br_fiscal.tax"].search(
+            [
+                (
+                    "tax_group_id",
+                    "=",
+                    self.env.ref("l10n_br_fiscal.tax_group_cbs").id,
+                ),
+                ("percent_amount", "=", cbs_percent),
+            ],
+            limit=1,
+        )
+        fiscal_tax_ids = line_attrs.get("fiscal_tax_ids", [])
+        if ibs_tax:
+            line_attrs["ibs_tax_id"] = ibs_tax.id
+            fiscal_tax_ids += [Command.link(ibs_tax.id)]
+        if cbs_tax:
+            line_attrs["cbs_tax_id"] = cbs_tax.id
+            fiscal_tax_ids += [Command.link(cbs_tax.id)]
+        line_attrs["fiscal_tax_ids"] = fiscal_tax_ids
+        if cst_ibs:
+            line_attrs["ibs_cst_id"] = cst_ibs.id
+        if cst_cbs:
+            line_attrs["cbs_cst_id"] = cst_cbs.id
+        line_attrs["ibs_base"] = v_bc
+        line_attrs["ibs_percent"] = ibs_percent
+        line_attrs["ibs_value"] = ibs_value
+        line_attrs["cbs_base"] = v_bc
+        line_attrs["cbs_percent"] = cbs_percent
+        line_attrs["cbs_value"] = cbs_value
+
     def import_binding_cte(self, binding, edoc_type="in", dry_run=False):
         if hasattr(binding, "CTe"):
             binding = binding.CTe
@@ -1909,6 +1985,9 @@ class CTe(spec_models.StackedModel):
                         .search([("code", "=", binding.infCte.ide.CFOP)], limit=1)
                         .id
                     )
+
+                # Extract IBSCBS values if present
+                self._add_ibscbs_line_attrs(binding, line_attrs)
 
                 for comp in binding.infCte.vPrest.comp or [None]:
                     if comp is not None:

--- a/l10n_br_cte/models/document.py
+++ b/l10n_br_cte/models/document.py
@@ -1866,68 +1866,14 @@ class CTe(spec_models.StackedModel):
     def _add_ibscbs_line_attrs(self, binding, line_attrs):
         """Extract IBS/CBS values from the binding and update line_attrs."""
         ibscbs = getattr(binding.infCte.imp, "IBSCBS", None)
-        if not (ibscbs and ibscbs.gIBSCBS):
-            return
-
-        gibscbs = ibscbs.gIBSCBS
-        v_bc = float(gibscbs.vBC) if gibscbs.vBC else 0.0
-
-        ibs_percent = ibs_value = 0.0
-        if gibscbs.gIBSUF:
-            ibs_percent = float(gibscbs.gIBSUF.pIBSUF) if gibscbs.gIBSUF.pIBSUF else 0.0
-            ibs_value = float(gibscbs.gIBSUF.vIBSUF) if gibscbs.gIBSUF.vIBSUF else 0.0
-        cbs_percent = cbs_value = 0.0
-        if gibscbs.gCBS:
-            cbs_percent = float(gibscbs.gCBS.pCBS) if gibscbs.gCBS.pCBS else 0.0
-            cbs_value = float(gibscbs.gCBS.vCBS) if gibscbs.gCBS.vCBS else 0.0
-
-        cst_code = ibscbs.CST if ibscbs.CST else "000"
-        cst_ibs = self.env.ref(
-            f"l10n_br_fiscal.cst_ibs_{cst_code}", raise_if_not_found=False
+        tax_ids = self.env["l10n_br_fiscal.document.line"]._add_imported_ibscbs_vals(
+            ibscbs, line_attrs
         )
-        cst_cbs = self.env.ref(
-            f"l10n_br_fiscal.cst_cbs_{cst_code}", raise_if_not_found=False
-        )
-        ibs_tax = self.env["l10n_br_fiscal.tax"].search(
-            [
-                (
-                    "tax_group_id",
-                    "=",
-                    self.env.ref("l10n_br_fiscal.tax_group_ibs").id,
-                ),
-                ("percent_amount", "=", ibs_percent),
-            ],
-            limit=1,
-        )
-        cbs_tax = self.env["l10n_br_fiscal.tax"].search(
-            [
-                (
-                    "tax_group_id",
-                    "=",
-                    self.env.ref("l10n_br_fiscal.tax_group_cbs").id,
-                ),
-                ("percent_amount", "=", cbs_percent),
-            ],
-            limit=1,
-        )
-        fiscal_tax_ids = line_attrs.get("fiscal_tax_ids", [])
-        if ibs_tax:
-            line_attrs["ibs_tax_id"] = ibs_tax.id
-            fiscal_tax_ids += [Command.link(ibs_tax.id)]
-        if cbs_tax:
-            line_attrs["cbs_tax_id"] = cbs_tax.id
-            fiscal_tax_ids += [Command.link(cbs_tax.id)]
-        line_attrs["fiscal_tax_ids"] = fiscal_tax_ids
-        if cst_ibs:
-            line_attrs["ibs_cst_id"] = cst_ibs.id
-        if cst_cbs:
-            line_attrs["cbs_cst_id"] = cst_cbs.id
-        line_attrs["ibs_base"] = v_bc
-        line_attrs["ibs_percent"] = ibs_percent
-        line_attrs["ibs_value"] = ibs_value
-        line_attrs["cbs_base"] = v_bc
-        line_attrs["cbs_percent"] = cbs_percent
-        line_attrs["cbs_value"] = cbs_value
+        if tax_ids:
+            # line_attrs feed a Command.create(), so m2m needs commands
+            fiscal_tax_ids = line_attrs.get("fiscal_tax_ids", [])
+            fiscal_tax_ids += [Command.link(tax_id) for tax_id in tax_ids]
+            line_attrs["fiscal_tax_ids"] = fiscal_tax_ids
 
     def import_binding_cte(self, binding, edoc_type="in", dry_run=False):
         if hasattr(binding, "CTe"):

--- a/l10n_br_cte/tests/cte/v4_00/leiauteCTe/CTe51160724686092000173570010000000031000000024.xml
+++ b/l10n_br_cte/tests/cte/v4_00/leiauteCTe/CTe51160724686092000173570010000000031000000024.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <CTe xmlns="http://www.portalfiscal.inf.br/cte">
-  <infCte Id="CTe51160724686092000173570010000000031000000024" versao="3.00">
+  <infCte Id="CTe51160724686092000173570010000000031000000024" versao="4.00">
     <ide>
       <cUF>51</cUF>
-      <cCT>570005757</cCT>
+      <cCT>57000575</cCT>
       <CFOP>5353</CFOP>
       <natOp>PREST. DE SERV. TRANSPORTE A ESTAB. COMERCIAL..</natOp>
       <mod>57</mod>
       <serie>1</serie>
       <nCT>571</nCT>
-      <dhEmi>2016-07-07T17:58:40-02:00</dhEmi>
+      <dhEmi>2026-07-07T17:58:40-02:00</dhEmi>
       <tpImp>1</tpImp>
       <tpEmis>1</tpEmis>
       <cDV>0</cDV>
@@ -53,6 +53,7 @@
         <UF>MT</UF>
         <fone>6599893021</fone>
       </enderEmit>
+      <CRT>3</CRT>
     </emit>
     <rem>
       <CPF>72304553915</CPF>
@@ -99,6 +100,26 @@
           <indSN>1</indSN>
         </ICMSSN>
       </ICMS>
+      <IBSCBS>
+        <CST>000</CST>
+        <cClassTrib>000001</cClassTrib>
+        <gIBSCBS>
+          <vBC>4000.00</vBC>
+          <gIBSUF>
+            <pIBSUF>0.10</pIBSUF>
+            <vIBSUF>4.00</vIBSUF>
+          </gIBSUF>
+          <gIBSMun>
+            <pIBSMun>0.00</pIBSMun>
+            <vIBSMun>0.00</vIBSMun>
+          </gIBSMun>
+          <vIBS>4.00</vIBS>
+          <gCBS>
+            <pCBS>0.90</pCBS>
+            <vCBS>36.00</vCBS>
+          </gCBS>
+        </gIBSCBS>
+      </IBSCBS>
     </imp>
     <infCTeNorm>
       <infCarga>
@@ -116,11 +137,11 @@
           <tpDoc>99</tpDoc>
           <descOutros>NOTA FISCAL MANUAL</descOutros>
           <nDoc>123456</nDoc>
-          <dEmi>2016-07-05</dEmi>
+          <dEmi>2026-07-05</dEmi>
           <vDocFisc>79400.00</vDocFisc>
         </infOutros>
       </infDoc>
-      <infModal versaoModal="3.00">
+      <infModal versaoModal="4.00">
         <rodo>
           <RNTRC>05277204</RNTRC>
         </rodo>

--- a/l10n_br_cte/tests/test_cte_import.py
+++ b/l10n_br_cte/tests/test_cte_import.py
@@ -89,5 +89,15 @@ class CTeImportTest(TransactionCase):
         self.assertEqual(cte.fiscal_line_ids[0].quantity, 1)
         self.assertEqual(cte.fiscal_line_ids[0].price_unit, 4000.0)
 
+        # IBSCBS data
+        self.assertAlmostEqual(cte.fiscal_line_ids[0].ibs_value, 4.0)
+        self.assertAlmostEqual(cte.fiscal_line_ids[0].cbs_value, 36.0)
+        self.assertAlmostEqual(cte.fiscal_line_ids[0].ibs_base, 4000.0)
+        self.assertAlmostEqual(cte.fiscal_line_ids[0].cbs_base, 4000.0)
+        self.assertAlmostEqual(cte.fiscal_line_ids[0].ibs_percent, 0.1)
+        self.assertAlmostEqual(cte.fiscal_line_ids[0].cbs_percent, 0.9)
+        self.assertEqual(cte.fiscal_line_ids[0].ibs_cst_id.code, "000")
+        self.assertEqual(cte.fiscal_line_ids[0].cbs_cst_id.code, "000")
+
     def test_import_out_cte(self):
         "(can be useful after an ERP migration)"

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -203,7 +203,7 @@ class Document(models.Model):
         store=True,
     )
 
-    imported_document = fields.Boolean(string="Imported", default=False)
+    imported_document = fields.Boolean(string="Imported", copy=False)
 
     xml_error_message = fields.Text(
         readonly=True,

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -127,3 +127,72 @@ class DocumentLine(models.Model):
             line.additional_data = line.comment_ids.compute_message(
                 line.__document_comment_vals(), line.manual_additional_data
             )
+
+    @api.model
+    def _add_imported_ibscbs_vals(self, ibscbs, vals):
+        """Merge into ``vals`` the IBS/CBS values of an imported IBSCBS
+        binding node (NFe and CTe share the same DFe schema for it).
+
+        Returns the list of matched fiscal tax ids so each caller can
+        link them into ``fiscal_tax_ids`` with its own convention (the
+        NFe import framework expects raw ids, the CTe one expects
+        Command tuples).
+        """
+        tax_ids = []
+        if not (ibscbs and ibscbs.gIBSCBS):
+            return tax_ids
+
+        gibscbs = ibscbs.gIBSCBS
+        base = float(gibscbs.vBC) if gibscbs.vBC else 0.0
+
+        ibs_percent = ibs_value = 0.0
+        if gibscbs.gIBSUF:
+            ibs_percent = float(gibscbs.gIBSUF.pIBSUF) if gibscbs.gIBSUF.pIBSUF else 0.0
+            ibs_value = float(gibscbs.gIBSUF.vIBSUF) if gibscbs.gIBSUF.vIBSUF else 0.0
+        cbs_percent = cbs_value = 0.0
+        if gibscbs.gCBS:
+            cbs_percent = float(gibscbs.gCBS.pCBS) if gibscbs.gCBS.pCBS else 0.0
+            cbs_value = float(gibscbs.gCBS.vCBS) if gibscbs.gCBS.vCBS else 0.0
+
+        cst_code = ibscbs.CST if ibscbs.CST else "000"
+        cst_ibs = self.env.ref(
+            f"l10n_br_fiscal.cst_ibs_{cst_code}", raise_if_not_found=False
+        )
+        if cst_ibs:
+            vals["ibs_cst_id"] = cst_ibs.id
+        cst_cbs = self.env.ref(
+            f"l10n_br_fiscal.cst_cbs_{cst_code}", raise_if_not_found=False
+        )
+        if cst_cbs:
+            vals["cbs_cst_id"] = cst_cbs.id
+
+        vals.update(
+            ibs_base=base,
+            ibs_percent=ibs_percent,
+            ibs_value=ibs_value,
+            cbs_base=base,
+            cbs_percent=cbs_percent,
+            cbs_value=cbs_value,
+        )
+
+        ibs_tax = self.env["l10n_br_fiscal.tax"].search(
+            [
+                ("tax_group_id", "=", self.env.ref("l10n_br_fiscal.tax_group_ibs").id),
+                ("percent_amount", "=", ibs_percent),
+            ],
+            limit=1,
+        )
+        if ibs_tax:
+            vals["ibs_tax_id"] = ibs_tax.id
+            tax_ids.append(ibs_tax.id)
+        cbs_tax = self.env["l10n_br_fiscal.tax"].search(
+            [
+                ("tax_group_id", "=", self.env.ref("l10n_br_fiscal.tax_group_cbs").id),
+                ("percent_amount", "=", cbs_percent),
+            ],
+            limit=1,
+        )
+        if cbs_tax:
+            vals["cbs_tax_id"] = cbs_tax.id
+            tax_ids.append(cbs_tax.id)
+        return tax_ids

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -944,6 +944,14 @@ class NFe(spec_models.StackedModel):
             )
         return res
 
+    @api.model
+    def _build_attr(self, node, fields, vals, path, attr):
+        key = f"nfe40_{attr[1].metadata.get('name', attr[0])}"
+        if key == "nfe40_IBSCBSTot":
+            # IBSCBSTot fields are computed from lines, skip importing
+            return
+        return super()._build_attr(node, fields, vals, path, attr)
+
     def _build_many2one(self, comodel, vals, new_value, key, value, path):
         if key == "nfe40_entrega" and self.env.context.get("edoc_type") == "in":
             enderEntreg_value = self.env["res.partner"].build_attrs(value, path=path)

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -967,8 +967,17 @@ class NFe(spec_models.StackedModel):
                 "company_type": "person",
             }
             new_value.update(new_vals)
+            # Store the delivery address on the stored partner_shipping_id
+            # field (like emit/dest write to partner_id). nfe40_entrega is a
+            # non-stored computed field, so writing to it would silently drop
+            # the imported delivery address.
             super()._build_many2one(
-                self.env["res.partner"], vals, new_value, key, value, path
+                self.env["res.partner"],
+                vals,
+                new_value,
+                "partner_shipping_id",
+                value,
+                path,
             )
         elif key == "nfe40_emit" and self.env.context.get("edoc_type") == "in":
             enderEmit_value = self.env["res.partner"].build_attrs(

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -1338,6 +1338,10 @@ class NFeLine(spec_models.StackedModel):
         if key in ["nfe40_CST", "nfe40_modBC", "nfe40_CSOSN"]:
             return  # (dealt with in _build_many2one)
 
+        if key == "nfe40_IBSCBS":
+            self._import_ibscbs_attrs(value, vals)
+            return
+
         if key.startswith("nfe40_ICMS") and key not in [
             "nfe40_ICMS",
             "nfe40_ICMSTot",
@@ -1446,6 +1450,17 @@ class NFeLine(spec_models.StackedModel):
                 value,
                 new_value,
             )
+
+        elif key == "nfe40_IBSCBS":
+            self._import_ibscbs_attrs(value, new_value)
+            if (
+                self._name == "account.invoice.line"
+                and comodel._name == "l10n_br_fiscal.document.line"
+            ):
+                # TODO do not hardcode!!
+                # stacked m2o
+                vals.update(new_value)
+            return
 
         if (
             self._name == "account.invoice.line"
@@ -1633,6 +1648,79 @@ class NFeLine(spec_models.StackedModel):
         # elif kind == "cofins":  # (will also apply to cofinsst)
         #     pass
         #     # TODO  qBCProd, vAliqProd
+
+    def _import_ibscbs_attrs(self, value, odoo_attrs):
+        """Import IBSCBS tax attributes from NFe binding."""
+        if not value or not value.gIBSCBS:
+            return
+
+        gibscbs = value.gIBSCBS
+
+        # Base calculation
+        v_bc = float(gibscbs.vBC) if gibscbs.vBC else 0.0
+
+        # CST - shared for both IBS and CBS
+        cst_code = value.CST if value.CST else "000"
+        cst_ibs = self.env.ref(
+            f"l10n_br_fiscal.cst_ibs_{cst_code}", raise_if_not_found=False
+        )
+        if cst_ibs:
+            odoo_attrs["ibs_cst_id"] = cst_ibs.id
+        cst_cbs = self.env.ref(
+            f"l10n_br_fiscal.cst_cbs_{cst_code}", raise_if_not_found=False
+        )
+        if cst_cbs:
+            odoo_attrs["cbs_cst_id"] = cst_cbs.id
+
+        # IBS values
+        ibs_percent = 0.0
+        ibs_value = 0.0
+        if gibscbs.gIBSUF:
+            ibs_percent = float(gibscbs.gIBSUF.pIBSUF) if gibscbs.gIBSUF.pIBSUF else 0.0
+            ibs_value = float(gibscbs.gIBSUF.vIBSUF) if gibscbs.gIBSUF.vIBSUF else 0.0
+
+        odoo_attrs["ibs_base"] = v_bc
+        odoo_attrs["ibs_percent"] = ibs_percent
+        odoo_attrs["ibs_value"] = ibs_value
+
+        # CBS values
+        cbs_percent = 0.0
+        cbs_value = 0.0
+        if gibscbs.gCBS:
+            cbs_percent = float(gibscbs.gCBS.pCBS) if gibscbs.gCBS.pCBS else 0.0
+            cbs_value = float(gibscbs.gCBS.vCBS) if gibscbs.gCBS.vCBS else 0.0
+
+        odoo_attrs["cbs_base"] = v_bc
+        odoo_attrs["cbs_percent"] = cbs_percent
+        odoo_attrs["cbs_value"] = cbs_value
+
+        # Find IBS tax
+        ibs_tax = self.env["l10n_br_fiscal.tax"].search(
+            [
+                ("tax_group_id", "=", self.env.ref("l10n_br_fiscal.tax_group_ibs").id),
+                ("percent_amount", "=", ibs_percent),
+            ],
+            limit=1,
+        )
+        if ibs_tax:
+            odoo_attrs["ibs_tax_id"] = ibs_tax.id
+            if not odoo_attrs.get("fiscal_tax_ids"):
+                odoo_attrs["fiscal_tax_ids"] = []
+            odoo_attrs["fiscal_tax_ids"].append(ibs_tax.id)
+
+        # Find CBS tax
+        cbs_tax = self.env["l10n_br_fiscal.tax"].search(
+            [
+                ("tax_group_id", "=", self.env.ref("l10n_br_fiscal.tax_group_cbs").id),
+                ("percent_amount", "=", cbs_percent),
+            ],
+            limit=1,
+        )
+        if cbs_tax:
+            odoo_attrs["cbs_tax_id"] = cbs_tax.id
+            if not odoo_attrs.get("fiscal_tax_ids"):
+                odoo_attrs["fiscal_tax_ids"] = []
+            odoo_attrs["fiscal_tax_ids"].append(cbs_tax.id)
 
     def _verify_related_many2ones(self, related_many2ones):
         if (

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -1651,76 +1651,14 @@ class NFeLine(spec_models.StackedModel):
 
     def _import_ibscbs_attrs(self, value, odoo_attrs):
         """Import IBSCBS tax attributes from NFe binding."""
-        if not value or not value.gIBSCBS:
-            return
-
-        gibscbs = value.gIBSCBS
-
-        # Base calculation
-        v_bc = float(gibscbs.vBC) if gibscbs.vBC else 0.0
-
-        # CST - shared for both IBS and CBS
-        cst_code = value.CST if value.CST else "000"
-        cst_ibs = self.env.ref(
-            f"l10n_br_fiscal.cst_ibs_{cst_code}", raise_if_not_found=False
+        tax_ids = self.env["l10n_br_fiscal.document.line"]._add_imported_ibscbs_vals(
+            value, odoo_attrs
         )
-        if cst_ibs:
-            odoo_attrs["ibs_cst_id"] = cst_ibs.id
-        cst_cbs = self.env.ref(
-            f"l10n_br_fiscal.cst_cbs_{cst_code}", raise_if_not_found=False
-        )
-        if cst_cbs:
-            odoo_attrs["cbs_cst_id"] = cst_cbs.id
-
-        # IBS values
-        ibs_percent = 0.0
-        ibs_value = 0.0
-        if gibscbs.gIBSUF:
-            ibs_percent = float(gibscbs.gIBSUF.pIBSUF) if gibscbs.gIBSUF.pIBSUF else 0.0
-            ibs_value = float(gibscbs.gIBSUF.vIBSUF) if gibscbs.gIBSUF.vIBSUF else 0.0
-
-        odoo_attrs["ibs_base"] = v_bc
-        odoo_attrs["ibs_percent"] = ibs_percent
-        odoo_attrs["ibs_value"] = ibs_value
-
-        # CBS values
-        cbs_percent = 0.0
-        cbs_value = 0.0
-        if gibscbs.gCBS:
-            cbs_percent = float(gibscbs.gCBS.pCBS) if gibscbs.gCBS.pCBS else 0.0
-            cbs_value = float(gibscbs.gCBS.vCBS) if gibscbs.gCBS.vCBS else 0.0
-
-        odoo_attrs["cbs_base"] = v_bc
-        odoo_attrs["cbs_percent"] = cbs_percent
-        odoo_attrs["cbs_value"] = cbs_value
-
-        # Find IBS tax
-        ibs_tax = self.env["l10n_br_fiscal.tax"].search(
-            [
-                ("tax_group_id", "=", self.env.ref("l10n_br_fiscal.tax_group_ibs").id),
-                ("percent_amount", "=", ibs_percent),
-            ],
-            limit=1,
-        )
-        if ibs_tax:
-            odoo_attrs["ibs_tax_id"] = ibs_tax.id
+        if tax_ids:
+            # the NFe import framework links m2m fields with raw ids
             if not odoo_attrs.get("fiscal_tax_ids"):
                 odoo_attrs["fiscal_tax_ids"] = []
-            odoo_attrs["fiscal_tax_ids"].append(ibs_tax.id)
-
-        # Find CBS tax
-        cbs_tax = self.env["l10n_br_fiscal.tax"].search(
-            [
-                ("tax_group_id", "=", self.env.ref("l10n_br_fiscal.tax_group_cbs").id),
-                ("percent_amount", "=", cbs_percent),
-            ],
-            limit=1,
-        )
-        if cbs_tax:
-            odoo_attrs["cbs_tax_id"] = cbs_tax.id
-            if not odoo_attrs.get("fiscal_tax_ids"):
-                odoo_attrs["fiscal_tax_ids"] = []
-            odoo_attrs["fiscal_tax_ids"].append(cbs_tax.id)
+            odoo_attrs["fiscal_tax_ids"].extend(tax_ids)
 
     def _verify_related_many2ones(self, related_many2ones):
         if (

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -10,11 +10,6 @@ from odoo.addons.spec_driven_model.models import spec_models
 
 
 class ResPartner(spec_models.SpecModel):
-    # NOTE TODO
-    # dest has a m2o tendereco. tlocal and tendereco are really similar...
-    # what happen to m2o to tendereco if we don't inherit from tendereco?
-    # should we stack tendereco from dest? will m2o to tendereco work?
-    # can we use related fields and context views to avoid troubles?
     _name = "res.partner"
     _inherit = [
         "res.partner",
@@ -35,8 +30,13 @@ class ResPartner(spec_models.SpecModel):
         values = super()._prepare_import_dict(
             values, model, parent_dict, defaults_model
         )
-        if not values.get("name") and values.get("legal_name"):
-            values["name"] = values["legal_name"]
+        if not values.get("name"):
+            if values.get("legal_name"):
+                values["name"] = values["legal_name"]
+            elif values.get("nfe40_CPF"):  # autXML for instance
+                values["name"] = f"contato CPF {values['nfe40_CPF']}"
+            elif values.get("nfe40_CNPJ"):
+                values["name"] = f"contato CNPJ {values['nfe40_CNPJ']}"
         return values
 
     # nfe.40.tlocal / nfe.40.enderEmit / 'nfe.40.enderDest

--- a/l10n_br_nfe/tests/test_nfe_import.py
+++ b/l10n_br_nfe/tests/test_nfe_import.py
@@ -106,5 +106,39 @@ class NFeImportTest(TransactionCase):
             nfe.fiscal_line_ids[2].product_id.name, "QUINOA PICANTE 100G (2X50G)"
         )
 
+    def test_import_in_nfe_delivery_address(self):
+        """A purchase NFe with an <entrega> block must import the delivery
+        address into the stored partner_shipping_id (nfe40_entrega is a
+        non-stored computed field, so it cannot hold the imported value)."""
+        res_items = (
+            "nfe",
+            "samples",
+            "v4_0",
+            "leiauteNFe",
+            "35180834128745000152550010000474281920007498-nfe.xml",
+        )
+        resource_path = "/".join(res_items)
+        nfe_stream = pkg_resources.resource_stream(nfelib.__name__, resource_path)
+        xml = nfe_stream.read().decode()
+        entrega = (
+            "<entrega>"
+            "<CNPJ>34128745000152</CNPJ>"
+            "<xLgr>Rua da Entrega</xLgr><nro>999</nro><xBairro>Centro</xBairro>"
+            "<cMun>3550308</cMun><xMun>SAO PAULO</xMun><UF>SP</UF>"
+            "<CEP>01001000</CEP><cPais>1058</cPais><xPais>Brasil</xPais>"
+            "</entrega>"
+        )
+        xml = xml.replace("</dest>", "</dest>" + entrega, 1)
+        binding = TnfeProc.from_xml(xml)
+        nfe = self.env["l10n_br_fiscal.document"].import_binding_nfe(
+            binding, edoc_type="in", dry_run=False
+        )
+        shipping = nfe.partner_shipping_id
+        self.assertTrue(shipping, "delivery address was not imported")
+        self.assertNotEqual(shipping, nfe.partner_id)
+        self.assertEqual(shipping.type, "delivery")
+        self.assertEqual(shipping.street_name, "Rua da Entrega")
+        self.assertEqual(shipping.zip, "01001-000")
+
     def test_import_out_nfe(self):
         "(can be useful after an ERP migration)"

--- a/l10n_br_nfe/wizards/document_import_wizard.py
+++ b/l10n_br_nfe/wizards/document_import_wizard.py
@@ -211,7 +211,13 @@ class DocumentImportWizard(models.TransientModel):
             edoc.document_type_id = self.env.ref("l10n_br_fiscal.document_55").id
             edoc.fiscal_operation_id = self.fiscal_operation_id
             for line in edoc.fiscal_line_ids:
+                # Preserve the XML price_unit because setting
+                # fiscal_operation_id triggers _compute_price_unit_fiscal
+                # which would overwrite it with the product's list/cost price
+                # (which is 0 when the product is created during import).
+                price_unit = line.price_unit
                 line.fiscal_operation_id = self.fiscal_operation_id
+                line.price_unit = price_unit
                 line.uom_id = line.uot_id
 
             if not self.partner_id:


### PR DESCRIPTION
O problema é que quando foi mesclado o teste de importação de NFe na 16.0 faltou o import do teste e acabou quebrando, assim como eu comentei aqui: https://github.com/OCA/l10n-brazil/pull/3811#issuecomment-4247602457

Com esse PR a importação pela UI volta a funcionar, porem o teste ainda não passa.

Tem tb um problema que ao tentar validar o account.move importado, pegamos um bloqueio:
```
2026-04-16 13:46:17,683 13633 WARNING odoo16 odoo.http: Não é possível realizar esta operação,
esta transição não é permitida:

De: autorizada

 Para: autorizada
```

Seria bom ver esse ponto da transição nesse refator aqui #4365