### PR TITLE
[18.0][FIX] l10n_br_hr: fix employee phone fields position

### DIFF
--- a/l10n_br_hr/views/hr_employee_view.xml
+++ b/l10n_br_hr/views/hr_employee_view.xml
@@ -29,7 +29,7 @@
             <xpath expr="//field[@name='coach_id']" position="after">
                 <field name="registration" />
             </xpath>
-            <xpath expr="//field[@name='work_contact_id']" position="after">
+            <xpath expr="//field[@name='private_phone']" position="after">
                 <field name="alternate_phone" />
                 <field name="emergency_phone" />
                 <field name="talk_to" />


### PR DESCRIPTION
This pull request makes a small update to the `hr_employee_view.xml` file, changing where the alternate and emergency phone fields are displayed in the employee form. The fields are now positioned after `private_phone` instead of `work_contact_id`.

**Antes**

<img width="984" height="759" alt="image" src="https://github.com/user-attachments/assets/2818b4d7-4503-4e44-96f6-58a46ac0177d" />

**Depois**

<img width="861" height="552" alt="image" src="https://github.com/user-attachments/assets/0798118b-30f6-4096-93f9-0c821d728387" />
