### PR TITLE
[17.0][IMP] l10n_br_account: partial indexes on the fiscal document links - FWP 4666

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -59,6 +59,7 @@ class AccountMove(models.Model):
         ondelete="cascade",
         store=True,
         readonly=False,
+        index="btree_not_null",
     )
 
     fiscal_document_ids = fields.One2many(

--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -33,6 +33,7 @@ class AccountMoveLine(models.Model):
         string="Fiscal Document Line",
         copy=False,
         ondelete="cascade",
+        index="btree_not_null",
     )
 
     document_type_id = fields.Many2one(


### PR DESCRIPTION
FWP #4666

Add index="btree_not_null" to the two _inherits delegation fields linking accounting records to their fiscal counterparts:

- account.move.fiscal_document_id
- account.move.line.fiscal_document_line_id

These columns are searched on every fiscal sync (ORM triggers issue WHERE fiscal_document_id IN (...) queries), but most rows are NULL (payments, misc entries) and NULL is never searched, so a partial btree index serves all existing queries at a fraction of the size and write overhead.