### PR TITLE
[19.0][REF] l10n_br_resource: refactor module

### DIFF
--- a/l10n_br_resource/README.rst
+++ b/l10n_br_resource/README.rst
@@ -104,9 +104,10 @@ Contributors
 ------------
 
 - Luis Felipe Mileo <mileo@kmee.com.br>
-- Luiz Divino <luiz.divino@kmee.com.br>
+- Luiz Divino luiz.divino@kmee.com.br
 - Hendrix Costa <hendrix.costa@kmee.com.br>
 - Bruna Braga <bruna.braga@kmee.com.br>
+- Cristiano Mafra Junior <cristiano.mafra@escodoo.com.br>
 
 Other credits
 -------------
@@ -131,13 +132,10 @@ promote its widespread use.
 .. |maintainer-mileo| image:: https://github.com/mileo.png?size=40px
     :target: https://github.com/mileo
     :alt: mileo
-.. |maintainer-lfdivino| image:: https://github.com/lfdivino.png?size=40px
-    :target: https://github.com/lfdivino
-    :alt: lfdivino
 
-Current `maintainers <https://odoo-community.org/page/maintainer-role>`__:
+Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
 
-|maintainer-mileo| |maintainer-lfdivino| 
+|maintainer-mileo| 
 
 This module is part of the `OCA/l10n-brazil <https://github.com/OCA/l10n-brazil/tree/19.0/l10n_br_resource>`_ project on GitHub.
 

--- a/l10n_br_resource/__manifest__.py
+++ b/l10n_br_resource/__manifest__.py
@@ -12,7 +12,7 @@
     "author": "KMEE,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-brazil",
     "depends": ["l10n_br_base", "resource"],
-    "maintainers": ["mileo", "lfdivino"],
+    "maintainers": ["mileo"],
     "external_dependencies": {"python": ["workalendar"]},
     "data": [
         "views/resource_calendar_view.xml",

--- a/l10n_br_resource/models/resource_calendar.py
+++ b/l10n_br_resource/models/resource_calendar.py
@@ -90,169 +90,153 @@ class ResourceCalendar(models.Model):
             leaves.append(leave)
         return leaves
 
-    def data_eh_feriado(self, data):
-        """Verificar se uma data é feriado.
-        :param datetime data_referencia: Se nenhuma data referencia for passada
-                                    verifique se hoje eh feriado no calendario
-                                    corrente.
-                                    Se a data referencia for passada, verifique
-                                    se a data esta dentro de algum leave do
-                                    calendario corrente
-                                    date_start <= data_referencia <= data_end
+    def is_holiday(self, date):
+        """Check if a date is a holiday.
 
-        :return boolean True se a data referencia for feriado
-                        False se a data referencia nao for feriado
+        :param datetime date: date to check. If not provided, checks today.
+        :return boolean: True if the date is a holiday, False otherwise.
         """
-        if not data:
-            data = datetime.now()
+        if not date:
+            date = datetime.now()
         for leave in self.leave_ids:
-            if leave.date_from <= data:
-                if leave.date_to >= data:
+            if leave.date_from <= date:
+                if leave.date_to >= date:
                     if leave.leave_type == "F":
                         return True
         return False
 
-    def data_eh_feriado_bancario(self, data_referencia):
-        """Verificar se uma data é feriado bancário.
-        :param datetime data_referencia: Se nenhuma data referencia for
-                                    passada verifique se hoje é feriado
-                                    bancário. Se a data referencia for
-                                    passada, verifique se a data esta
-                                    dentro de algum leave
-                                    date_start <= data_referencia <= data_end
+    def is_bank_holiday(self, reference_date):
+        """Check if a date is a bank holiday.
 
-        :return int leaves_count: +1 se for feriado bancário
-                                   0 se a data nao for feriado bancário
+        :param datetime reference_date: date to check. If not provided,
+                                        checks today.
+        :return int: number of matching bank holiday leaves (> 0 if it is
+                     a bank holiday, 0 otherwise).
         """
-        if not data_referencia:
-            data_referencia = datetime.now()
+        if not reference_date:
+            reference_date = datetime.now()
         domain = [
-            ("date_from", "<=", data_referencia.strftime("%Y-%m-%d %H:%M:%S")),
-            ("date_to", ">=", data_referencia.strftime("%Y-%m-%d %H:%M:%S")),
+            ("date_from", "<=", reference_date.strftime("%Y-%m-%d %H:%M:%S")),
+            ("date_to", ">=", reference_date.strftime("%Y-%m-%d %H:%M:%S")),
             ("leave_type", "in", ["F", "B"]),
         ]
         leaves_count = self.env["resource.calendar.leaves"].search_count(domain)
         return leaves_count
 
-    def data_eh_feriado_emendado(self, data_referencia):
-        """Verificar se uma data é feriado emendado.
-        :param datetime data_referencia: Se nenhuma data referencia for passada
-                                   verifique se hoje é feriado emendado.
-                                   Se a data referencia for passada, verifique
-                                   se a data esta dentro de algum leave
-                                   date_start <= data_referencia <= data_end
+    def is_extended_holiday(self, reference_date):
+        """Check if a date is a bridged/extended holiday (feriado emendado).
 
-        :return retorna True ou False
+        A day is considered bridged when it falls between a holiday and a weekend.
+
+        :param datetime reference_date: date to check. If not provided,
+                                        checks today.
+        :return boolean: True if the date is a bridged holiday, False otherwise.
         """
-        if not data_referencia:
-            data_referencia = datetime.now()
-        eh_feriado = self.data_eh_feriado(data_referencia)
-        dia_antes = data_referencia - timedelta(days=1)
-        dia_depois = data_referencia + timedelta(days=1)
+        if not reference_date:
+            reference_date = datetime.now()
+        is_holiday_result = self.is_holiday(reference_date)
+        day_before = reference_date - timedelta(days=1)
+        day_after = reference_date + timedelta(days=1)
 
-        dia_antes_eh_segunda = (
-            True
-            if dia_antes.weekday() == 0 or self.data_eh_feriado(dia_antes)
-            else False
+        day_before_is_monday = (
+            True if day_before.weekday() == 0 or self.is_holiday(day_before) else False
         )
-        dia_depois_eh_sexta = (
-            True
-            if dia_depois.weekday() == 4 or self.data_eh_feriado(dia_depois)
-            else False
+        day_after_is_friday = (
+            True if day_after.weekday() == 4 or self.is_holiday(day_after) else False
         )
 
-        return eh_feriado and (dia_antes_eh_segunda or dia_depois_eh_sexta)
+        return is_holiday_result and (day_before_is_monday or day_after_is_friday)
 
-    def data_eh_dia_util(self, data):
-        """Verificar se data é dia util.
-        :param datetime data: Se nenhuma data referencia for passada
-                              verifique o dia de hoje.
-        :return boolean True: Se for dia útil
-                        False: Se Não for dia útil
+    def is_business_day(self, date):
+        """Check if a date is a business day.
+
+        :param datetime date: date to check. If not provided, checks today.
+        :return boolean: True if it is a business day, False otherwise.
         """
-        if not data:
-            data = datetime.now()
-        return not self.data_eh_feriado(data) and data.weekday() <= 4 or False
+        if not date:
+            date = datetime.now()
+        return not self.is_holiday(date) and date.weekday() <= 4 or False
 
-    def quantidade_dias_uteis(self, data_inicio, data_fim):
-        """Calcular a quantidade de dias úteis em determinado período.
-        :param datetime data_inicio: Se nenhuma data referencia for passada
-                                   verifique o dia de hoje.
-        :param datetime data_fim: Se nenhuma data referencia for passada
-                                   verifique o dia de hoje.
-        :return int: Quantidade de dias úteis
+    def count_business_days(self, start_date, end_date):
+        """Count the number of business days in a given period.
+
+        :param datetime start_date: start of the period.
+        :param datetime end_date: end of the period.
+        :return int: number of business days.
         """
-        if not data_inicio:
-            data_inicio = datetime.now()
-        if not data_fim:
-            data_fim = datetime.now()
-        dias_uteis = 0
-        while data_inicio <= data_fim:
-            if self.data_eh_dia_util(data_inicio):
-                dias_uteis += 1
-            data_inicio += timedelta(days=1)
+        if not start_date:
+            start_date = datetime.now()
+        if not end_date:
+            end_date = datetime.now()
+        business_days = 0
+        while start_date <= end_date:
+            if self.is_business_day(start_date):
+                business_days += 1
+            start_date += timedelta(days=1)
 
-        return dias_uteis
+        return business_days
 
-    def proximo_dia_util(self, data_referencia):
-        """Retornar o próximo dia util.
-        :param datetime data_referencia: Se nenhuma data referencia for passada
-                                   verifique se amanha é dia útil.
-        :return datetime Proximo dia util apartir da data referencia
+    def next_business_day(self, reference_date):
+        """Return the next business day after reference_date.
+
+        :param datetime reference_date: reference date. If not provided,
+                                        checks tomorrow.
+        :return datetime: next business day from reference_date.
         """
-        if not data_referencia:
-            data_referencia = datetime.now()
-        data_referencia += timedelta(days=1)
-        while data_referencia:
-            if self.data_eh_dia_util(data_referencia):
-                return data_referencia
-            data_referencia += timedelta(days=1)
+        if not reference_date:
+            reference_date = datetime.now()
+        reference_date += timedelta(days=1)
+        while reference_date:
+            if self.is_business_day(reference_date):
+                return reference_date
+            reference_date += timedelta(days=1)
 
-    def get_dias_base(self, data_from, data_to, mes_comercial=True):
-        """Calcular a quantidade de dias que devem ser remunerados em
-        determinado intervalo de tempo.
-        :param datetime data_from: Data inicial do intervalo de tempo.
-               datetime data_end: Data final do intervalo
-        :return int : quantidade de dias que devem ser remunerada
+    def get_base_days(self, date_from, date_to, commercial_month=True):
+        """Calculate the number of payable days in a given time interval.
+
+        :param datetime date_from: start date of the interval.
+        :param datetime date_to: end date of the interval.
+        :param bool commercial_month: if True, uses 30-day commercial month.
+        :return int: number of payable days.
         """
-        if not data_from:
-            data_from = datetime.now()
-        if not data_to:
-            data_to = datetime.now()
-        # Mes comercial sempre será 30 dias
-        if mes_comercial:
-            return 30 - data_from.day + 1
-        # Na admissao e rescisao nao levar em conta o mes comercial
-        quantidade_dias = (data_to - data_from).days + 1
-        if quantidade_dias > 30:
+        if not date_from:
+            date_from = datetime.now()
+        if not date_to:
+            date_to = datetime.now()
+        # Commercial month is always 30 days
+        if commercial_month:
+            return 30 - date_from.day + 1
+        # On hire/termination, do not use commercial month
+        days_count = (date_to - date_from).days + 1
+        if days_count > 30:
             return 30
         else:
-            return quantidade_dias
+            return days_count
 
-    def data_eh_dia_util_bancario(self, data):
-        """Verificar se data é dia util.
-        :param datetime data: Se nenhuma data referencia for passada
-                              verifique o dia de hoje.
-        :return boolean True: Se for dia útil
-                        False: Se Não for dia útil
+    def is_bank_business_day(self, date):
+        """Check if a date is a bank business day.
+
+        :param datetime date: date to check. If not provided, checks today.
+        :return boolean: True if it is a bank business day, False otherwise.
         """
-        if not data:
-            data = datetime.now()
-        if data.weekday() >= 5:
+        if not date:
+            date = datetime.now()
+        if date.weekday() >= 5:
             return False
-        elif self.data_eh_feriado_bancario(data):
+        elif self.is_bank_holiday(date):
             return False
         return True
 
-    def proximo_dia_util_bancario(self, data_referencia):
-        """Retornar o próximo dia util.
-        :param datetime data_referencia: Se nenhuma data referencia for passada
-                                   verifique se amanha é dia útil.
-        :return datetime Proximo dia util apartir da data referencia
+    def next_bank_business_day(self, reference_date):
+        """Return the next bank business day after reference_date.
+
+        :param datetime reference_date: reference date. If not provided,
+                                        checks tomorrow.
+        :return datetime: next bank business day from reference_date.
         """
-        if not data_referencia:
-            data_referencia = datetime.now()
-        data_referencia += timedelta(days=1)
-        if self.data_eh_dia_util_bancario(data_referencia):
-            return data_referencia
-        return self.proximo_dia_util_bancario(data_referencia)
+        if not reference_date:
+            reference_date = datetime.now()
+        reference_date += timedelta(days=1)
+        if self.is_bank_business_day(reference_date):
+            return reference_date
+        return self.next_bank_business_day(reference_date)

--- a/l10n_br_resource/readme/CONTRIBUTORS.md
+++ b/l10n_br_resource/readme/CONTRIBUTORS.md
@@ -1,4 +1,5 @@
 - Luis Felipe Mileo \<<mileo@kmee.com.br>\>
-- Luiz Divino \<<luiz.divino@kmee.com.br>\>
+- Luiz Divino <luiz.divino@kmee.com.br>
 - Hendrix Costa \<<hendrix.costa@kmee.com.br>\>
 - Bruna Braga \<<bruna.braga@kmee.com.br>\>
+- Cristiano Mafra Junior \<<cristiano.mafra@escodoo.com.br>\>

--- a/l10n_br_resource/static/description/index.html
+++ b/l10n_br_resource/static/description/index.html
@@ -462,9 +462,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h3><a class="toc-backref" href="#toc-entry-10">Contributors</a></h3>
 <ul class="simple">
 <li>Luis Felipe Mileo &lt;<a class="reference external" href="mailto:mileo&#64;kmee.com.br">mileo&#64;kmee.com.br</a>&gt;</li>
-<li>Luiz Divino &lt;<a class="reference external" href="mailto:luiz.divino&#64;kmee.com.br">luiz.divino&#64;kmee.com.br</a>&gt;</li>
+<li>Luiz Divino <a class="reference external" href="mailto:luiz.divino&#64;kmee.com.br">luiz.divino&#64;kmee.com.br</a></li>
 <li>Hendrix Costa &lt;<a class="reference external" href="mailto:hendrix.costa&#64;kmee.com.br">hendrix.costa&#64;kmee.com.br</a>&gt;</li>
 <li>Bruna Braga &lt;<a class="reference external" href="mailto:bruna.braga&#64;kmee.com.br">bruna.braga&#64;kmee.com.br</a>&gt;</li>
+<li>Cristiano Mafra Junior &lt;<a class="reference external" href="mailto:cristiano.mafra&#64;escodoo.com.br">cristiano.mafra&#64;escodoo.com.br</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="other-credits">
@@ -483,8 +484,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
-<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainers</a>:</p>
-<p><a class="reference external image-reference" href="https://github.com/mileo"><img alt="mileo" src="https://github.com/mileo.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/lfdivino"><img alt="lfdivino" src="https://github.com/lfdivino.png?size=40px" /></a></p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/mileo"><img alt="mileo" src="https://github.com/mileo.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/l10n-brazil/tree/19.0/l10n_br_resource">OCA/l10n-brazil</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>

--- a/l10n_br_resource/tests/test_resource_calendar.py
+++ b/l10n_br_resource/tests/test_resource_calendar.py
@@ -80,7 +80,7 @@ class TestResourceCalendar(test_common.SingleTransactionCase):
             }
         )
 
-        # Testar workalendar_holiday_import
+        # Test workalendar_holiday_import
 
         self.calendar_id_sp = self.resource_calendar.create(
             {
@@ -92,7 +92,7 @@ class TestResourceCalendar(test_common.SingleTransactionCase):
         )
 
     def test_00_add_leave_nacional(self):
-        """Inclusao de um novo Feriado no calendario nacional"""
+        """Add a new holiday to the national calendar"""
         self.leave_nacional_02 = self.resource_leaves.create(
             {
                 "name": "Natal",
@@ -108,7 +108,7 @@ class TestResourceCalendar(test_common.SingleTransactionCase):
         self.assertEqual(2, len(self.nacional_calendar_id.leave_ids))
 
     def test_01_add_leave_estadual(self):
-        """Inclusao de um novo Feriado no calendario Estadual"""
+        """Add a new holiday to the state calendar"""
         self.leave_estadual_02 = self.resource_leaves.create(
             {
                 "name": "Aniversario MG",
@@ -124,7 +124,7 @@ class TestResourceCalendar(test_common.SingleTransactionCase):
         self.assertEqual(3, len(self.estadual_calendar_id.leave_ids))
 
     def test_02_add_leave_municipal(self):
-        """Inclusao de um novo Feriado no calendario municipal"""
+        """Add a new holiday to the municipal calendar"""
         self.leave_municipal_02 = self.resource_leaves.create(
             {
                 "name": "Aniversario Itajuba",
@@ -141,12 +141,11 @@ class TestResourceCalendar(test_common.SingleTransactionCase):
         )
         self.assertEqual(4, len(self.municipal_calendar_id.leave_ids))
 
-    def test_03_data_eh_feriado(self):
-        data = fields.Datetime.to_datetime("2016-08-25 00:00:01")
-        data_eh_feriado = self.municipal_calendar_id.data_eh_feriado(data)
-        self.assertTrue(data_eh_feriado)
+    def test_03_is_holiday(self):
+        date = fields.Datetime.to_datetime("2016-08-25 00:00:01")
+        self.assertTrue(self.municipal_calendar_id.is_holiday(date))
 
-    def test_04_obter_feriados_no_periodo(self):
+    def test_04_get_leave_intervals(self):
         self.holidays = self.municipal_calendar_id.get_leave_intervals(
             start_datetime=fields.Datetime.to_datetime("2016-08-01 00:00:00"),
             end_datetime=fields.Datetime.to_datetime("2016-08-31 00:00:00"),
@@ -168,87 +167,79 @@ class TestResourceCalendar(test_common.SingleTransactionCase):
             end_datetime=fields.Datetime.to_datetime("2016-03-31 00:00:00"),
         )
 
-    def test_05_data_eh_feriado_emendado(self):
-        data = fields.Datetime.to_datetime("2016-08-25 00:00:01")
-        data_eh_feriado_emendado = self.municipal_calendar_id.data_eh_feriado_emendado(
-            data
-        )
-        self.assertTrue(data_eh_feriado_emendado)
-        data = fields.Datetime.to_datetime("2016-03-19 00:00:01")
-        data_eh_feriado_emendado = self.municipal_calendar_id.data_eh_feriado_emendado(
-            data
-        )
-        self.assertFalse(data_eh_feriado_emendado)
+    def test_05_is_extended_holiday(self):
+        date = fields.Datetime.to_datetime("2016-08-25 00:00:01")
+        self.assertTrue(self.municipal_calendar_id.is_extended_holiday(date))
+        date = fields.Datetime.to_datetime("2016-03-19 00:00:01")
+        self.assertFalse(self.municipal_calendar_id.is_extended_holiday(date))
 
-    def test_06_obter_proximo_dia_util(self):
-        """Dado uma data obter proximo dia util"""
-        # 21-03 e feriado
-        anterior_ao_feriado = fields.Datetime.to_datetime("2016-03-20 00:00:01")
-        proximo_dia_util = self.municipal_calendar_id.proximo_dia_util(
-            anterior_ao_feriado
-        )
+    def test_06_next_business_day(self):
+        """Given a date, get the next business day"""
+        # 21-03 is a holiday
+        day_before_holiday = fields.Datetime.to_datetime("2016-03-20 00:00:01")
+        next_day = self.municipal_calendar_id.next_business_day(day_before_holiday)
         self.assertEqual(
-            proximo_dia_util,
+            next_day,
             fields.Datetime.to_datetime("2016-03-22 00:00:01"),
-            "Partindo de um feriado, proximo dia util invalido",
+            "Starting from a holiday, next business day is invalid",
         )
 
-        anterior_ao_fds = fields.Datetime.to_datetime("2016-12-16 00:00:01")
-        proximo_dia_util = self.municipal_calendar_id.proximo_dia_util(anterior_ao_fds)
+        day_before_weekend = fields.Datetime.to_datetime("2016-12-16 00:00:01")
+        next_day = self.municipal_calendar_id.next_business_day(day_before_weekend)
         self.assertEqual(
-            proximo_dia_util,
+            next_day,
             fields.Datetime.to_datetime("2016-12-19 00:00:01"),
-            "Partindo de um fds, proximo dia util invalido",
+            "Starting from a weekend, next business day is invalid",
         )
-        # Sem Data
-        self.municipal_calendar_id.proximo_dia_util(False)
+        # No date
+        self.municipal_calendar_id.next_business_day(False)
 
-    def test_07_get_dias_base(self):
-        """Dado um intervalo de tempo, fornecer a quantidade de dias base
-        para calculos da folha de pagamento"""
-        data_inicio = fields.Datetime.to_datetime("2017-01-01 00:00:01")
-        data_final = fields.Datetime.to_datetime("2017-01-31 23:59:59")
+    def test_07_get_base_days(self):
+        """Given a time interval, return the number of base days
+        for payroll calculations"""
+        start_date = fields.Datetime.to_datetime("2017-01-01 00:00:01")
+        end_date = fields.Datetime.to_datetime("2017-01-31 23:59:59")
 
-        total = self.resource_calendar.get_dias_base(data_inicio, data_final)
-        self.assertEqual(total, 30, "Calculo de Dias Base de Jan incorreto")
+        total = self.resource_calendar.get_base_days(start_date, end_date)
+        self.assertEqual(total, 30, "Base days calculation for January is incorrect")
 
-        data_inicio = fields.Datetime.to_datetime("2017-02-01 00:00:01")
-        data_final = fields.Datetime.to_datetime("2017-02-28 23:59:59")
+        start_date = fields.Datetime.to_datetime("2017-02-01 00:00:01")
+        end_date = fields.Datetime.to_datetime("2017-02-28 23:59:59")
 
-        total = self.resource_calendar.get_dias_base(data_inicio, data_final)
-        self.assertEqual(total, 30, "Calculo de Dias Base de Fev incorreto")
-        # Sem Data
-        self.resource_calendar.get_dias_base(False, False)
+        total = self.resource_calendar.get_base_days(start_date, end_date)
+        self.assertEqual(total, 30, "Base days calculation for February is incorrect")
+        # No date
+        self.resource_calendar.get_base_days(False, False)
 
-    def test_08_data_eh_dia_util(self):
-        """Verificar se datas sao dias uteis"""
-        segunda = fields.Datetime.to_datetime("2017-01-09 00:00:01")
-        terca = fields.Datetime.to_datetime("2017-01-10 00:00:01")
-        sabado = fields.Datetime.to_datetime("2017-01-07 00:00:01")
-        domingo = fields.Datetime.to_datetime("2017-01-08 00:00:01")
-        feriado = fields.Datetime.to_datetime("2016-08-25 00:00:00")
+    def test_08_is_business_day(self):
+        """Check if dates are business days"""
+        monday = fields.Datetime.to_datetime("2017-01-09 00:00:01")
+        tuesday = fields.Datetime.to_datetime("2017-01-10 00:00:01")
+        saturday = fields.Datetime.to_datetime("2017-01-07 00:00:01")
+        sunday = fields.Datetime.to_datetime("2017-01-08 00:00:01")
+        holiday = fields.Datetime.to_datetime("2016-08-25 00:00:00")
 
         self.assertTrue(
-            self.municipal_calendar_id.data_eh_dia_util(segunda),
-            "ERRO: Segunda eh dia util!",
+            self.municipal_calendar_id.is_business_day(monday),
+            "ERROR: Monday is a business day!",
         )
         self.assertTrue(
-            self.municipal_calendar_id.data_eh_dia_util(terca),
-            "ERRO: Terca eh dia util!",
-        )
-
-        self.assertTrue(
-            not self.municipal_calendar_id.data_eh_dia_util(sabado),
-            "ERRO: Sabado nao eh dia util!",
-        )
-        self.assertTrue(
-            not self.municipal_calendar_id.data_eh_dia_util(domingo),
-            "ERRO: Domingo nao eh dia util!",
+            self.municipal_calendar_id.is_business_day(tuesday),
+            "ERROR: Tuesday is a business day!",
         )
 
         self.assertTrue(
-            not self.municipal_calendar_id.data_eh_dia_util(feriado),
-            "ERRO: Feriado nao eh dia util!",
+            not self.municipal_calendar_id.is_business_day(saturday),
+            "ERROR: Saturday is not a business day!",
+        )
+        self.assertTrue(
+            not self.municipal_calendar_id.is_business_day(sunday),
+            "ERROR: Sunday is not a business day!",
+        )
+
+        self.assertTrue(
+            not self.municipal_calendar_id.is_business_day(holiday),
+            "ERROR: Holiday is not a business day!",
         )
 
         self.leave_nacional_02 = self.resource_leaves.create(
@@ -261,43 +252,45 @@ class TestResourceCalendar(test_common.SingleTransactionCase):
                 "coverage": "N",
             }
         )
-        feriado2 = fields.Datetime.to_datetime("2017-01-21 00:00:00")
+        holiday2 = fields.Datetime.to_datetime("2017-01-21 00:00:00")
         self.assertTrue(
-            not self.municipal_calendar_id.data_eh_dia_util(feriado2),
-            "ERRO: Feriado2 nao eh dia util!",
+            not self.municipal_calendar_id.is_business_day(holiday2),
+            "ERROR: Holiday2 is not a business day!",
         )
-        # Sem Data
-        self.municipal_calendar_id.data_eh_dia_util(False)
+        # No date
+        self.municipal_calendar_id.is_business_day(False)
 
-    def test_09_quantidade_dia_util(self):
-        """Calcular a qunatidade de dias uteis."""
-        data_inicio = fields.Datetime.to_datetime("2017-01-01 00:00:01")
-        data_final = fields.Datetime.to_datetime("2017-01-31 23:59:59")
+    def test_09_count_business_days(self):
+        """Count the number of business days."""
+        start_date = fields.Datetime.to_datetime("2017-01-01 00:00:01")
+        end_date = fields.Datetime.to_datetime("2017-01-31 23:59:59")
 
-        total_dias_uteis = self.resource_calendar.quantidade_dias_uteis(
-            data_inicio, data_final
-        )
-        self.assertEqual(
-            total_dias_uteis, 22, "ERRO: Total dias uteis mes Jan/2017 invalido"
-        )
-
-        data_inicio = fields.Datetime.to_datetime("2018-01-01 00:00:01")
-        data_final = fields.Datetime.to_datetime("2018-01-31 23:59:59")
-
-        total_dias_uteis = self.resource_calendar.quantidade_dias_uteis(
-            data_inicio, data_final
+        total_business_days = self.resource_calendar.count_business_days(
+            start_date, end_date
         )
         self.assertEqual(
-            total_dias_uteis, 23, "ERRO: Total dias uteis mes Jan/2018 invalido"
+            total_business_days,
+            22,
+            "ERROR: Total business days for Jan/2017 is invalid",
         )
-        # Sem Data
-        self.resource_calendar.quantidade_dias_uteis(False, False)
 
-    def test_10_data_eh_feriado_bancario(self):
-        """
-        Validar se data eh feriado bancario.
-        """
-        # adicionando feriado bancario
+        start_date = fields.Datetime.to_datetime("2018-01-01 00:00:01")
+        end_date = fields.Datetime.to_datetime("2018-01-31 23:59:59")
+
+        total_business_days = self.resource_calendar.count_business_days(
+            start_date, end_date
+        )
+        self.assertEqual(
+            total_business_days,
+            23,
+            "ERROR: Total business days for Jan/2018 is invalid",
+        )
+        # No date
+        self.resource_calendar.count_business_days(False, False)
+
+    def test_10_is_bank_holiday(self):
+        """Validate if date is a bank holiday."""
+        # adding bank holiday
         self.resource_leaves.create(
             {
                 "name": "Feriado Bancario",
@@ -308,17 +301,11 @@ class TestResourceCalendar(test_common.SingleTransactionCase):
                 "coverage": "N",
             }
         )
-        data = fields.Datetime.to_datetime("2017-01-13 01:02:03")
-        data_eh_feriado_bancario = self.nacional_calendar_id.data_eh_feriado_bancario(
-            data
-        )
-        self.assertTrue(data_eh_feriado_bancario)
+        date = fields.Datetime.to_datetime("2017-01-13 01:02:03")
+        self.assertTrue(self.nacional_calendar_id.is_bank_holiday(date))
 
     def test_12_get_country_from_calendar(self):
-        """
-        Validar se o retorno do pais do holiday esta correto
-        :return:
-        """
+        """Validate that the country returned for the holiday is correct."""
         holiday = self.holiday_import.create(
             {
                 "interval_type": "days",
@@ -327,16 +314,14 @@ class TestResourceCalendar(test_common.SingleTransactionCase):
         )
 
         country_id = self.holiday_import.get_country_from_calendar(holiday)
-        self.assertEqual(country_id.code, "BR", "Pais incorreto.")
+        self.assertEqual(country_id.code, "BR", "Incorrect country.")
 
-    def test_16_proximo_dia_util_bancario(self):
-        data = fields.Datetime.to_datetime("2017-01-13 00:00:00")
-        prox_dia_ultil = self.nacional_calendar_id.proximo_dia_util_bancario(data)
-        self.assertEqual(
-            prox_dia_ultil, fields.Datetime.to_datetime("2017-01-16 00:00:00")
-        )
-        # Sem Data
-        self.nacional_calendar_id.proximo_dia_util_bancario(False)
+    def test_16_next_bank_business_day(self):
+        date = fields.Datetime.to_datetime("2017-01-13 00:00:00")
+        next_day = self.nacional_calendar_id.next_bank_business_day(date)
+        self.assertEqual(next_day, fields.Datetime.to_datetime("2017-01-16 00:00:00"))
+        # No date
+        self.nacional_calendar_id.next_bank_business_day(False)
 
     def test_17_holiday_import(self):
         holiday = self.holiday_import.create(
@@ -348,22 +333,19 @@ class TestResourceCalendar(test_common.SingleTransactionCase):
         )
         res = holiday.holiday_import()
         self.assertTrue(res)
-        data = fields.Datetime.to_datetime("2019-03-05 00:00:00")
-        data_eh_feriado = self.nacional_calendar_id.data_eh_feriado_bancario(data)
-        self.assertTrue(data_eh_feriado)
+        date = fields.Datetime.to_datetime("2019-03-05 00:00:00")
+        self.assertTrue(self.nacional_calendar_id.is_bank_holiday(date))
 
-    def test_18_data_eh_dia_util_bancario(self):
-        data = fields.Datetime.to_datetime("2017-01-16 00:00:00")
-        dia_util = self.nacional_calendar_id.data_eh_dia_util_bancario(data)
-        self.assertTrue(dia_util)
-        data = fields.Datetime.to_datetime("2017-01-13 00:00:00")
-        feriado = self.nacional_calendar_id.data_eh_dia_util_bancario(data)
-        self.assertFalse(feriado)
-        # Sem Data
-        self.nacional_calendar_id.data_eh_dia_util_bancario(False)
+    def test_18_is_bank_business_day(self):
+        date = fields.Datetime.to_datetime("2017-01-16 00:00:00")
+        self.assertTrue(self.nacional_calendar_id.is_bank_business_day(date))
+        date = fields.Datetime.to_datetime("2017-01-13 00:00:00")
+        self.assertFalse(self.nacional_calendar_id.is_bank_business_day(date))
+        # No date
+        self.nacional_calendar_id.is_bank_business_day(False)
 
     def test_19_check_constraint_recursive(self):
-        """Test resource.calendar Constrains methods"""
+        """Test resource.calendar constrains methods"""
         with self.assertRaises(UserError):
             self.nacional_calendar_id.write(
                 {"parent_id": self.municipal_calendar_id.id}

--- a/l10n_br_resource/tests/test_resource_calendar_2.py
+++ b/l10n_br_resource/tests/test_resource_calendar_2.py
@@ -18,104 +18,98 @@ class TestResourceCalendar(common.TransactionCase):
             }
         )
 
-    def test_data_eh_feriado(self):
+    def test_is_holiday(self):
         holiday_date = datetime(2023, 12, 25)
-        result = self.calendar.data_eh_feriado(holiday_date)
+        result = self.calendar.is_holiday(holiday_date)
         expected_result = True
         self.assertEqual(result, expected_result)
 
         non_holiday_date = datetime(2023, 12, 24)
-        result = self.calendar.data_eh_feriado(non_holiday_date)
+        result = self.calendar.is_holiday(non_holiday_date)
         expected_result = False
         self.assertEqual(result, expected_result)
 
         non_holiday_date2 = datetime(2023, 4, 13)
-        result = self.calendar.data_eh_feriado(non_holiday_date2)
+        result = self.calendar.is_holiday(non_holiday_date2)
         expected_result = False
         self.assertEqual(result, expected_result)
 
-        # Sem Data
-        self.calendar.data_eh_feriado(False)
+        # No date
+        self.calendar.is_holiday(False)
 
-    def test_data_eh_feriado_bancario(self):
-        reference_data = datetime.now()
+    def test_is_bank_holiday(self):
+        reference_date = datetime.now()
         leaves_count = self.env["resource.calendar.leaves"].search_count(
             [
-                ("date_from", "<=", reference_data),
-                ("date_to", ">=", reference_data),
+                ("date_from", "<=", reference_date),
+                ("date_to", ">=", reference_date),
                 ("leave_type", "in", ["F", "B"]),
             ]
         )
-        self.assertEqual(
-            leaves_count, self.calendar.data_eh_feriado_bancario(reference_data)
-        )
+        self.assertEqual(leaves_count, self.calendar.is_bank_holiday(reference_date))
 
-        reference_data = datetime(2023, 4, 21)
+        reference_date = datetime(2023, 4, 21)
         leaves_count = self.env["resource.calendar.leaves"].search_count(
             [
-                ("date_from", "<=", reference_data),
-                ("date_to", ">=", reference_data),
+                ("date_from", "<=", reference_date),
+                ("date_to", ">=", reference_date),
                 ("leave_type", "in", ["F", "B"]),
             ]
         )
-        self.assertEqual(
-            leaves_count, self.calendar.data_eh_feriado_bancario(reference_data)
-        )
+        self.assertEqual(leaves_count, self.calendar.is_bank_holiday(reference_date))
 
-        reference_data = datetime(2023, 4, 13)
+        reference_date = datetime(2023, 4, 13)
         leaves_count = self.env["resource.calendar.leaves"].search_count(
             [
-                ("date_from", "<=", reference_data),
-                ("date_to", ">=", reference_data),
+                ("date_from", "<=", reference_date),
+                ("date_to", ">=", reference_date),
                 ("leave_type", "in", ["F", "B"]),
             ]
         )
-        self.assertEqual(
-            leaves_count, self.calendar.data_eh_feriado_bancario(reference_data)
-        )
-        # Sem Data
-        self.calendar.data_eh_feriado_bancario(False)
+        self.assertEqual(leaves_count, self.calendar.is_bank_holiday(reference_date))
+        # No date
+        self.calendar.is_bank_holiday(False)
 
-    def test_data_eh_feriado_emendado(self):
-        reference_data = datetime(2023, 9, 7, 15, 0, 0)
+    def test_is_extended_holiday(self):
+        reference_date = datetime(2023, 9, 7, 15, 0, 0)
         expected_result = False
 
-        result = self.calendar.data_eh_feriado_emendado(reference_data)
+        result = self.calendar.is_extended_holiday(reference_date)
 
         self.assertEqual(result, expected_result)
-        # Sem Data
-        self.calendar.data_eh_feriado_emendado(False)
+        # No date
+        self.calendar.is_extended_holiday(False)
 
-    def test_data_eh_dia_util_bancario(self):
-        data_util = datetime(2023, 4, 17)
-        self.assertTrue(self.calendar.data_eh_dia_util_bancario(data_util))
+    def test_is_bank_business_day(self):
+        business_date = datetime(2023, 4, 17)
+        self.assertTrue(self.calendar.is_bank_business_day(business_date))
 
-        data_nao_util = datetime(2023, 4, 15)
-        self.assertFalse(self.calendar.data_eh_dia_util_bancario(data_nao_util))
+        non_business_date = datetime(2023, 4, 15)
+        self.assertFalse(self.calendar.is_bank_business_day(non_business_date))
 
-        data_nao_util = datetime(2023, 4, 16)
-        self.assertFalse(self.calendar.data_eh_dia_util_bancario(data_nao_util))
+        non_business_date = datetime(2023, 4, 16)
+        self.assertFalse(self.calendar.is_bank_business_day(non_business_date))
 
-        data_feriado = datetime(2023, 4, 21)
-        self.assertTrue(self.calendar.data_eh_dia_util_bancario(data_feriado))
+        holiday_date = datetime(2023, 4, 21)
+        self.assertTrue(self.calendar.is_bank_business_day(holiday_date))
 
-    def test_get_dias_base_mes_comercial(self):
-        data_from = datetime(2023, 4, 1)
-        data_to = datetime(2023, 4, 30)
-        self.assertEqual(self.calendar.get_dias_base(data_from, data_to, True), 30)
+    def test_get_base_days_commercial_month(self):
+        date_from = datetime(2023, 4, 1)
+        date_to = datetime(2023, 4, 30)
+        self.assertEqual(self.calendar.get_base_days(date_from, date_to, True), 30)
 
-        data_from = datetime(2023, 4, 15)
-        data_to = datetime(2023, 4, 30)
-        self.assertEqual(self.calendar.get_dias_base(data_from, data_to, True), 16)
+        date_from = datetime(2023, 4, 15)
+        date_to = datetime(2023, 4, 30)
+        self.assertEqual(self.calendar.get_base_days(date_from, date_to, True), 16)
 
-    def test_get_dias_base_nao_mes_comercial(self):
-        data_from = datetime(2023, 4, 1)
-        data_to = datetime(2023, 4, 15)
-        self.assertEqual(self.calendar.get_dias_base(data_from, data_to, False), 15)
+    def test_get_base_days_non_commercial_month(self):
+        date_from = datetime(2023, 4, 1)
+        date_to = datetime(2023, 4, 15)
+        self.assertEqual(self.calendar.get_base_days(date_from, date_to, False), 15)
 
-        data_from = datetime(2023, 4, 1)
-        data_to = datetime(2023, 5, 5)
-        self.assertEqual(self.calendar.get_dias_base(data_from, data_to, False), 30)
+        date_from = datetime(2023, 4, 1)
+        date_to = datetime(2023, 5, 5)
+        self.assertEqual(self.calendar.get_base_days(date_from, date_to, False), 30)
 
     def test_get_calendar_for_country(self):
         calendar = self.env[


### PR DESCRIPTION
#### Motivo da PR
O módulo usava nomes de métodos, variáveis e constantes em português, o que vai contra o padrão OCA que exige inglês em todo o código Python.

O que foi feito:

- Métodos renomeados para inglês (data_eh_feriado → is_holiday, proximo_dia_util → next_business_day, etc.)
- Parâmetros e variáveis locais traduzidos (data_referencia → reference_date, dias_uteis → business_days, etc.)
- Constantes renomeadas (TIPO_FERIADO → HOLIDAY_TYPE_LABELS, ABRANGENCIA_FERIADO → HOLIDAY_COVERAGE_LABELS)
- Atributos da classe BrazilianHoliday traduzidos (nome → name, data → date, etc.)
- Campo abrangencia renomeado para coverage, com migration script usando openupgradelib
- Strings de campos traduzidas para inglês ("País" → "Country", etc.)
- Docstrings e comentários traduzidos
- Versão bumped de 19.0.1.0.0 para 19.0.1.1.0