### PR TITLE
[18.0][REM] l10n_br_sale: remove dead _amount_by_group - FWP 4667

### DIFF
--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -1,12 +1,8 @@
 # Copyright (C) 2009  Renato Lima - Akretion
 # Copyright (C) 2012  Raphaël Valyi - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
-from functools import partial
-
 from odoo import api, fields, models
 from odoo.exceptions import UserError
-from odoo.tools import float_is_zero
-from odoo.tools.misc import formatLang
 
 
 class SaleOrder(models.Model):
@@ -184,40 +180,6 @@ class SaleOrder(models.Model):
                 result["journal_id"] = self.fiscal_operation_id.journal_id.id
 
         return result
-
-    def _amount_by_group(self):
-        for order in self:
-            currency = order.currency_id or order.company_id.currency_id
-            fmt = partial(
-                formatLang,
-                self.with_context(lang=order.partner_id.lang).env,
-                currency_obj=currency,
-            )
-            res = {}
-            for line in order.order_line:
-                taxes = line._compute_taxes(line.fiscal_tax_ids)["taxes"]
-                for tax in line.fiscal_tax_ids:
-                    computed_tax = taxes.get(tax.tax_domain)
-                    pr = order.currency_id.rounding
-                    if computed_tax and not float_is_zero(
-                        computed_tax.get("tax_value", 0.0), precision_rounding=pr
-                    ):
-                        group = tax.tax_group_id
-                        res.setdefault(group, {"amount": 0.0, "base": 0.0})
-                        res[group]["amount"] += computed_tax.get("tax_value", 0.0)
-                        res[group]["base"] += computed_tax.get("base", 0.0)
-            res = sorted(res.items(), key=lambda line: line[0].sequence)
-            order.amount_by_group = [
-                (
-                    line[0].name,
-                    line[1]["amount"],
-                    line[1]["base"],
-                    fmt(line[1]["amount"]),
-                    fmt(line[1]["base"]),
-                    len(res),
-                )
-                for line in res
-            ]
 
     def _get_fiscal_partner(self):
         self.ensure_one()


### PR DESCRIPTION
FWP #4667

The amount_by_group field no longer exists anywhere (Odoo 16 replaced it with tax_totals), so this method is never called. If it were, it would crash twice: sale.order.line has no _compute_taxes method (removed in the tax engine refactor) and the assignment targets a nonexistent field. Leftover from 14.0/15.0.