### PR TITLE
[16.0][REF] l10n_br_account_payment_brcobranca: Movendo o método do calculo module11 para o arquivo de constantes

### DIFF
--- a/l10n_br_account_payment_brcobranca/constants/br_cobranca.py
+++ b/l10n_br_account_payment_brcobranca/constants/br_cobranca.py
@@ -85,3 +85,37 @@ def get_brcobranca_api_url(env):
         )
 
     return brcobranca_api_url
+
+
+# Caso Santander 400 precisa enviar o Nosso Numero com DV isso não acontece no
+# 240, por enquanto é o único caso mapeado.
+# Houve um PR https://github.com/kivanio/brcobranca/pull/236 na lib buscando
+# resolver isso e foi apontando a contradição em ter para esse mesmo banco no
+# caso do 400 a necessidade de informar o DV mas não precisar no 240,
+# mas o mantedor da biblioteca não aceito a alteração.
+# A melhor solução talvez seja ver a possibilidade de incluir ou fazer algo
+# semelhante ao git-aggregator https://github.com/acsone/git-aggregator
+# na API e com isso incluir um commit de outro repositorio que faça essa
+# simples alteração porém mantendo a API ligada diretamente ao repo pricipal
+# do BRcobranca, já que não existe o interesse em manter um Fork e um simples
+# commit resolve o problema, por enquanto o calculo esta sendo feito aqui, se
+# necessário ou isso for útil para outros casos pode ser visto de migrar esse
+# calculo do modulo11 para um lugar genereico e facilitar seu uso exemplo
+# l10n_br_account_payment_order/tools.py
+def modulo11(num, base=9, r=0):
+    soma = 0
+    fator = 2
+    for c in reversed(num):
+        soma += int(c) * fator
+        if fator == base:
+            fator = 1
+        fator += 1
+    if r == 0:
+        soma = soma * 10
+        digito = soma % 11
+        if digito == 10:
+            digito = 0
+        return digito
+    if r == 1:
+        resto = soma % 11
+        return resto

--- a/l10n_br_account_payment_brcobranca/models/account_payment_line.py
+++ b/l10n_br_account_payment_brcobranca/models/account_payment_line.py
@@ -8,6 +8,8 @@ import logging
 
 from odoo import models
 
+from ..constants.br_cobranca import modulo11
+
 _logger = logging.getLogger(__name__)
 
 
@@ -48,39 +50,6 @@ class AccountPaymentLine(models.Model):
     def _prepare_bank_line_banco_brasil(self, cnab_config, linhas_pagamentos):
         self._prepare_cod_primeira_instrucao_protest(cnab_config, linhas_pagamentos)
 
-    # Caso Santander 400 precisa enviar o Nosso Numero com DV isso não acontece no
-    # 240, por enquanto é o único caso mapeado.
-    # Houve um PR https://github.com/kivanio/brcobranca/pull/236 na lib buscando
-    # resolver isso e foi apontando a contradição em ter para esse mesmo banco no
-    # caso do 400 a necessidade de informar o DV mas não precisar no 240,
-    # mas o mantedor da biblioteca não aceito a alteração.
-    # A melhor solução talvez seja ver a possibilidade de incluir ou fazer algo
-    # semelhante ao git-aggregator https://github.com/acsone/git-aggregator
-    # na API e com isso incluir um commit de outro repositorio que faça essa
-    # simples alteração porém mantendo a API ligada diretamente ao repo pricipal
-    # do BRcobranca, já que não existe o interesse em manter um Fork e um simples
-    # commit resolve o problema, por enquanto o calculo esta sendo feito aqui, se
-    # necessário ou isso for útil para outros casos pode ser visto de migrar esse
-    # calculo do modulo11 para um lugar genereico e facilitar seu uso exemplo
-    # l10n_br_account_payment_order/tools.py
-    def modulo11(self, num, base=9, r=0):
-        soma = 0
-        fator = 2
-        for c in reversed(num):
-            soma += int(c) * fator
-            if fator == base:
-                fator = 1
-            fator += 1
-        if r == 0:
-            soma = soma * 10
-            digito = soma % 11
-            if digito == 10:
-                digito = 0
-            return digito
-        if r == 1:
-            resto = soma % 11
-            return resto
-
     def _prepare_bank_line_santander(self, cnab_config, linhas_pagamentos):
         if cnab_config.payment_method_id.code == "400":
             nosso_numero = linhas_pagamentos["nosso_numero"]
@@ -90,7 +59,7 @@ class AccountPaymentLine(models.Model):
                 start_point = len(nosso_numero) - 7
                 nosso_numero = nosso_numero[start_point : len(nosso_numero)]
 
-            dv = self.modulo11(nosso_numero, 9, 0)
+            dv = modulo11(nosso_numero, 9, 0)
             linhas_pagamentos["nosso_numero"] = str(nosso_numero) + str(dv)
         elif cnab_config.payment_method_id.code == "240":
             linhas_pagamentos[


### PR DESCRIPTION
Move module11 to constant file.

PR simples, apenas para mover o método de cálculo do module11 para o arquivo de constantes, objetivo é deixar o arquivo account_payment_line.py mais "limpo" o aquivo já tem que tratar as diferenças entre cada caso Banco/CNAB.

cc @OCA/local-brazil-maintainers 