### PR TITLE
[16.0][REF] l10n_br_nfse_focus: token password true

### DIFF
--- a/l10n_br_nfse_focus/views/res_company.xml
+++ b/l10n_br_nfse_focus/views/res_company.xml
@@ -14,10 +14,12 @@
                 <field
                     name="focusnfe_production_token"
                     attrs="{'invisible': ['|',('provedor_nfse','!=', 'focusnfe'),('nfse_environment', '!=', '1')]}"
+                    password="True"
                 />
                 <field
                     name="focusnfe_homologation_token"
                     attrs="{'invisible': ['|',('provedor_nfse','!=', 'focusnfe'),('nfse_environment', '!=', '2')]}"
+                    password="True"
                 />
                 <field
                     name="focusnfe_nfse_service_type_value"


### PR DESCRIPTION
Deixando `password=True` nos campos de Token da Focus