### PR TITLE
[18.0][FIX] l10n_br_cnpj_search: context default_partner_id

### DIFF
--- a/l10n_br_cnpj_search/wizard/partner_cnpj_search_wizard.py
+++ b/l10n_br_cnpj_search/wizard/partner_cnpj_search_wizard.py
@@ -96,16 +96,13 @@ class PartnerCnpjSearchWizard(models.TransientModel):
 
     def default_get(self, fields):
         res = super().default_get(fields)
-        active_model = self.env.context.get("active_model")
-        if active_model == "res.partner":
-            partner_id = self.env.context.get("default_partner_id")
-            if partner_id:
-                partner_model = self.env["res.partner"]
-                partner = partner_model.browse(partner_id)
-                cnpj_cpf = punctuation_rm(partner.vat)
-                misc.punctuation_rm(self.zip)
-                values = self._get_partner_values(cnpj_cpf)
-                res.update(values)
+        partner_id = self.env.context.get("default_partner_id")
+        if partner_id:
+            partner_model = self.env["res.partner"]
+            partner = partner_model.browse(partner_id)
+            cnpj_cpf = punctuation_rm(partner.vat)
+            values = self._get_partner_values(cnpj_cpf)
+            res.update(values)
         return res
 
     def action_update_partner(self):


### PR DESCRIPTION
## Objetivo da PR
Ao buscar hoje CNPJ pelo menu da empresa fica tudo zerado
<img width="1919" height="951" alt="Captura de tela de 2026-07-15 20-35-50" src="https://github.com/user-attachments/assets/71a8cfa1-a367-4825-91e6-43ca170dbee4" />

### Correção
O que mudei em `partner_cnpj_search_wizard.py:97-105` `l10n_br_cnpj_search/wizard/partner_cnpj_search_wizard.py#L97-L105)`: 
o default_get só buscava os dados quando active_model == "res.partner", mas o botão da tela de Empresa (Configurações) abre o wizard com active_model == "res.company", então a busca nunca era disparada e o wizard sempre abria vazio. Voltei a lógica para checar a presença de default_partner_id no contexto (como era antes de um refactor de jan/2025), o que cobre tanto res.partner quanto res.company, sem quebrar o caso de crm.lead (que usa default_lead_id e é tratado à parte pelo módulo l10n_br_crm_cnpj_search).