### PR TITLE
[18.0][FIX] l10n_br_fiscal: copy_data fiscal_type

### DIFF
--- a/l10n_br_fiscal/models/product_template.py
+++ b/l10n_br_fiscal/models/product_template.py
@@ -22,6 +22,13 @@ class ProductTemplate(models.Model):
         if fiscal_type == PRODUCT_FISCAL_TYPE_SERVICE:
             return self.env.ref(NCM_FOR_SERVICE_REF)
 
+    def copy_data(self, default=None):
+        vals_list = super().copy_data(default=default)
+        for template, vals in zip(self, vals_list, strict=False):
+            # company_dependent fields are not copied by default by the ORM
+            vals.setdefault("fiscal_type", template.fiscal_type)
+        return vals_list
+
     fiscal_type = fields.Selection(
         selection=PRODUCT_FISCAL_TYPE,
         company_dependent=True,


### PR DESCRIPTION
## Objetivo da PR

Duplicar produto não copia o Tipo Fiscal porque o campo é `company_dependent=True` (entendi que é usado isso por que o mesmo produto pode ter regime tributário diferente). O Odoo, por padrão, não copia campos company_dependent ao duplicar um registro. 
Corrigido sobrescrevendo `copy_data()` em `ProductTemplate` para repassar o valor de `fiscal_type` da empresa atual pro produto novo.

cc @marcelsavegnago @rvalyi @antoniospneto 

OBS: Não se se é a maneira correta, fica aberto a melhorias