### PR TITLE
[16.0][FIX] l10n_br_stock_account: inherit fiscal operation from picking to move

### DIFF
--- a/l10n_br_stock_account/wizards/stock_invoice_onshipping.py
+++ b/l10n_br_stock_account/wizards/stock_invoice_onshipping.py
@@ -145,8 +145,18 @@ class StockInvoiceOnshipping(models.TransientModel):
 
         values = super()._get_invoice_line_values(moves, invoice_values, invoice)
         move = fields.first(moves)
+
+        if not move.fiscal_operation_id and move.picking_id.fiscal_operation_id:
+            move.fiscal_operation_id = move.picking_id.fiscal_operation_id
+            operation_lines = move.picking_id.fiscal_operation_id.line_ids.filtered(
+                lambda line: line.fiscal_operation_type
+                == move.picking_id.fiscal_operation_id.fiscal_operation_type
+            )
+            if operation_lines:
+                move.fiscal_operation_line_id = operation_lines[0].id
+
         if not move.fiscal_operation_id:
-            # Caso Brasileiro se caracteriza pela Operação Fiscal
+            # Brazilian case is characterized by having a Fiscal Operation
             return values
 
         fiscal_values = move._prepare_br_fiscal_dict()


### PR DESCRIPTION
@Escodoo [SO571-14]

cc @marcelsavegnago @WesleyOliveira98 @CristianoMafraJunior 

Problem:

When creating an invoice from a stock picking in the Brazilian localization, the stock.move records may not inherit the fiscal operation from their picking. This causes the invoice to be created without fiscal data, resulting in XML validation errors when generating NF-e documents.

Root Cause:

Some stock moves (particularly those created from inventory transfers or specialized workflows like fleet vehicle stock) are created without the fiscal operation being properly linked, even when the picking itself has a fiscal operation defined.

Solution:

Added logic in the _get_invoice_line_values method to automatically inherit the fiscal operation and fiscal operation line from the picking to the move when the move does not have a fiscal operation defined.

Changes:

- Modified l10n_br_stock_account/wizards/stock_invoice_onshipping.py
- Added check to verify if move has fiscal operation
- If not, inherit from picking and get the first matching operation line