### PR TITLE
[18.0][FIX] l10n_br_account: form view

### DIFF
--- a/l10n_br_account/views/account_move_view.xml
+++ b/l10n_br_account/views/account_move_view.xml
@@ -463,8 +463,13 @@
                 expr="//field[@name='invoice_line_ids']/form/sheet/group/field[@name='name']"
                 position="after"
             >
-                <group name="fiscal_fields" invisible="1" />
                 <field name="tax_icms_or_issqn" invisible="1" />
+            </xpath>
+            <xpath
+                expr="//field[@name='invoice_line_ids']/form/sheet/group[2]"
+                position="after"
+            >
+                <group name="fiscal_fields" invisible="1" />
                 <notebook invisible="not document_type_id">
                     <page name="fiscal_taxes" string="Taxes" />
                     <page name="amounts" string="Amounts">


### PR DESCRIPTION
## Objetivo da PR

Correção do form do produto l10n_br_account

Antes:
<img width="1920" height="928" alt="Captura de tela de 2026-07-22 20-46-05" src="https://github.com/user-attachments/assets/be8993c8-9718-4678-8565-96299baaf19b" />
<img width="1920" height="928" alt="Captura de tela de 2026-07-22 20-46-10" src="https://github.com/user-attachments/assets/66af61b2-4fe1-4c4f-8d7a-feafa23f67b3" />

Depois:
<img width="1920" height="928" alt="image" src="https://github.com/user-attachments/assets/95e786e2-297b-4b39-8bd9-2153d6f41a0d" />
