### PR TITLE
[18.0][IMP] l10n_br_fiscal: add operation indicator, nbs and categ on best selection operation line

### DIFF
--- a/l10n_br_fiscal/models/operation.py
+++ b/l10n_br_fiscal/models/operation.py
@@ -266,6 +266,24 @@ class Operation(models.Model):
             ("icms_origin", "=", False),
         ]
 
+        domain += [
+            "|",
+            ("nbs_id", "=", product.nbs_id.id),
+            ("nbs_id", "=", False),
+        ]
+
+        domain += [
+            "|",
+            ("operation_indicator_id", "=", product.operation_indicator_id.id),
+            ("operation_indicator_id", "=", False),
+        ]
+
+        domain += [
+            "|",
+            ("categ_id", "=", product.categ_id.id),
+            ("categ_id", "=", False),
+        ]
+
         return domain
 
     def line_definition(self, company, partner, product):
@@ -289,6 +307,9 @@ class Operation(models.Model):
                 "product_type",
                 "tax_icms_or_issqn",
                 "icms_origin",
+                "nbs_id",
+                "operation_indicator_id",
+                "categ_id",
             ]
             return sum(1 for field in fields if getattr(line, field))
 

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -108,6 +108,24 @@ class OperationLine(models.Model):
         selection=PRODUCT_FISCAL_TYPE, string="Product Fiscal Type"
     )
 
+    categ_id = fields.Many2one(
+        comodel_name="product.category",
+        string="Product Category",
+        company_dependent=True,
+    )
+
+    nbs_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.nbs",
+        string="NBS",
+        company_dependent=True,
+    )
+
+    operation_indicator_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.operation.indicator",
+        string="Operation Indicator",
+        company_dependent=True,
+    )
+
     company_tax_framework = fields.Selection(selection=TAX_FRAMEWORK)
 
     add_to_amount = fields.Boolean(string="Add to Document Amount?", default=True)

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -35,11 +35,15 @@ class OperationLine(models.Model):
 
     name = fields.Char(required=True)
 
-    document_type_id = fields.Many2one(comodel_name="l10n_br_fiscal.document.type")
+    document_type_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.document.type",
+        help="Applied to the fiscal record when this operation line is selected.",
+    )
 
     tax_classification_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax.classification",
         string="Tax Classification",
+        help="Applied to the fiscal record when this operation line is selected.",
     )
 
     cfop_internal_id = fields.Many2one(
@@ -48,6 +52,7 @@ class OperationLine(models.Model):
         domain="[('type_in_out', '=', fiscal_operation_type), "
         "('destination', '=', '1'),"
         "('type_move', '=ilike', fiscal_type + '%')]",
+        help="Applied to the fiscal record when this operation line is selected.",
     )
 
     cfop_external_id = fields.Many2one(
@@ -56,6 +61,7 @@ class OperationLine(models.Model):
         domain="[('type_in_out', '=', fiscal_operation_type), "
         "('type_move', '=ilike', fiscal_type + '%'), "
         "('destination', '=', '2')]",
+        help="Applied to the fiscal record when this operation line is selected.",
     )
 
     cfop_export_id = fields.Many2one(
@@ -64,6 +70,7 @@ class OperationLine(models.Model):
         domain="[('type_in_out', '=', fiscal_operation_type), "
         "('type_move', '=ilike', fiscal_type + '%'), "
         "('destination', '=', '3')]",
+        help="Applied to the fiscal record when this operation line is selected.",
     )
 
     fiscal_operation_type = fields.Selection(
@@ -81,6 +88,10 @@ class OperationLine(models.Model):
     tax_icms_or_issqn = fields.Selection(
         selection=TAX_ICMS_OR_ISSQN,
         string="ICMS or ISSQN Tax",
+        help=(
+            "Selection criterion used to match this line with the product. "
+            "Leave empty to match any value."
+        ),
     )
 
     line_inverse_id = fields.Many2one(
@@ -97,46 +108,87 @@ class OperationLine(models.Model):
         copy=False,
     )
 
-    partner_tax_framework = fields.Selection(selection=TAX_FRAMEWORK)
+    partner_tax_framework = fields.Selection(
+        selection=TAX_FRAMEWORK,
+        help=(
+            "Selection criterion used to match this line with the partner. "
+            "Leave empty to match any value."
+        ),
+    )
 
     ind_ie_dest = fields.Selection(
         selection=NFE_IND_IE_DEST,
         string="ICMS Taxpayer",
+        help=(
+            "Selection criterion used to match this line with the partner. "
+            "Leave empty to match any value."
+        ),
     )
 
     product_type = fields.Selection(
-        selection=PRODUCT_FISCAL_TYPE, string="Product Fiscal Type"
+        selection=PRODUCT_FISCAL_TYPE,
+        string="Product Fiscal Type",
+        help=(
+            "Selection criterion used to match this line with the product. "
+            "Leave empty to match any value."
+        ),
     )
 
     categ_id = fields.Many2one(
         comodel_name="product.category",
         string="Product Category",
         company_dependent=True,
+        help=(
+            "Selection criterion used to match this line with the product. "
+            "Leave empty to match any value."
+        ),
     )
 
     nbs_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.nbs",
         string="NBS",
         company_dependent=True,
+        help=(
+            "Selection criterion used to match this line with the product. "
+            "Leave empty to match any value."
+        ),
     )
 
     operation_indicator_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.operation.indicator",
         string="Operation Indicator",
         company_dependent=True,
+        help=(
+            "Selection criterion used to match this line with the product. "
+            "Leave empty to match any value."
+        ),
     )
 
-    company_tax_framework = fields.Selection(selection=TAX_FRAMEWORK)
+    company_tax_framework = fields.Selection(
+        selection=TAX_FRAMEWORK,
+        help=(
+            "Selection criterion used to match this line with the company. "
+            "Leave empty to match any value."
+        ),
+    )
 
     add_to_amount = fields.Boolean(string="Add to Document Amount?", default=True)
 
-    icms_origin = fields.Selection(selection=ICMS_ORIGIN, string="Origin")
+    icms_origin = fields.Selection(
+        selection=ICMS_ORIGIN,
+        string="Origin",
+        help=(
+            "Selection criterion used to match this line with the product. "
+            "Leave empty to match any value."
+        ),
+    )
 
     tax_definition_ids = fields.One2many(
         comodel_name="l10n_br_fiscal.tax.definition",
         inverse_name="fiscal_operation_line_id",
         string="Tax Definition",
         copy=True,
+        help="Applied to the fiscal record when this operation line is selected.",
     )
 
     comment_ids = fields.Many2many(
@@ -154,9 +206,21 @@ class OperationLine(models.Model):
         copy=False,
     )
 
-    date_start = fields.Datetime(string="Start Date")
+    date_start = fields.Datetime(
+        string="Start Date",
+        help=(
+            "Selection criterion: this line only matches from this date on. "
+            "Leave empty for no start limit."
+        ),
+    )
 
-    date_end = fields.Datetime(string="End Date")
+    date_end = fields.Datetime(
+        string="End Date",
+        help=(
+            "Selection criterion: this line only matches until this date. "
+            "Leave empty for no end limit."
+        ),
+    )
 
     _sql_constraints = [
         (

--- a/l10n_br_fiscal/views/operation_line_view.xml
+++ b/l10n_br_fiscal/views/operation_line_view.xml
@@ -38,13 +38,26 @@
                         <label for="name" />
                         <field name="name" />
                     </h2>
+                    <div class="alert alert-info" role="status">
+                        The fields below define
+                        <strong>when</strong>
+                        this line is selected (matching criteria). The tabs
+                        below define
+                        <strong>what</strong>
+                        is applied to the fiscal record once this line is
+                        chosen.
+                    </div>
+                    <separator string="Matching Criteria (when to apply this line)" />
                     <group>
-                        <group string="Company and Partner" name="tax_framework">
+                        <group
+                            string="Selection Criteria: Company &amp; Partner"
+                            name="tax_framework"
+                        >
                             <field name="company_tax_framework" />
                             <field name="partner_tax_framework" />
                             <field name="ind_ie_dest" />
                         </group>
-                        <group string="Product Information">
+                        <group string="Selection Criteria: Product">
                             <field name="product_type" />
                             <field name="categ_id" />
                             <field name="tax_icms_or_issqn" />
@@ -52,7 +65,15 @@
                             <field name="nbs_id" />
                             <field name="operation_indicator_id" />
                         </group>
+                        <group
+                            string="Selection Criteria: Validity Period"
+                            name="validity_period"
+                        >
+                            <field name="date_start" />
+                            <field name="date_end" />
+                        </group>
                     </group>
+                    <separator string="Applied Values (what this line applies)" />
                     <notebook>
                         <page name="general" string="General">
                             <group name="gereral_settings">
@@ -88,14 +109,6 @@
                             />
                         </page>
                         <page name="extra_info" string="Extra Info">
-                            <group>
-                                <group>
-                                    <field name="date_start" />
-                                </group>
-                                <group>
-                                    <field name="date_end" />
-                                </group>
-                            </group>
                             <group>
                                 <field name="comment_ids" widget="many2many_tags" />
                             </group>

--- a/l10n_br_fiscal/views/operation_line_view.xml
+++ b/l10n_br_fiscal/views/operation_line_view.xml
@@ -46,8 +46,11 @@
                         </group>
                         <group string="Product Information">
                             <field name="product_type" />
+                            <field name="categ_id" />
                             <field name="tax_icms_or_issqn" />
                             <field name="icms_origin" />
+                            <field name="nbs_id" />
+                            <field name="operation_indicator_id" />
                         </group>
                     </group>
                     <notebook>


### PR DESCRIPTION
This pull request enhances the fiscal operation line functionality by introducing new fields for improved product classification and matching, and updates the domain logic and views to utilize these fields. These changes make the operation line assignment more granular and flexible, allowing for better handling of fiscal rules based on product category, NBS, and operation indicator.

**Model and Field Additions:**

* Added new fields to `OperationLine`: `categ_id` (Product Category), `nbs_id` (NBS), and `operation_indicator_id` (Operation Indicator), all as company-dependent Many2one relations.

**Domain and Matching Logic Improvements:**

* Updated `_line_domain` in `operation.py` to include matching logic for the new fields (`nbs_id`, `operation_indicator_id`, `categ_id`), allowing operation lines to be selected based on these attributes or when they are unset.
* Enhanced the `score` function to consider the new fields when determining the best matching operation line.

**User Interface Updates:**

* Added the new fields (`categ_id`, `nbs_id`, `operation_indicator_id`) to the operation line form view for easier user access and management.