### PR TITLE
[16.0][FIX] l10n_br_nfse_focus: inscricao_municipal_prestador

### DIFF
--- a/l10n_br_nfse_focus/models/nfse_nacional.py
+++ b/l10n_br_nfse_focus/models/nfse_nacional.py
@@ -108,11 +108,16 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
 
         regime_especial_tributacao = rps_info.get("regime_especial_tributacao") or 0
 
+        inscricao_municipal = ""
+        if company.focusnfe_nfse_nacional_send_im_prestador:
+            inscricao_municipal = rps_info.get("inscricao_municipal") or ""
+
         return {
             "is_cpf": is_cpf_prestador,
             "is_cnpj": is_cnpj_prestador,
             "cpf_limpo": cpf_prestador_limpo,
             "cnpj_limpo": cnpj_prestador_limpo,
+            "inscricao_municipal": inscricao_municipal,
             "codigo_opcao_simples_nacional": int(codigo_opcao_simples_nacional),
             "regime_especial_tributacao": int(regime_especial_tributacao),
             "codigo_municipio_emissora": int(company.city_id.ibge_code or 0),
@@ -304,6 +309,11 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
             **(
                 {"cpf_prestador": provider_data["cpf_limpo"]}
                 if provider_data["is_cpf"]
+                else {}
+            ),
+            **(
+                {"inscricao_municipal_prestador": provider_data["inscricao_municipal"]}
+                if provider_data["inscricao_municipal"]
                 else {}
             ),
             "codigo_opcao_simples_nacional": provider_data[

--- a/l10n_br_nfse_focus/models/res_company.py
+++ b/l10n_br_nfse_focus/models/res_company.py
@@ -71,6 +71,11 @@ class ResCompany(models.Model):
         help="Select whether to use NFSe (municipal) or NFSe Nacional (national) API",
     )
 
+    focusnfe_nfse_nacional_send_im_prestador = fields.Boolean(
+        string="Send Provider Municipal Registration (NFSe Nacional)",
+        default=True,
+    )
+
     def get_focusnfe_token(self):
         """
         Retrieve the appropriate FocusNFe API token based on the current NFSe

--- a/l10n_br_nfse_focus/readme/CONFIGURE.md
+++ b/l10n_br_nfse_focus/readme/CONFIGURE.md
@@ -26,3 +26,10 @@ para a empresa desejada:
     > - **Formato Taxa:** Selecione o formato da taxa (Decimal ou Percentage)
     > - **Incluir Documentos Autorizados na Verificação de Status:** Se marcado, documentos autorizados serão incluídos na verificação de status
     > - **Forçar DANFSE Odoo:** Se marcado, o sistema sempre usará o DANFSE do Odoo ao invés do DANFSE da FocusNFE
+    > - **Enviar Inscrição Municipal do Prestador (NFSe Nacional):** Visível
+    >   quando Tipo FocusNFe NFSe = NFSe Nacional. Por padrão a Inscrição
+    >   Municipal cadastrada na empresa é enviada na DPS. Alguns municípios
+    >   (ex.: Porto Alegre/RS) não possuem a Inscrição Municipal do
+    >   prestador registrada no CNC NFS-e nacional; nesses casos, desmarque
+    >   esta opção para que o campo seja omitido e evitar a rejeição da
+    >   DPS.

--- a/l10n_br_nfse_focus/tests/test_l10n_br_nfse_focus.py
+++ b/l10n_br_nfse_focus/tests/test_l10n_br_nfse_focus.py
@@ -714,6 +714,43 @@ class TestL10nBrNfseFocus(common.TransactionCase):
         self.assertIn("codigo_tributacao_nacional_iss", payload)
         self.assertIn("valor_servico", payload)
 
+    def test_prepare_payload_nacional_send_im_prestador(self):
+        """Tests that the provider IM is sent when the company option is enabled."""
+        nfse_nacional = self.env["focusnfe.nfse.nacional"]
+        edoc = {
+            "rps": PAYLOAD[0]["rps"],
+            "service": PAYLOAD[1]["service"],
+            "recipient": PAYLOAD[2]["recipient"],
+        }
+
+        self.company.city_id = self.env.ref("l10n_br_base.city_3550308")
+        self.company.focusnfe_nfse_nacional_send_im_prestador = True
+
+        payload = nfse_nacional._prepare_payload_nacional(edoc, self.company)
+
+        self.assertEqual(payload.get("inscricao_municipal_prestador"), "12345")
+
+    def test_prepare_payload_nacional_suppress_im_prestador(self):
+        """Tests that the provider IM is omitted when the company option is disabled.
+
+        Some municipalities (e.g. Porto Alegre/RS) do not have the provider's
+        Municipal Registration registered in the national CNC NFS-e environment,
+        and the DPS is rejected if the field is informed in that case.
+        """
+        nfse_nacional = self.env["focusnfe.nfse.nacional"]
+        edoc = {
+            "rps": PAYLOAD[0]["rps"],
+            "service": PAYLOAD[1]["service"],
+            "recipient": PAYLOAD[2]["recipient"],
+        }
+
+        self.company.city_id = self.env.ref("l10n_br_base.city_3550308")
+        self.company.focusnfe_nfse_nacional_send_im_prestador = False
+
+        payload = nfse_nacional._prepare_payload_nacional(edoc, self.company)
+
+        self.assertNotIn("inscricao_municipal_prestador", payload)
+
     @patch(
         "odoo.addons.l10n_br_nfse_focus.models.nfse_nacional.FocusnfeNfseNacional.process_focus_nfse_nacional_document"  # noqa: B950
     )

--- a/l10n_br_nfse_focus/views/res_company.xml
+++ b/l10n_br_nfse_focus/views/res_company.xml
@@ -45,6 +45,10 @@
                     name="focusnfe_nfse_type"
                     attrs="{'invisible': [('provedor_nfse','!=', 'focusnfe')]}"
                 />
+                <field
+                    name="focusnfe_nfse_nacional_send_im_prestador"
+                    attrs="{'invisible': ['|',('provedor_nfse','!=', 'focusnfe'),('focusnfe_nfse_type', '!=', 'nfse_nacional')]}"
+                />
             </field>
             <xpath expr="//field[@name='nfse_ssl_verify']" position="attributes">
                 <attribute name="invisible">0</attribute>


### PR DESCRIPTION
## Objetivo da PR

Na PR #4672 foi comentando isso aqui, essa PR tem como objetivo essa correção

Enfrentamos esse mesmo problema após uma atualização, sempre retornava: ("Error communicating with NFSe Nacional service: 69:0: ERROR: Element '{[http://www.sped.fazenda.gov.br/nfse}indTotTrib](http://www.sped.fazenda.gov.br/nfse%7DindTotTrib)': This element is not expected. ").

O jeito tem sido seguir utilizando a PR: https://github.com/OCA/l10n-brazil/pull/4404 que para nós está estável.

Testei esta PR e o XML foi montado corretamente, sem o erro relacionado ao indTotTrib. Entretanto, a NFS-e foi recusada posteriormente com a seguinte mensagem na aba EDI: "IM do prestador não deve ser informado, pois não existem informações complementares registradas no CNC NFS-e do município emissor informado na DPS."

No nosso caso, o município emissor é Porto Alegre/RS.
A documentação da Focus NFe (https://2025.focusnfe.com.br/guides/nfse/municipios-integrados/municipios-da-nfse-nacional/) aborda especificamente esse cenário:

"Inscrição Municipal (IM): atenção especial

O campo inscricao_municipal_prestador gera um volume significativo de dúvidas e chamados de suporte.

Em alguns municípios, a prefeitura não cadastrou a Inscrição Municipal do prestador no ambiente nacional. Nesses casos o campo inscricao_municipal_prestador deve ser suprimido. Essa regra é válida apenas quando o município não possui a IM registrada no emissor nacional."

Esta PR passou a incluir inscricao_municipal_prestador sempre que existe uma IM cadastrada no Odoo. Porém, possuir IM no cadastro local não significa necessariamente que ela esteja registrada no CNC NFS-e.
Seria possível tornar o envio desse campo configurável ou aplicar alguma condição que permita suprimi-lo nesses municípios? Para Porto Alegre, precisamos emitir a DPS sem inscricao_municipal_prestador.

