### PR TITLE
[16.0][FIX] l10n_br_purchase_blanket_order: fix line computes when switching views

### DIFF
--- a/l10n_br_purchase_blanket_order/models/purchase_blanket_order.py
+++ b/l10n_br_purchase_blanket_order/models/purchase_blanket_order.py
@@ -65,26 +65,21 @@ class PurchaseBlanketOrder(models.Model):
             order._compute_amount()
 
     @api.model
-    def fields_view_get(
-        self, view_id=None, view_type="form", toolbar=False, submenu=False
-    ):
-        order_view = super().fields_view_get(view_id, view_type, toolbar, submenu)
+    def _get_view(self, view_id=None, view_type="form", **options):
+        arch, view = super()._get_view(view_id, view_type, **options)
+        if self.env.company.country_id.code != "BR":
+            return arch, view
+        if view_type == "form" and self.env.company.country_id.code == "BR":
+            arch = self.env["purchase.blanket.order.line"].inject_fiscal_fields(arch)
 
-        if view_type == "form":
-            view = self.env["ir.ui.view"]
-            sub_form_view = order_view["fields"]["line_ids"]["views"]["form"]["arch"]
-            sub_form_node = self.env[
-                "purchase.blanket.order.line"
-            ].inject_fiscal_fields(sub_form_view)
-            sub_arch, sub_fields = view.postprocess_and_fields(
-                sub_form_node, "purchase.blanket.order.line", False
-            )
-            order_view["fields"]["line_ids"]["views"]["form"] = {
-                "fields": sub_fields,
-                "arch": sub_arch,
-            }
+        if view_type == "form" and (
+            self.user_has_groups("l10n_br_purchase.group_line_fiscal_detail")
+            or self.env.context.get("force_line_fiscal_detail")
+        ):
+            for sub_tree_node in arch.xpath("//field[@name='order_line']/tree"):
+                sub_tree_node.attrib["editable"] = ""
 
-        return order_view
+        return arch, view
 
     @api.onchange("fiscal_operation_id")
     def _onchange_fiscal_operation_id(self):

--- a/l10n_br_purchase_blanket_order/views/purchase_blanket_order.xml
+++ b/l10n_br_purchase_blanket_order/views/purchase_blanket_order.xml
@@ -27,6 +27,25 @@
                     options="{'currency_field': 'currency_id'}"
                 />
             </field>
+             <xpath expr="//field[@name='line_ids']/tree" position="inside">
+                <control name="fiscal_fields" invisible="1" />
+                <!-- this is a dynamic fiscal fields placeholder-->
+                <control name="fiscal_taxes_fields" string="Taxes" invisible="1" />
+                <!-- this is a dynamic fiscal fields placeholder-->
+                <!-- the fields below would be injected by the placeholders
+                    above, but we need to repeat them here to please the
+                    Form test framework or because they are used in some
+                    domain here that is checked before the dynamic fiscal
+                    placeholders kick in.
+                -->
+                <field name="fiscal_operation_type" invisible="1" />
+                <field name="cfop_id" invisible="1" />
+                <field name="tax_framework" invisible="1" />
+                <field name="fiscal_operation_id" invisible="1" />
+                <field name="freight_value" invisible="1" />
+                <field name="insurance_value" invisible="1" />
+                <field name="other_value" invisible="1" />
+            </xpath>
             <field name="validity_date" position="after">
                 <field name="fiscal_operation_id" required="True" />
                 <field name="ind_final" required="True" />


### PR DESCRIPTION
## Objetivo da PR

Ao alternar entre a edição direta na lista (tree view) e o detalhamento em popup (form view) nas linhas do acordo programado (blanket order), os campos fiscais e os impostos, ficavam vazios ou deixavam de recalcular.

Mesmo erro que acontece aqui #4567