### PR TITLE
[19.0][FIX] l10n_br_hr: move marital selection to hr.version

### DIFF
--- a/l10n_br_base/demo/l10n_br_base_demo.xml
+++ b/l10n_br_base/demo/l10n_br_base_demo.xml
@@ -606,11 +606,7 @@
         <field name="is_company">1</field>
         <field name="street">3404  Edgewood Road</field>
         <field name="city">Jonesboro</field>
-        <field
-            name="state_id"
-            model="res.country.state"
-            search="[('code','ilike','AR')]"
-        />
+        <field name="state_id" ref="base.state_us_4" />
         <field name="zip">72401</field>
         <field name="phone">(870)-931-0505</field>
         <field name="country_id" ref="base.us" />

--- a/l10n_br_hr/models/__init__.py
+++ b/l10n_br_hr/models/__init__.py
@@ -2,6 +2,7 @@ from . import data_abstract
 from . import l10n_br_hr_cbo
 from . import hr_employee
 from . import hr_job
+from . import hr_version
 from . import res_partner
 from . import res_company
 from . import hr_civil_certificate_type

--- a/l10n_br_hr/models/hr_employee.py
+++ b/l10n_br_hr/models/hr_employee.py
@@ -151,11 +151,6 @@ class HrEmployee(models.Model):
 
     alternate_email = fields.Char(groups="hr.group_hr_user")
 
-    marital = fields.Selection(
-        selection="_get_marital_status_selection",
-        groups="hr.group_hr_user",
-    )
-
     registration = fields.Char(string="Registration number", groups="hr.group_hr_user")
 
     country_id = fields.Many2one(
@@ -193,10 +188,3 @@ class HrEmployee(models.Model):
         cpf = cnpj_cpf.formata(str(self.cpf))
         if cpf:
             self.cpf = cpf
-
-    @api.model
-    def _get_marital_status_selection(self):
-        return super()._get_marital_status_selection() + [
-            ("common_law_marriage", self.env._("Common law marriage")),
-            ("separated", self.env._("Separated")),
-        ]

--- a/l10n_br_hr/models/hr_version.py
+++ b/l10n_br_hr/models/hr_version.py
@@ -1,0 +1,17 @@
+# (c) 2014 Kmee - Rafael da Silva Lima <rafael.lima@kmee.com.br>
+# (c) 2014 Kmee - Matheus Felix <matheus.felix@kmee.com.br>
+# (c) 2016 KMEE Informática - Daniel Sadamo <daniel.sadamo@kmee.com.br>
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import api, models
+
+
+class HrVersion(models.Model):
+    _inherit = "hr.version"
+
+    @api.model
+    def _get_marital_status_selection(self):
+        return super()._get_marital_status_selection() + [
+            ("common_law_marriage", self.env._("Common law marriage")),
+            ("separated", self.env._("Separated")),
+        ]

--- a/l10n_br_hr/tests/test_l10n_br_hr.py
+++ b/l10n_br_hr/tests/test_l10n_br_hr.py
@@ -67,3 +67,9 @@ class TestL10nBr(TransactionCase):
             "1 - Branca",
             "The ethnicity display_name is not valid, expected '1 - Branca'",
         )
+
+    def test_marital_status_selection(self):
+        selection = self.env["hr.version"]._get_marital_status_selection()
+        selection_keys = [item[0] for item in selection]
+        self.assertIn("common_law_marriage", selection_keys)
+        self.assertIn("separated", selection_keys)

--- a/l10n_br_hr/tests/test_l10n_br_hr.py
+++ b/l10n_br_hr/tests/test_l10n_br_hr.py
@@ -37,6 +37,11 @@ class TestL10nBr(TransactionCase):
         self.employee.onchange_cpf()
         self.assertEqual(self.employee.cpf, "780.048.630-35")
 
+    def test_onchange_cpf_empty(self):
+        self.employee.cpf = ""
+        self.employee.onchange_cpf()
+        self.assertFalse(self.employee.cpf)
+
     def test_invalid_employee_pis_pasep(self):
         try:
             result = self.employee.write({"pis_pasep": "496.851994.95-6"})
@@ -73,3 +78,7 @@ class TestL10nBr(TransactionCase):
         selection_keys = [item[0] for item in selection]
         self.assertIn("common_law_marriage", selection_keys)
         self.assertIn("separated", selection_keys)
+        self.employee.marital = "common_law_marriage"
+        self.assertEqual(self.employee.marital, "common_law_marriage")
+        self.employee.marital = "separated"
+        self.assertEqual(self.employee.marital, "separated")

--- a/l10n_br_hr/views/hr_employee_view.xml
+++ b/l10n_br_hr/views/hr_employee_view.xml
@@ -29,7 +29,7 @@
             <xpath expr="//field[@name='parent_id']" position="after">
                 <field name="registration" />
             </xpath>
-            <xpath expr="//field[@name='mobile_phone']" position="after">
+            <xpath expr="//field[@name='private_phone']" position="after">
                 <field name="alternate_phone" />
                 <field name="emergency_phone" />
                 <field name="talk_to" />


### PR DESCRIPTION
## Summary
- Move Brazilian marital status options (`common_law_marriage`, `separated`) from `hr.employee` to `hr.version`, where `_get_marital_status_selection` lives in Odoo 19.
- Fixes employee form crash (`AttributeError` on `super()._get_marital_status_selection()`).

Fixes #4602

## Test plan
- [x] Install `l10n_br_hr`
- [x] Open Employees form — view loads without RPC error
- [x] Marital Status includes Common law marriage and Separated


Made with [Cursor](https://cursor.com) e EU 