### PR TITLE
[16.0][FIX] l10n_br_fiscal_edi: Cancel Process

### DIFF
--- a/l10n_br_fiscal_edi/models/document.py
+++ b/l10n_br_fiscal_edi/models/document.py
@@ -180,7 +180,7 @@ class Document(models.Model):
         return self._action_document_back2draft()
 
     def action_document_cancel(self):
-        super().action_document_confirm()
+        super().action_document_cancel()
         return self._action_document_cancel()
 
     def action_document_invalidate(self):


### PR DESCRIPTION
o bug foi achado pelo @mbcosta ao migrar https://github.com/OCA/l10n-brazil/pull/4477 
Parece necessário para migrar alguns módulos para v17 e v18 mas faz sentido fazer um backport mesmo.
Foi preciso para ter as migrações verde para v17 de:

- #4457
- #4444 
- #4477