### PR TITLE
[16.0][FIX] l10n_br_fiscal: coherent demo purchase NF supplier

### DIFF
--- a/l10n_br_fiscal/demo/fiscal_document_demo.xml
+++ b/l10n_br_fiscal/demo/fiscal_document_demo.xml
@@ -543,7 +543,10 @@
         <field name="document_serie">1</field>
         <field name="document_number">123</field>
         <field name="issuer">partner</field>
-        <field name="partner_id" ref="l10n_br_base.res_partner_akretion" />
+        <!-- Fornecedor contribuinte normal (perfil CNT), coerente com a NF
+             destacando ICMS/IPI. Um fornecedor Simples (ex.: akretion/SNN)
+             não destacaria esses impostos. -->
+        <field name="partner_id" ref="l10n_br_base.res_partner_intel" />
         <field name="user_id" ref="base.user_demo" />
         <field name="fiscal_operation_type">in</field>
     </record>


### PR DESCRIPTION
The demo purchase NF (`demo_nfe_purchase_same_state`) pointed to Akretion, whose demo fiscal profile is **SNN (Simples Nacional non-taxpayer)**, while the NF lines map ICMS 18% + IPI — a Simples supplier would not highlight these taxes on its NF.

This repoints the partner to **Intel (SP, CNT profile — normal taxpayer)**, which is coherent with the taxes actually mapped. No values or structure changed.

Akretion's profile is left untouched on purpose: it is used as supplier across several other modules' demo data (l10n_br_purchase, l10n_br_purchase_stock, l10n_br_sale, l10n_br_delivery...), so changing its profile would ripple through them.

This also unblocks upcoming work on stock acquisition cost, where the supplier's tax framework starts to matter (a Simples supplier does not transfer ICMS/IPI credits — art. 23, LC 123/2006).
