### PR TITLE
[16.0][FIX] l10n_br_sale: recompute taxes on partial invoices

### DIFF
--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -195,7 +195,27 @@ class SaleOrderLine(models.Model):
         result = {}
         if not self.display_type and self.fiscal_operation_id:
             result = self._prepare_br_fiscal_dict()
-            result.pop("fiscal_quantity", None)
+            # Drop stored compute fields populated by _compute_tax_fields so
+            # the ORM recomputes them with the actual invoiced quantity rather
+            # than reusing values frozen on the SO line. Passing an explicit
+            # value for a `compute=..., store=True, readonly=False` field at
+            # create() makes the ORM accept the value and skip the compute,
+            # even when its `depends` (e.g. `quantity`) would otherwise trigger
+            # it. fiscal_quantity / fiscal_price are co-computed and follow the
+            # same rule.
+            fdl = self.env["l10n_br_fiscal.document.line"]
+            for fname, field in fdl._fields.items():
+                if not field.store or not field.compute:
+                    continue
+                compute = field.compute
+                name = compute if isinstance(compute, str) else compute.__name__
+                if name in (
+                    "_compute_tax_fields",
+                    "_compute_fiscal_quantity",
+                    "_compute_fiscal_price",
+                    "_compute_uot_id",
+                ):
+                    result.pop(fname, None)
         result.update(super()._prepare_invoice_line(**optional_values))
         return result
 

--- a/l10n_br_sale/tests/test_l10n_br_sale_lp.py
+++ b/l10n_br_sale/tests/test_l10n_br_sale_lp.py
@@ -44,6 +44,13 @@ class TestL10nBrSale(L10nBrSaleBaseTest, TransactionCase):
             self.assertAlmostEqual(inv_line.quantity, expected_qty, 2)
             self.assertAlmostEqual(inv_line.fiscal_quantity, expected_fiscal_qty, 2)
 
+        # Stored compute fields populated by _compute_tax_fields must match a
+        # fresh recompute. If they differ, _prepare_invoice_line is copying
+        # frozen values from the SO line (computed for the full ordered qty)
+        # and the ORM is skipping the compute because the values were passed
+        # explicitly at create().
+        self._assert_tax_fields_match_recompute(inv_lines)
+
         first_invoice.action_post()
 
         # Second delivery: remaining half
@@ -66,3 +73,40 @@ class TestL10nBrSale(L10nBrSaleBaseTest, TransactionCase):
             expected_fiscal_qty = expected_qty * uot_factor
             self.assertAlmostEqual(inv_line.quantity, expected_qty, 2)
             self.assertAlmostEqual(inv_line.fiscal_quantity, expected_fiscal_qty, 2)
+
+        self._assert_tax_fields_match_recompute(inv_lines)
+
+    def _assert_tax_fields_match_recompute(self, inv_lines):
+        """Assert each fiscal.document.line stored value populated by
+        _compute_tax_fields matches what a fresh recompute produces.
+
+        Mismatch indicates the value was copied frozen from the SO line at
+        invoice creation rather than computed for the actually-invoiced
+        quantity.
+        """
+        tax_fields = (
+            "icms_base",
+            "icms_value",
+            "icmssn_base",
+            "icmssn_credit_value",
+            "ipi_base",
+            "ipi_value",
+            "pis_base",
+            "pis_value",
+            "cofins_base",
+            "cofins_value",
+        )
+        for inv_line in inv_lines:
+            fdl = inv_line.fiscal_document_line_id
+            before = {f: fdl[f] for f in tax_fields}
+            fdl._compute_tax_fields()
+            for f, stored in before.items():
+                self.assertAlmostEqual(
+                    fdl[f],
+                    stored,
+                    2,
+                    f"{f} on invoice line for {inv_line.product_id.display_name}: "
+                    f"stored={stored}, recomputed={fdl[f]} — compute field was "
+                    f"copied frozen from SO line instead of computed for the "
+                    f"invoiced quantity",
+                )


### PR DESCRIPTION
## Problema

A PR #4371 corrigiu o `fiscal_quantity` em faturas parciais, mas a mesma causa-raiz continua afetando todos os outros campos `compute+store` populados por `_compute_tax_fields` — `icms_base`, `icms_value`, `icmssn_base`, `icmssn_credit_value`, além das bases/valores de IPI / PIS / COFINS e seus campos de percentual / redução correspondentes.

`l10n_br_sale.SaleOrderLine._prepare_invoice_line` chama `_prepare_br_fiscal_dict()`, que copia **todos** os campos fiscais da linha do pedido para o dict usado no `create()` da invoice line. No Odoo 16 esses campos são `compute=..., store=True, readonly=False`. Quando o ORM recebe um valor explícito no `create()` para um campo desse tipo, ele aceita o valor e **não dispara o compute** — mesmo com `quantity` no `depends` do campo.

Resultado: qualquer fatura gerada a partir de uma SOL com `qty_to_invoice ≠ product_uom_qty` (faturas parciais, ou `qty_delivered ≠ product_uom_qty` com `invoice_policy='delivery'`) mantém os impostos calculados para a quantidade originalmente pedida.

Isso produz valores errados no XML do SPED / NF-e (`<vBC>`, `<vICMS>`, `<vCredICMSSN>`, etc.) — embora os valores contábeis possam estar corretos, porque o recompute de `account.tax` do core trata `tax_ids` de forma independente.

O fluxo da v14 que protegia contra isso — `_update_fiscal_quantity` chamado de `account.move.line.create()` — foi removido no commit `2ed9a96e7` (`[REF] l10n_br_account: fisc qty/price -> compute`, 01/04/2025) quando `fiscal_quantity` / `fiscal_price` viraram compute fields.

## Correção

Remove do dict, antes do retorno, todo campo `compute+store` cujo método de compute seja `_compute_tax_fields`, `_compute_fiscal_quantity`, `_compute_fiscal_price` ou `_compute_uot_id`. Assim o ORM recomputa esses campos com a quantidade efetivamente faturada.

A detecção é feita por introspecção dos metadados de campo, então adicionar novos campos compute no `_compute_tax_fields` futuramente não exige atualizar este código.

## Teste

O `test_partial_invoice_fiscal_quantity` (adicionado em #4371) foi estendido com `_assert_tax_fields_match_recompute`, que tira um snapshot dos valores fiscais armazenados, força `_compute_tax_fields()` na linha do documento fiscal e valida que os valores batem.

Sem a correção o teste falha com mensagem clara:

```
icms_base on invoice line for [FURN_8855] Drawer: stored=1032.5, recomputed=516.25 — compute field was copied frozen from SO line instead of computed for the invoiced quantity
```

(fatura para metade da quantidade pedida — a base do ICMS deveria ser metade também)

Com a correção, todos os 24 testes do `l10n_br_sale` passam.

## Impacto

Reproduzível em `invoice_policy='delivery'` com `qty_delivered ≠ product_uom_qty`, e em faturas parciais em geral. Descoberto em produção em uma empresa do Simples Nacional, em que clientes recebiam NFs com `<vCredICMSSN>` calculado para a quantidade pedida em vez da efetivamente faturada.