### PR TITLE
[18.0] l10n_br_cnpj_search: handle request timeout

### DIFF
--- a/l10n_br_cnpj_search/models/cnpj_webservice.py
+++ b/l10n_br_cnpj_search/models/cnpj_webservice.py
@@ -403,7 +403,7 @@ class CNPJWebservice(models.AbstractModel):
         try:
             cep_values = self.env["l10n_br.zip"]._consultar_cep(cep)
         except UserError as error:
-            _logger.warning(error.name)
+            _logger.warning(str(error))
             return False
 
         return cep_values.get("city_id")

--- a/l10n_br_cnpj_search/tests/common.py
+++ b/l10n_br_cnpj_search/tests/common.py
@@ -3,6 +3,10 @@
 
 from odoo.tests import TransactionCase
 
+MOCK_REQUESTS_GET = (
+    "odoo.addons.l10n_br_cnpj_search.wizard.partner_cnpj_search_wizard.requests.get"
+)
+
 
 class TestCnpjCommon(TransactionCase):
     @classmethod

--- a/l10n_br_cnpj_search/tests/test_receitaws.py
+++ b/l10n_br_cnpj_search/tests/test_receitaws.py
@@ -26,9 +26,16 @@ class TestReceitaWS(TestCnpjCommon):
             }
         )
 
-        with mock.patch(
-            "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
-            return_value=self.mocked_response_ws_1,
+        with (
+            mock.patch(
+                "odoo.addons.l10n_br_cnpj_search.wizard."
+                "partner_cnpj_search_wizard.requests.get",
+                return_value=mock.Mock(status_code=200),
+            ),
+            mock.patch(
+                "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
+                return_value=self.mocked_response_ws_1,
+            ),
         ):
             action_wizard = kilian.action_open_cnpj_search_wizard()
             wizard_context = action_wizard.get("context")
@@ -57,7 +64,22 @@ class TestReceitaWS(TestCnpjCommon):
         self.assertEqual(kilian.cnae_main_id.code, "4751-2/01")
 
     def test_receita_ws_fail(self):
-        with self.assertRaises(ValidationError):
+        with (
+            mock.patch(
+                "odoo.addons.l10n_br_cnpj_search.wizard."
+                "partner_cnpj_search_wizard.requests.get",
+                return_value=mock.Mock(
+                    status_code=200,
+                    **{
+                        "json.return_value": {
+                            "status": "ERROR",
+                            "message": "CNPJ inválido",
+                        }
+                    },
+                ),
+            ),
+            self.assertRaises(ValidationError),
+        ):
             invalido = self.model.create({"name": "invalido", "vat": "00000000000000"})
             invalido._onchange_vat()
             action_wizard = invalido.action_open_cnpj_search_wizard()
@@ -66,9 +88,16 @@ class TestReceitaWS(TestCnpjCommon):
             self.env["partner.search.wizard"].with_context(**wizard_context).create({})
 
     def test_receita_ws_multiple_phones(self):
-        with mock.patch(
-            "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
-            return_value=self.mocked_response_ws_2,
+        with (
+            mock.patch(
+                "odoo.addons.l10n_br_cnpj_search.wizard."
+                "partner_cnpj_search_wizard.requests.get",
+                return_value=mock.Mock(status_code=200),
+            ),
+            mock.patch(
+                "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
+                return_value=self.mocked_response_ws_2,
+            ),
         ):
             isla = self.model.create({"name": "Isla", "vat": "92.666.056/0001-06"})
             isla._onchange_vat()

--- a/l10n_br_cnpj_search/tests/test_receitaws.py
+++ b/l10n_br_cnpj_search/tests/test_receitaws.py
@@ -8,7 +8,10 @@ from unittest import mock
 from odoo.exceptions import ValidationError
 from odoo.tests import tagged
 
-from odoo.addons.l10n_br_cnpj_search.tests.common import TestCnpjCommon
+from odoo.addons.l10n_br_cnpj_search.tests.common import (
+    MOCK_REQUESTS_GET,
+    TestCnpjCommon,
+)
 
 
 @tagged("post_install", "-at_install")
@@ -28,8 +31,7 @@ class TestReceitaWS(TestCnpjCommon):
 
         with (
             mock.patch(
-                "odoo.addons.l10n_br_cnpj_search.wizard."
-                "partner_cnpj_search_wizard.requests.get",
+                MOCK_REQUESTS_GET,
                 return_value=mock.Mock(status_code=200),
             ),
             mock.patch(
@@ -66,8 +68,7 @@ class TestReceitaWS(TestCnpjCommon):
     def test_receita_ws_fail(self):
         with (
             mock.patch(
-                "odoo.addons.l10n_br_cnpj_search.wizard."
-                "partner_cnpj_search_wizard.requests.get",
+                MOCK_REQUESTS_GET,
                 return_value=mock.Mock(
                     status_code=200,
                     **{
@@ -90,8 +91,7 @@ class TestReceitaWS(TestCnpjCommon):
     def test_receita_ws_multiple_phones(self):
         with (
             mock.patch(
-                "odoo.addons.l10n_br_cnpj_search.wizard."
-                "partner_cnpj_search_wizard.requests.get",
+                MOCK_REQUESTS_GET,
                 return_value=mock.Mock(status_code=200),
             ),
             mock.patch(

--- a/l10n_br_cnpj_search/tests/test_serpro.py
+++ b/l10n_br_cnpj_search/tests/test_serpro.py
@@ -10,10 +10,16 @@ import requests
 
 from odoo.exceptions import UserError, ValidationError
 from odoo.tests import tagged
+from odoo.tools import mute_logger
 
 from .common import MOCK_REQUESTS_GET, TestCnpjCommon
 
 _logger = logging.getLogger(__name__)
+
+MOCK_GET_CITY_ID = (
+    "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice."
+    "CNPJWebservice._get_city_id"
+)
 
 
 @tagged("post_install", "-at_install")
@@ -36,6 +42,7 @@ class TestTestSerPro(TestCnpjCommon):
                 "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
                 return_value=self.mocked_response_serpro_1,
             ),
+            mock.patch(MOCK_GET_CITY_ID, return_value=False),
         ):
             dummy_basica = self.model.create(
                 {"name": "Dummy Basica", "vat": "34.238.864/0001-68"}
@@ -69,6 +76,7 @@ class TestTestSerPro(TestCnpjCommon):
             self.assertEqual(dummy_basica.equity_capital, 0)
             self.assertEqual(dummy_basica.cnae_main_id.code, "6204-0/00")
 
+    @mute_logger("odoo.addons.l10n_br_cnpj_search.wizard.partner_cnpj_search_wizard")
     def test_serpro_timeout(self):
         with (
             mock.patch(
@@ -152,6 +160,7 @@ class TestTestSerPro(TestCnpjCommon):
                 "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
                 return_value=self.mocked_response_serpro_2,
             ),
+            mock.patch(MOCK_GET_CITY_ID, return_value=False),
         ):
             self.model.search([("vat", "=", "34.238.864/0002-49")]).write(
                 {"active": False}
@@ -194,6 +203,7 @@ class TestTestSerPro(TestCnpjCommon):
                 "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
                 return_value=self.mocked_response_serpro_3,
             ),
+            mock.patch(MOCK_GET_CITY_ID, return_value=False),
         ):
             self.model.search([("vat", "=", "34.238.864/0001-68")]).write(
                 {"active": False}

--- a/l10n_br_cnpj_search/tests/test_serpro.py
+++ b/l10n_br_cnpj_search/tests/test_serpro.py
@@ -25,9 +25,16 @@ class TestTestSerPro(TestCnpjCommon):
         cls.set_param("serpro_schema", "basica")
 
     def test_serpro_basica(self):
-        with mock.patch(
-            "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
-            return_value=self.mocked_response_serpro_1,
+        with (
+            mock.patch(
+                "odoo.addons.l10n_br_cnpj_search.wizard."
+                "partner_cnpj_search_wizard.requests.get",
+                return_value=mock.Mock(status_code=200),
+            ),
+            mock.patch(
+                "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
+                return_value=self.mocked_response_serpro_1,
+            ),
         ):
             dummy_basica = self.model.create(
                 {"name": "Dummy Basica", "vat": "34.238.864/0001-68"}
@@ -66,7 +73,14 @@ class TestTestSerPro(TestCnpjCommon):
         invalid = self.model.create({"name": "invalid", "vat": "44.356.113/0001-08"})
         invalid._onchange_vat()
 
-        with self.assertRaises(ValidationError):
+        with (
+            mock.patch(
+                "odoo.addons.l10n_br_cnpj_search.wizard."
+                "partner_cnpj_search_wizard.requests.get",
+                return_value=mock.Mock(status_code=404, reason="Not Found"),
+            ),
+            self.assertRaises(ValidationError),
+        ):
             action_wizard = invalid.action_open_cnpj_search_wizard()
             wizard_context = action_wizard.get("context")
             wizard_context["active_model"] = "res.partner"
@@ -112,9 +126,16 @@ class TestTestSerPro(TestCnpjCommon):
         self.assertEqual(socios, expected_socios)
 
     def test_serpro_empresa(self):
-        with mock.patch(
-            "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
-            return_value=self.mocked_response_serpro_2,
+        with (
+            mock.patch(
+                "odoo.addons.l10n_br_cnpj_search.wizard."
+                "partner_cnpj_search_wizard.requests.get",
+                return_value=mock.Mock(status_code=200),
+            ),
+            mock.patch(
+                "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
+                return_value=self.mocked_response_serpro_2,
+            ),
         ):
             self.model.search([("vat", "=", "34.238.864/0002-49")]).write(
                 {"active": False}
@@ -148,9 +169,16 @@ class TestTestSerPro(TestCnpjCommon):
         dummy_empresa.unlink()
 
     def test_serpro_qsa(self):
-        with mock.patch(
-            "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
-            return_value=self.mocked_response_serpro_3,
+        with (
+            mock.patch(
+                "odoo.addons.l10n_br_cnpj_search.wizard."
+                "partner_cnpj_search_wizard.requests.get",
+                return_value=mock.Mock(status_code=200),
+            ),
+            mock.patch(
+                "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate",
+                return_value=self.mocked_response_serpro_3,
+            ),
         ):
             self.model.search([("vat", "=", "34.238.864/0001-68")]).write(
                 {"active": False}

--- a/l10n_br_cnpj_search/tests/test_serpro.py
+++ b/l10n_br_cnpj_search/tests/test_serpro.py
@@ -6,10 +6,12 @@
 import logging
 from unittest import mock
 
-from odoo.exceptions import ValidationError
+import requests
+
+from odoo.exceptions import UserError, ValidationError
 from odoo.tests import tagged
 
-from .common import TestCnpjCommon
+from .common import MOCK_REQUESTS_GET, TestCnpjCommon
 
 _logger = logging.getLogger(__name__)
 
@@ -27,8 +29,7 @@ class TestTestSerPro(TestCnpjCommon):
     def test_serpro_basica(self):
         with (
             mock.patch(
-                "odoo.addons.l10n_br_cnpj_search.wizard."
-                "partner_cnpj_search_wizard.requests.get",
+                MOCK_REQUESTS_GET,
                 return_value=mock.Mock(status_code=200),
             ),
             mock.patch(
@@ -68,6 +69,23 @@ class TestTestSerPro(TestCnpjCommon):
             self.assertEqual(dummy_basica.equity_capital, 0)
             self.assertEqual(dummy_basica.cnae_main_id.code, "6204-0/00")
 
+    def test_serpro_timeout(self):
+        with (
+            mock.patch(
+                MOCK_REQUESTS_GET,
+                side_effect=requests.exceptions.Timeout,
+            ),
+            self.assertRaises(UserError),
+        ):
+            dummy = self.model.create(
+                {"name": "Dummy Timeout", "vat": "34.238.864/0001-68"}
+            )
+            dummy._onchange_vat()
+            action_wizard = dummy.action_open_cnpj_search_wizard()
+            wizard_context = action_wizard.get("context")
+            wizard_context["active_model"] = "res.partner"
+            self.env["partner.search.wizard"].with_context(**wizard_context).create({})
+
     def test_serpro_not_found(self):
         # In the Trial version there are only a few registered CNPJ records
         invalid = self.model.create({"name": "invalid", "vat": "44.356.113/0001-08"})
@@ -75,8 +93,7 @@ class TestTestSerPro(TestCnpjCommon):
 
         with (
             mock.patch(
-                "odoo.addons.l10n_br_cnpj_search.wizard."
-                "partner_cnpj_search_wizard.requests.get",
+                MOCK_REQUESTS_GET,
                 return_value=mock.Mock(status_code=404, reason="Not Found"),
             ),
             self.assertRaises(ValidationError),
@@ -128,8 +145,7 @@ class TestTestSerPro(TestCnpjCommon):
     def test_serpro_empresa(self):
         with (
             mock.patch(
-                "odoo.addons.l10n_br_cnpj_search.wizard."
-                "partner_cnpj_search_wizard.requests.get",
+                MOCK_REQUESTS_GET,
                 return_value=mock.Mock(status_code=200),
             ),
             mock.patch(
@@ -171,8 +187,7 @@ class TestTestSerPro(TestCnpjCommon):
     def test_serpro_qsa(self):
         with (
             mock.patch(
-                "odoo.addons.l10n_br_cnpj_search.wizard."
-                "partner_cnpj_search_wizard.requests.get",
+                MOCK_REQUESTS_GET,
                 return_value=mock.Mock(status_code=200),
             ),
             mock.patch(

--- a/l10n_br_cnpj_search/wizard/partner_cnpj_search_wizard.py
+++ b/l10n_br_cnpj_search/wizard/partner_cnpj_search_wizard.py
@@ -9,6 +9,7 @@ from erpbrasil.base.fiscal import cnpj_cpf
 from erpbrasil.base.misc import punctuation_rm
 
 from odoo import Command, api, fields, models
+from odoo.exceptions import UserError
 
 _logger = logging.getLogger(__name__)
 # This is the original 'send' method from the requests library that
@@ -78,8 +79,15 @@ class PartnerCnpjSearchWizard(models.TransientModel):
                     headers=webservice.get_headers(),
                     timeout=5,
                 )
-            except requests.exceptions.Timeout:
-                _logger.debug("Request timed out!")
+            except requests.exceptions.Timeout as exc:
+                _logger.warning(
+                    "CNPJ search request timed out (provider: %s)",
+                    provider_name,
+                    exc_info=True,
+                )
+                raise UserError(
+                    self.env._("The CNPJ search service did not respond in time.")
+                ) from exc
         data = webservice.validate(response)
         values = webservice.import_data(data)
         values["provider_name"] = provider_name


### PR DESCRIPTION
Forward-port do #4596 para a 18.0.

Os testes de busca de CNPJ dos provedores `serpro` e `receitaws` mockavam apenas o método `validate`, então o wizard ainda fazia uma requisição HTTP real à API externa. Isso fazia os testes dependerem da rede: quando a requisição dava timeout, eles falhavam de forma intermitente, e o wizard quebrava com `UnboundLocalError` porque `response` nunca era atribuído.

Agora esses testes mockam o `requests.get`, então não acessam mais os serviços externos e passam sem conexão de rede. O wizard também levanta um `UserError` claro no timeout, em vez de falhar com `UnboundLocalError`. Nesta versão foi necessário ainda trocar `error.name` por `str(error)` em `_get_city_id`, já que o atributo `UserError.name` foi removido no Odoo 17.
