### PR TITLE
[16.0][l10n_br_base][l10n_br_fiscal] vat future proof

### DIFF
--- a/l10n_br_base/models/party_mixin.py
+++ b/l10n_br_base/models/party_mixin.py
@@ -29,6 +29,12 @@ class PartyMixin(models.AbstractModel):
         index=True,
     )
 
+    vat_formatted_cnpj = fields.Char(
+        string="VAT Formatted (Brazil)",
+        compute="_compute_vat_formatted_cnpj",
+        help="CNPJ or CPF formatted with proper punctuation and special characters",
+    )
+
     l10n_br_ie_code = fields.Char(
         string="State Tax Number",
         size=17,
@@ -144,6 +150,34 @@ class PartyMixin(models.AbstractModel):
                 )
             else:
                 record.cnpj_cpf_stripped = False
+
+    @api.depends("vat", "country_id")
+    def _compute_vat_formatted_cnpj(self):
+        for record in self:
+            vat_formatted_cnpj = False
+            if record.vat and record.country_id and record.country_id.code == "BR":
+                vat_formatted_cnpj = cnpj_cpf.formata(record.vat)
+            record.vat_formatted_cnpj = vat_formatted_cnpj
+
+    def _normalize_vat(self, vals):
+        """Strip punctuation from Brazilian VAT values so they can be stored
+        unformatted. This is a no-op helper in 16.0; it will become active in
+        18.0 while keeping the API stable for forward-ports.
+        """
+        if not isinstance(vals, dict):
+            return
+        vat = vals.get("vat")
+        if not vat:
+            return
+        country_id = vals.get("country_id")
+        if country_id:
+            country = self.env["res.country"].browse(country_id)
+        elif self and len(self) == 1:
+            country = self.country_id
+        else:
+            country = self.env.company.country_id
+        if country and country.code == "BR":
+            vals["vat"] = misc.punctuation_rm(str(vat))
 
     @api.onchange("zip")
     def _onchange_zip(self):

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -375,10 +375,10 @@ class Document(models.Model):
                 name += " - " + _("Unidentified Consumer")
             elif self.partner_id.legal_name:
                 name += " - " + self.partner_id.legal_name
-                name += " - " + self.partner_id.vat
+                name += " - " + self.partner_id.vat_formatted_cnpj
             else:
                 name += " - " + self.partner_id.name
-                name += " - " + self.partner_id.vat
+                name += " - " + self.partner_id.vat_formatted_cnpj
         elif self._context.get("fiscal_document_no_company"):
             name += type_serie_number
         else:

--- a/l10n_br_fiscal/wizards/document_import_wizard.py
+++ b/l10n_br_fiscal/wizards/document_import_wizard.py
@@ -70,7 +70,9 @@ class DocumentImportWizard(models.TransientModel):
 
     @api.depends("issuer_cnpj", "company_id.cnpj_cpf")
     def _compute_fiscal_operation_type(self):
-        if self.issuer_cnpj == self.company_id.cnpj_cpf:
+        if punctuation_rm(self.issuer_cnpj) == punctuation_rm(
+            self.company_id.cnpj_cpf or ""
+        ):
             self.fiscal_operation_type = "out"
         else:
             self.fiscal_operation_type = "in"


### PR DESCRIPTION
a ideia eh preparar essa mudança https://github.com/OCA/l10n-brazil/pull/4671 deixando o codigo da v16 o mais compativel possivel ja na v16 para facilitar os ports, mas sem necessitar migraçao de dados na v16: o campo vat continua formatado ou nao na v16, enquanto que na v18, ele seria sem formataçao, assim como espera a versao 19 do Odoo.