### PR TITLE
[18.0][IMP] l10n_br_base: vat_formatted

### DIFF
--- a/l10n_br_base/models/party_mixin.py
+++ b/l10n_br_base/models/party_mixin.py
@@ -22,6 +22,12 @@ class PartyMixin(models.AbstractModel):
         index=True,
     )
 
+    vat_formatted_cnpj = fields.Char(
+        string="VAT Formatted (Brazil)",
+        compute="_compute_vat_formatted_cnpj",
+        help="CNPJ or CPF formatted with proper punctuation and special characters",
+    )
+
     l10n_br_ie_code = fields.Char(
         string="State Tax Number",
         size=17,
@@ -104,6 +110,14 @@ class PartyMixin(models.AbstractModel):
             else:
                 record.cnpj_cpf_stripped = False
 
+    @api.depends("vat", "country_id")
+    def _compute_vat_formatted_cnpj(self):
+        for record in self:
+            vat_formatted_cnpj = False
+            if record.vat and record.country_id and record.country_id.code == "BR":
+                vat_formatted_cnpj = cnpj_cpf.formata(str(record.vat))
+            record.vat_formatted_cnpj = vat_formatted_cnpj
+
     @api.onchange("zip")
     def _onchange_zip(self):
         if self.country_id:
@@ -124,5 +138,5 @@ class PartyMixin(models.AbstractModel):
     @api.onchange("vat")
     def _onchange_vat(self):
         """Format the VAT field (CNPJ/CPF) with proper punctuation."""
-        if self.vat:
+        if self.vat and self.country_id and self.country_id.code == "BR":
             self.vat = cnpj_cpf.formata(str(self.vat))

--- a/l10n_br_base/tests/test_valid_createid.py
+++ b/l10n_br_base/tests/test_valid_createid.py
@@ -247,6 +247,11 @@ class ValidCreateIdTest(TransactionCase):
             "93.429.799/0001-17",
             "The VAT must be the same as what was registered",
         )
+        self.assertEqual(
+            partner.vat_formatted_cnpj,
+            "93.429.799/0001-17",
+            "The VAT/CNPJ must be the same as what was registered",
+        )
 
     def test_create_company_in_brazil(self):
         """Test the creation of a company in Brazil"""


### PR DESCRIPTION
## Objetivo da PR

Introduz novo campo computado `vat_formatted` para separar armazenamento (VAT) de exibição (VAT formatado). Prepara migração gradual para v19.0 onde VAT será armazenado sem formatação.

## Motivação

Em v19.0 o plano é:
- Armazenar VAT **sem formatação**
- Usar campo `vat_formatted` **apenas para exibição**

Quando fiz migração do módulo https://github.com/OCA/l10n-brazil/pull/4555 o @rvalyi me alertou que na V19.0 o campo VAT vai ser armazenado sem formatação a ideia é ter um campo já na v18.0 para isso vat_formatted para apresentarar em relatorios ou algo do tipo, a ideia é fazer algo nesse sentido se o Raphael quiser comentar um pouco mais também e falar sobre, vou deixar em draft por enquanto mas só para trazer a ideia pra OCA.
