### PR TITLE
[16.0][FIX] l10n_br_sale_blanket_order: field fiscal_operation_line_id

### DIFF
--- a/l10n_br_sale_blanket_order/views/sale_blanket_order.xml
+++ b/l10n_br_sale_blanket_order/views/sale_blanket_order.xml
@@ -78,6 +78,11 @@
             >
                 <field name="fiscal_operation_id" options="{'no_create': True}" />
                 <field
+                    name="fiscal_operation_line_id"
+                    column_invisible="1"
+                    options="{'no_create': True}"
+                />
+                <field
                     name="fiscal_tax_ids"
                     widget="many2many_tags"
                     options="{'no_create': True}"


### PR DESCRIPTION
## Objetivo da PR 

@Escodoo SO571-27
Hoje quando cria um pedido de venda a linha da operação fiscal esta ficando vazia adicionando esse campo na view para assim rodar o onchange para abrir o pop-up já calculado