### PR TITLE
[16.0] l10n_br_fiscal, l10n_br_account, l10n_br_nfe and l10n_br_sale_stock: Dados de Demo e Testes para o IBS/CBS

### DIFF
--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -346,6 +346,11 @@ class AccountMoveLine(models.Model):
 
             # Compute 'price_total'.
             if line.tax_ids:
+                # line.fiscal_tax_ids (delegated via _inherits) can still read
+                # empty here even though it was just set on creation: reading
+                # through fiscal_document_line_id avoids that stale cache and
+                # keeps the embedded-tax split (e.g. IBS/CBS) from silently
+                # computing as 0.
                 taxes_res = line.tax_ids._origin.with_context().compute_all(
                     line_discount_price_unit,
                     currency=line.currency_id,
@@ -354,7 +359,7 @@ class AccountMoveLine(models.Model):
                     partner=line.partner_id,
                     is_refund=line.move_type in ("out_refund", "in_refund"),
                     handle_price_include=True,  # sure?
-                    fiscal_taxes=line.fiscal_tax_ids,
+                    fiscal_taxes=line.fiscal_document_line_id.fiscal_tax_ids,
                     operation_line=line.fiscal_operation_line_id,
                     cfop=line.cfop_id or None,
                     ncm=line.ncm_id,
@@ -497,7 +502,10 @@ class AccountMoveLine(models.Model):
                 handle_price_include=handle_price_include,
                 include_caba_tags=line.move_id.always_tax_exigible,
                 fixed_multiplicator=sign,
-                fiscal_taxes=line.fiscal_tax_ids,
+                # see the note in _compute_totals: read through
+                # fiscal_document_line_id to avoid a stale fiscal_tax_ids,
+                # otherwise every dynamic tax line silently computes as 0.
+                fiscal_taxes=line.fiscal_document_line_id.fiscal_tax_ids,
                 operation_line=line.fiscal_operation_line_id,
                 cfop=line.cfop_id or None,
                 ncm=line.ncm_id,

--- a/l10n_br_account/tests/test_move_edition.py
+++ b/l10n_br_account/tests/test_move_edition.py
@@ -218,7 +218,7 @@ class TestMoveEdition(TransactionCase):
             line_form.price_unit = 42
             line_form.quantity = 5
 
-            self.assertEqual(len(line_form.fiscal_tax_ids), 4)
+            self.assertEqual(len(line_form.fiscal_tax_ids), 6)
             self.assertEqual(
                 line_form.icms_tax_id, self.env.ref("l10n_br_fiscal.tax_icms_7")
             )
@@ -233,7 +233,7 @@ class TestMoveEdition(TransactionCase):
             line_form.fiscal_operation_line_id = self.env.ref(
                 "l10n_br_fiscal.fo_venda_venda"
             )
-            self.assertEqual(len(line_form.fiscal_tax_ids), 4)
+            self.assertEqual(len(line_form.fiscal_tax_ids), 6)
             self.assertEqual(
                 line_form.icms_tax_id, self.env.ref("l10n_br_fiscal.tax_icms_7")
             )

--- a/l10n_br_cte/tests/cte/v4_00/leiauteCTe/CTe35240759594315000157570010000057311040445890.xml
+++ b/l10n_br_cte/tests/cte/v4_00/leiauteCTe/CTe35240759594315000157570010000057311040445890.xml
@@ -148,6 +148,27 @@
           <indSN>1</indSN>
         </ICMSSN>
       </ICMS>
+      <IBSCBS>
+        <CST>000</CST>
+        <cClassTrib>000001</cClassTrib>
+        <gIBSCBS>
+          <vBC>100.00</vBC>
+          <gIBSUF>
+            <pIBSUF>0.1000</pIBSUF>
+            <vIBSUF>0.10</vIBSUF>
+          </gIBSUF>
+          <gIBSMun>
+            <pIBSMun>0.0000</pIBSMun>
+            <vIBSMun>0.00</vIBSMun>
+          </gIBSMun>
+          <vIBS>0.10</vIBS>
+          <gCBS>
+            <pCBS>0.9000</pCBS>
+            <vCBS>0.90</vCBS>
+          </gCBS>
+        </gIBSCBS>
+      </IBSCBS>
+      <vTotDFe>100.00</vTotDFe>
     </imp>
     <infCTeNorm>
       <infCarga>

--- a/l10n_br_cte/tests/cte/v4_00/leiauteCTe/CTe35240781583054000129570010000057311040645894.xml
+++ b/l10n_br_cte/tests/cte/v4_00/leiauteCTe/CTe35240781583054000129570010000057311040645894.xml
@@ -150,6 +150,27 @@
           <vICMS>18.00</vICMS>
         </ICMS00>
       </ICMS>
+      <IBSCBS>
+        <CST>000</CST>
+        <cClassTrib>000001</cClassTrib>
+        <gIBSCBS>
+          <vBC>78.35</vBC>
+          <gIBSUF>
+            <pIBSUF>0.1000</pIBSUF>
+            <vIBSUF>0.08</vIBSUF>
+          </gIBSUF>
+          <gIBSMun>
+            <pIBSMun>0.0000</pIBSMun>
+            <vIBSMun>0.00</vIBSMun>
+          </gIBSMun>
+          <vIBS>0.08</vIBS>
+          <gCBS>
+            <pCBS>0.9000</pCBS>
+            <vCBS>0.71</vCBS>
+          </gCBS>
+        </gIBSCBS>
+      </IBSCBS>
+      <vTotDFe>100.00</vTotDFe>
     </imp>
     <infCTeNorm>
       <infCarga>

--- a/l10n_br_cte/tests/cte/v4_00/leiauteCTe/CTe35240781583054000129570010000057411040645890.xml
+++ b/l10n_br_cte/tests/cte/v4_00/leiauteCTe/CTe35240781583054000129570010000057411040645890.xml
@@ -150,6 +150,27 @@
           <vICMS>18.00</vICMS>
         </ICMS00>
       </ICMS>
+      <IBSCBS>
+        <CST>000</CST>
+        <cClassTrib>000001</cClassTrib>
+        <gIBSCBS>
+          <vBC>78.35</vBC>
+          <gIBSUF>
+            <pIBSUF>0.1000</pIBSUF>
+            <vIBSUF>0.08</vIBSUF>
+          </gIBSUF>
+          <gIBSMun>
+            <pIBSMun>0.0000</pIBSMun>
+            <vIBSMun>0.00</vIBSMun>
+          </gIBSMun>
+          <vIBS>0.08</vIBS>
+          <gCBS>
+            <pCBS>0.9000</pCBS>
+            <vCBS>0.71</vCBS>
+          </gCBS>
+        </gIBSCBS>
+      </IBSCBS>
+      <vTotDFe>100.00</vTotDFe>
     </imp>
     <infCTeNorm>
       <infCarga>

--- a/l10n_br_cte/tests/cte/v4_00/leiauteCTe/CTe35240781583054000129570010000057511040645897.xml
+++ b/l10n_br_cte/tests/cte/v4_00/leiauteCTe/CTe35240781583054000129570010000057511040645897.xml
@@ -150,6 +150,27 @@
           <vICMS>18.00</vICMS>
         </ICMS00>
       </ICMS>
+      <IBSCBS>
+        <CST>000</CST>
+        <cClassTrib>000001</cClassTrib>
+        <gIBSCBS>
+          <vBC>78.35</vBC>
+          <gIBSUF>
+            <pIBSUF>0.1000</pIBSUF>
+            <vIBSUF>0.08</vIBSUF>
+          </gIBSUF>
+          <gIBSMun>
+            <pIBSMun>0.0000</pIBSMun>
+            <vIBSMun>0.00</vIBSMun>
+          </gIBSMun>
+          <vIBS>0.08</vIBS>
+          <gCBS>
+            <pCBS>0.9000</pCBS>
+            <vCBS>0.71</vCBS>
+          </gCBS>
+        </gIBSCBS>
+      </IBSCBS>
+      <vTotDFe>100.00</vTotDFe>
     </imp>
     <infCTeNorm>
       <infCarga>

--- a/l10n_br_cte/tests/cte/v4_00/leiauteCTe/CTe35240781583054000129570010000057611040645893.xml
+++ b/l10n_br_cte/tests/cte/v4_00/leiauteCTe/CTe35240781583054000129570010000057611040645893.xml
@@ -150,6 +150,27 @@
           <vICMS>18.00</vICMS>
         </ICMS00>
       </ICMS>
+      <IBSCBS>
+        <CST>000</CST>
+        <cClassTrib>000001</cClassTrib>
+        <gIBSCBS>
+          <vBC>78.35</vBC>
+          <gIBSUF>
+            <pIBSUF>0.1000</pIBSUF>
+            <vIBSUF>0.08</vIBSUF>
+          </gIBSUF>
+          <gIBSMun>
+            <pIBSMun>0.0000</pIBSMun>
+            <vIBSMun>0.00</vIBSMun>
+          </gIBSMun>
+          <vIBS>0.08</vIBS>
+          <gCBS>
+            <pCBS>0.9000</pCBS>
+            <vCBS>0.71</vCBS>
+          </gCBS>
+        </gIBSCBS>
+      </IBSCBS>
+      <vTotDFe>100.00</vTotDFe>
     </imp>
     <infCTeNorm>
       <infCarga>

--- a/l10n_br_cte/tests/cte/v4_00/leiauteCTe/CTe35240781583054000129570010000057711040645890.xml
+++ b/l10n_br_cte/tests/cte/v4_00/leiauteCTe/CTe35240781583054000129570010000057711040645890.xml
@@ -150,6 +150,27 @@
           <vICMS>18.00</vICMS>
         </ICMS00>
       </ICMS>
+      <IBSCBS>
+        <CST>000</CST>
+        <cClassTrib>000001</cClassTrib>
+        <gIBSCBS>
+          <vBC>78.35</vBC>
+          <gIBSUF>
+            <pIBSUF>0.1000</pIBSUF>
+            <vIBSUF>0.08</vIBSUF>
+          </gIBSUF>
+          <gIBSMun>
+            <pIBSMun>0.0000</pIBSMun>
+            <vIBSMun>0.00</vIBSMun>
+          </gIBSMun>
+          <vIBS>0.08</vIBS>
+          <gCBS>
+            <pCBS>0.9000</pCBS>
+            <vCBS>0.71</vCBS>
+          </gCBS>
+        </gIBSCBS>
+      </IBSCBS>
+      <vTotDFe>100.00</vTotDFe>
     </imp>
     <infCTeNorm>
       <infCarga>

--- a/l10n_br_cte/tests/test_cte_serialize.py
+++ b/l10n_br_cte/tests/test_cte_serialize.py
@@ -64,6 +64,7 @@ class TestCTeSerialize(TransactionCase):
     def prepare_modal_rodoviario_data(cls, cte):
         cte.cte40_RNTRC = "12345678"
         cte.cte40_occ = [
+            Command.clear(),
             Command.create(
                 {
                     "cte40_serie": "01",
@@ -95,6 +96,7 @@ class TestCTeSerialize(TransactionCase):
 
         # Lista de produtos perigosos
         cte.cte40_peri = [
+            Command.clear(),
             Command.create(
                 {
                     "cte40_nONU": "1234",  # Número ONU do produto perigoso
@@ -128,6 +130,7 @@ class TestCTeSerialize(TransactionCase):
 
         # Informações das balsas transportadas
         cte.cte40_balsa = [
+            Command.clear(),
             Command.create(
                 {
                     "cte40_xBalsa": "Balsa A",  # Identificador da primeira balsa

--- a/l10n_br_fiscal/demo/company_demo.xml
+++ b/l10n_br_fiscal/demo/company_demo.xml
@@ -42,6 +42,10 @@
         <field name="legal_nature_id" ref="l10n_br_fiscal.legal_nature_2062" />
         <field name="cnae_main_id" ref="l10n_br_fiscal.cnae_3101200" />
         <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
+        <field
+            name="tax_classification_id"
+            ref="l10n_br_fiscal.tax_classification_000001"
+        />
     </record>
 
     <record id="icms_tax_definition_main_company" model="l10n_br_fiscal.tax.definition">
@@ -52,6 +56,28 @@
         <field name="custom_tax">True</field>
         <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_com_credito" />
         <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_101" />
+        <field name="state">draft</field>
+    </record>
+
+    <record id="ibs_tax_definition_main_company" model="l10n_br_fiscal.tax.definition">
+        <field name="company_id" ref="base.main_company" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ibs" />
+        <field name="is_taxed">True</field>
+        <field name="is_debit_credit">True</field>
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ibs_0_1" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ibs_000" />
+        <field name="state">draft</field>
+    </record>
+
+    <record id="cbs_tax_definition_main_company" model="l10n_br_fiscal.tax.definition">
+        <field name="company_id" ref="base.main_company" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cbs" />
+        <field name="is_taxed">True</field>
+        <field name="is_debit_credit">True</field>
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cbs_0_9" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cbs_000" />
         <field name="state">draft</field>
     </record>
 
@@ -115,6 +141,10 @@
         <field name="cnae_main_id" ref="l10n_br_fiscal.cnae_3101200" />
         <field name="piscofins_id" ref="l10n_br_fiscal.tax_pis_cofins_columativo" />
         <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
+        <field
+            name="tax_classification_id"
+            ref="l10n_br_fiscal.tax_classification_000001"
+        />
     </record>
 
     <record
@@ -156,6 +186,34 @@
         <field name="custom_tax">True</field>
         <field name="tax_id" ref="l10n_br_fiscal.tax_issqn_5" />
         <field name="state">approved</field>
+    </record>
+
+    <record
+        id="ibs_tax_definition_empresa_lucro_presumido"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ibs" />
+        <field name="is_taxed">True</field>
+        <field name="is_debit_credit">True</field>
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ibs_0_1" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ibs_000" />
+        <field name="state">draft</field>
+    </record>
+
+    <record
+        id="cbs_tax_definition_empresa_lucro_presumido"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cbs" />
+        <field name="is_taxed">True</field>
+        <field name="is_debit_credit">True</field>
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cbs_0_9" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cbs_000" />
+        <field name="state">draft</field>
     </record>
 
     <record id="empresa_lc_document_55_serie_1" model="l10n_br_fiscal.document.serie">
@@ -291,6 +349,10 @@
         <field name="cnae_main_id" ref="l10n_br_fiscal.cnae_3101200" />
         <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
         <field name="annual_revenue">815000.00</field>
+        <field
+            name="tax_classification_id"
+            ref="l10n_br_fiscal.tax_classification_000001"
+        />
     </record>
 
     <record id="empresa_sn_document_55_serie_1" model="l10n_br_fiscal.document.serie">
@@ -383,6 +445,34 @@
         <field name="custom_tax">True</field>
         <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_outros" />
         <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_99" />
+        <field name="state">draft</field>
+    </record>
+
+    <record
+        id="ibs_tax_definition_simples_nacional"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="company_id" ref="l10n_br_base.empresa_simples_nacional" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ibs" />
+        <field name="is_taxed">True</field>
+        <field name="is_debit_credit">True</field>
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ibs_0_1" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ibs_000" />
+        <field name="state">draft</field>
+    </record>
+
+    <record
+        id="cbs_tax_definition_simples_nacional"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="company_id" ref="l10n_br_base.empresa_simples_nacional" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cbs" />
+        <field name="is_taxed">True</field>
+        <field name="is_debit_credit">True</field>
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cbs_0_9" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cbs_000" />
         <field name="state">draft</field>
     </record>
 

--- a/l10n_br_fiscal/tests/test_document_edition.py
+++ b/l10n_br_fiscal/tests/test_document_edition.py
@@ -69,7 +69,7 @@ class TestDocumentEdition(TransactionCase):
 
             line_form.price_unit = 50
             line_form.quantity = 2
-            self.assertEqual(len(line_form.fiscal_tax_ids), 4)
+            self.assertEqual(len(line_form.fiscal_tax_ids), 6)
             self.assertEqual(
                 line_form.icms_tax_id, self.env.ref("l10n_br_fiscal.tax_icms_12")
             )
@@ -109,7 +109,7 @@ class TestDocumentEdition(TransactionCase):
         self.assertEqual(line.fiscal_price, 100)
         self.assertEqual(line.quantity, 2)
         self.assertEqual(line.fiscal_quantity, 2)
-        self.assertEqual(len(line.fiscal_tax_ids), 4)
+        self.assertEqual(len(line.fiscal_tax_ids), 6)
 
         self.assertEqual(
             line.fiscal_operation_line_id,

--- a/l10n_br_fiscal/tests/test_fiscal_tax.py
+++ b/l10n_br_fiscal/tests/test_fiscal_tax.py
@@ -112,12 +112,14 @@ class TestFiscalTax(TransactionCase):
             + self.env.ref("l10n_br_fiscal.tax_ipi_15")
             + self.env.ref("l10n_br_fiscal.tax_pis_0_65")
             + self.env.ref("l10n_br_fiscal.tax_cofins_3")
+            + self.env.ref("l10n_br_fiscal.tax_ibs_0_1")
+            + self.env.ref("l10n_br_fiscal.tax_cbs_0_9")
         )
 
         compute_result = fiscal_taxes.compute_taxes(**kwargs)
 
         test_result = {
-            "amount_included": 4.04,
+            "amount_included": 4.34,
             "amount_not_included": 5.19,
             "amount_withholding": 0.0,
             "estimate_tax": 0.0,
@@ -154,6 +156,22 @@ class TestFiscalTax(TransactionCase):
                     "percent_reduction": 0.0,
                     "value_amount": 0.0,
                     "tax_value": 1.04,
+                },
+                "ibs": {
+                    "base": 30.54,
+                    "base_reduction": 0.0,
+                    "percent_amount": 0.10,
+                    "percent_reduction": 0.0,
+                    "value_amount": 0.0,
+                    "tax_value": 0.03,
+                },
+                "cbs": {
+                    "base": 30.54,
+                    "base_reduction": 0.0,
+                    "percent_amount": 0.90,
+                    "percent_reduction": 0.0,
+                    "value_amount": 0.0,
+                    "tax_value": 0.27,
                 },
             },
         }

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -14,8 +14,8 @@ from erpbrasil.base.fiscal.edoc import ChaveEdoc
 from erpbrasil.transmissao import TransmissaoSOAP
 from lxml import etree
 from nfelib.nfe.bindings.v4_0.dfe_tipos_basicos_v1_00 import TibscbsmonoTot
-from nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00 import TnfeProc
 from nfelib.nfe.bindings.v4_0.nfe_v4_00 import Nfe
+from nfelib.nfe.bindings.v4_0.proc_nfe_v4_00 import NfeProc
 from nfelib.nfe.ws.edoc_legacy import NFCeAdapter as edoc_nfce
 from nfelib.nfe.ws.edoc_legacy import NFeAdapter as edoc_nfe
 from requests import Session
@@ -1392,7 +1392,7 @@ class NFe(spec_models.StackedModel):
         if proc_nfe_xml:
             # it is not always possible to create nfeProc.
             parser = XmlParser()
-            nfe_proc = parser.from_string(proc_nfe_xml.decode(), TnfeProc)
+            nfe_proc = parser.from_string(proc_nfe_xml.decode(), NfeProc)
             ws_response_process.processo = nfe_proc
             ws_response_process.processo_xml = proc_nfe_xml
 

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000012062777161.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000012062777161.xml
@@ -110,7 +110,28 @@
             <vCOFINS>0.00</vCOFINS>
           </COFINSOutr>
         </COFINS>
+        <IBSCBS>
+          <CST>000</CST>
+          <cClassTrib>000001</cClassTrib>
+          <gIBSCBS>
+            <vBC>140.00</vBC>
+            <gIBSUF>
+              <pIBSUF>0.1000</pIBSUF>
+              <vIBSUF>0.14</vIBSUF>
+            </gIBSUF>
+            <gIBSMun>
+              <pIBSMun>0.0000</pIBSMun>
+              <vIBSMun>0.00</vIBSMun>
+            </gIBSMun>
+            <vIBS>0.14</vIBS>
+            <gCBS>
+              <pCBS>0.9000</pCBS>
+              <vCBS>1.26</vCBS>
+            </gCBS>
+            </gIBSCBS>
+        </IBSCBS>
       </imposto>
+      <vItem>140.00</vItem>
     </det>
     <total>
       <ICMSTot>
@@ -134,6 +155,32 @@
         <vOutro>0.00</vOutro>
         <vNF>140.00</vNF>
       </ICMSTot>
+      <IBSCBSTot>
+        <vBCIBSCBS>140.00</vBCIBSCBS>
+        <gIBS>
+          <gIBSUF>
+            <vDif>0.00</vDif>
+            <vDevTrib>0.00</vDevTrib>
+            <vIBSUF>0.14</vIBSUF>
+          </gIBSUF>
+          <gIBSMun>
+            <vDif>0.00</vDif>
+            <vDevTrib>0.00</vDevTrib>
+            <vIBSMun>0.00</vIBSMun>
+          </gIBSMun>
+          <vIBS>0.14</vIBS>
+          <vCredPres>0.00</vCredPres>
+          <vCredPresCondSus>0.00</vCredPresCondSus>
+        </gIBS>
+        <gCBS>
+          <vDif>0.00</vDif>
+          <vDevTrib>0.00</vDevTrib>
+          <vCBS>1.26</vCBS>
+          <vCredPres>0.00</vCredPres>
+          <vCredPresCondSus>0.00</vCredPresCondSus>
+        </gCBS>
+      </IBSCBSTot>
+      <vNFTot>140.00</vNFTot>
     </total>
     <transp>
       <modFrete>9</modFrete>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000022062777169.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000022062777169.xml
@@ -111,7 +111,28 @@
             <vCOFINS>58.50</vCOFINS>
           </COFINSAliq>
         </COFINS>
+        <IBSCBS>
+          <CST>000</CST>
+          <cClassTrib>000001</cClassTrib>
+          <gIBSCBS>
+            <vBC>1707.22</vBC>
+            <gIBSUF>
+              <pIBSUF>0.1000</pIBSUF>
+              <vIBSUF>1.71</vIBSUF>
+            </gIBSUF>
+            <gIBSMun>
+              <pIBSMun>0.0000</pIBSMun>
+              <vIBSMun>0.00</vIBSMun>
+            </gIBSMun>
+            <vIBS>1.71</vIBS>
+            <gCBS>
+              <pCBS>0.9000</pCBS>
+              <vCBS>15.36</vCBS>
+            </gCBS>
+            </gIBSCBS>
+        </IBSCBS>
       </imposto>
+      <vItem>1950.00</vItem>
     </det>
     <total>
       <ICMSTot>
@@ -135,6 +156,32 @@
         <vOutro>0.00</vOutro>
         <vNF>1950.00</vNF>
       </ICMSTot>
+      <IBSCBSTot>
+        <vBCIBSCBS>1707.22</vBCIBSCBS>
+        <gIBS>
+          <gIBSUF>
+            <vDif>0.00</vDif>
+            <vDevTrib>0.00</vDevTrib>
+            <vIBSUF>1.71</vIBSUF>
+          </gIBSUF>
+          <gIBSMun>
+            <vDif>0.00</vDif>
+            <vDevTrib>0.00</vDevTrib>
+            <vIBSMun>0.00</vIBSMun>
+          </gIBSMun>
+          <vIBS>1.71</vIBS>
+          <vCredPres>0.00</vCredPres>
+          <vCredPresCondSus>0.00</vCredPresCondSus>
+        </gIBS>
+        <gCBS>
+          <vDif>0.00</vDif>
+          <vDevTrib>0.00</vDevTrib>
+          <vCBS>15.36</vCBS>
+          <vCredPres>0.00</vCredPres>
+          <vCredPresCondSus>0.00</vCredPresCondSus>
+        </gCBS>
+      </IBSCBSTot>
+      <vNFTot>1950.00</vNFTot>
     </total>
     <transp>
       <modFrete>9</modFrete>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000032062777166.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000032062777166.xml
@@ -113,7 +113,28 @@
             <vCOFINS>2.82</vCOFINS>
           </COFINSAliq>
         </COFINS>
+        <IBSCBS>
+          <CST>000</CST>
+          <cClassTrib>000001</cClassTrib>
+          <gIBSCBS>
+            <vBC>86.81</vBC>
+            <gIBSUF>
+              <pIBSUF>0.1000</pIBSUF>
+              <vIBSUF>0.09</vIBSUF>
+            </gIBSUF>
+            <gIBSMun>
+              <pIBSMun>0.0000</pIBSMun>
+              <vIBSMun>0.00</vIBSMun>
+            </gIBSMun>
+            <vIBS>0.09</vIBS>
+            <gCBS>
+              <pCBS>0.9000</pCBS>
+              <vCBS>0.78</vCBS>
+            </gCBS>
+            </gIBSCBS>
+        </IBSCBS>
       </imposto>
+      <vItem>94.00</vItem>
     </det>
     <total>
       <ICMSTot>
@@ -137,6 +158,32 @@
         <vOutro>0.00</vOutro>
         <vNF>94.00</vNF>
       </ICMSTot>
+      <IBSCBSTot>
+        <vBCIBSCBS>86.81</vBCIBSCBS>
+        <gIBS>
+          <gIBSUF>
+            <vDif>0.00</vDif>
+            <vDevTrib>0.00</vDevTrib>
+            <vIBSUF>0.09</vIBSUF>
+          </gIBSUF>
+          <gIBSMun>
+            <vDif>0.00</vDif>
+            <vDevTrib>0.00</vDevTrib>
+            <vIBSMun>0.00</vIBSMun>
+          </gIBSMun>
+          <vIBS>0.09</vIBS>
+          <vCredPres>0.00</vCredPres>
+          <vCredPresCondSus>0.00</vCredPresCondSus>
+        </gIBS>
+        <gCBS>
+          <vDif>0.00</vDif>
+          <vDevTrib>0.00</vDevTrib>
+          <vCBS>0.78</vCBS>
+          <vCredPres>0.00</vCredPres>
+          <vCredPresCondSus>0.00</vCredPresCondSus>
+        </gCBS>
+      </IBSCBSTot>
+      <vNFTot>94.00</vNFTot>
     </total>
     <transp>
       <modFrete>9</modFrete>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200181583054000129550010000000052062777166.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200181583054000129550010000000052062777166.xml
@@ -112,6 +112,26 @@
               <vCOFINS>0.00</vCOFINS>
             </COFINSOutr>
           </COFINS>
+          <IBSCBS>
+            <CST>000</CST>
+            <cClassTrib>000001</cClassTrib>
+            <gIBSCBS>
+              <vBC>14.00</vBC>
+              <gIBSUF>
+                <pIBSUF>0.1000</pIBSUF>
+                <vIBSUF>0.01</vIBSUF>
+              </gIBSUF>
+              <gIBSMun>
+                <pIBSMun>0.0000</pIBSMun>
+                <vIBSMun>0.00</vIBSMun>
+              </gIBSMun>
+              <vIBS>0.01</vIBS>
+              <gCBS>
+                <pCBS>0.9000</pCBS>
+                <vCBS>0.13</vCBS>
+              </gCBS>
+              </gIBSCBS>
+          </IBSCBS>
         </imposto>
       </det>
       <total>
@@ -140,6 +160,31 @@
           <vNF>14.00</vNF>
           <vTotTrib>0.00</vTotTrib>
         </ICMSTot>
+        <IBSCBSTot>
+          <vBCIBSCBS>14.00</vBCIBSCBS>
+          <gIBS>
+            <gIBSUF>
+              <vDif>0.00</vDif>
+              <vDevTrib>0.00</vDevTrib>
+              <vIBSUF>0.01</vIBSUF>
+            </gIBSUF>
+            <gIBSMun>
+              <vDif>0.00</vDif>
+              <vDevTrib>0.00</vDevTrib>
+              <vIBSMun>0.00</vIBSMun>
+            </gIBSMun>
+            <vIBS>0.01</vIBS>
+            <vCredPres>0.00</vCredPres>
+            <vCredPresCondSus>0.00</vCredPresCondSus>
+          </gIBS>
+          <gCBS>
+            <vDif>0.00</vDif>
+            <vDevTrib>0.00</vDevTrib>
+            <vCBS>0.13</vCBS>
+            <vCredPres>0.00</vCredPres>
+            <vCredPresCondSus>0.00</vCredPresCondSus>
+          </gCBS>
+        </IBSCBSTot>
       </total>
       <transp>
         <modFrete>9</modFrete>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200681583054000129550010000000012760018057-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200681583054000129550010000000012760018057-nf-e.xml
@@ -113,6 +113,26 @@
             <vCOFINS>9.60</vCOFINS>
           </COFINSAliq>
         </COFINS>
+        <IBSCBS>
+          <CST>000</CST>
+          <cClassTrib>000001</cClassTrib>
+          <gIBSCBS>
+            <vBC>269.92</vBC>
+            <gIBSUF>
+              <pIBSUF>0.1000</pIBSUF>
+              <vIBSUF>0.27</vIBSUF>
+            </gIBSUF>
+            <gIBSMun>
+              <pIBSMun>0.0000</pIBSMun>
+              <vIBSMun>0.00</vIBSMun>
+            </gIBSMun>
+            <vIBS>0.27</vIBS>
+            <gCBS>
+              <pCBS>0.9000</pCBS>
+              <vCBS>2.43</vCBS>
+            </gCBS>
+          </gIBSCBS>
+        </IBSCBS>
       </imposto>
     </det>
     <det nItem="2">
@@ -169,6 +189,26 @@
             <vCOFINS>109.35</vCOFINS>
           </COFINSAliq>
         </COFINS>
+        <IBSCBS>
+          <CST>000</CST>
+          <cClassTrib>000001</cClassTrib>
+          <gIBSCBS>
+            <vBC>269.92</vBC>
+            <gIBSUF>
+              <pIBSUF>0.1000</pIBSUF>
+              <vIBSUF>0.27</vIBSUF>
+            </gIBSUF>
+            <gIBSMun>
+              <pIBSMun>0.0000</pIBSMun>
+              <vIBSMun>0.00</vIBSMun>
+            </gIBSMun>
+            <vIBS>0.27</vIBS>
+            <gCBS>
+              <pCBS>0.9000</pCBS>
+              <vCBS>2.43</vCBS>
+            </gCBS>
+          </gIBSCBS>
+        </IBSCBS>
       </imposto>
       <infAdProd>Valor Aprox. dos Tributos: R$ 182.25</infAdProd>
     </det>
@@ -194,6 +234,31 @@
         <vOutro>0.00</vOutro>
         <vNF>4147.25</vNF>
       </ICMSTot>
+      <IBSCBSTot>
+        <vBCIBSCBS>539.84</vBCIBSCBS>
+        <gIBS>
+          <gIBSUF>
+            <vDif>0.00</vDif>
+            <vDevTrib>0.00</vDevTrib>
+            <vIBSUF>0.54</vIBSUF>
+          </gIBSUF>
+          <gIBSMun>
+            <vDif>0.00</vDif>
+            <vDevTrib>0.00</vDevTrib>
+            <vIBSMun>0.00</vIBSMun>
+          </gIBSMun>
+          <vIBS>0.54</vIBS>
+          <vCredPres>0.00</vCredPres>
+          <vCredPresCondSus>0.00</vCredPresCondSus>
+        </gIBS>
+        <gCBS>
+          <vDif>0.00</vDif>
+          <vDevTrib>0.00</vDevTrib>
+          <vCBS>4.86</vCBS>
+          <vCredPres>0.00</vCredPres>
+          <vCredPresCondSus>0.00</vCredPresCondSus>
+        </gCBS>
+      </IBSCBSTot>
     </total>
     <transp>
       <modFrete>9</modFrete>

--- a/l10n_br_nfe/tests/test_nfe_xml_validation.py
+++ b/l10n_br_nfe/tests/test_nfe_xml_validation.py
@@ -84,7 +84,7 @@ class TestXMLValidation(TransactionCase):
                 "fiscal_quantity": 22,
             }
         )
-        self.assertEqual(len(line.fiscal_tax_ids), 4)
+        self.assertEqual(len(line.fiscal_tax_ids), 6)
         line.write(
             {
                 "icms_tax_id": self.env.ref("l10n_br_fiscal.tax_icms_12_st").id,

--- a/l10n_br_sale_stock/demo/sale_order_demo.xml
+++ b/l10n_br_sale_stock/demo/sale_order_demo.xml
@@ -15,7 +15,7 @@
         />
     </record>
 
-    <!-- Main Company Simples Nacional -->
+    <!-- Empresa Simples Nacional -->
     <record id="main_company-sale_order_1" model="sale.order">
         <field
             name="name"
@@ -32,7 +32,7 @@
         <!-- Necessario para corrigir o campo ind_final, por padrão vem com o
          valor Sim, o que está errado, porque deve ser Não -->
         <field name="ind_final">0</field>
-        <field name="company_id" ref="base.main_company" />
+        <field name="company_id" ref="l10n_br_base.empresa_simples_nacional" />
         <field name="copy_note">True</field>
         <field name="note">TESTE - TERMOS E CONDIÇÕES 1</field>
         <field
@@ -128,7 +128,7 @@
         <!-- Necessario para corrigir o campo ind_final, por padrão vem com o
          valor Sim, o que está errado, porque deve ser Não -->
         <field name="ind_final">0</field>
-        <field name="company_id" ref="base.main_company" />
+        <field name="company_id" ref="l10n_br_base.empresa_simples_nacional" />
         <field name="copy_note">True</field>
         <field name="note">TESTE de criação de duas Notas de Serviço e Produto</field>
         <field
@@ -205,7 +205,7 @@
         <!-- Necessario para corrigir o campo ind_final, por padrão vem com o
          valor Sim, o que está errado, porque deve ser Não -->
         <field name="ind_final">0</field>
-        <field name="company_id" ref="base.main_company" />
+        <field name="company_id" ref="l10n_br_base.empresa_simples_nacional" />
         <field name="copy_note">True</field>
         <field name="note">TESTE - TERMOS E CONDIÇÕES 3</field>
         <field
@@ -300,7 +300,7 @@
         <!-- Necessario para corrigir o campo ind_final, por padrão vem com o
          valor Sim, o que está errado, porque deve ser Não -->
         <field name="ind_final">0</field>
-        <field name="company_id" ref="base.main_company" />
+        <field name="company_id" ref="l10n_br_base.empresa_simples_nacional" />
         <field name="copy_note">True</field>
         <field name="note">TESTE - TERMOS E CONDIÇÕES 4</field>
         <field

--- a/l10n_br_sale_stock/tests/test_sale_stock.py
+++ b/l10n_br_sale_stock/tests/test_sale_stock.py
@@ -83,12 +83,21 @@ class TestSaleStock(TestBrPickingInvoicingCommon):
         common_fields = list(set(sm_fields) & set(sol_fields) - set(skipped_fields))
 
         for field in common_fields:
-            self.assertEqual(
-                stock_move[field],
-                sale_order_line[field],
-                "Field %s failed to transfer from "
-                "sale.order.line to stock.move" % field,
-            )
+            if isinstance(stock_move[field], float):
+                self.assertAlmostEqual(
+                    stock_move[field],
+                    sale_order_line[field],
+                    2,
+                    "Field %s failed to transfer from "
+                    "sale.order.line to stock.move" % field,
+                )
+            else:
+                self.assertEqual(
+                    stock_move[field],
+                    sale_order_line[field],
+                    "Field %s failed to transfer from "
+                    "sale.order.line to stock.move" % field,
+                )
 
         self.env["stock.immediate.transfer"].create(
             {"pick_ids": [Command.link(stock_picking.id)]}
@@ -118,17 +127,27 @@ class TestSaleStock(TestBrPickingInvoicingCommon):
         common_fields = list(set(sm_fields) & set(sol_fields) - set(skipped_fields))
 
         for field in common_fields:
-            self.assertEqual(
-                stock_move[field],
-                sale_order_line[field],
-                "Field %s failed to transfer from "
-                "sale.order.line to stock.move" % field,
-            )
+            if isinstance(stock_move[field], float):
+                self.assertAlmostEqual(
+                    stock_move[field],
+                    sale_order_line[field],
+                    2,
+                    "Field %s failed to transfer from "
+                    "sale.order.line to stock.move" % field,
+                )
+            else:
+                self.assertEqual(
+                    stock_move[field],
+                    sale_order_line[field],
+                    "Field %s failed to transfer from "
+                    "sale.order.line to stock.move" % field,
+                )
 
     def test_picking_sale_order_product_and_service(self):
         """
         Test Sale Order with product and service
         """
+        self._change_user_company(self.env.ref("l10n_br_base.empresa_simples_nacional"))
         sale_order_2 = self.env.ref("l10n_br_sale_stock.main_company-sale_order_2")
         self.env.ref(
             "l10n_br_sale_stock.main_company-sale_order_line_2_1"
@@ -229,12 +248,21 @@ class TestSaleStock(TestBrPickingInvoicingCommon):
             line.save()
 
         for field in common_fields:
-            self.assertEqual(
-                sale_order_line[field],
-                invoice_lines[field],
-                "Field %s failed to transfer from "
-                "sale.order.line to account.move.line" % field,
-            )
+            if isinstance(sale_order_line[field], float):
+                self.assertAlmostEqual(
+                    sale_order_line[field],
+                    invoice_lines[field],
+                    2,
+                    "Field %s failed to transfer from "
+                    "sale.order.line to account.move.line" % field,
+                )
+            else:
+                self.assertEqual(
+                    sale_order_line[field],
+                    invoice_lines[field],
+                    "Field %s failed to transfer from "
+                    "sale.order.line to account.move.line" % field,
+                )
 
         for inv_line in invoice_lines.filtered(
             lambda ln: ln.product_id == sale_order_line.product_id
@@ -275,6 +303,7 @@ class TestSaleStock(TestBrPickingInvoicingCommon):
         picking and 3 moves per picking, but Partner to Shipping is
         different from Partner to Invoice.
         """
+        self._change_user_company(self.env.ref("l10n_br_base.empresa_simples_nacional"))
         sale_order_1 = self.env.ref("l10n_br_sale_stock.main_company-sale_order_1")
         sale_order_1.action_confirm()
         picking = sale_order_1.picking_ids
@@ -333,6 +362,7 @@ class TestSaleStock(TestBrPickingInvoicingCommon):
         picking and 3 moves per picking, the 3 has the same Partner to
         Invoice but one has Partner to Shipping so shouldn't be grouping.
         """
+        self._change_user_company(self.env.ref("l10n_br_base.empresa_simples_nacional"))
         sale_order_1 = self.env.ref("l10n_br_sale_stock.main_company-sale_order_1")
         sale_order_1.action_confirm()
         picking = sale_order_1.picking_ids
@@ -390,6 +420,7 @@ class TestSaleStock(TestBrPickingInvoicingCommon):
         """
         Test the synchronize Sale Partner Shipping in Stock Picking
         """
+        self._change_user_company(self.env.ref("l10n_br_base.empresa_simples_nacional"))
         sale_order_1 = self.env.ref("l10n_br_sale_stock.main_company-sale_order_1")
         sale_order_1.action_confirm()
         picking = sale_order_1.picking_ids
@@ -450,6 +481,7 @@ class TestSaleStock(TestBrPickingInvoicingCommon):
 
     def test_form_stock_picking(self):
         """Test Stock Picking with Form"""
+        self._change_user_company(self.env.ref("l10n_br_base.empresa_simples_nacional"))
         sale_order = self.env.ref("l10n_br_sale_stock.main_company-sale_order_1")
         sale_order.action_confirm()
         picking = sale_order.picking_ids
@@ -467,6 +499,7 @@ class TestSaleStock(TestBrPickingInvoicingCommon):
 
     def test_down_payment(self):
         """Test the case with Down Payment"""
+        self._change_user_company(self.env.ref("l10n_br_base.empresa_simples_nacional"))
         sale_order_1 = self.env.ref("l10n_br_sale_stock.main_company-sale_order_1")
         sale_order_1.action_confirm()
         # Create Invoice Sale
@@ -525,6 +558,7 @@ class TestSaleStock(TestBrPickingInvoicingCommon):
 
     def test_generate_document_number_on_invoice_create_wizard(self):
         """Test Invoicing Picking with Document Number"""
+        self._change_user_company(self.env.ref("l10n_br_base.empresa_simples_nacional"))
         sale_order = self.env.ref("l10n_br_sale_stock.main_company-sale_order_1")
         sale_order.action_confirm()
         picking = sale_order.picking_ids


### PR DESCRIPTION
# Suporte os impostos IBS/CBS: dados de demo, ajustes de teste e correção de um bug de sincronização de impostos

## Contexto

Essa PR substitui o #4299 adiciona cobertura de teste para os novos tributos da Reforma Tributária (IBS 0,1% e CBS 0,9%) na empresa `l10n_br_base.empresa_simples_nacional`, e corrige um bug real que essa cobertura expôs em `l10n_br_account` (imposto embutido calculado como zero em determinadas situações, presente mas invisível enquanto todas as alíquotas testadas eram 0%).

## Commits

### `c609fd2d` [ADD] l10n_br_fiscal: company ibs/cbs demo data

Adiciona `l10n_br_fiscal.tax.definition` de IBS e CBS para as empresas de demo (Simples Nacional, Lucro Presumido) e o `tax_classification_id` padrão nas empresas de demo, habilitando o cálculo desses tributos nos cenários fiscais de teste.

### `f9938431` [IMP] l10n_br_fiscal: ibs/cbs fiscal tax test

Atualiza `test_fiscal_tax.py` e `test_document_edition.py`: inclui IBS/CBS na lista de impostos computados nos testes (`fiscal_tax_ids` passa de 4 para 6 impostos) e ajusta o resultado esperado de `amount_included`.

### `10a45f9e` [IMP] l10n_br_account: ibs/cbs fiscal tax test

Ajusta `test_move_edition.py` para refletir os 6 impostos fiscais (antes 4) agora aplicados à linha de fatura com IBS/CBS habilitado.

### `3ea54111` [IMP] l10n_br_nfe: ibs/cbs fiscal tax test

Atualiza os fixtures XML de NF-e usados nos testes de serialização para incluir o bloco `<IBSCBS>`/`<IBSCBSTot>` (tributo embutido) gerado pelo motor fiscal, corrige a contagem de impostos em `test_nfe_xml_validation.py` (4→6) e Corrige o uso de TnfeProc (tipo XSD genérico, com Meta.name="TNfeProc") por NfeProc (classe específica do elemento <nfeProc>, com Meta.name correto) ao fazer parse da resposta processada da NF-e, evitando que uma futura serialização desse objeto gere XML com tag raiz inválida.

### `bd032a08` [IMP] l10n_br_sale_stock: ibs/cbs fiscal tax test

Migra os pedidos de venda de demo (`main_company-sale_order_1..4`) de `base.main_company` para `l10n_br_base.empresa_simples_nacional`, com `_change_user_company()` nos 7 métodos de teste afetados. Necessário porque `base.main_company` herda o plano de contas genérico (`l10n_generic_coa`) e nunca teria o `account.tax` corretamente vinculado ao `l10n_br_fiscal.tax` do IBS/CBS. Também torna as comparações de campo entre `stock.move`/`sale.order.line`/`account.move.line` tolerantes a pequenas diferenças de arredondamento (`assertAlmostEqual` para campos float).

### `6e41c716` [FIX] l10n_br_account: changed line.fiscal_tax_ids to line.fiscal_document_line_id.fiscal_tax_ids on compute_all call

Correção de causa raiz: em `account_move_line.py`, `_compute_totals()` e `_compute_all_tax()` liam `line.fiscal_tax_ids` — campo delegado via `_inherits` para `l10n_br_fiscal.document.line` — que podia retornar vazio nesse ponto específico do fluxo de criação da fatura, mesmo já populado no registro delegado (`line.fiscal_document_line_id.fiscal_tax_ids`). Isso fazia o imposto embutido (IBS/CBS, ou qualquer imposto com `tax_include=True`) ser silenciosamente calculado como zero no lado contábil, sem gerar a linha de imposto correspondente — causando faturas "not balanced" quando o valor do imposto é diferente de zero. Como todas as alíquotas testadas antes eram 0%, o bug nunca havia se manifestado. A correção lê o campo através do registro delegado, evitando o cache desatualizado.

### `a811e59b` [FIX] l10n_br_cte: fix cte serialization test

Duas correções nos testes de serialização de CT-e:

1. `test_cte_serialize.py`: adiciona `Command.clear()` antes de `Command.create()` nas listas one2many (`cte40_occ`, `cte40_peri`, `cte40_balsa`), evitando duplicação de registros quando o mesmo documento de demo é reexportado mais de uma vez na mesma transação.
2. Atualiza os 6 fixtures XML esperados (5 modais do `TestCTeExportLC` + 1 do `TestCTeExportSN`) incluindo o bloco `<IBSCBS>`/`<vTotDFe>` que o motor fiscal já gera corretamente quando a empresa tem IBS/CBS configurado, mas que os fixtures estáticos nunca haviam incorporado.
