### PR TITLE
[16.0] teste do update da nfelib

### DIFF
--- a/l10n_br_cte_spec/tests/test_cte_import.py
+++ b/l10n_br_cte_spec/tests/test_cte_import.py
@@ -3,7 +3,9 @@
 # flake8: noqa: C901
 
 import re
+import typing
 from datetime import datetime
+from functools import cache
 
 import nfelib
 import pkg_resources
@@ -17,6 +19,38 @@ from odoo.tools import OrderedSet
 from ..models import spec_mixin
 
 tz_datetime = re.compile(r".*[-+]0[0-9]:00$")
+
+
+@cache
+def _resolve_type_hints(cls):
+    """Resolve a binding dataclass' annotations into real typing objects.
+
+    xsdata >= 26 emits ``from __future__ import annotations`` (PEP 563) so
+    ``field.type`` is a plain string; get_type_hints evaluates it back into
+    real types. Safe for older xsdata versions too.
+    """
+    try:
+        return typing.get_type_hints(cls)
+    except Exception:
+        return {}
+
+
+def _unwrap_binding_type(ftype):
+    """Return (inner_type_or_None, is_list) for a resolved annotation."""
+    origin = typing.get_origin(ftype)
+    if origin is list:
+        args = typing.get_args(ftype)
+        return (args[0] if args else None, True)
+    if origin is not None:
+        for arg in typing.get_args(ftype):
+            if arg is type(None):
+                continue
+            if typing.get_origin(arg) is list:
+                largs = typing.get_args(arg)
+                return (largs[0] if largs else None, True)
+            return (arg, False)
+        return (None, False)
+    return (ftype, False)
 
 
 @api.model
@@ -34,6 +68,7 @@ def build_attrs_fake(self, node, create_m2o=False):
     """
     fields = self.fields_get()
     vals = self.default_get(fields.keys())
+    hints = _resolve_type_hints(type(node))
     for fname, fspec in node.__dataclass_fields__.items():
         if fname == "any_element":  # FIXME in spec_driven_model
             continue
@@ -41,9 +76,12 @@ def build_attrs_fake(self, node, create_m2o=False):
         if value is None:
             continue
         key = f"{self._field_prefix}{fname}"
-        if (
-            fspec.type == str or not any(["." in str(i) for i in fspec.type.__args__])
-        ) and not str(fspec.type).startswith("typing.List"):
+        ftype = hints.get(fname, fspec.type)
+        inner_type, is_list = _unwrap_binding_type(ftype)
+        is_complex = inner_type is not None and hasattr(
+            inner_type, "__dataclass_fields__"
+        )
+        if not is_complex:
             # SimpleType
             if fields[key]["type"] == "datetime":
                 if "T" in value:
@@ -55,10 +93,7 @@ def build_attrs_fake(self, node, create_m2o=False):
             vals[key] = value
 
         else:
-            if hasattr(fspec.type.__args__[0], "__name__"):
-                binding_type = fspec.type.__args__[0].__name__
-            else:
-                binding_type = fspec.type.__args__[0].__forward_arg__
+            binding_type = inner_type.__qualname__
 
             # ComplexType
             if fields.get(key) and fields[key].get("related"):
@@ -79,7 +114,7 @@ def build_attrs_fake(self, node, create_m2o=False):
             if comodel is None:  # example skip ICMS100 class
                 continue
 
-            if not str(fspec.type).startswith("typing.List"):
+            if not is_list:
                 # m2o
                 new_value = comodel.build_attrs_fake(
                     value,

--- a/l10n_br_mdfe_spec/tests/test_mdfe_import.py
+++ b/l10n_br_mdfe_spec/tests/test_mdfe_import.py
@@ -3,7 +3,9 @@
 # flake8: noqa: C901
 
 import re
+import typing
 from datetime import datetime
+from functools import cache
 
 import nfelib
 import pkg_resources
@@ -17,6 +19,38 @@ from odoo.tools import OrderedSet
 from ..models import spec_mixin
 
 tz_datetime = re.compile(r".*[-+]0[0-9]:00$")
+
+
+@cache
+def _resolve_type_hints(cls):
+    """Resolve a binding dataclass' annotations into real typing objects.
+
+    xsdata >= 26 emits ``from __future__ import annotations`` (PEP 563) so
+    ``field.type`` is a plain string; get_type_hints evaluates it back into
+    real types. Safe for older xsdata versions too.
+    """
+    try:
+        return typing.get_type_hints(cls)
+    except Exception:
+        return {}
+
+
+def _unwrap_binding_type(ftype):
+    """Return (inner_type_or_None, is_list) for a resolved annotation."""
+    origin = typing.get_origin(ftype)
+    if origin is list:
+        args = typing.get_args(ftype)
+        return (args[0] if args else None, True)
+    if origin is not None:
+        for arg in typing.get_args(ftype):
+            if arg is type(None):
+                continue
+            if typing.get_origin(arg) is list:
+                largs = typing.get_args(arg)
+                return (largs[0] if largs else None, True)
+            return (arg, False)
+        return (None, False)
+    return (ftype, False)
 
 
 @api.model
@@ -34,6 +68,7 @@ def build_attrs_fake(self, node, create_m2o=False):
     """
     fields = self.fields_get()
     vals = self.default_get(fields.keys())
+    hints = _resolve_type_hints(type(node))
     for fname, fspec in node.__dataclass_fields__.items():
         if fname == "any_element":  # FIXME in spec_driven_model
             continue
@@ -41,9 +76,12 @@ def build_attrs_fake(self, node, create_m2o=False):
         if value is None:
             continue
         key = f"mdfe30_{fspec.metadata.get('name', fname)}"
-        if (
-            fspec.type == str or not any(["." in str(i) for i in fspec.type.__args__])
-        ) and not str(fspec.type).startswith("typing.List"):
+        ftype = hints.get(fname, fspec.type)
+        inner_type, is_list = _unwrap_binding_type(ftype)
+        is_complex = inner_type is not None and hasattr(
+            inner_type, "__dataclass_fields__"
+        )
+        if not is_complex:
             # SimpleType
             if fields[key]["type"] == "datetime":
                 if "T" in value:
@@ -55,10 +93,7 @@ def build_attrs_fake(self, node, create_m2o=False):
             vals[key] = value
 
         else:
-            if hasattr(fspec.type.__args__[0], "__name__"):
-                binding_type = fspec.type.__args__[0].__name__
-            else:
-                binding_type = fspec.type.__args__[0].__forward_arg__
+            binding_type = inner_type.__qualname__
 
             # ComplexType
             if fields.get(key) and fields[key].get("related"):
@@ -71,7 +106,7 @@ def build_attrs_fake(self, node, create_m2o=False):
             if comodel is None:  # example skip ICMS100 class
                 continue
 
-            if not str(fspec.type).startswith("typing.List"):
+            if not is_list:
                 # m2o
                 new_value = comodel.build_attrs_fake(
                     value,

--- a/l10n_br_nfe_spec/tests/test_nfe_import.py
+++ b/l10n_br_nfe_spec/tests/test_nfe_import.py
@@ -3,7 +3,9 @@
 # flake8: noqa: C901
 
 import re
+import typing
 from datetime import datetime
+from functools import cache
 
 import nfelib
 import pkg_resources
@@ -17,6 +19,38 @@ from odoo.tools import OrderedSet
 from ..models import spec_mixin
 
 tz_datetime = re.compile(r".*[-+]0[0-9]:00$")
+
+
+@cache
+def _resolve_type_hints(cls):
+    """Resolve a binding dataclass' annotations into real typing objects.
+
+    xsdata >= 26 emits ``from __future__ import annotations`` (PEP 563) so
+    ``field.type`` is a plain string; get_type_hints evaluates it back into
+    real types. Safe for older xsdata versions too.
+    """
+    try:
+        return typing.get_type_hints(cls)
+    except Exception:
+        return {}
+
+
+def _unwrap_binding_type(ftype):
+    """Return (inner_type_or_None, is_list) for a resolved annotation."""
+    origin = typing.get_origin(ftype)
+    if origin is list:
+        args = typing.get_args(ftype)
+        return (args[0] if args else None, True)
+    if origin is not None:
+        for arg in typing.get_args(ftype):
+            if arg is type(None):
+                continue
+            if typing.get_origin(arg) is list:
+                largs = typing.get_args(arg)
+                return (largs[0] if largs else None, True)
+            return (arg, False)
+        return (None, False)
+    return (ftype, False)
 
 
 @api.model
@@ -33,14 +67,18 @@ def build_attrs_fake(self, node, create_m2o=False):
     """
     fields = self.fields_get()
     vals = self.default_get(fields.keys())
+    hints = _resolve_type_hints(type(node))
     for fname, fspec in node.__dataclass_fields__.items():
         value = getattr(node, fname)
         if value is None:
             continue
         key = f"nfe40_{fspec.metadata.get('name', fname)}"
-        if (
-            fspec.type == str or not any(["." in str(i) for i in fspec.type.__args__])
-        ) and not str(fspec.type).startswith("typing.List"):
+        ftype = hints.get(fname, fspec.type)
+        inner_type, is_list = _unwrap_binding_type(ftype)
+        is_complex = inner_type is not None and hasattr(
+            inner_type, "__dataclass_fields__"
+        )
+        if not is_complex:
             # SimpleType
             if fields[key]["type"] == "datetime":
                 if "T" in value:
@@ -52,10 +90,7 @@ def build_attrs_fake(self, node, create_m2o=False):
             vals[key] = value
 
         else:
-            if hasattr(fspec.type.__args__[0], "__name__"):
-                binding_type = fspec.type.__args__[0].__name__
-            else:
-                binding_type = fspec.type.__args__[0].__forward_arg__
+            binding_type = inner_type.__qualname__
 
             # ComplexType
             if fields.get(key) and fields[key].get("related"):
@@ -68,7 +103,7 @@ def build_attrs_fake(self, node, create_m2o=False):
             if comodel is None:  # example skip ICMS100 class
                 continue
 
-            if not str(fspec.type).startswith("typing.List"):
+            if not is_list:
                 # m2o
                 new_value = comodel.build_attrs_fake(
                     value,

--- a/spec_driven_model/models/spec_import.py
+++ b/spec_driven_model/models/spec_import.py
@@ -2,13 +2,14 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
 
 import dataclasses
+import functools
 import inspect
 import itertools
 import logging
 import re
+import typing
 from datetime import datetime
 from enum import Enum
-from typing import ForwardRef
 
 from odoo import Command, api, models
 
@@ -16,6 +17,55 @@ _logger = logging.getLogger(__name__)
 
 
 tz_datetime = re.compile(r".*[-+]0[0-9]:00$")
+
+
+@functools.cache
+def _resolve_type_hints(cls):
+    """Resolve a dataclass' annotations into real runtime typing objects.
+
+    xsdata >= 26 generates bindings with ``from __future__ import annotations``
+    (PEP 563), so every ``field.type`` is a plain string such as
+    ``"list[Foo.Bar]"`` or ``"None | Foo"`` instead of a real typing object.
+    ``typing.get_type_hints`` evaluates those lazy annotations back into real
+    types. It is also safe (and normalizing) for older xsdata versions where
+    the annotations were already concrete objects (e.g. ``typing.List`` or
+    ``Optional[ForwardRef(...)]``).
+
+    Cached because it is called for every field of every node during import.
+    """
+    try:
+        return typing.get_type_hints(cls)
+    except Exception:  # pragma: no cover - defensive fallback
+        return {}
+
+
+def _unwrap_binding_type(ftype):
+    """Classify a resolved field annotation.
+
+    Returns a ``(inner_type, is_list)`` tuple where ``inner_type`` is the
+    meaningful (non ``NoneType``) type wrapped by the annotation, or ``None``
+    when it cannot be determined. Handles:
+
+    * ``list[X]`` / ``typing.List[X]``  -> (X, True)      # o2m
+    * ``Optional[X]`` / ``X | None``    -> (X, False)     # m2o / simple
+    * bare ``X`` (e.g. ``str``)         -> (X, False)     # simple
+    """
+    origin = typing.get_origin(ftype)
+    if origin is list:
+        args = typing.get_args(ftype)
+        return (args[0] if args else None, True)
+    if origin is not None:
+        # Optional[...] / Union[...] / X | None
+        for arg in typing.get_args(ftype):
+            if arg is type(None):
+                continue
+            # Optional wrapping a list is theoretically possible: unwrap it too
+            if typing.get_origin(arg) is list:
+                largs = typing.get_args(arg)
+                return (largs[0] if largs else None, True)
+            return (arg, False)
+        return (None, False)
+    return (ftype, False)
 
 
 class SpecMixinImport(models.AbstractModel):
@@ -79,14 +129,19 @@ class SpecMixinImport(models.AbstractModel):
         child_path = f"{path}.{key}"
 
         # Is attr a xsd SimpleType or a ComplexType?
-        # with xsdata a ComplexType can have a type like:
-        # typing.Union[nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00.TinfRespTec, NoneType]
-        # or typing.Union[ForwardRef('Tnfe.InfNfe.Det.Imposto'), NoneType]
-        # that's why we test if the 1st Union type is a dataclass or a ForwardRef
-        if attr[1].type == str or (
-            not isinstance(attr[1].type.__args__[0], ForwardRef)
-            and not dataclasses.is_dataclass(attr[1].type.__args__[0])
-        ):
+        # A ComplexType field points to another binding dataclass, e.g.:
+        #   Optional[TinfRespTec]            (m2o, resolved class)
+        #   Optional[ForwardRef('Tnfe...')]  (m2o, xsdata < 26 forward ref)
+        #   list['Tnfe.InfNfe.Det']          (o2m)
+        # xsdata >= 26 emits ``from __future__ import annotations`` (PEP 563)
+        # so every ``attr[1].type`` is a plain string; we must resolve the real
+        # runtime types with typing.get_type_hints before introspecting them.
+        hints = _resolve_type_hints(type(node))
+        ftype = hints.get(attr[0], attr[1].type)
+        inner_type, is_list = _unwrap_binding_type(ftype)
+        is_complex = inner_type is not None and dataclasses.is_dataclass(inner_type)
+
+        if not is_complex:
             # SimpleType
             if isinstance(value, Enum):
                 value = value.value
@@ -100,14 +155,11 @@ class SpecMixinImport(models.AbstractModel):
             vals[key] = value
 
         else:
-            if str(attr[1].type).startswith("typing.List") or "ForwardRef" in str(
-                attr[1].type
-            ):  # o2m
-                binding_type = attr[1].type.__args__[0].__forward_arg__
-            else:
-                binding_type = attr[1].type.__args__[0].__name__
+            # ComplexType: use the qualified binding class name (e.g.
+            # "Tnfe.InfNfe.Det") which is what the xsdata-odoo generated
+            # abstract models are keyed on.
+            binding_type = inner_type.__qualname__
 
-            # ComplexType
             if fields.get(key) and fields[key].related:
                 if fields[key].readonly and fields[key].type == "many2one":
                     return False  # ex: don't import NFe infRespTec
@@ -125,7 +177,7 @@ class SpecMixinImport(models.AbstractModel):
             if comodel is None:  # example skip ICMS100 class
                 return
 
-            if str(attr[1].type).startswith("typing.List"):
+            if is_list:
                 # o2m
                 lines = []
                 for line in [li for li in value if li]:


### PR DESCRIPTION
PR para testar a compatibilidade com a próxima versão da nflelib que atualiza os schemas da NFe e da CTe mas principalmente pula do xsdata 24.11 pro 26.2, que é algo necessário para remover os warnings de Enum com valores errados com CTe e MDFe. Porém vale anotar que essa versão vai remover a compatibilidade com  Python 3.8 e então Odoo 14.