### PR TITLE
[16.0][FIX] l10n_br_fiscal: fix ICMS base calculation on discount lines

### DIFF
--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -217,6 +217,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         "icms_value",
         "ii_value",
         "ii_customhouse_charges",
+        "ipi_value",
     )
     def _compute_fiscal_amounts(self):
         for record in self:
@@ -916,6 +917,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
             fields_to_amount.append("icms_value")
             fields_to_amount.append("ii_value")
             fields_to_amount.append("ii_customhouse_charges")
+            fields_to_amount.append("ipi_value")
         return fields_to_amount
 
     @api.model


### PR DESCRIPTION
Em operações de importação (CFOP iniciando em `3`, `fiscal_operation_type = 'in'`), o método `l10n_br_fiscal.document.line._compute_fiscal_amounts` não inclui o `ipi_value` em `fiscal_amount_untaxed`, `fiscal_amount_total` nem `amount_taxed`, enquanto todos os demais tributos pertinentes à importação (PIS, COFINS, ICMS, II,`ii_customhouse_charges`) são corretamente incluídos.


O IPI estava ausente do _add_fields_to_amount no ramo de importação e do @api.depends de _compute_fiscal_amounts, fazendo com que fiscal_amount_total e nfe40_vNF subestimassem o total da NF no valor do IPI.

Closes #4500 