### PR TITLE
[18.0][FIX] l10n_br_base_l10n_br_compat: Correção view CRM

### DIFF
--- a/l10n_br_base_l10n_br_compat/__manifest__.py
+++ b/l10n_br_base_l10n_br_compat/__manifest__.py
@@ -14,6 +14,7 @@
     "data": [
         "views/res_partner_views.xml",
         "views/res_company_view.xml",
+        "views/res_country_views.xml",
     ],
     "post_init_hook": "post_init_hook",
     "auto_install": True,

--- a/l10n_br_base_l10n_br_compat/views/res_country_views.xml
+++ b/l10n_br_base_l10n_br_compat/views/res_country_views.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="base.br" model="res.country">
+        <field
+            name="address_view_id"
+            ref="l10n_br_base.l10n_br_base_res_partner_address"
+        />
+    </record>
+</odoo>


### PR DESCRIPTION


### Hoje ao acesar módulo de CRM estamos com esse erro:

```
UncaughtPromiseError > OwlError

Uncaught Promise > An error occured in the owl lifecycle (see this Error's "cause" property)

Occured on localhost:18069 on 2026-07-04 14:46:33 GMT

OwlError: An error occured in the owl lifecycle (see this Error's "cause" property)
    Error: An error occured in the owl lifecycle (see this Error's "cause" property)
        at handleError (http://localhost:18069/web/assets/c12a37d/web.assets_web.min.js:972:101)
        at App.handleError (http://localhost:18069/web/assets/c12a37d/web.assets_web.min.js:1631:29)
        at ComponentNode.initiateRender (http://localhost:18069/web/assets/c12a37d/web.assets_web.min.js:1065:19)

Caused by: Error: "crm.lead"."country_enforce_cities" field is undefined.
    at Field.parseFieldNode (http://localhost:18069/web/assets/c12a37d/web.assets_web.min.js:7792:330)
    at http://localhost:18069/web/assets/c12a37d/web.assets_web.min.js:8735:954
    at visit (http://localhost:18069/web/assets/c12a37d/web.assets_web.min.js:4796:51)
    at visitChildren (http://localhost:18069/web/assets/c12a37d/web.assets_web.min.js:4795:171)
    at visit (http://localhost:18069/web/assets/c12a37d/web.assets_web.min.js:4796:129)
    at visitChildren (http://localhost:18069/web/assets/c12a37d/web.assets_web.min.js:4795:171)
    at visit (http://localhost:18069/web/assets/c12a37d/web.assets_web.min.js:4796:129)
    at visitChildren (http://localhost:18069/web/assets/c12a37d/web.assets_web.min.js:4795:171)
    at visit (http://localhost:18069/web/assets/c12a37d/web.assets_web.min.js:4796:129)
    at visitChildren (http://localhost:18069/web/assets/c12a37d/web.assets_web.min.js:4795:171)
```
## Problema
Os dados do módulo legado l10n_br sobrescrevem o res.country.address_view_id do Brasil com l10n_br.br_partner_address_form, uma view feita apenas para res.partner (ela usa campos como country_enforce_cities que não existem em outros modelos).

O patch do format.address.mixin no l10n_br_base permite que modelos que não são res.partner (como crm.lead, que herda format.address.mixin) reaproveitem essa mesma view de endereço do país. Assim que o l10n_br sobrescreve o address_view_id com sua view exclusiva de res.partner, essa substituição passa a ser aplicada também no bloco de endereço do crm.lead, injetando campos (country_enforce_cities, parent_id, type, …) que não existem em crm.lead. A checagem de segurança do Odoo nesse ponto só valida os campos por completo quando a view está sendo salva, não quando está sendo lida — então o arch inválido chega até o cliente, e a renderização quebra.

## Solução 
Adiciona views/res_country_views.xml, reapontando o address_view_id do Brasil de volta para l10n_br_base.l10n_br_base_res_partner_address — uma view que só usa campos também presentes nos outros modelos (city_id, district, street_name, etc., disponibilizados no crm.lead via l10n_br_crm). Como essa atualização do registro ocorre durante a instalação do próprio l10n_br_base_l10n_br_compat, ela é aplicada independentemente do noupdate dos dados do l10n_br.