### PR TITLE
[16.0][FIX] spec_driven_model: keep the concrete models it builds out of module_to_models

### DIFF
--- a/spec_driven_model/models/spec_mixin.py
+++ b/spec_driven_model/models/spec_mixin.py
@@ -125,6 +125,9 @@ class SpecMixin(models.AbstractModel):
             odoo_module = spec_module.split("_spec.")[0].split(".")[-1]
         else:  # for tests:
             odoo_module = "spec_driven_model"
+        # concrete classes we build below, tracked so we can drop them
+        # from module_to_models at the end of this method
+        concrete_models = []
         for name in remaining_models:
             spec_class = StackedModel._odoo_name_to_class(name, spec_module)
             if spec_class is None:
@@ -171,6 +174,7 @@ class SpecMixin(models.AbstractModel):
             model_type._spec_schema = spec_schema
             model_type._spec_version = spec_version
             models.MetaModel.module_to_models[odoo_module] += [model_type]
+            concrete_models.append(model_type)
 
             # now we init these models properly
             # a bit like odoo.modules.loading#load_module_graph would do
@@ -214,6 +218,20 @@ class SpecMixin(models.AbstractModel):
         )
         with mute_logger("odoo.models"):
             imd_recs.unlink()
+
+        # The concrete classes we built above are rebuilt from scratch every
+        # time this hook runs, but Odoo's MetaModel registered them in
+        # module_to_models, which persists across registry rebuilds. Leaving
+        # them there would make the next Registry.new() -- triggered by any
+        # module install/update -- rebuild these *stale* classes as extra bases
+        # of their model; being subclasses of the downstream classes that extend
+        # the model via _inherit, they break the C3 linearization and crash
+        # setup_models() with an inconsistent MRO (#4668). Drop exactly the ones
+        # we just built; the hook recreates them on every registry (re)load.
+        registered = models.MetaModel.module_to_models[odoo_module]
+        models.MetaModel.module_to_models[odoo_module] = [
+            cls for cls in registered if cls not in concrete_models
+        ]
 
     @classmethod
     def _auto_fill_access_data(cls, env, module_name: str, access_data: list):

--- a/spec_driven_model/tests/fake_comment_extension.py
+++ b/spec_driven_model/tests/fake_comment_extension.py
@@ -1,0 +1,18 @@
+# Copyright 2026 Akretion - Raphael Valyi <raphael.valyi@akretion.com>
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
+from odoo import fields, models
+
+
+class CommentExtension(models.AbstractModel):
+    """Downstream extension of the *remaining* spec model poxsd.10.comment.
+
+    poxsd.10.comment is never injected into a concrete Odoo model, so the
+    _register_remaining_schema_models_hook turns it into a concrete model on
+    its own. This class mirrors how a downstream module (e.g. l10n_br_account_nfe
+    for nfe.40.detpag) adds a field to such a remaining model via _inherit. It is
+    what makes the leaked synthesized class fatal on a registry rebuild (#4668).
+    """
+
+    _inherit = "poxsd.10.comment"
+
+    poxsd10_extra = fields.Char(string="extra")

--- a/spec_driven_model/tests/test_spec_model.py
+++ b/spec_driven_model/tests/test_spec_model.py
@@ -40,6 +40,10 @@ class TestSpecModel(TransactionCase, FakeModelLoader):
             PurchaseOrderLine as SpecPurchaseOrderLine,
         )
 
+        # a downstream _inherit extension of the remaining model poxsd.10.comment
+        # (mirrors l10n_br_account_nfe extending nfe.40.detpag, see issue #4668)
+        from .fake_comment_extension import CommentExtension
+
         cls.loader.update_registry(
             (
                 PoXsdMixin,
@@ -47,6 +51,7 @@ class TestSpecModel(TransactionCase, FakeModelLoader):
                 Item,
                 Usaddress,
                 Comment,
+                CommentExtension,
                 PurchaseOrderType,
                 ResPartner,
                 FakePurchaseOrder,
@@ -240,3 +245,86 @@ class TestSpecModel(TransactionCase, FakeModelLoader):
 
         assert actual_calls == expected_model_suffixes
         assert mock_get_concrete_model.call_count == len(expected_model_suffixes)
+
+    def test_registry_reload_with_extended_remaining_model(self):
+        """Regression test for issue #4668.
+
+        _register_remaining_schema_models_hook turns *remaining* spec models
+        (those not injected into a concrete Odoo model, e.g. poxsd.10.comment
+        or nfe.40.detpag) into concrete models by building a class
+        ``type(name, (SpecModel, *definition_bases))``. A real server rebuilds
+        the whole registry (``Registry.new``) on every module install/update.
+        If that concrete class lingers in ``MetaModel.module_to_models``, that
+        rebuild re-consumes it as a stale base of the model; being a subclass of
+        the very classes that extend the model via ``_inherit`` (here
+        CommentExtension, like l10n_br_account_nfe for nfe.40.detpag), Odoo
+        accumulates it after the extension and ``setup_models`` crashes with
+        "Cannot create a consistent method resolution order".
+        """
+        from unittest import mock
+
+        from odoo_test_helper.fake_model_loader import FakePackage
+
+        from odoo.models import MetaModel, is_definition_class
+
+        from odoo.addons.spec_driven_model.models.spec_models import SpecModel
+
+        from .fake_comment_extension import CommentExtension
+        from .fake_mixin import PoXsdMixin
+        from .spec_poxsd import Comment
+
+        registry = self.env.registry
+        cr = self.env.cr
+        module_to_models = MetaModel.module_to_models
+
+        def concrete_classes_left():
+            # the concrete class the hook builds for poxsd.10.comment is a
+            # SpecModel subclass named after the model (the genuine definition
+            # classes -- Comment, CommentExtension -- are plain AbstractModels)
+            return [
+                cls
+                for cls in module_to_models["spec_driven_model"]
+                if is_definition_class(cls)
+                and issubclass(cls, SpecModel)
+                and cls._name == "poxsd.10.comment"
+            ]
+
+        def clear_hook_guard():
+            # a fresh Registry.new() has no per-schema guard, so the hook runs
+            registry.__dict__.pop("_poxsd_register_hook_loaded", None)
+
+        ready = registry.ready
+        saved_module_classes = list(module_to_models["spec_driven_model"])
+        try:
+            # build #1: rebuild the remaining model and its downstream _inherit
+            # extension as abstract mixins, then run setup_models() so the hook
+            # builds the concrete poxsd.10.comment (setup_models only runs
+            # the registry hooks when the registry is ready, as after a real
+            # module load). On a real server this concrete class stays
+            # registered in module_to_models across registry rebuilds; the fix
+            # must not leave it there.
+            clear_hook_guard()
+            self.loader.update_registry((PoXsdMixin, Comment, CommentExtension))
+            registry.ready = True
+            registry.setup_models(cr)
+
+            self.assertEqual(
+                concrete_classes_left(),
+                [],
+                "the hook left a concrete class in module_to_models; "
+                "the next Registry.new() would rebuild it as a stale base and "
+                "crash with an inconsistent MRO (#4668)",
+            )
+
+            # build #2: mimic the next Registry.new() -- re-consume
+            # module_to_models and re-run setup_models() without scrubbing it
+            # first (as a real server does). Were a stale concrete class
+            # present, Odoo would rebuild it as a base of poxsd.10.comment and
+            # raise "Cannot create a consistent method resolution order".
+            clear_hook_guard()
+            with mock.patch.object(cr, "commit"):
+                registry.load(cr, FakePackage("spec_driven_model"))
+                registry.setup_models(cr)
+        finally:
+            module_to_models["spec_driven_model"] = saved_module_classes
+            registry.ready = ready


### PR DESCRIPTION
Corrige #4668

## Problema

Numa base com `l10n_br_nfe`, instalar/atualizar um módulo a partir de um servidor no ar quebra com:

    TypeError: Cannot create a consistent method resolution order (MRO)
    for bases DetPag, nfe.40.detpag, spec.mixin.nfe, base

Só acontece no **segundo** `Registry.new()` do processo (ex.: botão Instalar/Atualizar: `button_immediate_install` → `Registry.new(update_module=True)`), não no boot a frio / `-u`. Por isso instalar funciona, mas atualizar uma base no ar falha.

## Causa raiz

O `_register_remaining_schema_models_hook` torna concretos os spec models *remaining* (os que não são injetados em nenhum modelo concreto, ex.: `nfe.40.detpag`) construindo uma classe `type(name, (SpecModel, *definition_bases))`.

O `MetaModel` do Odoo registra toda classe de modelo em `MetaModel.module_to_models`, que persiste entre reconstruções do registry. No `Registry.new()` seguinte, o `Registry.load()` reconstrói essa classe obsoleta como base extra do modelo. Desde a #4664 a classe é construída a partir das bases mescladas do registry, então ela vira subclasse das classes que estendem o modelo via `_inherit` (ex.: o `DetPag` do `l10n_br_account_nfe` sobre `nfe.40.detpag`). O Odoo então ordena a extensão *antes* da própria subclasse em `__base_classes`, e o `setup_models()` → `_prepare_setup()` falha a linearização C3.

## Correção

Remover do `module_to_models`, no fim do hook, as classes concretas que ele constrói. Elas são reconstruídas a cada (re)carga do registry, então não precisam persistir — mantê-las só envenena a próxima reconstrução.

## Teste

`test_registry_reload_with_extended_remaining_model` reproduz as duas reconstruções de registry com o schema fake PurchaseOrder: um modelo *remaining* (`poxsd.10.comment`) estendido via `_inherit` (`CommentExtension`, espelhando o `DetPag`). Falha no 16.0 antes deste patch e passa depois.

Também validado de ponta a ponta com módulos reais: numa base com `l10n_br_account_nfe` instalado, disparar um segundo `Registry.new(update_module=True)` no mesmo processo quebra antes da correção e passa depois.
