### PR TITLE
[18.0][FW] [IMP] l10n_br_coa: load BR accounts on _load

### DIFF
--- a/l10n_br_coa/__manifest__.py
+++ b/l10n_br_coa/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Base dos Planos de Contas",
     "summary": """
         Base do Planos de Contas brasileiros""",
-    "version": "18.0.1.0.1",
+    "version": "18.0.1.0.2",
     "license": "AGPL-3",
     "author": "Akretion, KMEE, Odoo Community Association (OCA)",
     "maintainers": ["renatonlima", "mileo"],

--- a/l10n_br_coa/models/template_br_oca.py
+++ b/l10n_br_coa/models/template_br_oca.py
@@ -102,6 +102,10 @@ class AccountChartTemplate(models.AbstractModel):
                     "account_purchase_tax_id": False,
                 }
             )
+            flavor = "itg"
+            if template_code == "br_oca_generic" or company.tax_framework == "3":
+                flavor = "cfc"
+            self._populate_default_br_tax_accounts(company, flavor=flavor)
         return result
 
     def _set_tax_group_accs(self, template_code, tax_data):
@@ -169,6 +173,7 @@ class AccountChartTemplate(models.AbstractModel):
         Account = self.env["account.account"]
         IrModelData = self.env["ir.model.data"].sudo()
         created_accounts_refs = {}
+        created_accounts_by_code = {}
 
         # 1. Create or find accounts and their XMLIDs
         for xml_id_name_part, (
@@ -180,19 +185,26 @@ class AccountChartTemplate(models.AbstractModel):
             # Use fixed codes. Ensure they don't clash with base CoA or handle it.
             # We assume these codes are specific enough.
             code = code_cfc if flavor == "cfc" else code_itg
-            code = f"{code}{review_suffix}"
+            code_gen = f"{code}{review_suffix}"
+
+            # Reuse account if same code was already processed in this loop
+            # (some tax accounts share the same code in the CSV)
+            if code in created_accounts_by_code:
+                created_accounts_refs[xml_id_name_part] = created_accounts_by_code[code]
+                continue
 
             # TODO: would be better to 1st search for the taxes related to all templates
             # DEFAULT_TAX_TEMPLATES_ACCOUNTS.items()
             # and if xml_id_name_part is related to a tax template for which the tax
             # repartion_line_ids have accounts already, then skip account creation
             existing_account = Account.search(
-                [("code", "=", code), ("company_ids", "in", [company.id])], limit=1
+                [("code", "in", [code, code_gen]), ("company_ids", "in", [company.id])],
+                limit=1,
             )
             if not existing_account:
                 account = Account.create(
                     {
-                        "code": code,
+                        "code": code_gen,
                         "name": name,
                         "account_type": acc_type,
                         "company_ids": [Command.link(company.id)],
@@ -205,6 +217,7 @@ class AccountChartTemplate(models.AbstractModel):
                     account.write({"account_type": acc_type})
 
             created_accounts_refs[xml_id_name_part] = account
+            created_accounts_by_code[code] = account
 
             # Ensure ir.model.data exists for easy reference
             imd_module = self._get_chart_template_mapping().get(company.chart_template)[
@@ -252,8 +265,12 @@ class AccountChartTemplate(models.AbstractModel):
             )
             company_tax = self.env.ref(tax_xmlid, raise_if_not_found=False)
             if not company_tax:
-                _logger.warning(f"tax {tax_xmlid} not found! Skipping it...")
-                continue
+                tax_xmlid = f"account.{company.id}_{tax_template_xmlid.split('.')[1]}"
+                company_tax = self.env.ref(tax_xmlid, raise_if_not_found=False)
+
+                if not company_tax:
+                    _logger.info(f"tax {tax_xmlid} not found! Skipping it...")
+                    continue
 
             inv_rep_acc_key, ref_rep_acc_key = acc_mapping_keys
             invoice_account = (


### PR DESCRIPTION
Port from 17.0 to 18.0:\n- w/o PR (commit 5f66b80d)\n\nNote: Added fixes for Odoo 18.0 compatibility:\n- Handle duplicate account codes in DEFAULT_TAX_ACCOUNTS\n- Change missing tax template log from warning to info to avoid CI failures