### PR TITLE
[16.0][IMP] l10n_br_account: partial indexes on the fiscal document links

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -60,6 +60,7 @@ class AccountMove(models.Model):
         ondelete="cascade",
         store=True,
         readonly=False,
+        index="btree_not_null",
     )
 
     fiscal_document_ids = fields.One2many(

--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -24,6 +24,7 @@ class AccountMoveLine(models.Model):
         string="Fiscal Document Line",
         copy=False,
         ondelete="cascade",
+        index="btree_not_null",
     )
 
     document_type_id = fields.Many2one(


### PR DESCRIPTION
## Resumo

Adiciona `index="btree_not_null"` aos dois campos de delegação do `_inherits` que ligam os registros contábeis às suas contrapartes fiscais:

- `account.move.fiscal_document_id`
- `account.move.line.fiscal_document_line_id`

O ORM cria os índices parciais (`WHERE ... IS NOT NULL`) no upgrade do módulo.

## Problema

O `account.move` é buscado por documento fiscal em todo sync fiscal — faturar pelo picking (`stock_picking_invoicing` + glue do l10n_br) dispara centenas dessas buscas por fatura, via os writes das linhas de documento (os triggers do ORM emitem `WHERE fiscal_document_id IN (...)`). Sem índice, cada busca faz **seq scan na tabela inteira de `account_move`**: em base real com 88k lançamentos, o `EXPLAIN` mostra `Seq Scan on account_move (88.407 rows)`, ~15ms por chamada — **~5 segundos desperdiçados por fatura**. O espelho da linha (`fiscal_document_line_id`, 482k linhas, também sem índice) sofre o mesmo padrão nas leituras de `move_line_ids`.

**Impacto medido** em base de tamanho de produção (picking de 42 linhas, execução warm): faturamento caiu de **9.6s para 5.7s** por fatura.

## Por que `btree_not_null` (e não `index=True`)

Em base real, **~76% dos lançamentos e ~75% das linhas não têm contraparte fiscal** (pagamentos, lançamentos diversos), e NULL nunca é buscado — não existe nenhum domain no repo filtrando `fiscal_document_id = False` ou `fiscal_document_line_id = False`. O índice parcial atende as mesmas consultas com índice ~4x menor e zero overhead de escrita nas linhas NULL — o caso de livro do `btree_not_null`.

Bônus: como os campos têm `ondelete="cascade"`, o índice também acelera a validação da FK ao deletar documentos fiscais (sem ele o PG seq-scaneia a tabela referenciadora a cada linha deletada).

## Precedente no core do Odoo

É exatamente o que o core faz nos seus próprios "decorators" `_inherits` de `account.move`. O `account.payment` e o `account.bank.statement.line` delegam pro `account.move` como o `l10n_br_account` delega pro `l10n_br_fiscal.document`, e o core indexa os dois lados do link:

- Lado da delegação (required): `account.payment.move_id` e `account.bank.statement.line.move_id` → `index=True`
- Lado do move (NULL na maioria dos lançamentos): `account.move.payment_id` e `account.move.statement_line_id` → `index='btree_not_null'` ([account_move.py L166-L181](https://github.com/odoo/odoo/blob/16.0/addons/account/models/account_move.py#L166-L181))

`fiscal_document_id` é semanticamente idêntico a `payment_id`: aponta pra contraparte especializada do lançamento e é NULL quando ele não é daquele tipo. Outros exemplos do mesmo padrão no 16.0: `account_move.stock_move_id` (stock_account), `pos_order.account_move` (point_of_sale), `stock_move.sale_line_id` (sale_stock), `stock_move.purchase_line_id` (purchase_stock) — e na própria `account.move.line`: `payment_id`, `statement_id`, `full_reconcile_id`.

## Validação

- Suíte do `l10n_br_account`: 85/85 verde.
- Red-green em instalações limpas: com `index=True` os índices saem cheios; com `btree_not_null` saem parciais (predicado `IS NOT NULL` confirmado no `pg_indexes.indexdef`).

