### PR TITLE
[18.0][FIX] l10n_br_hr: _rec_names_search

### DIFF
--- a/l10n_br_hr/models/data_abstract.py
+++ b/l10n_br_hr/models/data_abstract.py
@@ -1,14 +1,14 @@
 # Copyright (C) 2019  Renato Lima - Akretion <renato.lima@akretion.com.br>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import api, fields, models
-from odoo.osv import expression
+from odoo import fields, models
 
 
 class DataAbstract(models.AbstractModel):
     _name = "l10n_br_hr.data.abstract"
     _description = "HR Data Abstract"
     _order = "code"
+    _rec_names_search = ["code", "name"]
 
     code = fields.Char(required=True, index=True)
 
@@ -16,20 +16,3 @@ class DataAbstract(models.AbstractModel):
 
     def name_get(self):
         return [(r.id, f"{r.code} - {r.name}") for r in self]
-
-    @api.model
-    def _search_display_name(
-        self, name, args=None, operator="ilike", limit=100, name_get_uid=None
-    ):
-        args = args or []
-        domain = []
-        if name:
-            domain = ["|", ("code", operator, name), ("name", operator, name)]
-            return self._search(
-                expression.AND([domain, args]),
-                limit=limit,
-                access_rights_uid=name_get_uid,
-            )
-        return super()._search_display_name(
-            name, args=args, operator=operator, limit=limit, name_get_uid=name_get_uid
-        )


### PR DESCRIPTION
## Objetivo da PR

Removi o override antigo de `_search_display_name` (baseado na API pré-18) e substitui por `_rec_names_search = ["code", "name"], `que é o mecanismo nativo do Odoo 18 para buscar por múltiplos campos — mesmo resultado (busca por código ou nome), sem a chamada quebrada a `_search()`.