### PR TITLE
[18.0][REF] l10n_br_base, l10n_br_fiscal: Adaptando as Visões do res.partner e res.company para os casos que o country_id não é Brasil

### DIFF
--- a/l10n_br_base/models/party_mixin.py
+++ b/l10n_br_base/models/party_mixin.py
@@ -69,6 +69,11 @@ class PartyMixin(models.AbstractModel):
         size=32,
     )
 
+    show_l10n_br = fields.Boolean(
+        compute="_compute_show_l10n_br",
+        help="Should display Brazilian localization fields?",
+    )
+
     def _default_country_id(self):
         """Default country set to Brazil if the current company is Brazilian.
         Can be overridden in other modules if needed.
@@ -140,3 +145,14 @@ class PartyMixin(models.AbstractModel):
         """Format the VAT field (CNPJ/CPF) with proper punctuation."""
         if self.vat and self.country_id and self.country_id.code == "BR":
             self.vat = cnpj_cpf.formata(str(self.vat))
+
+    @api.depends("country_id")
+    def _compute_show_l10n_br(self):
+        """
+        Defines when Brazilian localization fields should be displayed.
+        """
+        for record in self:
+            show_l10n_br = False
+            if record.country_id == record.env.ref("base.br"):
+                show_l10n_br = True
+            record.show_l10n_br = show_l10n_br

--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -45,11 +45,6 @@ class Partner(models.Model):
         help="Keys for Brazilian instant payment (pix)",
     )
 
-    show_l10n_br = fields.Boolean(
-        compute="_compute_show_l10n_br",
-        help="Should display Brazilian localization fields?",
-    )
-
     is_br_partner = fields.Boolean(
         compute="_compute_br_partner",
         help="Is it a Brazilian partner?",
@@ -242,16 +237,6 @@ class Partner(models.Model):
     @api.onchange("city_id")
     def _onchange_city_id(self):
         self.city = self.city_id.name
-
-    def _compute_show_l10n_br(self):
-        """
-        Defines when Brazilian localization fields should be displayed.
-        """
-        for rec in self:
-            if rec.company_id and rec.company_id.country_id != self.env.ref("base.br"):
-                rec.show_l10n_br = False
-            else:
-                rec.show_l10n_br = True
 
     def create_company(self):
         self.ensure_one()

--- a/l10n_br_base/views/res_company_view.xml
+++ b/l10n_br_base/views/res_company_view.xml
@@ -13,27 +13,24 @@
                 <field
                     name="legal_name"
                     placeholder="Legal Name..."
-                    invisible="country_id != %(base.br)d"
+                    invisible="not show_l10n_br"
                 />
                 <field
                     name="l10n_br_ie_code"
                     placeholder="State Tax Number..."
-                    invisible="country_id != %(base.br)d"
+                    invisible="not show_l10n_br"
                 />
                 <field
                     name="l10n_br_im_code"
                     placeholder="Municipal Tax Number..."
-                    invisible="country_id != %(base.br)d"
+                    invisible="not show_l10n_br"
                 />
                 <field
                     name="l10n_br_isuf_code"
                     placeholder="Suframa"
                     invisible="state_id != %(base.state_br_am)d"
                 />
-                <field
-                    name="state_tax_number_ids"
-                    invisible="country_id != %(base.br)d"
-                >
+                <field name="state_tax_number_ids" invisible="not show_l10n_br">
                     <list editable="bottom">
                         <!-- field name="company_id" column_invisible="1" /-->
                         <field name="l10n_br_ie_code" />

--- a/l10n_br_base/views/res_partner_view.xml
+++ b/l10n_br_base/views/res_partner_view.xml
@@ -40,7 +40,8 @@
             <xpath expr="//h1" position="after">
                 <field name="city_id" invisible="1" />
                 <!-- Allow inject city_id on context above -->
-                <div>
+                <div invisible="not show_l10n_br">
+                    <field name="show_l10n_br" invisible="1" />
                     <label for="legal_name" string="Full Name" invisible="is_company" />
                     <label
                         for="legal_name"
@@ -48,8 +49,8 @@
                         invisible="not is_company"
                     />
                 </div>
-                <field name="legal_name" nolabel="1" />
-                <div>
+                <field name="legal_name" nolabel="1" invisible="not show_l10n_br" />
+                <div invisible="not show_l10n_br">
                     <label for="vat" string="CPF" invisible="is_company" />
                     <label
                         for="vat"
@@ -58,11 +59,15 @@
                     />
                 </div>
                 <field name="vat" nolabel="1" />
-                <div>
+                <div invisible="not show_l10n_br">
                     <label for="l10n_br_rg_code" string="RG" invisible="is_company" />
                 </div>
-                <field name="l10n_br_rg_code" nolabel="1" invisible="is_company" />
-                <div name="l10n_br_ie_code">
+                <field
+                    name="l10n_br_rg_code"
+                    nolabel="1"
+                    invisible="is_company and not show_l10n_br"
+                />
+                <div name="l10n_br_ie_code" invisible="not show_l10n_br">
                     <label
                         for="l10n_br_ie_code"
                         string="IE"
@@ -73,11 +78,11 @@
                     colspan="4"
                     name="l10n_br_ie_code"
                     nolabel="1"
-                    invisible="not is_company and parent_id"
+                    invisible="not is_company and parent_id and not show_l10n_br"
                 />
             </xpath>
             <page position="after" name="sales_purchases">
-                <page string="Fiscal" name="fiscal">
+                <page string="Fiscal" name="fiscal" invisible="not show_l10n_br">
                     <group name="fiscal">
                         <group string="Fiscal Infos" name="fiscal_numbers">
                             <field name="l10n_br_im_code" invisible="not is_company" />

--- a/l10n_br_fiscal/views/res_company_view.xml
+++ b/l10n_br_fiscal/views/res_company_view.xml
@@ -10,6 +10,7 @@
                     name="fiscal"
                     string="Fiscal"
                     groups="l10n_br_fiscal.group_manager"
+                    invisible="not show_l10n_br"
                 >
                     <notebook>
                         <page name="tax_framework" string="Tax Framework">


### PR DESCRIPTION
Adaptando as Visões do res.partner e res.company para os casos que o country_id não é Brasil, alguns pontos:

* Campos do tipo compute precisam do api.depends para serem chamados, isso estava faltando no campo show_l10n_br.
* Movi o campo show_l10n_br do objeto res.partner para o l10n_br_base.party.mixin para poder ser usado tanto no res.partner quanto no res.company.
* Alterei a lógica do compute show_l10n_br que estava usando a Empresa/company_id como referencia para definir quando os campos do Brasil devem ou não serem mostrados, porque mesmo uma Empresa do Brasil pode ter tanto Clientes como Fornecedores que não estão no Brasil.
* A visão do res.company já estava parcialmente adaptada apenas a aba Fiscal permanecia, incluída pelo módulo l10n_br_fiscal, mas alterei a lógica no l10n_br_base/views/res_company_view.xml para usar o campo show_l10n_br. 
* Apesar de ter mais de um módulo nesse PR a alteração no l10n_br_fiscal é bem simples, mas se for necessário posso remover o commit e fazer a alteração em outro PR.

Segue imagens da tela Sem e Com esse PR para comparação:

* **Sem esse PR**

<img width="1051" height="644" alt="image" src="https://github.com/user-attachments/assets/2bb468b3-d5a0-4eeb-9cf4-ef7d75cd6a90" />

<img width="1014" height="600" alt="image" src="https://github.com/user-attachments/assets/986ba580-93a2-489f-882d-34500dd70309" />

<img width="982" height="639" alt="image" src="https://github.com/user-attachments/assets/4c244429-ce5f-4f32-ad5d-e599717e2420" />

<img width="989" height="575" alt="image" src="https://github.com/user-attachments/assets/db9df8a7-704b-44d3-b21d-e1dde94f8eb8" />


* **Com esse PR**

<img width="1040" height="592" alt="image" src="https://github.com/user-attachments/assets/647a049f-36ae-44a4-ac78-3fcc47145800" />

<img width="978" height="632" alt="image" src="https://github.com/user-attachments/assets/38800363-2767-4be8-a83e-e1502b38f5e3" />

Caso Brasil

<img width="1156" height="716" alt="image" src="https://github.com/user-attachments/assets/aa526104-8639-4a33-a102-3f2c5734e8fc" />

<img width="1072" height="537" alt="image" src="https://github.com/user-attachments/assets/743e31a7-257c-4b57-b8cf-5ac5f8c24ae5" />

<img width="1001" height="720" alt="image" src="https://github.com/user-attachments/assets/ab94045a-9969-48b0-9ac4-d79977b92a80" />

<img width="1079" height="713" alt="image" src="https://github.com/user-attachments/assets/92250b7c-f38b-4428-ba45-173e31653a8f" />

cc @OCA/local-brazil-maintainers 