### PR TITLE
[18.0][FIX] l10n_br_fiscal: tax.est. version field

### DIFF
--- a/l10n_br_fiscal/models/data_ncm_nbs_abstract.py
+++ b/l10n_br_fiscal/models/data_ncm_nbs_abstract.py
@@ -104,6 +104,7 @@ class DataNcmNbsAbstract(models.AbstractModel):
                         object_field: record.id,
                         "key": result.chave,
                         "origin": result.fonte,
+                        "version": result.versao,
                         "state_id": company.state_id.id,
                         "state_taxes": result.estadual,
                         "federal_taxes_national": result.nacional,

--- a/l10n_br_fiscal/models/tax_estimate.py
+++ b/l10n_br_fiscal/models/tax_estimate.py
@@ -41,6 +41,8 @@ class TaxEstimate(models.Model):
 
     key = fields.Char(size=32)
 
+    version = fields.Char(size=32)
+
     origin = fields.Char(string="Source", size=32)
 
     company_id = fields.Many2one(


### PR DESCRIPTION
From field Versao in API (not key and not origin)

<img width="977" height="468" alt="image" src="https://github.com/user-attachments/assets/50790aeb-56c5-4080-87fb-36980d62faed" />
