### PR TITLE
[16.0][FIX] spec_driven_model: Carregar as classes *_spec com as classes herdadas

### DIFF
--- a/spec_driven_model/models/spec_mixin.py
+++ b/spec_driven_model/models/spec_mixin.py
@@ -4,6 +4,7 @@
 from importlib import import_module
 
 from odoo import api, models
+from odoo.models import is_definition_class
 from odoo.tools import mute_logger
 
 from .spec_models import SPEC_MIXIN_MAPPINGS, SpecModel, StackedModel
@@ -128,7 +129,25 @@ class SpecMixin(models.AbstractModel):
             spec_class = StackedModel._odoo_name_to_class(name, spec_module)
             if spec_class is None:
                 continue
-            fields = self.env[spec_class._name]._fields
+            # By the time this hook runs, all modules extending this spec
+            # mixin via _inherit (e.g. custom fields added by a downstream
+            # *_nfe module) have already been merged by Odoo into the
+            # registry class for `name`. spec_class only reflects the single
+            # class literally defined in spec_module though, so using it
+            # alone as the base below would silently drop those extra
+            # fields. Pull in every genuine definition class that
+            # contributed to the merged registry class (skipping registry
+            # ("NewClass") wrappers themselves, which cannot safely be reused
+            # as a base for another _build_model() call).
+            merged_class = self.env.registry[name]
+            # accessed via getattr to avoid Python's name mangling of the
+            # double-underscore "__base_classes" attribute set by Odoo's
+            # BaseModel._build_model()
+            merged_base_classes = merged_class._BaseModel__base_classes
+            definition_bases = tuple(
+                base for base in merged_base_classes if is_definition_class(base)
+            )
+            fields = merged_class._fields
             rec_name = next(
                 filter(
                     lambda x: (x.startswith(field_prefix) and "_choice" not in x),
@@ -138,7 +157,7 @@ class SpecMixin(models.AbstractModel):
             )
             model_type = type(
                 name,
-                (SpecModel, spec_class),
+                (SpecModel,) + definition_bases,
                 {
                     "_name": name,
                     "_inherit": spec_class._inherit,


### PR DESCRIPTION
Em spec_driven_model/models/spec_mixin.py, no método _register_remaining_schema_models_hook, os modelos "spec" que não são injetados (stacked) em nenhum modelo concreto — como nfe.40.di — são promovidos automaticamente para modelos concretos assim:

```python
spec_class = StackedModel._odoo_name_to_class(name, spec_module)
model_type = type(name, (SpecModel, spec_class), {"_inherit": spec_class._inherit, ...})
```

spec_class é obtido via getmembers() escaneando apenas o módulo gerado do XSD (l10n_br_nfe_spec/models/v4_0/leiaute_nfe_v4_00.py). Ele não reflete a classe já mesclada pelo registro do Odoo, que inclui as extensões feitas em outros módulos via _inherit = "nfe.40.di" por exemplo.

A correção é ao montar model_type, agora buscamos as classes de definição genuínas que já foram mescladas na classe abstrata do registro (self.env.registry[name].__base_classes, filtradas com is_definition_class) em vez de usar apenas spec_class. Isso preserva todos os campos adicionados por módulos de extensão.