### PR TITLE
[16.0][FIX] l10n_br_account_payment_order: Permitir selecionar os Métodos de Pagamento CNAB no Diário

### DIFF
--- a/l10n_br_account_payment_order/models/__init__.py
+++ b/l10n_br_account_payment_order/models/__init__.py
@@ -8,6 +8,7 @@ from . import account_payment_mode
 from . import account_payment_order
 from . import account_payment_line
 from . import account_payment
+from . import account_payment_method
 from . import l10n_br_cnab_event
 from . import l10n_br_cnab_lot
 from . import l10n_br_cnab_return_log

--- a/l10n_br_account_payment_order/models/account_payment_method.py
+++ b/l10n_br_account_payment_order/models/account_payment_method.py
@@ -1,0 +1,51 @@
+# Copyright (C) 2026-Today - Akretion (<http://www.akretion.com>).
+# @author Magno Costa <magno.costa@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class AccountPaymentMethod(models.Model):
+    _inherit = "account.payment.method"
+
+    @api.model
+    def _get_payment_method_information(self):
+        """
+        Contains details about how to initialize a payment method
+        with the code x.
+        The contained info are:
+            mode: Either unique if we only want one of them at a single time
+                (payment providers for example) or multi if we want the
+                method on each journal fitting the domain.
+            domain: The domain defining the eligible journals.
+            currency_id: The id of the currency necessary on the journal
+                (or company) for it to be eligible.
+            country_id: The id of the country needed on the company
+                for it to be eligible.
+            hidden: If set to true, the method will not be automatically
+                added to the journal, and will not be selectable by the user.
+        """
+        res = super()._get_payment_method_information()
+
+        res["240"] = {
+            "mode": "multi",
+            "domain": [("type", "=", "bank")],
+            "currency_id": self.env.ref("base.BRL").id,
+            "country_id": self.env.ref("base.br").id,
+        }
+
+        res["400"] = {
+            "mode": "multi",
+            "domain": [("type", "=", "bank")],
+            "currency_id": self.env.ref("base.BRL").id,
+            "country_id": self.env.ref("base.br").id,
+        }
+
+        res["500"] = {
+            "mode": "multi",
+            "domain": [("type", "=", "bank")],
+            "currency_id": self.env.ref("base.BRL").id,
+            "country_id": self.env.ref("base.br").id,
+        }
+
+        return res


### PR DESCRIPTION
CNAB in Journal

Permitir selecionar os **Métodos de Pagamento/account.payment.method** do tipo CNAB no **Diário/account.journal**, esse erro provavelmente passou despercebido  porque ao criar no novo Diário já são adicionadas as **Linhas de Pagamentos Recebidos e de Despesas** mas se forem removidos não é possível selecionar novamente, o erro foi reportado em:

* https://github.com/OCA/l10n-brazil/issues/4570

**Antes desse PR**

<img width="1202" height="457" alt="image" src="https://github.com/user-attachments/assets/c44b20c7-f916-470a-917d-c7fe0b371fed" />

<img width="1197" height="492" alt="image" src="https://github.com/user-attachments/assets/35b90144-5c57-405d-b443-19f4bba32617" />

**Com esse PR**

<img width="1197" height="505" alt="image" src="https://github.com/user-attachments/assets/81423436-ef26-47c7-ac43-6f059941d661" />

<img width="1203" height="505" alt="image" src="https://github.com/user-attachments/assets/726acf44-3f4e-4c3d-bb4d-15e3733ad556" />

Eu adicionei no filtro que a Empresa deve estar com a Moeda/res.currency com BRL e o País/res.country como Brasil.

cc @OCA/local-brazil-maintainers @Mauricio-ATS


