### PR TITLE
[16.0][IMP] l10n_br_fiscal: Adicionado a chave de contexto default_document_type_id nos actions do documento fiscal

### DIFF
--- a/l10n_br_fiscal/views/l10n_br_fiscal_action.xml
+++ b/l10n_br_fiscal/views/l10n_br_fiscal_action.xml
@@ -449,6 +449,10 @@
             name="domain"
             eval="[('document_type_id', '=', ref('l10n_br_fiscal.document_55'))]"
         />
+        <field
+            name="context"
+            eval="{'default_document_type_id': ref('l10n_br_fiscal.document_55')}"
+        />
         <field name="view_id" ref="document_tree" />
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">Add a new NFe</p>
@@ -466,6 +470,10 @@
             name="domain"
             eval="[('document_type_id', '=', ref('l10n_br_fiscal.document_SE'))]"
         />
+        <field
+            name="context"
+            eval="{'default_document_type_id': ref('l10n_br_fiscal.document_SE')}"
+        />
         <field name="view_id" ref="document_tree" />
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">Add a new NFSe</p>
@@ -482,6 +490,10 @@
         <field
             name="domain"
             eval="[('document_type_id', '=', ref('l10n_br_fiscal.document_57'))]"
+        />
+        <field
+            name="context"
+            eval="{'default_document_type_id': ref('l10n_br_fiscal.document_57')}"
         />
         <field name="view_id" ref="document_tree" />
         <field name="help" type="html">


### PR DESCRIPTION
Adicionei a chave default_document_type_id para ao criar um novo registro seja preenchido o document_type_id por padrão para as ações do menus NF-e, NFS-e e CT-e