### PR TITLE
[16.0][IMP] spec_driven_model: skip reflection writes on ordinary registry loads

### DIFF
--- a/spec_driven_model/models/spec_mixin.py
+++ b/spec_driven_model/models/spec_mixin.py
@@ -7,6 +7,7 @@ from importlib import import_module
 from odoo import api, models
 from odoo.models import is_definition_class
 from odoo.tools import mute_logger
+from odoo.tools.sql import existing_tables
 
 from .spec_models import SPEC_MIXIN_MAPPINGS, SpecModel, StackedModel
 
@@ -179,6 +180,11 @@ class SpecMixin(models.AbstractModel):
     ):
         access_data = []
         access_fields = []
+        # names of every remaining model we build, and the SQL tables of the
+        # concrete (non-abstract) ones, used to decide whether the DB
+        # reflection is already in place (see _spec_reflection_needed)
+        built_model_names = []
+        concrete_tables = []
         for name in remaining_models:
             spec_class = StackedModel._odoo_name_to_class(name, spec_module)
             if spec_class is None:
@@ -236,6 +242,18 @@ class SpecMixin(models.AbstractModel):
             self.env[name]._setup_fields()
             self.env[name]._setup_complete()
 
+            built_model_names.append(name)
+            built_model = self.env[name]
+            # only concrete (non-abstract) models get an SQL table; the abstract
+            # remaining models (event and IBS/CBS reform nodes, only serialized
+            # to XML) never do, so they must not force the reflection below
+            if built_model._auto and not built_model._abstract:
+                concrete_tables.append(built_model._table)
+
+        # Now that the classes exist we know exactly which tables the reflection
+        # would create, so we can tell an ordinary (read-only) load from one that
+        # must reflect. On the read-only path we skip everything that writes.
+        if self._spec_reflection_needed(concrete_tables):
             access_fields = [
                 "id",
                 "name",
@@ -246,29 +264,31 @@ class SpecMixin(models.AbstractModel):
                 "perm_create",
                 "perm_unlink",
             ]
-            model._auto_fill_access_data(self.env, odoo_module, access_data)
-
-        self.env["ir.model.access"].load(access_fields, access_data)
-        self.env.registry.init_models(
-            self.env.cr, remaining_models, {"module": odoo_module}
-        )
-
-        # init_models just created ir.model.data records for the "MAGIC FIELDS"
-        # of the remaining_models. If we let these fields, next Odoo update
-        # will decide that these MAGIC FIELDS do not match the fields of the
-        # abstract schema mixins and would take a long time to delete these records
-        # and the fields. This is not what we want, so we just remove these records:
-        imd_magic_field_names = []
-        for model in remaining_models:
-            for field in models.MAGIC_COLUMNS + ["display_name", "__last_update"]:
-                imd_magic_field_names.append(
-                    f"field_{model.replace('.', '_')}__{field}"
+            for name in built_model_names:
+                self.env[name]._auto_fill_access_data(
+                    self.env, odoo_module, access_data
                 )
-        imd_recs = self.env["ir.model.data"].search(
-            [("name", "in", imd_magic_field_names)]
-        )
-        with mute_logger("odoo.models"):
-            imd_recs.unlink()
+            self.env["ir.model.access"].load(access_fields, access_data)
+            self.env.registry.init_models(
+                self.env.cr, remaining_models, {"module": odoo_module}
+            )
+
+            # init_models just created ir.model.data records for the "MAGIC FIELDS"
+            # of the remaining_models. If we let these fields, next Odoo update
+            # will decide that these MAGIC FIELDS do not match the fields of the
+            # abstract schema mixins and would take a long time to delete these records
+            # and the fields. This is not what we want, so we just remove these records:
+            imd_magic_field_names = []
+            for model in remaining_models:
+                for field in models.MAGIC_COLUMNS + ["display_name", "__last_update"]:
+                    imd_magic_field_names.append(
+                        f"field_{model.replace('.', '_')}__{field}"
+                    )
+            imd_recs = self.env["ir.model.data"].search(
+                [("name", "in", imd_magic_field_names)]
+            )
+            with mute_logger("odoo.models"):
+                imd_recs.unlink()
 
         # The concrete classes we built above are rebuilt from scratch every
         # time this hook runs, but Odoo's MetaModel registered them in
@@ -283,6 +303,24 @@ class SpecMixin(models.AbstractModel):
         models.MetaModel.module_to_models[odoo_module] = [
             cls for cls in registered if cls not in concrete_models
         ]
+
+    def _spec_reflection_needed(self, concrete_tables):
+        """Whether this hook run must reflect the remaining spec models into the
+        database instead of staying read-only.
+
+        True while a module install/update is in progress (``registry.updated_modules``
+        set), or when a concrete table is still missing -- e.g. a post_init_hook
+        (l10n_br_cte importing a CT-e) can exercise the ORM and run this hook before
+        STEP 8, while ``updated_modules`` is still empty. We check the SQL table, not
+        ``ir.model``, because remaining models already have an ``ir.model`` row as
+        abstract mixins long before they get a table here.
+        """
+        if self.env.registry.updated_modules:
+            return True
+        if not concrete_tables:
+            return False
+        existing = set(existing_tables(self.env.cr, list(concrete_tables)))
+        return not set(concrete_tables).issubset(existing)
 
     @classmethod
     def _auto_fill_access_data(cls, env, module_name: str, access_data: list):

--- a/spec_driven_model/tests/test_spec_model.py
+++ b/spec_driven_model/tests/test_spec_model.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 from odoo_test_helper import FakeModelLoader
 
-from odoo.models import NewId
+from odoo.models import MetaModel, NewId
 from odoo.tests import TransactionCase
 
 
@@ -419,3 +419,149 @@ class TestSpecModel(TransactionCase, FakeModelLoader):
             hasattr(self.env.registry, "_nosuch_register_hook_loaded"),
             "the model with no spec module consumed the load key of the schema",
         )
+
+    def _clear_poxsd_hook_guard(self):
+        # a fresh Registry.new() has no per-schema guard, so the hook runs;
+        # here we clear it to run the hook again inside a single test process
+        self.env.registry.__dict__.pop("_poxsd_register_hook_loaded", None)
+
+    def test_hook_read_only_on_ordinary_registry_load(self):
+        """hook v2: an ordinary registry load performs zero reflection writes.
+
+        _register_remaining_schema_models_hook runs on every registry load
+        (every ``Registry.new``). It must always rebuild the Python classes of
+        the *remaining* spec models (poxsd.10.comment here, nfe.40.detpag/det/...
+        in l10n_br_nfe) in memory, but reflecting them into the database (via
+        ``registry.init_models``, plus ir.model.access and the ir.model.data
+        magic-field create/unlink cycle) only has to happen on install/update.
+        Once the models are reflected, a subsequent ordinary load (server boot,
+        a fresh worker's own registry, a second ``Registry.new`` for another
+        database on a dbfilter instance) must be read-only: it must NOT call
+        ``init_models`` for the remaining models again -- that is the write
+        churn concurrent workers race on (duplicate key / serialization /
+        deadlock on ir_model_data). This is the write-churn sibling of the
+        class-leak fixes #4664/#4670 and the successor of #3809.
+
+        The hook cannot be invoked twice by hand on a live registry (the second
+        build would consume the concrete class the first one left among the
+        model bases and crash with an inconsistent MRO -- exactly #4668), so we
+        drive it through real registry rebuilds like
+        ``test_registry_reload_with_extended_remaining_model`` does, and spy on
+        ``registry.init_models`` to see whether the hook reflected the remaining
+        models on each rebuild.
+        """
+        from unittest import mock
+
+        from odoo_test_helper.fake_model_loader import FakePackage
+
+        from .fake_comment_extension import CommentExtension
+        from .fake_mixin import PoXsdMixin
+        from .spec_poxsd import Comment
+
+        registry = self.env.registry
+        cr = self.env.cr
+
+        real_init_models = registry.init_models
+        # setup_models() never calls init_models(); within a registry rebuild
+        # the only caller reflecting poxsd.10.comment is our hook, so this spy
+        # captures exactly the hook's reflection.
+        reflected = []
+
+        def spy_init_models(cr_, model_names, context, install=True):
+            if "poxsd.10.comment" in set(model_names):
+                reflected.append(list(model_names))
+            return real_init_models(cr_, model_names, context, install)
+
+        ready = registry.ready
+        saved_updated_modules = registry.updated_modules
+        saved_module_classes = list(MetaModel.module_to_models["spec_driven_model"])
+        try:
+            # rebuild #1 -- install/update in progress: the hook must reflect the
+            # remaining model, whatever how the test db was built
+            registry.updated_modules = ["spec_driven_model"]
+            self._clear_poxsd_hook_guard()
+            self.loader.update_registry((PoXsdMixin, Comment, CommentExtension))
+            registry.ready = True
+            with mock.patch.object(
+                registry, "init_models", side_effect=spy_init_models
+            ):
+                registry.setup_models(cr)
+            self.assertTrue(
+                reflected,
+                "sanity: on an install/update the hook must reflect the "
+                "remaining models (else the read-only assertion below is void)",
+            )
+
+            # rebuild #2 -- an ordinary registry load (nothing installed or
+            # updated): the hook must NOT reflect the remaining models again.
+            reflected.clear()
+            registry.updated_modules = []
+            self._clear_poxsd_hook_guard()
+            with mock.patch.object(
+                registry, "init_models", side_effect=spy_init_models
+            ), mock.patch.object(cr, "commit"):
+                registry.load(cr, FakePackage("spec_driven_model"))
+                registry.setup_models(cr)
+            self.assertEqual(
+                reflected,
+                [],
+                "an ordinary registry load re-reflected the remaining spec "
+                "models (called init_models); it must be read-only once they "
+                "are reflected, or concurrent workers race the same "
+                "ir_model_data writes on a dbfilter instance",
+            )
+        finally:
+            MetaModel.module_to_models["spec_driven_model"] = saved_module_classes
+            registry.updated_modules = saved_updated_modules
+            registry.ready = ready
+            self._clear_poxsd_hook_guard()
+
+    def test_reflection_needed_signals(self):
+        """hook v2 guard: _spec_reflection_needed picks the full (writing) path
+        exactly when it must -- while a module is installing/updating, and (the
+        essential safety net) whenever a concrete remaining model is not yet
+        backed by its SQL table -- and only then. This is what keeps
+        install/update (and the pre-STEP-9 post_init_hook load, where a CT-e
+        import builds cte.40.infoutros before its table exists) on the full path
+        while letting the ordinary boot skip it.
+        """
+        registry = self.env.registry
+        hook_model = self.env["spec.mixin.poxsd"]
+        # a table that certainly exists, and one that certainly does not
+        existing_table = self.env["ir.model"]._table  # "ir_model"
+        missing_table = "poxsd_10_does_not_exist"
+
+        saved_updated_modules = registry.updated_modules
+        try:
+            # a module install/update in progress always forces the full path,
+            # even when every concrete table is already present
+            registry.updated_modules = ["spec_driven_model"]
+            self.assertTrue(
+                hook_model._spec_reflection_needed([existing_table]),
+                "an install/update in progress must take the full "
+                "reflection path",
+            )
+
+            # ordinary load with a concrete table still missing -> full path. This is
+            # the CI #4718 case: l10n_br_cte's post_init_hook runs the hook before
+            # STEP 9, and reflecting is mandatory or the import INSERT fails
+            registry.updated_modules = []
+            self.assertTrue(
+                hook_model._spec_reflection_needed([existing_table, missing_table]),
+                "a concrete remaining model without its SQL table must fall "
+                "back to the full reflection path",
+            )
+
+            # ordinary load with every concrete table present -> read-only
+            self.assertFalse(
+                hook_model._spec_reflection_needed([existing_table]),
+                "with every concrete table present the load must be read-only",
+            )
+
+            # ordinary load with no concrete tables at all -> nothing to reflect
+            self.assertFalse(
+                hook_model._spec_reflection_needed([]),
+                "with no concrete remaining models there is nothing to reflect",
+            )
+        finally:
+            registry.updated_modules = saved_updated_modules


### PR DESCRIPTION
## Summary

Make `_register_remaining_schema_models_hook` **read-only on ordinary registry loads**: skip `registry.init_models` + the create/delete cycle of magic-field `ir.model.data` records when the remaining spec models are already reflected in the database and no module is being installed/updated.

This is the next step of the hook series after #3809 (faster/cleaner update), #4664 (merged registry bases) and #4670 (module_to_models scrub, fixes #4668).

## The problem

The hook runs on **every** registry load and today it always:
1. rebuilds the remaining concrete models (in memory - this part is required and untouched),
2. runs `registry.init_models`, which **creates** `ir.model.data` records for the magic fields, and then the hook itself **deletes** them (so the next update does not purge slowly - see #3809).

Measured on a database with `l10n_br_nfe`: **~1,150 `ir_model_data_id_seq` increments per ordinary boot** (create+delete of ~336 records plus reflection updates), on a boot where nothing changed.

Beyond the waste (WAL/replication noise, autovacuum pressure on `ir_model_data`), this is a **concurrency failure class**: with `dbfilter` and no `db_name` there is no master preload - each worker builds the registry on its first request and executes this write cycle **concurrently on the same rows** right after a restart (duplicate key / serialization failures / deadlocks). With `db_name` set the master preloads before forking, which is why some instances never see it.

## Mechanism

New helper `_spec_reflection_needed(remaining_models)`:
- **Install/update in progress** -> full path. Signal: `registry.updated_modules` - populated by `odoo/modules/loading.py` (STEP 8) right before `_register_hook` (STEP 9), and only with modules that actually needed install/upgrade. Empty on ordinary boots.
- **Safety fallback** -> full path if any remaining model has no `ir_model` row (1 SELECT). `ir_model` (not SQL tables) is the correct probe: several remaining models are abstract (e.g. IBS/CBS and event nodes) and legitimately never get a table, while `ir_model` is exactly what `init_models._reflect_models` writes.

When reflection is not needed: the Python classes are still rebuilt (the registry needs them to resolve stacked comodels), but `ir.model.access.load`, `registry.init_models` and the magic-field IMD create/delete cycle are skipped. The #4670 `module_to_models` scrub runs on both paths.

## Measured impact (db with l10n_br_nfe, workers=0, 3 ordinary boots each)

| | Registry load | `ir_model_data_id_seq` delta per boot |
|---|---|---|
| Before | 2.80 / 2.70 / 2.40 s | **+1,154** |
| After | 2.08 / 2.13 / 2.03 s | **0** |

Ordinary boots become **write-free**, which removes the concurrent-boot failure class by construction (the remaining write path - install/update - runs in a single process).

## Tests

- `test_hook_read_only_on_ordinary_registry_load`: drives two real registry rebuilds and asserts the hook reflects on the update rebuild and performs zero reflection writes on the ordinary one.
- `test_reflection_needed_signals`: unit-tests the guard decision (update in progress -> full path; missing `ir_model` row -> full path; nothing remaining -> skip).
- `-u l10n_br_nfe` still runs the full path and leaves a consistent database (155 `nfe.40.*` models / 48 tables). `spec_driven_model` suite: 7/7 green. The 12 pre-existing `TestNFeIBSCBS` errors (nfelib version mismatch) are identical on pristine HEAD - unrelated.

