### PR TITLE
[16.0][FIX] l10n_br_nfse_focus: nfse_nacional

### DIFF
--- a/l10n_br_nfse_focus/models/nfse_nacional.py
+++ b/l10n_br_nfse_focus/models/nfse_nacional.py
@@ -121,6 +121,8 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
             "codigo_opcao_simples_nacional": int(codigo_opcao_simples_nacional),
             "regime_especial_tributacao": int(regime_especial_tributacao),
             "codigo_municipio_emissora": int(company.city_id.ibge_code or 0),
+            "telefone": company.partner_id.phone or "",
+            "email": company.partner_id.email or "",
         }
 
     def _prepare_recipient_nacional(self, recipient_info):
@@ -181,6 +183,8 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
 
         # TODO: improve logic to get ISS retention code
         tipo_retencao_iss = "2" if service_info.get("iss_retido") == "1" else "1"
+        if int(tributacao_iss) in (2, 3, 4):
+            tipo_retencao_iss = "1"
 
         percentual_total_tributos_federais = service_info.get(
             "percentual_total_tributos_federais", 0.0
@@ -246,19 +250,28 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
                 if not base_calculo_pis_cofins or base_calculo_pis_cofins == 0:
                     base_calculo_pis_cofins = round(valor_servico, 2)
 
-        # Format rates as strings with 2 decimal places
-        aliquota_pis_raw = round(service_info.get("aliquota_pis", 0), 2)
-        aliquota_pis = f"{aliquota_pis_raw:.2f}"
-        aliquota_cofins_raw = round(service_info.get("aliquota_cofins", 0), 2)
-        aliquota_cofins = f"{aliquota_cofins_raw:.2f}"
+        valor_pis = round(service_info.get("valor_pis", 0), 2)
+        valor_cofins = round(service_info.get("valor_cofins", 0), 2)
+        if base_calculo_pis_cofins:
+            aliquota_pis = f"{round(valor_pis / base_calculo_pis_cofins * 100, 2):.2f}"
+            aliquota_cofins = (
+                f"{round(valor_cofins / base_calculo_pis_cofins * 100, 2):.2f}"
+            )
+        else:
+            aliquota_pis = "0.00"
+            aliquota_cofins = "0.00"
 
         return {
-            "situacao_tributaria_pis_cofins": situacao_tributaria_pis_cofins or "",
+            **(
+                {"situacao_tributaria_pis_cofins": situacao_tributaria_pis_cofins}
+                if situacao_tributaria_pis_cofins
+                else {}
+            ),
             "base_calculo_pis_cofins": round(base_calculo_pis_cofins, 2),
             "aliquota_pis": aliquota_pis,
             "aliquota_cofins": aliquota_cofins,
-            "valor_pis": round(service_info.get("valor_pis", 0), 2),
-            "valor_cofins": round(service_info.get("valor_cofins", 0), 2),
+            "valor_pis": valor_pis,
+            "valor_cofins": valor_cofins,
             "tipo_retencao_pis_cofins": service_info.get(
                 "tipo_retencao_pis_cofins", "2"
             ),
@@ -296,6 +309,10 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
         service_basic = self._prepare_service_basic_nacional(service_info)
         tax_data = self._prepare_tax_data_nacional(service_info, service_basic["valor"])
 
+        regime_especial_tributacao = provider_data["regime_especial_tributacao"]
+        if service_basic["tributacao_iss"] in (2, 3, 4):
+            regime_especial_tributacao = 0
+
         # Build payload
         payload = {
             "data_emissao": emission_date,
@@ -316,10 +333,20 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
                 if provider_data["inscricao_municipal"]
                 else {}
             ),
+            **(
+                {"telefone_prestador": provider_data["telefone"]}
+                if provider_data["telefone"]
+                else {}
+            ),
+            **(
+                {"email_prestador": provider_data["email"]}
+                if provider_data["email"]
+                else {}
+            ),
             "codigo_opcao_simples_nacional": provider_data[
                 "codigo_opcao_simples_nacional"
             ],
-            "regime_especial_tributacao": provider_data["regime_especial_tributacao"],
+            "regime_especial_tributacao": regime_especial_tributacao,
             **(
                 {"cnpj_tomador": recipient_data["cnpj_limpo"]}
                 if recipient_data["is_cnpj"]
@@ -360,7 +387,16 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
             "valor_servico": service_basic["valor"],
             "tributacao_iss": service_basic["tributacao_iss"],
             "tipo_retencao_iss": service_basic["tipo_retencao_iss"],
-            "percentual_aliquota_relativa_municipio": service_basic["aliquota_iss"],
+            **(
+                {
+                    "percentual_aliquota_relativa_municipio": service_basic[
+                        "aliquota_iss"
+                    ]
+                }
+                if regime_especial_tributacao == 0
+                and service_basic["tributacao_iss"] not in (2, 3, 4)
+                else {}
+            ),
             "percentual_total_tributos_federais": service_basic[
                 "percentual_total_tributos_federais"
             ],
@@ -370,7 +406,6 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
             "percentual_total_tributos_municipais": service_basic[
                 "percentual_total_tributos_municipais"
             ],
-            "indicador_total_tributacao": 0,
             "informacoes_complementares": (
                 rps_info.get("customer_additional_data", False)[:2000]
                 if rps_info.get("customer_additional_data")


### PR DESCRIPTION
## WIP 
@Escodoo HT01925

### Problema
Ao migrar a emissão de NFS-e de um município para o padrão NFS-e Nacional (Focus NFe), o payload gerado por nfse_nacional.py violava validações do XSD/regras de negócio do ambiente nacional, impedindo a emissão. Foram encontrados e corrigidos 4 problemas, revelados em sequência conforme os anteriores eram resolvidos.

### Alterações
indTotTrib enviado incondicionalmente
Removido o envio fixo de "indicador_total_tributacao": 0. Esse campo é alternativo aos percentuais de tributos (pTotTribFed/Est/Mun) — indica que o emitente optou por não informar nenhuma estimativa de tributos. Como o módulo já envia sempre os percentuais, enviar os dois juntos violava a sequência/choice do XSD nacional (indTotTrib: This element is not expected).

Alíquota (pAliq) enviada junto com regime especial de tributação
A NFS-e Nacional não permite informar percentual_aliquota_relativa_municipio quando o prestador possui regime especial de tributação (regime_especial_tributacao != 0) — erro E0604. O campo agora só é incluído no payload quando regime_especial_tributacao == 0.

CST do PIS/COFINS enviado vazio
situacao_tributaria_pis_cofins era sempre incluído no payload, mesmo vazio, violando a enumeração do XSD (CST precisa ser um dos códigos 00–99). O campo agora só é enviado quando há valor.

Inconsistência entre aliquota_pis/aliquota_cofins e valor_pis/valor_cofins
As alíquotas vinham do percentual "normal" do imposto, enquanto os valores podiam vir de um cálculo de retenção (com alíquota diferente), quebrando a regra da Nacional de que base_calculo_pis_cofins × alíquota == valor (erro E0694). As alíquotas agora são derivadas de valor_pis/valor_cofins ÷ base_calculo_pis_cofins, garantindo consistência interna.

IM do prestador nunca enviada
inscricao_municipal_prestador (tag IM) não estava sendo repassada ao payload, mesmo já disponível em rps_info. Passou a ser incluída (quando presente), logo após CNPJ/CPF do prestador.