### PR TITLE
[16.0][FIX][l10n_br_fiscal]: Correção do calculo dos impostos IBS, CBS e IS na entradas de importação de mercadoria

### DIFF
--- a/l10n_br_fiscal/data/l10n_br_fiscal.tax.group.csv
+++ b/l10n_br_fiscal/data/l10n_br_fiscal.tax.group.csv
@@ -20,7 +20,7 @@
 "tax_group_issqn_wh","ISSQN RET","issqn_wh","True","True",70,"50","city","res_partner_prefeitura_municipal",10,"False"
 "tax_group_ibs","IBS","ibs","True","False",999,"999","federal",,,"True"
 "tax_group_cbs","CBS","cbs","True","False",999,"999","federal",,,"True"
-"tax_group_is","IS","is","True","False",999,"999","federal",,,"True"
+"tax_group_is","IS","is","True","False",990,"990","federal",,,"True"
 "tax_group_others","Outros","others","True","False",999,"999","other",,,"False"
 "tax_group_pis","PIS","pis","True","False",50,"40","federal",,,"True"
 "tax_group_pis_wh","PIS RET","pis_wh","True","True",90,"40","federal","res_partner_ministerio_fazenda",20,"False"

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -7,11 +7,15 @@ from odoo.exceptions import UserError
 from ..constants.fiscal import (
     CFOP_DESTINATION_EXPORT,
     FISCAL_COMMENT_LINE,
+    FISCAL_IN,
     NFE_IND_IE_DEST,
     OPERATION_STATE,
     OPERATION_STATE_DEFAULT,
     PRODUCT_FISCAL_TYPE,
+    TAX_DOMAIN_CBS,
+    TAX_DOMAIN_IBS,
     TAX_DOMAIN_ICMS,
+    TAX_DOMAIN_II,
     TAX_DOMAIN_IPI,
     TAX_DOMAIN_ISSQN,
     TAX_FRAMEWORK,
@@ -297,13 +301,13 @@ class OperationLine(models.Model):
 
         # 1_5 From Tax Classification
         if mapping_result["tax_classification"]:
-            mapping_result["taxes"][
-                mapping_result["tax_classification"].tax_cbs_id.tax_domain
-            ] = mapping_result["tax_classification"].tax_cbs_id
+            mapping_result["taxes"][TAX_DOMAIN_CBS] = mapping_result[
+                "tax_classification"
+            ].tax_cbs_id
 
-            mapping_result["taxes"][
-                mapping_result["tax_classification"].tax_ibs_id.tax_domain
-            ] = mapping_result["tax_classification"].tax_ibs_id
+            mapping_result["taxes"][TAX_DOMAIN_IBS] = mapping_result[
+                "tax_classification"
+            ].tax_ibs_id
 
         # 2 From NCM
         if not ncm and product:
@@ -312,7 +316,7 @@ class OperationLine(models.Model):
         if company.tax_framework == TAX_FRAMEWORK_NORMAL:
             tax_ipi = ncm.tax_ipi_id
             tax_ii = ncm.tax_ii_id
-            mapping_result["taxes"][tax_ipi.tax_domain] = tax_ipi
+            mapping_result["taxes"][TAX_DOMAIN_IPI] = tax_ipi
 
             if len(ncm.piscofins_ids) == 1:
                 mapping_result["taxes"][
@@ -322,8 +326,11 @@ class OperationLine(models.Model):
                     ncm.piscofins_ids[0].tax_cofins_id.tax_domain
                 ] = ncm.piscofins_ids[0].tax_cofins_id
 
-            if mapping_result["cfop"].destination == CFOP_DESTINATION_EXPORT:
-                mapping_result["taxes"][tax_ii.tax_domain] = tax_ii
+            if (
+                mapping_result["cfop"].destination == CFOP_DESTINATION_EXPORT
+                and mapping_result["cfop"].type_in_out == FISCAL_IN
+            ):
+                mapping_result["taxes"][TAX_DOMAIN_II] = tax_ii
 
             # 3 From ICMS Regulation
             if company.icms_regulation_id:

--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -681,15 +681,30 @@ class Tax(models.Model):
         """The IBS (Tax on Goods and Services) must have the
         following taxes removed from its calculation base:
         ICMS, PIS, and COFINS."""
+        cfop = kwargs.get("cfop")
+        operation_line = kwargs.get("operation_line")
+        fiscal_operation_type = operation_line.fiscal_operation_type or FISCAL_OUT
         tax_dict = taxes_dict.get(tax.tax_domain)
+        tax_dict_ii = taxes_dict.get("ii", {})
+        tax_dict_is = taxes_dict.get("is", {})
         tax_dict_icms = taxes_dict.get("icms", {})
         tax_dict_pis = taxes_dict.get("pis", {})
         tax_dict_cofins = taxes_dict.get("cofins", {})
-        tax_dict["remove_from_base"] += (
-            tax_dict_icms.get("tax_value", 0.00)
-            + tax_dict_pis.get("tax_value", 0.00)
-            + tax_dict_cofins.get("tax_value", 0.00)
-        )
+        if (
+            cfop.destination == CFOP_DESTINATION_EXPORT
+            and fiscal_operation_type == FISCAL_IN
+        ):
+            tax_dict["add_to_base"] += (
+                tax_dict_ii.get("tax_value", 0.00)
+                + tax_dict_is.get("tax_value", 0.00)
+                + kwargs.get("ii_customhouse_charges", 0.00)
+            )
+        else:
+            tax_dict["remove_from_base"] += (
+                tax_dict_icms.get("tax_value", 0.00)
+                + tax_dict_pis.get("tax_value", 0.00)
+                + tax_dict_cofins.get("tax_value", 0.00)
+            )
         return self._compute_tax(tax, taxes_dict, **kwargs)
 
     @api.model
@@ -697,15 +712,30 @@ class Tax(models.Model):
         """The CBS (Contribution on Goods and Services) must have the
         following taxes removed from its calculation base:
         ICMS, PIS, and COFINS."""
+        cfop = kwargs.get("cfop")
+        operation_line = kwargs.get("operation_line")
+        fiscal_operation_type = operation_line.fiscal_operation_type or FISCAL_OUT
         tax_dict = taxes_dict.get(tax.tax_domain)
+        tax_dict_ii = taxes_dict.get("ii", {})
+        tax_dict_is = taxes_dict.get("is", {})
         tax_dict_icms = taxes_dict.get("icms", {})
         tax_dict_pis = taxes_dict.get("pis", {})
         tax_dict_cofins = taxes_dict.get("cofins", {})
-        tax_dict["remove_from_base"] += (
-            tax_dict_icms.get("tax_value", 0.00)
-            + tax_dict_pis.get("tax_value", 0.00)
-            + tax_dict_cofins.get("tax_value", 0.00)
-        )
+        if (
+            cfop.destination == CFOP_DESTINATION_EXPORT
+            and fiscal_operation_type == FISCAL_IN
+        ):
+            tax_dict["add_to_base"] += (
+                tax_dict_ii.get("tax_value", 0.00)
+                + tax_dict_is.get("tax_value", 0.00)
+                + kwargs.get("ii_customhouse_charges", 0.00)
+            )
+        else:
+            tax_dict["remove_from_base"] += (
+                tax_dict_icms.get("tax_value", 0.00)
+                + tax_dict_pis.get("tax_value", 0.00)
+                + tax_dict_cofins.get("tax_value", 0.00)
+            )
         return self._compute_tax(tax, taxes_dict, **kwargs)
 
     @api.model
@@ -713,15 +743,27 @@ class Tax(models.Model):
         """The IS tax (Selective Tax) must have the
         following taxes removed from its calculation base:
         ICMS, PIS, and COFINS."""
+        cfop = kwargs.get("cfop")
+        operation_line = kwargs.get("operation_line")
+        fiscal_operation_type = operation_line.fiscal_operation_type or FISCAL_OUT
         tax_dict = taxes_dict.get(tax.tax_domain)
+        tax_dict_ii = taxes_dict.get("ii", {})
         tax_dict_icms = taxes_dict.get("icms", {})
         tax_dict_pis = taxes_dict.get("pis", {})
         tax_dict_cofins = taxes_dict.get("cofins", {})
-        tax_dict["remove_from_base"] += (
-            tax_dict_icms.get("tax_value", 0.00)
-            + tax_dict_pis.get("tax_value", 0.00)
-            + tax_dict_cofins.get("tax_value", 0.00)
-        )
+        if (
+            cfop.destination == CFOP_DESTINATION_EXPORT
+            and fiscal_operation_type == FISCAL_IN
+        ):
+            tax_dict["add_to_base"] += tax_dict_ii.get("tax_value", 0.00) + kwargs.get(
+                "ii_customhouse_charges", 0.00
+            )
+        else:
+            tax_dict["remove_from_base"] += (
+                tax_dict_icms.get("tax_value", 0.00)
+                + tax_dict_pis.get("tax_value", 0.00)
+                + tax_dict_cofins.get("tax_value", 0.00)
+            )
         return self._compute_tax(tax, taxes_dict, **kwargs)
 
     @api.model


### PR DESCRIPTION
Esse PR faz algumas correções no calculo dos impostos nas operações de importação de mercadorias, por padrão no Odoo nos casos da emissão do documento fiscal de entrada de importação de mercadorias e preço unitário já é sem impostos e deve ser adicionado na base de calculo os valores dos impostos de II (Imposto de Importação), IS (Imposto Seletivo), despesas.
Também foi feito uma alteração no mapeamento dos impostos na linha da operação fiscal para adicionar o II (Imposto de importação) apenas quando é uma operação de entrada, no caso de exportação (venda para o exterior) não tem incidência do II.