### PR TITLE
[16.0][l10n_br_fiscal][l10n_br_sale][l10n_br_purchase][l10n_br_stock_account] warning fixes backport

### DIFF
--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -1051,7 +1051,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     )
 
     fiscal_operation_type = fields.Selection(
-        string="Operation Type",
+        string="Fiscal Operation Type",
         related="fiscal_operation_id.fiscal_operation_type",
     )
 

--- a/l10n_br_purchase/models/purchase_order_line.py
+++ b/l10n_br_purchase/models/purchase_order_line.py
@@ -59,13 +59,16 @@ class PurchaseOrderLine(models.Model):
         string="Comments",
     )
 
-    ind_final = fields.Selection(related="order_id.ind_final")
-
     # Usado para tornar Somente Leitura os campos totais dos custos
     # de entrega quando a definição for por Linha
     delivery_costs = fields.Selection(
         related="company_id.delivery_costs",
     )
+
+    # adapted for _compute_find_final:
+    def _get_document(self):
+        self.ensure_one()
+        return self.order_id
 
     @api.depends(
         "product_uom_qty",

--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -100,8 +100,6 @@ class SaleOrderLine(models.Model):
         precompute=True,
     )
 
-    ind_final = fields.Selection(related="order_id.ind_final")
-
     # Usado para tornar Somente Leitura os campos dos custos
     # de entrega quando a definição for por Total
     delivery_costs = fields.Selection(
@@ -123,6 +121,11 @@ class SaleOrderLine(models.Model):
         string="CNAE Code",
         domain=lambda self: self._cnae_domain(),
     )
+
+    # adapted for _compute_find_final:
+    def _get_document(self):
+        self.ensure_one()
+        return self.order_id
 
     # Depends on price_unit because we need a field to force compute in new records
     # not created yet. This field is necessary to compute readonly condition for

--- a/l10n_br_stock_account/models/stock_move.py
+++ b/l10n_br_stock_account/models/stock_move.py
@@ -71,8 +71,6 @@ class StockMove(models.Model):
     # A Fatura é criada com os dois valores positivos.
     fiscal_price = fields.Float(compute="_compute_fiscal_price")
 
-    ind_final = fields.Selection(related="picking_id.ind_final")
-
     # Usado para tornar Somente Leitura os campos totais dos custos
     # de entrega quando a definição for por Linha
     delivery_costs = fields.Selection(
@@ -87,6 +85,11 @@ class StockMove(models.Model):
         compute="_compute_tax_ids",
         store=True,
     )
+
+    # adapted for _compute_find_final:
+    def _get_document(self):
+        self.ensure_one()
+        return self.picking_id
 
     @api.depends("fiscal_tax_ids", "fiscal_operation_line_id")
     def _compute_tax_ids(self):


### PR DESCRIPTION
Migrando para para a v18, tive que resolver alguns warnings: aquele do ind_final e uns de label igual. Da para fazer backport na 16.0 aqui.

antes: 1738 warnings (principalmente labels duplicados com CTe e MDFe; vamos resover a maioria na 18.0 tb)
depois: 1660 warnings