### PR TITLE
[19.0][REF] l10n_br_resource: translate models and add migration

### DIFF
--- a/l10n_br_resource/__manifest__.py
+++ b/l10n_br_resource/__manifest__.py
@@ -7,7 +7,7 @@
         This module extend core resource to create important brazilian
         informations. Define a Brazilian calendar and some tools to compute
         dates used in financial and payroll modules""",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.1.0",
     "license": "AGPL-3",
     "author": "KMEE,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-brazil",

--- a/l10n_br_resource/migrations/19.0.1.1.0/pre-migrate.py
+++ b/l10n_br_resource/migrations/19.0.1.1.0/pre-migrate.py
@@ -1,0 +1,12 @@
+# Copyright 2026 - TODAY, Cristiano Mafra Junior <cristiano.mafra@escodoo.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.rename_columns(
+        env.cr,
+        {"resource_calendar_leaves": [("abrangencia", "coverage")]},
+    )

--- a/l10n_br_resource/models/resource_calendar.py
+++ b/l10n_br_resource/models/resource_calendar.py
@@ -35,12 +35,12 @@ class ResourceCalendar(models.Model):
 
     parent_path = fields.Char(index=True)
 
-    country_id = fields.Many2one("res.country", "País")
+    country_id = fields.Many2one("res.country", "Country")
     state_id = fields.Many2one(
-        "res.country.state", "Estado", domain="[('country_id','=',country_id)]"
+        "res.country.state", "State", domain="[('country_id','=',country_id)]"
     )
     l10n_br_city_id = fields.Many2one(
-        "res.city", "Municipio", domain="[('state_id','=',state_id)]"
+        "res.city", "Municipality", domain="[('state_id','=',state_id)]"
     )
     leave_ids = fields.Many2many(
         comodel_name="resource.calendar.leaves", compute="_compute_leave_ids"

--- a/l10n_br_resource/models/resource_calendar_leaves.py
+++ b/l10n_br_resource/models/resource_calendar_leaves.py
@@ -8,18 +8,18 @@ from odoo import fields, models
 
 _logger = logging.getLogger(__name__)
 
-TIPO_FERIADO = {
-    "F": "Feriado",
-    "B": "Feriado bancário",
-    "C": "Data comemorativa",
-}
+HOLIDAY_TYPE_LABELS = [
+    ("F", "Feriado"),
+    ("B", "Feriado bancário"),
+    ("C", "Data comemorativa"),
+]
 
 
-ABRANGENCIA_FERIADO = {
-    "N": "Nacional",
-    "E": "Estadual",
-    "M": "Municipal",
-}
+HOLIDAY_COVERAGE_LABELS = [
+    ("N", "Nacional"),
+    ("E", "Estadual"),
+    ("M", "Municipal"),
+]
 
 
 class ResourceCalendarLeave(models.Model):
@@ -27,25 +27,25 @@ class ResourceCalendarLeave(models.Model):
 
     country_id = fields.Many2one(
         "res.country",
-        string="País",
+        string="Country",
         related="calendar_id.country_id",
     )
     state_id = fields.Many2one(
         "res.country.state",
-        "Estado",
+        "State",
         related="calendar_id.state_id",
         domain="[('country_id','=',country_id)]",
     )
     l10n_br_city_id = fields.Many2one(
         "res.city",
-        "Municipio",
+        "Municipality",
         related="calendar_id.l10n_br_city_id",
         domain="[('state_id','=',state_id)]",
     )
     leave_type = fields.Selection(
-        string="Tipo",
-        selection=[item for item in TIPO_FERIADO.items()],
+        string="Type",
+        selection=HOLIDAY_TYPE_LABELS,
     )
-    abrangencia = fields.Selection(
-        selection=[item for item in ABRANGENCIA_FERIADO.items()],
+    coverage = fields.Selection(
+        selection=HOLIDAY_COVERAGE_LABELS,
     )

--- a/l10n_br_resource/tests/test_resource_calendar.py
+++ b/l10n_br_resource/tests/test_resource_calendar.py
@@ -43,7 +43,7 @@ class TestResourceCalendar(test_common.SingleTransactionCase):
                 "date_to": fields.Datetime.to_datetime("2016-03-21 23:59:59"),
                 "calendar_id": self.nacional_calendar_id.id,
                 "leave_type": "F",
-                "abrangencia": "N",
+                "coverage": "N",
                 "resource_id": self.resource_1.id,
             }
         )
@@ -60,7 +60,7 @@ class TestResourceCalendar(test_common.SingleTransactionCase):
                 "date_to": fields.Datetime.to_datetime("2016-01-25 23:59:59"),
                 "calendar_id": self.estadual_calendar_id.id,
                 "leave_type": "F",
-                "abrangencia": "E",
+                "coverage": "E",
             }
         )
         self.municipal_calendar_id = self.resource_calendar.create(
@@ -76,7 +76,7 @@ class TestResourceCalendar(test_common.SingleTransactionCase):
                 "date_to": fields.Datetime.to_datetime("2016-08-25 23:59:59"),
                 "calendar_id": self.municipal_calendar_id.id,
                 "leave_type": "F",
-                "abrangencia": "M",
+                "coverage": "M",
             }
         )
 
@@ -100,7 +100,7 @@ class TestResourceCalendar(test_common.SingleTransactionCase):
                 "date_to": fields.Datetime.to_datetime("2016-12-24 23:59:59"),
                 "calendar_id": self.nacional_calendar_id.id,
                 "leave_type": "F",
-                "abrangencia": "N",
+                "coverage": "N",
             }
         )
         self.assertEqual(self.leave_nacional_02.name, "Natal")
@@ -116,7 +116,7 @@ class TestResourceCalendar(test_common.SingleTransactionCase):
                 "date_to": fields.Datetime.to_datetime("2016-07-16 23:59:59"),
                 "calendar_id": self.estadual_calendar_id.id,
                 "leave_type": "F",
-                "abrangencia": "E",
+                "coverage": "E",
             }
         )
         self.assertEqual(self.leave_estadual_02.name, "Aniversario MG")
@@ -132,7 +132,7 @@ class TestResourceCalendar(test_common.SingleTransactionCase):
                 "date_to": fields.Datetime.to_datetime("2016-03-19 23:59:59"),
                 "calendar_id": self.municipal_calendar_id.id,
                 "leave_type": "F",
-                "abrangencia": "M",
+                "coverage": "M",
             }
         )
         self.assertEqual(self.leave_municipal_02.name, "Aniversario Itajuba")
@@ -258,7 +258,7 @@ class TestResourceCalendar(test_common.SingleTransactionCase):
                 "date_to": fields.Datetime.to_datetime("2017-01-21 23:59:59"),
                 "calendar_id": self.nacional_calendar_id.id,
                 "leave_type": "F",
-                "abrangencia": "N",
+                "coverage": "N",
             }
         )
         feriado2 = fields.Datetime.to_datetime("2017-01-21 00:00:00")
@@ -305,7 +305,7 @@ class TestResourceCalendar(test_common.SingleTransactionCase):
                 "date_to": fields.Datetime.to_datetime("2017-01-13 23:59:59"),
                 "calendar_id": self.nacional_calendar_id.id,
                 "leave_type": "B",
-                "abrangencia": "N",
+                "coverage": "N",
             }
         )
         data = fields.Datetime.to_datetime("2017-01-13 01:02:03")

--- a/l10n_br_resource/views/resource_calendar_leaves_view.xml
+++ b/l10n_br_resource/views/resource_calendar_leaves_view.xml
@@ -14,7 +14,7 @@
             </field>
             <field name="name" position="after">
                 <field name="leave_type" />
-                <field name="abrangencia" />
+                <field name="coverage" />
             </field>
         </field>
     </record>
@@ -26,7 +26,7 @@
         <field name="arch" type="xml">
             <field name="calendar_id" position="after">
                 <field name="leave_type" />
-                <field name="abrangencia" />
+                <field name="coverage" />
             </field>
         </field>
     </record>
@@ -38,7 +38,7 @@
         <field name="arch" type="xml">
             <field name="calendar_id" position="after">
                 <field name="leave_type" />
-                <field name="abrangencia" />
+                <field name="coverage" />
             </field>
         </field>
     </record>

--- a/l10n_br_resource/wizards/workalendar_holiday_import_wizard.py
+++ b/l10n_br_resource/wizards/workalendar_holiday_import_wizard.py
@@ -66,7 +66,6 @@ class WorkalendarHolidayImport(models.TransientModel):
                 {
                     "name": "Calendar " + country.name,
                     "country_id": country.id,
-                    # '':u'N',
                 }
             )
             return calendar
@@ -204,7 +203,7 @@ class WorkalendarHolidayImport(models.TransientModel):
                                 "date_from": date_from,
                                 "date_to": date_to,
                                 "leave_type": holiday.tipo,
-                                "abrangencia": holiday.abrangencia,
+                                "coverage": holiday.abrangencia,
                             }
                         )
                 date_reference += relativedelta(years=1)


### PR DESCRIPTION
### Motivo da PR
O módulo usava nomes de métodos, variáveis e constantes em português, o que vai contra o padrão OCA que exige inglês em todo o código Python.

### O que foi feito:

Métodos renomeados para inglês (data_eh_feriado → is_holiday, proximo_dia_util → next_business_day, etc.)
Parâmetros e variáveis locais traduzidos (data_referencia → reference_date, dias_uteis → business_days, etc.)
Atributos da classe BrazilianHoliday traduzidos (nome → name, data → date, etc.)

Quebrando PR da #4580 para faciltiar revisão
cc @rvalyi 