### PR TITLE
[16.0][FIX] l10n_br_sale: recalcula valores fiscais antes do faturamento

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -246,12 +246,14 @@ class AccountMove(models.Model):
     )
     def _compute_amount(self):
         if "force_fiscal_amount_recompute" in self._context:
-            for move in self.filtered(lambda m: m.fiscal_operation_id):
+            for move in self.filtered(
+                lambda m: m.fiscal_operation_id and m.fiscal_document_id
+            ):
                 # this is a ugly hack required for importing composite
                 # fiscal documents for instance. It should be used
                 # exceptionnaly as it breaks the dependency chain and
                 # can leave fields such as payment_state inconsistent.
-                move._compute_fiscal_amount()
+                move.fiscal_document_id._compute_fiscal_amount()
 
         result = super()._compute_amount()
         for move in self.filtered(lambda m: m.fiscal_operation_id):

--- a/l10n_br_sale/models/sale_order.py
+++ b/l10n_br_sale/models/sale_order.py
@@ -133,7 +133,9 @@ class SaleOrder(models.Model):
         moves = self.env["account.move"]
         for document_type in document_types:
             self = self.with_context(
-                document_type_id=document_type.id, l10n_br_fiscal_active=True
+                document_type_id=document_type.id,
+                l10n_br_fiscal_active=True,
+                force_fiscal_amount_recompute=True,
             )
             try:
                 moves |= super()._create_invoices(

--- a/l10n_br_sale/tests/test_l10n_br_sale_sn.py
+++ b/l10n_br_sale/tests/test_l10n_br_sale_sn.py
@@ -3,7 +3,9 @@
 #   Renato Lima <renato.lima@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo.tests import TransactionCase
+from unittest.mock import patch
+
+from odoo.tests import Form, TransactionCase
 
 from .test_l10n_br_sale import L10nBrSaleBaseTest
 
@@ -15,3 +17,106 @@ class TestL10nBrSaleSN(L10nBrSaleBaseTest, TransactionCase):
     so_products_ref = "l10n_br_sale.sn_so_only_products"
     so_services_ref = "l10n_br_sale.sn_so_only_services"
     so_product_service_ref = "l10n_br_sale.sn_so_product_service"
+
+    def test_create_service_invoice_with_withholding_taxes(self):
+        self._change_user_company(self.company)
+        self.fsc_op_sale.deductible_taxes = False
+        self.company.write(
+            {
+                "tax_issqn_wh_id": False,
+                "tax_cofins_wh_id": False,
+                "tax_pis_wh_id": False,
+                "tax_csll_wh_id": False,
+                "tax_inss_wh_id": False,
+            }
+        )
+        self.company.tax_definition_ids.filtered(
+            lambda definition: definition.tax_group_id.tax_withholding
+        ).unlink()
+
+        tax_definition_model = self.env["l10n_br_fiscal.tax.definition"]
+        withholding_taxes = (
+            "l10n_br_fiscal.tax_issqn_wh_5",
+            "l10n_br_fiscal.tax_cofins_wh_3",
+            "l10n_br_fiscal.tax_pis_wh_0_65",
+            "l10n_br_fiscal.tax_csll_wh_1",
+            "l10n_br_fiscal.tax_inss_wh_11",
+        )
+        for tax_xmlid in withholding_taxes:
+            tax = self.env.ref(tax_xmlid)
+            tax_definition_model.create(
+                {
+                    "fiscal_operation_line_id": self.fsc_op_line_serv.id,
+                    "tax_group_id": tax.tax_group_id.id,
+                    "is_taxed": True,
+                    "is_debit_credit": True,
+                    "custom_tax": True,
+                    "tax_id": tax.id,
+                    "state": "approved",
+                }
+            )
+
+        sale_order_form = Form(self.env["sale.order"])
+        sale_order_form.partner_id = self.env.ref("l10n_br_base.res_partner_akretion")
+        sale_order_form.fiscal_operation_id = self.fsc_op_sale
+        sale_order_form.note = "Service invoice with withholding taxes"
+        with sale_order_form.order_line.new() as line_form:
+            line_form.product_id = self.env.ref(
+                "l10n_br_fiscal.customized_development_sale"
+            )
+            line_form.product_uom_qty = 90
+            line_form.price_unit = 100
+        sale_order = sale_order_form.save()
+        self.env["sale.order.line"].create(
+            {
+                "order_id": sale_order.id,
+                "display_type": "line_note",
+                "name": "Invoice note",
+            }
+        )
+
+        service_line = sale_order.order_line.filtered(
+            lambda line: not line.display_type
+        )
+        expected_taxes = self.env["l10n_br_fiscal.tax"].browse(
+            [self.env.ref(xmlid).id for xmlid in withholding_taxes]
+        )
+        self.assertEqual(
+            service_line.fiscal_tax_ids & expected_taxes,
+            expected_taxes,
+        )
+        self.assertGreater(service_line.amount_tax_withholding, 0.0)
+
+        sale_order.action_confirm()
+        self.env.flush_all()
+        self.env.invalidate_all()
+        sale_order = self.env["sale.order"].browse(sale_order.id)
+        forced_recomputes = []
+        account_move_model = type(self.env["account.move"])
+        original_compute_amount = account_move_model._compute_amount
+
+        def _compute_amount(moves):
+            if moves.env.context.get("force_fiscal_amount_recompute"):
+                forced_recomputes.append(moves)
+            return original_compute_amount(moves)
+
+        with patch.object(account_move_model, "_compute_amount", _compute_amount):
+            invoices = sale_order._create_invoices(final=True)
+
+        self.assertTrue(forced_recomputes)
+        self.assertEqual(len(invoices), 1)
+        invoice_line = invoices.invoice_line_ids.filtered(
+            lambda line: line.display_type == "product"
+        )
+        for field_name in (
+            "fiscal_amount_untaxed",
+            "fiscal_amount_tax",
+            "fiscal_amount_total",
+            "amount_tax_withholding",
+        ):
+            self.assertAlmostEqual(
+                service_line[field_name],
+                invoice_line[field_name],
+                2,
+            )
+        self.assertAlmostEqual(sum(invoices.line_ids.mapped("balance")), 0.0, 2)


### PR DESCRIPTION
## Problema

Ao criar uma fatura a partir de determinados pedidos de venda com retenções fiscais, os valores fiscais armazenados podem não estar atualizados quando o Odoo executa a verificação de balanceamento do lançamento contábil.

Nessa situação, a criação da fatura falha informando que os débitos e créditos não estão balanceados. Alterações manuais no pedido, como modificar o frete, uma linha, uma nota ou determinadas configurações fiscais, podem fazer o problema desaparecer porque provocam um novo cálculo dos valores.

## Solução

Esta alteração propaga o contexto `force_fiscal_amount_recompute=True` durante a criação das faturas pelo `l10n_br_sale`.

Também corrige o tratamento desse contexto no `l10n_br_account`. O método `_compute_fiscal_amount()` pertence ao documento fiscal (`l10n_br_fiscal.document`) associado à fatura, e não diretamente ao `account.move`.

## Testes

Foi adicionado um teste cobrindo a criação de uma fatura de serviço com a configuração descrita na issue:

- Empresa do Simples Nacional, com `deductible_taxes=False` e sem retenções padrão configuradas na empresa.
- Definições fiscais de ISSQN RET 5%, COFINS RET 3%, PIS RET 0,65%, CSLL RET 1% e INSS RET 11% na linha de operação de serviço.
- Pedido e linha de serviço criados pela API `Form`, com quantidade 90 e preço unitário 100.
- Linha de nota adicionada ao pedido pelo ORM após salvar o formulário.
- Limpeza do cache do ORM antes do faturamento, aproximando a separação entre as chamadas RPC de confirmar o pedido e criar a fatura.

Durante a criação da fatura, o teste instrumenta `_compute_amount()` apenas para observar se o contexto `force_fiscal_amount_recompute` foi recebido. A implementação real continua sendo executada; o cálculo fiscal não é substituído nem simulado.

O teste também verifica:

- A aplicação das cinco retenções fiscais no pedido.
- A correspondência de `fiscal_amount_untaxed`, `fiscal_amount_tax`, `fiscal_amount_total` e `amount_tax_withholding` entre a linha do pedido e a linha da fatura.
- O balanceamento final do lançamento contábil, cuja soma das linhas deve ser zero.

Closes #4704
Related to #4455