### PR TITLE
[18.0][FIX] l10n_br_account_fleet: refactor view

### DIFF
--- a/l10n_br_account_fleet/views/account_move.xml
+++ b/l10n_br_account_fleet/views/account_move.xml
@@ -14,7 +14,8 @@
                 <field name='need_vehicle' invisible='1' />
                 <field
                     name='vehicle_id'
-                    attrs="{'required': [('need_vehicle', '=', True), ('parent.move_type', 'in', ('in_invoice', 'in_refund'))], 'column_invisible': [('parent.move_type', 'not in', ('in_invoice', 'in_refund'))]}"
+                    required="need_vehicle and parent.move_type in ('in_invoice', 'in_refund')"
+                    column_invisible="parent.move_type not in ('in_invoice', 'in_refund')"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
Correção para:
`required="need_vehicle and parent.move_type in ('in_invoice', 'in_refund')"`
`column_invisible="parent.move_type not in ('in_invoice', 'in_refund')"`