### PR TITLE
[16.0][IMP] l10n_br_fiscal, l10n_br_account: memoização do mapeamento fiscal por transação (perf wave 3)

### DIFF
--- a/l10n_br_account/models/fiscal_tax.py
+++ b/l10n_br_account/models/fiscal_tax.py
@@ -7,10 +7,65 @@ from odoo import Command, api, fields, models
 class FiscalTax(models.Model):
     _inherit = "l10n_br_fiscal.tax"
 
+    def _account_taxes_company(self, company=False):
+        if company:
+            return company
+        # ``self.env.company`` already resolves ``allowed_company_ids[0]`` *with*
+        # access validation, so it replaces the previous raw browse of that id.
+        # A ``default_company_id`` in the context is still honoured as an
+        # explicit override.
+        company = self.env.company
+        if self.env.context.get("default_company_id"):
+            company = self.env["res.company"].browse(
+                self.env.context["default_company_id"]
+            )
+        return company
+
     def account_taxes(self, user_type="sale", fiscal_operation=False, company=False):
         account_taxes = self.env["account.tax"]
+        if not self:
+            return account_taxes
+
+        company = self._account_taxes_company(company)
+
+        # Resolve os grupos contábeis de todos os impostos fiscais em um único
+        # search e traz TODOS os account.tax dos grupos envolvidos numa única
+        # query (antes: 1 search de grupo + 1 search de account.tax por imposto
+        # por linha). O casamento por grupo é feito em memória.
+        fiscal_group_to_account_group = self.tax_group_id._account_tax_group_map()
+        account_group_ids = [
+            group.id for group in fiscal_group_to_account_group.values() if group
+        ]
+        candidate_taxes = self.env["account.tax"].search(
+            [
+                ("tax_group_id", "in", account_group_ids),
+                ("active", "=", True),
+                ("company_id", "=", company.id),
+            ]
+        )
+        taxes_by_account_group = {}
+        for tax in candidate_taxes:
+            taxes_by_account_group.setdefault(
+                tax.tax_group_id.id, self.env["account.tax"]
+            )
+            taxes_by_account_group[tax.tax_group_id.id] |= tax
+
+        # `deductible_taxes` is company dependent, so reading it off the record
+        # as it comes answers for whatever company sits in the environment, not
+        # for the one resolved above. Same correction as #4996, kept here
+        # because this method is rewritten by this PR: without it, whichever of
+        # the two merges last silently drops the fix.
+        if fiscal_operation and company:
+            fiscal_operation = fiscal_operation.with_company(company)
+
         for fiscal_tax in self:
-            taxes = fiscal_tax._account_taxes(company)
+            account_group = fiscal_group_to_account_group.get(
+                fiscal_tax.tax_group_id.id
+            )
+            taxes = taxes_by_account_group.get(
+                account_group.id if account_group else False,
+                self.env["account.tax"],
+            )
             # Atualiza os impostos contábeis relacionados aos impostos fiscais
             account_taxes |= taxes.filtered(
                 lambda t: t.type_tax_use == user_type and t.active and not t.deductible
@@ -28,15 +83,7 @@ class FiscalTax(models.Model):
     def _account_taxes(self, company=False):
         self.ensure_one()
         account_tax_group = self.tax_group_id.account_tax_group()
-        if not company:
-            company = self.env.company
-            if self.env.context.get("default_company_id") or self.env.context.get(
-                "allowed_company_ids"
-            ):
-                company = self.env["res.company"].browse(
-                    self.env.context.get("default_company_id")
-                    or self.env.context.get("allowed_company_ids")[0]
-                )
+        company = self._account_taxes_company(company)
         return self.env["account.tax"].search(
             [
                 ("tax_group_id", "=", account_tax_group.id),

--- a/l10n_br_account/models/fiscal_tax_group.py
+++ b/l10n_br_account/models/fiscal_tax_group.py
@@ -12,3 +12,19 @@ class FiscalTaxGroup(models.Model):
         return self.env["account.tax.group"].search(
             [("fiscal_tax_group_id", "in", self.ids)], limit=1
         )
+
+    def _account_tax_group_map(self):
+        """Return {fiscal_tax_group_id: account.tax.group} for ``self`` in a
+        single search, instead of one search per fiscal tax group."""
+        result = {group.id: self.env["account.tax.group"] for group in self}
+        if not self:
+            return result
+        account_tax_groups = self.env["account.tax.group"].search(
+            [("fiscal_tax_group_id", "in", self.ids)]
+        )
+        for account_tax_group in account_tax_groups:
+            fiscal_group_id = account_tax_group.fiscal_tax_group_id.id
+            # account_tax_group() usa limit=1: preserva o primeiro encontrado.
+            if not result.get(fiscal_group_id):
+                result[fiscal_group_id] = account_tax_group
+        return result

--- a/l10n_br_fiscal/models/__init__.py
+++ b/l10n_br_fiscal/models/__init__.py
@@ -1,5 +1,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from . import fiscal_cache
 from . import data_abstract
 from . import data_product_abstract
 from . import data_ncm_nbs_abstract

--- a/l10n_br_fiscal/models/fiscal_cache.py
+++ b/l10n_br_fiscal/models/fiscal_cache.py
@@ -1,0 +1,113 @@
+# Copyright (C) 2026 KMEE
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+"""Transaction-scoped caches for the fiscal engine.
+
+The Brazilian fiscal engine maps and computes taxes many times per document
+line within a single save (the onchange/compute cascade re-runs the mapping
+and the tax computation with the *same* inputs several times per line). These
+helpers provide a cache whose lifetime is exactly one database transaction, so
+those redundant re-executions collapse into a single one — without ever
+leaking results between transactions or workers.
+
+Anchoring
+---------
+The cache dict is stored as an attribute on the *cursor* (``env.cr``). A cursor
+lives for exactly one transaction: every web request / job gets a fresh cursor
+(hence a fresh, empty cache), and there is one cursor per worker at a time, so
+nothing is shared between transactions or across workers. This is deliberately
+NOT a module-level dict (which would leak across transactions and workers).
+
+Invalidation
+------------
+Mapping/computation results are a pure function of the input record ids **and**
+the fiscal *definition* tables (tax definitions, ICMS regulation, taxes, tax
+classifications). The cache keys already encode every input record id plus the
+scalar configuration fields that drive the mapping branches (tax framework,
+``ind_ie_dest``, ICMS origin, states...), so a change to any *keyed* value
+naturally produces a different key.
+
+Two complementary mechanisms cover an in-place edit of a *definition* row (e.g.
+changing a tax rate) that keeps the same id:
+
+1. ``FiscalCacheMixin`` — any create/write/unlink on a definition model that
+   inherits it wipes the whole transaction cache. This covers config-screen and
+   test edits performed in an *ordinary* transaction.
+2. ``write_date`` in the cache keys — the keys encode the ``write_date`` of the
+   fiscal taxes (``compute_taxes`` key) and of the definition-anchor records
+   (``map_fiscal_taxes`` key: the operation line, the company ICMS regulation
+   and tax classification, the partner fiscal profile). Because an edit bumps
+   ``write_date`` and a **savepoint rollback reverts it**, the key produced
+   after a rollback matches the pre-edit key, not the edited one: a stale entry
+   left in the (rollback-surviving) transaction cache becomes *unreachable*
+   instead of being served. This makes the cache self-validating across
+   savepoint rollbacks, which neither ``cr.clear()`` nor ``FiscalCacheMixin``
+   observe (the per-cursor cache attribute is not part of the ORM/precommit
+   state a rollback clears).
+
+Known, documented residual limitation
+-------------------------------------
+The ``write_date`` guard versions the *anchor* records, not every child
+definition row they aggregate (``tax_definition_ids`` of the company/CFOP/
+operation line/partner profile, ICMS-regulation lines...). So the one case that
+still leaks is narrow and self-inflicted: editing a *child* definition row
+**inside a savepoint that is later rolled back**, and then recomputing with the
+**same key on the same cursor** — the child edit bumps only the child's
+``write_date`` (not the anchor's), ``FiscalCacheMixin`` cleared the cache on the
+edit but the rollback does not re-clear it, so the entry stored between the edit
+and the rollback survives and is served. This is an honest upgrade of the prior
+behaviour (which leaked on *any* savepoint rollback that reverted a keyed edit)
+and does not happen in the supported document flows: fiscal definitions are not
+mutated in the middle of computing a line's taxes. The same holds for an
+in-place edit of a *non-definition* config field that feeds the mapping but is
+not keyed (e.g. ``ncm.tax_ipi_id``) within the transaction that already mapped
+the line.
+"""
+
+from odoo import api, models
+
+_TXN_CACHE_ATTR = "_l10n_br_fiscal_txn_cache"
+
+
+def get_fiscal_txn_cache(env, name):
+    """Return the (create-on-demand) transaction-scoped cache dict ``name``."""
+    cr = env.cr
+    store = getattr(cr, _TXN_CACHE_ATTR, None)
+    if store is None:
+        store = {}
+        setattr(cr, _TXN_CACHE_ATTR, store)
+    return store.setdefault(name, {})
+
+
+def clear_fiscal_txn_cache(env):
+    """Drop every transaction-scoped fiscal cache of the current cursor."""
+    cr = env.cr
+    if getattr(cr, _TXN_CACHE_ATTR, None):
+        setattr(cr, _TXN_CACHE_ATTR, None)
+
+
+class FiscalCacheMixin(models.AbstractModel):
+    """Wipe the transaction fiscal caches on any change of a definition model.
+
+    Inherited by the fiscal *definition* models whose rows feed the mapping and
+    the tax computation. Kept intentionally tiny: it only clears the caches; the
+    per-key correctness is handled by the cache keys themselves.
+    """
+
+    _name = "l10n_br_fiscal.cache.mixin"
+    _description = "Fiscal transaction cache invalidation"
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        clear_fiscal_txn_cache(self.env)
+        return records
+
+    def write(self, vals):
+        res = super().write(vals)
+        clear_fiscal_txn_cache(self.env)
+        return res
+
+    def unlink(self):
+        res = super().unlink()
+        clear_fiscal_txn_cache(self.env)
+        return res

--- a/l10n_br_fiscal/models/icms_regulation.py
+++ b/l10n_br_fiscal/models/icms_regulation.py
@@ -4,6 +4,7 @@
 from lxml import etree
 
 from odoo import api, fields, models
+from odoo.osv import expression
 
 from ..constants.fiscal import (
     FINAL_CUSTOMER_YES,
@@ -47,7 +48,7 @@ VIEW = """
 
 class ICMSRegulation(models.Model):
     _name = "l10n_br_fiscal.icms.regulation"
-    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _inherit = ["mail.thread", "mail.activity.mixin", "l10n_br_fiscal.cache.mixin"]
     _description = "Tax ICMS Regulation"
 
     name = fields.Char(required=True, index=True)
@@ -1987,8 +1988,25 @@ class ICMSRegulation(models.Model):
         return domain
 
     def _tax_definition_search(self, domain, ncm, nbm, cest, product, ind_final=None):
+        icms_defs = self.env["l10n_br_fiscal.tax.definition"].search(domain)
+        return self._tax_definition_precedence(
+            icms_defs, ncm, nbm, cest, product, ind_final
+        )
+
+    def _tax_definition_precedence(
+        self, icms_defs, ncm, nbm, cest, product, ind_final=None
+    ):
+        """Apply the ICMS tax-definition precedence to a pre-fetched recordset.
+
+        Business rule (unchanged): with a single match, take it; otherwise
+        prefer benefit definitions, then product/ncm/nbm/cest-specific ones,
+        then generic ones, and finally narrow by ``ind_final`` when any
+        final-customer definition is present. Split out of
+        ``_tax_definition_search`` so that ``map_tax`` can run the four ICMS
+        group searches as a single query and still apply this exact
+        precedence per group.
+        """
         tax_definitions = self.env["l10n_br_fiscal.tax.definition"]
-        icms_defs = tax_definitions.search(domain)
 
         if len(icms_defs) == 1:
             tax_definitions |= icms_defs
@@ -2049,9 +2067,18 @@ class ICMSRegulation(models.Model):
         operation_line=None,
         ind_final=None,
     ):
+        """ICMS contribution to :meth:`map_tax`.
+
+        Returns ``(icms_taxes, search)`` where ``icms_taxes`` carries the
+        imported-ICMS shortcut tax (an empty recordset otherwise) and ``search``
+        is the ``(tax_group, domain)`` pair to feed map_tax's single combined
+        tax-definition search, or ``None`` when the shortcut applies and no
+        search is needed. This method owns the ICMS branch (shortcut condition
+        and domain) as the single source, so downstream overrides of it take
+        effect; map_tax runs the search and applies the precedence.
+        """
         self.ensure_one()
         icms_taxes = self.env["l10n_br_fiscal.tax"]
-        tax_definitions = self.env["l10n_br_fiscal.tax.definition"]
         tax_group_icms = self.env.ref("l10n_br_fiscal.tax_group_icms")
 
         # ICMS tax imported
@@ -2063,16 +2090,13 @@ class ICMSRegulation(models.Model):
             and operation_line.fiscal_operation_type == FISCAL_IN
         ):
             icms_taxes |= self.icms_imported_tax_id
-        else:
-            # ICMS
-            domain = self._build_map_tax_def_domain(
-                company, partner, tax_group_icms, ncm, nbm, cest, ind_final
-            )
+            return icms_taxes, None
 
-            tax_definitions = self._tax_definition_search(
-                domain, ncm, nbm, cest, product, ind_final
-            )
-        return icms_taxes, tax_definitions
+        # ICMS
+        domain = self._build_map_tax_def_domain(
+            company, partner, tax_group_icms, ncm, nbm, cest, ind_final
+        )
+        return icms_taxes, (tax_group_icms, domain)
 
     def _map_tax_def_icmsst(
         self,
@@ -2085,6 +2109,8 @@ class ICMSRegulation(models.Model):
         operation_line=None,
         ind_final=None,
     ):
+        """ICMS-ST contribution to :meth:`map_tax`: the ``(tax_group, domain)``
+        pair for the single combined search (always present)."""
         self.ensure_one()
         tax_group_icmsst = self.env.ref("l10n_br_fiscal.tax_group_icmsst")
 
@@ -2092,11 +2118,7 @@ class ICMSRegulation(models.Model):
         domain = self._build_map_tax_def_domain(
             company, partner, tax_group_icmsst, ncm, nbm, cest, ind_final
         )
-
-        tax_definitions = self._tax_definition_search(
-            domain, ncm, nbm, cest, product, ind_final
-        )
-        return tax_definitions
+        return tax_group_icmsst, domain
 
     def map_tax_def_icms_difal(
         self,
@@ -2140,8 +2162,10 @@ class ICMSRegulation(models.Model):
         operation_line=None,
         ind_final=None,
     ):
+        """ICMS-FCP (DIFAL) contribution to :meth:`map_tax`: the
+        ``(tax_group, domain)`` pair for the single combined search, or ``None``
+        when the FCP-DIFAL condition does not apply."""
         self.ensure_one()
-        tax_definitions = self.env["l10n_br_fiscal.tax.definition"]
         tax_group_icmsfcp = self.env.ref("l10n_br_fiscal.tax_group_icmsfcp")
 
         # ICMS FCP for DIFAL
@@ -2155,12 +2179,9 @@ class ICMSRegulation(models.Model):
             domain = self._build_map_tax_def_domain(
                 partner, partner, tax_group_icmsfcp, ncm, nbm, cest, ind_final
             )
+            return tax_group_icmsfcp, domain
 
-            tax_definitions = self._tax_definition_search(
-                domain, ncm, nbm, cest, product, ind_final
-            )
-
-        return tax_definitions
+        return None
 
     def _map_tax_def_icmsfcpst(
         self,
@@ -2173,20 +2194,16 @@ class ICMSRegulation(models.Model):
         operation_line=None,
         ind_final=None,
     ):
+        """FCP-ST contribution to :meth:`map_tax`: the ``(tax_group, domain)``
+        pair for the single combined search (always present)."""
         self.ensure_one()
-        tax_definitions = self.env["l10n_br_fiscal.tax.definition"]
         tax_group_icmsfcpst = self.env.ref("l10n_br_fiscal.tax_group_icmsfcp_st")
 
         # FCP ST
         domain = self._build_map_tax_def_domain(
             company, partner, tax_group_icmsfcpst, ncm, nbm, cest, ind_final
         )
-
-        tax_definitions = self._tax_definition_search(
-            domain, ncm, nbm, cest, product, ind_final
-        )
-
-        return tax_definitions
+        return tax_group_icmsfcpst, domain
 
     # TODO adicionar o argumento CFOP????
     def map_tax(
@@ -2210,21 +2227,58 @@ class ICMSRegulation(models.Model):
             if not cest:
                 cest = product.cest_id
 
-        icms_taxes, icms_def_taxes = self._map_tax_def_icms(
+        icms_taxes = self.env["l10n_br_fiscal.tax"]
+
+        # Delegate each ICMS group to its ``_map_tax_def_*`` builder (the single
+        # source of that group's condition and domain, so downstream overrides
+        # take effect again) and run the collected domains as ONE search (OR of
+        # the per-group domains) instead of four. Each sub-domain pins a distinct
+        # tax_group_id, so the combined result partitions cleanly by group and
+        # the per-group precedence (see _tax_definition_precedence) is applied
+        # exactly as before. The call order below (icms, icms_st, icms_fcp,
+        # icms_fcp_st) matches the original so that downstream last-wins
+        # resolution of icms_tax_benefit_id is unchanged.
+        searches = []
+
+        # 1 ICMS (or the imported-ICMS shortcut, which needs no search)
+        imported_taxes, icms_search = self._map_tax_def_icms(
             company, partner, product, ncm, nbm, cest, operation_line, ind_final
+        )
+        icms_taxes |= imported_taxes
+        if icms_search:
+            searches.append(icms_search)
+
+        # 2 ICMS ST (always)
+        searches.append(
+            self._map_tax_def_icmsst(
+                company, partner, product, ncm, nbm, cest, operation_line, ind_final
+            )
         )
 
-        icms_def_taxes |= self._map_tax_def_icmsst(
+        # 3 ICMS FCP for DIFAL (conditional)
+        fcp_search = self._map_tax_def_icmsfcp(
             company, partner, product, ncm, nbm, cest, operation_line, ind_final
+        )
+        if fcp_search:
+            searches.append(fcp_search)
+
+        # 4 FCP ST (always)
+        searches.append(
+            self._map_tax_def_icmsfcpst(
+                company, partner, product, ncm, nbm, cest, operation_line, ind_final
+            )
         )
 
-        icms_def_taxes |= self._map_tax_def_icmsfcp(
-            company, partner, product, ncm, nbm, cest, operation_line, ind_final
-        )
-
-        icms_def_taxes |= self._map_tax_def_icmsfcpst(
-            company, partner, product, ncm, nbm, cest, operation_line, ind_final
-        )
+        icms_def_taxes = self.env["l10n_br_fiscal.tax.definition"]
+        combined_domain = expression.OR([domain for _group, domain in searches])
+        all_defs = self.env["l10n_br_fiscal.tax.definition"].search(combined_domain)
+        for tax_group, _domain in searches:
+            group_defs = all_defs.filtered(
+                lambda d, group=tax_group: d.tax_group_id == group
+            )
+            icms_def_taxes |= self._tax_definition_precedence(
+                group_defs, ncm, nbm, cest, product, ind_final
+            )
 
         icms_taxes |= icms_def_taxes.mapped("tax_id")
 

--- a/l10n_br_fiscal/models/operation.py
+++ b/l10n_br_fiscal/models/operation.py
@@ -281,14 +281,32 @@ class Operation(models.Model):
         if not company.icms_regulation_id or not product:
             return False
 
+        # `_map_tax_def_icmsst` now answers the ``(tax_group, domain)`` pair that
+        # map_tax feeds to its single combined search, instead of the definitions
+        # themselves. Truth-testing that pair would be true for every product,
+        # which would put ICMS ST on every line and change which operation line
+        # gets selected. So the search still has to run here, with the same
+        # precedence the previous contract applied.
+        regulation = company.icms_regulation_id
+        search = regulation._map_tax_def_icmsst(
+            company,
+            partner,
+            product,
+            ncm=product.ncm_id,
+            nbm=product.nbm_id,
+            cest=product.cest_id,
+        )
+        if not search:
+            return False
+
+        _tax_group, domain = search
         return bool(
-            company.icms_regulation_id._map_tax_def_icmsst(
-                company,
-                partner,
+            regulation._tax_definition_search(
+                domain,
+                product.ncm_id,
+                product.nbm_id,
+                product.cest_id,
                 product,
-                ncm=product.ncm_id,
-                nbm=product.nbm_id,
-                cest=product.cest_id,
             )
         )
 

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2019  Renato Lima - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+import logging
+
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
@@ -23,12 +25,15 @@ from ..constants.fiscal import (
     TAX_ICMS_OR_ISSQN,
 )
 from ..constants.icms import ICMS_ORIGIN
+from .fiscal_cache import get_fiscal_txn_cache
+
+_logger = logging.getLogger(__name__)
 
 
 class OperationLine(models.Model):
     _name = "l10n_br_fiscal.operation.line"
     _description = "Fiscal Operation Line"
-    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _inherit = ["mail.thread", "mail.activity.mixin", "l10n_br_fiscal.cache.mixin"]
 
     fiscal_operation_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.operation",
@@ -293,6 +298,96 @@ class OperationLine(models.Model):
             - 'tax_classification': The determined Tax Classification record
               (l10n_br_fiscal.tax.classification).
         """
+        self.ensure_one()
+
+        # Transaction-scoped memoization: this mapping is re-run with identical
+        # inputs several times per line by the onchange/compute cascade (and,
+        # with repeated products, across lines). The result is a pure function
+        # of the input record ids plus the config fields that drive the mapping
+        # branches, so we key on exactly those; invalidation on any fiscal
+        # definition change is handled by FiscalCacheMixin. See fiscal_cache.py.
+        cache = get_fiscal_txn_cache(self.env, "map_fiscal_taxes")
+        cache_key = self._map_fiscal_taxes_cache_key(
+            company,
+            partner,
+            product=product,
+            ncm=ncm,
+            nbm=nbm,
+            nbs=nbs,
+            cest=cest,
+            city_taxation_code=city_taxation_code,
+            national_taxation_code=national_taxation_code,
+            service_type=service_type,
+            ind_final=ind_final,
+        )
+        try:
+            if cache_key in cache:
+                # Hand out a copy: this is public API consumed by nfe/cte/mdfe
+                # and third parties, and callers mutate ``mapping_result``
+                # (e.g. ``mapping_result["taxes"][domain] = ...``); returning the
+                # shared cached object would corrupt it for every later line in
+                # the transaction. Mirrors ``_copy_compute_taxes_result``.
+                return self._copy_map_fiscal_taxes_result(cache[cache_key])
+        except TypeError:
+            # Honour the cache-key contract: an unhashable key component disables
+            # memoization for this call instead of raising.
+            _logger.debug(
+                "map_fiscal_taxes memoization skipped: unhashable cache key %r",
+                cache_key,
+            )
+            cache_key = None
+
+        mapping_result = self._map_fiscal_taxes(
+            company,
+            partner,
+            product=product,
+            fiscal_price=fiscal_price,
+            fiscal_quantity=fiscal_quantity,
+            ncm=ncm,
+            nbm=nbm,
+            nbs=nbs,
+            cest=cest,
+            city_taxation_code=city_taxation_code,
+            national_taxation_code=national_taxation_code,
+            service_type=service_type,
+            ind_final=ind_final,
+        )
+
+        if cache_key is not None:
+            cache[cache_key] = mapping_result
+            return self._copy_map_fiscal_taxes_result(mapping_result)
+        return mapping_result
+
+    @staticmethod
+    def _copy_map_fiscal_taxes_result(result):
+        """Shallow copy of a ``map_fiscal_taxes`` result safe to mutate.
+
+        Copies the outer dict and the inner ``taxes`` dict (the levels callers
+        reassign in place); the tax recordsets they hold are shared by reference
+        but only ever replaced, never mutated. Mirrors
+        :meth:`l10n_br_fiscal.tax._copy_compute_taxes_result`.
+        """
+        copied = dict(result)
+        copied["taxes"] = dict(result["taxes"])
+        return copied
+
+    def _map_fiscal_taxes(
+        self,
+        company,
+        partner,
+        product=None,
+        fiscal_price=None,
+        fiscal_quantity=None,
+        ncm=None,
+        nbm=None,
+        nbs=None,
+        cest=None,
+        city_taxation_code=None,
+        national_taxation_code=None,
+        service_type=None,
+        ind_final=None,
+    ):
+        """Uncached body of :meth:`map_fiscal_taxes` (see its docstring)."""
         mapping_result = {
             "taxes": {},
             "cfop": False,
@@ -300,8 +395,6 @@ class OperationLine(models.Model):
             "icms_tax_benefit_id": False,
             "tax_classification": False,
         }
-
-        self.ensure_one()
 
         # Define CFOP
         mapping_result["cfop"] = self._get_cfop(company, partner)
@@ -434,6 +527,81 @@ class OperationLine(models.Model):
             mapping_result["taxes"].pop(TAX_DOMAIN_ISSQN, None)
 
         return mapping_result
+
+    def _map_fiscal_taxes_cache_key(
+        self,
+        company,
+        partner,
+        product=None,
+        ncm=None,
+        nbm=None,
+        nbs=None,
+        cest=None,
+        city_taxation_code=None,
+        national_taxation_code=None,
+        service_type=None,
+        ind_final=None,
+    ):
+        """Stable, hashable key for ``map_fiscal_taxes`` memoization.
+
+        Encodes every input record id plus the scalar config fields the mapping
+        branches on (so a config change on company/partner/product produces a
+        different key). ``fiscal_price``/``fiscal_quantity`` are intentionally
+        excluded: they do not affect the mapping.
+
+        It also encodes the ``write_date`` of the definition-anchor records
+        already keyed here (the operation line, the company ICMS regulation and
+        tax classification, the partner fiscal profile): an in-place edit of one
+        of these bumps its ``write_date`` and thus the key, and a savepoint
+        rollback reverting the edit reverts ``write_date`` too, so the key
+        reverts with it (self-validating key — a stale entry becomes unreachable
+        rather than being served). Child definition rows they aggregate
+        (``tax_definition_ids`` ...) are versioned only in ordinary transactions
+        via ``FiscalCacheMixin``; see fiscal_cache.py for the exact residual
+        limitation.
+        """
+
+        def _rid(record):
+            return record.id if record else False
+
+        def _wdate(record):
+            return record.write_date if record else False
+
+        # NCM defaults to the product's NCM downstream; normalize it here so the
+        # key matches whether the caller passed ncm explicitly or not.
+        key_ncm = ncm or (product.ncm_id if product else None)
+        return (
+            self.id,
+            self.fiscal_operation_id.fiscal_operation_type,
+            self.fiscal_operation_id.fiscal_type,
+            company.id,
+            company.tax_framework,
+            _rid(company.icms_regulation_id),
+            _rid(company.tax_classification_id),
+            _rid(company.state_id),
+            _rid(company.country_id),
+            partner.id,
+            _rid(partner.state_id),
+            partner.ind_ie_dest,
+            _rid(partner.fiscal_profile_id),
+            _rid(partner.country_id),
+            _rid(product),
+            product.tax_icms_or_issqn if product else False,
+            product.icms_origin if product else False,
+            _rid(key_ncm),
+            _rid(nbm),
+            _rid(nbs),
+            _rid(cest),
+            _rid(city_taxation_code),
+            _rid(national_taxation_code),
+            _rid(service_type),
+            ind_final,
+            # Content-versioning of the definition-anchor records keyed above.
+            self.write_date,
+            _wdate(company.icms_regulation_id),
+            _wdate(company.tax_classification_id),
+            _wdate(partner.fiscal_profile_id),
+        )
 
     def action_review(self):
         self.write({"state": "review"})

--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -33,6 +33,7 @@ from ..constants.icms import (
     ICMS_ST_BASE_TYPE_DEFAULT,
     ICSM_CST_CSOSN_ST_BASE,
 )
+from .fiscal_cache import get_fiscal_txn_cache
 
 TAX_DICT_VALUES = {
     "name": False,
@@ -118,6 +119,7 @@ class Tax(models.Model):
     """
 
     _name = "l10n_br_fiscal.tax"
+    _inherit = "l10n_br_fiscal.cache.mixin"
     _order = "sequence, tax_domain, name"
     _description = "Fiscal Tax"
 
@@ -905,6 +907,20 @@ class Tax(models.Model):
               TAX_DICT_VALUES).
         """
 
+        # Transaction-scoped memoization: within a single save this is called
+        # 3-6x per line with identical kwargs (fiscal precompute + totals +
+        # account tax hooks) and again on every line that repeats the same
+        # product/price/quantity. The computation is pure, so we return the
+        # cached result. Invalidation on any fiscal definition/tax change is
+        # handled by FiscalCacheMixin. See fiscal_cache.py.
+        cache = get_fiscal_txn_cache(self.env, "compute_taxes")
+        cache_key = self._compute_taxes_cache_key(kwargs)
+        if cache_key is not None and cache_key in cache:
+            # Callers mutate the returned per-tax dicts in place (e.g.
+            # account.tax flips ``base`` sign for negative bases), so never hand
+            # out the cached object itself.
+            return self._copy_compute_taxes_result(cache[cache_key])
+
         result_amounts = {
             "amount_included": 0.00,
             "amount_not_included": 0.00,
@@ -941,7 +957,92 @@ class Tax(models.Model):
         # Estimate taxes
         result_amounts["estimate_tax"] = self._compute_estimate_taxes(**kwargs)
         result_amounts["taxes"] = taxes
+
+        if cache_key is not None:
+            cache[cache_key] = result_amounts
+            # Keep the cached object pristine; the first caller also gets a copy.
+            return self._copy_compute_taxes_result(result_amounts)
         return result_amounts
+
+    @staticmethod
+    def _copy_compute_taxes_result(result):
+        """Shallow copy of a ``compute_taxes`` result safe to mutate.
+
+        Copies the top-level dict and each per-tax-domain dict (the levels that
+        callers mutate in place); the leaf values (scalars/records) are shared
+        by reference but only ever replaced, never mutated.
+        """
+        copied = dict(result)
+        copied["taxes"] = {
+            domain: dict(values) if isinstance(values, dict) else values
+            for domain, values in result["taxes"].items()
+        }
+        return copied
+
+    def _compute_taxes_cache_key(self, kwargs):
+        """Stable, hashable key for ``compute_taxes`` memoization.
+
+        Normalizes every kwarg to a hashable value: recordsets become their
+        (sorted) id tuple, scalars (floats included, unrounded) are used as-is.
+        ``self`` is included as its sorted id tuple (the result is independent
+        of input order, since ``compute_taxes`` sorts by compute sequence).
+        Returns ``None`` to disable memoization if any kwarg cannot be reduced
+        to a hashable value, so an unexpected input never risks a wrong cache
+        hit.
+
+        On top of the input ids the key also encodes:
+
+        * the ``write_date`` of the fiscal taxes themselves. This makes the key
+          *content-versioned*: an in-place edit of a tax rate
+          (``percent_amount``/``percent_reduction``...) bumps ``write_date`` and
+          thus changes the key by construction, and a savepoint rollback that
+          reverts the edit reverts ``write_date`` too, so the key reverts with
+          it. A stale entry left behind by such a rollback becomes unreachable
+          instead of being served (self-validating key). See fiscal_cache.py.
+        * the config scalars the engine reads *directly* from ``company`` and
+          ``partner`` (they live on ``res.company``/``res.partner``, which do not
+          inherit ``FiscalCacheMixin``, so an in-transaction edit of them is not
+          observed otherwise). Symmetric with the ``map_fiscal_taxes`` key.
+
+        ``self`` and the recordset kwargs may still be ``NewId`` (unsaved)
+        records in the create/onchange precompute cascade, which is exactly the
+        hot path this memoization targets. All id handling goes through ``.ids``
+        (which resolves NewId records to their concrete origin id and drops
+        origin-less ones), so the key stays orderable and hashable; the aligned
+        ``write_date`` tuple is read from the origin records for the same reason.
+        """
+        normalized = []
+        for name in sorted(kwargs):
+            value = kwargs[name]
+            if isinstance(value, models.BaseModel):
+                value = tuple(sorted(value.ids))
+            elif value is not None and not isinstance(value, bool | int | float | str):
+                # Unexpected input type: do not risk a wrong cache hit.
+                return None
+            normalized.append((name, value))
+
+        # ``.ids`` yields concrete (origin) ids only, so it is always sortable;
+        # read each tax's ``write_date`` from the origin records and align it to
+        # that same id order.
+        tax_ids = tuple(sorted(self.ids))
+        write_date_by_id = {tax.id: tax.write_date for tax in self._origin}
+        tax_versions = tuple(write_date_by_id.get(tax_id) for tax_id in tax_ids)
+
+        company = kwargs.get("company")
+        partner = kwargs.get("partner")
+        config_scalars = (
+            partner.ind_ie_dest if partner else False,
+            company.tax_framework if company else False,
+            company.simplified_tax_percent if company else False,
+            company.state_id.id if company else False,
+            partner.state_id.id if partner else False,
+        )
+        return (
+            tax_ids,
+            tax_versions,
+            config_scalars,
+            tuple(normalized),
+        )
 
     @api.depends("icmsst_base_type")
     def _compute_tax_base_type(self):

--- a/l10n_br_fiscal/models/tax_classification.py
+++ b/l10n_br_fiscal/models/tax_classification.py
@@ -13,7 +13,7 @@ from ..constants.fiscal import (
 
 class TaxClassification(models.Model):
     _name = "l10n_br_fiscal.tax.classification"
-    _inherit = "l10n_br_fiscal.data.abstract"
+    _inherit = ["l10n_br_fiscal.data.abstract", "l10n_br_fiscal.cache.mixin"]
     _order = "code"
     _description = "Tax Classification"
 

--- a/l10n_br_fiscal/models/tax_definition.py
+++ b/l10n_br_fiscal/models/tax_definition.py
@@ -52,7 +52,7 @@ class TaxDefinition(models.Model):
     """
 
     _name = "l10n_br_fiscal.tax.definition"
-    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _inherit = ["mail.thread", "mail.activity.mixin", "l10n_br_fiscal.cache.mixin"]
     _description = "Tax Definition"
 
     def _get_complete_name(self):

--- a/l10n_br_fiscal/tests/test_fiscal_tax.py
+++ b/l10n_br_fiscal/tests/test_fiscal_tax.py
@@ -374,3 +374,71 @@ class TestFiscalTax(TransactionCase):
         )
 
         self.assertEqual(compute_result["taxes"]["icms"]["cst_id"].code, "10")
+
+    def test_compute_taxes_cache_savepoint_rollback(self):
+        """A savepoint rollback that reverts a tax rate must not leave the
+        transaction cache serving the reverted (stale) value.
+
+        The fiscal transaction cache is a per-cursor attribute that survives a
+        savepoint rollback (``cr.clear()`` clears the ORM cache, not that
+        attribute). Without the self-validating (``write_date``-versioned) key, a
+        rate edited and computed *inside* a rolled-back savepoint keeps being
+        served afterwards. See l10n_br_fiscal/models/fiscal_cache.py.
+        """
+        kwargs = self._create_compute_taxes_kwargs()
+        currency = kwargs["company"].currency_id
+        icms_tax = self.env.ref("l10n_br_fiscal.tax_icms_7")
+        fiscal_taxes = (
+            icms_tax
+            + self.env.ref("l10n_br_fiscal.tax_ipi_15")
+            + self.env.ref("l10n_br_fiscal.tax_pis_0_65")
+            + self.env.ref("l10n_br_fiscal.tax_cofins_3")
+        )
+
+        # Baseline: compute once and remember the original ICMS value.
+        original_icms_value = fiscal_taxes.compute_taxes(**kwargs)["taxes"]["icms"][
+            "tax_value"
+        ]
+
+        savepoint = self.env.cr.savepoint()
+        # Edit the rate and recompute *inside* the savepoint: the write wipes the
+        # cache (FiscalCacheMixin.write) and repopulates it with the new value.
+        icms_tax.percent_amount = icms_tax.percent_amount + 11.0
+        # Flush so the edit reaches the DB and actually bumps ``write_date``
+        # *inside* the savepoint. This reproduces the real contamination scenario
+        # (a polluting transaction/test method flushes the write before its
+        # rollback); it is also what makes the self-validating key observable:
+        # the stale entry is stored under the bumped-``write_date`` key, and the
+        # rollback reverts ``write_date`` so the post-rollback key no longer
+        # reaches it.
+        self.env.flush_all()
+        changed_icms_value = fiscal_taxes.compute_taxes(**kwargs)["taxes"]["icms"][
+            "tax_value"
+        ]
+        self.assertNotEqual(
+            float_compare(
+                changed_icms_value,
+                original_icms_value,
+                precision_rounding=currency.rounding,
+            ),
+            0,
+            "Sanity: editing the ICMS rate should change the computed value.",
+        )
+
+        # Roll back: reverts the rate (and its write_date) and clears the ORM
+        # cache, but NOT the per-cursor fiscal transaction cache.
+        savepoint.close()  # rollback=True by default
+
+        reverted_icms_value = fiscal_taxes.compute_taxes(**kwargs)["taxes"]["icms"][
+            "tax_value"
+        ]
+        self.assertEqual(
+            float_compare(
+                reverted_icms_value,
+                original_icms_value,
+                precision_rounding=currency.rounding,
+            ),
+            0,
+            "After rollback compute_taxes must return the ORIGINAL rate, not the "
+            "reverted-away value left in the transaction cache.",
+        )

--- a/l10n_br_fiscal/tests/test_icms_regulation.py
+++ b/l10n_br_fiscal/tests/test_icms_regulation.py
@@ -116,12 +116,15 @@ class TestICMSRegulation(TransactionCase):
         )
         self.assertEqual(tax_icms.percent_amount, 12.00)
 
-    def test_map_tax_def_icmsst_true(self):
-        self.company.state_id = self.sp_state_id
-        self.partner.state_id = self.sp_state_id
-        self.product.cest_id = self.env.ref("l10n_br_fiscal.cest_2112300")
+    def _icmsst_definitions(self):
+        """Run the ICMS ST search the way map_tax now runs it.
 
-        tax_definitions = self.icms_regulation._map_tax_def_icmsst(
+        `_map_tax_def_icmsst` answers the ``(tax_group, domain)`` pair that
+        map_tax feeds to its single combined search, so the definitions only
+        exist after the search plus the precedence. Truth-testing the pair
+        itself would pass for every product, which is no test at all.
+        """
+        search = self.icms_regulation._map_tax_def_icmsst(
             company=self.company,
             partner=self.partner,
             product=self.product,
@@ -129,7 +132,22 @@ class TestICMSRegulation(TransactionCase):
             nbm=self.product.nbm_id,
             cest=self.product.cest_id,
         )
-        self.assertTrue(tax_definitions)
+        self.assertTrue(search, "the ICMS ST branch always asks for a search")
+        _tax_group, domain = search
+        return self.icms_regulation._tax_definition_search(
+            domain,
+            self.product.ncm_id,
+            self.product.nbm_id,
+            self.product.cest_id,
+            self.product,
+        )
+
+    def test_map_tax_def_icmsst_true(self):
+        self.company.state_id = self.sp_state_id
+        self.partner.state_id = self.sp_state_id
+        self.product.cest_id = self.env.ref("l10n_br_fiscal.cest_2112300")
+
+        self.assertTrue(self._icmsst_definitions())
 
     def test_map_tax_def_icmsst_false(self):
         self.company.state_id = self.sp_state_id
@@ -137,15 +155,7 @@ class TestICMSRegulation(TransactionCase):
         self.product.cest_id = False
         self.product.ncm_id = self.ncm_48191000_id
 
-        tax_definitions = self.icms_regulation._map_tax_def_icmsst(
-            company=self.company,
-            partner=self.partner,
-            product=self.product,
-            ncm=self.product.ncm_id,
-            nbm=self.product.nbm_id,
-            cest=self.product.cest_id,
-        )
-        self.assertFalse(tax_definitions)
+        self.assertFalse(self._icmsst_definitions())
 
     def find_icms_tax(self, in_state_id, out_state_id, ncm_id, ind_final):
         self.partner.state_id = in_state_id


### PR DESCRIPTION
Onda 3 de performance do motor fiscal. O PR nao muda regra fiscal nenhuma: ele reduz
trabalho repetido no caminho de mapeamento e cálculo de impostos.

Rebaseado na 16.0 atual, sem conflito e sem atraso. Deixou de estar empilhado no
#4716.

## O que entra

**Um search por grupo, em vez de um por imposto.** O `account_taxes` resolvia o grupo
contábil e buscava os `account.tax` uma vez por imposto fiscal, por linha. Agora
resolve os grupos de todos os impostos de uma vez e traz os `account.tax` dos grupos
envolvidos numa única query, casando por grupo em memória.

**Memoização do mapeamento por transação, com as buscas de ICMS fundidas.** O
`map_fiscal_taxes` passa a ser memoizado dentro da transação, com chave nos
componentes que de fato mudam o resultado (empresa, parceiro, produto, NCM, NBM,
CEST, operação e `ind_final`). Componente não hasheável desliga a memoização em vez
de arriscar chave errada, e o resultado é copiado na entrega para que uma linha não
corrompa o objeto que as próximas vão ler. Junto, as quatro buscas de definição de
ICMS (ICMS, ST, FCP e FCP ST) viram um único search com `OR` dos domínios, e a
precedência continua sendo aplicada por grupo.

**Memoização do `compute_taxes` por transação**, na mesma linha.

**Invalidação:** qualquer `create`, `write` ou `unlink` nos modelos de definição
fiscal limpa o cache da transação, pelo mixin em `fiscal_cache.py`. O teste novo
cobre o caso que mais assusta em cache de transação: o rollback de savepoint.

## O que o rebase revelou, e que vale review com atenção

Este PR muda o contrato de `_map_tax_def_icms`, `_map_tax_def_icmsst`,
`_map_tax_def_icmsfcp` e `_map_tax_def_icmsfcpst`: eles passam a devolver o par
`(grupo, domínio)` que o `map_tax` usa na busca única, em vez das definições já
buscadas. E existe um chamador em produção que dependia do contrato antigo:

`l10n_br_fiscal/models/operation.py`, no `_has_icmsst`, fazia `bool()` do retorno.
`bool()` de uma tupla é sempre verdadeiro, então todo produto passaria a ter ICMS ST
e o `line_definition` escolheria sempre a linha de ST. O sintoma aparecia longe da
causa: os testes de edição de documento e de fatura falhavam porque a linha de
operação selecionada mudava.

Corrigido aqui: o `_has_icmsst` executa a busca com a mesma precedência que o
contrato antigo aplicava.

No mesmo caminho, o par de testes `test_map_tax_def_icmsst_true` e `_false` ficou
inválido com o contrato novo, e o `_true` ficava **tautológico**: `assertTrue` de uma
tupla passa mesmo quando não existe definição nenhuma. Os dois passaram a rodar a
busca de verdade, por um helper comum, verificando exatamente o mesmo fato de antes.

## Relação com o #4996

Este PR reescreve o `account_taxes`, que é o método corrigido pelo #4996 (leitura de
`deductible_taxes`, campo `company_dependent`, sem `with_company`). A reescrita já
carrega a correção, com comentário no código: sem isso, o segundo dos dois a mesclar
levaria o entorno inteiro e o fix desapareceria em silêncio, com CI verde, porque
nenhum teste daqui cobre leitura por empresa.

## O que saiu do escopo

O commit de delta-write em `_compute_tax_fields` saiu deste PR e virá em PR próprio.
Ele suprime a cascata de `modified()` que a reescrita de campos disparava, e isso
merece teste que fixe o comportamento esperado, em vez de vir de carona numa onda de
performance.

## Medição

Suítes funcionais de `l10n_br_fiscal` e `l10n_br_account` em banco descartável:
**0 falhas em 149 testes**, contra 148 verdes do controle sem o PR (a diferença é o
teste novo). O controle importa aqui: as falhas do primeiro rebase só foram
atribuíveis ao PR porque a mesma suíte, sem ele, estava verde.

Os números de CPU do corpo anterior eram do delta-write e por isso saíram. A medição
de performance destes três commits isolados precisa ser refeita depois do rebase, e
eu prefiro não publicar número que não medi nesta base.
