### PR TITLE
[17.0][REM] l10n_br_hr: drop duplicate emergency contact fields

### DIFF
--- a/l10n_br_hr/migrations/17.0.1.2.0/pre-migrate.py
+++ b/l10n_br_hr/migrations/17.0.1.2.0/pre-migrate.py
@@ -1,0 +1,20 @@
+# Copyright 2026 Escodoo
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if openupgrade.column_exists(env.cr, "hr_employee", "talk_to"):
+        openupgrade.logged_query(
+            env.cr,
+            """
+            UPDATE hr_employee
+               SET emergency_contact = talk_to
+             WHERE talk_to IS NOT NULL
+               AND talk_to != ''
+               AND (emergency_contact IS NULL OR emergency_contact = '')
+            """,
+        )
+        openupgrade.drop_columns(env.cr, [("hr_employee", "talk_to")])

--- a/l10n_br_hr/models/hr_employee.py
+++ b/l10n_br_hr/models/hr_employee.py
@@ -145,10 +145,6 @@ class HrEmployee(models.Model):
 
     alternate_phone = fields.Char(groups="hr.group_hr_user")
 
-    emergency_phone = fields.Char(groups="hr.group_hr_user")
-
-    talk_to = fields.Char(string="Emergency contact name", groups="hr.group_hr_user")
-
     alternate_email = fields.Char(groups="hr.group_hr_user")
 
     marital = fields.Selection(

--- a/l10n_br_hr/views/hr_employee_view.xml
+++ b/l10n_br_hr/views/hr_employee_view.xml
@@ -31,8 +31,6 @@
             </xpath>
             <xpath expr="//field[@name='private_phone']" position="after">
                 <field name="alternate_phone" />
-                <field name="emergency_phone" />
-                <field name="talk_to" />
                 <field name="alternate_email" />
             </xpath>
             <field name="work_contact_id" position="attributes">


### PR DESCRIPTION
Core hr already provides emergency_contact and emergency_phone. Migrate talk_to into emergency_contact when empty and stop redefining/displaying the duplicated fields; keep alternate_*.

Port from: https://github.com/OCA/l10n-brazil/pull/4750