### PR TITLE
[16.0][ADD] l10n_br_base, l10n_br_fiscal: demo company Lucro Real

### DIFF
--- a/l10n_br_base/demo/res_company_demo.xml
+++ b/l10n_br_base/demo/res_company_demo.xml
@@ -86,4 +86,33 @@
         <field name="currency_id" ref="base.BRL" />
     </record>
 
+    <!-- Empresa Lucro Real -->
+    <record id="lucro_real_partner" model="res.partner">
+        <field name="name">Empresa Lucro Real</field>
+        <field name="legal_name">Empresa Lucro Real Ltda</field>
+        <field name="street_name">Avenida Brigadeiro Faria Lima</field>
+        <field name="street_number">1000</field>
+        <field name="district">Itaim Bibi</field>
+        <field name="state_id" ref="base.state_br_sp" />
+        <field name="city_id" ref="l10n_br_base.city_3550308" />
+        <field name="country_id" ref="base.br" />
+        <field name="zip">04538-132</field>
+        <field name="website">www.lucroreal.example.com</field>
+        <field name="phone">+55 11 8888-8888</field>
+        <field name="email">info@lucroreal.example.com</field>
+        <field name="is_company" eval="True" />
+        <field name="vat">46.312.887/0001-54</field>
+        <field name="l10n_br_ie_code">463.128.870.009</field>
+    </record>
+    <function model="res.partner" name="_onchange_city_id">
+        <value eval="[ref('lucro_real_partner')]" />
+    </function>
+
+    <record id="empresa_lucro_real" model="res.company">
+        <field name="name">Empresa Lucro Real</field>
+        <field name="legal_name">Empresa Lucro Real Ltda</field>
+        <field name="partner_id" ref="lucro_real_partner" />
+        <field name="currency_id" ref="base.BRL" />
+    </record>
+
 </odoo>

--- a/l10n_br_base/demo/res_users_demo.xml
+++ b/l10n_br_base/demo/res_users_demo.xml
@@ -4,13 +4,13 @@
     <record id="base.user_admin" model="res.users">
         <field
             name="company_ids"
-            eval="[Command.link(ref('base.main_company')), Command.link(ref('l10n_br_base.empresa_simples_nacional')), Command.link(ref('l10n_br_base.empresa_lucro_presumido'))]"
+            eval="[Command.link(ref('base.main_company')), Command.link(ref('l10n_br_base.empresa_simples_nacional')), Command.link(ref('l10n_br_base.empresa_lucro_presumido')), Command.link(ref('l10n_br_base.empresa_lucro_real'))]"
         />
     </record>
     <record id="base.user_demo" model="res.users">
         <field
             name="company_ids"
-            eval="[Command.link(ref('base.main_company')), Command.link(ref('l10n_br_base.empresa_simples_nacional')), Command.link(ref('l10n_br_base.empresa_lucro_presumido'))]"
+            eval="[Command.link(ref('base.main_company')), Command.link(ref('l10n_br_base.empresa_simples_nacional')), Command.link(ref('l10n_br_base.empresa_lucro_presumido')), Command.link(ref('l10n_br_base.empresa_lucro_real'))]"
         />
     </record>
     <record id="partner_demo_simples" model="res.partner">

--- a/l10n_br_fiscal/demo/company_demo.xml
+++ b/l10n_br_fiscal/demo/company_demo.xml
@@ -190,6 +190,92 @@
         <field name="active">True</field>
     </record>
 
+    <!-- Empresa Lucro Real -->
+    <record id="l10n_br_base.empresa_lucro_real" model="res.company">
+        <field name="tax_framework">3</field>
+        <field name="profit_calculation">real</field>
+        <field name="is_industry" eval="True" />
+        <field name="ripi" eval="True" />
+        <field name="icms_regulation_id" ref="tax_icms_regulation" />
+        <field name="legal_nature_id" ref="l10n_br_fiscal.legal_nature_2062" />
+        <field name="cnae_main_id" ref="l10n_br_fiscal.cnae_3101200" />
+        <field name="piscofins_id" ref="l10n_br_fiscal.tax_pis_cofins_nao_columativo" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
+    </record>
+
+    <record
+        id="cofins_tax_definition_empresa_lucro_real"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed">True</field>
+        <field name="is_debit_credit">True</field>
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_7_6" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_01" />
+        <field name="state">draft</field>
+    </record>
+
+    <record
+        id="pis_tax_definition_empresa_lucro_real"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed">True</field>
+        <field name="is_debit_credit">True</field>
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_1_65" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_01" />
+        <field name="state">draft</field>
+    </record>
+
+    <record
+        id="issqn_tax_definition_empresa_lucro_real"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_issqn" />
+        <field name="is_taxed">True</field>
+        <field name="is_debit_credit">True</field>
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_issqn_5" />
+        <field name="state">approved</field>
+    </record>
+
+    <record id="empresa_lr_document_55_serie_1" model="l10n_br_fiscal.document.serie">
+        <field name="code">1</field>
+        <field name="name">Série 1</field>
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="active">True</field>
+    </record>
+
+    <record id="empresa_lr_document_57_serie_1" model="l10n_br_fiscal.document.serie">
+        <field name="code">1</field>
+        <field name="name">Série 1</field>
+        <field name="document_type_id" ref="l10n_br_fiscal.document_57" />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="active">True</field>
+    </record>
+
+    <record id="empresa_lr_document_58_serie_1" model="l10n_br_fiscal.document.serie">
+        <field name="code">1</field>
+        <field name="name">Série 1</field>
+        <field name="document_type_id" ref="l10n_br_fiscal.document_58" />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="active">True</field>
+    </record>
+
+    <record id="empresa_lr_document_65_serie_1" model="l10n_br_fiscal.document.serie">
+        <field name="code">1</field>
+        <field name="name">Série 1</field>
+        <field name="document_type_id" ref="l10n_br_fiscal.document_65" />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="active">True</field>
+    </record>
+
     <!-- Empresa Simples Nacional -->
     <record id="l10n_br_base.empresa_simples_nacional" model="res.company">
         <field name="tax_framework">1</field>


### PR DESCRIPTION
Demo data only ships **Simples Nacional** and **Lucro Presumido** companies, so scenarios that depend on the **Lucro Real** regime (non-cumulative PIS/COFINS credits, full tax credit on purchases, multi-regime comparisons, SPED scenarios) cannot be exercised with demo data.

This adds "Empresa Lucro Real" with the complete fiscal setup required for the tax engine to actually map taxes for it:

- company + partner (valid CNPJ `46.312.887/0001-54` and IE-SP `463.128.870.009`, both validated with `erpbrasil.base`) in `l10n_br_base`;
- `tax_framework` 3, `profit_calculation` real, industrial (`ripi`);
- `piscofins_id`: non-cumulative regime (PIS 1.65% / COFINS 7.6%);
- company tax definitions for PIS/COFINS (non-cumulative rates) and ISSQN, mirroring the Lucro Presumido company structure;
- document series (NF-e, CT-e, NFC-e, MDF-e);
- admin and demo users linked to the new company.

Note: without the `piscofins_id` and the per-company tax definitions the engine maps **no taxes at all** for the company — a bare company record is not enough, which is why the full block is included.

Sanity check on a fresh database with demo data: the same purchase NF line (R$ 800, ICMS 18% + IPI) yields the expected regime-dependent behavior — the Lucro Real company maps ICMS/PIS/COFINS/IPI and credits them (non-cumulative), while the Lucro Presumido one only credits ICMS.
