### PR TITLE
[16.0][IMP] l10n_br_fiscal: auto-pick ST operation line via requires_st flag

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -10,7 +10,7 @@
     "maintainers": ["renatonlima", "rvalyi"],
     "website": "https://github.com/OCA/l10n-brazil",
     "development_status": "Production/Stable",
-    "version": "16.0.21.2.2",
+    "version": "16.0.21.3.0",
     "depends": [
         "product",
         "uom_alias",

--- a/l10n_br_fiscal/data/operation_data.xml
+++ b/l10n_br_fiscal/data/operation_data.xml
@@ -42,6 +42,18 @@
         <field name="product_type">00</field>
     </record>
 
+    <record id="fo_venda_revenda_st" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="name">Revenda com ST</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5405" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6404" />
+        <field name="cfop_export_id" ref="l10n_br_fiscal.cfop_7102" />
+        <field name="requires_st" eval="True" />
+        <field name="state">approved</field>
+        <field name="product_type">00</field>
+    </record>
+
     <record id="fo_venda_venda_nao_contribuinte" model="l10n_br_fiscal.operation.line">
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
         <field name="name">Venda não Contribuinte</field>

--- a/l10n_br_fiscal/models/operation.py
+++ b/l10n_br_fiscal/models/operation.py
@@ -275,7 +275,13 @@ class Operation(models.Model):
             ("icms_origin", "=", False),
         ]
 
+        if not self._product_requires_st(product):
+            domain += [("requires_st", "=", False)]
+
         return domain
+
+    def _product_requires_st(self, product):
+        return bool(product and product.cest_id)
 
     def line_definition(self, company, partner, product):
         self.ensure_one()
@@ -298,6 +304,7 @@ class Operation(models.Model):
                 "product_type",
                 "tax_icms_or_issqn",
                 "icms_origin",
+                "requires_st",
             ]
             return sum(1 for field in fields if getattr(line, field))
 

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -112,6 +112,17 @@ class OperationLine(models.Model):
 
     add_to_amount = fields.Boolean(string="Add to Document Amount?", default=True)
 
+    requires_st = fields.Boolean(
+        string="Requires ICMS-ST",
+        help=(
+            "When enabled, this operation line is selected automatically only "
+            "for products subject to ICMS Substituição Tributária (products "
+            "with a CEST configured). Useful to differentiate fiscal lines "
+            "such as 'Revenda' from 'Revenda com ST' without manual "
+            "intervention on the document."
+        ),
+    )
+
     icms_origin = fields.Selection(selection=ICMS_ORIGIN, string="Origin")
 
     tax_definition_ids = fields.One2many(

--- a/l10n_br_fiscal/tests/test_operation.py
+++ b/l10n_br_fiscal/tests/test_operation.py
@@ -11,3 +11,55 @@ class TestOperation(TransactionCase):
         operation_venda_copy = operation_venda.copy()
         self.assertEqual(operation_venda_copy.name, "Venda")
         self.assertEqual(operation_venda_copy.code, "VD (Copy)")
+
+
+class TestOperationLineRequiresST(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.operation_venda = cls.env.ref("l10n_br_fiscal.fo_venda")
+        cls.line_revenda = cls.env.ref("l10n_br_fiscal.fo_venda_revenda")
+        cls.line_revenda_st = cls.env.ref("l10n_br_fiscal.fo_venda_revenda_st")
+        cls.company = cls.env.ref("l10n_br_base.empresa_lucro_presumido")
+        cls.partner = cls.env.ref("l10n_br_base.res_partner_akretion")
+        cest = cls.env.ref("l10n_br_fiscal.cest_0100100")
+        ncm = cest.ncm_ids[:1]
+        cls.product_with_st = cls.env["product.product"].create(
+            {
+                "name": "Produto Teste com ST",
+                "ncm_id": ncm.id,
+                "cest_id": cest.id,
+                "fiscal_type": cls.line_revenda.product_type,
+            }
+        )
+        cls.product_without_st = cls.env["product.product"].create(
+            {
+                "name": "Produto Teste sem ST",
+                "ncm_id": ncm.id,
+                "fiscal_type": cls.line_revenda.product_type,
+            }
+        )
+
+    def test_line_definition_without_st_returns_revenda(self):
+        result = self.operation_venda.line_definition(
+            company=self.company,
+            partner=self.partner,
+            product=self.product_without_st,
+        )
+        self.assertEqual(result, self.line_revenda)
+
+    def test_line_definition_with_st_returns_revenda_st(self):
+        result = self.operation_venda.line_definition(
+            company=self.company,
+            partner=self.partner,
+            product=self.product_with_st,
+        )
+        self.assertEqual(result, self.line_revenda_st)
+
+    def test_line_domain_excludes_st_line_when_product_has_no_cest(self):
+        domain = self.operation_venda._line_domain(
+            self.company, self.partner, self.product_without_st
+        )
+        candidates = self.env["l10n_br_fiscal.operation.line"].search(domain)
+        self.assertIn(self.line_revenda, candidates)
+        self.assertNotIn(self.line_revenda_st, candidates)

--- a/l10n_br_fiscal/views/operation_line_view.xml
+++ b/l10n_br_fiscal/views/operation_line_view.xml
@@ -48,6 +48,7 @@
                             <field name="product_type" />
                             <field name="tax_icms_or_issqn" />
                             <field name="icms_origin" />
+                            <field name="requires_st" />
                         </group>
                     </group>
                     <notebook>


### PR DESCRIPTION
Add a boolean field `requires_st` on `l10n_br_fiscal.operation.line` that flags lines meant only for products subject to Substituição Tributária. The selection criterion is the presence of a CEST on the product, mirroring how the regulator identifies ST items.

`_line_domain` excludes ST-only lines for products without a CEST, and `_select_best_line` factors the new flag into the score so the ST line wins for ST products. The trigger is configurable: a sibling override can change `_product_requires_st` to use any other product attribute.

A ready-to-use `Revenda com ST` operation line (CFOPs 5405 and 6404) ships in the default operation data, mirroring the existing `Revenda` line. Tests cover both ST and non-ST scenarios.