### PR TITLE
[16.0][REM] l10n_br_sale, l10n_br_nfse: remove dead code from the old _compute_taxes

### DIFF
--- a/l10n_br_nfse/models/document_line.py
+++ b/l10n_br_nfse/models/document_line.py
@@ -29,13 +29,6 @@ class DocumentLine(models.Model):
             if line.product_id and line.product_id.fiscal_deductions_value:
                 line.fiscal_deductions_value = line.product_id.fiscal_deductions_value
 
-    def _compute_taxes(self, taxes, cst=None):
-        discount_value = self.discount_value
-        self.discount_value += self.fiscal_deductions_value
-        res = super()._compute_taxes(taxes, cst)
-        self.discount_value = discount_value
-        return res
-
     @api.model
     def fields_view_get(
         self, view_id=None, view_type="form", toolbar=False, submenu=False

--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -1,12 +1,8 @@
 # Copyright (C) 2009  Renato Lima - Akretion
 # Copyright (C) 2012  Raphaël Valyi - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
-from functools import partial
-
 from odoo import api, fields, models
 from odoo.exceptions import UserError
-from odoo.tools import float_is_zero
-from odoo.tools.misc import formatLang
 
 
 class SaleOrder(models.Model):
@@ -187,40 +183,6 @@ class SaleOrder(models.Model):
                 result["journal_id"] = self.fiscal_operation_id.journal_id.id
 
         return result
-
-    def _amount_by_group(self):
-        for order in self:
-            currency = order.currency_id or order.company_id.currency_id
-            fmt = partial(
-                formatLang,
-                self.with_context(lang=order.partner_id.lang).env,
-                currency_obj=currency,
-            )
-            res = {}
-            for line in order.order_line:
-                taxes = line._compute_taxes(line.fiscal_tax_ids)["taxes"]
-                for tax in line.fiscal_tax_ids:
-                    computed_tax = taxes.get(tax.tax_domain)
-                    pr = order.currency_id.rounding
-                    if computed_tax and not float_is_zero(
-                        computed_tax.get("tax_value", 0.0), precision_rounding=pr
-                    ):
-                        group = tax.tax_group_id
-                        res.setdefault(group, {"amount": 0.0, "base": 0.0})
-                        res[group]["amount"] += computed_tax.get("tax_value", 0.0)
-                        res[group]["base"] += computed_tax.get("base", 0.0)
-            res = sorted(res.items(), key=lambda line: line[0].sequence)
-            order.amount_by_group = [
-                (
-                    line[0].name,
-                    line[1]["amount"],
-                    line[1]["base"],
-                    fmt(line[1]["amount"]),
-                    fmt(line[1]["base"]),
-                    len(res),
-                )
-                for line in res
-            ]
 
     def _get_fiscal_partner(self):
         self.ensure_one()


### PR DESCRIPTION
## O que

Remove dois restos do refactor do motor de impostos (quando `_compute_taxes` da `l10n_br_fiscal.document.line` deixou de existir):

- **l10n_br_sale**: `_amount_by_group` — nunca é chamado (o campo `amount_by_group` não existe em lugar nenhum; o Odoo 16 o substituiu por `tax_totals`). Se fosse chamado, quebraria duas vezes: `sale.order.line` não tem `_compute_taxes` e a atribuição é a um campo inexistente. Sobra da 14.0/15.0.
- **l10n_br_nfse**: override de `_compute_taxes` — inalcançável; o `super()._compute_taxes(...)` não existe mais em lugar nenhum e nada o chama.

## Atenção

O override do nfse era o mecanismo que fazia `fiscal_deductions_value` **reduzir a base de cálculo** durante a apuração. Isso está silenciosamente inerte desde o refactor — hoje o campo só alimenta `valor_deducoes` no XML da NFS-e. Se essa redução de base ainda for desejada, precisa ser reimplementada no motor novo (tarefa separada; esta PR só remove o código morto).

Sem mudança de comportamento: nenhum dos dois caminhos é executável hoje.
