### PR TITLE
[16.0][FIX] l10n_br_sale_blanket_order: fix sale blanket order constraint error

### DIFF
--- a/l10n_br_sale_blanket_order/views/sale_blanket_order_line.xml
+++ b/l10n_br_sale_blanket_order/views/sale_blanket_order_line.xml
@@ -88,6 +88,7 @@
 
         <xpath expr="//page[@name='sale_lines']" position="before">
             <field name="country_id" invisible="1" />
+            <field name="product_uom" invisible="1" force_save="1" />
             <page name="fiscal_taxes" string="Taxes" />
 
             <page name="amounts" string="Amounts">


### PR DESCRIPTION
Identificamos que o seguinte erro `A operação não pode ser concluída: Campos obrigatórios ausentes na linha contabilizável do pedido de venda.` é disparado quando adicionamos uma linha via form ao invés de inline
<img width="1457" height="628" alt="image" src="https://github.com/user-attachments/assets/6c91ae42-0934-496a-ab7a-8fab8a2cc049" />

Esse erro vem da constraint definida no próprio sale blanket order https://github.com/OCA/sale-workflow/blob/16.0/sale_blanket_order/models/blanket_orders.py#L693

Foi necessário incluir o campo `product_uom` com `force_save="1"` para que seu valor fosse atualizado nos computes.

Após a mudança na view, o erro deixou de ser exibido.

cc: @marcelsavegnago @CristianoMafraJunior @kaynnan 