### PR TITLE
[18.0][FIX] l10n_br_account: _account_taxes company_id

### DIFF
--- a/l10n_br_account/models/fiscal_tax.py
+++ b/l10n_br_account/models/fiscal_tax.py
@@ -27,13 +27,6 @@ class FiscalTax(models.Model):
 
     def _account_taxes(self, company=False):
         self.ensure_one()
-        account_tax_group = self.env["account.tax.group"].search(
-            [
-                ("fiscal_tax_group_id", "=", self.tax_group_id.id),
-                ("company_id", "=", company.id),
-            ],
-            limit=1,
-        )
         if not company:
             company = self.env.company
             if self.env.context.get("default_company_id") or self.env.context.get(
@@ -43,6 +36,13 @@ class FiscalTax(models.Model):
                     self.env.context.get("default_company_id")
                     or self.env.context.get("allowed_company_ids")[0]
                 )
+        account_tax_group = self.env["account.tax.group"].search(
+            [
+                ("fiscal_tax_group_id", "=", self.tax_group_id.id),
+                ("company_id", "=", company.id),
+            ],
+            limit=1,
+        )
         return self.env["account.tax"].search(
             [
                 ("tax_group_id", "=", account_tax_group.id),


### PR DESCRIPTION
## Motivo do bug:
O método `_account_taxes(self, company=False)` em `l10n_br_account/models/fiscal_tax.py` recebe company com valor padrão False. O problema é a ordem das operações dentro do método: ele usa `company.id` na busca de `account.tax.group` antes de resolver o fallback (`if not company: company = self.env.company`), que só acontece logo depois.
Ou seja, sempre que o método é chamado sem passar company explicitamente — como acontece em `unlink()`, que chama `fiscal_tax._account_taxes()` sem argumento — company permanece `False (booleano)` no momento da primeira query, e a tentativa de acessar company.id gera:

`AttributeError: 'bool' object has no attribute 'id'`
Esse erro ocorreu em produção durante a atualização de módulo (-u), quando o Odoo tentou remover um registro l10n_br.fiscal.tax órfão (dado que não existe mais no módulo l10n_br_fiscal) via `_process_end_unlink_record`, que por sua vez chama `unlink()` — travando totalmente a inicialização do banco.
### Correção: 
mover o bloco de resolução do fallback de company para antes da busca que usa company.id, garantindo que company nunca seja False no momento em que .id é acessado.

Erro ao Atualizar:
```
2026-07-22 00:09:51,317 45 INFO prod odoo.addons.base.models.ir_model: Deleting 396@l10n_br_fiscal.tax (l10n_br_fiscal.tax_pis_value_46_5800) 
2026-07-22 00:09:51,323 45 WARNING prod odoo.modules.loading: Transient module states were reset 
2026-07-22 00:09:51,324 45 ERROR prod odoo.modules.registry: Failed to load registry 
2026-07-22 00:09:51,324 45 CRITICAL prod odoo.service.server: Failed to initialize database prod. 
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/service/server.py", line 1414, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "<decorator-gen-13>", line 2, in new
  File "/opt/odoo/custom/src/odoo/odoo/tools/func.py", line 97, in locked
    return func(inst, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/modules/registry.py", line 115, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 545, in load_modules
    env['ir.model.data']._process_end(processed_modules)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_model.py", line 2714, in _process_end
    self._process_end_unlink_record(record)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_model.py", line 2643, in _process_end_unlink_record
    record.unlink()
  File "/opt/odoo/auto/addons/l10n_br_account/models/fiscal_tax.py", line 82, in unlink
    account_taxes = fiscal_tax._account_taxes()
  File "/opt/odoo/auto/addons/l10n_br_account/models/fiscal_tax.py", line 33, in _account_taxes
    ("company_id", "=", company.id),
AttributeError: 'bool' object has no attribute 'id'
2026-07-22 00:09:51,326 45 INFO prod odoo.service.server: Initiating shutdown 
2026-07-22 00:09:51,326 45 INFO prod odoo.service.server: Hit CTRL-C again or send a second signal to force the shutdown. 
2026-07-22 00:09:51,326 45 INFO prod odoo.sql_db: ConnectionPool(read/write;used=0/count=0/max=64): Closed 1 connections
```