### PR TITLE
[14.0][FIX] l10n_br_nfse_focus: nfse_nacional

### DIFF
--- a/l10n_br_nfse_focus/models/nfse_nacional.py
+++ b/l10n_br_nfse_focus/models/nfse_nacional.py
@@ -121,6 +121,8 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
             "codigo_opcao_simples_nacional": int(codigo_opcao_simples_nacional),
             "regime_especial_tributacao": int(regime_especial_tributacao),
             "codigo_municipio_emissora": int(company.city_id.ibge_code or 0),
+            "telefone": company.partner_id.phone or "",
+            "email": company.partner_id.email or "",
         }
 
     def _prepare_recipient_nacional(self, recipient_info):
@@ -181,6 +183,8 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
 
         # TODO: improve logic to get ISS retention code
         tipo_retencao_iss = "2" if service_info.get("iss_retido") == "1" else "1"
+        if int(tributacao_iss) in (2, 3, 4):
+            tipo_retencao_iss = "1"
 
         percentual_total_tributos_federais = service_info.get(
             "percentual_total_tributos_federais", 0.0
@@ -248,19 +252,28 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
                 if not base_calculo_pis_cofins or base_calculo_pis_cofins == 0:
                     base_calculo_pis_cofins = round(valor_servico, 2)
 
-        # Format rates as strings with 2 decimal places
-        aliquota_pis_raw = round(service_info.get("aliquota_pis", 0), 2)
-        aliquota_pis = f"{aliquota_pis_raw:.2f}"
-        aliquota_cofins_raw = round(service_info.get("aliquota_cofins", 0), 2)
-        aliquota_cofins = f"{aliquota_cofins_raw:.2f}"
+        valor_pis = round(service_info.get("valor_pis", 0), 2)
+        valor_cofins = round(service_info.get("valor_cofins", 0), 2)
+        if base_calculo_pis_cofins:
+            aliquota_pis = f"{round(valor_pis / base_calculo_pis_cofins * 100, 2):.2f}"
+            aliquota_cofins = (
+                f"{round(valor_cofins / base_calculo_pis_cofins * 100, 2):.2f}"
+            )
+        else:
+            aliquota_pis = "0.00"
+            aliquota_cofins = "0.00"
 
         return {
-            "situacao_tributaria_pis_cofins": situacao_tributaria_pis_cofins or "",
+            **(
+                {"situacao_tributaria_pis_cofins": situacao_tributaria_pis_cofins}
+                if situacao_tributaria_pis_cofins
+                else {}
+            ),
             "base_calculo_pis_cofins": round(base_calculo_pis_cofins, 2),
             "aliquota_pis": aliquota_pis,
             "aliquota_cofins": aliquota_cofins,
-            "valor_pis": round(service_info.get("valor_pis", 0), 2),
-            "valor_cofins": round(service_info.get("valor_cofins", 0), 2),
+            "valor_pis": valor_pis,
+            "valor_cofins": valor_cofins,
             "tipo_retencao_pis_cofins": service_info.get(
                 "tipo_retencao_pis_cofins", "2"
             ),
@@ -298,6 +311,10 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
         service_basic = self._prepare_service_basic_nacional(service_info)
         tax_data = self._prepare_tax_data_nacional(service_info, service_basic["valor"])
 
+        regime_especial_tributacao = provider_data["regime_especial_tributacao"]
+        if service_basic["tributacao_iss"] in (2, 3, 4):
+            regime_especial_tributacao = 0
+
         # Build payload
         payload = {
             "data_emissao": emission_date,
@@ -318,10 +335,20 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
                 if provider_data["inscricao_municipal"]
                 else {}
             ),
+            **(
+                {"telefone_prestador": provider_data["telefone"]}
+                if provider_data["telefone"]
+                else {}
+            ),
+            **(
+                {"email_prestador": provider_data["email"]}
+                if provider_data["email"]
+                else {}
+            ),
             "codigo_opcao_simples_nacional": provider_data[
                 "codigo_opcao_simples_nacional"
             ],
-            "regime_especial_tributacao": provider_data["regime_especial_tributacao"],
+            "regime_especial_tributacao": regime_especial_tributacao,
             **(
                 {"cnpj_tomador": recipient_data["cnpj_limpo"]}
                 if recipient_data["is_cnpj"]
@@ -362,7 +389,16 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
             "valor_servico": service_basic["valor"],
             "tributacao_iss": service_basic["tributacao_iss"],
             "tipo_retencao_iss": service_basic["tipo_retencao_iss"],
-            "percentual_aliquota_relativa_municipio": service_basic["aliquota_iss"],
+            **(
+                {
+                    "percentual_aliquota_relativa_municipio": service_basic[
+                        "aliquota_iss"
+                    ]
+                }
+                if regime_especial_tributacao == 0
+                and service_basic["tributacao_iss"] not in (2, 3, 4)
+                else {}
+            ),
             "percentual_total_tributos_federais": service_basic[
                 "percentual_total_tributos_federais"
             ],
@@ -372,7 +408,6 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
             "percentual_total_tributos_municipais": service_basic[
                 "percentual_total_tributos_municipais"
             ],
-            "indicador_total_tributacao": 0,
             "informacoes_complementares": (
                 rps_info.get("customer_additional_data", False)[:2000]
                 if rps_info.get("customer_additional_data")

--- a/l10n_br_nfse_focus/tests/test_l10n_br_nfse_focus.py
+++ b/l10n_br_nfse_focus/tests/test_l10n_br_nfse_focus.py
@@ -749,6 +749,56 @@ class TestL10nBrNfseFocus(common.TransactionCase):
 
         self.assertNotIn("inscricao_municipal_prestador", payload)
 
+    def test_prepare_service_basic_nacional_tipo_retencao_iss_override(self):
+        """Tests that tipo_retencao_iss is forced to '1' for tributacao_iss 2/3/4.
+
+        Even when iss_retido indicates retention, exigibilidade codes 2, 3 and 4
+        (isento/imune/exportacao) must never report ISS as retido.
+        """
+        nfse_nacional = self.env["focusnfe.nfse.nacional"]
+        service_info = dict(
+            PAYLOAD[1]["service"], iss_retido="1", codigo_tributacao_iss=2
+        )
+
+        result = nfse_nacional._prepare_service_basic_nacional(service_info)
+
+        self.assertEqual(result["tipo_retencao_iss"], 1)
+
+    def test_prepare_tax_data_nacional_situacao_isenta_zeroes_base(self):
+        """Tests that base_calculo_pis_cofins is zeroed for isenta/imune situations."""
+        nfse_nacional = self.env["focusnfe.nfse.nacional"]
+        service_info = {
+            "situacao_tributaria_pis": "00",
+            "base_calculo_pis": 100.0,
+        }
+
+        result = nfse_nacional._prepare_tax_data_nacional(service_info, 100.0)
+
+        self.assertEqual(result["base_calculo_pis_cofins"], 0.0)
+
+    def test_prepare_tax_data_nacional_situacao_tributada_uses_valor_servico(self):
+        """Tests that a taxable situation with no base falls back to valor_servico."""
+        nfse_nacional = self.env["focusnfe.nfse.nacional"]
+        service_info = {"situacao_tributaria_pis": "01"}
+
+        result = nfse_nacional._prepare_tax_data_nacional(service_info, 150.0)
+
+        self.assertEqual(result["base_calculo_pis_cofins"], 150.0)
+
+    def test_prepare_tax_data_nacional_aliquota_calculation(self):
+        """Tests aliquota_pis/cofins are computed from valor and base when present."""
+        nfse_nacional = self.env["focusnfe.nfse.nacional"]
+        service_info = {
+            "base_calculo_pis": 100.0,
+            "valor_pis": 1.5,
+            "valor_cofins": 3.0,
+        }
+
+        result = nfse_nacional._prepare_tax_data_nacional(service_info, 100.0)
+
+        self.assertEqual(result["aliquota_pis"], "1.50")
+        self.assertEqual(result["aliquota_cofins"], "3.00")
+
     @patch(
         "odoo.addons.l10n_br_nfse_focus.models.nfse_nacional.FocusnfeNfseNacional.process_focus_nfse_nacional_document"  # noqa: B950
     )


### PR DESCRIPTION
@Escodoo HT02002

## Contexto

Ajustes no payload enviado à Focus NFe para o layout **NFS-e Nacional (Padrão Nacional)**, corrigindo campos que estavam sendo enviados incorretamente (ou faltando) em cenários de isenção/imunidade/exportação de ISS e no cálculo de PIS/COFINS.

## Alterações

- **Telefone/e-mail do prestador**: passa a incluir `telefone_prestador` e `email_prestador` no payload (obtidos de `company.partner_id`), enviados apenas quando preenchidos.
- **Tipo de retenção do ISS**: quando `tributacao_iss` é `2`, `3` ou `4` (isento/imune/exportação), `tipo_retencao_iss` agora é sempre forçado para `"1"` (não retido), mesmo que `iss_retido` indique retenção — retenção de ISS não se aplica a esses casos.
- **Regime especial de tributação**: também é forçado para `0` quando `tributacao_iss` está em `(2, 3, 4)`.
- **Percentual de alíquota do município**: `percentual_aliquota_relativa_municipio` só é enviado quando `regime_especial_tributacao == 0` e `tributacao_iss` não está em `(2, 3, 4)`, evitando envio indevido do campo nesses regimes/tributações especiais.
- **Situação tributária PIS/COFINS**: `situacao_tributaria_pis_cofins` deixa de ser enviado como string vazia — só entra no payload quando há valor.
- **Alíquotas de PIS/COFINS**: `aliquota_pis` e `aliquota_cofins` deixam de vir prontas de `service_info` e passam a ser **calculadas** a partir de `valor_pis` / `valor_cofins` sobre `base_calculo_pis_cofins` (`valor / base * 100`, com fallback `"0.00"` quando não há base), garantindo consistência entre valor e alíquota informados.

cc @marcelsavegnago @mileo @rvalyi @WesleyOliveira98 @kaynnan 