### PR TITLE
[19.0][REM] l10n_br_hr: drop duplicate emergency contact fields

### DIFF
--- a/l10n_br_hr/__manifest__.py
+++ b/l10n_br_hr/__manifest__.py
@@ -7,7 +7,7 @@
     "category": "Localization",
     "author": "KMEE, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-brazil",
-    "version": "19.0.1.3.0",
+    "version": "19.0.1.4.0",
     "depends": ["hr", "l10n_br_base", "hr_employee_relative"],
     "data": [
         "data/l10n_br_hr.cbo.csv",

--- a/l10n_br_hr/migrations/19.0.1.4.0/pre-migrate.py
+++ b/l10n_br_hr/migrations/19.0.1.4.0/pre-migrate.py
@@ -1,0 +1,20 @@
+# Copyright 2026 Escodoo
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if openupgrade.column_exists(env.cr, "hr_employee", "talk_to"):
+        openupgrade.logged_query(
+            env.cr,
+            """
+            UPDATE hr_employee
+               SET emergency_contact = talk_to
+             WHERE talk_to IS NOT NULL
+               AND talk_to != ''
+               AND (emergency_contact IS NULL OR emergency_contact = '')
+            """,
+        )
+        openupgrade.drop_columns(env.cr, [("hr_employee", "talk_to")])

--- a/l10n_br_hr/models/hr_employee.py
+++ b/l10n_br_hr/models/hr_employee.py
@@ -145,10 +145,6 @@ class HrEmployee(models.Model):
 
     alternate_phone = fields.Char(groups="hr.group_hr_user")
 
-    emergency_phone = fields.Char(groups="hr.group_hr_user")
-
-    talk_to = fields.Char(string="Emergency contact name", groups="hr.group_hr_user")
-
     alternate_email = fields.Char(groups="hr.group_hr_user")
 
     registration = fields.Char(string="Registration number", groups="hr.group_hr_user")

--- a/l10n_br_hr/views/hr_employee_view.xml
+++ b/l10n_br_hr/views/hr_employee_view.xml
@@ -31,8 +31,6 @@
             </xpath>
             <xpath expr="//field[@name='private_phone']" position="after">
                 <field name="alternate_phone" />
-                <field name="emergency_phone" />
-                <field name="talk_to" />
                 <field name="alternate_email" />
             </xpath>
             <xpath expr="//page[@name='personal_information']" position="after">


### PR DESCRIPTION
This pull request migrates the emergency contact information in the HR employee module by consolidating fields and cleaning up the model and views. The key change is moving data from the deprecated `talk_to` field to the `emergency_contact` field, and then removing `talk_to` from the codebase.

**Database migration:**
* Adds a migration script (`pre-migrate.py`) that copies data from the `talk_to` column to the `emergency_contact` column in the `hr_employee` table (when appropriate), and then drops the `talk_to` column.

**Model and view cleanup:**
* Removes the `talk_to` field from the `hr_employee` model (`hr_employee.py`).
* Removes the `talk_to` field from the employee form view (`hr_employee_view.xml`).

port from: https://github.com/OCA/l10n-brazil/pull/4750