### PR TITLE
[17.0] l10n_br_cnpj_search: handle request timeout

### DIFF
--- a/l10n_br_cnpj_search/models/cnpj_webservice.py
+++ b/l10n_br_cnpj_search/models/cnpj_webservice.py
@@ -403,7 +403,7 @@ class CNPJWebservice(models.AbstractModel):
         try:
             cep_values = self.env["l10n_br.zip"]._consultar_cep(cep)
         except UserError as error:
-            _logger.warning(error.name)
+            _logger.warning(str(error))
             return False
 
         return cep_values.get("city_id")

--- a/l10n_br_cnpj_search/tests/common.py
+++ b/l10n_br_cnpj_search/tests/common.py
@@ -3,6 +3,10 @@
 
 from odoo.tests import TransactionCase
 
+MOCK_REQUESTS_GET = (
+    "odoo.addons.l10n_br_cnpj_search.wizard.partner_cnpj_search_wizard.requests.get"
+)
+
 
 class TestCnpjCommon(TransactionCase):
     @classmethod

--- a/l10n_br_cnpj_search/tests/test_receitaws.py
+++ b/l10n_br_cnpj_search/tests/test_receitaws.py
@@ -27,6 +27,10 @@ class TestReceitaWS(TestCnpjCommon):
         )
 
         with mock.patch(
+            "odoo.addons.l10n_br_cnpj_search.wizard."
+            "partner_cnpj_search_wizard.requests.get",
+            return_value=mock.Mock(status_code=200),
+        ), mock.patch(
             "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
             return_value=self.mocked_response_ws_1,
         ):
@@ -57,7 +61,16 @@ class TestReceitaWS(TestCnpjCommon):
         self.assertEqual(kilian.cnae_main_id.code, "4751-2/01")
 
     def test_receita_ws_fail(self):
-        with self.assertRaises(ValidationError):
+        with mock.patch(
+            "odoo.addons.l10n_br_cnpj_search.wizard."
+            "partner_cnpj_search_wizard.requests.get",
+            return_value=mock.Mock(
+                status_code=200,
+                **{
+                    "json.return_value": {"status": "ERROR", "message": "CNPJ inválido"}
+                },
+            ),
+        ), self.assertRaises(ValidationError):
             invalido = self.model.create(
                 {"name": "invalido", "cnpj_cpf": "00000000000000"}
             )
@@ -69,6 +82,10 @@ class TestReceitaWS(TestCnpjCommon):
 
     def test_receita_ws_multiple_phones(self):
         with mock.patch(
+            "odoo.addons.l10n_br_cnpj_search.wizard."
+            "partner_cnpj_search_wizard.requests.get",
+            return_value=mock.Mock(status_code=200),
+        ), mock.patch(
             "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
             return_value=self.mocked_response_ws_2,
         ):

--- a/l10n_br_cnpj_search/tests/test_receitaws.py
+++ b/l10n_br_cnpj_search/tests/test_receitaws.py
@@ -8,7 +8,10 @@ from unittest import mock
 from odoo.exceptions import ValidationError
 from odoo.tests import tagged
 
-from odoo.addons.l10n_br_cnpj_search.tests.common import TestCnpjCommon
+from odoo.addons.l10n_br_cnpj_search.tests.common import (
+    MOCK_REQUESTS_GET,
+    TestCnpjCommon,
+)
 
 
 @tagged("post_install", "-at_install")
@@ -27,8 +30,7 @@ class TestReceitaWS(TestCnpjCommon):
         )
 
         with mock.patch(
-            "odoo.addons.l10n_br_cnpj_search.wizard."
-            "partner_cnpj_search_wizard.requests.get",
+            MOCK_REQUESTS_GET,
             return_value=mock.Mock(status_code=200),
         ), mock.patch(
             "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
@@ -62,8 +64,7 @@ class TestReceitaWS(TestCnpjCommon):
 
     def test_receita_ws_fail(self):
         with mock.patch(
-            "odoo.addons.l10n_br_cnpj_search.wizard."
-            "partner_cnpj_search_wizard.requests.get",
+            MOCK_REQUESTS_GET,
             return_value=mock.Mock(
                 status_code=200,
                 **{
@@ -82,8 +83,7 @@ class TestReceitaWS(TestCnpjCommon):
 
     def test_receita_ws_multiple_phones(self):
         with mock.patch(
-            "odoo.addons.l10n_br_cnpj_search.wizard."
-            "partner_cnpj_search_wizard.requests.get",
+            MOCK_REQUESTS_GET,
             return_value=mock.Mock(status_code=200),
         ), mock.patch(
             "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",

--- a/l10n_br_cnpj_search/tests/test_serpro.py
+++ b/l10n_br_cnpj_search/tests/test_serpro.py
@@ -6,10 +6,12 @@
 import logging
 from unittest import mock
 
-from odoo.exceptions import ValidationError
+import requests
+
+from odoo.exceptions import UserError, ValidationError
 from odoo.tests import tagged
 
-from .common import TestCnpjCommon
+from .common import MOCK_REQUESTS_GET, TestCnpjCommon
 
 _logger = logging.getLogger(__name__)
 
@@ -26,8 +28,7 @@ class TestTestSerPro(TestCnpjCommon):
 
     def test_serpro_basica(self):
         with mock.patch(
-            "odoo.addons.l10n_br_cnpj_search.wizard."
-            "partner_cnpj_search_wizard.requests.get",
+            MOCK_REQUESTS_GET,
             return_value=mock.Mock(status_code=200),
         ), mock.patch(
             "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
@@ -65,6 +66,20 @@ class TestTestSerPro(TestCnpjCommon):
             self.assertEqual(dummy_basica.equity_capital, 0)
             self.assertEqual(dummy_basica.cnae_main_id.code, "6204-0/00")
 
+    def test_serpro_timeout(self):
+        with mock.patch(
+            MOCK_REQUESTS_GET,
+            side_effect=requests.exceptions.Timeout,
+        ), self.assertRaises(UserError):
+            dummy = self.model.create(
+                {"name": "Dummy Timeout", "cnpj_cpf": "34.238.864/0001-68"}
+            )
+            dummy._onchange_cnpj_cpf()
+            action_wizard = dummy.action_open_cnpj_search_wizard()
+            wizard_context = action_wizard.get("context")
+            wizard_context["active_model"] = "res.partner"
+            self.env["partner.search.wizard"].with_context(**wizard_context).create({})
+
     def test_serpro_not_found(self):
         # In the Trial version there are only a few registered CNPJ records
         invalid = self.model.create(
@@ -73,8 +88,7 @@ class TestTestSerPro(TestCnpjCommon):
         invalid._onchange_cnpj_cpf()
 
         with mock.patch(
-            "odoo.addons.l10n_br_cnpj_search.wizard."
-            "partner_cnpj_search_wizard.requests.get",
+            MOCK_REQUESTS_GET,
             return_value=mock.Mock(status_code=404, reason="Not Found"),
         ), self.assertRaises(ValidationError):
             action_wizard = invalid.action_open_cnpj_search_wizard()
@@ -123,8 +137,7 @@ class TestTestSerPro(TestCnpjCommon):
 
     def test_serpro_empresa(self):
         with mock.patch(
-            "odoo.addons.l10n_br_cnpj_search.wizard."
-            "partner_cnpj_search_wizard.requests.get",
+            MOCK_REQUESTS_GET,
             return_value=mock.Mock(status_code=200),
         ), mock.patch(
             "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
@@ -163,8 +176,7 @@ class TestTestSerPro(TestCnpjCommon):
 
     def test_serpro_qsa(self):
         with mock.patch(
-            "odoo.addons.l10n_br_cnpj_search.wizard."
-            "partner_cnpj_search_wizard.requests.get",
+            MOCK_REQUESTS_GET,
             return_value=mock.Mock(status_code=200),
         ), mock.patch(
             "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",

--- a/l10n_br_cnpj_search/tests/test_serpro.py
+++ b/l10n_br_cnpj_search/tests/test_serpro.py
@@ -26,6 +26,10 @@ class TestTestSerPro(TestCnpjCommon):
 
     def test_serpro_basica(self):
         with mock.patch(
+            "odoo.addons.l10n_br_cnpj_search.wizard."
+            "partner_cnpj_search_wizard.requests.get",
+            return_value=mock.Mock(status_code=200),
+        ), mock.patch(
             "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
             return_value=self.mocked_response_serpro_1,
         ):
@@ -68,7 +72,11 @@ class TestTestSerPro(TestCnpjCommon):
         )
         invalid._onchange_cnpj_cpf()
 
-        with self.assertRaises(ValidationError):
+        with mock.patch(
+            "odoo.addons.l10n_br_cnpj_search.wizard."
+            "partner_cnpj_search_wizard.requests.get",
+            return_value=mock.Mock(status_code=404, reason="Not Found"),
+        ), self.assertRaises(ValidationError):
             action_wizard = invalid.action_open_cnpj_search_wizard()
             wizard_context = action_wizard.get("context")
             wizard_context["active_model"] = "res.partner"
@@ -115,6 +123,10 @@ class TestTestSerPro(TestCnpjCommon):
 
     def test_serpro_empresa(self):
         with mock.patch(
+            "odoo.addons.l10n_br_cnpj_search.wizard."
+            "partner_cnpj_search_wizard.requests.get",
+            return_value=mock.Mock(status_code=200),
+        ), mock.patch(
             "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
             return_value=self.mocked_response_serpro_2,
         ):
@@ -151,6 +163,10 @@ class TestTestSerPro(TestCnpjCommon):
 
     def test_serpro_qsa(self):
         with mock.patch(
+            "odoo.addons.l10n_br_cnpj_search.wizard."
+            "partner_cnpj_search_wizard.requests.get",
+            return_value=mock.Mock(status_code=200),
+        ), mock.patch(
             "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
             return_value=self.mocked_response_serpro_3,
         ):

--- a/l10n_br_cnpj_search/wizard/partner_cnpj_search_wizard.py
+++ b/l10n_br_cnpj_search/wizard/partner_cnpj_search_wizard.py
@@ -8,7 +8,8 @@ from erpbrasil.base import misc
 from erpbrasil.base.fiscal import cnpj_cpf
 from erpbrasil.base.misc import punctuation_rm
 
-from odoo import Command, api, fields, models
+from odoo import Command, _, api, fields, models
+from odoo.exceptions import UserError
 
 _logger = logging.getLogger(__name__)
 # This is the original 'send' method from the requests library that
@@ -78,8 +79,15 @@ class PartnerCnpjSearchWizard(models.TransientModel):
                     headers=webservice.get_headers(),
                     timeout=5,
                 )
-            except requests.exceptions.Timeout:
-                _logger.debug("Request timed out!")
+            except requests.exceptions.Timeout as exc:
+                _logger.warning(
+                    "CNPJ search request timed out (provider: %s)",
+                    provider_name,
+                    exc_info=True,
+                )
+                raise UserError(
+                    _("The CNPJ search service did not respond in time.")
+                ) from exc
         data = webservice.validate(response)
         values = webservice.import_data(data)
         values["provider_name"] = provider_name


### PR DESCRIPTION
Forward-port do #4596 para a 17.0.

Os testes de busca de CNPJ dos provedores `serpro` e `receitaws` mockavam apenas o método `validate`, então o wizard ainda fazia uma requisição HTTP real à API externa. Isso fazia os testes dependerem da rede: quando a requisição dava timeout, eles falhavam de forma intermitente, e o wizard quebrava com `UnboundLocalError` porque `response` nunca era atribuído.

Agora esses testes mockam o `requests.get`, então não acessam mais os serviços externos e passam sem conexão de rede. O wizard também levanta um `UserError` claro no timeout, em vez de falhar com `UnboundLocalError`. Nesta versão foi necessário ainda trocar `error.name` por `str(error)` em `_get_city_id`, já que o atributo `UserError.name` foi removido no Odoo 17.
