### PR TITLE
[17.0][FIX] l10n_br_hr: fix employee phone fields position

### DIFF
--- a/l10n_br_hr/views/hr_employee_view.xml
+++ b/l10n_br_hr/views/hr_employee_view.xml
@@ -29,7 +29,7 @@
             <xpath expr="//field[@name='coach_id']" position="after">
                 <field name="registration" />
             </xpath>
-            <xpath expr="//field[@name='work_contact_id']" position="after">
+            <xpath expr="//field[@name='private_phone']" position="after">
                 <field name="alternate_phone" />
                 <field name="emergency_phone" />
                 <field name="talk_to" />


### PR DESCRIPTION
This pull request makes a small update to the `hr_employee_view.xml` file, changing where a set of phone-related fields are inserted in the employee form view. The fields `alternate_phone`, `emergency_phone`, and `talk_to` will now appear after the `private_phone` field instead of after `work_contact_id`.

Port From: https://github.com/OCA/l10n-brazil/pull/4746