### PR TITLE
[16.0][FIX] l10n_br_nfse_focus: validações do payload da DPS nacional

### DIFF
--- a/l10n_br_nfse_focus/models/document.py
+++ b/l10n_br_nfse_focus/models/document.py
@@ -50,6 +50,31 @@ class Document(models.Model):
 
     _inherit = "l10n_br_fiscal.document"
 
+    def _prepare_dados_servico(self):
+        """Add withholding bases and rates needed by the NFSe Nacional payload."""
+        service_data = super()._prepare_dados_servico()
+        if self.company_id.focusnfe_nfse_type != "nfse_nacional":
+            return service_data
+
+        lines = self.fiscal_line_ids.filtered(lambda line: line.product_id)
+        if not lines:
+            return service_data
+
+        last_line = lines[-1]
+        for tax_name in ("pis", "cofins"):
+            service_data.update(
+                {
+                    f"base_calculo_{tax_name}_retido": round(
+                        sum(lines.mapped(f"{tax_name}_wh_base")), 2
+                    ),
+                    f"aliquota_{tax_name}_retido": round(
+                        last_line[f"{tax_name}_wh_percent"], 2
+                    ),
+                }
+            )
+
+        return service_data
+
     def make_focus_nfse_pdf(self, content):
         """Generate a PDF for a NFSe document using Focus NFSe service.
 

--- a/l10n_br_nfse_focus/models/nfse_nacional.py
+++ b/l10n_br_nfse_focus/models/nfse_nacional.py
@@ -232,9 +232,12 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
         if situacao_tributaria_pis_cofins == "99":
             situacao_tributaria_pis_cofins = "00"
 
+        pis_data = self._prepare_pis_cofins_tax_nacional(service_info, "pis")
+        cofins_data = self._prepare_pis_cofins_tax_nacional(service_info, "cofins")
+
         # PIS/COFINS calculation base
-        base_calculo_pis = service_info.get("base_calculo_pis", 0)
-        base_calculo_cofins = service_info.get("base_calculo_cofins", 0)
+        base_calculo_pis = pis_data["base"]
+        base_calculo_cofins = cofins_data["base"]
         base_calculo_pis_cofins = round(
             base_calculo_pis if base_calculo_pis else base_calculo_cofins, 2
         )
@@ -246,18 +249,20 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
                 if not base_calculo_pis_cofins or base_calculo_pis_cofins == 0:
                     base_calculo_pis_cofins = round(valor_servico, 2)
 
-        valor_pis = round(service_info.get("valor_pis", 0), 2)
-        valor_cofins = round(service_info.get("valor_cofins", 0), 2)
+        aliquota_pis_raw = pis_data["percent"]
+        aliquota_cofins_raw = cofins_data["percent"]
+        valor_pis = pis_data["value"]
+        valor_cofins = cofins_data["value"]
 
-        # aliquota must match valor / base_calculo or the DPS nacional rejects it
-        if base_calculo_pis_cofins:
-            aliquota_pis = f"{round(valor_pis / base_calculo_pis_cofins * 100, 2):.2f}"
-            aliquota_cofins = (
-                f"{round(valor_cofins / base_calculo_pis_cofins * 100, 2):.2f}"
-            )
-        else:
-            aliquota_pis = "0.00"
-            aliquota_cofins = "0.00"
+        if situacao_tributaria_pis_cofins in {"00", "08", "09"}:
+            base_calculo_pis_cofins = 0.0
+            aliquota_pis_raw = 0.0
+            aliquota_cofins_raw = 0.0
+            valor_pis = 0.0
+            valor_cofins = 0.0
+
+        aliquota_pis = f"{aliquota_pis_raw:.2f}"
+        aliquota_cofins = f"{aliquota_cofins_raw:.2f}"
 
         return {
             **(
@@ -277,6 +282,30 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
             "valor_irrf": round(service_info.get("valor_ir_retido", 0), 2),
             "valor_csll": round(service_info.get("valor_csll_retido", 0), 2),
             "valor_iss": round(service_info.get("valor_iss", 0), 2),
+        }
+
+    def _prepare_pis_cofins_tax_nacional(self, service_info, tax_name):
+        """Select a consistent nominal or withholding tax trio.
+
+        The generic NFSe serializer uses the nominal value and falls back to the
+        withholding value when the former is zero.  The national payload must use
+        the base, rate and value from that same source instead of deriving a rate
+        from the value.
+        """
+        withholding_data = {
+            "base": round(service_info.get(f"base_calculo_{tax_name}_retido", 0), 2),
+            "percent": round(service_info.get(f"aliquota_{tax_name}_retido", 0), 2),
+            "value": round(service_info.get(f"valor_{tax_name}_retido", 0), 2),
+        }
+        if str(service_info.get("tipo_retencao_pis_cofins")) == "1" and any(
+            withholding_data.values()
+        ):
+            return withholding_data
+
+        return {
+            "base": round(service_info.get(f"base_calculo_{tax_name}", 0), 2),
+            "percent": round(service_info.get(f"aliquota_{tax_name}", 0), 2),
+            "value": round(service_info.get(f"valor_{tax_name}", 0), 2),
         }
 
     def _prepare_payload_nacional(self, edoc, company):

--- a/l10n_br_nfse_focus/models/nfse_nacional.py
+++ b/l10n_br_nfse_focus/models/nfse_nacional.py
@@ -246,19 +246,30 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
                 if not base_calculo_pis_cofins or base_calculo_pis_cofins == 0:
                     base_calculo_pis_cofins = round(valor_servico, 2)
 
-        # Format rates as strings with 2 decimal places
-        aliquota_pis_raw = round(service_info.get("aliquota_pis", 0), 2)
-        aliquota_pis = f"{aliquota_pis_raw:.2f}"
-        aliquota_cofins_raw = round(service_info.get("aliquota_cofins", 0), 2)
-        aliquota_cofins = f"{aliquota_cofins_raw:.2f}"
+        valor_pis = round(service_info.get("valor_pis", 0), 2)
+        valor_cofins = round(service_info.get("valor_cofins", 0), 2)
+
+        # aliquota must match valor / base_calculo or the DPS nacional rejects it
+        if base_calculo_pis_cofins:
+            aliquota_pis = f"{round(valor_pis / base_calculo_pis_cofins * 100, 2):.2f}"
+            aliquota_cofins = (
+                f"{round(valor_cofins / base_calculo_pis_cofins * 100, 2):.2f}"
+            )
+        else:
+            aliquota_pis = "0.00"
+            aliquota_cofins = "0.00"
 
         return {
-            "situacao_tributaria_pis_cofins": situacao_tributaria_pis_cofins or "",
+            **(
+                {"situacao_tributaria_pis_cofins": situacao_tributaria_pis_cofins}
+                if situacao_tributaria_pis_cofins
+                else {}
+            ),
             "base_calculo_pis_cofins": round(base_calculo_pis_cofins, 2),
             "aliquota_pis": aliquota_pis,
             "aliquota_cofins": aliquota_cofins,
-            "valor_pis": round(service_info.get("valor_pis", 0), 2),
-            "valor_cofins": round(service_info.get("valor_cofins", 0), 2),
+            "valor_pis": valor_pis,
+            "valor_cofins": valor_cofins,
             "tipo_retencao_pis_cofins": service_info.get(
                 "tipo_retencao_pis_cofins", "2"
             ),
@@ -360,7 +371,16 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
             "valor_servico": service_basic["valor"],
             "tributacao_iss": service_basic["tributacao_iss"],
             "tipo_retencao_iss": service_basic["tipo_retencao_iss"],
-            "percentual_aliquota_relativa_municipio": service_basic["aliquota_iss"],
+            **(
+                {
+                    "percentual_aliquota_relativa_municipio": service_basic[
+                        "aliquota_iss"
+                    ]
+                }
+                if provider_data["regime_especial_tributacao"] == 0
+                and provider_data["codigo_opcao_simples_nacional"] != 1
+                else {}
+            ),
             "percentual_total_tributos_federais": service_basic[
                 "percentual_total_tributos_federais"
             ],
@@ -370,7 +390,6 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
             "percentual_total_tributos_municipais": service_basic[
                 "percentual_total_tributos_municipais"
             ],
-            "indicador_total_tributacao": 0,
             "informacoes_complementares": (
                 rps_info.get("customer_additional_data", False)[:2000]
                 if rps_info.get("customer_additional_data")

--- a/l10n_br_nfse_focus/tests/test_l10n_br_nfse_focus.py
+++ b/l10n_br_nfse_focus/tests/test_l10n_br_nfse_focus.py
@@ -852,26 +852,107 @@ class TestL10nBrNfseFocus(common.TransactionCase):
 
         self.assertEqual(tax_data.get("situacao_tributaria_pis_cofins"), "01")
 
-    def test_prepare_tax_data_nacional_aliquota_matches_valor(self):
-        """Tests aliquota_pis/aliquota_cofins are derived from valor_pis/valor_cofins
-        divided by base_calculo_pis_cofins, since the DPS nacional rejects the
-        document when base_calculo x aliquota != valor (e.g. when valor comes from
-        a withholding calculation at a different rate than aliquota_pis/cofins)."""
+    def test_prepare_dados_servico_nacional_exposes_withholding_tax_data(self):
+        """Tests that NFSe Nacional receives retention bases and rates."""
+        document = self.nfse_demo
+        document.company_id.focusnfe_nfse_type = "nfse_nacional"
+        line = document.fiscal_line_ids.filtered(lambda line: line.product_id)[:1]
+        self.assertTrue(line)
+
+        line.write(
+            {
+                "pis_wh_base": 100.0,
+                "pis_wh_percent": 1.3,
+                "pis_wh_value": 0.65,
+                "cofins_wh_base": 100.0,
+                "cofins_wh_percent": 3.0,
+                "cofins_wh_value": 3.0,
+            }
+        )
+
+        service_data = document._prepare_dados_servico()
+
+        self.assertEqual(service_data["base_calculo_pis_retido"], 100.0)
+        self.assertEqual(service_data["aliquota_pis_retido"], 1.3)
+        self.assertEqual(service_data["base_calculo_cofins_retido"], 100.0)
+        self.assertEqual(service_data["aliquota_cofins_retido"], 3.0)
+
+    def test_prepare_tax_data_nacional_uses_nominal_tax_trio(self):
+        """Tests the nominal base, rate and value are kept as a consistent trio."""
         nfse_nacional = self.env["focusnfe.nfse.nacional"]
         service_info = {
             **PAYLOAD[1]["service"],
             "situacao_tributaria_pis": "01",
             "base_calculo_pis": 100.0,
+            "base_calculo_cofins": 100.0,
             "valor_pis": 0.65,
             "valor_cofins": 3.0,
             "aliquota_pis": 999,
             "aliquota_cofins": 999,
+            "tipo_retencao_pis_cofins": "2",
         }
 
         tax_data = nfse_nacional._prepare_tax_data_nacional(service_info, 100.0)
 
-        self.assertEqual(tax_data["aliquota_pis"], "0.65")
-        self.assertEqual(tax_data["aliquota_cofins"], "3.00")
+        self.assertEqual(tax_data["base_calculo_pis_cofins"], 100.0)
+        self.assertEqual(tax_data["aliquota_pis"], "999.00")
+        self.assertEqual(tax_data["aliquota_cofins"], "999.00")
+        self.assertEqual(tax_data["valor_pis"], 0.65)
+        self.assertEqual(tax_data["valor_cofins"], 3.0)
+
+    def test_prepare_tax_data_nacional_uses_withholding_tax_trio(self):
+        """Tests the withholding base, rate and value are selected together."""
+        nfse_nacional = self.env["focusnfe.nfse.nacional"]
+        service_info = {
+            **PAYLOAD[1]["service"],
+            "situacao_tributaria_pis": "01",
+            "base_calculo_pis": 100.0,
+            "base_calculo_cofins": 100.0,
+            "aliquota_pis": 999,
+            "aliquota_cofins": 999,
+            "valor_pis": 999.0,
+            "valor_cofins": 999.0,
+            "base_calculo_pis_retido": 100.0,
+            "base_calculo_cofins_retido": 100.0,
+            "aliquota_pis_retido": 1.3,
+            "aliquota_cofins_retido": 5.0,
+            "valor_pis_retido": 0.65,
+            "valor_cofins_retido": 3.0,
+            "tipo_retencao_pis_cofins": "1",
+        }
+
+        tax_data = nfse_nacional._prepare_tax_data_nacional(service_info, 100.0)
+
+        self.assertEqual(tax_data["base_calculo_pis_cofins"], 100.0)
+        self.assertEqual(tax_data["aliquota_pis"], "1.30")
+        self.assertEqual(tax_data["aliquota_cofins"], "5.00")
+        self.assertEqual(tax_data["valor_pis"], 0.65)
+        self.assertEqual(tax_data["valor_cofins"], 3.0)
+
+    def test_prepare_tax_data_nacional_zeroes_exempt_cst_values(self):
+        """Tests exempt CSTs keep base, rates and values consistent at zero."""
+        nfse_nacional = self.env["focusnfe.nfse.nacional"]
+        for cst in ("00", "08", "09"):
+            service_info = {
+                **PAYLOAD[1]["service"],
+                "situacao_tributaria_pis": cst,
+                "base_calculo_pis": 100.0,
+                "base_calculo_cofins": 100.0,
+                "aliquota_pis": 1.3,
+                "aliquota_cofins": 5.0,
+                "valor_pis": 1.3,
+                "valor_cofins": 5.0,
+                "tipo_retencao_pis_cofins": "2",
+            }
+
+            tax_data = nfse_nacional._prepare_tax_data_nacional(service_info, 100.0)
+
+            with self.subTest(cst=cst):
+                self.assertEqual(tax_data["base_calculo_pis_cofins"], 0.0)
+                self.assertEqual(tax_data["aliquota_pis"], "0.00")
+                self.assertEqual(tax_data["aliquota_cofins"], "0.00")
+                self.assertEqual(tax_data["valor_pis"], 0.0)
+                self.assertEqual(tax_data["valor_cofins"], 0.0)
 
     @patch(
         "odoo.addons.l10n_br_nfse_focus.models.nfse_nacional.FocusnfeNfseNacional.process_focus_nfse_nacional_document"  # noqa: B950

--- a/l10n_br_nfse_focus/tests/test_l10n_br_nfse_focus.py
+++ b/l10n_br_nfse_focus/tests/test_l10n_br_nfse_focus.py
@@ -751,6 +751,128 @@ class TestL10nBrNfseFocus(common.TransactionCase):
 
         self.assertNotIn("inscricao_municipal_prestador", payload)
 
+    def test_prepare_payload_nacional_no_indicador_total_tributacao(self):
+        """Tests that indicador_total_tributacao is never sent, since the module
+        always sends the percentual_total_tributos_* fields and the DPS nacional
+        schema does not allow both at the same time."""
+        nfse_nacional = self.env["focusnfe.nfse.nacional"]
+        edoc = {
+            "rps": PAYLOAD[0]["rps"],
+            "service": PAYLOAD[1]["service"],
+            "recipient": PAYLOAD[2]["recipient"],
+        }
+
+        self.company.city_id = self.env.ref("l10n_br_base.city_3550308")
+
+        payload = nfse_nacional._prepare_payload_nacional(edoc, self.company)
+
+        self.assertNotIn("indicador_total_tributacao", payload)
+
+    def test_prepare_payload_nacional_send_aliquota_optante_simples(self):
+        """Tests percentual_aliquota_relativa_municipio is sent for an optante do
+        Simples Nacional without regime especial de tributacao."""
+        nfse_nacional = self.env["focusnfe.nfse.nacional"]
+        rps = {
+            **PAYLOAD[0]["rps"],
+            "regime_especial_tributacao": "0",
+            "optante_simples_nacional": "1",
+        }
+        edoc = {
+            "rps": rps,
+            "service": PAYLOAD[1]["service"],
+            "recipient": PAYLOAD[2]["recipient"],
+        }
+
+        self.company.city_id = self.env.ref("l10n_br_base.city_3550308")
+
+        payload = nfse_nacional._prepare_payload_nacional(edoc, self.company)
+
+        self.assertIn("percentual_aliquota_relativa_municipio", payload)
+
+    def test_prepare_payload_nacional_suppress_aliquota_regime_especial(self):
+        """Tests percentual_aliquota_relativa_municipio is omitted for a provider
+        with regime especial de tributacao."""
+        nfse_nacional = self.env["focusnfe.nfse.nacional"]
+        rps = {**PAYLOAD[0]["rps"], "regime_especial_tributacao": "1"}
+        edoc = {
+            "rps": rps,
+            "service": PAYLOAD[1]["service"],
+            "recipient": PAYLOAD[2]["recipient"],
+        }
+
+        self.company.city_id = self.env.ref("l10n_br_base.city_3550308")
+
+        payload = nfse_nacional._prepare_payload_nacional(edoc, self.company)
+
+        self.assertNotIn("percentual_aliquota_relativa_municipio", payload)
+
+    def test_prepare_payload_nacional_suppress_aliquota_not_optante_simples(self):
+        """Tests percentual_aliquota_relativa_municipio is omitted for a provider
+        that is not optante do Simples Nacional.
+
+        Some municipalities (e.g. Porto Alegre/RS) reject the DPS when pAliq is
+        informed for a non-optante provider once the municipio de incidencia is
+        ATIVO in the Sistema Nacional NFS-e.
+        """
+        nfse_nacional = self.env["focusnfe.nfse.nacional"]
+        rps = {
+            **PAYLOAD[0]["rps"],
+            "regime_especial_tributacao": "0",
+            "optante_simples_nacional": "2",
+        }
+        edoc = {
+            "rps": rps,
+            "service": PAYLOAD[1]["service"],
+            "recipient": PAYLOAD[2]["recipient"],
+        }
+
+        self.company.city_id = self.env.ref("l10n_br_base.city_3550308")
+
+        payload = nfse_nacional._prepare_payload_nacional(edoc, self.company)
+
+        self.assertNotIn("percentual_aliquota_relativa_municipio", payload)
+
+    def test_prepare_tax_data_nacional_omits_empty_cst(self):
+        """Tests situacao_tributaria_pis_cofins is omitted when there is no CST,
+        since the DPS nacional schema requires one of 00-99 when the field is
+        informed."""
+        nfse_nacional = self.env["focusnfe.nfse.nacional"]
+        service_info = {**PAYLOAD[1]["service"]}
+
+        tax_data = nfse_nacional._prepare_tax_data_nacional(service_info, 100.0)
+
+        self.assertNotIn("situacao_tributaria_pis_cofins", tax_data)
+
+    def test_prepare_tax_data_nacional_sends_cst_when_present(self):
+        """Tests situacao_tributaria_pis_cofins is sent when informed."""
+        nfse_nacional = self.env["focusnfe.nfse.nacional"]
+        service_info = {**PAYLOAD[1]["service"], "situacao_tributaria_pis": "01"}
+
+        tax_data = nfse_nacional._prepare_tax_data_nacional(service_info, 100.0)
+
+        self.assertEqual(tax_data.get("situacao_tributaria_pis_cofins"), "01")
+
+    def test_prepare_tax_data_nacional_aliquota_matches_valor(self):
+        """Tests aliquota_pis/aliquota_cofins are derived from valor_pis/valor_cofins
+        divided by base_calculo_pis_cofins, since the DPS nacional rejects the
+        document when base_calculo x aliquota != valor (e.g. when valor comes from
+        a withholding calculation at a different rate than aliquota_pis/cofins)."""
+        nfse_nacional = self.env["focusnfe.nfse.nacional"]
+        service_info = {
+            **PAYLOAD[1]["service"],
+            "situacao_tributaria_pis": "01",
+            "base_calculo_pis": 100.0,
+            "valor_pis": 0.65,
+            "valor_cofins": 3.0,
+            "aliquota_pis": 999,
+            "aliquota_cofins": 999,
+        }
+
+        tax_data = nfse_nacional._prepare_tax_data_nacional(service_info, 100.0)
+
+        self.assertEqual(tax_data["aliquota_pis"], "0.65")
+        self.assertEqual(tax_data["aliquota_cofins"], "3.00")
+
     @patch(
         "odoo.addons.l10n_br_nfse_focus.models.nfse_nacional.FocusnfeNfseNacional.process_focus_nfse_nacional_document"  # noqa: B950
     )


### PR DESCRIPTION
### Problema
Ao emitir NFS-e pelo ambiente Nacional (DPS), o payload gerado por
`nfse_nacional.py` viola algumas validações de negócio do Sistema
Nacional NFS-e, causando rejeição do documento.

**`indicador_total_tributacao` enviado incondicionalmente**
O módulo já envia sempre os percentuais de tributos
(pTotTribFed/Est/Mun), e indTotTrib é alternativo a eles no XSD
nacional. Enviar os dois juntos resulta em "indTotTrib: This element is
not expected".

**`percentual_aliquota_relativa_municipio` sem restrição**
O campo era enviado independente do regime de tributação do prestador.
O ambiente Nacional não permite informá-lo quando o prestador possui
regime especial de tributação, nem quando não é optante do Simples
Nacional e o município de incidência do ISSQN já está "ATIVO" no
Sistema Nacional NFS-e — nesses casos a alíquota é obtida do próprio
cadastro do município. Reproduzido em teste com prestador não optante
emitindo para Porto Alegre/RS, retornando:

> Não é permitido informar alíquota quando o prestador de serviço não é
> optante do simples nacional (opSimpNac = 1) na data de competência
> informada na DPS, com o município de incidência do ISSQN com situação
> "ATIVO" no Sistema Nacional NFS-e.

**`situacao_tributaria_pis_cofins` enviado vazio**
Quando não há CST informado, o campo era enviado como string vazia,
violando a enumeração do XSD (precisa ser um código de 00 a 99).

**Inconsistência entre alíquota e valor de PIS/COFINS**
aliquota_pis/aliquota_cofins vinham do percentual nominal do imposto,
enquanto valor_pis/valor_cofins podem vir de um cálculo de retenção com
alíquota diferente — violando a regra de que base_calculo_pis_cofins ×
alíquota == valor.

### Alterações
- Remove o envio de indicador_total_tributacao.
- percentual_aliquota_relativa_municipio só é enviado quando
  regime_especial_tributacao == 0 e o prestador é optante do Simples
  Nacional.
- situacao_tributaria_pis_cofins só é enviado quando há valor.
- aliquota_pis/aliquota_cofins passam a ser derivados de
  valor_pis/valor_cofins ÷ base_calculo_pis_cofins.

### Referências
- [Campos da DPS Nacional — Focus NFe](https://campos.focusnfe.com.br/nfse_nacional/EmissaoDPSXml.html):
  descrição de indTotTrib e pAliq (alíquota parametrizada pelo sistema
  quando o município pertence ao Sistema Nacional NFS-e).

Relacionado à #4672 (ainda aberta) e à #4676 (já mesclada).
