### PR TITLE
[18.0][FIX] l10n_br_account_payment_order: FWD Permitir selecionar os Métodos de Pagamento CNAB no Diário

### DIFF
--- a/l10n_br_account_payment_order/models/__init__.py
+++ b/l10n_br_account_payment_order/models/__init__.py
@@ -9,6 +9,7 @@ from . import account_payment_mode
 from . import account_payment_order
 from . import account_payment_line
 from . import account_payment
+from . import account_payment_method
 from . import l10n_br_cnab_event
 from . import l10n_br_cnab_lot
 from . import l10n_br_cnab_return_log

--- a/l10n_br_account_payment_order/models/account_payment_method.py
+++ b/l10n_br_account_payment_order/models/account_payment_method.py
@@ -1,0 +1,51 @@
+# Copyright (C) 2026-Today - Akretion (<http://www.akretion.com>).
+# @author Magno Costa <magno.costa@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class AccountPaymentMethod(models.Model):
+    _inherit = "account.payment.method"
+
+    @api.model
+    def _get_payment_method_information(self):
+        """
+        Contains details about how to initialize a payment method
+        with the code x.
+        The contained info are:
+            mode: Either unique if we only want one of them at a single time
+                (payment providers for example) or multi if we want the
+                method on each journal fitting the domain.
+            domain: The domain defining the eligible journals.
+            currency_id: The id of the currency necessary on the journal
+                (or company) for it to be eligible.
+            country_id: The id of the country needed on the company
+                for it to be eligible.
+            hidden: If set to true, the method will not be automatically
+                added to the journal, and will not be selectable by the user.
+        """
+        res = super()._get_payment_method_information()
+
+        res["240"] = {
+            "mode": "multi",
+            "domain": [("type", "=", "bank")],
+            "currency_id": self.env.ref("base.BRL").id,
+            "country_id": self.env.ref("base.br").id,
+        }
+
+        res["400"] = {
+            "mode": "multi",
+            "domain": [("type", "=", "bank")],
+            "currency_id": self.env.ref("base.BRL").id,
+            "country_id": self.env.ref("base.br").id,
+        }
+
+        res["500"] = {
+            "mode": "multi",
+            "domain": [("type", "=", "bank")],
+            "currency_id": self.env.ref("base.BRL").id,
+            "country_id": self.env.ref("base.br").id,
+        }
+
+        return res


### PR DESCRIPTION
CNAB in Journal.

Permitir selecionar os Métodos de Pagamento/account.payment.method do tipo CNAB no Diário/account.journal, "Forward-Port" do PR:

* https://github.com/OCA/l10n-brazil/pull/4601
* https://github.com/OCA/l10n-brazil/pull/4600
 Mais detalhes no PR.

cc @OCA/local-brazil-maintainers 
