### PR TITLE
[14.0][FIX] l10n_br_nfse_focus: add informacoes_complementares and logic nbs

### DIFF
--- a/l10n_br_nfse_focus/models/nfse_nacional.py
+++ b/l10n_br_nfse_focus/models/nfse_nacional.py
@@ -191,7 +191,9 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
             "codigo_municipio_prestacao": int(codigo_municipio_prestacao),
             "codigo_tributacao_nacional": codigo_tributacao_nacional,
             "codigo_tributacao_municipio": codigo_tributacao_municipio,
-            "codigo_nbs": service_info.get("codigo_nbs", ""),
+            "codigo_nbs": ""
+            if self.env.company.city_id.ibge_code == "3516200"
+            else service_info.get("codigo_nbs", ""),
             "descricao": service_info.get("discriminacao", ""),
             "valor": round(service_info.get("valor_servicos", 0), 2),
             "tributacao_iss": int(tributacao_iss),
@@ -361,6 +363,11 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
                 "percentual_total_tributos_municipais"
             ],
             "indicador_total_tributacao": 0,
+            "informacoes_complementares": (
+                rps_info.get("customer_additional_data", False)[:2000]
+                if rps_info.get("customer_additional_data")
+                else False
+            ),
             **tax_data,
         }
 


### PR DESCRIPTION
@Escodoo HT01920

## Objetivo da PR
https://github.com/OCA/l10n-brazil/pull/4409/changes
https://github.com/OCA/l10n-brazil/pull/4417/changes
Quando foi feito FWP para 14.0 se perdeu a questão de informacoes_complementares corrigido
<img width="1919" height="807" alt="4332was232" src="https://github.com/user-attachments/assets/f4da9df6-2fce-497c-9f2c-557e1cc121ec" />


Hoje também a prefeitura de Franca não manda o código NBS então feito a logica para quando a empresa for da cidade de franca enviar vazio