### PR TITLE
[16.0][IMP] l10n_br_fiscal, l10n_br_account: performance optimizations for the invoice/sale fiscal flow

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -411,18 +411,21 @@ class AccountMove(models.Model):
         self.update_payment_term_number()
 
     def update_payment_term_number(self):
-        payment_term_lines = self.line_ids.filtered(
-            lambda line: line.display_type == "payment_term"
-        )
-        payment_term_lines_sorted = payment_term_lines.sorted(
-            key=lambda line: line.date_maturity
-        )
-        for idx, line in enumerate(payment_term_lines_sorted, start=1):
-            line.with_context(skip_invoice_sync=True).write(
-                {
-                    "payment_term_number": f"{idx}-{len(payment_term_lines_sorted)}",
-                }
-            )
+        for move in self.filtered(
+            lambda m: m.fiscal_operation_id and m.is_invoice(include_receipts=True)
+        ):
+            payment_term_lines_sorted = move.line_ids.filtered(
+                lambda line: line.display_type == "payment_term"
+            ).sorted(key=lambda line: line.date_maturity)
+            total = len(payment_term_lines_sorted)
+            for idx, line in enumerate(payment_term_lines_sorted, start=1):
+                number = f"{idx}-{total}"
+                # payment_term_number feeds the stored _compute_name of the aml;
+                # only write (and re-trigger the rename) when it actually changes.
+                if line.payment_term_number != number:
+                    line.with_context(skip_invoice_sync=True).write(
+                        {"payment_term_number": number}
+                    )
 
     def unlink(self):
         """Allow to delete draft or cancelled invoices"""

--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -436,7 +436,6 @@ class AccountMove(models.Model):
             unlink_moves |= move
         result = super(AccountMove, unlink_moves).unlink()
         unlink_documents.unlink()
-        self.clear_caches()
         return result
 
     @api.depends("move_type", "fiscal_operation_id")

--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -192,7 +192,6 @@ class AccountMoveLine(models.Model):
                 unlink_fiscal_lines |= inv_line.fiscal_document_line_id
         result = super().unlink()
         unlink_fiscal_lines.unlink()
-        self.clear_caches()
         return result
 
     @contextmanager

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -390,7 +390,11 @@ class FiscalDocumentLineMixin(models.AbstractModel):
             fiscal_taxes = line.fiscal_tax_ids.filtered(
                 lambda ft, taxes_groups=taxes_groups: ft.tax_domain not in taxes_groups
             )
-            line.fiscal_tax_ids = fiscal_taxes + taxes
+            new_fiscal_tax_ids = fiscal_taxes + taxes
+            # fiscal_tax_ids está nos depends de _compute_tax_fields; só
+            # reatribui (e re-dispara o compute) quando o conjunto muda de fato.
+            if new_fiscal_tax_ids != line.fiscal_tax_ids:
+                line.fiscal_tax_ids = new_fiscal_tax_ids
 
     @api.onchange(*FISCAL_TAX_ID_FIELDS)
     def _onchange_fiscal_taxes(self):

--- a/l10n_br_fiscal/models/tax_definition.py
+++ b/l10n_br_fiscal/models/tax_definition.py
@@ -491,6 +491,9 @@ class TaxDefinition(models.Model):
             l10n_br_fiscal.tax.definition.
         """
 
+        if not self:
+            return self
+
         if not ncm:
             ncm = product.ncm_id
 


### PR DESCRIPTION
Code-only performance optimizations for the fiscal document flow. The performance test framework that measured these was split into a separate opt-in PR so this one can be reviewed as pure code.

Four low-risk patches:

1. `l10n_br_fiscal`: short-circuit empty recordset in `map_tax_definition`. Avoids up to 3 guaranteed-empty searches per line when company/CFOP/fiscal-profile have no tax definitions (common in production).
2. `l10n_br_fiscal`: skip redundant `fiscal_tax_ids` re-sync in `_update_fiscal_tax_ids`. Only reassigns when the set actually changes, avoiding a second tax-engine pass on persisted writes.
3. `l10n_br_account`: drop global `clear_caches()` from move/aml unlink. `_sync_dynamic_lines` deletes and recreates term/tax lines on every save, so these unlinks wiped all worker ormcaches (views, ACLs, translations) inside the create/post flow itself. The ORM already invalidates deleted records, and git archaeology found no recorded motivation for the global clear. Systemic win: on production with N workers the effect is multiplicative.
4. `l10n_br_account`: guard `update_payment_term_number` writes. Filters by `fiscal_operation_id` and `is_invoice`, and only writes when the value changes.

Measured impact (30-line invoice, Form path): post -40%, invoice_post -52%, so_create -67% queries. The full before/after numbers are in the split framework PR.

Functional suites of l10n_br_fiscal / l10n_br_account / l10n_br_sale: 0 failed. The 13 pre-existing errors in l10n_br_sale (a CacheMiss on account.move.journal_id) are present on pristine oca/16.0 too and are unrelated to this change.
