### PR TITLE
[16.0][FIX] l10n_br_base: detecta CNPJ/CPF duplicado ignorando a formatação

### DIFF
--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -111,10 +111,14 @@ class Partner(models.Model):
             ) or self.env.context.get("allow_vat_duplicate"):
                 return
 
-            allow_cnpj_multi_ie = (
+            # allow_cnpj_multi_ie is a res.config.settings boolean: it is stored
+            # as "True" when enabled and removed entirely when disabled
+            # (set_param deletes on a False bool), so a plain bool() reads it
+            # correctly (absent -> strict), matching base_setup.show_effect.
+            allow_cnpj_multi_ie = bool(
                 record.env["ir.config_parameter"]
                 .sudo()
-                .get_param("l10n_br_base.allow_cnpj_multi_ie", default=True)
+                .get_param("l10n_br_base.allow_cnpj_multi_ie")
             )
 
             if record.parent_id:
@@ -123,19 +127,25 @@ class Partner(models.Model):
                     ("parent_id", "not in", record.parent_id.ids),
                 ]
 
-            if record.vat:
-                domain += [
-                    ("vat", "=", record.vat),
-                    ("id", "!=", record.id),
-                    ("parent_id", "!=", record.id),
-                ]
-                return
+            # Compare by the normalized CNPJ/CPF (cnpj_cpf_stripped, without mask)
+            # so the same number typed with a different mask is still detected as
+            # a duplicate: `vat` is only normalized when written through the
+            # `cnpj_cpf` alias, so a direct `vat` write could store a different
+            # mask and slip past a raw `vat` comparison.
+            # NOTE for the v19 migration: once `vat` is stored unformatted and
+            # `cnpj_cpf_stripped` is retired, comparing by `vat` directly here is
+            # enough.
+            domain += [
+                ("cnpj_cpf_stripped", "=", record.cnpj_cpf_stripped),
+                ("id", "!=", record.id),
+                ("parent_id", "!=", record.id),
+            ]
 
             matches = record.env["res.partner"].search(domain)
             if matches:
                 if cnpj_cpf.validar_cnpj(record.vat):
-                    if allow_cnpj_multi_ie == "True":
-                        for partner in record.env["res.partner"].search(domain):
+                    if allow_cnpj_multi_ie:
+                        for partner in matches:
                             if (
                                 partner.l10n_br_ie_code == record.l10n_br_ie_code
                                 and record.l10n_br_ie_code

--- a/l10n_br_base/tests/__init__.py
+++ b/l10n_br_base/tests/__init__.py
@@ -4,3 +4,4 @@ from . import test_base_onchange
 from . import test_other_ie
 from . import test_valid_pix
 from . import test_partner_bank
+from . import test_duplicate_cnpj

--- a/l10n_br_base/tests/test_duplicate_cnpj.py
+++ b/l10n_br_base/tests/test_duplicate_cnpj.py
@@ -1,0 +1,90 @@
+# Copyright (C) 2026 - Antônio S. Pereira Neto - Engenere <neto@engenere.one>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.exceptions import ValidationError
+from odoo.tests import TransactionCase
+
+
+class DuplicateCnpjTest(TransactionCase):
+    """The same CNPJ must not be registered twice, regardless of the
+    formatting that was typed.
+
+    Regression for OCA/l10n-brazil#4430: ``_check_cnpj_l10n_br_ie_code``
+    compared the already formatted ``vat`` (so "06.990.590/0001-23" !=
+    "06.990.590/000123") and, on top of that, a misplaced ``return`` killed the
+    check entirely. The correct comparison is by the normalized
+    ``cnpj_cpf_stripped`` value.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # allow_cnpj_multi_ie OFF: the settings field represents "off" by
+        # removing the parameter (set_param deletes on a False bool), so the
+        # default is strict and any duplicate CNPJ is blocked regardless of IE.
+        cls.env["ir.config_parameter"].sudo().set_param(
+            "l10n_br_base.allow_cnpj_multi_ie", False
+        )
+        # Real (valid) CNPJ of Google Brasil, used as an example.
+        cls.google_cnpj = "06.990.590/0001-23"
+        cls.google_cnpj_unformatted = "06.990.590/000123"
+        # Another valid and distinct CNPJ, for the negative case.
+        cls.other_cnpj = "02.960.895/0001-31"
+
+        cls.partner_model = cls.env["res.partner"].with_context(tracking_disable=True)
+        cls.base_vals = {
+            "is_company": True,
+            "country_id": cls.env.ref("base.br").id,
+            "state_id": cls.env.ref("base.state_br_es").id,
+            "city_id": cls.env.ref("l10n_br_base.city_3205002").id,
+        }
+
+    def _create_partner(self, name, vat):
+        return self.partner_model.create(dict(self.base_vals, name=name, vat=vat))
+
+    def test_dup_same_format(self):
+        """Case 1: same CNPJ, same formatting -> ValidationError."""
+        self._create_partner("Google 1", self.google_cnpj)
+        with self.assertRaises(ValidationError):
+            self._create_partner("Google 2", self.google_cnpj)
+
+    def test_dup_different_format(self):
+        """Case 2 (the bug): same CNPJ, different formatting -> ValidationError."""
+        self._create_partner("Google 1", self.google_cnpj)
+        with self.assertRaises(ValidationError):
+            self._create_partner("Google 2", self.google_cnpj_unformatted)
+
+    def test_distinct_cnpj_allowed(self):
+        """A distinct CNPJ must not be blocked (guard against false positives)."""
+        self._create_partner("Google 1", self.google_cnpj)
+        partner = self._create_partner("Other Co", self.other_cnpj)
+        self.assertTrue(partner.id, "A partner with a distinct CNPJ should be created.")
+
+    def _create_partner_with_ie(self, name, vat, ie):
+        # disable_ie_validation keeps the test focused on the duplicate/IE
+        # branch instead of state-wise IE checksums (covered by test_other_ie).
+        return self.partner_model.with_context(disable_ie_validation=True).create(
+            dict(self.base_vals, name=name, vat=vat, l10n_br_ie_code=ie)
+        )
+
+    def test_multi_ie_allows_different_ie(self):
+        """With allow_cnpj_multi_ie enabled, the same CNPJ under a *different*
+        State Tax Number is allowed (multi-establishment scenario)."""
+        self.env["ir.config_parameter"].sudo().set_param(
+            "l10n_br_base.allow_cnpj_multi_ie", True
+        )
+        self._create_partner_with_ie("Branch 1", self.google_cnpj, "111111111")
+        partner = self._create_partner_with_ie(
+            "Branch 2", self.google_cnpj, "222222222"
+        )
+        self.assertTrue(partner.id, "Same CNPJ with a distinct IE should be allowed.")
+
+    def test_multi_ie_blocks_same_ie(self):
+        """With allow_cnpj_multi_ie enabled, the same CNPJ under the *same*
+        State Tax Number is still blocked."""
+        self.env["ir.config_parameter"].sudo().set_param(
+            "l10n_br_base.allow_cnpj_multi_ie", True
+        )
+        self._create_partner_with_ie("Branch 1", self.google_cnpj, "111111111")
+        with self.assertRaises(ValidationError):
+            self._create_partner_with_ie("Branch 2", self.google_cnpj, "111111111")


### PR DESCRIPTION
## Problema (#4430)

A validação de CNPJ/CPF duplicado em `res.partner._check_cnpj_l10n_br_ie_code`
não impedia o cadastro de duplicados quando a mesma numeração era informada com
formatação diferente (ex.: `06.990.590/0001-23` vs `06.990.590/000123`).

A verificação está **inativa**: há um `return` no fim do bloco `if record.vat:`
que sai do método antes do `search`. Duplicatas com a **mesma** formatação ainda
são barradas pelo módulo `partner_vat_unique` (que compara o `vat` literal, via
`same_vat_partner_id` do core), mas as de **formatação diferente** escapam dos
dois: do `partner_vat_unique` (string diferente) e desta constraint (código morto).

## Correção

- Remove o `return` que tornava o `search`/`raise` código morto.
- Compara pelo campo normalizado `cnpj_cpf_stripped` (sem máscara, já `store`/`index`)
  em vez do `vat` formatado, detectando o duplicado independente da formatação e do
  caminho de entrada (form, ORM, import).
- Reaproveita o resultado do `search` (evita uma busca duplicada).
- Lê `allow_cnpj_multi_ie` com `bool(get_param(...))` (idiom do core, cf.
  `base_setup.show_effect`): o settings representa "off" apagando o parâmetro, então
  `bool()` o lê corretamente. Remove o `default=True` enganoso. Sem mudança de
  comportamento: o padrão continua estrito.

## Por que a checagem parou de pegar

A duplicidade por formatação diferente passou a vazar por causa da migração
`cnpj_cpf`→`vat` na `16.0` (Raphaël Valyi/Akretion), em dois passos:

1. **#3566 "[16.0][REF] l10n_br_base: use vat field for CNPJ and CPF"**
   (merge jul/2025, commit `bb088007b1`) — inverteu o campo mestre. Antes `cnpj_cpf`
   era o editável, normalizado no input pelo `@api.onchange("cnpj_cpf")`
   (`cnpj_cpf.formata(...)`), e `vat` era computado dele; a constraint comparava esse
   valor já normalizado. Depois, `vat` virou o campo do base e `cnpj_cpf` um alias, e a
   comparação passou a ser pelo **`vat` cru**. Como o `formata()` só roda no caminho do
   alias `cnpj_cpf`, uma escrita direta em `vat` (ORM/import/campo Tax ID) não normaliza
   — a mesma numeração pode ficar gravada com máscaras diferentes e escapar de uma
   comparação por `vat`.
2. **#3893 "[16.0] l10n_br_base: cnpj_cpf -> vat - complete replace"**
   (merge jul/2025, commit `0f43819c07`) — ao colapsar `if record.vat: … else: return`,
   moveu o `return` para **dentro** do `if`, tornando o `search`/`raise` código morto.

A duplicata de **mesma** formatação continuou barrada esse tempo todo pelo
`partner_vat_unique` (compara o `vat` literal via `same_vat_partner_id` do core) — por
isso o defeito só aparece com **formatação diferente**, onde nem ele nem esta constraint
pegavam.

Por isso o fix não só remove o `return` morto, como compara pelo `cnpj_cpf_stripped`
(normalizado): fecha justamente o caso de formatação diferente.

## Testes

Novo `tests/test_duplicate_cnpj.py`:
- mesmo CNPJ, mesma formatação → `ValidationError`
- mesmo CNPJ, formatação diferente → `ValidationError` (o bug)
- CNPJ distinto → permitido
- mesmo CNPJ, IE diferente, com `allow_cnpj_multi_ie` ligado → permitido
- mesmo CNPJ, mesma IE, com `allow_cnpj_multi_ie` ligado → `ValidationError`

Suíte completa do módulo em banco limpo: `0 failed, 0 error(s) of 47 tests`.

## Nota sobre 17.0/18.0/19.0

O mesmo defeito existe nas demais branches. `cnpj_cpf_stripped` é o valor
normalizado canônico hoje; quando o `vat` passar a ser armazenado sem formatação
(v19, cf. discussão do #4622) e o `cnpj_cpf_stripped` for aposentado, basta
comparar por `vat` diretamente (já anotado em comentário no código).

Fixes #4430
