### PR TITLE
[16.0][IMP] l10n_br_fiscal: reduce injected tree field collection (-33% Form time)

### DIFF
--- a/l10n_br_account/models/fiscal_tax.py
+++ b/l10n_br_account/models/fiscal_tax.py
@@ -7,10 +7,65 @@ from odoo import Command, api, fields, models
 class FiscalTax(models.Model):
     _inherit = "l10n_br_fiscal.tax"
 
+    def _account_taxes_company(self, company=False):
+        if company:
+            return company
+        # ``self.env.company`` already resolves ``allowed_company_ids[0]`` *with*
+        # access validation, so it replaces the previous raw browse of that id.
+        # A ``default_company_id`` in the context is still honoured as an
+        # explicit override.
+        company = self.env.company
+        if self.env.context.get("default_company_id"):
+            company = self.env["res.company"].browse(
+                self.env.context["default_company_id"]
+            )
+        return company
+
     def account_taxes(self, user_type="sale", fiscal_operation=False, company=False):
         account_taxes = self.env["account.tax"]
+        if not self:
+            return account_taxes
+
+        company = self._account_taxes_company(company)
+
+        # Resolve os grupos contábeis de todos os impostos fiscais em um único
+        # search e traz TODOS os account.tax dos grupos envolvidos numa única
+        # query (antes: 1 search de grupo + 1 search de account.tax por imposto
+        # por linha). O casamento por grupo é feito em memória.
+        fiscal_group_to_account_group = self.tax_group_id._account_tax_group_map()
+        account_group_ids = [
+            group.id for group in fiscal_group_to_account_group.values() if group
+        ]
+        candidate_taxes = self.env["account.tax"].search(
+            [
+                ("tax_group_id", "in", account_group_ids),
+                ("active", "=", True),
+                ("company_id", "=", company.id),
+            ]
+        )
+        taxes_by_account_group = {}
+        for tax in candidate_taxes:
+            taxes_by_account_group.setdefault(
+                tax.tax_group_id.id, self.env["account.tax"]
+            )
+            taxes_by_account_group[tax.tax_group_id.id] |= tax
+
+        # `deductible_taxes` is company dependent, so reading it off the record
+        # as it comes answers for whatever company sits in the environment, not
+        # for the one resolved above. Same correction as #4996, kept here
+        # because this method is rewritten by this PR: without it, whichever of
+        # the two merges last silently drops the fix.
+        if fiscal_operation and company:
+            fiscal_operation = fiscal_operation.with_company(company)
+
         for fiscal_tax in self:
-            taxes = fiscal_tax._account_taxes(company)
+            account_group = fiscal_group_to_account_group.get(
+                fiscal_tax.tax_group_id.id
+            )
+            taxes = taxes_by_account_group.get(
+                account_group.id if account_group else False,
+                self.env["account.tax"],
+            )
             # Atualiza os impostos contábeis relacionados aos impostos fiscais
             account_taxes |= taxes.filtered(
                 lambda t: t.type_tax_use == user_type and t.active and not t.deductible
@@ -28,15 +83,7 @@ class FiscalTax(models.Model):
     def _account_taxes(self, company=False):
         self.ensure_one()
         account_tax_group = self.tax_group_id.account_tax_group()
-        if not company:
-            company = self.env.company
-            if self.env.context.get("default_company_id") or self.env.context.get(
-                "allowed_company_ids"
-            ):
-                company = self.env["res.company"].browse(
-                    self.env.context.get("default_company_id")
-                    or self.env.context.get("allowed_company_ids")[0]
-                )
+        company = self._account_taxes_company(company)
         return self.env["account.tax"].search(
             [
                 ("tax_group_id", "=", account_tax_group.id),

--- a/l10n_br_account/models/fiscal_tax_group.py
+++ b/l10n_br_account/models/fiscal_tax_group.py
@@ -12,3 +12,19 @@ class FiscalTaxGroup(models.Model):
         return self.env["account.tax.group"].search(
             [("fiscal_tax_group_id", "in", self.ids)], limit=1
         )
+
+    def _account_tax_group_map(self):
+        """Return {fiscal_tax_group_id: account.tax.group} for ``self`` in a
+        single search, instead of one search per fiscal tax group."""
+        result = {group.id: self.env["account.tax.group"] for group in self}
+        if not self:
+            return result
+        account_tax_groups = self.env["account.tax.group"].search(
+            [("fiscal_tax_group_id", "in", self.ids)]
+        )
+        for account_tax_group in account_tax_groups:
+            fiscal_group_id = account_tax_group.fiscal_tax_group_id.id
+            # account_tax_group() usa limit=1: preserva o primeiro encontrado.
+            if not result.get(fiscal_group_id):
+                result[fiscal_group_id] = account_tax_group
+        return result

--- a/l10n_br_account/tests/__init__.py
+++ b/l10n_br_account/tests/__init__.py
@@ -2,6 +2,7 @@ from . import test_account_move_sn
 from . import test_account_move_lc
 from . import test_account_taxes
 from . import test_move_edition
+from . import test_fiscal_view_prune
 from . import test_per_tax_draft_edition
 from . import test_move_document_discount
 from . import test_invoice_refund

--- a/l10n_br_account/tests/__init__.py
+++ b/l10n_br_account/tests/__init__.py
@@ -2,6 +2,7 @@ from . import test_account_move_sn
 from . import test_account_move_lc
 from . import test_account_taxes
 from . import test_move_edition
+from . import test_per_tax_draft_edition
 from . import test_move_document_discount
 from . import test_invoice_refund
 from . import test_multi_localizations_invoice

--- a/l10n_br_account/tests/test_fiscal_view_prune.py
+++ b/l10n_br_account/tests/test_fiscal_view_prune.py
@@ -1,0 +1,63 @@
+# Copyright 2026 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from unittest import mock
+
+from lxml import etree
+
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestFiscalViewPruneClosure(TransactionCase):
+    """C4: the reduced line tree must keep every field referenced in a kept
+    node's modifier, even when a downstream ``_fiscal_view_pruned_fields()``
+    override also prunes it, otherwise the view crashes at load."""
+
+    def test_pruned_modifier_referenced_field_survives_in_tree(self):
+        company = self.env.ref("l10n_br_base.empresa_lucro_presumido")
+        fiscal_line = self.env["l10n_br_fiscal.document.line"]
+        mixin = self.env["l10n_br_fiscal.document.line.mixin"]
+
+        fiscal_view = self.env.ref(
+            "l10n_br_fiscal.document_fiscal_line_mixin_form"
+        ).sudo()
+        fsc_doc = etree.fromstring(
+            fiscal_view.with_context(inherit_branding=True).get_combined_arch()
+        )
+        field_names = set(mixin._fields) | set(fiscal_line._fields)
+        modifier_refs = fiscal_line._fiscal_line_modifier_refs(fsc_doc, field_names)
+        taxes_names = {
+            node.attrib["name"]
+            for node in fsc_doc.xpath("//page[@name='fiscal_taxes']//field")
+        }
+        # A fiscal_taxes tree field kept ONLY by the modifier closure: droppable
+        # on its own, so pruning it must not remove it from the tree.
+        candidates = sorted(
+            (modifier_refs & taxes_names) - fiscal_line._fiscal_line_view_fields()
+        )
+        self.assertTrue(
+            candidates,
+            "no modifier-referenced prunable fiscal tree field to exercise C4",
+        )
+        victim = candidates[0]
+
+        base_pruned = fiscal_line._fiscal_view_pruned_fields()
+
+        def _patched_pruned(self):
+            return base_pruned | {victim}
+
+        move = self.env["account.move"].with_company(company)
+        with mock.patch.object(
+            type(fiscal_line), "_fiscal_view_pruned_fields", _patched_pruned
+        ):
+            # Must not raise "Unknown field ... in modifier" at view load.
+            view = move.with_context(force_line_fiscal_detail=True).get_view(
+                view_type="form"
+            )
+        arch = etree.fromstring(view["arch"])
+        self.assertTrue(
+            arch.xpath(f"//tree//field[@name='{victim}']"),
+            f"{victim} is referenced in a modifier but was dropped from the line "
+            "tree despite the modifier closure (C4 regression).",
+        )

--- a/l10n_br_account/tests/test_move_edition.py
+++ b/l10n_br_account/tests/test_move_edition.py
@@ -250,9 +250,6 @@ class TestMoveEdition(TransactionCase):
             self.assertEqual(
                 line_form.ipi_tax_id, self.env.ref("l10n_br_fiscal.tax_ipi_5")
             )
-            line_form.icmsfcp_base = line_form.price_unit
-            line_form.icmsfcp_value = 3  # ensure manually setting FCP value works
-            self.assertEqual(line_form.icmsfcp_value, 3)
 
         move = move_form.save()
 
@@ -289,6 +286,15 @@ class TestMoveEdition(TransactionCase):
         )
         self.assertEqual(aml.ipi_tax_id, self.env.ref("l10n_br_fiscal.tax_ipi_5"))
         self.assertEqual(aml.icms_value, 79.38)
+
+        # The FCP detail fields moved from the (reduced) inline line tree to the
+        # line form dialog (popup) with the fiscal tree-field whitelist, so they
+        # are edited there now, as a user would. Ensure the manual FCP override
+        # still persists (the stored compute must not clobber a client value).
+        with Form(aml.fiscal_document_line_id) as line_popup:
+            line_popup.icmsfcp_base = line_popup.price_unit
+            line_popup.icmsfcp_value = 3  # ensure manually setting FCP value works
+            self.assertEqual(line_popup.icmsfcp_value, 3)
         self.assertEqual(aml.icmsfcp_base, aml.price_unit)
         self.assertEqual(aml.icmsfcp_value, 3)
 

--- a/l10n_br_account/tests/test_per_tax_draft_edition.py
+++ b/l10n_br_account/tests/test_per_tax_draft_edition.py
@@ -1,0 +1,191 @@
+# Copyright 2026 - TODAY KMEE
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import Command
+from odoo.tests import tagged
+from odoo.tests.common import Form
+
+from .common import AccountMoveBRCommon
+
+
+@tagged("post_install", "-at_install")
+class TestPerTaxDraftEdition(AccountMoveBRCommon):
+    """Per-tax value regression suite for DRAFT invoice-line editing.
+
+    These tests pin the behaviour that, while an ``out_invoice`` is still in
+    draft and edited through a ``Form`` (the UI path, i.e. the full per-line
+    onchange cascade), the stored fiscal value fields track the *true* line
+    inputs:
+
+      (a) overriding a per-tax selector (``icms_tax_id``, ``ipi_tax_id`` ...)
+          makes base/percent/value recompute with the NEW tax rate;
+      (b) changing ``quantity`` / ``price_unit`` rescales the values;
+      (c) changing ``fiscal_operation_line_id`` remaps CFOP and taxes.
+
+    They guard the #4721 class of regressions, where a draft fiscal value could
+    be left stale -- e.g. ICMS stuck at the mapped rate after the user selected
+    another tax. Assertions are relationship based (value == base * rate) so
+    they hold regardless of the company-specific mapped rates.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.configure_normal_company_taxes()
+        nfe_group = cls.env.ref("l10n_br_nfe.group_user", raise_if_not_found=False)
+        if nfe_group:
+            cls.env.user.write({"groups_id": [Command.link(nfe_group.id)]})
+        cls.currency = cls.company_data["currency"]
+        cls.document_55 = cls.env.ref("l10n_br_fiscal.document_55")
+        cls.fo_venda = cls.env.ref("l10n_br_fiscal.fo_venda")
+        cls.fo_venda_venda = cls.env.ref("l10n_br_fiscal.fo_venda_venda")
+        cls.fo_venda_revenda = cls.env.ref("l10n_br_fiscal.fo_venda_revenda")
+        cls.tax_icms_7 = cls.env.ref("l10n_br_fiscal.tax_icms_7")
+        cls.tax_icms_18 = cls.env.ref("l10n_br_fiscal.tax_icms_18")
+        cls.tax_ipi_10 = cls.env.ref("l10n_br_fiscal.tax_ipi_10")
+        cls.tax_pis_1_65 = cls.env.ref("l10n_br_fiscal.tax_pis_1_65")
+        cls.tax_cofins_7_6 = cls.env.ref("l10n_br_fiscal.tax_cofins_7_6")
+
+    # ------------------------------------------------------------------ helpers
+
+    def _invoice_form(self):
+        """A draft out_invoice Form with the fiscal header already filled in."""
+        move_form = Form(
+            self.env["account.move"].with_context(default_move_type="out_invoice")
+        )
+        move_form.partner_id = self.partner_a
+        move_form.document_type_id = self.document_55
+        move_form.document_serie_id = self.empresa_lc_document_55_serie_1
+        move_form.fiscal_operation_id = self.fo_venda
+        return move_form
+
+    def _init_line(self, line, price_unit=1000.0, quantity=1.0):
+        line.product_id = self.product_a
+        line.fiscal_operation_line_id = self.fo_venda_venda
+        line.price_unit = price_unit
+        line.quantity = quantity
+
+    def _assert_value_tracks_rate(self, line, domain, percent, msg=""):
+        """Assert ``<domain>_value == round(<domain>_base * percent / 100)`` and
+        that ``<domain>_percent`` equals ``percent`` (non-reduced taxes)."""
+        base = getattr(line, f"{domain}_base")
+        value = getattr(line, f"{domain}_value")
+        self.assertAlmostEqual(
+            getattr(line, f"{domain}_percent"),
+            percent,
+            places=2,
+            msg=f"{domain} percent mismatch {msg}",
+        )
+        expected = self.currency.round(base * percent / 100.0)
+        self.assertAlmostEqual(
+            value,
+            expected,
+            places=2,
+            msg=f"{domain} value {value} != base {base} * {percent}% {msg}",
+        )
+
+    # ------------------------------------------------------------------- (a) tax
+
+    def test_draft_icms_tax_id_override(self):
+        """Overriding icms_tax_id in draft recomputes icms_value with the new
+        rate (the exact #4721 scenario, in the full view payload)."""
+        move_form = self._invoice_form()
+        with move_form.invoice_line_ids.new() as line:
+            self._init_line(line)
+            initial_percent = line.icms_percent
+            # sanity: the mapped ICMS is computed and self-consistent
+            self._assert_value_tracks_rate(line, "icms", initial_percent, "(mapped)")
+
+            line.icms_tax_id = self.tax_icms_18
+            self._assert_value_tracks_rate(line, "icms", 18.0, "(after ->18%)")
+
+            line.icms_tax_id = self.tax_icms_7
+            self._assert_value_tracks_rate(line, "icms", 7.0, "(after ->7%)")
+
+    def test_draft_ipi_tax_id_override(self):
+        move_form = self._invoice_form()
+        with move_form.invoice_line_ids.new() as line:
+            self._init_line(line)
+            line.ipi_tax_id = self.tax_ipi_10
+            self._assert_value_tracks_rate(line, "ipi", 10.0, "(after ->10%)")
+
+    def test_draft_pis_tax_id_override(self):
+        move_form = self._invoice_form()
+        with move_form.invoice_line_ids.new() as line:
+            self._init_line(line)
+            line.pis_tax_id = self.tax_pis_1_65
+            self._assert_value_tracks_rate(line, "pis", 1.65, "(after ->1.65%)")
+
+    def test_draft_cofins_tax_id_override(self):
+        move_form = self._invoice_form()
+        with move_form.invoice_line_ids.new() as line:
+            self._init_line(line)
+            line.cofins_tax_id = self.tax_cofins_7_6
+            self._assert_value_tracks_rate(line, "cofins", 7.6, "(after ->7.6%)")
+
+    def test_draft_icms_override_survives_save(self):
+        """The overridden rate must persist through save() to the posted-ready
+        fiscal line (draft correctness must not depend on the view round-trip)."""
+        move_form = self._invoice_form()
+        with move_form.invoice_line_ids.new() as line:
+            self._init_line(line)
+            line.icms_tax_id = self.tax_icms_18
+        move = move_form.save()
+        fisc_line = move.fiscal_line_ids[0]
+        self.assertEqual(fisc_line.icms_tax_id, self.tax_icms_18)
+        self.assertAlmostEqual(fisc_line.icms_percent, 18.0, places=2)
+        self.assertAlmostEqual(
+            fisc_line.icms_value,
+            self.currency.round(fisc_line.icms_base * 0.18),
+            places=2,
+        )
+
+    # ---------------------------------------------------------- (b) qty / price
+
+    def test_draft_quantity_edition(self):
+        move_form = self._invoice_form()
+        with move_form.invoice_line_ids.new() as line:
+            self._init_line(line, price_unit=1000.0, quantity=1.0)
+            percent = line.icms_percent
+            self._assert_value_tracks_rate(line, "icms", percent, "(qty=1)")
+            base_1 = line.icms_base
+
+            line.quantity = 3.0
+            self._assert_value_tracks_rate(line, "icms", percent, "(qty=3)")
+            self.assertAlmostEqual(line.icms_base, base_1 * 3.0, places=2)
+
+    def test_draft_price_unit_edition(self):
+        move_form = self._invoice_form()
+        with move_form.invoice_line_ids.new() as line:
+            self._init_line(line, price_unit=1000.0, quantity=1.0)
+            percent = line.icms_percent
+            base_1000 = line.icms_base
+
+            line.price_unit = 2500.0
+            self._assert_value_tracks_rate(line, "icms", percent, "(price=2500)")
+            self.assertAlmostEqual(line.icms_base, base_1000 * 2.5, places=2)
+
+    # -------------------------------------------------- (c) operation line remap
+
+    def test_draft_fiscal_operation_line_remap(self):
+        """Changing fiscal_operation_line_id in draft remaps CFOP and taxes."""
+        move_form = self._invoice_form()
+        with move_form.invoice_line_ids.new() as line:
+            self._init_line(line)
+            cfop_before = line.cfop_id
+            self.assertTrue(cfop_before, "mapped CFOP expected for venda_venda")
+
+            line.fiscal_operation_line_id = self.fo_venda_revenda
+            cfop_after = line.cfop_id
+            self.assertTrue(cfop_after, "mapped CFOP expected for venda_revenda")
+            # produção (5101) vs revenda (5102): the CFOP must be remapped
+            self.assertNotEqual(
+                cfop_before,
+                cfop_after,
+                "CFOP must be remapped when the fiscal operation line changes",
+            )
+            # taxes remain consistent with the new mapping
+            self.assertTrue(line.fiscal_tax_ids, "taxes must be remapped")
+            self._assert_value_tracks_rate(
+                line, "icms", line.icms_percent, "(after op-line remap)"
+            )

--- a/l10n_br_account/tests/test_per_tax_draft_edition.py
+++ b/l10n_br_account/tests/test_per_tax_draft_edition.py
@@ -26,6 +26,13 @@ class TestPerTaxDraftEdition(AccountMoveBRCommon):
     be left stale -- e.g. ICMS stuck at the mapped rate after the user selected
     another tax. Assertions are relationship based (value == base * rate) so
     they hold regardless of the company-specific mapped rates.
+
+    ICMS base/value/percent stay in the inline line tree, so the ICMS cases are
+    checked live on the Form. IPI/PIS/COFINS detail moved to the line form
+    dialog (popup) with the #4721 tree-field reduction and is no longer part of
+    the inline onchange payload, so those cases select the tax live (the tax
+    selector is kept in the tree) and assert P2b's deterministic recompute on
+    the saved fiscal line -- the exact value #4721 could leave stale.
     """
 
     @classmethod
@@ -106,22 +113,29 @@ class TestPerTaxDraftEdition(AccountMoveBRCommon):
         move_form = self._invoice_form()
         with move_form.invoice_line_ids.new() as line:
             self._init_line(line)
+            # the IPI selector is kept in the tree; the IPI detail moved to the
+            # line popup, so the value is asserted on the saved line (P2b).
             line.ipi_tax_id = self.tax_ipi_10
-            self._assert_value_tracks_rate(line, "ipi", 10.0, "(after ->10%)")
+        fisc_line = move_form.save().fiscal_line_ids[0]
+        self._assert_value_tracks_rate(fisc_line, "ipi", 10.0, "(after ->10%, saved)")
 
     def test_draft_pis_tax_id_override(self):
         move_form = self._invoice_form()
         with move_form.invoice_line_ids.new() as line:
             self._init_line(line)
             line.pis_tax_id = self.tax_pis_1_65
-            self._assert_value_tracks_rate(line, "pis", 1.65, "(after ->1.65%)")
+        fisc_line = move_form.save().fiscal_line_ids[0]
+        self._assert_value_tracks_rate(fisc_line, "pis", 1.65, "(after ->1.65%, saved)")
 
     def test_draft_cofins_tax_id_override(self):
         move_form = self._invoice_form()
         with move_form.invoice_line_ids.new() as line:
             self._init_line(line)
             line.cofins_tax_id = self.tax_cofins_7_6
-            self._assert_value_tracks_rate(line, "cofins", 7.6, "(after ->7.6%)")
+        fisc_line = move_form.save().fiscal_line_ids[0]
+        self._assert_value_tracks_rate(
+            fisc_line, "cofins", 7.6, "(after ->7.6%, saved)"
+        )
 
     def test_draft_icms_override_survives_save(self):
         """The overridden rate must persist through save() to the posted-ready

--- a/l10n_br_fiscal/models/__init__.py
+++ b/l10n_br_fiscal/models/__init__.py
@@ -1,5 +1,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from . import fiscal_cache
 from . import data_abstract
 from . import data_product_abstract
 from . import data_ncm_nbs_abstract

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -103,6 +103,46 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         return domain
 
     @api.model
+    def _fiscal_view_compute_methods(self):
+        """Compute methods whose (stored) fields must be kept available in the
+        business-document line views (invisible), so the fiscal onchange
+        protocol can round-trip them. Formalizes the implicit triad used by
+        ``inject_fiscal_fields``. A submodule adding a fiscal compute to the
+        line can extend it::
+
+            @api.model
+            def _fiscal_view_compute_methods(self):
+                return super()._fiscal_view_compute_methods() + [
+                    "_compute_my_tax_fields",
+                ]
+        """
+        return [
+            "_compute_tax_fields",
+            "_compute_fiscal_tax_ids",
+            "_compute_product_fiscal_fields",
+        ]
+
+    @api.model
+    def _fiscal_view_pruned_fields(self):
+        """Stored fiscal computes that no business-document line view reads,
+        displays, edits or references in a modifier/domain (C4 census "dead"):
+        they are *not* injected into the invisible onchange collection. They
+        keep being recomputed server-side on write, so dropping them from the
+        view is value-preserving. Override to force one back in::
+
+            @api.model
+            def _fiscal_view_pruned_fields(self):
+                return super()._fiscal_view_pruned_fields() - {"ii_percent"}
+        """
+        return {
+            "ii_percent",
+            "simple_value",
+            "simple_without_icms_value",
+            "cofins_wh_base_type",
+            "pis_wh_base_type",
+        }
+
+    @api.model
     def inject_fiscal_fields(
         self,
         doc,
@@ -115,20 +155,15 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         """
 
         # the list of computed fields we will add to the view when missing
-        missing_line_fields = set(
-            [
-                fname
-                for fname, _field in filter(
-                    lambda item: item[1].compute
-                    in (
-                        "_compute_tax_fields",
-                        "_compute_fiscal_tax_ids",
-                        "_compute_product_fiscal_fields",
-                    ),
-                    self.env["l10n_br_fiscal.document.line.mixin"]._fields.items(),
-                )
-            ]
-        )
+        compute_methods = tuple(self._fiscal_view_compute_methods())
+        pruned_fields = self._fiscal_view_pruned_fields()
+        missing_line_fields = {
+            fname
+            for fname, _field in self.env[
+                "l10n_br_fiscal.document.line.mixin"
+            ]._fields.items()
+            if _field.compute in compute_methods and fname not in pruned_fields
+        }
 
         fiscal_view = self.env.ref(
             "l10n_br_fiscal.document_fiscal_line_mixin_form"
@@ -180,6 +215,9 @@ class FiscalDocumentLineMixin(models.AbstractModel):
                     for fiscal_node in fiscal_nodes:
                         if fiscal_node.attrib["name"] in missing_line_fields:
                             missing_line_fields.remove(fiscal_node.attrib["name"])
+                        if fiscal_node.attrib["name"] in pruned_fields:
+                            # dead fiscal computes never belong in the views
+                            continue
                         if fiscal_node.attrib["name"] in existing_fields:
                             continue
                         field = deepcopy(fiscal_node)

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -119,6 +119,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         return [
             "_compute_tax_fields",
             "_compute_fiscal_tax_ids",
+            "_compute_fiscal_operation_data",
             "_compute_product_fiscal_fields",
         ]
 
@@ -341,7 +342,28 @@ class FiscalDocumentLineMixin(models.AbstractModel):
                     )
                 )
 
-    @api.depends(
+    # The fiscal operation mapping feeds two kinds of fields:
+    #
+    # * ``fiscal_tax_ids`` (the set of taxes actually applied), and
+    # * the *fiscal decoration* fields ``cfop_id``, ``ipi_guideline_id``,
+    #   ``tax_classification_id`` and ``icms_tax_benefit_id``.
+    #
+    # These used to share a single multi-field compute. That coupling made the
+    # draft correctness of ``fiscal_tax_ids`` depend on the view payload: when
+    # the user overrides a ``*_tax_id`` (e.g. ``icms_tax_id``), the onchange
+    # ``_onchange_fiscal_taxes`` reconciles the override into ``fiscal_tax_ids``,
+    # but manually assigning ONE output of a multi-field editable compute does
+    # NOT protect its siblings. If a sibling decoration field (say
+    # ``ipi_guideline_id``) was left out of the line view/onchange payload it
+    # stays flagged "to compute"; reading it later re-runs the whole compute,
+    # which re-derives ``fiscal_tax_ids`` from the operation-line mapping and
+    # silently discards the user's override (issue #4721: ICMS stuck at the
+    # mapped 7% after selecting 18%). Splitting the computes makes
+    # ``fiscal_tax_ids`` recompute *only* when its real inputs change, so the
+    # draft value is deterministic and independent of which decoration fields
+    # travel in the view. ``map_fiscal_taxes`` is memoized per transaction, so
+    # calling it from both computes is virtually free.
+    _FISCAL_MAP_DEPENDS = (
         "partner_id",
         "fiscal_operation_line_id",
         "product_id",
@@ -354,34 +376,71 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         "service_type_id",
         "ind_final",
     )
+
+    def _delta_update(self, to_update):
+        """Assign ``to_update`` on a single record, skipping fields whose cached
+        value is already equal. Re-assigning a computed field with its current
+        value still fires ``modified()`` on its dependents; on the Form onchange
+        cascade that needlessly re-flags downstream fiscal computes and, in the
+        reduced draft payload, lets a re-mapping clobber a manual tax override
+        (root cause of #4721). Mirrors the delta-write already used in
+        ``_compute_tax_fields``."""
+        self.ensure_one()
+        cache = self.env.cache
+        changed = {}
+        for field_name, value in to_update.items():
+            field = self._fields.get(field_name)
+            if (
+                field is not None
+                and cache.contains(self, field)
+                and cache.get(self, field)
+                == field.convert_to_cache(value, self, validate=False)
+            ):
+                continue
+            changed[field_name] = value
+        if not changed:
+            return
+        if self != self._origin:
+            self.update(changed)
+        else:
+            self.write(changed)
+
+    def _map_fiscal_taxes(self):
+        """Return ``map_fiscal_taxes`` for a single line (memoized upstream)."""
+        self.ensure_one()
+        return self.fiscal_operation_line_id.map_fiscal_taxes(
+            company=self.company_id,
+            partner=self._get_fiscal_partner(),
+            product=self.product_id,
+            ncm=self.ncm_id,
+            nbm=self.nbm_id,
+            nbs=self.nbs_id,
+            cest=self.cest_id,
+            city_taxation_code=self.city_taxation_code_id,
+            national_taxation_code=self.national_taxation_code_id,
+            service_type=self.service_type_id,
+            ind_final=self.ind_final,
+        )
+
+    @api.depends(*_FISCAL_MAP_DEPENDS)
     def _compute_fiscal_tax_ids(self):
         for line in self:
-            if line.fiscal_operation_line_id:
-                mapping_result = line.fiscal_operation_line_id.map_fiscal_taxes(
-                    company=line.company_id,
-                    partner=line._get_fiscal_partner(),
-                    product=line.product_id,
-                    ncm=line.ncm_id,
-                    nbm=line.nbm_id,
-                    nbs=line.nbs_id,
-                    cest=line.cest_id,
-                    city_taxation_code=line.city_taxation_code_id,
-                    national_taxation_code=line.national_taxation_code_id,
-                    service_type=line.service_type_id,
-                    ind_final=line.ind_final,
-                )
-                line.cfop_id = mapping_result["cfop"]
-                line.ipi_guideline_id = mapping_result["ipi_guideline"]
-                line.tax_classification_id = mapping_result["tax_classification"]
-                line.icms_tax_benefit_id = mapping_result["icms_tax_benefit_id"]
-
-                if line._is_imported():
-                    continue
-
+            if line.fiscal_operation_line_id and not line._is_imported():
+                mapping_result = line._map_fiscal_taxes()
                 taxes = line.env["l10n_br_fiscal.tax"]
                 for tax in mapping_result["taxes"].values():
                     taxes |= tax
                 line.fiscal_tax_ids = taxes
+
+    @api.depends(*_FISCAL_MAP_DEPENDS)
+    def _compute_fiscal_operation_data(self):
+        for line in self:
+            if line.fiscal_operation_line_id:
+                mapping_result = line._map_fiscal_taxes()
+                line.cfop_id = mapping_result["cfop"]
+                line.ipi_guideline_id = mapping_result["ipi_guideline"]
+                line.tax_classification_id = mapping_result["tax_classification"]
+                line.icms_tax_benefit_id = mapping_result["icms_tax_benefit_id"]
 
     @api.depends("fiscal_operation_line_id")
     def _compute_comment_ids(self):
@@ -535,11 +594,15 @@ class FiscalDocumentLineMixin(models.AbstractModel):
                     "estimate_tax": compute_result.get("estimate_tax", 0.0),
                 }
             )
-            in_draft_mode = line != line._origin
-            if in_draft_mode:
-                line.update(to_update)
-            else:
-                line.write(to_update)
+            # Delta-write: only propagate the fields whose value actually
+            # changes. Re-assigning a field with its current value still fires
+            # ``modified()`` on its dependents (document monetary totals, stored
+            # ``related`` fields such as ``*_cst_code``); in the Form onchange
+            # cascade that re-triggers this very compute for the whole document,
+            # and on a persisted ``write()`` it makes the ``write`` override
+            # re-sync ``fiscal_tax_ids`` and re-run the tax engine (double-pass).
+            # See ``_delta_update`` for the full rationale.
+            line._delta_update(to_update)
 
     def _prepare_tax_fields(self, compute_result):
         self.ensure_one()
@@ -589,31 +652,43 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     def _compute_product_fiscal_fields(self):
         for line in self:
             if not line.product_id:
-                # reset to default values:
-                line.fiscal_type = False
-                line.ncm_id = False
-                line.nbm_id = False
-                line.tax_icms_or_issqn = TAX_DOMAIN_ICMS
-                line.icms_origin = ICMS_ORIGIN_DEFAULT
-                line.cest_id = False
-                line.nbs_id = False
-                line.fiscal_genre_id = False
-                line.service_type_id = False
-                line.national_taxation_code_id = False
-                line.operation_indicator_id = False
-                continue
-            p = line.product_id
-            line.fiscal_type = p.fiscal_type
-            line.ncm_id = p.ncm_id
-            line.nbm_id = p.nbm_id
-            line.tax_icms_or_issqn = p.tax_icms_or_issqn
-            line.icms_origin = p.icms_origin
-            line.cest_id = p.cest_id
-            line.nbs_id = p.nbs_id
-            line.fiscal_genre_id = p.fiscal_genre_id
-            line.service_type_id = p.service_type_id
-            line.national_taxation_code_id = p.national_taxation_code_id
-            line.operation_indicator_id = p.operation_indicator_id
+                to_update = {
+                    "fiscal_type": False,
+                    "ncm_id": False,
+                    "nbm_id": False,
+                    "tax_icms_or_issqn": TAX_DOMAIN_ICMS,
+                    "icms_origin": ICMS_ORIGIN_DEFAULT,
+                    "cest_id": False,
+                    "nbs_id": False,
+                    "fiscal_genre_id": False,
+                    "service_type_id": False,
+                    "national_taxation_code_id": False,
+                    "operation_indicator_id": False,
+                }
+            else:
+                p = line.product_id
+                to_update = {
+                    "fiscal_type": p.fiscal_type,
+                    "ncm_id": p.ncm_id.id,
+                    "nbm_id": p.nbm_id.id,
+                    "tax_icms_or_issqn": p.tax_icms_or_issqn,
+                    "icms_origin": p.icms_origin,
+                    "cest_id": p.cest_id.id,
+                    "nbs_id": p.nbs_id.id,
+                    "fiscal_genre_id": p.fiscal_genre_id.id,
+                    "service_type_id": p.service_type_id.id,
+                    "national_taxation_code_id": p.national_taxation_code_id.id,
+                    "operation_indicator_id": p.operation_indicator_id.id,
+                }
+            # Delta-write: re-assigning a field with its current value still
+            # fires ``modified()`` on its dependents. Several of these product
+            # fields are inputs of ``_compute_fiscal_tax_ids``/
+            # ``_compute_fiscal_operation_data``; a redundant re-assignment
+            # during the Form onchange cascade re-flags the fiscal tax mapping
+            # for recompute, which re-derives (and clobbers) a manual tax
+            # override in draft (part of the #4721 root cause). Only propagate
+            # the fields whose value actually changes.
+            line._delta_update(to_update)
 
     @api.depends("product_id")
     def _compute_city_taxation_code_id(self):
@@ -1117,7 +1192,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         comodel_name="l10n_br_fiscal.cfop",
         string="CFOP",
         domain="[('type_in_out', '=', fiscal_operation_type)]",
-        compute="_compute_fiscal_tax_ids",
+        compute="_compute_fiscal_operation_data",
         store=True,
         precompute=True,
         readonly=False,
@@ -1456,7 +1531,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
             ("is_benefit", "=", True),
             ("tax_domain", "=", TAX_DOMAIN_ICMS),
         ],
-        compute="_compute_fiscal_tax_ids",
+        compute="_compute_fiscal_operation_data",
         store=True,
         precompute=True,
         readonly=False,
@@ -1892,7 +1967,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         comodel_name="l10n_br_fiscal.tax.ipi.guideline",
         string="IPI Guideline",
         domain="['|', ('cst_in_id', '=', ipi_cst_id),('cst_out_id', '=', ipi_cst_id)]",
-        compute="_compute_fiscal_tax_ids",
+        compute="_compute_fiscal_operation_data",
         store=True,
         precompute=True,
         readonly=False,
@@ -2047,7 +2122,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     tax_classification_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.tax.classification",
         string="Tax Classification",
-        compute="_compute_fiscal_tax_ids",
+        compute="_compute_fiscal_operation_data",
         store=True,
         precompute=True,
         readonly=False,

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2019  Renato Lima - Akretion <renato.lima@akretion.com.br>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+import re
 from copy import deepcopy
 
 from lxml import etree
@@ -144,6 +145,74 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         }
 
     @api.model
+    def _fiscal_line_view_fields(self):
+        """Fiscal ``fiscal_taxes`` fields kept in the *invisible* onchange
+        collection of the business-document line TREES.
+
+        The fiscal taxes block is ~180 fields wide. In an editable o2m tree the
+        inline onchange payload is driven by the tree fields (not the line form
+        dialog), so every extra invisible field is fetched/computed on every
+        onchange round, for every line. Keeping only the fields the inline
+        protocol actually needs shrinks that payload while the full fiscal
+        detail stays editable in the line FORM dialog (the popup opened from the
+        tree), which is a separate, isolated datapoint.
+
+        Kept here:
+
+        * the tax selector fields (``FISCAL_TAX_ID_FIELDS``);
+        * every field with an ``@api.onchange`` (its handler must keep firing on
+          inline edits);
+        * stored, non-computed fields (their client-set value is not recomputed
+          server-side, so it must round-trip through the tree onchange).
+
+        Fields referenced by a modifier/domain/context are additionally forced
+        back in by :meth:`inject_fiscal_fields` (modifier closure), so a view
+        never fails to load. Every other (compute+store) fiscal field is
+        recomputed server-side on write, hence value-preserving to drop from the
+        tree. Override to bring one back to the trees::
+
+            @api.model
+            def _fiscal_line_view_fields(self):
+                return super()._fiscal_line_view_fields() | {"icms_value"}
+        """
+        keep = set(FISCAL_TAX_ID_FIELDS)
+        keep |= set(self._onchange_methods)
+        for name, field in self._fields.items():
+            if (
+                field.store
+                and not field.compute
+                and field.type not in ("one2many", "many2many")
+            ):
+                keep.add(name)
+        return keep
+
+    @api.model
+    def _fiscal_line_modifier_refs(self, arch, field_names):
+        """Return the ``field_names`` referenced by a modifier/domain/context of
+        any node in ``arch`` (``parent.`` references are dropped, they resolve on
+        the parent record). Used to keep the modifier closure of the reduced
+        line trees, so removing a field can never raise "Unknown field ... in
+        modifier" at view load."""
+        refs = set()
+        token = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+        for node in arch.iter():
+            for attr in (
+                "attrs",
+                "domain",
+                "context",
+                "invisible",
+                "readonly",
+                "required",
+                "column_invisible",
+            ):
+                value = node.get(attr)
+                if not value:
+                    continue
+                value = re.sub(r"parent\.[A-Za-z0-9_]+", " ", value)
+                refs.update(tok for tok in token.findall(value) if tok in field_names)
+        return refs
+
+    @api.model
     def inject_fiscal_fields(
         self,
         doc,
@@ -172,6 +241,32 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         fsc_doc = etree.fromstring(
             fiscal_view.with_context(inherit_branding=True).get_combined_arch()
         )
+
+        # Whitelist of fiscal_taxes fields kept in the invisible tree
+        # collection (the rest stays only in the line form dialog). The
+        # injected tree nodes carry their attrs from the fiscal source block,
+        # so its modifier closure is force-kept: a kept node can never
+        # reference a dropped field ("Unknown field ... in modifier").
+        field_names = set(self.env["l10n_br_fiscal.document.line.mixin"]._fields) | set(
+            self._fields
+        )
+        tree_keep = self._fiscal_line_view_fields()
+        tree_keep |= self._fiscal_line_modifier_refs(fsc_doc, field_names)
+
+        # Fiscal detail fields dropped from the invisible TREE collections
+        # (they stay only in the line form dialog): the fiscal_taxes page
+        # fields that are not whitelisted, plus the dead computes. The form
+        # dialog (replaced wholesale below) is never touched.
+        taxes_names = {
+            node.attrib["name"]
+            for node in fsc_doc.xpath("//page[@name='fiscal_taxes']//field")
+        }
+        # Subtract ``tree_keep`` LAST so it always wins: a field referenced in a
+        # kept node's modifier (attrs/invisible/domain) must never be dropped,
+        # even when a downstream ``_fiscal_view_pruned_fields()`` override also
+        # lists it in ``pruned_fields`` -- otherwise the kept node would point at
+        # a removed field and crash the view load ("Unknown field").
+        drop_from_tree = (taxes_names | pruned_fields) - tree_keep
 
         if xpath_mappings is None:
             xpath_mappings = (
@@ -203,29 +298,33 @@ class FiscalDocumentLineMixin(models.AbstractModel):
             fiscal_nodes = fsc_doc.xpath(fiscal_xpath)
             for target_node in placeholder_nodes:
                 if len(fiscal_nodes) == 1:
-                    # replace unique placeholder
+                    # replace unique placeholder with the full fiscal block
+                    # (form dialog): keeps the whole fiscal detail editable.
                     # (deepcopy is required to inject fiscal nodes in possible
                     # next places)
                     replace_node = deepcopy(fiscal_nodes[0])
                     target_node.getparent().replace(target_node, replace_node)
                 else:
-                    # append multiple fields to placeholder container
+                    # append multiple (invisible) fields to a tree placeholder,
+                    # skipping the fiscal detail fields kept only in the dialog
                     existing_fields = [
                         e.attrib["name"] for e in target_node if e.tag == "field"
                     ]
                     for fiscal_node in fiscal_nodes:
-                        if fiscal_node.attrib["name"] in missing_line_fields:
-                            missing_line_fields.remove(fiscal_node.attrib["name"])
-                        if fiscal_node.attrib["name"] in pruned_fields:
-                            # dead fiscal computes never belong in the views
+                        fiscal_name = fiscal_node.attrib["name"]
+                        if fiscal_name in missing_line_fields:
+                            missing_line_fields.remove(fiscal_name)
+                        if fiscal_name in drop_from_tree:
                             continue
-                        if fiscal_node.attrib["name"] in existing_fields:
+                        if fiscal_name in existing_fields:
                             continue
                         field = deepcopy(fiscal_node)
                         if not field.attrib.get("optional"):
                             field.attrib["optional"] = "hide"
                         target_node.append(field)
                     for fname in missing_line_fields:
+                        if fname in drop_from_tree:
+                            continue
                         if fname not in existing_fields:
                             target_node.append(
                                 E.field(name=fname, string=fname, optional="hide")

--- a/l10n_br_fiscal/models/fiscal_cache.py
+++ b/l10n_br_fiscal/models/fiscal_cache.py
@@ -1,0 +1,113 @@
+# Copyright (C) 2026 KMEE
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+"""Transaction-scoped caches for the fiscal engine.
+
+The Brazilian fiscal engine maps and computes taxes many times per document
+line within a single save (the onchange/compute cascade re-runs the mapping
+and the tax computation with the *same* inputs several times per line). These
+helpers provide a cache whose lifetime is exactly one database transaction, so
+those redundant re-executions collapse into a single one — without ever
+leaking results between transactions or workers.
+
+Anchoring
+---------
+The cache dict is stored as an attribute on the *cursor* (``env.cr``). A cursor
+lives for exactly one transaction: every web request / job gets a fresh cursor
+(hence a fresh, empty cache), and there is one cursor per worker at a time, so
+nothing is shared between transactions or across workers. This is deliberately
+NOT a module-level dict (which would leak across transactions and workers).
+
+Invalidation
+------------
+Mapping/computation results are a pure function of the input record ids **and**
+the fiscal *definition* tables (tax definitions, ICMS regulation, taxes, tax
+classifications). The cache keys already encode every input record id plus the
+scalar configuration fields that drive the mapping branches (tax framework,
+``ind_ie_dest``, ICMS origin, states...), so a change to any *keyed* value
+naturally produces a different key.
+
+Two complementary mechanisms cover an in-place edit of a *definition* row (e.g.
+changing a tax rate) that keeps the same id:
+
+1. ``FiscalCacheMixin`` — any create/write/unlink on a definition model that
+   inherits it wipes the whole transaction cache. This covers config-screen and
+   test edits performed in an *ordinary* transaction.
+2. ``write_date`` in the cache keys — the keys encode the ``write_date`` of the
+   fiscal taxes (``compute_taxes`` key) and of the definition-anchor records
+   (``map_fiscal_taxes`` key: the operation line, the company ICMS regulation
+   and tax classification, the partner fiscal profile). Because an edit bumps
+   ``write_date`` and a **savepoint rollback reverts it**, the key produced
+   after a rollback matches the pre-edit key, not the edited one: a stale entry
+   left in the (rollback-surviving) transaction cache becomes *unreachable*
+   instead of being served. This makes the cache self-validating across
+   savepoint rollbacks, which neither ``cr.clear()`` nor ``FiscalCacheMixin``
+   observe (the per-cursor cache attribute is not part of the ORM/precommit
+   state a rollback clears).
+
+Known, documented residual limitation
+-------------------------------------
+The ``write_date`` guard versions the *anchor* records, not every child
+definition row they aggregate (``tax_definition_ids`` of the company/CFOP/
+operation line/partner profile, ICMS-regulation lines...). So the one case that
+still leaks is narrow and self-inflicted: editing a *child* definition row
+**inside a savepoint that is later rolled back**, and then recomputing with the
+**same key on the same cursor** — the child edit bumps only the child's
+``write_date`` (not the anchor's), ``FiscalCacheMixin`` cleared the cache on the
+edit but the rollback does not re-clear it, so the entry stored between the edit
+and the rollback survives and is served. This is an honest upgrade of the prior
+behaviour (which leaked on *any* savepoint rollback that reverted a keyed edit)
+and does not happen in the supported document flows: fiscal definitions are not
+mutated in the middle of computing a line's taxes. The same holds for an
+in-place edit of a *non-definition* config field that feeds the mapping but is
+not keyed (e.g. ``ncm.tax_ipi_id``) within the transaction that already mapped
+the line.
+"""
+
+from odoo import api, models
+
+_TXN_CACHE_ATTR = "_l10n_br_fiscal_txn_cache"
+
+
+def get_fiscal_txn_cache(env, name):
+    """Return the (create-on-demand) transaction-scoped cache dict ``name``."""
+    cr = env.cr
+    store = getattr(cr, _TXN_CACHE_ATTR, None)
+    if store is None:
+        store = {}
+        setattr(cr, _TXN_CACHE_ATTR, store)
+    return store.setdefault(name, {})
+
+
+def clear_fiscal_txn_cache(env):
+    """Drop every transaction-scoped fiscal cache of the current cursor."""
+    cr = env.cr
+    if getattr(cr, _TXN_CACHE_ATTR, None):
+        setattr(cr, _TXN_CACHE_ATTR, None)
+
+
+class FiscalCacheMixin(models.AbstractModel):
+    """Wipe the transaction fiscal caches on any change of a definition model.
+
+    Inherited by the fiscal *definition* models whose rows feed the mapping and
+    the tax computation. Kept intentionally tiny: it only clears the caches; the
+    per-key correctness is handled by the cache keys themselves.
+    """
+
+    _name = "l10n_br_fiscal.cache.mixin"
+    _description = "Fiscal transaction cache invalidation"
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        clear_fiscal_txn_cache(self.env)
+        return records
+
+    def write(self, vals):
+        res = super().write(vals)
+        clear_fiscal_txn_cache(self.env)
+        return res
+
+    def unlink(self):
+        res = super().unlink()
+        clear_fiscal_txn_cache(self.env)
+        return res

--- a/l10n_br_fiscal/models/icms_regulation.py
+++ b/l10n_br_fiscal/models/icms_regulation.py
@@ -4,6 +4,7 @@
 from lxml import etree
 
 from odoo import api, fields, models
+from odoo.osv import expression
 
 from ..constants.fiscal import (
     FINAL_CUSTOMER_YES,
@@ -47,7 +48,7 @@ VIEW = """
 
 class ICMSRegulation(models.Model):
     _name = "l10n_br_fiscal.icms.regulation"
-    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _inherit = ["mail.thread", "mail.activity.mixin", "l10n_br_fiscal.cache.mixin"]
     _description = "Tax ICMS Regulation"
 
     name = fields.Char(required=True, index=True)
@@ -1987,8 +1988,25 @@ class ICMSRegulation(models.Model):
         return domain
 
     def _tax_definition_search(self, domain, ncm, nbm, cest, product, ind_final=None):
+        icms_defs = self.env["l10n_br_fiscal.tax.definition"].search(domain)
+        return self._tax_definition_precedence(
+            icms_defs, ncm, nbm, cest, product, ind_final
+        )
+
+    def _tax_definition_precedence(
+        self, icms_defs, ncm, nbm, cest, product, ind_final=None
+    ):
+        """Apply the ICMS tax-definition precedence to a pre-fetched recordset.
+
+        Business rule (unchanged): with a single match, take it; otherwise
+        prefer benefit definitions, then product/ncm/nbm/cest-specific ones,
+        then generic ones, and finally narrow by ``ind_final`` when any
+        final-customer definition is present. Split out of
+        ``_tax_definition_search`` so that ``map_tax`` can run the four ICMS
+        group searches as a single query and still apply this exact
+        precedence per group.
+        """
         tax_definitions = self.env["l10n_br_fiscal.tax.definition"]
-        icms_defs = tax_definitions.search(domain)
 
         if len(icms_defs) == 1:
             tax_definitions |= icms_defs
@@ -2049,9 +2067,18 @@ class ICMSRegulation(models.Model):
         operation_line=None,
         ind_final=None,
     ):
+        """ICMS contribution to :meth:`map_tax`.
+
+        Returns ``(icms_taxes, search)`` where ``icms_taxes`` carries the
+        imported-ICMS shortcut tax (an empty recordset otherwise) and ``search``
+        is the ``(tax_group, domain)`` pair to feed map_tax's single combined
+        tax-definition search, or ``None`` when the shortcut applies and no
+        search is needed. This method owns the ICMS branch (shortcut condition
+        and domain) as the single source, so downstream overrides of it take
+        effect; map_tax runs the search and applies the precedence.
+        """
         self.ensure_one()
         icms_taxes = self.env["l10n_br_fiscal.tax"]
-        tax_definitions = self.env["l10n_br_fiscal.tax.definition"]
         tax_group_icms = self.env.ref("l10n_br_fiscal.tax_group_icms")
 
         # ICMS tax imported
@@ -2063,16 +2090,13 @@ class ICMSRegulation(models.Model):
             and operation_line.fiscal_operation_type == FISCAL_IN
         ):
             icms_taxes |= self.icms_imported_tax_id
-        else:
-            # ICMS
-            domain = self._build_map_tax_def_domain(
-                company, partner, tax_group_icms, ncm, nbm, cest, ind_final
-            )
+            return icms_taxes, None
 
-            tax_definitions = self._tax_definition_search(
-                domain, ncm, nbm, cest, product, ind_final
-            )
-        return icms_taxes, tax_definitions
+        # ICMS
+        domain = self._build_map_tax_def_domain(
+            company, partner, tax_group_icms, ncm, nbm, cest, ind_final
+        )
+        return icms_taxes, (tax_group_icms, domain)
 
     def _map_tax_def_icmsst(
         self,
@@ -2085,6 +2109,8 @@ class ICMSRegulation(models.Model):
         operation_line=None,
         ind_final=None,
     ):
+        """ICMS-ST contribution to :meth:`map_tax`: the ``(tax_group, domain)``
+        pair for the single combined search (always present)."""
         self.ensure_one()
         tax_group_icmsst = self.env.ref("l10n_br_fiscal.tax_group_icmsst")
 
@@ -2092,11 +2118,7 @@ class ICMSRegulation(models.Model):
         domain = self._build_map_tax_def_domain(
             company, partner, tax_group_icmsst, ncm, nbm, cest, ind_final
         )
-
-        tax_definitions = self._tax_definition_search(
-            domain, ncm, nbm, cest, product, ind_final
-        )
-        return tax_definitions
+        return tax_group_icmsst, domain
 
     def map_tax_def_icms_difal(
         self,
@@ -2140,8 +2162,10 @@ class ICMSRegulation(models.Model):
         operation_line=None,
         ind_final=None,
     ):
+        """ICMS-FCP (DIFAL) contribution to :meth:`map_tax`: the
+        ``(tax_group, domain)`` pair for the single combined search, or ``None``
+        when the FCP-DIFAL condition does not apply."""
         self.ensure_one()
-        tax_definitions = self.env["l10n_br_fiscal.tax.definition"]
         tax_group_icmsfcp = self.env.ref("l10n_br_fiscal.tax_group_icmsfcp")
 
         # ICMS FCP for DIFAL
@@ -2155,12 +2179,9 @@ class ICMSRegulation(models.Model):
             domain = self._build_map_tax_def_domain(
                 partner, partner, tax_group_icmsfcp, ncm, nbm, cest, ind_final
             )
+            return tax_group_icmsfcp, domain
 
-            tax_definitions = self._tax_definition_search(
-                domain, ncm, nbm, cest, product, ind_final
-            )
-
-        return tax_definitions
+        return None
 
     def _map_tax_def_icmsfcpst(
         self,
@@ -2173,20 +2194,16 @@ class ICMSRegulation(models.Model):
         operation_line=None,
         ind_final=None,
     ):
+        """FCP-ST contribution to :meth:`map_tax`: the ``(tax_group, domain)``
+        pair for the single combined search (always present)."""
         self.ensure_one()
-        tax_definitions = self.env["l10n_br_fiscal.tax.definition"]
         tax_group_icmsfcpst = self.env.ref("l10n_br_fiscal.tax_group_icmsfcp_st")
 
         # FCP ST
         domain = self._build_map_tax_def_domain(
             company, partner, tax_group_icmsfcpst, ncm, nbm, cest, ind_final
         )
-
-        tax_definitions = self._tax_definition_search(
-            domain, ncm, nbm, cest, product, ind_final
-        )
-
-        return tax_definitions
+        return tax_group_icmsfcpst, domain
 
     # TODO adicionar o argumento CFOP????
     def map_tax(
@@ -2210,21 +2227,58 @@ class ICMSRegulation(models.Model):
             if not cest:
                 cest = product.cest_id
 
-        icms_taxes, icms_def_taxes = self._map_tax_def_icms(
+        icms_taxes = self.env["l10n_br_fiscal.tax"]
+
+        # Delegate each ICMS group to its ``_map_tax_def_*`` builder (the single
+        # source of that group's condition and domain, so downstream overrides
+        # take effect again) and run the collected domains as ONE search (OR of
+        # the per-group domains) instead of four. Each sub-domain pins a distinct
+        # tax_group_id, so the combined result partitions cleanly by group and
+        # the per-group precedence (see _tax_definition_precedence) is applied
+        # exactly as before. The call order below (icms, icms_st, icms_fcp,
+        # icms_fcp_st) matches the original so that downstream last-wins
+        # resolution of icms_tax_benefit_id is unchanged.
+        searches = []
+
+        # 1 ICMS (or the imported-ICMS shortcut, which needs no search)
+        imported_taxes, icms_search = self._map_tax_def_icms(
             company, partner, product, ncm, nbm, cest, operation_line, ind_final
+        )
+        icms_taxes |= imported_taxes
+        if icms_search:
+            searches.append(icms_search)
+
+        # 2 ICMS ST (always)
+        searches.append(
+            self._map_tax_def_icmsst(
+                company, partner, product, ncm, nbm, cest, operation_line, ind_final
+            )
         )
 
-        icms_def_taxes |= self._map_tax_def_icmsst(
+        # 3 ICMS FCP for DIFAL (conditional)
+        fcp_search = self._map_tax_def_icmsfcp(
             company, partner, product, ncm, nbm, cest, operation_line, ind_final
+        )
+        if fcp_search:
+            searches.append(fcp_search)
+
+        # 4 FCP ST (always)
+        searches.append(
+            self._map_tax_def_icmsfcpst(
+                company, partner, product, ncm, nbm, cest, operation_line, ind_final
+            )
         )
 
-        icms_def_taxes |= self._map_tax_def_icmsfcp(
-            company, partner, product, ncm, nbm, cest, operation_line, ind_final
-        )
-
-        icms_def_taxes |= self._map_tax_def_icmsfcpst(
-            company, partner, product, ncm, nbm, cest, operation_line, ind_final
-        )
+        icms_def_taxes = self.env["l10n_br_fiscal.tax.definition"]
+        combined_domain = expression.OR([domain for _group, domain in searches])
+        all_defs = self.env["l10n_br_fiscal.tax.definition"].search(combined_domain)
+        for tax_group, _domain in searches:
+            group_defs = all_defs.filtered(
+                lambda d, group=tax_group: d.tax_group_id == group
+            )
+            icms_def_taxes |= self._tax_definition_precedence(
+                group_defs, ncm, nbm, cest, product, ind_final
+            )
 
         icms_taxes |= icms_def_taxes.mapped("tax_id")
 

--- a/l10n_br_fiscal/models/operation.py
+++ b/l10n_br_fiscal/models/operation.py
@@ -281,14 +281,32 @@ class Operation(models.Model):
         if not company.icms_regulation_id or not product:
             return False
 
+        # `_map_tax_def_icmsst` now answers the ``(tax_group, domain)`` pair that
+        # map_tax feeds to its single combined search, instead of the definitions
+        # themselves. Truth-testing that pair would be true for every product,
+        # which would put ICMS ST on every line and change which operation line
+        # gets selected. So the search still has to run here, with the same
+        # precedence the previous contract applied.
+        regulation = company.icms_regulation_id
+        search = regulation._map_tax_def_icmsst(
+            company,
+            partner,
+            product,
+            ncm=product.ncm_id,
+            nbm=product.nbm_id,
+            cest=product.cest_id,
+        )
+        if not search:
+            return False
+
+        _tax_group, domain = search
         return bool(
-            company.icms_regulation_id._map_tax_def_icmsst(
-                company,
-                partner,
+            regulation._tax_definition_search(
+                domain,
+                product.ncm_id,
+                product.nbm_id,
+                product.cest_id,
                 product,
-                ncm=product.ncm_id,
-                nbm=product.nbm_id,
-                cest=product.cest_id,
             )
         )
 

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2019  Renato Lima - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+import logging
+
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
@@ -23,12 +25,15 @@ from ..constants.fiscal import (
     TAX_ICMS_OR_ISSQN,
 )
 from ..constants.icms import ICMS_ORIGIN
+from .fiscal_cache import get_fiscal_txn_cache
+
+_logger = logging.getLogger(__name__)
 
 
 class OperationLine(models.Model):
     _name = "l10n_br_fiscal.operation.line"
     _description = "Fiscal Operation Line"
-    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _inherit = ["mail.thread", "mail.activity.mixin", "l10n_br_fiscal.cache.mixin"]
 
     fiscal_operation_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.operation",
@@ -293,6 +298,96 @@ class OperationLine(models.Model):
             - 'tax_classification': The determined Tax Classification record
               (l10n_br_fiscal.tax.classification).
         """
+        self.ensure_one()
+
+        # Transaction-scoped memoization: this mapping is re-run with identical
+        # inputs several times per line by the onchange/compute cascade (and,
+        # with repeated products, across lines). The result is a pure function
+        # of the input record ids plus the config fields that drive the mapping
+        # branches, so we key on exactly those; invalidation on any fiscal
+        # definition change is handled by FiscalCacheMixin. See fiscal_cache.py.
+        cache = get_fiscal_txn_cache(self.env, "map_fiscal_taxes")
+        cache_key = self._map_fiscal_taxes_cache_key(
+            company,
+            partner,
+            product=product,
+            ncm=ncm,
+            nbm=nbm,
+            nbs=nbs,
+            cest=cest,
+            city_taxation_code=city_taxation_code,
+            national_taxation_code=national_taxation_code,
+            service_type=service_type,
+            ind_final=ind_final,
+        )
+        try:
+            if cache_key in cache:
+                # Hand out a copy: this is public API consumed by nfe/cte/mdfe
+                # and third parties, and callers mutate ``mapping_result``
+                # (e.g. ``mapping_result["taxes"][domain] = ...``); returning the
+                # shared cached object would corrupt it for every later line in
+                # the transaction. Mirrors ``_copy_compute_taxes_result``.
+                return self._copy_map_fiscal_taxes_result(cache[cache_key])
+        except TypeError:
+            # Honour the cache-key contract: an unhashable key component disables
+            # memoization for this call instead of raising.
+            _logger.debug(
+                "map_fiscal_taxes memoization skipped: unhashable cache key %r",
+                cache_key,
+            )
+            cache_key = None
+
+        mapping_result = self._map_fiscal_taxes(
+            company,
+            partner,
+            product=product,
+            fiscal_price=fiscal_price,
+            fiscal_quantity=fiscal_quantity,
+            ncm=ncm,
+            nbm=nbm,
+            nbs=nbs,
+            cest=cest,
+            city_taxation_code=city_taxation_code,
+            national_taxation_code=national_taxation_code,
+            service_type=service_type,
+            ind_final=ind_final,
+        )
+
+        if cache_key is not None:
+            cache[cache_key] = mapping_result
+            return self._copy_map_fiscal_taxes_result(mapping_result)
+        return mapping_result
+
+    @staticmethod
+    def _copy_map_fiscal_taxes_result(result):
+        """Shallow copy of a ``map_fiscal_taxes`` result safe to mutate.
+
+        Copies the outer dict and the inner ``taxes`` dict (the levels callers
+        reassign in place); the tax recordsets they hold are shared by reference
+        but only ever replaced, never mutated. Mirrors
+        :meth:`l10n_br_fiscal.tax._copy_compute_taxes_result`.
+        """
+        copied = dict(result)
+        copied["taxes"] = dict(result["taxes"])
+        return copied
+
+    def _map_fiscal_taxes(
+        self,
+        company,
+        partner,
+        product=None,
+        fiscal_price=None,
+        fiscal_quantity=None,
+        ncm=None,
+        nbm=None,
+        nbs=None,
+        cest=None,
+        city_taxation_code=None,
+        national_taxation_code=None,
+        service_type=None,
+        ind_final=None,
+    ):
+        """Uncached body of :meth:`map_fiscal_taxes` (see its docstring)."""
         mapping_result = {
             "taxes": {},
             "cfop": False,
@@ -300,8 +395,6 @@ class OperationLine(models.Model):
             "icms_tax_benefit_id": False,
             "tax_classification": False,
         }
-
-        self.ensure_one()
 
         # Define CFOP
         mapping_result["cfop"] = self._get_cfop(company, partner)
@@ -434,6 +527,81 @@ class OperationLine(models.Model):
             mapping_result["taxes"].pop(TAX_DOMAIN_ISSQN, None)
 
         return mapping_result
+
+    def _map_fiscal_taxes_cache_key(
+        self,
+        company,
+        partner,
+        product=None,
+        ncm=None,
+        nbm=None,
+        nbs=None,
+        cest=None,
+        city_taxation_code=None,
+        national_taxation_code=None,
+        service_type=None,
+        ind_final=None,
+    ):
+        """Stable, hashable key for ``map_fiscal_taxes`` memoization.
+
+        Encodes every input record id plus the scalar config fields the mapping
+        branches on (so a config change on company/partner/product produces a
+        different key). ``fiscal_price``/``fiscal_quantity`` are intentionally
+        excluded: they do not affect the mapping.
+
+        It also encodes the ``write_date`` of the definition-anchor records
+        already keyed here (the operation line, the company ICMS regulation and
+        tax classification, the partner fiscal profile): an in-place edit of one
+        of these bumps its ``write_date`` and thus the key, and a savepoint
+        rollback reverting the edit reverts ``write_date`` too, so the key
+        reverts with it (self-validating key — a stale entry becomes unreachable
+        rather than being served). Child definition rows they aggregate
+        (``tax_definition_ids`` ...) are versioned only in ordinary transactions
+        via ``FiscalCacheMixin``; see fiscal_cache.py for the exact residual
+        limitation.
+        """
+
+        def _rid(record):
+            return record.id if record else False
+
+        def _wdate(record):
+            return record.write_date if record else False
+
+        # NCM defaults to the product's NCM downstream; normalize it here so the
+        # key matches whether the caller passed ncm explicitly or not.
+        key_ncm = ncm or (product.ncm_id if product else None)
+        return (
+            self.id,
+            self.fiscal_operation_id.fiscal_operation_type,
+            self.fiscal_operation_id.fiscal_type,
+            company.id,
+            company.tax_framework,
+            _rid(company.icms_regulation_id),
+            _rid(company.tax_classification_id),
+            _rid(company.state_id),
+            _rid(company.country_id),
+            partner.id,
+            _rid(partner.state_id),
+            partner.ind_ie_dest,
+            _rid(partner.fiscal_profile_id),
+            _rid(partner.country_id),
+            _rid(product),
+            product.tax_icms_or_issqn if product else False,
+            product.icms_origin if product else False,
+            _rid(key_ncm),
+            _rid(nbm),
+            _rid(nbs),
+            _rid(cest),
+            _rid(city_taxation_code),
+            _rid(national_taxation_code),
+            _rid(service_type),
+            ind_final,
+            # Content-versioning of the definition-anchor records keyed above.
+            self.write_date,
+            _wdate(company.icms_regulation_id),
+            _wdate(company.tax_classification_id),
+            _wdate(partner.fiscal_profile_id),
+        )
 
     def action_review(self):
         self.write({"state": "review"})

--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -33,6 +33,7 @@ from ..constants.icms import (
     ICMS_ST_BASE_TYPE_DEFAULT,
     ICSM_CST_CSOSN_ST_BASE,
 )
+from .fiscal_cache import get_fiscal_txn_cache
 
 TAX_DICT_VALUES = {
     "name": False,
@@ -118,6 +119,7 @@ class Tax(models.Model):
     """
 
     _name = "l10n_br_fiscal.tax"
+    _inherit = "l10n_br_fiscal.cache.mixin"
     _order = "sequence, tax_domain, name"
     _description = "Fiscal Tax"
 
@@ -905,6 +907,20 @@ class Tax(models.Model):
               TAX_DICT_VALUES).
         """
 
+        # Transaction-scoped memoization: within a single save this is called
+        # 3-6x per line with identical kwargs (fiscal precompute + totals +
+        # account tax hooks) and again on every line that repeats the same
+        # product/price/quantity. The computation is pure, so we return the
+        # cached result. Invalidation on any fiscal definition/tax change is
+        # handled by FiscalCacheMixin. See fiscal_cache.py.
+        cache = get_fiscal_txn_cache(self.env, "compute_taxes")
+        cache_key = self._compute_taxes_cache_key(kwargs)
+        if cache_key is not None and cache_key in cache:
+            # Callers mutate the returned per-tax dicts in place (e.g.
+            # account.tax flips ``base`` sign for negative bases), so never hand
+            # out the cached object itself.
+            return self._copy_compute_taxes_result(cache[cache_key])
+
         result_amounts = {
             "amount_included": 0.00,
             "amount_not_included": 0.00,
@@ -941,7 +957,92 @@ class Tax(models.Model):
         # Estimate taxes
         result_amounts["estimate_tax"] = self._compute_estimate_taxes(**kwargs)
         result_amounts["taxes"] = taxes
+
+        if cache_key is not None:
+            cache[cache_key] = result_amounts
+            # Keep the cached object pristine; the first caller also gets a copy.
+            return self._copy_compute_taxes_result(result_amounts)
         return result_amounts
+
+    @staticmethod
+    def _copy_compute_taxes_result(result):
+        """Shallow copy of a ``compute_taxes`` result safe to mutate.
+
+        Copies the top-level dict and each per-tax-domain dict (the levels that
+        callers mutate in place); the leaf values (scalars/records) are shared
+        by reference but only ever replaced, never mutated.
+        """
+        copied = dict(result)
+        copied["taxes"] = {
+            domain: dict(values) if isinstance(values, dict) else values
+            for domain, values in result["taxes"].items()
+        }
+        return copied
+
+    def _compute_taxes_cache_key(self, kwargs):
+        """Stable, hashable key for ``compute_taxes`` memoization.
+
+        Normalizes every kwarg to a hashable value: recordsets become their
+        (sorted) id tuple, scalars (floats included, unrounded) are used as-is.
+        ``self`` is included as its sorted id tuple (the result is independent
+        of input order, since ``compute_taxes`` sorts by compute sequence).
+        Returns ``None`` to disable memoization if any kwarg cannot be reduced
+        to a hashable value, so an unexpected input never risks a wrong cache
+        hit.
+
+        On top of the input ids the key also encodes:
+
+        * the ``write_date`` of the fiscal taxes themselves. This makes the key
+          *content-versioned*: an in-place edit of a tax rate
+          (``percent_amount``/``percent_reduction``...) bumps ``write_date`` and
+          thus changes the key by construction, and a savepoint rollback that
+          reverts the edit reverts ``write_date`` too, so the key reverts with
+          it. A stale entry left behind by such a rollback becomes unreachable
+          instead of being served (self-validating key). See fiscal_cache.py.
+        * the config scalars the engine reads *directly* from ``company`` and
+          ``partner`` (they live on ``res.company``/``res.partner``, which do not
+          inherit ``FiscalCacheMixin``, so an in-transaction edit of them is not
+          observed otherwise). Symmetric with the ``map_fiscal_taxes`` key.
+
+        ``self`` and the recordset kwargs may still be ``NewId`` (unsaved)
+        records in the create/onchange precompute cascade, which is exactly the
+        hot path this memoization targets. All id handling goes through ``.ids``
+        (which resolves NewId records to their concrete origin id and drops
+        origin-less ones), so the key stays orderable and hashable; the aligned
+        ``write_date`` tuple is read from the origin records for the same reason.
+        """
+        normalized = []
+        for name in sorted(kwargs):
+            value = kwargs[name]
+            if isinstance(value, models.BaseModel):
+                value = tuple(sorted(value.ids))
+            elif value is not None and not isinstance(value, bool | int | float | str):
+                # Unexpected input type: do not risk a wrong cache hit.
+                return None
+            normalized.append((name, value))
+
+        # ``.ids`` yields concrete (origin) ids only, so it is always sortable;
+        # read each tax's ``write_date`` from the origin records and align it to
+        # that same id order.
+        tax_ids = tuple(sorted(self.ids))
+        write_date_by_id = {tax.id: tax.write_date for tax in self._origin}
+        tax_versions = tuple(write_date_by_id.get(tax_id) for tax_id in tax_ids)
+
+        company = kwargs.get("company")
+        partner = kwargs.get("partner")
+        config_scalars = (
+            partner.ind_ie_dest if partner else False,
+            company.tax_framework if company else False,
+            company.simplified_tax_percent if company else False,
+            company.state_id.id if company else False,
+            partner.state_id.id if partner else False,
+        )
+        return (
+            tax_ids,
+            tax_versions,
+            config_scalars,
+            tuple(normalized),
+        )
 
     @api.depends("icmsst_base_type")
     def _compute_tax_base_type(self):

--- a/l10n_br_fiscal/models/tax_classification.py
+++ b/l10n_br_fiscal/models/tax_classification.py
@@ -13,7 +13,7 @@ from ..constants.fiscal import (
 
 class TaxClassification(models.Model):
     _name = "l10n_br_fiscal.tax.classification"
-    _inherit = "l10n_br_fiscal.data.abstract"
+    _inherit = ["l10n_br_fiscal.data.abstract", "l10n_br_fiscal.cache.mixin"]
     _order = "code"
     _description = "Tax Classification"
 

--- a/l10n_br_fiscal/models/tax_definition.py
+++ b/l10n_br_fiscal/models/tax_definition.py
@@ -52,7 +52,7 @@ class TaxDefinition(models.Model):
     """
 
     _name = "l10n_br_fiscal.tax.definition"
-    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _inherit = ["mail.thread", "mail.activity.mixin", "l10n_br_fiscal.cache.mixin"]
     _description = "Tax Definition"
 
     def _get_complete_name(self):

--- a/l10n_br_fiscal/tests/test_fiscal_tax.py
+++ b/l10n_br_fiscal/tests/test_fiscal_tax.py
@@ -374,3 +374,71 @@ class TestFiscalTax(TransactionCase):
         )
 
         self.assertEqual(compute_result["taxes"]["icms"]["cst_id"].code, "10")
+
+    def test_compute_taxes_cache_savepoint_rollback(self):
+        """A savepoint rollback that reverts a tax rate must not leave the
+        transaction cache serving the reverted (stale) value.
+
+        The fiscal transaction cache is a per-cursor attribute that survives a
+        savepoint rollback (``cr.clear()`` clears the ORM cache, not that
+        attribute). Without the self-validating (``write_date``-versioned) key, a
+        rate edited and computed *inside* a rolled-back savepoint keeps being
+        served afterwards. See l10n_br_fiscal/models/fiscal_cache.py.
+        """
+        kwargs = self._create_compute_taxes_kwargs()
+        currency = kwargs["company"].currency_id
+        icms_tax = self.env.ref("l10n_br_fiscal.tax_icms_7")
+        fiscal_taxes = (
+            icms_tax
+            + self.env.ref("l10n_br_fiscal.tax_ipi_15")
+            + self.env.ref("l10n_br_fiscal.tax_pis_0_65")
+            + self.env.ref("l10n_br_fiscal.tax_cofins_3")
+        )
+
+        # Baseline: compute once and remember the original ICMS value.
+        original_icms_value = fiscal_taxes.compute_taxes(**kwargs)["taxes"]["icms"][
+            "tax_value"
+        ]
+
+        savepoint = self.env.cr.savepoint()
+        # Edit the rate and recompute *inside* the savepoint: the write wipes the
+        # cache (FiscalCacheMixin.write) and repopulates it with the new value.
+        icms_tax.percent_amount = icms_tax.percent_amount + 11.0
+        # Flush so the edit reaches the DB and actually bumps ``write_date``
+        # *inside* the savepoint. This reproduces the real contamination scenario
+        # (a polluting transaction/test method flushes the write before its
+        # rollback); it is also what makes the self-validating key observable:
+        # the stale entry is stored under the bumped-``write_date`` key, and the
+        # rollback reverts ``write_date`` so the post-rollback key no longer
+        # reaches it.
+        self.env.flush_all()
+        changed_icms_value = fiscal_taxes.compute_taxes(**kwargs)["taxes"]["icms"][
+            "tax_value"
+        ]
+        self.assertNotEqual(
+            float_compare(
+                changed_icms_value,
+                original_icms_value,
+                precision_rounding=currency.rounding,
+            ),
+            0,
+            "Sanity: editing the ICMS rate should change the computed value.",
+        )
+
+        # Roll back: reverts the rate (and its write_date) and clears the ORM
+        # cache, but NOT the per-cursor fiscal transaction cache.
+        savepoint.close()  # rollback=True by default
+
+        reverted_icms_value = fiscal_taxes.compute_taxes(**kwargs)["taxes"]["icms"][
+            "tax_value"
+        ]
+        self.assertEqual(
+            float_compare(
+                reverted_icms_value,
+                original_icms_value,
+                precision_rounding=currency.rounding,
+            ),
+            0,
+            "After rollback compute_taxes must return the ORIGINAL rate, not the "
+            "reverted-away value left in the transaction cache.",
+        )

--- a/l10n_br_fiscal/tests/test_icms_regulation.py
+++ b/l10n_br_fiscal/tests/test_icms_regulation.py
@@ -116,12 +116,15 @@ class TestICMSRegulation(TransactionCase):
         )
         self.assertEqual(tax_icms.percent_amount, 12.00)
 
-    def test_map_tax_def_icmsst_true(self):
-        self.company.state_id = self.sp_state_id
-        self.partner.state_id = self.sp_state_id
-        self.product.cest_id = self.env.ref("l10n_br_fiscal.cest_2112300")
+    def _icmsst_definitions(self):
+        """Run the ICMS ST search the way map_tax now runs it.
 
-        tax_definitions = self.icms_regulation._map_tax_def_icmsst(
+        `_map_tax_def_icmsst` answers the ``(tax_group, domain)`` pair that
+        map_tax feeds to its single combined search, so the definitions only
+        exist after the search plus the precedence. Truth-testing the pair
+        itself would pass for every product, which is no test at all.
+        """
+        search = self.icms_regulation._map_tax_def_icmsst(
             company=self.company,
             partner=self.partner,
             product=self.product,
@@ -129,7 +132,22 @@ class TestICMSRegulation(TransactionCase):
             nbm=self.product.nbm_id,
             cest=self.product.cest_id,
         )
-        self.assertTrue(tax_definitions)
+        self.assertTrue(search, "the ICMS ST branch always asks for a search")
+        _tax_group, domain = search
+        return self.icms_regulation._tax_definition_search(
+            domain,
+            self.product.ncm_id,
+            self.product.nbm_id,
+            self.product.cest_id,
+            self.product,
+        )
+
+    def test_map_tax_def_icmsst_true(self):
+        self.company.state_id = self.sp_state_id
+        self.partner.state_id = self.sp_state_id
+        self.product.cest_id = self.env.ref("l10n_br_fiscal.cest_2112300")
+
+        self.assertTrue(self._icmsst_definitions())
 
     def test_map_tax_def_icmsst_false(self):
         self.company.state_id = self.sp_state_id
@@ -137,15 +155,7 @@ class TestICMSRegulation(TransactionCase):
         self.product.cest_id = False
         self.product.ncm_id = self.ncm_48191000_id
 
-        tax_definitions = self.icms_regulation._map_tax_def_icmsst(
-            company=self.company,
-            partner=self.partner,
-            product=self.product,
-            ncm=self.product.ncm_id,
-            nbm=self.product.nbm_id,
-            cest=self.product.cest_id,
-        )
-        self.assertFalse(tax_definitions)
+        self.assertFalse(self._icmsst_definitions())
 
     def find_icms_tax(self, in_state_id, out_state_id, ncm_id, ind_final):
         self.partner.state_id = in_state_id

--- a/l10n_br_fiscal/tests/test_tax_benefit.py
+++ b/l10n_br_fiscal/tests/test_tax_benefit.py
@@ -35,8 +35,9 @@ class TestTaxBenefit(TransactionCase):
                 "state": "approved",
             }
         )
-        # force update
-        cls.nfe_tax_benefit.fiscal_line_ids._compute_fiscal_tax_ids()
+        # force update: icms_tax_benefit_id is now derived by
+        # _compute_fiscal_operation_data
+        cls.nfe_tax_benefit.fiscal_line_ids._compute_fiscal_operation_data()
 
     def test_nfe_tax_benefit(self):
         """Test NFe with tax benefit."""

--- a/l10n_br_nfse/models/document_line.py
+++ b/l10n_br_nfse/models/document_line.py
@@ -1,10 +1,14 @@
 # Copyright 2020 KMEE INFORMATICA LTDA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import logging
+
 from erpbrasil.base import misc
 from lxml import etree
 
 from odoo import api, fields, models
+
+_logger = logging.getLogger(__name__)
 
 
 class DocumentLine(models.Model):
@@ -30,36 +34,36 @@ class DocumentLine(models.Model):
                 line.fiscal_deductions_value = line.product_id.fiscal_deductions_value
 
     @api.model
-    def fields_view_get(
-        self, view_id=None, view_type="form", toolbar=False, submenu=False
-    ):
-        model_view = super().fields_view_get(view_id, view_type, toolbar, submenu)
-
+    def _get_view(self, view_id=None, view_type="form", **options):
+        arch, view = super()._get_view(view_id, view_type, **options)
+        # ``other_retentions_value`` has no placeholder of its own: it is meant
+        # to be shown right after ``issqn_wh_value``, a field that only exists
+        # in the line form through the fiscal fields injection (fiscal_taxes
+        # page, see l10n_br_fiscal.document.line.mixin.inject_fiscal_fields,
+        # already applied by super()._get_view here). We add it on the modern
+        # ``_get_view`` flow.
+        #
+        # This used to live in a ``fields_view_get`` override, which the 16.0
+        # web client never calls (get_views -> get_view -> _get_view): the
+        # field had silently vanished from the NFS-e line form, and a bare
+        # ``except Exception`` hid a missing anchor as a no-op. We now fail
+        # loudly (diagnosable log) instead of swallowing the regression.
         if view_type == "form":
-            try:
-                doc = etree.fromstring(model_view.get("arch"))
-                field = doc.xpath("//field[@name='issqn_wh_value']")[0]
-                parent = field.getparent()
-                parent.insert(
-                    parent.index(field) + 1,
-                    etree.XML('<field name="other_retentions_value"/>'),
+            anchors = arch.xpath("//field[@name='issqn_wh_value']")
+            if anchors:
+                anchors[0].addnext(
+                    etree.fromstring('<field name="other_retentions_value"/>')
                 )
-
-                model_view["arch"] = etree.tostring(doc, encoding="unicode")
-            except Exception:
-                return model_view
-
-        arch_tree = self.inject_fiscal_fields(model_view["arch"])
-        View = self.env["ir.ui.view"]
-        # Override context for postprocessing
-        if view_id and model_view.get("base_model", self._name) != self._name:
-            View = View.with_context(base_model_name=model_view["base_model"])
-
-        # Apply post processing, groups and modifiers etc...
-        xarch, xfields = View.postprocess_and_fields(node=arch_tree, model=self._name)
-        model_view["arch"] = xarch
-        model_view["fields"] = xfields
-        return model_view
+            else:
+                _logger.warning(
+                    "l10n_br_nfse: cannot place 'other_retentions_value' on the "
+                    "%s form view: the anchor field 'issqn_wh_value' is missing "
+                    "from the injected fiscal line arch (fiscal_taxes page). The "
+                    "field will not be shown on the NFS-e line form. Keep "
+                    "'issqn_wh_value' in the injected line form.",
+                    self._name,
+                )
+        return arch, view
 
     def _prepare_line_service(self):
         return {

--- a/l10n_br_purchase/models/purchase_order_line.py
+++ b/l10n_br_purchase/models/purchase_order_line.py
@@ -164,6 +164,7 @@ class PurchaseOrderLine(models.Model):
                 "_compute_fiscal_quantity",
                 "_compute_fiscal_price",
                 "_compute_fiscal_tax_ids",
+                "_compute_fiscal_operation_data",
                 "_compute_tax_fields",
                 "_compute_fiscal_operation_line_id",
                 "_compute_comment_ids",

--- a/l10n_br_purchase/tests/test_l10n_br_purchase.py
+++ b/l10n_br_purchase/tests/test_l10n_br_purchase.py
@@ -515,11 +515,29 @@ class L10nBrPurchaseBaseTest(TransactionCase):
         purchase_form.save()
 
     def test_get_view(self):
+        """Executable spec of the fiscal fields injection contract: the fiscal
+        drivers (operation, tax ids) are injected into the order line views,
+        while the C4 census "dead" fiscal computes are pruned out of them."""
         arch, models = self.po_products._get_view()
-        self.assertTrue(
-            arch.findall(".//field[@name='fiscal_operation_id']"),
+        injected = {el.get("name") for el in arch.findall(".//field")}
+        self.assertIn(
+            "fiscal_operation_id",
+            injected,
             "Error to included Operation Line from Purchase Order Line.",
         )
+        self.assertIn("icms_tax_id", injected)
+        for dead in (
+            "ii_percent",
+            "simple_value",
+            "simple_without_icms_value",
+            "cofins_wh_base_type",
+            "pis_wh_base_type",
+        ):
+            self.assertNotIn(
+                dead,
+                injected,
+                "Pruned dead fiscal field %s must not be injected." % dead,
+            )
 
     def test_fields_freight_insurance_other_costs(self):
         """Test fields Freight, Insurance and Other Costs when

--- a/l10n_br_sale_blanket_order/tests/test_l10n_br_sale_blanket_order.py
+++ b/l10n_br_sale_blanket_order/tests/test_l10n_br_sale_blanket_order.py
@@ -4,8 +4,6 @@
 from contextlib import contextmanager
 from datetime import date, timedelta
 
-from lxml import etree
-
 from odoo.exceptions import UserError
 from odoo.fields import Command
 from odoo.tests import tagged
@@ -553,9 +551,18 @@ class L10nBrSaleBLanketOrderTest(TransactionCase):
 
         with self.subTest("BR company - form view - fiscal fields injected"):
             arch, _ = sale_blanket_order._get_view(view_type="form")
-            self.assertIn(
-                "fiscal_operation_id", etree.tostring(arch, encoding="unicode")
-            )
+            injected = {el.get("name") for el in arch.findall(".//field")}
+            self.assertIn("fiscal_operation_id", injected)
+            self.assertIn("icms_tax_id", injected)
+            # C4 census "dead" fiscal computes are pruned from the injection
+            for dead in (
+                "ii_percent",
+                "simple_value",
+                "simple_without_icms_value",
+                "cofins_wh_base_type",
+                "pis_wh_base_type",
+            ):
+                self.assertNotIn(dead, injected)
 
         with self.subTest("Non-BR company - form view - line_ids tree not modified"):
             us_country = self.env.ref("base.us")


### PR DESCRIPTION
> Note: the performance test framework was split into a separate opt-in PR (#4741). This PR contains only the code change, reviewable on its own.

## What it does

Reduces the fiscal field collection injected into the **business-document line TREES** (`account.move`, `sale.order`, `purchase.order`, stock, blanket orders) from ~240 to ~120 fields, keeping the **full fiscal detail editable in the line form dialog** (the popup opened from the tree - the web client loads it as an isolated datapoint, outside the line onchange spec).

Why the tree: with the default editable tree the o2m **edition view is the tree**, and the per-line onchange payload/spec is built from the tree fields only (`basic_model.js` uses `fieldsInfo["list"]`; `odoo.tests.Form` resolves the same way). Every extra invisible field in that collection is fetched/computed on every onchange round, for every line - that is where the read-side cost of the Form path lives.

Whitelist kept in the tree (`_fiscal_line_view_fields`): the `FISCAL_TAX_ID` tax selectors, every `@api.onchange` trigger and every stored **non-computed** field. The modifier/domain/context closure of the injected nodes is force-kept (`_fiscal_line_modifier_refs`), so a reduced tree can never raise *"Unknown field ... in modifier"* at view load. The ~121 removed fields are all stored **computed** fields - they keep being computed and stored server-side, so dropping them from the inline onchange collection is value-preserving.

## Prerequisite - stacked on #4727

This PR is **stacked on #4727** (`[16.0][FIX] draft tax override clobbered by spurious compute re-fire`), which is itself stacked on the perf series #4711 -> #4716 -> #4719 -> #4720. Only the **top commit** is new here; the perf baseline tests from #4711 live in the branch so CI measures this patch objectively.

#4727 is a hard prerequisite: it decouples draft fiscal correctness from the view payload (deterministic server-side recompute). Without it, reducing the onchange spec regressed the draft ICMS rate; stacked on it, the value is correct. Full mechanism of that regression in the **root-cause comment**: https://github.com/OCA/l10n-brazil/pull/4721#issuecomment-5011764003

## Measured (perf baseline from #4711, warm round, `perf-oca`)

| Step | Before (on #4727) | After |
|---|---|---|
| create_form 30 lines | 5874q / ~20.6s | **5571q / ~13.7s (-33% wall time)** |
| create_form 2 lines | 616q / ~1.29s | 599q / ~1.07s |
| post / so_create / create_invoices | unchanged | unchanged |

Query count is deterministic; wall time is logged, never asserted (machine-dependent). Reproduce: check out the branch and run `--test-tags l10n_br_performance` on the l10n_br_account/l10n_br_sale suites.

## Test migration - tree column -> line popup

Removing the ~121 computed fields from the tree also removes them as **optional tree columns**, which a few tests edited/read directly through the inline `Form`. Those were migrated to preserve their intent (the fiscal detail is now edited in the line dialog, not the tree):

- `l10n_br_account` `TestMoveEdition.test_out_fiscal_invoice`: the manual FCP override (`icmsfcp_base` / `icmsfcp_value`) is now set through the line form dialog (popup) `Form` and asserted to persist through save.
- `l10n_br_account` `TestPerTaxDraftEdition`: the IPI/PIS/COFINS override cases select the tax live (the selector stays in the tree) and assert the per-tax value on the **saved fiscal line** - the exact value #4721 could leave stale. ICMS base/value/percent stay in the tree, so ICMS is still checked live on the inline Form.

Suites `l10n_br_fiscal` / `l10n_br_account` / `l10n_br_sale`: **0 failed** (incl. `test_out_fiscal_invoice` and the full `TestPerTaxDraftEdition`).

## Structural note

The residual cost of the 30-line Form is protected by the compute web (the stored fiscal totals/related recompute on every line touch). Reducing it further is an Onda-3 structural change (C5/RFC), not a view prune - this PR takes the safe payload reduction that #4727 makes correct.


