### PR TITLE
[18.0][FIX] l10n_br_fiscal: remove ISS from IBS/CBS base

### DIFF
--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -687,10 +687,12 @@ class Tax(models.Model):
         ICMS, PIS, and COFINS."""
         tax_dict = taxes_dict.get(tax.tax_domain)
         tax_dict_icms = taxes_dict.get("icms", {})
+        tax_dict_issqn = taxes_dict.get("issqn", {})
         tax_dict_pis = taxes_dict.get("pis", {})
         tax_dict_cofins = taxes_dict.get("cofins", {})
         tax_dict["remove_from_base"] += (
             tax_dict_icms.get("tax_value", 0.00)
+            + tax_dict_issqn.get("tax_value", 0.00)
             + tax_dict_pis.get("tax_value", 0.00)
             + tax_dict_cofins.get("tax_value", 0.00)
         )
@@ -703,10 +705,12 @@ class Tax(models.Model):
         ICMS, PIS, and COFINS."""
         tax_dict = taxes_dict.get(tax.tax_domain)
         tax_dict_icms = taxes_dict.get("icms", {})
+        tax_dict_issqn = taxes_dict.get("issqn", {})
         tax_dict_pis = taxes_dict.get("pis", {})
         tax_dict_cofins = taxes_dict.get("cofins", {})
         tax_dict["remove_from_base"] += (
             tax_dict_icms.get("tax_value", 0.00)
+            + tax_dict_issqn.get("tax_value", 0.00)
             + tax_dict_pis.get("tax_value", 0.00)
             + tax_dict_cofins.get("tax_value", 0.00)
         )


### PR DESCRIPTION
## Objetivo

Remover ISS da base de cálculo do IBS/CBS

## Fontes

1. https://piloto-cbs.tributos.gov.br/servico/calculadora-consumo/calculadora/bases-de-calculo
<img width="1426" height="973" alt="image" src="https://github.com/user-attachments/assets/51745dd1-afd5-4712-9cb4-d36450fcb2fb" />



2. https://ajuda.contaazul.com/hc/pt-br/articles/44180488585741-NFS-e-como-calcular-a-base-de-c%C3%A1lculo-do-IBS-e-da-CBS
"Base de Cálculo = Valor do Serviço − Valor do ISS − Valor do PIS − Valor da COFINS"