### PR TITLE
[18.0] oca-port blacklist: l10n_br_mdfe_spec avoid test conflict

### DIFF
--- a/.oca/oca-port/blacklist/l10n_br_mdfe_spec.json
+++ b/.oca/oca-port/blacklist/l10n_br_mdfe_spec.json
@@ -1,0 +1,5 @@
+{
+  "pull_requests": {
+    "w/o PR - commit 0492347": "Should not be ported to 18.0 until l10n_br_mdfe is ported, as it would kill test coverage"
+  }
+}


### PR DESCRIPTION
Blacklist the commit that avoids test conflict in l10n_br_mdfe_spec.\n\nThis commit should not be ported to 18.0 until l10n_br_mdfe is ported, as it would kill test coverage.\n\nRelated to closed PR #4513.