### PR TITLE
[18.0][FIX] l10n_br_nfe: populate nfe40_detPag for NF-e (modelo 55)

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -90,6 +90,7 @@ class NFe(spec_models.StackedModel):
         "infnfe.exporta",
         "infnfe.cobr",
         "infnfe.cobr.fat",
+        "infnfe.pag",
     )
     _nfe_search_keys = ["nfe40_Id"]
 
@@ -1458,6 +1459,8 @@ class NFe(spec_models.StackedModel):
     def _eletronic_document_send(self):
         super()._eletronic_document_send()
         for record in self.filtered(filter_processador_edoc_nfe):
+            if record.document_type == MODELO_FISCAL_NFE:
+                record._prepare_payments_for_nfe()
             if record.xml_error_message:
                 return  # Skip
             if record.state_edoc not in ["enviada", "a_enviar"]:
@@ -1758,6 +1761,59 @@ class NFe(spec_models.StackedModel):
             rec.nfe40_detPag.filtered(lambda p: p.nfe40_tPag == "99").write(
                 {"nfe40_xPag": "Outros"}
             )
+
+    def _prepare_payments_for_nfe(self):
+        """Populate nfe40_detPag from invoice payment terms for NF-e (modelo 55).
+
+        NF-e requires at least one <detPag> inside <pag> in the XML.
+        This method reads the linked account.move's payment term and creates
+        nfe.40.detpag records accordingly.
+        """
+        for rec in self.filtered(
+            lambda d: d.document_type == MODELO_FISCAL_NFE
+        ):
+            if rec.nfe40_detPag:
+                continue
+            moves = self.env["account.move"].search([
+                ("fiscal_document_id", "=", rec.id),
+                ("move_type", "=", "out_invoice"),
+            ])
+            if not moves:
+                moves = rec.move_ids.filtered(
+                    lambda m: m.move_type == "out_invoice"
+                )
+            if not moves:
+                rec.nfe40_detPag = [(0, 0, {
+                    "nfe40_indPag": "0",
+                    "nfe40_tPag": "17",
+                    "nfe40_vPag": rec.fiscal_amount_total,
+                })]
+                continue
+            for move in moves:
+                payment_term = move.invoice_payment_term_id
+                if not payment_term or not payment_term.line_ids:
+                    rec.nfe40_detPag = [(0, 0, {
+                        "nfe40_indPag": "0",
+                        "nfe40_tPag": "17",
+                        "nfe40_vPag": move.amount_total,
+                    })]
+                    continue
+                lines = payment_term.line_ids.sorted(
+                    key=lambda l: l.nb_days or 0
+                )
+                is_installment = len(lines) > 1
+                for line in lines:
+                    if line.value == "percent":
+                        line_amount = move.amount_total * (line.value_amount / 100.0)
+                    elif line.value == "fixed":
+                        line_amount = line.value_amount
+                    else:
+                        line_amount = move.amount_total
+                    rec.nfe40_detPag = [(0, 0, {
+                        "nfe40_indPag": "1" if is_installment else "0",
+                        "nfe40_tPag": "17",
+                        "nfe40_vPag": line_amount,
+                    })]
 
     def action_danfe_nfce_report(self):
         return (


### PR DESCRIPTION
## Description

NF-e (modelo 55) requires at least one \<detPag\> inside \<pag\> in the XML. The NFE spec defines the structure but no method populates the data for NF-e, causing SEFAZ rejection with:

> Element '{http://www.portalfiscal.inf.br/nfe}pag': Missing child element(s). Expected is ( {http://www.portalfiscal.inf.br/nfe}detPag ).

NFC-e already had `_prepare_payments_for_nfce()` but NFe (modelo 55) support was missing.

## Changes

1. Added `"infnfe.pag"` to `_nfe40_stacking_force_paths` so the XML serialization includes the pag node (stacked from `nfe.40.pag` / `nfe.40.detpag` spec models).

2. Added `_prepare_payments_for_nfe()` method that reads the linked `account.move`'s payment term and creates `nfe.40.detpag` records accordingly:
   - Parses payment term lines (percent/fixed/balance values)
   - Sets `nfe40_indPag` to 0 (à vista) or 1 (à prazo) based on installment count
   - Defaults to PIX (tPag=17) with total amount when no payment term is set
   - Skips if detPag already populated (idempotent)

3. Calls `_prepare_payments_for_nfe()` before the error check in `_eletronic_document_send()` for NFe documents.

## Testing

Tested on Odoo 18.0 with a real NF-e emission. Before the fix, SEFAZ rejected with the missing \<detPag\> error. After the fix, the XML is generated with proper payment data and the error is gone.

## Notes

The `nfe40_tPag` defaults to code 17 (PIX) as a sensible default for Brazilian market. Users can customize the method or set payment forms via fiscal payment mode mapping in future improvements.

Closes #???