### PR TITLE
[16.0][FIX] l10n_br_coa_simple: duplicate accounts

### DIFF
--- a/l10n_br_coa_simple/data/account_group_template.xml
+++ b/l10n_br_coa_simple/data/account_group_template.xml
@@ -600,27 +600,6 @@
         <field name="chart_template_id" ref="l10n_br_coa_simple_chart_template" />
     </record>
 
-    <record id="account_group_template_3320301" model="account.group.template">
-        <field name="code_prefix_start">3.3.2.03.01</field>
-        <field name="name">Taxas e Tributos Municipais</field>
-        <field name="parent_id" ref="account_group_template_33203" />
-        <field name="chart_template_id" ref="l10n_br_coa_simple_chart_template" />
-    </record>
-
-    <record id="account_group_template_3320302" model="account.group.template">
-        <field name="code_prefix_start">3.3.2.03.02</field>
-        <field name="name">PIS s/ Outras Receitas</field>
-        <field name="parent_id" ref="account_group_template_33203" />
-        <field name="chart_template_id" ref="l10n_br_coa_simple_chart_template" />
-    </record>
-
-    <record id="account_group_template_3320303" model="account.group.template">
-        <field name="code_prefix_start">3.3.2.03.03</field>
-        <field name="name">COFINS s/ Outras Receitas</field>
-        <field name="parent_id" ref="account_group_template_33203" />
-        <field name="chart_template_id" ref="l10n_br_coa_simple_chart_template" />
-    </record>
-
     <record id="account_group_template_339" model="account.group.template">
         <field name="code_prefix_start">3.3.9</field>
         <field name="name">Outros Resultados Operacionais</field>


### PR DESCRIPTION
removed duplicate accounts from account.group file

Bug encontrado ao migrar para a 17.0 em #4370

Essas 3 contas analíticas (account.account) ficaram duplicadas nesse arquivo de contas sintéticas (account.group). Por algum motivo só deu erro na 17, mas voltei aqui pra arrumar na 16 também 

<img width="772" height="114" alt="image" src="https://github.com/user-attachments/assets/3fcc49d6-4bc2-4a35-9108-8b02c5e83dc1" />
_Anexo 7 - ITG 1000 v2022_
