### PR TITLE
[16.0][IMP] l10n_br_base, l10n_br_cnab_structure: suporte a CNPJ Alfanumérico

### DIFF
--- a/l10n_br_base/models/party_mixin.py
+++ b/l10n_br_base/models/party_mixin.py
@@ -95,7 +95,10 @@ class PartyMixin(models.AbstractModel):
 
     def _inverse_cnpj_cpf(self):
         for partner in self:
-            partner.vat = cnpj_cpf.formata(str(self.cnpj_cpf))
+            if partner.cnpj_cpf:
+                partner.vat = cnpj_cpf.formata(str(partner.cnpj_cpf))
+            else:
+                partner.vat = False
 
     @api.model
     def search(self, domain, offset=0, limit=None, order=None, count=False):

--- a/l10n_br_base/models/res_partner_pix.py
+++ b/l10n_br_base/models/res_partner_pix.py
@@ -92,12 +92,12 @@ class PartnerPix(models.Model):
         return phone
 
     def _normalize_cnpj_cpf(self, doc_number):
-        doc_number = "".join(char for char in doc_number if char.isdigit())
+        doc_number = "".join(char for char in doc_number if char.isalnum())
         if not 11 <= len(doc_number) <= 14:
             raise ValidationError(
                 _(
                     f"Invalid Document Number {doc_number}: "
-                    f"\nThe CPF must have 11 digits and the CNPJ 14 digits."
+                    f"\nThe CPF must have 11 characters and the CNPJ 14 characters."
                 )
             )
         is_valid = cnpj_cpf.validar(doc_number)

--- a/l10n_br_base/tests/__init__.py
+++ b/l10n_br_base/tests/__init__.py
@@ -5,3 +5,4 @@ from . import test_other_ie
 from . import test_valid_pix
 from . import test_partner_bank
 from . import test_duplicate_cnpj
+from . import test_cnpj_alfanumerico

--- a/l10n_br_base/tests/test_cnpj_alfanumerico.py
+++ b/l10n_br_base/tests/test_cnpj_alfanumerico.py
@@ -1,0 +1,141 @@
+# Copyright (C) 2024-Today - Escodoo (<https://www.escodoo.com.br>)
+# @author Cristiano Mafra Junior
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.exceptions import ValidationError
+from odoo.tests import TransactionCase
+
+
+class CNPJAlfanumericoTest(TransactionCase):
+    """Tests for alphanumeric CNPJ support (CNPJ Alfanumérico - Receita Federal)."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.br_country = cls.env.ref("base.br")
+        cls.state_es = cls.env.ref("base.state_br_es")
+        cls.city_serra = cls.env.ref("l10n_br_base.city_3205002")
+
+        cls.base_address = {
+            "street": "Av. Paulista",
+            "street_number": "1000",
+            "district": "Bela Vista",
+            "state_id": cls.state_es.id,
+            "city_id": cls.city_serra.id,
+            "country_id": cls.br_country.id,
+            "city": "Serra",
+            "zip": "29161-695",
+        }
+
+        cls.partner_pix = cls.env.ref("l10n_br_base.res_partner_amd")
+
+    def test_company_valid_alphanumeric_cnpj(self):
+        """Creating a company with a valid alphanumeric CNPJ must succeed."""
+        vals = {
+            "name": "Empresa CNPJ Alfa Teste",
+            "legal_name": "Empresa CNPJ Alfanumérico Ltda",
+            "cnpj_cpf": "A8.7HB.ZHB/0001-61",
+            **self.base_address,
+        }
+        company = (
+            self.env["res.company"].with_context(tracking_disable=True).create(vals)
+        )
+        self.assertTrue(company.id, "Company with alphanumeric CNPJ was not created")
+        self.assertEqual(
+            company.cnpj_cpf,
+            "A8.7HB.ZHB/0001-61",
+            "Formatted alphanumeric CNPJ should be preserved",
+        )
+        self.assertEqual(
+            company.cnpj_cpf_stripped,
+            "A87HBZHB000161",
+            "Stripped alphanumeric CNPJ should contain only alphanumeric characters",
+        )
+
+    def test_company_invalid_alphanumeric_cnpj(self):
+        """Creating a company with an invalid alphanumeric CNPJ must raise
+        ValidationError."""
+        vals = {
+            "name": "Empresa CNPJ Alfa Invalido",
+            "legal_name": "Empresa CNPJ Alfanumérico Inválido Ltda",
+            "cnpj_cpf": "A8.7HB.ZHB/0001-99",
+            **self.base_address,
+        }
+        with self.assertRaises(ValidationError):
+            self.env["res.company"].with_context(tracking_disable=True).create(vals)
+
+    def test_partner_valid_alphanumeric_cnpj(self):
+        """Creating a partner (company type) with a valid alphanumeric CNPJ
+        must succeed."""
+        vals = {
+            "name": "Parceiro CNPJ Alfa Teste",
+            "legal_name": "Parceiro CNPJ Alfanumérico Ltda",
+            "is_company": True,
+            "cnpj_cpf": "A8.7HB.ZHB/0001-61",
+            **self.base_address,
+        }
+        partner = (
+            self.env["res.partner"].with_context(tracking_disable=True).create(vals)
+        )
+        self.assertTrue(partner.id, "Partner with alphanumeric CNPJ was not created")
+        self.assertTrue(
+            partner.is_br_partner,
+            "Partner with alphanumeric CNPJ should be recognized as Brazilian",
+        )
+
+    def test_partner_alphanumeric_cnpj_stripped(self):
+        """cnpj_cpf_stripped must contain only alphanumeric characters (no mask)."""
+        vals = {
+            "name": "Parceiro Stripped Alfa",
+            "is_company": True,
+            "cnpj_cpf": "A8.7HB.ZHB/0001-61",
+            **self.base_address,
+        }
+        partner = (
+            self.env["res.partner"].with_context(tracking_disable=True).create(vals)
+        )
+        self.assertEqual(partner.cnpj_cpf_stripped, "A87HBZHB000161")
+
+    def test_pix_valid_alphanumeric_cnpj(self):
+        """Creating a PIX key with a valid alphanumeric CNPJ must succeed."""
+        pix_vals = {
+            "partner_id": self.partner_pix.id,
+            "key_type": "cnpj_cpf",
+            "key": "LC.X4R.RVT/0001-23",
+        }
+        pix = (
+            self.env["res.partner.pix"]
+            .with_context(tracking_disable=True)
+            .create(pix_vals)
+        )
+        self.assertTrue(pix.id, "PIX key with alphanumeric CNPJ was not created")
+
+    def test_pix_invalid_alphanumeric_cnpj(self):
+        """Creating a PIX key with an invalid alphanumeric CNPJ must raise
+        ValidationError."""
+        pix_vals = {
+            "partner_id": self.partner_pix.id,
+            "key_type": "cnpj_cpf",
+            "key": "LC.X4R.RVT/0001-99",
+        }
+        with self.assertRaises(ValidationError):
+            self.env["res.partner.pix"].with_context(tracking_disable=True).create(
+                pix_vals
+            )
+
+    def test_pix_alphanumeric_cnpj_without_mask(self):
+        """PIX key with unmasked valid alphanumeric CNPJ must succeed."""
+        pix_vals = {
+            "partner_id": self.partner_pix.id,
+            "key_type": "cnpj_cpf",
+            "key": "LCX4RRVT000123",
+        }
+        pix = (
+            self.env["res.partner.pix"]
+            .with_context(tracking_disable=True)
+            .create(pix_vals)
+        )
+        self.assertTrue(
+            pix.id, "PIX key with unmasked alphanumeric CNPJ was not created"
+        )

--- a/l10n_br_base/tools.py
+++ b/l10n_br_base/tools.py
@@ -71,7 +71,7 @@ def check_cnpj_cpf(env, cnpj_cpf_value, country):
                     # 76586507812 - CPF
                     document = "CPF"
                     if (
-                        len("".join(char for char in cnpj_cpf_value if char.isdigit()))
+                        len("".join(char for char in cnpj_cpf_value if char.isalnum()))
                         == 14
                     ):
                         document = "CNPJ"

--- a/l10n_br_cnab_structure/wizard/cnab_import_wizard.py
+++ b/l10n_br_cnab_structure/wizard/cnab_import_wizard.py
@@ -412,7 +412,7 @@ class CNABImportWizard(models.TransientModel):
             )
 
     def _check_company(self, return_dict):
-        cnpj_cpf = "".join(char for char in self.company_id.cnpj_cpf if char.isdigit())
+        cnpj_cpf = self.company_id.cnpj_cpf_stripped or ""
         if cnpj_cpf.zfill(14) != str(return_dict["cnpj_cpf"]).zfill(14):
             raise UserError(
                 _("CNPJ/CPF of your active company is different of the file.")


### PR DESCRIPTION
### Contexto

A Receita Federal do Brasil passa a emitir CNPJs alfanuméricos, onde os
primeiros 8 caracteres da raiz podem conter letras além de dígitos
(ex: `A8.7HB.ZHB/0001-61`). O formato com máscara permanece o mesmo
(`XX.XXX.XXX/XXXX-DD`), com 14 caracteres sem máscara, porém agora podendo
conter letras.

Esta PR adapta os módulos do l10n-brazil para aceitar o novo formato,
acompanhando a atualização da biblioteca `erpbrasil.base`
---

### Mudanças

#### `l10n_br_base/tools.py`

- **`check_cnpj_cpf()`**: substituído `char.isdigit()` por `char.isalnum()`
  na lógica que distingue CNPJ de CPF na mensagem de erro de validação.
  Um CNPJ alfanumérico tem 14 caracteres alfanuméricos, não apenas dígitos.

#### `l10n_br_base/models/party_mixin.py`

- **`_inverse_cnpj_cpf()`**: adicionado guard para o caso em que `cnpj_cpf`
  é `False`/vazio. A nova versão da `erpbrasil.base` passou a retornar a
  string de entrada sem alteração quando ela não é reconhecida como CNPJ/CPF
  (antes retornava `None`), o que causava `partner.vat = "False"` e
  disparava a constraint de validação.

#### `l10n_br_base/models/res_partner_pix.py`

- **`_normalize_cnpj_cpf()`**: substituído `char.isdigit()` por
  `char.isalnum()` para preservar letras ao remover a máscara de um CNPJ
  alfanumérico. Mensagem de erro atualizada de _"digits"_ para _"characters"_.

#### `l10n_br_cnab_structure/wizard/cnab_import_wizard.py`

- **`_check_company()`**: substituída a extração manual de dígitos
  (`char.isdigit()`) pelo campo computado `cnpj_cpf_stripped`, que já usa
  `isalnum()` e está disponível via `party.mixin`.

#### `l10n_br_base/tests/test_cnpj_alfanumerico.py` *(novo)*

7 testes cobrindo:

| Teste | Cenário |
|---|---|
| `test_company_valid_alphanumeric_cnpj` | Empresa criada com CNPJ alfa válido + verifica `cnpj_cpf_stripped` |
| `test_company_invalid_alphanumeric_cnpj` | CNPJ alfa com dígito verificador errado levanta `ValidationError` |
| `test_partner_valid_alphanumeric_cnpj` | Parceiro empresa reconhecido como `is_br_partner` |
| `test_partner_alphanumeric_cnpj_stripped` | `cnpj_cpf_stripped` sem máscara preserva letras |
| `test_pix_valid_alphanumeric_cnpj` | Chave Pix com CNPJ alfa com máscara aceita |
| `test_pix_invalid_alphanumeric_cnpj` | Chave Pix com CNPJ alfa inválido levanta `ValidationError` |
| `test_pix_alphanumeric_cnpj_without_mask` | Chave Pix com CNPJ alfa sem máscara aceita |

#### `test-requirements.txt`

- Atualizada referência da `erpbrasil.base` para a branch com suporte a
  CNPJ alfanumérico.

---

### O que não mudou

Os módulos `l10n_br_fiscal`, `l10n_br_nfe`, `l10n_br_cte`, `l10n_br_mdfe`,
`l10n_br_crm` e `l10n_br_hr` **não precisaram de alterações** — toda a
validação nesses módulos é delegada às funções `cnpj_cpf.validar()` /
`cnpj_cpf.validar_cnpj()` da `erpbrasil.base`, já atualizadas na biblioteca.
O campo `cnpj_cpf_stripped` em `party_mixin.py` já usava `isalnum()` desde
sua implementação original.
