### PR TITLE
[16.0][l10n_br_fiscal][l10n_br_nfe][l10n_br_account_nfe] melhorias na importaçao dos documentos fiscais/NFe

### DIFF
--- a/l10n_br_account/models/document.py
+++ b/l10n_br_account/models/document.py
@@ -338,3 +338,28 @@ class FiscalDocument(models.Model):
         ):
             self._document_deny()
         return super().exec_after_SITUACAO_EDOC_DENEGADA(old_state, new_state)
+
+    def _check_document_import(self):
+        """Ensure an imported fiscal document has the minimum data required
+        to generate a valid account move (and a sound SPED basis).
+
+        Raises a single UserError listing every problem found so the user
+        can fix the de-para in one pass instead of one error at a time.
+        """
+        self.ensure_one()
+        errors = []
+        for line in self.fiscal_line_ids:
+            label = line.name or line.product_id.display_name or _("Unknown")
+            if not line.product_id:
+                errors.append(_("- %s: no product matched.") % label)
+            if not line.uom_id:
+                errors.append(_("- %s: no unit of measure.") % label)
+            if not line.quantity:
+                errors.append(_("- %s: no quantity.") % label)
+            if not line.price_unit:
+                errors.append(_("- %s: no unit price.") % label)
+        if errors:
+            raise UserError(
+                _("The document cannot be imported due to incomplete lines:\n%s")
+                % "\n".join(errors)
+            )

--- a/l10n_br_account/wizards/document_import_wizard.py
+++ b/l10n_br_account/wizards/document_import_wizard.py
@@ -31,6 +31,7 @@ class DocumentImportWizard(models.TransientModel):
         account.move(s) at the end of the attachments sequence.
         """
         _binding, fiscal_document = self._import_edoc()
+        fiscal_document._check_document_import()
         move_type = f"{self.fiscal_operation_type}_invoice"
         move_id = (
             self.env["account.move"]

--- a/l10n_br_account_nfe/tests/test_nfe_import.py
+++ b/l10n_br_account_nfe/tests/test_nfe_import.py
@@ -70,6 +70,7 @@ class NFeImportTest(TransactionCase):
             del line["id"]
             del line["product_id"]
             del line["ncm_internal"]
+            del line["cfop_warning"]
         self.assertEqual(len(lines), 4)
         self.assertDictEqual(
             lines[0],

--- a/l10n_br_account_nfe/tests/test_nfe_import.py
+++ b/l10n_br_account_nfe/tests/test_nfe_import.py
@@ -5,6 +5,7 @@ import base64
 import os
 
 from odoo import Command
+from odoo.exceptions import UserError
 from odoo.tests import TransactionCase
 from odoo.tests.common import Form
 
@@ -238,3 +239,26 @@ class NFeImportTest(TransactionCase):
         self.assertAlmostEqual(move.due_line_ids[0].credit, 4075.95, places=2)
         self.assertAlmostEqual(move.due_line_ids[1].credit, 4075.95, places=2)
         self.assertAlmostEqual(move.due_line_ids[2].credit, 4075.96, places=2)
+
+    def test_import_incomplete_document_is_blocked(self):
+        """A document with a line missing its product/uom/qty/price must not
+        be importable into an account move (SPED data integrity)."""
+        file_path = os.path.join(
+            l10n_br_account_nfe.__path__[0],
+            "tests",
+            "nfe",
+            "35231149647316000169550010000661061151600085-nfe.xml",
+        )
+        with open(file_path, "rb") as file:
+            file_content = file.read()
+
+        wizard = self.env["l10n_br_fiscal.document.import.wizard"].create({})
+        with Form(wizard) as import_form:
+            import_form.file = base64.b64encode(file_content)
+            import_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_compras")
+
+        _binding, document = wizard._import_edoc()
+        # Break one line to simulate an unmatched product.
+        document.fiscal_line_ids[0].product_id = False
+        with self.assertRaises(UserError):
+            document._check_document_import()

--- a/l10n_br_account_nfe/tests/test_nfe_import.py
+++ b/l10n_br_account_nfe/tests/test_nfe_import.py
@@ -179,6 +179,13 @@ class NFeImportTest(TransactionCase):
 
         self.assertEqual(len(move.invoice_line_ids), 4)
 
+        # The supplier declared CFOP 6101 (interstate sale); the de-para
+        # recomputes it to the company's inbound CFOP, but partner_cfop_id
+        # preserves the declared value for bookkeeping / SPED (C197).
+        doc_line = move.fiscal_document_id.fiscal_line_ids[0]
+        self.assertEqual(doc_line.partner_cfop_id.code, "6101")
+        self.assertNotEqual(doc_line.cfop_id.code, "6101")
+
         self.assertEqual(
             move.invoice_line_ids[0].product_id.name,
             "PAPEL CELOFANE (CELULOSE) 35GSM 19x24CM",

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -1090,6 +1090,14 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         string="CFOP Destination",
     )
 
+    partner_cfop_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.cfop",
+        string="Partner CFOP",
+        help="CFOP as declared by the counterparty in the imported document. "
+        "It is preserved as-is for fiscal bookkeeping / SPED (e.g. C197), "
+        "while cfop_id reflects the company's own operation after the de-para.",
+    )
+
     fiscal_price = fields.Float(
         digits="Product Price",
         compute="_compute_fiscal_price",

--- a/l10n_br_fiscal/security/ir.model.access.csv
+++ b/l10n_br_fiscal/security/ir.model.access.csv
@@ -104,3 +104,4 @@
 "l10n_br_fiscal_national_taxation_code_manager","Fiscal National Taxation Code for Manager","model_l10n_br_fiscal_national_taxation_code","l10n_br_fiscal.group_user",1,1,1,1
 "l10n_br_fiscal_document_status_wizard_user",l10n_br_fiscal_document_status_wizard,model_l10n_br_fiscal_document_status_wizard,base.group_user,1,1,1,1
 "l10n_br_fiscal_document_import_wizard_user",l10n_br_fiscal_document_import_wizard_user,model_l10n_br_fiscal_document_import_wizard,base.group_user,1,1,1,1
+"l10n_br_fiscal_document_import_wizard_line_user",l10n_br_fiscal_document_import_wizard_line_user,model_l10n_br_fiscal_document_import_wizard_line,base.group_user,1,1,1,1

--- a/l10n_br_fiscal/wizards/__init__.py
+++ b/l10n_br_fiscal/wizards/__init__.py
@@ -1,3 +1,4 @@
 from . import base_wizard_mixin
 from . import document_status_wizard
+from . import document_import_wizard_line
 from . import document_import_wizard

--- a/l10n_br_fiscal/wizards/document_import_wizard.py
+++ b/l10n_br_fiscal/wizards/document_import_wizard.py
@@ -38,6 +38,12 @@ class DocumentImportWizard(models.TransientModel):
 
     file = fields.Binary(string="File to Import")
 
+    imported_products_ids = fields.One2many(
+        string="Imported Products",
+        comodel_name="l10n_br_fiscal.document.import.wizard.line",
+        inverse_name="import_xml_id",
+    )
+
     fiscal_operation_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.operation",
         string="Fiscal Operation",

--- a/l10n_br_fiscal/wizards/document_import_wizard.py
+++ b/l10n_br_fiscal/wizards/document_import_wizard.py
@@ -231,6 +231,22 @@ class DocumentImportWizard(models.TransientModel):
         if operation_lines:
             return operation_lines[0].fiscal_operation_id
 
+    def _match_uom_by_code(self, *codes):
+        """Match a fiscal UoM from one or more XML unit codes (uCom/uTrib).
+
+        First try the fiscal ``code`` field, then fall back to the
+        ``uom_alias`` module aliases so that supplier abbreviations
+        (e.g. ``MIL`` -> ``MILHEIRO``, ``UNID`` -> ``Units``) resolve to
+        the company's own UoM.
+        """
+        codes = [code for code in codes if code]
+        if not codes:
+            return self.env["uom.uom"]
+        uom = self.env["uom.uom"].search([("code", "in", codes)], limit=1)
+        if not uom:
+            uom = self.env["uom.uom"].search([("alias_ids.code", "in", codes)], limit=1)
+        return uom
+
     def _parse_file(self):
         return self._parse_file_data(self.file)
 

--- a/l10n_br_fiscal/wizards/document_import_wizard_line.py
+++ b/l10n_br_fiscal/wizards/document_import_wizard_line.py
@@ -3,7 +3,7 @@
 # Copyright 2025 Akretion - Raphaël Valyi <raphael.valyi@akretion.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import Command, fields, models
+from odoo import Command, _, api, fields, models
 
 
 class DocumentImportWizardLine(models.TransientModel):
@@ -74,6 +74,49 @@ class DocumentImportWizardLine(models.TransientModel):
         comodel_name="l10n_br_fiscal.cfop",
         string="Change CFOP",
     )
+
+    cfop_warning = fields.Char(
+        compute="_compute_cfop_warning",
+        string="CFOP Alert",
+        help="Warns when the CFOP declared in the XML is inconsistent with "
+        "the actual geography (issuer state vs company state). Useful to "
+        "spot supplier mistakes before they pollute the SPED books.",
+    )
+
+    @api.depends("cfop_xml", "import_xml_id.issuer_partner_id.state_id")
+    def _compute_cfop_warning(self):
+        for line in self:
+            line.cfop_warning = line._get_cfop_warning()
+
+    def _get_cfop_warning(self):
+        """Compare the XML CFOP scope (from its first digit) with the real
+        issuer/company geography. CFOP first digit: 1/5 = intrastate,
+        2/6 = interstate, 3/7 = foreign trade."""
+        self.ensure_one()
+        if not self.cfop_xml:
+            return False
+        declared = self.cfop_xml[0]
+        wizard = self.import_xml_id
+        issuer_state = wizard.issuer_partner_id.state_id
+        company_state = wizard.company_id.state_id
+        if not issuer_state or not company_state:
+            return False
+        same_state = issuer_state == company_state
+        if declared in ("1", "5") and not same_state:
+            return _(
+                "XML CFOP %(cfop)s is intrastate but issuer (%(issuer)s) "
+                "and company (%(company)s) are in different states."
+            ) % {
+                "cfop": self.cfop_xml,
+                "issuer": issuer_state.code,
+                "company": company_state.code,
+            }
+        if declared in ("2", "6") and same_state:
+            return _(
+                "XML CFOP %(cfop)s is interstate but issuer "
+                "and company are both in %(state)s."
+            ) % {"cfop": self.cfop_xml, "state": company_state.code}
+        return False
 
     def _find_or_create_product_supplierinfo(self):
         for line in self:

--- a/l10n_br_fiscal/wizards/document_import_wizard_line.py
+++ b/l10n_br_fiscal/wizards/document_import_wizard_line.py
@@ -1,0 +1,118 @@
+# Copyright (C) 2021  Gabriel Cardoso de Faria - Kmee
+# Copyright (C) 2023  Felipe Zago Rodrigues - Kmee
+# Copyright 2025 Akretion - Raphaël Valyi <raphael.valyi@akretion.com>
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import Command, fields, models
+
+
+class DocumentImportWizardLine(models.TransientModel):
+    """Generic line of the fiscal document import wizard.
+
+    This model holds the document-type agnostic data of an imported
+    fiscal document line so the "de-para" (matching between the supplier
+    nomenclature coming from the XML and the company's own fiscal settings)
+    can be reviewed before the fiscal document and the account move are
+    actually created.
+
+    It is meant to be extended (via ``_inherit``) by each specialized fiscal
+    document importer (NFe, and CTe in the future) to add the fields and the
+    behavior that are specific to that document type (e.g. NFe taxes or the
+    commercial/tax unit split).
+    """
+
+    _name = "l10n_br_fiscal.document.import.wizard.line"
+    _description = "Fiscal Document Import Wizard Line"
+
+    import_xml_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.document.import.wizard",
+    )
+
+    imported_partner_id = fields.Many2one(related="import_xml_id.partner_id")
+
+    # XML (supplier nomenclature) data:
+    product_name = fields.Char()
+
+    product_code = fields.Char(string="XML Product Code")
+
+    ncm_xml = fields.Char(string="XML NCM Code")
+
+    cfop_xml = fields.Char(string="XML CFOP")
+
+    uom_com = fields.Char(string="UOM Comercial")
+
+    quantity_com = fields.Float(string="Comercial Quantity")
+
+    price_unit_com = fields.Float(string="Comercial Price Unit")
+
+    total = fields.Float()
+
+    # Internal (company fiscal settings) data used for the de-para:
+    product_id = fields.Many2one(
+        comodel_name="product.product",
+        string="Product Internal Reference",
+    )
+
+    product_supplier_id = fields.Many2one(
+        comodel_name="product.supplierinfo",
+        string="Product Supplier",
+    )
+
+    uom_internal = fields.Many2one(
+        comodel_name="uom.uom",
+        help="Internal UoM, equivalent to the comercial one in the document",
+    )
+
+    uom_conversion_factor = fields.Float(string="UOM Conversion Factor", default=1)
+
+    ncm_internal = fields.Char(
+        related="product_id.ncm_id.code",
+        string="Internal NCM Code",
+    )
+
+    new_cfop_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.cfop",
+        string="Change CFOP",
+    )
+
+    def _find_or_create_product_supplierinfo(self):
+        for line in self:
+            if not line.product_id:
+                continue
+
+            if not line.product_supplier_id:
+                line._create_product_supplier()
+            else:
+                line._update_product_supplier()
+
+    def _get_supplierinfo_price(self):
+        """Price of the supplierinfo expressed in the product main UoM."""
+        if self.uom_internal:
+            return self.uom_internal._compute_price(
+                self.price_unit_com, self.product_id.uom_id
+            )
+        return self.product_id.lst_price
+
+    def _prepare_supplierinfo_vals(self):
+        """Common supplierinfo values.
+
+        Overriden by specialized document types (e.g. NFe) to add the
+        partner UoM de-para values.
+        """
+        return {
+            "product_id": self.product_id.id,
+            "product_name": self.product_name,
+            "product_code": self.product_code,
+            "price": self._get_supplierinfo_price(),
+        }
+
+    def _create_product_supplier(self):
+        vals = self._prepare_supplierinfo_vals()
+        vals["partner_id"] = self.imported_partner_id.id
+        self.product_supplier_id = self.env["product.supplierinfo"].create(vals)
+        self.product_id.write(
+            {"seller_ids": [Command.link(self.product_supplier_id.id)]}
+        )
+
+    def _update_product_supplier(self):
+        self.product_supplier_id.write(self._prepare_supplierinfo_vals())

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -1376,6 +1376,16 @@ class NFeLine(spec_models.StackedModel):
                 .search([("code_unmasked", "=", value)], limit=1)
                 .id
             )
+        if key == "nfe40_CFOP" and value:
+            # Preserve the CFOP declared by the counterparty. cfop_id itself is
+            # recomputed by the de-para; partner_cfop_id keeps the original for
+            # bookkeeping / SPED (C197).
+            vals["partner_cfop_id"] = (
+                self.env["l10n_br_fiscal.cfop"]
+                .search([("code", "=", value)], limit=1)
+                .id
+            )
+
         if key == "nfe40_qCom":
             vals["quantity"] = float(value)
         if key == "nfe40_qTrib":

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -7,7 +7,7 @@ from enum import Enum
 
 from nfelib.nfe.bindings.v4_0.dfe_tipos_basicos_v1_00 import Tcibs, TtribNfe
 
-from odoo import api, fields
+from odoo import _, api, fields
 
 from odoo.addons.l10n_br_fiscal.constants.fiscal import (
     CFOP_DESTINATION_EXTERNAL,
@@ -1563,6 +1563,13 @@ class NFeLine(spec_models.StackedModel):
                 tax_domain_with_red,
                 limit=1,
             )
+            # If no fiscal tax with this base reduction exists yet, create it
+            # instead of falling back to a plain (no-reduction) tax, which
+            # would compute a wrong ICMS credit and diverge from the NFe/SPED.
+            if not fiscal_tax_id and percent:
+                fiscal_tax_id = self._create_reduced_fiscal_tax(
+                    tax_group_id, percent, cst_id, icms_percent_red
+                )
 
         if not fiscal_tax_id:
             if tax_domain_with_cst:
@@ -1661,6 +1668,34 @@ class NFeLine(spec_models.StackedModel):
         # elif kind == "cofins":  # (will also apply to cofinsst)
         #     pass
         #     # TODO  qBCProd, vAliqProd
+
+    def _create_reduced_fiscal_tax(
+        self, tax_group_id, percent, cst_id, percent_reduction
+    ):
+        """Create an ICMS fiscal tax with a base reduction when the company
+        has none configured for this rate/reduction combination.
+
+        Without this, an imported NFe line that declares an ICMS base
+        reduction (redução de base de cálculo) would fall back to a plain
+        no-reduction tax, computing a higher ICMS credit than the supplier
+        actually charged and diverging from the NFe / SPED. The created tax
+        carries the proper percent_reduction so it is reused on the next
+        import (idempotent via the earlier search on percent_reduction).
+        """
+        cst_field = "cst_{}_id".format(self.env.context.get("edoc_type", "in"))
+        vals = {
+            "name": _("ICMS %(percent)s%% Com Red. %(red)s%%")
+            % {"percent": percent, "red": percent_reduction},
+            "tax_group_id": tax_group_id,
+            "percent_amount": percent,
+            "percent_reduction": percent_reduction,
+            "percent_debit_credit": 0,
+            "value_amount": 0,
+            "icmsst_mva_percent": 0,
+            "icmsst_value": 0,
+            cst_field: cst_id,
+        }
+        return self.env["l10n_br_fiscal.tax"].create(vals)
 
     def _import_ibscbs_attrs(self, value, odoo_attrs):
         """Import IBSCBS tax attributes from NFe binding."""

--- a/l10n_br_nfe/security/ir.model.access.csv
+++ b/l10n_br_nfe/security/ir.model.access.csv
@@ -1,5 +1,3 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
-access_l10n_br_fiscal_import_products_wizard_user,l10n_br_nfe_import_xml_products_user,model_l10n_br_nfe_import_xml_products,l10n_br_nfe.group_user,1,0,0,0
-access_l10n_br_fiscal_import_products_wizard_manager,l10n_br_nfe_import_xml_products_manager,model_l10n_br_nfe_import_xml_products,l10n_br_nfe.group_manager,1,1,1,1
 access_l10n_br_nfe_mde_user,access_l10n_br_nfe_mde_user,model_l10n_br_nfe_mde,l10n_br_nfe.group_user,1,0,0,0
 access_l10n_br_nfe_mde_manager,access_l10n_br_nfe_mde_manager,model_l10n_br_nfe_mde,l10n_br_nfe.group_manager,1,1,1,1

--- a/l10n_br_nfe/tests/test_nfe_import.py
+++ b/l10n_br_nfe/tests/test_nfe_import.py
@@ -1,6 +1,8 @@
 # Copyright 2021 - TODAY Akretion - Raphael Valyi <raphael.valyi@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+import re
+
 import nfelib
 import pkg_resources
 from nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00 import TnfeProc
@@ -139,6 +141,58 @@ class NFeImportTest(TransactionCase):
         self.assertEqual(shipping.type, "delivery")
         self.assertEqual(shipping.street_name, "Rua da Entrega")
         self.assertEqual(shipping.zip, "01001-000")
+
+    def test_import_in_nfe_creates_reduced_tax(self):
+        """A purchase NFe line declaring an ICMS base reduction (CST 20 with
+        pRedBC) for which the company has no matching fiscal tax must create a
+        tax carrying that percent_reduction, instead of falling back to a
+        plain no-reduction tax (which would compute a wrong ICMS credit)."""
+        res_items = (
+            "nfe",
+            "samples",
+            "v4_0",
+            "leiauteNFe",
+            "35180834128745000152550010000474281920007498-nfe.xml",
+        )
+        resource_path = "/".join(res_items)
+        nfe_stream = pkg_resources.resource_stream(nfelib.__name__, resource_path)
+        xml = nfe_stream.read().decode()
+        # Replace the first ICMS00 node with an ICMS20 (base reduction).
+        # pICMS 7.00 + 33.33% reduction is unlikely to pre-exist -> forces
+        # the create-if-not-found branch.
+        icms20 = (
+            "<ICMS20>"
+            "<orig>0</orig><CST>20</CST><modBC>3</modBC>"
+            "<pRedBC>33.33</pRedBC><vBC>33.73</vBC>"
+            "<pICMS>7.00</pICMS><vICMS>2.36</vICMS>"
+            "</ICMS20>"
+        )
+        xml = re.sub(r"<ICMS00>.*?</ICMS00>", icms20, xml, count=1, flags=re.S)
+
+        existing = self.env["l10n_br_fiscal.tax"].search(
+            [
+                ("tax_group_id", "=", self.env.ref("l10n_br_fiscal.tax_group_icms").id),
+                ("percent_amount", "=", 7.0),
+                ("percent_reduction", "=", 33.33),
+            ]
+        )
+        self.assertFalse(existing, "test precondition: reduced tax must not exist")
+
+        binding = TnfeProc.from_xml(xml)
+        nfe = self.env["l10n_br_fiscal.document"].import_binding_nfe(
+            binding, edoc_type="in", dry_run=False
+        )
+        created = self.env["l10n_br_fiscal.tax"].search(
+            [
+                ("tax_group_id", "=", self.env.ref("l10n_br_fiscal.tax_group_icms").id),
+                ("percent_amount", "=", 7.0),
+                ("percent_reduction", "=", 33.33),
+            ]
+        )
+        self.assertTrue(created, "reduced ICMS tax was not created on import")
+        line = nfe.fiscal_line_ids[0]
+        self.assertEqual(line.icms_tax_id, created)
+        self.assertEqual(line.icms_tax_id.percent_reduction, 33.33)
 
     def test_import_out_nfe(self):
         "(can be useful after an ERP migration)"

--- a/l10n_br_nfe/tests/test_nfe_import_wizard.py
+++ b/l10n_br_nfe/tests/test_nfe_import_wizard.py
@@ -203,6 +203,28 @@ class NFeImportWizardTest(TransactionCase):
         prod_id = self.wizard._match_product(MagicMock())
         self.assertFalse(prod_id)
 
+    def test_match_product_by_purchase(self):
+        """The purchase-order priority match is a soft dependency on
+        l10n_br_purchase (which adds partner_order/partner_order_line to
+        purchase.order.line). It must be a no-op when those fields are absent,
+        so _match_product falls back to supplierinfo/default_code/barcode."""
+        self._prepare_wizard(self.xml_1)
+        pol = self.env.get("purchase.order.line")
+        has_fields = pol is not None and "partner_order" in pol._fields
+        mock = MagicMock()
+        mock.xPed = "NONEXISTENT-PO-REF"
+        mock.nItemPed = "999"
+        # No PO references this xPed (and/or l10n_br_purchase absent) -> no
+        # match, and crucially no crash on a missing field.
+        self.assertFalse(self.wizard._match_product_by_purchase(mock))
+        if not has_fields:
+            # guard short-circuits before any purchase.order.line search
+            self.assertFalse(
+                self.wizard._match_product_by_purchase(
+                    self.wizard._parse_file().infNFe.det[0].prod
+                )
+            )
+
     def test__parse_xml(self):
         self._prepare_wizard(self.xml_1)
 

--- a/l10n_br_nfe/tests/test_nfe_import_wizard.py
+++ b/l10n_br_nfe/tests/test_nfe_import_wizard.py
@@ -246,3 +246,38 @@ class NFeImportWizardTest(TransactionCase):
         self.assertEqual(taxes["vICMS"], 100)
         self.assertEqual(taxes["pIPI"], 5)
         self.assertEqual(taxes["vIPI"], 100)
+
+    def test_cfop_warning(self):
+        """The wizard line flags a CFOP whose scope (intra/interstate) is
+        inconsistent with the real issuer/company geography."""
+        sp = self.env.ref("base.state_br_sp")
+        rj = self.env.ref("base.state_br_rj")
+        company = self.env.ref("base.main_company")
+        company.state_id = sp
+        issuer = self.env["res.partner"].create(
+            {"name": "Issuer SP", "state_id": sp.id}
+        )
+        wizard = self.env["l10n_br_fiscal.document.import.wizard"].create(
+            {"company_id": company.id, "issuer_partner_id": issuer.id}
+        )
+        line = self.env["l10n_br_fiscal.document.import.wizard.line"].create(
+            {"import_xml_id": wizard.id}
+        )
+
+        # interstate CFOP but both parties in SP -> warn
+        line.cfop_xml = "6101"
+        self.assertTrue(line.cfop_warning)
+
+        # intrastate CFOP and both parties in SP -> no warning
+        line.cfop_xml = "1101"
+        self.assertFalse(line.cfop_warning)
+
+        # issuer now in RJ: intrastate CFOP is inconsistent -> warn
+        issuer.state_id = rj
+        line._compute_cfop_warning()
+        self.assertTrue(line.cfop_warning)
+
+        # interstate CFOP with issuer RJ / company SP -> consistent, no warning
+        line.cfop_xml = "6101"
+        line._compute_cfop_warning()
+        self.assertFalse(line.cfop_warning)

--- a/l10n_br_nfe/wizards/document_import_wizard.py
+++ b/l10n_br_nfe/wizards/document_import_wizard.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2022  Renan Hiroki Bastos - Kmee
 # Copyright (C) 2023  Luiz Felipe do Divino - Kmee
 # Copyright (C) 2023  Felipe Zago Rodrigues - Kmee
+# Copyright (C) 2026  Raphaël Valyi - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 import base64
@@ -163,6 +164,10 @@ class DocumentImportWizard(models.TransientModel):
         return variant_ids[0]
 
     def _match_product(self, xml_product):
+        product_id = self._match_product_by_purchase(xml_product)
+        if product_id:
+            return product_id
+
         product_id = self._get_product_by_supplier(xml_product.cProd)
         if product_id:
             return product_id
@@ -178,6 +183,74 @@ class DocumentImportWizard(models.TransientModel):
         if domain:
             rec_id = self.env["product.product"].search(domain, limit=1)
         return rec_id
+
+    def _match_product_by_purchase(self, xml_product):
+        """Priority match from the referenced purchase order.
+
+        When ``l10n_br_purchase`` is installed and the XML line references the
+        buyer's purchase order (xPed / nItemPed), take the product from the
+        matching purchase order line first: it is the most authoritative match
+        since the buyer already stated which product was ordered.
+
+        Soft dependency: no-op unless l10n_br_purchase is installed (it adds
+        the partner_order / partner_order_line fields to purchase.order.line;
+        core ``purchase`` alone does not provide them).
+        """
+        pol_model = self.env.get("purchase.order.line")
+        if pol_model is None or "partner_order" not in pol_model._fields:
+            return False
+        xped = (getattr(xml_product, "xPed", "") or "").strip()
+        if not xped:
+            return False
+
+        partner = self.partner_id.id
+        pol = pol_model.sudo()
+        nitemped = (getattr(xml_product, "nItemPed", "") or "").strip()
+
+        # 1) exact agreed reference: xPed + nItemPed on the purchase order line
+        if nitemped:
+            line = pol.search(
+                [
+                    ("order_id.partner_id", "=", partner),
+                    ("partner_order", "=", xped),
+                    ("partner_order_line", "=", nitemped),
+                ],
+                limit=1,
+            )
+            if line:
+                return line.product_id
+
+        # 2) heuristic: narrow to the referenced order (partner_order on the
+        # line, else the buyer PO name / vendor reference), then disambiguate
+        # the line by the XML product code / barcode.
+        lines = pol.search(
+            [("order_id.partner_id", "=", partner), ("partner_order", "=", xped)]
+        )
+        if not lines:
+            order = (
+                self.env["purchase.order"]
+                .sudo()
+                .search(
+                    [
+                        ("partner_id", "=", partner),
+                        "|",
+                        ("partner_ref", "=", xped),
+                        ("name", "=", xped),
+                    ],
+                    limit=1,
+                )
+            )
+            lines = order.order_line
+        if len(lines) == 1:
+            return lines.product_id
+        cprod = getattr(xml_product, "cProd", None)
+        ean = getattr(xml_product, "cEANTrib", None)
+        for line in lines:
+            if cprod and line.product_id.default_code == cprod:
+                return line.product_id
+            if ean and ean != "SEM GTIN" and line.product_id.barcode == ean:
+                return line.product_id
+        return False
 
     def _get_taxes_from_xml_product(self, product):
         vICMS = 0

--- a/l10n_br_nfe/wizards/document_import_wizard.py
+++ b/l10n_br_nfe/wizards/document_import_wizard.py
@@ -19,12 +19,6 @@ from odoo.addons.l10n_br_fiscal.constants.fiscal import MODELO_FISCAL_NFE
 class DocumentImportWizard(models.TransientModel):
     _inherit = "l10n_br_fiscal.document.import.wizard"
 
-    imported_products_ids = fields.One2many(
-        string="Imported Products",
-        comodel_name="l10n_br_nfe.import_xml.products",
-        inverse_name="import_xml_id",
-    )
-
     nat_op = fields.Char(string="Natureza da Operação")
 
     @api.model
@@ -85,7 +79,7 @@ class DocumentImportWizard(models.TransientModel):
         product_ids = []
         for product in binding.infNFe.det:
             product_ids.append(
-                self.env["l10n_br_nfe.import_xml.products"]
+                self.env["l10n_br_fiscal.document.import.wizard.line"]
                 .create(self._prepare_imported_product_values(product))
                 .id
             )
@@ -96,29 +90,23 @@ class DocumentImportWizard(models.TransientModel):
         taxes = self._get_taxes_from_xml_product(product)
         supplier_id = self._search_product_supplier_by_product_code(product.prod.cProd)
         product_id = self._match_product(product.prod)
-        # if self.fiscal_operation_type == "in"
-        # and product_id and product_id.purchase_ok:
-        if False:  # seems former test is always true after you
-            # imported the product once -> it screws the UOM.
-            uom_id = product_id.uom_po_id
-        else:
+        uom_id = self.env["uom.uom"].search(
+            [
+                "|",
+                ("code", "=", product.prod.uCom),
+                ("code", "=", product.prod.uTrib),
+            ],
+            limit=1,
+        )
+        if not uom_id:  # search for alias
             uom_id = self.env["uom.uom"].search(
                 [
                     "|",
-                    ("code", "=", product.prod.uCom),
-                    ("code", "=", product.prod.uTrib),
+                    ("name", "=", product.prod.uCom),
+                    ("name", "=", product.prod.uTrib),
                 ],
                 limit=1,
             )
-            if not uom_id:  # search for alias
-                uom_id = self.env["uom.uom"].search(
-                    [
-                        "|",
-                        ("name", "=", product.prod.uCom),
-                        ("name", "=", product.prod.uTrib),
-                    ],
-                    limit=1,
-                )
 
         return {
             "product_name": product.prod.xProd,
@@ -331,64 +319,21 @@ class DocumentImportWizard(models.TransientModel):
         return parsed_xml
 
 
-# TODO transform that into a generic l10n_br_fiscal.document.line.import.wizard
-# as proposed https://github.com/OCA/l10n-brazil/pull/3546
-# https://github.com/kmee/l10n-brazil/blob/14.0-refactor-import-edoc
-# /l10n_br_nfe/wizards/document_line_import_wizard.py
-class NfeImportProducts(models.TransientModel):
-    _name = "l10n_br_nfe.import_xml.products"
-    _description = "Import XML NFe Products"
+class DocumentImportWizardLine(models.TransientModel):
+    """NFe specialization of the generic fiscal import wizard line.
 
-    product_name = fields.Char()
+    It only adds the NFe specific data: the commercial/tax unit split and
+    the ICMS/IPI taxes read from the XML. It also injects the partner UoM
+    de-para into the generated ``product.supplierinfo``.
+    """
 
-    uom_com = fields.Char(string="UOM Comercial")
-
-    quantity_com = fields.Float(string="Comercial Quantity")
-
-    price_unit_com = fields.Float(string="Comercial Price Unit")
+    _inherit = "l10n_br_fiscal.document.import.wizard.line"
 
     uom_trib = fields.Char(string="UOM Fiscal")
 
     quantity_trib = fields.Float()
 
     price_unit_trib = fields.Float(string="Fiscal Price Unit")
-
-    total = fields.Float()
-
-    import_xml_id = fields.Many2one(
-        comodel_name="l10n_br_fiscal.document.import.wizard"
-    )
-
-    product_code = fields.Char(string="XML Product Code")
-
-    product_id = fields.Many2one(
-        comodel_name="product.product",
-        string="Product Internal Reference",
-    )
-
-    product_supplier_id = fields.Many2one(
-        comodel_name="product.supplierinfo",
-        string="Product Supplier",
-    )
-
-    uom_internal = fields.Many2one(
-        comodel_name="uom.uom",
-        help="Internal UoM, equivalent to the comercial one in the document",
-    )
-
-    ncm_xml = fields.Char(string="XML NCM Code")
-
-    ncm_internal = fields.Char(
-        related="product_id.ncm_id.code",
-        string="Internal NCM Code",
-    )
-
-    cfop_xml = fields.Char(string="XML CFOP")
-
-    new_cfop_id = fields.Many2one(
-        comodel_name="l10n_br_fiscal.cfop",
-        string="Change CFOP",
-    )
 
     icms_percent = fields.Char(string="Alíquota ICMS")
 
@@ -398,53 +343,12 @@ class NfeImportProducts(models.TransientModel):
 
     ipi_value = fields.Char(string="IPI Value")
 
-    imported_partner_id = fields.Many2one(related="import_xml_id.partner_id")
-
-    uom_conversion_factor = fields.Float(string="UOM Conversion Factor", default=1)
-
-    def _find_or_create_product_supplierinfo(self):
-        for product in self:
-            if not product.product_id:
-                continue
-
-            if not product.product_supplier_id:
-                product._create_product_supplier()
-            else:
-                product._update_product_supplier()
-
-    def _create_product_supplier(self):
-        if self.uom_internal:
-            price = self.uom_internal._compute_price(
-                self.price_unit_com, self.product_id.uom_id
-            )
-        else:
-            price = self.product_id.lst_price
-
-        self.product_supplier_id = self.env["product.supplierinfo"].create(
+    def _prepare_supplierinfo_vals(self):
+        vals = super()._prepare_supplierinfo_vals()
+        vals.update(
             {
-                "product_id": self.product_id.id,
-                "product_name": self.product_name,
-                "product_code": self.product_code,
-                "price": price,
-                "partner_id": self.imported_partner_id.id,
                 "partner_uom_id": self.uom_internal.id,
                 "partner_uom_factor": self.uom_conversion_factor,
             }
         )
-        self.product_id.write(
-            {"seller_ids": [Command.link(self.product_supplier_id.id)]}
-        )
-
-    def _update_product_supplier(self):
-        self.product_supplier_id.write(
-            {
-                "product_id": self.product_id.id,
-                "product_name": self.product_name,
-                "product_code": self.product_code,
-                "price": self.uom_internal._compute_price(
-                    self.price_unit_com, self.product_id.uom_id
-                ),
-                "partner_uom_id": self.uom_internal.id,
-                "partner_uom_factor": self.uom_conversion_factor,
-            }
-        )
+        return vals

--- a/l10n_br_nfe/wizards/document_import_wizard.py
+++ b/l10n_br_nfe/wizards/document_import_wizard.py
@@ -90,23 +90,7 @@ class DocumentImportWizard(models.TransientModel):
         taxes = self._get_taxes_from_xml_product(product)
         supplier_id = self._search_product_supplier_by_product_code(product.prod.cProd)
         product_id = self._match_product(product.prod)
-        uom_id = self.env["uom.uom"].search(
-            [
-                "|",
-                ("code", "=", product.prod.uCom),
-                ("code", "=", product.prod.uTrib),
-            ],
-            limit=1,
-        )
-        if not uom_id:  # search for alias
-            uom_id = self.env["uom.uom"].search(
-                [
-                    "|",
-                    ("name", "=", product.prod.uCom),
-                    ("name", "=", product.prod.uTrib),
-                ],
-                limit=1,
-            )
+        uom_id = self._match_uom_by_code(product.prod.uCom, product.prod.uTrib)
 
         return {
             "product_name": product.prod.xProd,

--- a/l10n_br_nfe/wizards/document_import_wizard.py
+++ b/l10n_br_nfe/wizards/document_import_wizard.py
@@ -6,6 +6,7 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 import base64
+from collections import Counter
 
 from erpbrasil.base.fiscal.cnpj_cpf import formata
 
@@ -39,10 +40,25 @@ class DocumentImportWizard(models.TransientModel):
             infNFe = binding.infNFe
             self.nat_op = infNFe.ide.natOp
             self.fiscal_operation_id = self._find_fiscal_operation(
-                infNFe.det[0].prod.CFOP, self.nat_op, self.fiscal_operation_type
+                self._most_common_cfop(infNFe),
+                self.nat_op,
+                self.fiscal_operation_type,
             )
             self._create_imported_products_by_xml(binding)
         return res
+
+    @api.model
+    def _most_common_cfop(self, infNFe):
+        """Return the CFOP shared by most of the NFe lines.
+
+        A single NFe can mix CFOPs (e.g. a freight or one-off line), so
+        picking the first line's CFOP is unreliable. The majority CFOP
+        better represents the document's fiscal operation.
+        """
+        cfops = [det.prod.CFOP for det in infNFe.det if det.prod.CFOP]
+        if not cfops:
+            return False
+        return Counter(cfops).most_common(1)[0][0]
 
     def _destination_partner_from_binding(self, binding):
         if self.document_type == MODELO_FISCAL_NFE:

--- a/l10n_br_nfe/wizards/document_import_wizard.xml
+++ b/l10n_br_nfe/wizards/document_import_wizard.xml
@@ -53,6 +53,11 @@
                 <field name="ncm_internal" readonly="1" />
                 <field name="cfop_xml" readonly="1" />
                 <field name="new_cfop_id" />
+                <field
+                    name="cfop_warning"
+                    readonly="1"
+                    decoration-warning="cfop_warning != False"
+                />
                 <field name="icms_percent" readonly="1" />
                 <field name="icms_value" readonly="1" />
                 <field name="ipi_percent" readonly="1" />

--- a/l10n_br_nfe/wizards/document_import_wizard.xml
+++ b/l10n_br_nfe/wizards/document_import_wizard.xml
@@ -36,8 +36,8 @@
     </record>
 
     <record id="l10n_br_nfe_import_xml_products_tree" model="ir.ui.view">
-        <field name="name">l10n_br_nfe.import_xml.products.tree</field>
-        <field name="model">l10n_br_nfe.import_xml.products</field>
+        <field name="name">l10n_br_fiscal.document.import.wizard.line.tree</field>
+        <field name="model">l10n_br_fiscal.document.import.wizard.line</field>
         <field name="arch" type="xml">
             <tree editable="top">
                 <field


### PR DESCRIPTION
melhorias na importaçao da NFe por cima de https://github.com/OCA/l10n-brazil/pull/4494 (temos que mesclar primeiro para dividir o trabalho)
faz um port de algumas ideias mal implementadas aqui https://github.com/OCA/l10n-brazil/pull/3546

## Resumo

Continua a limpeza técnica e o fortalecimento do assistente de importação de
NF-e, com foco em torná-lo uma base sólida para o SPED (Bloco C) e para a
reforma tributária (IBS/CBS). Várias ideias foram resgatadas da PR #3546 da KMEE
(feita para a 14.0 sobre uma versão antiga do assistente) e reimplementadas de
forma limpa sobre a base 16.0 já melhorada.

## O que este branch acrescenta

### Refatoração técnica

- **Linha de importação genérica** (`[REF] generic import wizard line`):
  o modelo de linha do assistente, antes específico de NF-e
  (`l10n_br_nfe.import_xml.products`), foi extraído para um modelo genérico
  `l10n_br_fiscal.document.import.wizard.line` em `l10n_br_fiscal`, pronto para
  ser reutilizado por outros documentos (CT-e etc.). A camada NF-e passa a
  estendê-lo, adicionando só o que é específico (split comercial/tributável,
  ICMS/IPI). Remove o `if False` morto e o TODO antigo que apontava para a
  PR #3546.

- **Casamento de UoM via `uom_alias`** (`[REF] use uom_alias for UoM match`):
  o casamento da unidade do XML (uCom/uTrib) passa a usar explicitamente o
  módulo `uom_alias` (código fiscal primeiro, depois `uom.alias.code`), num
  helper reutilizável `_match_uom_by_code`. Antes, os apelidos (MIL, UNID…) só
  funcionavam por efeito colateral implícito do override de `search()`.

### Correções e melhorias funcionais (base SPED / de-para)

- **Operação por CFOP majoritário** (`[IMP] pick import operation by majority
  CFOP`): a operação fiscal deixa de ser resolvida só pelo CFOP da primeira
  linha (`det[0]`) e passa a usar o CFOP predominante entre as linhas — uma
  NF-e pode misturar CFOPs (frete, item avulso). *(Ideia resgatada da KMEE,
  crédito ao autor original.)*

- **Validação de integridade do documento importado** (`[IMP] validate imported
  document integrity`): antes de gerar o `account.move`, verifica que toda linha
  tem produto, UoM, quantidade e preço, reportando **todos** os problemas de uma
  vez num único `UserError`. Evita dados ruins silenciosos que quebrariam o
  SPED. *(Ideia resgatada da KMEE, crédito ao autor original.)*

### Alertas de conferência (SPED)

- **Alerta de CFOP inconsistente** (`[IMP] flag inconsistent XML CFOP scope`):
  como o de-para recalcula o CFOP a partir da configuração da empresa, ele pode
  divergir silenciosamente do CFOP declarado pelo fornecedor. Um aviso na linha
  do assistente sinaliza quando o escopo do CFOP do XML (intra/interestadual, 1º
  dígito) é incompatível com a geografia real (UF do emitente × UF da empresa) —
  um erro comum do fornecedor, que poluiria a escrituração.

- **Alerta de redução de base de ICMS** (`[IMP] flag ICMS base reduction`):
  sinaliza quando o XML declara redução de base (`pRedBC`, CST 20/70), para o
  usuário conferir se o cadastro de imposto do produto modela a redução —
  senão o crédito recalculado não bateria com a NF-e / SPED.

### Impostos com redução de base (importação)

- **Criação de imposto ICMS com redução** (`[IMP] create ICMS tax with base
  reduction on import`): quando o XML declara redução de base e a empresa não
  tem um imposto fiscal cadastrado para aquela alíquota + redução, o import
  **cria** o imposto com o `percent_reduction` correto, em vez de cair num
  imposto sem redução (que calcularia crédito maior do que o fornecedor
  destacou). Idempotente (reutiliza nas próximas importações) e com CST correto
  por direção (`cst_in_id`/`cst_out_id`). *(Ideia resgatada da KMEE, crédito ao
  autor original.)*

### Preparação para SPED / Reforma Tributária

- **Preserva o CFOP declarado pelo emitente** (`[IMP] preserve counterparty CFOP
  on import`): novo campo `partner_cfop_id` (armazenado, na mixin da linha
  fiscal) guarda o CFOP como declarado pelo fornecedor, enquanto `cfop_id`
  segue refletindo a operação de entrada da empresa após o de-para. Necessário
  para a escrituração / SPED (notadamente C197) e, adiante, para o IBS/CBS da
  reforma, onde o crédito deve refletir o que a contraparte declarou.

## Créditos

Três commits reimplementam de perto ideias da PR #3546 da KMEE e são atribuídos
ao autor original **Luis Felipe Miléo <mileo@kmee.com.br>** (operação por CFOP
majoritário, validação de integridade, criação de imposto ICMS com redução).
Os demais são trabalho novo ou redesenhos sobre a base 16.0.

## Testes

Todos os testes de `l10n_br_nfe` (108), `l10n_br_account_nfe` (22) e
`l10n_br_fiscal` passam na base `odoo16` (0 falhas, 0 erros). Cada melhoria
funcional acompanha teste dedicado (CFOP majoritário, integridade, alerta de
CFOP, alerta e criação de imposto com redução, `partner_cfop_id`).