### PR TITLE
[16.0][IMP] Neutralizar ambiente de transmissão fiscal para homologação

### DIFF
--- a/l10n_br_cte/data/neutralize.sql
+++ b/l10n_br_cte/data/neutralize.sql
@@ -1,0 +1,3 @@
+-- force the CT-e transmission environment to homologação (SEFAZ test)
+UPDATE res_company
+   SET cte_environment = '2';

--- a/l10n_br_fiscal_dfe/data/neutralize.sql
+++ b/l10n_br_fiscal_dfe/data/neutralize.sql
@@ -1,0 +1,3 @@
+-- force the DF-e distribution environment to homologação (SEFAZ test)
+UPDATE res_company
+   SET dfe_environment = '2';

--- a/l10n_br_mdfe/data/neutralize.sql
+++ b/l10n_br_mdfe/data/neutralize.sql
@@ -1,0 +1,3 @@
+-- force the MDF-e transmission environment to homologação (SEFAZ test)
+UPDATE res_company
+   SET mdfe_environment = '2';

--- a/l10n_br_nfe/data/neutralize.sql
+++ b/l10n_br_nfe/data/neutralize.sql
@@ -1,0 +1,3 @@
+-- force the NF-e transmission environment to homologação (SEFAZ test)
+UPDATE res_company
+   SET nfe_environment = '2';

--- a/l10n_br_nfse/data/neutralize.sql
+++ b/l10n_br_nfse/data/neutralize.sql
@@ -1,0 +1,3 @@
+-- force the NFS-e transmission environment to homologação (city test)
+UPDATE res_company
+   SET nfse_environment = '2';


### PR DESCRIPTION
A neutralização de banco de dados é uma funcionalidade nativa do **Odoo 16**: ao restaurar uma cópia de produção
num ambiente de teste, ela desativa crons, e-mail, provedores de pagamento, etc.
Cada módulo declara o que neutralizar num arquivo `data/neutralize.sql`,
executado pelo comando:

```bash
odoo-bin neutralize -d nome_do_banco
```

Faltava neutralizar o ambiente de transmissão fiscal: hoje um banco de produção
restaurado para teste continua apontando para a SEFAZ de produção (`tpAmb=1`) e
pode transmitir documentos reais. Este PR adiciona `data/neutralize.sql` aos
módulos de documentos fiscais para forçar o ambiente para **homologação**
(`tpAmb=2`): `l10n_br_nfe`, `l10n_br_cte`, `l10n_br_mdfe`, `l10n_br_nfse` e
`l10n_br_fiscal_dfe`.


Referencias:
https://www.odoo.com/documentation/16.0/administration/neutralized_database.html
https://www.odoo.com/documentation/16.0/developer/reference/cli.html#neutralize