### PR TITLE
[16.0][FIX] l10n_br_sale_blanket_order: recalcular valores fiscais ao gerar Pedido de Venda com quantidade parcial

### DIFF
--- a/l10n_br_sale_blanket_order/tests/test_l10n_br_sale_blanket_order.py
+++ b/l10n_br_sale_blanket_order/tests/test_l10n_br_sale_blanket_order.py
@@ -214,6 +214,62 @@ class L10nBrSaleBLanketOrderTest(TransactionCase):
             "Error: Not all invoices are in posted state after validation.",
         )
 
+    def test_partial_quantity_recomputes_fiscal_amounts(self):
+        """A sale order created from a blanket order line for a partial
+        quantity must have its fiscal amounts recomputed for that quantity,
+        not copied over from the blanket order line's original quantity.
+        """
+        blanket_order = self._create_blanket_order()
+        blanket_order._onchange_fiscal_operation_id()
+        blanket_order._amount_all()
+        blanket_order.sudo().action_confirm()
+
+        bo_line = blanket_order.line_ids[0]
+        self.assertEqual(bo_line.quantity, 20.0)
+        bo_line.write(
+            {
+                "fiscal_operation_id": self.env.ref("l10n_br_fiscal.fo_venda").id,
+                "fiscal_operation_line_id": self.env.ref(
+                    "l10n_br_fiscal.fo_venda_revenda"
+                ).id,
+            }
+        )
+
+        full_price_subtotal = bo_line.price_subtotal
+        self.assertTrue(full_price_subtotal)
+        partial_qty = 5.0
+        wizard = (
+            self.env["sale.blanket.order.wizard"]
+            .with_context(active_id=blanket_order.id, active_model="sale.blanket.order")
+            .create(
+                {
+                    "blanket_order_id": blanket_order.id,
+                    "line_ids": [
+                        Command.create(
+                            {
+                                "blanket_line_id": bo_line.id,
+                                "product_id": bo_line.product_id.id,
+                                "date_schedule": bo_line.date_schedule,
+                                "remaining_uom_qty": bo_line.remaining_uom_qty,
+                                "price_unit": bo_line.price_unit,
+                                "product_uom": bo_line.product_uom,
+                                "qty": partial_qty,
+                                "partner_id": bo_line.partner_id.id,
+                            }
+                        )
+                    ],
+                }
+            )
+        )
+
+        result = wizard.create_sale_order()
+        sale_order = self.env["sale.order"].browse(result["domain"][0][2][0])
+        so_line = sale_order.order_line[0]
+        self.assertEqual(so_line.product_uom_qty, partial_qty)
+        expected_subtotal = full_price_subtotal * partial_qty / bo_line.quantity
+        self.assertAlmostEqual(so_line.price_subtotal, expected_subtotal, 2)
+        self.assertNotAlmostEqual(so_line.price_subtotal, full_price_subtotal, 2)
+
     def test_cnae_domain(self):
         domain = self.env["sale.blanket.order.line"]._cnae_domain()
         expected_domain = [

--- a/l10n_br_sale_blanket_order/wizards/sale_blanket_order_wizard.py
+++ b/l10n_br_sale_blanket_order/wizards/sale_blanket_order_wizard.py
@@ -11,9 +11,13 @@ class SaleBlanketOrderWizard(models.TransientModel):
     def _prepare_so_line_vals(self, line):
         fiscal_vals = line.blanket_line_id._prepare_br_fiscal_dict()
 
-        # change quantity
-        fiscal_vals["quantity"] = line.qty
-        fiscal_vals["fiscal_quantity"] = line.qty
+        if line.qty != fiscal_vals["quantity"]:
+            virtual = self.env["l10n_br_fiscal.document.line"].new(fiscal_vals)
+            virtual.quantity = line.qty
+            fiscal_vals = {
+                fname: virtual._fields[fname].convert_to_write(virtual[fname], virtual)
+                for fname in fiscal_vals
+            }
 
         # set company
         fiscal_vals["company_id"] = self.blanket_order_id.company_id.id


### PR DESCRIPTION
## Issue #4643

### Problema
Ao gerar um Pedido de Venda (SO) a partir de um Pedido Guarda-Chuva (Blanket Order) pedindo apenas parte da quantidade restante, o total do SO criado aparecia igual ao total do Guarda-Chuva (calculado para a quantidade original/total), e não ao total correspondente à quantidade efetivamente pedida.

Exemplo: BO com 500 unidades e total de R$ 125.000,00. Ao criar um SO pedindo apenas 15 unidades, o SO era criado com "Quantidade" = 15, mas o subtotal/total continuava a mostrar R$ 125.000,00 (o valor das 500 unidades). Só era corrigido se o utilizador editasse manualmente a quantidade no formulário, forçando um recompute.

### Causa
Em sale_blanket_order_wizard.py, o método _prepare_so_line_vals monta os valores da nova linha do SO chamando blanket_line_id._prepare_br_fiscal_dict(), que lê todos os campos fiscais do l10n_br_fiscal.document.line.mixin já calculados na linha do BO (ICMS, IPI, PIS, COFINS, bases, valores de imposto, etc.) — todos computados para a quantidade original do BO.

O código depois só substituía os campos quantity/fiscal_quantity pela quantidade pedida, mas passava esse dicionário inteiro (com os valores fiscais "congelados" na quantidade original) diretamente para o create() da nova linha. Como o Odoo recebe valores explícitos para campos computados armazenados (store=True), ele confia neles e não os recalcula, mesmo a quantidade tendo mudado — daí o total errado.

### Correção
Segui a mesma técnica usada pela própria OCA para corrigir um problema análogo em faturamento parcial ([OCA/l10n-brazil#4569](https://github.com/OCA/l10n-brazil/pull/4569)):

Constrói-se um registo v`irtual (.new())` do modelo genérico `l10n_br_fiscal.document.line`, com os valores fiscais originais da linha do BO.
Só depois de criado o registo virtual, atribui-se `virtual.quantity = <quantidade pedida>.`
Como essa atribuição ocorre depois de o registo já existir, o Odoo trata-a como uma mudança de campo — o mesmo mecanismo do onchange — e recalcula automaticamente, em cascata, todos os campos fiscais dependentes (bases e valores de ICMS/IPI/PIS/COFINS, totais, fiscal_quantity considerando o uot_factor do produto, etc.) para a nova quantidade.
Os valores recalculados são extraídos de volta `(convert_to_write)` e usados na criação da linha do SO.
Passar todos os campos juntos no `create()/.new() `não dispara recompute; mudar um campo depois de o registo já existir, sim — é essa diferença que a correção explora.

Arquivo alterado: `wizards/sale_blanket_order_wizard.py.`

Teste
Adicionado test_partial_quantity_recomputes_fiscal_amounts em `tests/test_l10n_br_sale_blanket_order.py`: cria um BO com 20 unidades, define uma operação fiscal real na linha, gera um SO pedindo apenas 5 unidades, e verifica que o subtotal do SO escala proporcionalmente à quantidade pedida (e não permanece igual ao subtotal total do BO).

## Teste Funcional

<img width="1919" height="926" alt="Captura de tela de 2026-07-04 10-42-24" src="https://github.com/user-attachments/assets/da6a10b6-ebd7-413f-9a60-e01397af50fe" />
<img width="1919" height="415" alt="Captura de tela de 2026-07-04 10-42-36" src="https://github.com/user-attachments/assets/a8a336cd-ea57-4959-b8af-fb88809ffbf3" />
<img width="1919" height="415" alt="Captura de tela de 2026-07-04 10-42-41" src="https://github.com/user-attachments/assets/886a0e91-8b26-48dd-a67f-3863c0954d7c" />
<img width="1919" height="923" alt="Captura de tela de 2026-07-04 10-42-47" src="https://github.com/user-attachments/assets/03cd89af-3d80-444c-a811-2db865552f1a" />
