### PR TITLE
[17.0][IMP] l10n_br_nfe: FWP neutralize sets NF-e environment to homologação - FWP 4615

### DIFF
--- a/l10n_br_nfe/data/neutralize.sql
+++ b/l10n_br_nfe/data/neutralize.sql
@@ -1,0 +1,3 @@
+-- force the NF-e transmission environment to homologação (SEFAZ test)
+UPDATE res_company
+   SET nfe_environment = '2';


### PR DESCRIPTION
FWP #4615

Add data/neutralize.sql so that database neutralization (`odoo neutralize`, available since Odoo 16) forces the NF-e transmission environment to homologação (tpAmb=2).

This prevents a production database restored into a test/dev environment from transmitting fiscal documents to the production SEFAZ environment.