### PR TITLE
[16.0][IMP] l10n_br_fiscal: extensible fiscal view field hooks + prune dead injected fields

### DIFF
--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -103,6 +103,46 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         return domain
 
     @api.model
+    def _fiscal_view_compute_methods(self):
+        """Compute methods whose (stored) fields must be kept available in the
+        business-document line views (invisible), so the fiscal onchange
+        protocol can round-trip them. Formalizes the implicit triad used by
+        ``inject_fiscal_fields``. A submodule adding a fiscal compute to the
+        line can extend it::
+
+            @api.model
+            def _fiscal_view_compute_methods(self):
+                return super()._fiscal_view_compute_methods() + [
+                    "_compute_my_tax_fields",
+                ]
+        """
+        return [
+            "_compute_tax_fields",
+            "_compute_fiscal_tax_ids",
+            "_compute_product_fiscal_fields",
+        ]
+
+    @api.model
+    def _fiscal_view_pruned_fields(self):
+        """Stored fiscal computes that no business-document line view reads,
+        displays, edits or references in a modifier/domain (C4 census "dead"):
+        they are *not* injected into the invisible onchange collection. They
+        keep being recomputed server-side on write, so dropping them from the
+        view is value-preserving. Override to force one back in::
+
+            @api.model
+            def _fiscal_view_pruned_fields(self):
+                return super()._fiscal_view_pruned_fields() - {"ii_percent"}
+        """
+        return {
+            "ii_percent",
+            "simple_value",
+            "simple_without_icms_value",
+            "cofins_wh_base_type",
+            "pis_wh_base_type",
+        }
+
+    @api.model
     def inject_fiscal_fields(
         self,
         doc,
@@ -115,20 +155,15 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         """
 
         # the list of computed fields we will add to the view when missing
-        missing_line_fields = set(
-            [
-                fname
-                for fname, _field in filter(
-                    lambda item: item[1].compute
-                    in (
-                        "_compute_tax_fields",
-                        "_compute_fiscal_tax_ids",
-                        "_compute_product_fiscal_fields",
-                    ),
-                    self.env["l10n_br_fiscal.document.line.mixin"]._fields.items(),
-                )
-            ]
-        )
+        compute_methods = tuple(self._fiscal_view_compute_methods())
+        pruned_fields = self._fiscal_view_pruned_fields()
+        missing_line_fields = {
+            fname
+            for fname, _field in self.env[
+                "l10n_br_fiscal.document.line.mixin"
+            ]._fields.items()
+            if _field.compute in compute_methods and fname not in pruned_fields
+        }
 
         fiscal_view = self.env.ref(
             "l10n_br_fiscal.document_fiscal_line_mixin_form"
@@ -180,6 +215,9 @@ class FiscalDocumentLineMixin(models.AbstractModel):
                     for fiscal_node in fiscal_nodes:
                         if fiscal_node.attrib["name"] in missing_line_fields:
                             missing_line_fields.remove(fiscal_node.attrib["name"])
+                        if fiscal_node.attrib["name"] in pruned_fields:
+                            # dead fiscal computes never belong in the views
+                            continue
                         if fiscal_node.attrib["name"] in existing_fields:
                             continue
                         field = deepcopy(fiscal_node)

--- a/l10n_br_purchase/tests/test_l10n_br_purchase.py
+++ b/l10n_br_purchase/tests/test_l10n_br_purchase.py
@@ -515,11 +515,29 @@ class L10nBrPurchaseBaseTest(TransactionCase):
         purchase_form.save()
 
     def test_get_view(self):
+        """Executable spec of the fiscal fields injection contract: the fiscal
+        drivers (operation, tax ids) are injected into the order line views,
+        while the C4 census "dead" fiscal computes are pruned out of them."""
         arch, models = self.po_products._get_view()
-        self.assertTrue(
-            arch.findall(".//field[@name='fiscal_operation_id']"),
+        injected = {el.get("name") for el in arch.findall(".//field")}
+        self.assertIn(
+            "fiscal_operation_id",
+            injected,
             "Error to included Operation Line from Purchase Order Line.",
         )
+        self.assertIn("icms_tax_id", injected)
+        for dead in (
+            "ii_percent",
+            "simple_value",
+            "simple_without_icms_value",
+            "cofins_wh_base_type",
+            "pis_wh_base_type",
+        ):
+            self.assertNotIn(
+                dead,
+                injected,
+                "Pruned dead fiscal field %s must not be injected." % dead,
+            )
 
     def test_fields_freight_insurance_other_costs(self):
         """Test fields Freight, Insurance and Other Costs when

--- a/l10n_br_sale_blanket_order/tests/test_l10n_br_sale_blanket_order.py
+++ b/l10n_br_sale_blanket_order/tests/test_l10n_br_sale_blanket_order.py
@@ -4,8 +4,6 @@
 from contextlib import contextmanager
 from datetime import date, timedelta
 
-from lxml import etree
-
 from odoo.exceptions import UserError
 from odoo.fields import Command
 from odoo.tests import tagged
@@ -553,9 +551,18 @@ class L10nBrSaleBLanketOrderTest(TransactionCase):
 
         with self.subTest("BR company - form view - fiscal fields injected"):
             arch, _ = sale_blanket_order._get_view(view_type="form")
-            self.assertIn(
-                "fiscal_operation_id", etree.tostring(arch, encoding="unicode")
-            )
+            injected = {el.get("name") for el in arch.findall(".//field")}
+            self.assertIn("fiscal_operation_id", injected)
+            self.assertIn("icms_tax_id", injected)
+            # C4 census "dead" fiscal computes are pruned from the injection
+            for dead in (
+                "ii_percent",
+                "simple_value",
+                "simple_without_icms_value",
+                "cofins_wh_base_type",
+                "pis_wh_base_type",
+            ):
+                self.assertNotIn(dead, injected)
 
         with self.subTest("Non-BR company - form view - line_ids tree not modified"):
             us_country = self.env.ref("base.us")


### PR DESCRIPTION
## Summary

Two related improvements to the fiscal line view injection (`inject_fiscal_fields`), with no behavior change for standard flows:

1. **Extensibility hooks** - the injection contract becomes overridable downstream:
 - `_fiscal_view_compute_methods()`: formalizes the (previously hardcoded) triad of compute methods whose fields are collected into line views;
 - `_fiscal_view_pruned_fields()`: the list of fields excluded from injection, so custom modules can re-add a pruned field (or prune more) with a simple `super()` override.

2. **Prune 5 dead injected fields** - `ii_percent`, `simple_value`, `simple_without_icms_value`, `cofins_wh_base_type`, `pis_wh_base_type`. Census across the whole repo (views, modifiers/attrs/domains, `@api.onchange` triggers, compute bodies, JS, QWeb): these are stored computed fields injected only through the synthetic `missing_line_fields` append, never read by any onchange, never referenced by any modifier, never displayed. They keep being computed and stored server-side - they only leave the onchange payload/view spec. Value-preserving by construction.

Fields that had any uncertain usage (e.g. `amount_tax_included`, which IS read by `_sync_invoice`; the `*_cst_code` related fields read by nfse/downstream) were deliberately **kept** - the rule applied was "any doubt -> keep".

The injection tests in `l10n_br_purchase` and `l10n_br_sale_blanket_order` were extended to assert the new contract (they are the executable spec of the injection).

Part of the fiscal performance series (#4711/#4716/#4717) as groundwork for view-payload work, but standalone and independent - this PR is deliberately perf-neutral.

