### PR TITLE
[16.0][REF] l10n_br_account: mv tests to move_workflow

### DIFF
--- a/l10n_br_account/tests/__init__.py
+++ b/l10n_br_account/tests/__init__.py
@@ -1,5 +1,3 @@
-# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
-
 from . import test_account_move_sn
 from . import test_account_move_lc
 from . import test_account_taxes
@@ -8,3 +6,4 @@ from . import test_move_document_discount
 from . import test_invoice_refund
 from . import test_multi_localizations_invoice
 from . import test_payment_status
+from . import test_move_workflow

--- a/l10n_br_account/tests/test_account_move_lc.py
+++ b/l10n_br_account/tests/test_account_move_lc.py
@@ -2131,31 +2131,3 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
         )
         self.assertEqual(len(self.move_in_compra_para_revenda.line_ids), 11)
         self.assertEqual(self.move_in_compra_para_revenda.amount_total, 2065.0)
-
-    def test_change_states(self):
-        # first we make a few assertions about an existing vendor bill:
-        document_id = self.move_out_venda.fiscal_document_id
-        self.assertEqual(self.move_out_venda.state, "draft")
-        self.assertEqual(document_id.state, "em_digitacao")
-        self.move_out_venda.action_post()
-        self.assertEqual(self.move_out_venda.state, "posted")
-        fiscal_edi = self.env["ir.module.module"].search(
-            [("name", "=", "l10n_br_fiscal_edi")]
-        )
-        if fiscal_edi and fiscal_edi.state == "installed":
-            self.assertEqual(document_id.state, "a_enviar")
-            self.move_out_venda.button_draft()
-            self.assertEqual(self.move_out_venda.state, "draft")
-            self.assertEqual(document_id.state, "em_digitacao")
-            document_id.action_document_confirm()
-            self.assertEqual(self.move_out_venda.state, "posted")
-            self.assertEqual(document_id.state, "a_enviar")
-            document_id.action_document_back2draft()
-            self.assertEqual(self.move_out_venda.state, "draft")
-            self.assertEqual(document_id.state, "em_digitacao")
-
-    def test_document_deny(self):
-        document_id = self.move_out_venda.fiscal_document_id
-        self.assertEqual(self.move_out_venda.state, "draft")
-        document_id.exec_after_SITUACAO_EDOC_DENEGADA("em_digitacao", "denegada")
-        self.assertEqual(self.move_out_venda.state, "cancel")

--- a/l10n_br_account/tests/test_move_workflow.py
+++ b/l10n_br_account/tests/test_move_workflow.py
@@ -1,0 +1,50 @@
+# Copyright (C) 2025 Diego Paradeda - KMEE
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests.common import tagged
+
+from .common import AccountMoveBRCommon
+
+
+@tagged("post_install", "-at_install")
+class TestMoveWorkflow(AccountMoveBRCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.configure_normal_company_taxes()
+
+        cls.move_out_venda = cls.init_invoice(
+            "out_invoice",
+            products=[cls.product_a],
+            document_type=cls.env.ref("l10n_br_fiscal.document_55"),
+            document_serie_id=cls.empresa_lc_document_55_serie_1,
+            fiscal_operation=cls.env.ref("l10n_br_fiscal.fo_venda"),
+            fiscal_operation_lines=[cls.env.ref("l10n_br_fiscal.fo_venda_venda")],
+        )
+
+    def test_change_states(self):
+        document_id = self.move_out_venda.fiscal_document_id
+        self.assertEqual(self.move_out_venda.state, "draft")
+        self.assertEqual(document_id.state, "em_digitacao")
+        self.move_out_venda.action_post()
+        self.assertEqual(self.move_out_venda.state, "posted")
+        fiscal_edi = self.env["ir.module.module"].search(
+            [("name", "=", "l10n_br_fiscal_edi")]
+        )
+        if fiscal_edi and fiscal_edi.state == "installed":
+            self.assertEqual(document_id.state, "a_enviar")
+            self.move_out_venda.button_draft()
+            self.assertEqual(self.move_out_venda.state, "draft")
+            self.assertEqual(document_id.state, "em_digitacao")
+            document_id.action_document_confirm()
+            self.assertEqual(self.move_out_venda.state, "posted")
+            self.assertEqual(document_id.state, "a_enviar")
+            document_id.action_document_back2draft()
+            self.assertEqual(self.move_out_venda.state, "draft")
+            self.assertEqual(document_id.state, "em_digitacao")
+
+    def test_document_deny(self):
+        document_id = self.move_out_venda.fiscal_document_id
+        self.assertEqual(self.move_out_venda.state, "draft")
+        document_id.exec_after_SITUACAO_EDOC_DENEGADA("em_digitacao", "denegada")
+        self.assertEqual(self.move_out_venda.state, "cancel")


### PR DESCRIPTION
move some l10n_br_account tests to a dedicated test_move_workflow.py file (test_account_move_lc.py is only for account move entry tests)