### PR TITLE
[16.0][FIX] l10n_br_sale_blanket_order: fix line computes when switching views

### DIFF
--- a/l10n_br_sale_blanket_order/models/sale_blanket_order.py
+++ b/l10n_br_sale_blanket_order/models/sale_blanket_order.py
@@ -85,30 +85,20 @@ class SaleBlanketOrder(models.Model):
             order._compute_amount()
 
     @api.model
-    def fields_view_get(
-        self, view_id=None, view_type="form", toolbar=False, submenu=False
-    ):
-        order_view = super().fields_view_get(view_id, view_type, toolbar, submenu)
+    def _get_view(self, view_id=None, view_type="form", **options):
+        arch, view = super()._get_view(view_id, view_type, **options)
+        if self.env.company.country_id.code != "BR":
+            return arch, view
+        if view_type == "form" and self.env.company.country_id.code == "BR":
+            arch = self.env["sale.blanket.order.line"].inject_fiscal_fields(arch)
+        if view_type == "form" and (
+            self.user_has_groups("l10n_br_sale.group_line_fiscal_detail")
+            or self.env.context.get("force_line_fiscal_detail_edition")
+        ):
+            for sub_tree_node in arch.xpath("//field[@name='line_ids']/tree"):
+                sub_tree_node.attrib["editable"] = ""
 
-        if view_type == "form":
-            view = self.env["ir.ui.view"]
-
-            sub_form_view = order_view["fields"]["line_ids"]["views"]["form"]["arch"]
-
-            sub_form_node = self.env["sale.blanket.order.line"].inject_fiscal_fields(
-                sub_form_view
-            )
-
-            sub_arch, sub_fields = view.postprocess_and_fields(
-                sub_form_node, "sale.blanket.order.line", False
-            )
-
-            order_view["fields"]["line_ids"]["views"]["form"] = {
-                "fields": sub_fields,
-                "arch": sub_arch,
-            }
-
-        return order_view
+        return arch, view
 
     @api.onchange("fiscal_operation_id")
     def _onchange_fiscal_operation_id(self):

--- a/l10n_br_sale_blanket_order/tests/test_l10n_br_sale_blanket_order.py
+++ b/l10n_br_sale_blanket_order/tests/test_l10n_br_sale_blanket_order.py
@@ -1,7 +1,10 @@
 # Copyright 2023 - TODAY, Kaynnan Lemes <kaynnan.lemes@escodoo.com.br>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from contextlib import contextmanager
 from datetime import date, timedelta
+
+from lxml import etree
 
 from odoo.fields import Command
 from odoo.tests.common import TransactionCase
@@ -82,6 +85,24 @@ class L10nBrSaleBLanketOrderTest(TransactionCase):
         )
 
         return wizard
+
+    @contextmanager
+    def _temporary_company_country(self, country):
+        original_country = self.company.country_id
+        self.company.country_id = country
+        try:
+            yield
+        finally:
+            self.company.country_id = original_country
+
+    @contextmanager
+    def _temporary_user_groups(self, groups):
+        original_groups = self.env.user.groups_id
+        self.env.user.groups_id = groups
+        try:
+            yield
+        finally:
+            self.env.user.groups_id = original_groups
 
     # Test method to confirm and process a Blanket Order.
     def test_confirm_and_process_blanket_order_and_invoice(self):
@@ -201,3 +222,56 @@ class L10nBrSaleBLanketOrderTest(TransactionCase):
             ("id", "=", self.company.cnae_main_id.id),
         ]
         self.assertEqual(domain, expected_domain)
+
+    def test_get_view(self):
+        """Covers all _get_view branches for sale.blanket.order."""
+
+        sale_blanket_order = self.env["sale.blanket.order"]
+        group_fiscal = self.env.ref(
+            "l10n_br_sale.group_line_fiscal_detail", raise_if_not_found=False
+        ) or self.skipTest("Group l10n_br_sale.group_line_fiscal_detail not found.")
+
+        with self.subTest("BR company - form view - fiscal fields injected"):
+            arch, _ = sale_blanket_order._get_view(view_type="form")
+            self.assertIn(
+                "fiscal_operation_id", etree.tostring(arch, encoding="unicode")
+            )
+
+        with self.subTest("Non-BR company - form view - line_ids tree not modified"):
+            us_country = self.env.ref("base.us")
+            with self._temporary_company_country(us_country):
+                arch_non_br, _ = sale_blanket_order._get_view(view_type="form")
+                self.assertFalse(
+                    any(
+                        sub_tree.get("editable") == ""
+                        for sub_tree in arch_non_br.xpath(
+                            "//field[@name='line_ids']/tree"
+                        )
+                    ),
+                    "Error: line_ids tree should not be editable for non-BR company.",
+                )
+
+        with self.subTest("BR company - fiscal group - line_ids tree editable"):
+            with self._temporary_user_groups([(4, group_fiscal.id)]):
+                arch_group, _ = sale_blanket_order._get_view(view_type="form")
+                self.assertTrue(
+                    all(
+                        sub_tree.get("editable", "NOT_SET") == ""
+                        for sub_tree in arch_group.xpath(
+                            "//field[@name='line_ids']/tree"
+                        )
+                    ),
+                    "Error: line_ids tree should be editable for fiscal detail group.",
+                )
+
+        with self.subTest("BR company - force_line_fiscal_detail_edition context"):
+            arch_ctx, _ = sale_blanket_order.with_context(
+                force_line_fiscal_detail_edition=True
+            )._get_view(view_type="form")
+            self.assertTrue(
+                all(
+                    sub_tree.get("editable", "NOT_SET") == ""
+                    for sub_tree in arch_ctx.xpath("//field[@name='line_ids']/tree")
+                ),
+                "Error: line_ids tree editable with force_line_fiscal_detail_edition.",
+            )

--- a/l10n_br_sale_blanket_order/views/sale_blanket_order.xml
+++ b/l10n_br_sale_blanket_order/views/sale_blanket_order.xml
@@ -25,6 +25,25 @@
                     options="{'currency_field': 'currency_id'}"
                 />
             </field>
+            <xpath expr="//field[@name='line_ids']/tree" position="inside">
+                <control name="fiscal_fields" invisible="1" />
+                <!-- this is a dynamic fiscal fields placeholder-->
+                <control name="fiscal_taxes_fields" string="Taxes" invisible="1" />
+                <!-- this is a dynamic fiscal fields placeholder-->
+                <!-- the fields below would be injected by the placeholders
+                    above, but we need to repeat them here to please the
+                    Form test framework or because they are used in some
+                    domain here that is checked before the dynamic fiscal
+                    placeholders kick in.
+                -->
+                <field name="fiscal_operation_type" invisible="1" />
+                <field name="cfop_id" invisible="1" />
+                <field name="tax_framework" invisible="1" />
+                <field name="fiscal_operation_id" invisible="1" />
+                <field name="freight_value" invisible="1" />
+                <field name="insurance_value" invisible="1" />
+                <field name="other_value" invisible="1" />
+            </xpath>
             <field name="validity_date" position="after">
                 <field name="fiscal_operation_id" required="True" />
                 <field name="ind_final" required="True" />


### PR DESCRIPTION
[[BUG] Erro no preenchimento entre inline e form](https://github.com/OCA/l10n-brazil/issues/4586)
@Escodoo [SO571-57]

cc @marcelsavegnago @WesleyOliveira98 @CristianoMafraJunior 

## Problema

Ao alternar entre a edição direta na lista (tree view) e o detalhamento em popup (form view) nas linhas do acordo programado (blanket order), os campos fiscais e os impostos, ficavam vazios ou deixavam de recalcular.

