### PR TITLE
[18.0][FIX] l10n_br_nfse: nfse doc and report

### DIFF
--- a/l10n_br_nfse/models/document.py
+++ b/l10n_br_nfse/models/document.py
@@ -75,8 +75,8 @@ class Document(models.Model):
     def make_pdf(self):
         if not self.filtered(filter_processador_edoc_nfse):
             return super().make_pdf()
-        pdf = self.env.ref("l10n_br_nfse.report_br_nfse_danfe")._render_qweb_pdf(
-            self.ids
+        pdf = self.env["ir.actions.report"]._render_qweb_pdf(
+            "l10n_br_nfse.report_br_nfse_danfe", self.ids
         )[0]
 
         if self.document_number:
@@ -215,7 +215,7 @@ class Document(models.Model):
         nbs_id = self.fiscal_line_ids[0].nbs_id
         tax_estimate = nbs_id.tax_estimate_ids.filtered(
             lambda x: x.state_id == state_id
-        )
+        ).sorted(key=lambda x: x.id, reverse=True)[:1]
 
         percentual_total_tributos_federais = tax_estimate.federal_taxes_national
         if self.partner_id.country_id.code != "BR":

--- a/l10n_br_nfse/report/danfse.xml
+++ b/l10n_br_nfse/report/danfse.xml
@@ -103,7 +103,7 @@ row {
             <div class="row bt bb br bl">
                 <div class="col-2">
                     <img
-                        t-att-src="'data:image/png;base64,%s' % to_text(doc.company_id.nfse_city_logo)"
+                        t-att-src="doc.company_id.nfse_city_logo and image_data_uri(doc.company_id.nfse_city_logo)"
                         style="max-height:80px; margin-top:4px; margin-left:10px;"
                     />
                 </div>
@@ -186,7 +186,7 @@ row {
                 <div class="col-2">
                     <img
                         style="max-height: 150px; padding-left: 25px; padding-top: 25px; max-width: 125px;"
-                        t-att-src="'data:image/png;base64,%s' % to_text(doc.company_id.logo)"
+                        t-att-src="doc.company_id.logo and image_data_uri(doc.company_id.logo)"
                     />
                     <br />
                 </div>
@@ -444,7 +444,7 @@ row {
                     Valor dos Serviços R$
                 </div>
                 <div class="col-2 linha centro br">
-                    <span t-field="doc.amount_untaxed" />
+                    <span t-field="doc.fiscal_amount_untaxed" />
                 </div>
                 <div class="col-2 rotulo br">
                     Natureza Operação


### PR DESCRIPTION
## Fixes
1. make_pdf update syntax Odoo 18 self.env["ir.actions.report"]._render_qweb_pdf( report, ids)
2. renamed fiscal field: fiscal_amount_untaxed
3. image format in report - using image_data_uri
4. multi-line estimate taxes bug


## Error details
<details><summary>Details</summary>
<p>

### 1.
<img width="1539" height="887" alt="image" src="https://github.com/user-attachments/assets/cef2227a-f621-41da-a390-99022975e40d" />

### 2.
new field name
please see https://github.com/OCA/l10n-brazil/commit/63e982e68d5731798fe78e1b5ede46521fef3c56

### 3.
following Odoo 18 format

### 4.
<img width="1129" height="702" alt="image" src="https://github.com/user-attachments/assets/44b95037-94ea-433f-ace3-7e702a5af44e" />


</p>
</details> 


