### PR TITLE
[16.0][FIX] l10n_br_purchase_blanket_order: recalcular valores fiscais ao gerar Pedido de Compra com quantidade parcial

### DIFF
--- a/l10n_br_purchase_blanket_order/tests/test_l10n_br_purchase_blanket_order.py
+++ b/l10n_br_purchase_blanket_order/tests/test_l10n_br_purchase_blanket_order.py
@@ -146,6 +146,41 @@ class L10nBrPurchaseBlanketOrderTest(TransactionCase):
             purchase_order.order_line[0].fiscal_operation_id,
         )
 
+    def test_partial_quantity_recomputes_fiscal_amounts(self):
+        """A purchase order created from a blanket order line for a partial
+        quantity must have its fiscal amounts recomputed for that quantity,
+        not copied over from the blanket order line's original quantity.
+        """
+        blanket_order = self._create_blanket_order()
+        blanket_order._onchange_fiscal_operation_id()
+        blanket_order._amount_all()
+        blanket_order.sudo().action_confirm()
+
+        bo_line = blanket_order.line_ids[0]
+        self.assertEqual(bo_line.quantity, 20.0)
+        bo_line.write(
+            {
+                "fiscal_operation_id": self.env.ref("l10n_br_fiscal.fo_compras").id,
+                "fiscal_operation_line_id": self.env.ref(
+                    "l10n_br_fiscal.fo_compras_compras"
+                ).id,
+            }
+        )
+
+        full_price_subtotal = bo_line.price_subtotal
+        self.assertTrue(full_price_subtotal)
+        partial_qty = 5.0
+        wizard = self._create_wizard(blanket_order)
+        wizard.line_ids.qty = partial_qty
+
+        result = wizard.create_purchase_order()
+        purchase_order = self.env["purchase.order"].browse(result["domain"][0][2][0])
+        po_line = purchase_order.order_line[0]
+        self.assertEqual(po_line.product_qty, partial_qty)
+        expected_subtotal = full_price_subtotal * partial_qty / bo_line.quantity
+        self.assertAlmostEqual(po_line.price_subtotal, expected_subtotal, 2)
+        self.assertNotAlmostEqual(po_line.price_subtotal, full_price_subtotal, 2)
+
     def test_prepare_po_line_uses_order_start_without_schedule(self):
         blanket_order = self._create_blanket_order({"date_schedule": False})
         wizard = self._create_wizard(blanket_order)

--- a/l10n_br_purchase_blanket_order/wizards/create_purchase_orders.py
+++ b/l10n_br_purchase_blanket_order/wizards/create_purchase_orders.py
@@ -13,8 +13,18 @@ class PurchaseBlanketOrderWizard(models.TransientModel):
     def _prepare_po_line_vals(self, line):
         fiscal_vals = line.blanket_line_id._prepare_br_fiscal_dict()
 
-        fiscal_vals["quantity"] = line.qty
-        fiscal_vals["fiscal_quantity"] = line.qty
+        if line.qty != fiscal_vals["quantity"]:
+            # The tax/amount fields above were computed for the blanket
+            # order line's original quantity. Changing the quantity on a
+            # virtual record lets the ORM detect the change and recompute
+            # them naturally, the same mechanism used by onchange.
+            virtual = self.env["l10n_br_fiscal.document.line"].new(fiscal_vals)
+            virtual.quantity = line.qty
+            fiscal_vals = {
+                fname: virtual._fields[fname].convert_to_write(virtual[fname], virtual)
+                for fname in fiscal_vals
+            }
+
         fiscal_vals["company_id"] = self.blanket_order_id.company_id.id
 
         fiscal_vals = self._simulate_onchange_price_subtotal(fiscal_vals)


### PR DESCRIPTION
## Problema

Ao gerar um Pedido de Compra (PO) a partir de um Pedido Guarda-Chuva de Compras
(Purchase Blanket Order) pedindo **apenas parte** da quantidade restante, o
total do PO criado aparecia igual ao total do Guarda-Chuva (calculado para a
quantidade original/total), e não ao total correspondente à quantidade
efetivamente pedida.

Exemplo: BO com 20 unidades e preço unitário de R$ 25,00 (subtotal total de
R$ 500,00). Ao criar um PO pedindo apenas 5 unidades, o PO era criado com a
quantidade correta (5), mas o subtotal/total continuava a refletir o valor das
20 unidades, e não das 5 pedidas.

## Causa

Em `wizards/create_purchase_orders.py`, o método `_prepare_po_line_vals`
monta os valores da nova linha do PO chamando
`blanket_line_id._prepare_br_fiscal_dict()`, que lê **todos** os campos
fiscais do `l10n_br_fiscal.document.line.mixin` já calculados na linha do
Guarda-Chuva (bases e valores de ICMS, IPI, PIS, COFINS, etc.) — todos
computados para a quantidade original da linha do BO.

O código então apenas substituía os campos `quantity`/`fiscal_quantity` pela
quantidade pedida, mas passava esse dicionário inteiro (com os valores
fiscais "congelados" na quantidade original) diretamente para o `create()`
da nova linha do PO. Como o Odoo recebe valores explícitos para campos
computados armazenados (`store=True`), ele confia neles e **não os
recalcula**, mesmo a quantidade tendo mudado — daí o total errado.

Esse é o mesmo problema já identificado e corrigido no módulo irmão
`l10n_br_sale_blanket_order`, e segue o mesmo padrão de bug corrigido pela
OCA em [OCA/l10n-brazil#4569](https://github.com/OCA/l10n-brazil/pull/4569)
para faturamento parcial (uma tentativa anterior, mencionada na descrição
daquela PR, apenas removia o campo `fiscal_quantity` copiado, o que não era
suficiente — os demais campos fiscais computados continuavam presos ao
valor original).

## Correção

Aplicada a mesma técnica usada pela OCA:

1. Constrói-se um registo **virtual** (`.new()`) do modelo genérico
   `l10n_br_fiscal.document.line`, com os valores fiscais originais da linha
   do BO.
2. Só **depois** de criado o registo virtual, atribui-se
   `virtual.quantity = <quantidade pedida>`.
3. Como essa atribuição ocorre depois de o registo já existir, o Odoo
   trata-a como uma mudança de campo — o mesmo mecanismo do `onchange` — e
   recalcula automaticamente, em cascata, todos os campos fiscais
   dependentes (bases e valores de ICMS/IPI/PIS/COFINS, totais,
   `fiscal_quantity` considerando o `uot_factor` do produto, etc.) para a
   nova quantidade.
4. Os valores recalculados são extraídos de volta (`convert_to_write`) e
   usados na criação da linha do PO.

O recompute só é disparado quando a quantidade pedida difere da quantidade
original da linha do BO (`line.qty != fiscal_vals["quantity"]`), evitando
trabalho desnecessário quando o pedido cobre a quantidade total.

Passar todos os campos juntos no `create()`/`.new()` não dispara recompute;
mudar um campo *depois* de o registo já existir, sim — é essa diferença que
a correção explora.

**Arquivo alterado:** `wizards/create_purchase_orders.py`.

## Teste

Adicionado `test_partial_quantity_recomputes_fiscal_amounts` em
`tests/test_l10n_br_purchase_blanket_order.py`: cria um Guarda-Chuva de
Compras com 20 unidades, define uma operação fiscal real na linha, gera um
PO pedindo apenas 5 unidades, e verifica que o subtotal do PO escala
proporcionalmente à quantidade pedida (e não permanece igual ao subtotal
total do BO).