### PR TITLE
[18.0][FIX] l10n_br_fiscal: substituir parent.tax_framework por campos Json computados no dominio

### DIFF
--- a/l10n_br_fiscal/models/res_company.py
+++ b/l10n_br_fiscal/models/res_company.py
@@ -221,6 +221,12 @@ class ResCompany(models.Model):
         domain="[('piscofins_type', '=', 'company')]",
     )
 
+    # Computed domains replace parent.tax_framework (Odoo 17 client-side JS).
+    # Odoo 18 evaluates Many2one domains server-side; parent. is invalid there.
+    piscofins_id_domain = fields.Json(compute="_compute_piscofins_id_domain")
+    tax_ipi_id_domain = fields.Json(compute="_compute_tax_ipi_id_domain")
+    tax_icms_id_domain = fields.Json(compute="_compute_tax_icms_id_domain")
+
     tax_cofins_wh_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax",
         string="Default COFINS RET",
@@ -358,6 +364,55 @@ class ResCompany(models.Model):
             tax_def.update(tax_def_values)
         else:
             self.tax_definition_ids |= self.tax_definition_ids.create(tax_def_values)
+
+    @api.depends("tax_framework")
+    def _compute_piscofins_id_domain(self):
+        sn_ref = self.env.ref(
+            "l10n_br_fiscal.tax_pis_cofins_simples_nacional",
+            raise_if_not_found=False,
+        )
+        sn_id = sn_ref.id if sn_ref else 0
+        for rec in self:
+            base = [("piscofins_type", "=", "company")]
+            if rec.tax_framework == TAX_FRAMEWORK_NORMAL:
+                rec.piscofins_id_domain = base + [("id", "!=", sn_id)]
+            else:
+                rec.piscofins_id_domain = base + [("id", "=", sn_id)]
+
+    @api.depends("tax_framework")
+    def _compute_tax_ipi_id_domain(self):
+        ipi_outros = self.env.ref(
+            "l10n_br_fiscal.tax_ipi_outros", raise_if_not_found=False
+        )
+        tax_group_ipi = self.env.ref(
+            "l10n_br_fiscal.tax_group_ipi", raise_if_not_found=False
+        )
+        outros_id = ipi_outros.id if ipi_outros else 0
+        group_id = tax_group_ipi.id if tax_group_ipi else 0
+        for rec in self:
+            if rec.tax_framework == TAX_FRAMEWORK_NORMAL:
+                rec.tax_ipi_id_domain = [
+                    ("id", "!=", outros_id),
+                    ("tax_group_id", "=", group_id),
+                ]
+            else:
+                rec.tax_ipi_id_domain = [("id", "=", outros_id)]
+
+    @api.depends("tax_framework")
+    def _compute_tax_icms_id_domain(self):
+        icms_group = self.env.ref(
+            "l10n_br_fiscal.tax_group_icms", raise_if_not_found=False
+        )
+        icmssn_group = self.env.ref(
+            "l10n_br_fiscal.tax_group_icmssn", raise_if_not_found=False
+        )
+        icms_id = icms_group.id if icms_group else 0
+        icmssn_id = icmssn_group.id if icmssn_group else 0
+        for rec in self:
+            if rec.tax_framework == TAX_FRAMEWORK_NORMAL:
+                rec.tax_icms_id_domain = [("tax_group_id", "=", icms_id)]
+            else:
+                rec.tax_icms_id_domain = [("tax_group_id", "=", icmssn_id)]
 
     @api.onchange("profit_calculation", "tax_framework")
     def _onchange_profit_calculation(self):

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -16,4 +16,5 @@ from . import (
     test_partner_profile,
     test_service_type,
     test_operation,
+    test_company_tax_domain,
 )

--- a/l10n_br_fiscal/tests/test_company_tax_domain.py
+++ b/l10n_br_fiscal/tests/test_company_tax_domain.py
@@ -1,0 +1,85 @@
+# Copyright 2026 Claudio Noronha - Zaion Solutions
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tests import TransactionCase, tagged
+
+from ..constants.fiscal import TAX_FRAMEWORK_NORMAL, TAX_FRAMEWORK_SIMPLES
+
+
+@tagged("post_install", "-at_install")
+class TestCompanyTaxDomain(TransactionCase):
+    """Test computed domain fields on res.company.
+
+    In Odoo 18, Many2one field domains are evaluated server-side (SQL/Python).
+    The view previously used parent.tax_framework which was resolved client-side
+    in Odoo <=17.  These tests ensure the computed fields return the correct
+    domains so the PIS/COFINS, IPI and ICMS dropdowns filter properly.
+
+    Note: fields.Json round-trips through JSON, so domain leaves are stored as
+    lists, not tuples.  Assertions must compare against lists accordingly.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.ref("base.main_company")
+        cls.sn_piscofins = cls.env.ref("l10n_br_fiscal.tax_pis_cofins_simples_nacional")
+        cls.ipi_outros = cls.env.ref("l10n_br_fiscal.tax_ipi_outros")
+        cls.tax_group_icms = cls.env.ref("l10n_br_fiscal.tax_group_icms")
+        cls.tax_group_icmssn = cls.env.ref("l10n_br_fiscal.tax_group_icmssn")
+
+    def test_piscofins_domain_regime_normal(self):
+        """Regime Normal: exclude Simples Nacional PIS/COFINS group."""
+        self.company.tax_framework = TAX_FRAMEWORK_NORMAL
+        domain = self.company.piscofins_id_domain
+        self.assertIn(["piscofins_type", "=", "company"], domain)
+        self.assertIn(["id", "!=", self.sn_piscofins.id], domain)
+        # Simples Nacional group must NOT appear in search results
+        results_ids = [
+            r[0]
+            for r in self.env["l10n_br_fiscal.tax.pis.cofins"].name_search(
+                "", args=domain
+            )
+        ]
+        self.assertNotIn(self.sn_piscofins.id, results_ids)
+
+    def test_piscofins_domain_simples_nacional(self):
+        """Simples Nacional: show only the Simples Nacional PIS/COFINS group."""
+        self.company.tax_framework = TAX_FRAMEWORK_SIMPLES
+        domain = self.company.piscofins_id_domain
+        self.assertIn(["piscofins_type", "=", "company"], domain)
+        self.assertIn(["id", "=", self.sn_piscofins.id], domain)
+        results_ids = [
+            r[0]
+            for r in self.env["l10n_br_fiscal.tax.pis.cofins"].name_search(
+                "", args=domain
+            )
+        ]
+        self.assertIn(self.sn_piscofins.id, results_ids)
+        self.assertEqual(len(results_ids), 1)
+
+    def test_ipi_domain_regime_normal(self):
+        """Regime Normal: IPI group must exclude tax_ipi_outros."""
+        self.company.tax_framework = TAX_FRAMEWORK_NORMAL
+        domain = self.company.tax_ipi_id_domain
+        self.assertIn(["id", "!=", self.ipi_outros.id], domain)
+
+    def test_ipi_domain_simples_nacional(self):
+        """Simples Nacional: only tax_ipi_outros is valid."""
+        self.company.tax_framework = TAX_FRAMEWORK_SIMPLES
+        domain = self.company.tax_ipi_id_domain
+        self.assertIn(["id", "=", self.ipi_outros.id], domain)
+
+    def test_icms_domain_regime_normal(self):
+        """Regime Normal: ICMS domain uses regular tax_group_icms."""
+        self.company.tax_framework = TAX_FRAMEWORK_NORMAL
+        domain = self.company.tax_icms_id_domain
+        self.assertIn(["tax_group_id", "=", self.tax_group_icms.id], domain)
+        self.assertNotIn(["tax_group_id", "=", self.tax_group_icmssn.id], domain)
+
+    def test_icms_domain_simples_nacional(self):
+        """Simples Nacional: ICMS domain uses tax_group_icmssn."""
+        self.company.tax_framework = TAX_FRAMEWORK_SIMPLES
+        domain = self.company.tax_icms_id_domain
+        self.assertIn(["tax_group_id", "=", self.tax_group_icmssn.id], domain)
+        self.assertNotIn(["tax_group_id", "=", self.tax_group_icms.id], domain)

--- a/l10n_br_fiscal/views/res_company_view.xml
+++ b/l10n_br_fiscal/views/res_company_view.xml
@@ -85,7 +85,7 @@
                                     <field
                                         name="piscofins_id"
                                         required="1"
-                                        domain="[ ('piscofins_type', '=', 'company'), '|', '&amp;', ('parent.tax_framework', '=', 3), ('id', '!=', %(l10n_br_fiscal.tax_pis_cofins_simples_nacional)d), '&amp;', ('parent.tax_framework', '!=', 3), ('id', '=', %(l10n_br_fiscal.tax_pis_cofins_simples_nacional)d) ]"
+                                        domain="piscofins_id_domain"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
                                     <field name="tax_pis_wh_id" />
@@ -100,7 +100,7 @@
                                         name="tax_ipi_id"
                                         invisible="tax_framework == '3' and ripi"
                                         required="tax_framework != '3'"
-                                        domain="['|', '&amp;', ('parent.tax_framework', '=', 3), '&amp;', ('id', '!=', %(l10n_br_fiscal.tax_ipi_outros)d), ('tax_group_id', '=', %(l10n_br_fiscal.tax_group_ipi)d), '&amp;', ('parent.tax_framework', '!=', 3), ('id', '=', %(l10n_br_fiscal.tax_ipi_outros)d) ]"
+                                        domain="tax_ipi_id_domain"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
                                     <div
@@ -114,7 +114,7 @@
                                         name="tax_icms_id"
                                         invisible="tax_framework == '3'"
                                         required="tax_framework in ('1', '2')"
-                                        domain="['|', '&amp;', ('parent.tax_framework', '=', 3), ('tax_group_id', '=', %(l10n_br_fiscal.tax_group_icms)d), '&amp;', ('parent.tax_framework', '!=', 3), ('tax_group_id', '=', %(l10n_br_fiscal.tax_group_icmssn)d) ]"
+                                        domain="tax_icms_id_domain"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
                                     <field


### PR DESCRIPTION
Corrige #4565

## Resumo

No Odoo 18, os domínios de campos `Many2one` são avaliados **no servidor**
(Python/SQL). A notação `parent.campo` que funcionava no Odoo 17 (JavaScript
no cliente) agora causa:

```
ValueError: Invalid field l10n_br_fiscal.tax.pis.cofins.parent
  in leaf ('parent.tax_framework', '=', 3)
```

Isso afeta os campos `piscofins_id`, `tax_ipi_id` e `tax_icms_id` na aba
de configurações fiscais da empresa.

## Alterações

- `l10n_br_fiscal/models/res_company.py`: adiciona três campos computados
  `fields.Json` (`piscofins_id_domain`, `tax_ipi_id_domain`, `tax_icms_id_domain`)
  que retornam o domínio correto de acordo com o `tax_framework` da empresa
- `l10n_br_fiscal/views/res_company_view.xml`: substitui as expressões estáticas
  `parent.tax_framework` pelos novos campos de domínio computados
- `l10n_br_fiscal/tests/test_company_tax_domain.py`: testes unitários cobrindo
  as seis combinações de domínio (3 campos x 2 regimes tributários: Regime Normal
  e Simples Nacional)

## Como testar

```
odoo --test-enable -i l10n_br_fiscal --stop-after-init
```
