### PR TITLE
[16.0] Dados de demonstração para Empresa do Lucro Real

### DIFF
--- a/l10n_br_account_payment_order/demo/account_journal.xml
+++ b/l10n_br_account_payment_order/demo/account_journal.xml
@@ -65,6 +65,27 @@
         <field name="journal_id" ref="lucro_presumido_bank_journal" />
     </record>
 
+    <!-- Account Journal for Lucro Real -->
+    <record id="lucro_real_bank_journal" model="account.journal">
+        <field name="name">Diário de Banco - Lucro Real</field>
+        <field name="code">TPO3</field>
+        <field name="type">sale</field>
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="edi_format_ids" eval="False" />
+    </record>
+
+    <record
+        id="lucro_real_bank_journal_payment_method"
+        model="account.payment.method.line"
+    >
+        <field name="name">Manual</field>
+        <field
+            name="payment_method_id"
+            ref="account.account_payment_method_manual_in"
+        />
+        <field name="journal_id" ref="lucro_real_bank_journal" />
+    </record>
+
     <!-- Diario Bradesco -->
     <record id="bradesco_journal" model="account.journal">
         <field name="name">Banco Bradesco</field>

--- a/l10n_br_account_payment_order/demo/ir_sequence.xml
+++ b/l10n_br_account_payment_order/demo/ir_sequence.xml
@@ -290,4 +290,13 @@
         <field eval="10" name="padding" />
     </record>
 
+    <record id="sequence_own_number_empresa_lucro_real" model="ir.sequence">
+        <field name="name">Nosso número - Empresa Lucro Real</field>
+        <field name="code">nosso.numero - Empresa Lucro Real</field>
+        <field eval="1" name="number_next" />
+        <field eval="1" name="number_increment" />
+        <field eval="False" name="company_id" />
+        <field eval="10" name="padding" />
+    </record>
+
 </odoo>

--- a/l10n_br_account_payment_order/demo/res_partner_bank.xml
+++ b/l10n_br_account_payment_order/demo/res_partner_bank.xml
@@ -368,6 +368,128 @@
         <field name="bank_name">Banco Sicredi</field>
     </record>
 
+    <!-- Bank Accounts for Lucro Real Company -->
+    <record id="lucro_real_bank_bb" model="res.partner.bank">
+        <field name="acc_number">5387</field>
+        <field name="acc_number_dig">8</field>
+        <field name="bra_number">7033</field>
+        <field name="bra_number_dig">8</field>
+        <field name="bank_id" ref="l10n_br_base.res_bank_001" />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="partner_id" ref="l10n_br_base.lucro_real_partner" />
+        <field name="bank_name">Banco do Brasil</field>
+    </record>
+
+    <record id="lucro_real_bank_hsbc" model="res.partner.bank">
+        <field name="acc_number">5165</field>
+        <field name="acc_number_dig">0</field>
+        <field name="bra_number">103</field>
+        <field name="bra_number_dig">3</field>
+        <field name="bank_id" ref="l10n_br_base.res_bank_399" />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="partner_id" ref="l10n_br_base.lucro_real_partner" />
+        <field name="bank_name">Banco HSBC</field>
+    </record>
+
+    <record id="lucro_real_bank_itau" model="res.partner.bank">
+        <field name="acc_number">15019</field>
+        <field name="acc_number_dig">0</field>
+        <field name="bra_number">8518</field>
+        <field name="bra_number_dig">0</field>
+        <field name="bank_id" ref="l10n_br_base.res_bank_341" />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="partner_id" ref="l10n_br_base.lucro_real_partner" />
+        <field name="bank_name">Banco ITAÚ</field>
+    </record>
+
+    <record id="lucro_real_bank_santander" model="res.partner.bank">
+        <field name="acc_number">1336</field>
+        <field name="acc_number_dig">0</field>
+        <field name="bra_number">710</field>
+        <field name="bra_number_dig">0</field>
+        <field name="bank_id" ref="l10n_br_base.res_bank_033" />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="partner_id" ref="l10n_br_base.lucro_real_partner" />
+        <field name="bank_name">Banco Santander</field>
+    </record>
+
+    <record id="lucro_real_bank_cef" model="res.partner.bank">
+        <field name="acc_number">417</field>
+        <field name="acc_number_dig">3</field>
+        <field name="bra_number">1568</field>
+        <field name="bra_number_dig">1</field>
+        <field name="bank_id" ref="l10n_br_base.res_bank_104" />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="partner_id" ref="l10n_br_base.lucro_real_partner" />
+        <field name="bank_name">Caixa Economica Federal</field>
+    </record>
+
+    <record id="lucro_real_bank_bradesco" model="res.partner.bank">
+        <field name="acc_number">398</field>
+        <field name="acc_number_dig">0</field>
+        <field name="bra_number">1614</field>
+        <field name="bra_number_dig">0</field>
+        <field name="bank_id" ref="l10n_br_base.res_bank_237" />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="partner_id" ref="l10n_br_base.lucro_real_partner" />
+        <field name="bank_name">Banco Bradesco</field>
+    </record>
+
+    <record id="lucro_real_bank_nordeste" model="res.partner.bank">
+        <field name="acc_number">126</field>
+        <field name="acc_number_dig">0</field>
+        <field name="bra_number">1237</field>
+        <field name="bra_number_dig">0</field>
+        <field name="bank_id" ref="l10n_br_base.res_bank_004" />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="partner_id" ref="l10n_br_base.lucro_real_partner" />
+        <field name="bank_name">Banco do Nordeste</field>
+    </record>
+
+    <record id="lucro_real_bank_banrisul" model="res.partner.bank">
+        <field name="acc_number">324</field>
+        <field name="acc_number_dig">0</field>
+        <field name="bra_number">1237</field>
+        <field name="bra_number_dig">0</field>
+        <field name="bank_id" ref="l10n_br_base.res_bank_041" />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="partner_id" ref="l10n_br_base.lucro_real_partner" />
+        <field name="bank_name">Banco do Estado do Rio Grande do Sul</field>
+    </record>
+
+    <record id="lucro_real_bank_banestes" model="res.partner.bank">
+        <field name="acc_number">234</field>
+        <field name="acc_number_dig">0</field>
+        <field name="bra_number">1237</field>
+        <field name="bra_number_dig">0</field>
+        <field name="bank_id" ref="l10n_br_base.res_bank_021" />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="partner_id" ref="l10n_br_base.lucro_real_partner" />
+        <field name="bank_name">Banco BANESTES</field>
+    </record>
+
+    <record id="lucro_real_bank_sicoob" model="res.partner.bank">
+        <field name="acc_number">315</field>
+        <field name="acc_number_dig">0</field>
+        <field name="bra_number">1240</field>
+        <field name="bra_number_dig">0</field>
+        <field name="bank_id" ref="l10n_br_base.res_bank_756" />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="partner_id" ref="l10n_br_base.lucro_real_partner" />
+        <field name="bank_name">Banco SICOOB</field>
+    </record>
+
+    <record id="lucro_real_bank_sicredi" model="res.partner.bank">
+        <field name="acc_number">334</field>
+        <field name="acc_number_dig">0</field>
+        <field name="bra_number">1239</field>
+        <field name="bra_number_dig">0</field>
+        <field name="bank_id" ref="l10n_br_base.res_bank_748" />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="partner_id" ref="l10n_br_base.lucro_real_partner" />
+        <field name="bank_name">Banco Sicredi</field>
+    </record>
+
     <record id="main_company_bank_unicredi" model="res.partner.bank">
         <field name="acc_number">371</field>
         <field name="acc_number_dig">0</field>

--- a/l10n_br_base/demo/res_users_demo.xml
+++ b/l10n_br_base/demo/res_users_demo.xml
@@ -39,6 +39,19 @@
         <field name="tz">America/Sao_Paulo</field>
         <field name="email">presumido@example.com</field>
     </record>
+    <record id="partner_demo_real" model="res.partner">
+        <field name="name">Demo Real</field>
+        <field name="company_id" eval="None" />
+        <field name="company_name">Empresa Lucro Real</field>
+        <field name="street_name">AV Paulista</field>
+        <field name="street_number">1001</field>
+        <field name="city_id" ref="l10n_br_base.city_3501152" />
+        <field name="zip">18125-000</field>
+        <field name='country_id' ref='base.br' />
+        <field name='state_id' ref='base.state_br_sp' />
+        <field name="tz">America/Sao_Paulo</field>
+        <field name="email">real@example.com</field>
+    </record>
     <record id="user_demo_simples" model="res.users">
         <field name="partner_id" ref="partner_demo_simples" />
         <field name="login">simples</field>
@@ -69,6 +82,24 @@
         <field
             name="company_ids"
             eval="[Command.link(ref('l10n_br_base.empresa_lucro_presumido'))]"
+        />
+        <field
+            name="groups_id"
+            eval="[(6,0,[ref('base.group_user'), ref('base.group_partner_manager')])]"
+        />
+    </record>
+    <record id="user_demo_real" model="res.users">
+        <field name="partner_id" ref="partner_demo_real" />
+        <field name="login">real</field>
+        <field name="password">real</field>
+        <field name="signature" type="html">
+            <span>--<br />+Mr Real
+            </span>
+        </field>
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field
+            name="company_ids"
+            eval="[Command.link(ref('l10n_br_base.empresa_lucro_real'))]"
         />
         <field
             name="groups_id"

--- a/l10n_br_coa_generic/demo/account_journal.xml
+++ b/l10n_br_coa_generic/demo/account_journal.xml
@@ -20,6 +20,21 @@
                 'xml_id': 'l10n_br_coa_generic.general_journal_empresa_lp',
                 'record': obj().env['account.journal'].sudo().search([('type', '=', 'general'), ('company_id', '=', obj().env.ref('l10n_br_base.empresa_lucro_presumido').id)], limit=1),
                 'noupdate': True,
+            },
+            {
+                'xml_id': 'l10n_br_coa_generic.sale_journal_empresa_lr',
+                'record': obj().env['account.journal'].sudo().search([('type', '=', 'sale'), ('company_id', '=', obj().env.ref('l10n_br_base.empresa_lucro_real').id)], limit=1),
+                'noupdate': True,
+            },
+            {
+                'xml_id': 'l10n_br_coa_generic.purchase_journal_empresa_lr',
+                'record': obj().env['account.journal'].sudo().search([('type', '=', 'purchase'), ('company_id', '=', obj().env.ref('l10n_br_base.empresa_lucro_real').id)], limit=1),
+                'noupdate': True,
+            },
+            {
+                'xml_id': 'l10n_br_coa_generic.general_journal_empresa_lr',
+                'record': obj().env['account.journal'].sudo().search([('type', '=', 'general'), ('company_id', '=', obj().env.ref('l10n_br_base.empresa_lucro_real').id)], limit=1),
+                'noupdate': True,
             },]"
         />
     </function>

--- a/l10n_br_coa_generic/hooks.py
+++ b/l10n_br_coa_generic/hooks.py
@@ -14,6 +14,12 @@ def post_init_hook(cr, registry):
     )
     if company_lc:
         coa_generic_tmpl.try_loading(company=company_lc)
+
+    company_lr = env.ref("l10n_br_base.empresa_lucro_real", raise_if_not_found=False)
+    if company_lr:
+        coa_generic_tmpl.try_loading(company=company_lr)
+
+    if company_lc or company_lr:
         tools.convert_file(
             cr,
             "l10n_br_coa_generic",

--- a/l10n_br_contract/demo/company.xml
+++ b/l10n_br_contract/demo/company.xml
@@ -18,4 +18,12 @@
         />
     </record>
 
+    <record id="l10n_br_base.empresa_lucro_real" model="res.company">
+        <field name="contract_sale_fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field
+            name="contract_purchase_fiscal_operation_id"
+            ref="l10n_br_fiscal.fo_compras"
+        />
+    </record>
+
 </odoo>

--- a/l10n_br_cte/demo/company_demo.xml
+++ b/l10n_br_cte/demo/company_demo.xml
@@ -21,4 +21,14 @@
     </record>
 
 
+    <!-- Empresa Lucro Real -->
+    <record id="l10n_br_base.empresa_lucro_real" model="res.company">
+        <field name="processador_edoc">oca</field>
+    </record>
+
+    <record id="l10n_br_base.lucro_real_partner" model="res.partner">
+        <field name="rntrc_code">07946021</field>
+    </record>
+
+
 </odoo>

--- a/l10n_br_cte/demo/fiscal_document_demo.xml
+++ b/l10n_br_cte/demo/fiscal_document_demo.xml
@@ -508,6 +508,513 @@
         <field name="document_total_amount">33.19</field>
     </record>
 
+    <!-- Empresa Lucro Real -->
+
+    <!-- CTe Test - Modal Rodoviário - LC -->
+    <record id="demo_cte_lr_modal_rodoviario" model="l10n_br_fiscal.document">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_57" />
+        <field
+            name="document_serie_id"
+            ref="l10n_br_fiscal.empresa_lr_document_57_serie_1"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="document_number">583</field>
+        <field name="document_serie">1</field>
+        <field name="document_key">35240781583054000129570010000057311040645894</field>
+        <field name="cte_environment">2</field>
+        <field name="processador_edoc">oca</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
+        <field name="service_provider">3</field>
+        <field name="transport_modal">01</field>
+
+        <!--Remetente-->
+        <field name="partner_sendering_id" ref="l10n_br_base.res_partner_cliente2_sp" />
+
+        <!--Expedidor-->
+        <field
+            name="partner_shippering_id"
+            ref="l10n_br_base.res_partner_cliente2_sp"
+        />
+
+        <!--Destinatario-->
+        <field name="partner_shipping_id" ref="l10n_br_base.res_partner_cliente3_am" />
+
+        <!--Recebedor-->
+        <field
+            name="partner_receivering_id"
+            ref="l10n_br_base.res_partner_cliente4_am"
+        />
+
+        <field name="user_id" ref="base.user_demo" />
+        <field name="fiscal_operation_type">out</field>
+
+        <field name="cte40_proPred">XYZ Product</field>
+        <field name="cte40_xOutCat">Other Product Data</field>
+        <field name="cte40_vCarga">1000</field>
+        <field name="cte40_vCargaAverb">1000</field>
+
+    </record>
+
+    <!-- CTe Test - Modal Rodoviário - LC - Cargo Quantity Infos -->
+    <record
+        id="demo_cte_lr_modal_rodoviario_cargo_quantity_info_1"
+        model="l10n_br_cte.cargo.quantity.infos"
+    >
+        <field name="document_id" ref="demo_cte_lr_modal_rodoviario" />
+        <field name="cte40_cUnid">00</field>
+        <field name="cte40_tpMed">Volume</field>
+        <field name="cte40_qCarga">1000.0</field>
+    </record>
+
+    <record
+        id="demo_cte_lr_modal_rodoviario_cargo_quantity_info_2"
+        model="l10n_br_cte.cargo.quantity.infos"
+    >
+        <field name="document_id" ref="demo_cte_lr_modal_rodoviario" />
+        <field name="cte40_cUnid">01</field>
+        <field name="cte40_tpMed">Peso Bruto</field>
+        <field name="cte40_qCarga">500.0</field>
+    </record>
+
+    <record
+        id="demo_cte_lr_modal_rodoviario_cargo_quantity_info_3"
+        model="l10n_br_cte.cargo.quantity.infos"
+    >
+        <field name="document_id" ref="demo_cte_lr_modal_rodoviario" />
+        <field name="cte40_cUnid">03</field>
+        <field name="cte40_tpMed">Unidade</field>
+        <field name="cte40_qCarga">2</field>
+    </record>
+
+    <!-- CTe Test - Modal Rodoviário - LC - Document Lines -->
+    <record id="demo_cte_lr_modal_rodoviario_1-1" model="l10n_br_fiscal.document.line">
+        <field name="document_id" ref="demo_cte_lr_modal_rodoviario" />
+        <field name="name">Frete</field>
+        <field name="product_id" ref="product.product_product_9" />
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="quantity">1</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_revenda" />
+    </record>
+
+    <!-- CTe Test - Modal Rodoviário - LC - Document Related -->
+    <record
+        id="demo_cte_lr_modal_rodoviario_related_nfe"
+        model="l10n_br_fiscal.document.related"
+    >
+        <field name="document_id" ref="demo_cte_lr_modal_rodoviario" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
+        <field name="document_key">41190806117473000150550010000586251016759484</field>
+        <field name="document_total_weight">10</field>
+        <field name="document_total_amount">33.19</field>
+    </record>
+
+    <!-- CTe Test - Modal Aereo - LC -->
+    <record id="demo_cte_lr_modal_aereo" model="l10n_br_fiscal.document">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_57" />
+        <field
+            name="document_serie_id"
+            ref="l10n_br_fiscal.empresa_lr_document_57_serie_1"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="document_number">584</field>
+        <field name="document_serie">1</field>
+        <field name="document_key">35240781583054000129570010000057411040645890</field>
+        <field name="cte_environment">2</field>
+        <field name="processador_edoc">oca</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
+        <field name="service_provider">3</field>
+        <field name="transport_modal">02</field>
+
+        <!--Remetente-->
+        <field name="partner_sendering_id" ref="l10n_br_base.res_partner_cliente2_sp" />
+
+        <!--Expedidor-->
+        <field
+            name="partner_shippering_id"
+            ref="l10n_br_base.res_partner_cliente2_sp"
+        />
+
+        <!--Destinatario-->
+        <field name="partner_shipping_id" ref="l10n_br_base.res_partner_cliente3_am" />
+
+        <!--Recebedor-->
+        <field
+            name="partner_receivering_id"
+            ref="l10n_br_base.res_partner_cliente4_am"
+        />
+
+        <field name="user_id" ref="base.user_demo" />
+        <field name="fiscal_operation_type">out</field>
+
+        <field name="cte40_proPred">XYZ Product</field>
+        <field name="cte40_xOutCat">Other Product Data</field>
+        <field name="cte40_vCarga">1000</field>
+        <field name="cte40_vCargaAverb">1000</field>
+
+    </record>
+
+    <!-- CTe Test - Modal Aereo - LC - Cargo Quantity Infos -->
+    <record
+        id="demo_cte_lr_modal_aereo_cargo_quantity_info_1"
+        model="l10n_br_cte.cargo.quantity.infos"
+    >
+        <field name="document_id" ref="demo_cte_lr_modal_aereo" />
+        <field name="cte40_cUnid">00</field>
+        <field name="cte40_tpMed">Volume</field>
+        <field name="cte40_qCarga">1000.0</field>
+    </record>
+
+    <record
+        id="demo_cte_lr_modal_aereo_cargo_quantity_info_2"
+        model="l10n_br_cte.cargo.quantity.infos"
+    >
+        <field name="document_id" ref="demo_cte_lr_modal_aereo" />
+        <field name="cte40_cUnid">01</field>
+        <field name="cte40_tpMed">Peso Bruto</field>
+        <field name="cte40_qCarga">500.0</field>
+    </record>
+
+    <record
+        id="demo_cte_lr_modal_aereo_cargo_quantity_info_3"
+        model="l10n_br_cte.cargo.quantity.infos"
+    >
+        <field name="document_id" ref="demo_cte_lr_modal_aereo" />
+        <field name="cte40_cUnid">03</field>
+        <field name="cte40_tpMed">Unidade</field>
+        <field name="cte40_qCarga">2</field>
+    </record>
+
+    <!-- CTe Test - Modal Aereo - LC - Document Lines -->
+    <record id="demo_cte_lr_modal_aereo_1-1" model="l10n_br_fiscal.document.line">
+        <field name="document_id" ref="demo_cte_lr_modal_aereo" />
+        <field name="name">Frete</field>
+        <field name="product_id" ref="product.product_product_9" />
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="quantity">1</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_revenda" />
+    </record>
+
+    <!-- CTe Test - Modal Arere - LC - Document Related -->
+    <record
+        id="demo_cte_lr_modal_aereo_related_nfe"
+        model="l10n_br_fiscal.document.related"
+    >
+        <field name="document_id" ref="demo_cte_lr_modal_aereo" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
+        <field name="document_key">41190806117473000150550010000586251016759484</field>
+        <field name="document_total_weight">10</field>
+        <field name="document_total_amount">33.19</field>
+    </record>
+
+    <!-- CTe Test - Modal Aquaviario - LC -->
+    <record id="demo_cte_lr_modal_aquaviario" model="l10n_br_fiscal.document">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_57" />
+        <field
+            name="document_serie_id"
+            ref="l10n_br_fiscal.empresa_lr_document_57_serie_1"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="document_number">585</field>
+        <field name="document_serie">1</field>
+        <field name="document_key">35240781583054000129570010000057511040645897</field>
+        <field name="cte_environment">2</field>
+        <field name="processador_edoc">oca</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
+        <field name="service_provider">3</field>
+        <field name="transport_modal">03</field>
+
+        <!--Remetente-->
+        <field name="partner_sendering_id" ref="l10n_br_base.res_partner_cliente2_sp" />
+
+        <!--Expedidor-->
+        <field
+            name="partner_shippering_id"
+            ref="l10n_br_base.res_partner_cliente2_sp"
+        />
+
+        <!--Destinatario-->
+        <field name="partner_shipping_id" ref="l10n_br_base.res_partner_cliente3_am" />
+
+        <!--Recebedor-->
+        <field
+            name="partner_receivering_id"
+            ref="l10n_br_base.res_partner_cliente4_am"
+        />
+
+        <field name="user_id" ref="base.user_demo" />
+        <field name="fiscal_operation_type">out</field>
+
+        <field name="cte40_proPred">XYZ Product</field>
+        <field name="cte40_xOutCat">Other Product Data</field>
+        <field name="cte40_vCarga">1000</field>
+        <field name="cte40_vCargaAverb">1000</field>
+
+    </record>
+
+    <!-- CTe Test - Modal Aquaviario - LC - Cargo Quantity Infos -->
+    <record
+        id="demo_cte_lr_modal_aquaviario_cargo_quantity_info_1"
+        model="l10n_br_cte.cargo.quantity.infos"
+    >
+        <field name="document_id" ref="demo_cte_lr_modal_aquaviario" />
+        <field name="cte40_cUnid">00</field>
+        <field name="cte40_tpMed">Volume</field>
+        <field name="cte40_qCarga">1000.0</field>
+    </record>
+
+    <record
+        id="demo_cte_lr_modal_aquaviario_cargo_quantity_info_2"
+        model="l10n_br_cte.cargo.quantity.infos"
+    >
+        <field name="document_id" ref="demo_cte_lr_modal_aquaviario" />
+        <field name="cte40_cUnid">01</field>
+        <field name="cte40_tpMed">Peso Bruto</field>
+        <field name="cte40_qCarga">500.0</field>
+    </record>
+
+    <record
+        id="demo_cte_lr_modal_aquaviario_cargo_quantity_info_3"
+        model="l10n_br_cte.cargo.quantity.infos"
+    >
+        <field name="document_id" ref="demo_cte_lr_modal_aquaviario" />
+        <field name="cte40_cUnid">03</field>
+        <field name="cte40_tpMed">Unidade</field>
+        <field name="cte40_qCarga">2</field>
+    </record>
+
+    <!-- CTe Test - Modal Aquaviario - LC - Document Lines -->
+    <record id="demo_cte_lr_modal_aquaviario_1-1" model="l10n_br_fiscal.document.line">
+        <field name="document_id" ref="demo_cte_lr_modal_aquaviario" />
+        <field name="name">Frete</field>
+        <field name="product_id" ref="product.product_product_9" />
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="quantity">1</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_revenda" />
+    </record>
+
+    <!-- CTe Test - Modal Aquaviario - LC - Document Related -->
+    <record
+        id="demo_cte_lr_modal_aquaviario_related_nfe"
+        model="l10n_br_fiscal.document.related"
+    >
+        <field name="document_id" ref="demo_cte_lr_modal_aquaviario" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
+        <field name="document_key">41190806117473000150550010000586251016759484</field>
+        <field name="document_total_weight">10</field>
+        <field name="document_total_amount">33.19</field>
+    </record>
+
+    <!-- CTe Test - Modal Ferroviario - LC -->
+    <record id="demo_cte_lr_modal_ferroviario" model="l10n_br_fiscal.document">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_57" />
+        <field
+            name="document_serie_id"
+            ref="l10n_br_fiscal.empresa_lr_document_57_serie_1"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="document_number">586</field>
+        <field name="document_serie">1</field>
+        <field name="document_key">35240781583054000129570010000057611040645893</field>
+        <field name="cte_environment">2</field>
+        <field name="processador_edoc">oca</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
+        <field name="service_provider">3</field>
+        <field name="transport_modal">04</field>
+
+        <!--Remetente-->
+        <field name="partner_sendering_id" ref="l10n_br_base.res_partner_cliente2_sp" />
+
+        <!--Expedidor-->
+        <field
+            name="partner_shippering_id"
+            ref="l10n_br_base.res_partner_cliente2_sp"
+        />
+
+        <!--Destinatario-->
+        <field name="partner_shipping_id" ref="l10n_br_base.res_partner_cliente3_am" />
+
+        <!--Recebedor-->
+        <field
+            name="partner_receivering_id"
+            ref="l10n_br_base.res_partner_cliente4_am"
+        />
+
+        <field name="user_id" ref="base.user_demo" />
+        <field name="fiscal_operation_type">out</field>
+
+        <field name="cte40_proPred">XYZ Product</field>
+        <field name="cte40_xOutCat">Other Product Data</field>
+        <field name="cte40_vCarga">1000</field>
+        <field name="cte40_vCargaAverb">1000</field>
+
+    </record>
+
+    <!-- CTe Test - Modal Ferroviario - LC - Cargo Quantity Infos -->
+    <record
+        id="demo_cte_lr_modal_ferroviario_cargo_quantity_info_1"
+        model="l10n_br_cte.cargo.quantity.infos"
+    >
+        <field name="document_id" ref="demo_cte_lr_modal_ferroviario" />
+        <field name="cte40_cUnid">00</field>
+        <field name="cte40_tpMed">Volume</field>
+        <field name="cte40_qCarga">1000.0</field>
+    </record>
+
+    <record
+        id="demo_cte_lr_modal_ferroviario_cargo_quantity_info_2"
+        model="l10n_br_cte.cargo.quantity.infos"
+    >
+        <field name="document_id" ref="demo_cte_lr_modal_ferroviario" />
+        <field name="cte40_cUnid">01</field>
+        <field name="cte40_tpMed">Peso Bruto</field>
+        <field name="cte40_qCarga">500.0</field>
+    </record>
+
+    <record
+        id="demo_cte_lr_modal_ferroviario_cargo_quantity_info_3"
+        model="l10n_br_cte.cargo.quantity.infos"
+    >
+        <field name="document_id" ref="demo_cte_lr_modal_ferroviario" />
+        <field name="cte40_cUnid">03</field>
+        <field name="cte40_tpMed">Unidade</field>
+        <field name="cte40_qCarga">2</field>
+    </record>
+
+    <!-- CTe Test - Modal Ferroviario - LC - Document Lines -->
+    <record id="demo_cte_lr_modal_ferroviario_1-1" model="l10n_br_fiscal.document.line">
+        <field name="document_id" ref="demo_cte_lr_modal_ferroviario" />
+        <field name="name">Frete</field>
+        <field name="product_id" ref="product.product_product_9" />
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="quantity">1</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_revenda" />
+    </record>
+
+    <!-- CTe Test - Modal Ferroviario - LC - Document Related -->
+    <record
+        id="demo_cte_lr_modal_ferroviario_related_nfe"
+        model="l10n_br_fiscal.document.related"
+    >
+        <field name="document_id" ref="demo_cte_lr_modal_ferroviario" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
+        <field name="document_key">41190806117473000150550010000586251016759484</field>
+        <field name="document_total_weight">10</field>
+        <field name="document_total_amount">33.19</field>
+    </record>
+
+    <!-- CTe Test - Modal Dutoviario - LC -->
+    <record id="demo_cte_lr_modal_dutoviario" model="l10n_br_fiscal.document">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_57" />
+        <field
+            name="document_serie_id"
+            ref="l10n_br_fiscal.empresa_lr_document_57_serie_1"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="document_number">587</field>
+        <field name="document_serie">1</field>
+        <field name="document_key">35240781583054000129570010000057711040645890</field>
+        <field name="cte_environment">2</field>
+        <field name="processador_edoc">oca</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
+        <field name="service_provider">3</field>
+        <field name="transport_modal">05</field>
+
+        <!--Remetente-->
+        <field name="partner_sendering_id" ref="l10n_br_base.res_partner_cliente2_sp" />
+
+        <!--Expedidor-->
+        <field
+            name="partner_shippering_id"
+            ref="l10n_br_base.res_partner_cliente2_sp"
+        />
+
+        <!--Destinatario-->
+        <field name="partner_shipping_id" ref="l10n_br_base.res_partner_cliente3_am" />
+
+        <!--Recebedor-->
+        <field
+            name="partner_receivering_id"
+            ref="l10n_br_base.res_partner_cliente4_am"
+        />
+
+        <field name="user_id" ref="base.user_demo" />
+        <field name="fiscal_operation_type">out</field>
+
+        <field name="cte40_proPred">XYZ Product</field>
+        <field name="cte40_xOutCat">Other Product Data</field>
+        <field name="cte40_vCarga">1000</field>
+        <field name="cte40_vCargaAverb">1000</field>
+
+    </record>
+
+    <!-- CTe Test - Modal Dutoviario - LC - Cargo Quantity Infos -->
+    <record
+        id="demo_cte_lr_modal_dutoviario_cargo_quantity_info_1"
+        model="l10n_br_cte.cargo.quantity.infos"
+    >
+        <field name="document_id" ref="demo_cte_lr_modal_dutoviario" />
+        <field name="cte40_cUnid">00</field>
+        <field name="cte40_tpMed">Volume</field>
+        <field name="cte40_qCarga">1000.0</field>
+    </record>
+
+    <record
+        id="demo_cte_lr_modal_dutoviario_cargo_quantity_info_2"
+        model="l10n_br_cte.cargo.quantity.infos"
+    >
+        <field name="document_id" ref="demo_cte_lr_modal_dutoviario" />
+        <field name="cte40_cUnid">01</field>
+        <field name="cte40_tpMed">Peso Bruto</field>
+        <field name="cte40_qCarga">500.0</field>
+    </record>
+
+    <record
+        id="demo_cte_lr_modal_dutoviario_cargo_quantity_info_3"
+        model="l10n_br_cte.cargo.quantity.infos"
+    >
+        <field name="document_id" ref="demo_cte_lr_modal_dutoviario" />
+        <field name="cte40_cUnid">03</field>
+        <field name="cte40_tpMed">Unidade</field>
+        <field name="cte40_qCarga">2</field>
+    </record>
+
+    <!-- CTe Test - Modal Dutoviario - LC - Document Lines -->
+    <record id="demo_cte_lr_modal_dutoviario_1-1" model="l10n_br_fiscal.document.line">
+        <field name="document_id" ref="demo_cte_lr_modal_dutoviario" />
+        <field name="name">Frete</field>
+        <field name="product_id" ref="product.product_product_9" />
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="quantity">1</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_revenda" />
+    </record>
+
+    <!-- CTe Test - Modal Dutoviario - LC - Document Related -->
+    <record
+        id="demo_cte_lr_modal_dutoviario_related_nfe"
+        model="l10n_br_fiscal.document.related"
+    >
+        <field name="document_id" ref="demo_cte_lr_modal_dutoviario" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
+        <field name="document_key">41190806117473000150550010000586251016759484</field>
+        <field name="document_total_weight">10</field>
+        <field name="document_total_amount">33.19</field>
+    </record>
+
     <!-- Empresa Simples Nacional -->
 
     <!-- CTe Test - Modal Rodoviário - SN -->

--- a/l10n_br_fiscal/data/operation_data.xml
+++ b/l10n_br_fiscal/data/operation_data.xml
@@ -478,6 +478,70 @@
         <field name="state">approved</field>
     </record>
 
+    <record id="fo_transferencia" model="l10n_br_fiscal.operation">
+        <field name="code">TR</field>
+        <field name="name">Transferência</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">return_out</field>
+        <field name="default_price_unit">cost_price</field>
+        <field name="state">approved</field>
+    </record>
+
+    <record id="fol_manifesto_produto_acabado" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_transferencia" />
+        <field name="name">Transferenia de Produção</field>
+        <field name="tax_classification_id" ref="tax_classification_410002" />
+        <field name="product_type">04</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">return_out</field>
+        <field name="add_to_amount" eval="True" />
+        <field name="state">approved</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5151" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6151" />
+    </record>
+
+    <record id="fol_manifesto_mercadoria" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_transferencia" />
+        <field name="name">Transferenia de Mercadoria</field>
+        <field name="tax_classification_id" ref="tax_classification_410002" />
+        <field name="product_type">00</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">return_out</field>
+        <field name="add_to_amount" eval="True" />
+        <field name="state">approved</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5152" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6152" />
+    </record>
+
+    <record id="fol_manifesto_ativo" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_transferencia" />
+        <field name="name">Transferenia de Ativo Imobilizado</field>
+        <field name="tax_classification_id" ref="tax_classification_410002" />
+        <field name="product_type">08</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">return_out</field>
+        <field name="add_to_amount" eval="True" />
+        <field name="state">approved</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5552" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6552" />
+    </record>
+
+    <record
+        id="fol_manifesto_material_uso_consumo"
+        model="l10n_br_fiscal.operation.line"
+    >
+        <field name="fiscal_operation_id" ref="fo_transferencia" />
+        <field name="name">Transferenia Material de Uso e Consumo</field>
+        <field name="tax_classification_id" ref="tax_classification_410002" />
+        <field name="product_type">07</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">return_out</field>
+        <field name="add_to_amount" eval="True" />
+        <field name="state">approved</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5557" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6557" />
+    </record>
+
     <!-- l10n_br_fiscal.operation relations -->
     <record id="fo_venda" model="l10n_br_fiscal.operation">
         <field name="return_fiscal_operation_id" ref="fo_devolucao_venda" />

--- a/l10n_br_fiscal/demo/company_demo.xml
+++ b/l10n_br_fiscal/demo/company_demo.xml
@@ -2,33 +2,6 @@
 <odoo noupdate="1">
 
     <!-- Sua Empresa -->
-    <record id="base.main_partner" model="res.partner">
-        <field
-            name="fiscal_profile_id"
-            ref="l10n_br_fiscal.partner_fiscal_profile_snc"
-        />
-        <field name="legal_nature_id" ref="l10n_br_fiscal.legal_nature_2062" />
-    </record>
-
-    <!-- Empresa Lucro Presumido -->
-    <record id="l10n_br_base.lucro_presumido_partner" model="res.partner">
-        <field
-            name="fiscal_profile_id"
-            ref="l10n_br_fiscal.partner_fiscal_profile_cnt"
-        />
-        <field name="legal_nature_id" ref="l10n_br_fiscal.legal_nature_2062" />
-    </record>
-
-    <!-- Empresa Simples Nacional -->
-    <record id="l10n_br_base.simples_nacional_partner" model="res.partner">
-        <field
-            name="fiscal_profile_id"
-            ref="l10n_br_fiscal.partner_fiscal_profile_snc"
-        />
-        <field name="legal_nature_id" ref="l10n_br_fiscal.legal_nature_2062" />
-    </record>
-
-    <!-- Sua Empresa -->
     <record id="base.main_company" model="res.company">
         <field name="tax_framework">1</field>
         <field name="is_industry" eval="True" />

--- a/l10n_br_fiscal/demo/fiscal_document_demo.xml
+++ b/l10n_br_fiscal/demo/fiscal_document_demo.xml
@@ -574,4 +574,399 @@
     >
     </record>
 
+    <!-- NFe Test - Empresa Lucro Real -->
+
+    <!-- NFe Test - Empresa Lucro Real - Mesmo Estado -->
+    <record id="demo_nfe_lr_same_state" model="l10n_br_fiscal.document">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
+        <field
+            name="document_serie_id"
+            ref="l10n_br_fiscal.empresa_lr_document_55_serie_1"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="document_serie">1</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
+        <field name="user_id" ref="base.user_demo" />
+        <field name="fiscal_operation_type">out</field>
+<!--        <field name="file_xml_autorizacao_id" ref="dummy_file_1"/> FIXME: Este é um campo related!!!!-->
+    </record>
+
+    <record id="demo_nfe_line_lr_same_state_1-1" model="l10n_br_fiscal.document.line">
+        <field name="document_id" ref="demo_nfe_lr_same_state" />
+        <field name="name">Teste</field>
+        <field name="product_id" ref="product.product_product_6" />
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="quantity">1</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda" />
+    </record>
+
+    <record id="demo_nfe_line_lr_same_state_1-1" model="l10n_br_fiscal.document.line">
+    </record>
+
+    <record id="demo_nfe_line_lr_same_state_1-2" model="l10n_br_fiscal.document.line">
+        <field name="document_id" ref="demo_nfe_lr_same_state" />
+        <field name="name">Teste</field>
+        <field name="product_id" ref="product.product_product_27" />
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="quantity">1</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda" />
+    </record>
+
+    <record id="demo_nfe_line_lr_same_state_1-2" model="l10n_br_fiscal.document.line">
+    </record>
+
+    <!-- NFe Test - Empresa Lucro Real - Outro Estado -->
+    <record id="demo_nfe_lr_other_state" model="l10n_br_fiscal.document">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
+        <field
+            name="document_serie_id"
+            ref="l10n_br_fiscal.empresa_lr_document_55_serie_1"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="document_serie">1</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente5_pe" />
+        <field name="user_id" ref="base.user_demo" />
+        <field name="fiscal_operation_type">out</field>
+    </record>
+
+    <record id="demo_nfe_line_lr_other_state_1-3" model="l10n_br_fiscal.document.line">
+        <field name="document_id" ref="demo_nfe_lr_other_state" />
+        <field name="name">Teste</field>
+        <field name="product_id" ref="product.product_product_6" />
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="quantity">1</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda" />
+    </record>
+
+    <record id="demo_nfe_line_lr_other_state_1-3" model="l10n_br_fiscal.document.line">
+    </record>
+
+    <record id="demo_nfe_line_lr_other_state_2-3" model="l10n_br_fiscal.document.line">
+        <field name="document_id" ref="demo_nfe_lr_other_state" />
+        <field name="name">Teste</field>
+        <field name="product_id" ref="product.product_product_27" />
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="quantity">1</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda" />
+    </record>
+
+    <record id="demo_nfe_line_lr_other_state_2-3" model="l10n_br_fiscal.document.line">
+    </record>
+
+    <record id="demo_nfe_line_lr_other_state_3-3" model="l10n_br_fiscal.document.line">
+        <field name="document_id" ref="demo_nfe_lr_other_state" />
+        <field name="name">Teste</field>
+        <field name="product_id" ref="product.product_product_25" />
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="price_unit">2400</field>
+        <field name="quantity">1</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda" />
+    </record>
+
+    <record id="demo_nfe_line_lr_other_state_3-3" model="l10n_br_fiscal.document.line">
+    </record>
+
+    <!-- NFe Test - Empresa Lucro Real - Exterior -->
+    <record id="demo_nfe_lr_export" model="l10n_br_fiscal.document">
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
+        <field
+            name="document_serie_id"
+            ref="l10n_br_fiscal.empresa_lr_document_55_serie_1"
+        />
+        <field name="document_serie">1</field>
+        <field name="user_id" ref="base.user_demo" />
+        <field name="document_key">26180812984794000154550010000016871192213339</field>
+        <field name="document_number">19221333</field>
+        <field name="partner_id" ref="base.res_partner_2" />
+        <field name="fiscal_operation_type">out</field>
+    </record>
+
+    <record id="demo_nfe_line_lr_export_3-1" model="l10n_br_fiscal.document.line">
+        <field name="document_id" ref="demo_nfe_lr_export" />
+        <field name="name">Teste</field>
+        <field name="product_id" ref="product.product_product_6" />
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="quantity">1</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda" />
+    </record>
+
+    <record id="demo_nfe_line_lr_export_3-1" model="l10n_br_fiscal.document.line">
+    </record>
+
+    <record id="demo_nfe_line_lr_export_3-2" model="l10n_br_fiscal.document.line">
+        <field name="document_id" ref="demo_nfe_lr_export" />
+        <field name="name">Teste</field>
+        <field name="product_id" ref="product.product_product_27" />
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="quantity">1</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda" />
+    </record>
+
+    <record id="demo_nfe_line_lr_export_3-2" model="l10n_br_fiscal.document.line">
+    </record>
+
+    <!-- NFe Test - Empresa Lucro Real - Nao Contribuinte PJ -->
+    <record id="demo_nfe_lr_nao_contribuinte" model="l10n_br_fiscal.document">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
+        <field
+            name="document_serie_id"
+            ref="l10n_br_fiscal.empresa_lr_document_55_serie_1"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="document_serie">1</field>
+                <field name="partner_id" ref="l10n_br_base.res_partner_cliente9_mg" />
+        <field name="user_id" ref="base.user_demo" />
+        <field name="fiscal_operation_type">out</field>
+    </record>
+
+    <record
+        id="demo_nfe_line_lr_nao_contribuinte_4-1"
+        model="l10n_br_fiscal.document.line"
+    >
+        <field name="document_id" ref="demo_nfe_lr_nao_contribuinte" />
+        <field name="name">Teste</field>
+        <field name="product_id" ref="product.product_product_6" />
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="quantity">1</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_venda_venda_nao_contribuinte"
+        />
+        <field
+            name="comment_ids"
+            eval="[Command.set([ref('l10n_br_fiscal.fiscal_line_comment_dummy')])]"
+        />
+        <field name="manual_additional_data">manual comment test</field>
+    </record>
+
+    <record
+        id="demo_nfe_line_lr_nao_contribuinte_4-1"
+        model="l10n_br_fiscal.document.line"
+    >
+    </record>
+
+    <record
+        id="demo_nfe_line_lr_nao_contribuinte_4-2"
+        model="l10n_br_fiscal.document.line"
+    >
+        <field name="document_id" ref="demo_nfe_lr_nao_contribuinte" />
+        <field name="name">Teste</field>
+        <field name="product_id" ref="product.product_product_27" />
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="quantity">1</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_venda_venda_nao_contribuinte"
+        />
+    </record>
+
+    <record
+        id="demo_nfe_line_lr_nao_contribuinte_4-2"
+        model="l10n_br_fiscal.document.line"
+    >
+    </record>
+
+    <!-- NFe Test - Empresa Lucro Real - Nao Contribuinte PJ Tax Benefit -->
+    <record id="demo_nfe_lr_tax_benefit" model="l10n_br_fiscal.document">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
+        <field
+            name="document_serie_id"
+            ref="l10n_br_fiscal.empresa_lr_document_55_serie_1"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="document_serie">1</field>
+                <field name="partner_id" ref="l10n_br_base.res_partner_cliente9_mg" />
+        <field name="user_id" ref="base.user_demo" />
+        <field name="fiscal_operation_type">out</field>
+    </record>
+
+    <record id="demo_nfe_lr_tax_benefit_4-1" model="l10n_br_fiscal.document.line">
+        <field name="document_id" ref="demo_nfe_lr_tax_benefit" />
+        <field name="name">Teste</field>
+        <field name="product_id" ref="product.product_product_7" />
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="quantity">1</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_venda_venda_nao_contribuinte"
+        />
+        <field
+            name="comment_ids"
+            eval="[Command.set([ref('l10n_br_fiscal.fiscal_line_comment_dummy')])]"
+        />
+        <field name="manual_additional_data">manual comment test</field>
+    </record>
+
+    <record id="demo_nfe_lr_tax_benefit_4-1" model="l10n_br_fiscal.document.line">
+    </record>
+
+    <!-- NFe Test - Empresa Lucro Real - Nao Contribuinte PF -->
+    <record id="demo_nfe_lr_nao_contribuinte_pf" model="l10n_br_fiscal.document">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
+        <field
+            name="document_serie_id"
+            ref="l10n_br_fiscal.empresa_lr_document_55_serie_1"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="document_serie">1</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente10_mg" />
+        <field name="user_id" ref="base.user_demo" />
+        <field name="fiscal_operation_type">out</field>
+    </record>
+
+    <record
+        id="demo_nfe_lr_nao_contribuinte_pf_1-2"
+        model="l10n_br_fiscal.document.line"
+    >
+        <field name="document_id" ref="demo_nfe_lr_nao_contribuinte_pf" />
+        <field name="name">Teste</field>
+        <field name="product_id" ref="product.product_product_6" />
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="quantity">1</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_venda_venda_nao_contribuinte"
+        />
+    </record>
+
+    <record
+        id="demo_nfe_lr_nao_contribuinte_pf_1-2"
+        model="l10n_br_fiscal.document.line"
+    >
+    </record>
+
+    <record
+        id="demo_nfe_lr_nao_contribuinte_pf_2-2"
+        model="l10n_br_fiscal.document.line"
+    >
+        <field name="document_id" ref="demo_nfe_lr_nao_contribuinte_pf" />
+        <field name="name">Teste</field>
+        <field name="product_id" ref="product.product_product_27" />
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="quantity">1</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_venda_venda_nao_contribuinte"
+        />
+    </record>
+
+    <record
+        id="demo_nfe_lr_nao_contribuinte_pf_2-2"
+        model="l10n_br_fiscal.document.line"
+    >
+    </record>
+
+    <!-- NFe Test - Subsequent Operation - Simples Faturamento -->
+    <record id="demo_nfe_lr_so_simples_faturamento" model="l10n_br_fiscal.document">
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_simples_faturamento" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
+        <field
+            name="document_serie_id"
+            ref="l10n_br_fiscal.empresa_lr_document_55_serie_1"
+        />
+        <field name="document_serie">1</field>
+        <field name="document_key">35200497231608000169550010000000371161029083</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
+        <field name="user_id" ref="base.user_demo" />
+        <field name="fiscal_operation_type">out</field>
+    </record>
+
+    <record
+        id="demo_nfe_line_lr_so_simples_faturamento_7-1"
+        model="l10n_br_fiscal.document.line"
+    >
+        <field name="document_id" ref="demo_nfe_lr_so_simples_faturamento" />
+        <field name="name">Teste</field>
+        <field name="product_id" ref="product.product_product_6" />
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="quantity">1</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_simples_faturamento" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_simples_faturamento_simples_faturamento"
+        />
+        <field name="icms_tax_id" ref="l10n_br_fiscal.tax_icms_0" />
+        <field name="pis_tax_id" ref="l10n_br_fiscal.tax_pis_0_65" />
+        <field name="cofins_tax_id" ref="l10n_br_fiscal.tax_cofins_3" />
+        <field name="cfop_id" ref="l10n_br_fiscal.cfop_5922" />
+    </record>
+
+    <record
+        id="demo_nfe_line_lr_so_simples_faturamento_7-1"
+        model="l10n_br_fiscal.document.line"
+    >
+    </record>
+
+    <!-- NFe Compras Test - Empresa Lucro Real - Mesmo Estado -->
+    <record id="demo_nfe_purchase_lr_same_state" model="l10n_br_fiscal.document">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="document_serie">1</field>
+        <field name="document_number">123</field>
+        <field name="issuer">partner</field>
+        <!-- Fornecedor contribuinte normal (perfil CNT), coerente com a NF
+             destacando ICMS/IPI. Um fornecedor Simples (ex.: akretion/SNN)
+             não destacaria esses impostos. -->
+        <field name="partner_id" ref="l10n_br_base.res_partner_intel" />
+        <field name="user_id" ref="base.user_demo" />
+        <field name="fiscal_operation_type">in</field>
+    </record>
+
+    <record
+        id="demo_nfe_purchase_line_lr_same_state_1-1"
+        model="l10n_br_fiscal.document.line"
+    >
+        <field name="document_id" ref="demo_nfe_purchase_lr_same_state" />
+        <field name="name">Purchase Test</field>
+        <field name="product_id" ref="product.product_product_6" />
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="quantity">1</field>
+        <field name="fiscal_operation_type">in</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_compras_compras"
+        />
+    </record>
+
+    <record
+        id="demo_nfe_purchase_line_lr_same_state_1-1"
+        model="l10n_br_fiscal.document.line"
+    >
+    </record>
+
 </odoo>

--- a/l10n_br_fiscal/demo/product_demo.xml
+++ b/l10n_br_fiscal/demo/product_demo.xml
@@ -45,6 +45,23 @@
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
+    <!-- fiscal_type property for product_product_1 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="fiscal_type_product_product_1_lr"
+        model="ir.property"
+    >
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">09</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_1').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
 
     <!-- Virtual Home Staging -->
     <record id="product.product_product_2" model="product.product">
@@ -89,6 +106,23 @@
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
+    <!-- fiscal_type property for product_product_2 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="fiscal_type_product_product_2_lr"
+        model="ir.property"
+    >
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">09</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_2').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
 
     <record id="product.expense_hotel" model="product.product">
         <field name="ncm_id" ref="l10n_br_fiscal.ncm_00000000" />
@@ -123,6 +157,19 @@
             name="res_id"
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+    <!-- fiscal_type property for expense_hotel for lucro real company -->
+    <record forcecreate="True" id="fiscal_type_expense_hotel_lr" model="ir.property">
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">09</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.expense_hotel').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
     </record>
 
     <!-- Physical Products -->
@@ -167,6 +214,23 @@
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
+    <!-- fiscal_type property for product_delivery_01 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="fiscal_type_product_delivery_01_lr"
+        model="ir.property"
+    >
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">00</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_delivery_01').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
     <!-- icms_origin property for product_delivery_01 for simples nacional company -->
     <record
         forcecreate="True"
@@ -200,6 +264,23 @@
             name="res_id"
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+    <!-- icms_origin property for product_delivery_01 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="icms_origin_product_delivery_01_lr"
+        model="ir.property"
+    >
+        <field name="name">icms_origin</field>
+        <field name="fields_id" ref="field_product_template__icms_origin" />
+        <field name="value">5</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_delivery_01').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
     </record>
 
     <!-- Office Lamp -->
@@ -244,6 +325,23 @@
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
+    <!-- fiscal_type property for product_delivery_02 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="fiscal_type_product_delivery_02_lr"
+        model="ir.property"
+    >
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">00</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_delivery_02').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
     <!-- icms_origin property for product_delivery_02 for simples nacional company -->
     <record
         forcecreate="True"
@@ -277,6 +375,23 @@
             name="res_id"
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+    <!-- icms_origin property for product_delivery_02 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="icms_origin_product_delivery_02_lr"
+        model="ir.property"
+    >
+        <field name="name">icms_origin</field>
+        <field name="fields_id" ref="field_product_template__icms_origin" />
+        <field name="value">5</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_delivery_02').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
     </record>
 
     <!-- Office Design Software -->
@@ -312,6 +427,19 @@
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
+    <!-- fiscal_type property for product_order_01 for lucro real company -->
+    <record forcecreate="True" id="fiscal_type_product_order_01_lr" model="ir.property">
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">00</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_order_01').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
     <!-- icms_origin property for product_order_01 for simples nacional company -->
     <record forcecreate="True" id="icms_origin_product_order_01_sn" model="ir.property">
         <field name="name">icms_origin</field>
@@ -337,6 +465,19 @@
             name="res_id"
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+    <!-- icms_origin property for product_order_01 for lucro real company -->
+    <record forcecreate="True" id="icms_origin_product_order_01_lr" model="ir.property">
+        <field name="name">icms_origin</field>
+        <field name="fields_id" ref="field_product_template__icms_origin" />
+        <field name="value">5</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_order_01').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
     </record>
 
     <!-- Desk Combination -->
@@ -380,6 +521,23 @@
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
+    <!-- fiscal_type property for product_product_3 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="fiscal_type_product_product_3_lr"
+        model="ir.property"
+    >
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">04</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_3').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
     <!-- icms_origin property for product_product_3 for simples nacional company -->
     <record
         forcecreate="True"
@@ -413,6 +571,23 @@
             name="res_id"
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+    <!-- icms_origin property for product_product_3 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="icms_origin_product_product_3_lr"
+        model="ir.property"
+    >
+        <field name="name">icms_origin</field>
+        <field name="fields_id" ref="field_product_template__icms_origin" />
+        <field name="value">0</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_3').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
     </record>
 
     <!-- FURN_0096 - Customizable Desk -->
@@ -456,6 +631,23 @@
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
+    <!-- fiscal_type property for product_product_4 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="fiscal_type_product_product_4_lr"
+        model="ir.property"
+    >
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">04</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_4').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
     <!-- icms_origin property for product_product_4 for simples nacional company -->
     <record
         forcecreate="True"
@@ -489,6 +681,23 @@
             name="res_id"
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+    <!-- icms_origin property for product_product_4 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="icms_origin_product_product_4_lr"
+        model="ir.property"
+    >
+        <field name="name">icms_origin</field>
+        <field name="fields_id" ref="field_product_template__icms_origin" />
+        <field name="value">5</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_4').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
     </record>
 
     <!-- FURN_0097 - Customizable Desk -->
@@ -548,6 +757,23 @@
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
+    <!-- fiscal_type property for product_product_5 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="fiscal_type_product_product_5_lr"
+        model="ir.property"
+    >
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">00</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_5').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
     <!-- icms_origin property for product_product_5 for simples nacional company -->
     <record
         forcecreate="True"
@@ -581,6 +807,23 @@
             name="res_id"
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+    <!-- icms_origin property for product_product_5 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="icms_origin_product_product_5_lr"
+        model="ir.property"
+    >
+        <field name="name">icms_origin</field>
+        <field name="fields_id" ref="field_product_template__icms_origin" />
+        <field name="value">0</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_5').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
     </record>
 
     <!-- Large Cabinet -->
@@ -624,6 +867,23 @@
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
+    <!-- fiscal_type property for product_product_6 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="fiscal_type_product_product_6_lr"
+        model="ir.property"
+    >
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">00</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_6').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
     <!-- icms_origin property for product_product_6 for simples nacional company -->
     <record
         forcecreate="True"
@@ -657,6 +917,23 @@
             name="res_id"
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+    <!-- icms_origin property for product_product_6 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="icms_origin_product_product_6_lr"
+        model="ir.property"
+    >
+        <field name="name">icms_origin</field>
+        <field name="fields_id" ref="field_product_template__icms_origin" />
+        <field name="value">5</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_6').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
     </record>
 
     <!-- Storage Box -->
@@ -700,6 +977,23 @@
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
+    <!-- fiscal_type property for product_product_7 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="fiscal_type_product_product_7_lr"
+        model="ir.property"
+    >
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">00</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_7').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
     <!-- icms_origin property for product_product_7 for simples nacional company -->
     <record
         forcecreate="True"
@@ -733,6 +1027,23 @@
             name="res_id"
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+    <!-- icms_origin property for product_product_7 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="icms_origin_product_product_7_lr"
+        model="ir.property"
+    >
+        <field name="name">icms_origin</field>
+        <field name="fields_id" ref="field_product_template__icms_origin" />
+        <field name="value">5</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_7').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
     </record>
 
     <!-- Large Desk -->
@@ -776,6 +1087,23 @@
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
+    <!-- fiscal_type property for product_product_8 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="fiscal_type_product_product_8_lr"
+        model="ir.property"
+    >
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">00</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_8').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
     <!-- icms_origin property for product_product_8 for simples nacional company -->
     <record
         forcecreate="True"
@@ -809,6 +1137,23 @@
             name="res_id"
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+    <!-- icms_origin property for product_product_8 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="icms_origin_product_product_8_lr"
+        model="ir.property"
+    >
+        <field name="name">icms_origin</field>
+        <field name="fields_id" ref="field_product_template__icms_origin" />
+        <field name="value">5</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_8').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
     </record>
 
     <!-- Pedal Bin -->
@@ -852,6 +1197,23 @@
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
+    <!-- fiscal_type property for product_product_9 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="fiscal_type_product_product_9_lr"
+        model="ir.property"
+    >
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">00</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_9').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
     <!-- icms_origin property for product_product_9 for simples nacional company -->
     <record
         forcecreate="True"
@@ -885,6 +1247,23 @@
             name="res_id"
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+    <!-- icms_origin property for product_product_9 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="icms_origin_product_product_9_lr"
+        model="ir.property"
+    >
+        <field name="name">icms_origin</field>
+        <field name="fields_id" ref="field_product_template__icms_origin" />
+        <field name="value">2</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_9').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
     </record>
 
     <!-- Cabinet with Doors -->
@@ -928,6 +1307,23 @@
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
+    <!-- fiscal_type property for product_product_10 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="fiscal_type_product_product_10_lr"
+        model="ir.property"
+    >
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">00</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_10').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
     <!-- icms_origin property for product_product_10 for simples nacional company -->
     <record
         forcecreate="True"
@@ -961,6 +1357,23 @@
             name="res_id"
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+    <!-- icms_origin property for product_product_10 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="icms_origin_product_product_10_lr"
+        model="ir.property"
+    >
+        <field name="name">icms_origin</field>
+        <field name="fields_id" ref="field_product_template__icms_origin" />
+        <field name="value">0</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_10').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
     </record>
 
     <!-- Conference Chair -->
@@ -1004,6 +1417,23 @@
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
+    <!-- fiscal_type property for product_product_11 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="fiscal_type_product_product_11_lr"
+        model="ir.property"
+    >
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">00</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_11').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
     <!-- icms_origin property for product_product_11 for simples nacional company -->
     <record
         forcecreate="True"
@@ -1037,6 +1467,23 @@
             name="res_id"
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+    <!-- icms_origin property for product_product_11 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="icms_origin_product_product_11_lr"
+        model="ir.property"
+    >
+        <field name="name">icms_origin</field>
+        <field name="fields_id" ref="field_product_template__icms_origin" />
+        <field name="value">0</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_11').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
     </record>
 
     <!-- Conference Chair -->
@@ -1089,6 +1536,23 @@
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
+    <!-- fiscal_type property for product_product_12 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="fiscal_type_product_product_12_lr"
+        model="ir.property"
+    >
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">00</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_12').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
     <!-- icms_origin property for product_product_12 for simples nacional company -->
     <record
         forcecreate="True"
@@ -1122,6 +1586,23 @@
             name="res_id"
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+    <!-- icms_origin property for product_product_12 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="icms_origin_product_product_12_lr"
+        model="ir.property"
+    >
+        <field name="name">icms_origin</field>
+        <field name="fields_id" ref="field_product_template__icms_origin" />
+        <field name="value">0</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_12').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
     </record>
 
     <!-- Corner Desk Black -->
@@ -1165,6 +1646,23 @@
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
+    <!-- fiscal_type property for product_product_13 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="fiscal_type_product_product_13_lr"
+        model="ir.property"
+    >
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">00</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_13').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
     <!-- icms_origin property for product_product_13 for simples nacional company -->
     <record
         forcecreate="True"
@@ -1198,6 +1696,23 @@
             name="res_id"
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+    <!-- icms_origin property for product_product_13 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="icms_origin_product_product_13_lr"
+        model="ir.property"
+    >
+        <field name="name">icms_origin</field>
+        <field name="fields_id" ref="field_product_template__icms_origin" />
+        <field name="value">0</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_13').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
     </record>
 
     <!-- Drawer Black -->
@@ -1241,6 +1756,23 @@
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
+    <!-- fiscal_type property for product_product_16 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="fiscal_type_product_product_16_lr"
+        model="ir.property"
+    >
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">00</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_16').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
     <!-- icms_origin property for product_product_16 for simples nacional company -->
     <record
         forcecreate="True"
@@ -1274,6 +1806,23 @@
             name="res_id"
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+    <!-- icms_origin property for product_product_16 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="icms_origin_product_product_16_lr"
+        model="ir.property"
+    >
+        <field name="name">icms_origin</field>
+        <field name="fields_id" ref="field_product_template__icms_origin" />
+        <field name="value">5</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_16').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
     </record>
 
     <!-- Flipover -->
@@ -1317,6 +1866,23 @@
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
+    <!-- fiscal_type property for product_product_20 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="fiscal_type_product_product_20_lr"
+        model="ir.property"
+    >
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">00</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_20').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
     <!-- icms_origin property for product_product_20 for simples nacional company -->
     <record
         forcecreate="True"
@@ -1350,6 +1916,23 @@
             name="res_id"
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+    <!-- icms_origin property for product_product_20 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="icms_origin_product_product_20_lr"
+        model="ir.property"
+    >
+        <field name="name">icms_origin</field>
+        <field name="fields_id" ref="field_product_template__icms_origin" />
+        <field name="value">0</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_20').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
     </record>
 
     <!-- Desk Stand with Screen -->
@@ -1393,6 +1976,23 @@
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
+    <!-- fiscal_type property for product_product_22 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="fiscal_type_product_product_22_lr"
+        model="ir.property"
+    >
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">00</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_22').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
     <!-- icms_origin property for product_product_22 for simples nacional company -->
     <record
         forcecreate="True"
@@ -1426,6 +2026,23 @@
             name="res_id"
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+    <!-- icms_origin property for product_product_22 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="icms_origin_product_product_22_lr"
+        model="ir.property"
+    >
+        <field name="name">icms_origin</field>
+        <field name="fields_id" ref="field_product_template__icms_origin" />
+        <field name="value">0</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_22').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
     </record>
 
     <!-- Individual Workplace -->
@@ -1469,6 +2086,23 @@
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
+    <!-- fiscal_type property for product_product_24 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="fiscal_type_product_product_24_lr"
+        model="ir.property"
+    >
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">00</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_24').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
     <!-- icms_origin property for product_product_24 for simples nacional company -->
     <record
         forcecreate="True"
@@ -1502,6 +2136,23 @@
             name="res_id"
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+    <!-- icms_origin property for product_product_24 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="icms_origin_product_product_24_lr"
+        model="ir.property"
+    >
+        <field name="name">icms_origin</field>
+        <field name="fields_id" ref="field_product_template__icms_origin" />
+        <field name="value">0</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_24').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
     </record>
 
     <!-- Acoustic Bloc Screens -->
@@ -1545,6 +2196,23 @@
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
+    <!-- fiscal_type property for product_product_25 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="fiscal_type_product_product_25_lr"
+        model="ir.property"
+    >
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">00</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_25').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
     <!-- icms_origin property for product_product_25 for simples nacional company -->
     <record
         forcecreate="True"
@@ -1578,6 +2246,23 @@
             name="res_id"
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+    <!-- icms_origin property for product_product_25 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="icms_origin_product_product_25_lr"
+        model="ir.property"
+    >
+        <field name="name">icms_origin</field>
+        <field name="fields_id" ref="field_product_template__icms_origin" />
+        <field name="value">3</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_25').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
     </record>
 
     <!-- Drawer -->
@@ -1621,6 +2306,23 @@
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
+    <!-- fiscal_type property for product_product_27 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="fiscal_type_product_product_27_lr"
+        model="ir.property"
+    >
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">04</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_27').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
     <!-- icms_origin property for product_product_27 for simples nacional company -->
     <record
         forcecreate="True"
@@ -1654,6 +2356,23 @@
             name="res_id"
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+    <!-- icms_origin property for product_product_27 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="icms_origin_product_product_27_lr"
+        model="ir.property"
+    >
+        <field name="name">icms_origin</field>
+        <field name="fields_id" ref="field_product_template__icms_origin" />
+        <field name="value">5</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.product_product_27').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
     </record>
 
     <!-- Four Person Desk -->
@@ -1697,6 +2416,23 @@
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
+    <!-- fiscal_type property for consu_delivery_03 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="fiscal_type_consu_delivery_03_lr"
+        model="ir.property"
+    >
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">00</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.consu_delivery_03').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
     <!-- icms_origin property for consu_delivery_03 for simples nacional company -->
     <record
         forcecreate="True"
@@ -1730,6 +2466,23 @@
             name="res_id"
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+    <!-- icms_origin property for consu_delivery_03 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="icms_origin_consu_delivery_03_lr"
+        model="ir.property"
+    >
+        <field name="name">icms_origin</field>
+        <field name="fields_id" ref="field_product_template__icms_origin" />
+        <field name="value">0</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.consu_delivery_03').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
     </record>
 
     <!-- Large Meeting Table -->
@@ -1773,6 +2526,23 @@
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
+    <!-- fiscal_type property for consu_delivery_02 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="fiscal_type_consu_delivery_02_lr"
+        model="ir.property"
+    >
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">00</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.consu_delivery_02').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
     <!-- icms_origin property for consu_delivery_02 for simples nacional company -->
     <record
         forcecreate="True"
@@ -1806,6 +2576,23 @@
             name="res_id"
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+    <!-- icms_origin property for consu_delivery_02 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="icms_origin_consu_delivery_02_lr"
+        model="ir.property"
+    >
+        <field name="name">icms_origin</field>
+        <field name="fields_id" ref="field_product_template__icms_origin" />
+        <field name="value">0</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.consu_delivery_02').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
     </record>
 
     <!-- Three-Seat Sofa -->
@@ -1849,6 +2636,23 @@
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
+    <!-- fiscal_type property for consu_delivery_01 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="fiscal_type_consu_delivery_01_lr"
+        model="ir.property"
+    >
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">04</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.consu_delivery_01').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
     <!-- icms_origin property for consu_delivery_01 for simples nacional company -->
     <record
         forcecreate="True"
@@ -1883,6 +2687,23 @@
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
+    <!-- icms_origin property for consu_delivery_01 for lucro real company -->
+    <record
+        forcecreate="True"
+        id="icms_origin_consu_delivery_01_lr"
+        model="ir.property"
+    >
+        <field name="name">icms_origin</field>
+        <field name="fields_id" ref="field_product_template__icms_origin" />
+        <field name="value">0</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.consu_delivery_01').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
 
     <!-- TODO: Restaurant Expenses: How expenses must be record at fiscal? -->
     <record id="product.expense_product" model="product.product">
@@ -1914,6 +2735,19 @@
             name="res_id"
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+    <!-- fiscal_type property for expense_product for lucro real company -->
+    <record forcecreate="True" id="fiscal_type_expense_product_lr" model="ir.property">
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">99</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('product.expense_product').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
     </record>
 
     <!-- Service products -->
@@ -1967,6 +2801,23 @@
             name="res_id"
         />
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+    </record>
+    <!-- fiscal_type property for customized_development_sale for lucro real company -->
+    <record
+        forcecreate="True"
+        id="fiscal_type_customized_development_sale_lr"
+        model="ir.property"
+    >
+        <field name="name">fiscal_type</field>
+        <field name="fields_id" ref="field_product_template__fiscal_type" />
+        <field name="value">09</field>
+        <field name="type">selection</field>
+        <field
+            eval="'product.template,'+str(obj().env.ref('l10n_br_fiscal.customized_development_sale').product_tmpl_id.id)"
+            model="product.template"
+            name="res_id"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
     </record>
 
 </odoo>

--- a/l10n_br_fiscal_certificate/hooks.py
+++ b/l10n_br_fiscal_certificate/hooks.py
@@ -38,8 +38,9 @@ def post_init_hook(cr, registry):
     if env.cr.fetchone()[0]:
         companies = [
             env.ref("base.main_company", raise_if_not_found=False),
-            env.ref("l10n_br_base.empresa_lucro_presumido", raise_if_not_found=False),
             env.ref("l10n_br_base.empresa_simples_nacional", raise_if_not_found=False),
+            env.ref("l10n_br_base.empresa_lucro_presumido", raise_if_not_found=False),
+            env.ref("l10n_br_base.empresa_lucro_real", raise_if_not_found=False),
         ]
         try:
             for company in companies:

--- a/l10n_br_fiscal_notification/demo/l10n_br_fiscal_document_email.xml
+++ b/l10n_br_fiscal_notification/demo/l10n_br_fiscal_document_email.xml
@@ -51,4 +51,29 @@
         <field name="company_id" ref="l10n_br_base.empresa_simples_nacional" />
     </record>
 
+    <record
+        id="fiscal_document_email_definition_5"
+        model="l10n_br_fiscal.document.email"
+    >
+        <field name="issuer">company</field>
+        <field
+            name="email_template_id"
+            ref="l10n_br_fiscal_notification.fiscal_document_change_state_template"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
+
+    <record
+        id="fiscal_document_email_definition_6"
+        model="l10n_br_fiscal.document.email"
+    >
+        <field name="document_type_id" ref="l10n_br_fiscal.document_SE" />
+        <field name="issuer">company</field>
+        <field
+            name="email_template_id"
+            ref="l10n_br_fiscal_notification.fiscal_document_change_state_template_nfse"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
+
 </odoo>

--- a/l10n_br_mdfe/demo/company_demo.xml
+++ b/l10n_br_mdfe/demo/company_demo.xml
@@ -11,4 +11,9 @@
         <field name="processador_edoc">oca</field>
     </record>
 
+    <!-- Empresa Lucro Real -->
+    <record id="l10n_br_base.empresa_lucro_real" model="res.company">
+        <field name="processador_edoc">oca</field>
+    </record>
+
 </odoo>

--- a/l10n_br_mdfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_mdfe/demo/fiscal_document_demo.xml
@@ -138,6 +138,65 @@
     </record>
 
 
+    <!-- MDFe Test - Modal Rodoviário - LR -->
+    <record id="demo_mdfe_lr_modal_rodoviario" model="l10n_br_fiscal.document">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_manifesto" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_58" />
+        <field
+            name="document_serie_id"
+            ref="l10n_br_fiscal.empresa_lr_document_58_serie_1"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="document_number">6</field>
+        <field name="document_serie">1</field>
+        <field name="document_key">35230905472475000102580200000602071611554500</field>
+        <field name="mdfe_environment">2</field>
+        <field name="processador_edoc">oca</field>
+        <field name="user_id" ref="base.user_demo" />
+        <field name="fiscal_operation_type">out</field>
+        <field name="mdfe_initial_state_id" ref="base.state_br_ac" />
+        <field name="mdfe_final_state_id" ref="base.state_br_ac" />
+        <field
+            name="mdfe_loading_city_ids"
+            eval="[Command.set([ref('l10n_br_base.city_1200013')])]"
+        />
+        <field
+            name="mdfe_route_state_ids"
+            eval="[Command.set([ref('base.state_br_pb')])]"
+        />
+        <field name="mdfe_modal">1</field>
+    </record>
+
+    <record
+        id="demo_mdfe_lr_descarga_rodoviario"
+        model="l10n_br_mdfe.municipio.descarga"
+    >
+        <field name="document_id" ref="demo_mdfe_lr_modal_rodoviario" />
+        <field name="state_id" ref="base.state_br_ac" />
+        <field name="city_id" ref="l10n_br_base.city_1200013" />
+        <field name="document_type">nfe</field>
+        <field
+            name="nfe_ids"
+            eval="[Command.set([ref('l10n_br_mdfe.demo_mdfe_related_nfe')])]"
+        />
+    </record>
+
+    <!-- MDFe Test - Modal Rodoviário - LR - Document Lines -->
+    <record id="demo_mdfe_lr_modal_rodoviario_1-1" model="l10n_br_fiscal.document.line">
+        <field name="document_id" ref="demo_mdfe_lr_modal_rodoviario" />
+        <field name="name">Manifesto</field>
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="price_unit">0</field>
+        <field name="quantity">1</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_manifesto" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_manifesto_manifesto"
+        />
+    </record>
+
+
     <!-- MDFe Test - Modal Aéreo - SN -->
     <record id="demo_mdfe_sn_modal_aereo" model="l10n_br_fiscal.document">
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_manifesto" />

--- a/l10n_br_nfe/demo/company_demo.xml
+++ b/l10n_br_nfe/demo/company_demo.xml
@@ -1,13 +1,18 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo noupdate="1">
 
+    <!-- Empresa Simples Nacional -->
+    <record id="l10n_br_base.empresa_simples_nacional" model="res.company">
+        <field name="processador_edoc">oca</field>
+    </record>
+
     <!-- Empresa Lucro Presumido -->
     <record id="l10n_br_base.empresa_lucro_presumido" model="res.company">
         <field name="processador_edoc">oca</field>
     </record>
 
-    <!-- Empresa Simples Nacional -->
-    <record id="l10n_br_base.empresa_simples_nacional" model="res.company">
+    <!-- Empresa Lucro Real-->
+    <record id="l10n_br_base.empresa_lucro_real" model="res.company">
         <field name="processador_edoc">oca</field>
     </record>
 

--- a/l10n_br_nfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_nfe/demo/fiscal_document_demo.xml
@@ -175,4 +175,149 @@
         <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda" />
     </record>
 
+    <!-- NFe/NFCe Test - Empresa Lucro Real -->
+
+    <!-- NFe Test - Empresa Lucro Real - Mesmo Estado -->
+    <record id="demo_nfe_lr_same_state" model="l10n_br_fiscal.document">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
+        <field
+            name="document_serie_id"
+            ref="l10n_br_fiscal.empresa_lr_document_55_serie_1"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="document_serie">1</field>
+        <field name="nfe_environment">2</field>
+        <field name="processador_edoc">oca</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
+        <field name="user_id" ref="base.user_demo" />
+        <field name="fiscal_operation_type">out</field>
+    </record>
+
+    <record id="demo_nfe_line_lr_same_state_1-1" model="l10n_br_fiscal.document.line">
+        <field name="document_id" ref="demo_nfe_lr_same_state" />
+        <field name="name">Teste</field>
+        <field name="product_id" ref="product.product_product_6" />
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="price_unit">100</field>
+        <field name="quantity">1</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda" />
+    </record>
+
+    <record id="demo_nfe_line_lr_same_state_1-2" model="l10n_br_fiscal.document.line">
+        <field name="document_id" ref="demo_nfe_lr_same_state" />
+        <field name="name">Teste</field>
+        <field name="product_id" ref="product.product_product_27" />
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="price_unit">100</field>
+        <field name="quantity">1</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda" />
+    </record>
+
+    <!-- NFe Test - Empresa Lucro Real - Pessoa Física - ICMS 18% with a reduction of 51.11% -->
+    <record id="demo_nfe_lr_natural_icms_18_red_51_11" model="l10n_br_fiscal.document">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
+        <field
+            name="document_serie_id"
+            ref="l10n_br_fiscal.empresa_lr_document_55_serie_1"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="document_number">12</field>
+        <field name="document_serie">1</field>
+        <field name="document_key">35200159594315000157550010000000022062777169</field>
+        <field name="document_date">2020-01-01 11:00:00</field>
+        <field name="date_in_out">2020-01-01 11:00:00</field>
+        <field name="nfe_environment">2</field>
+        <field name="processador_edoc">oca</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente11_sp" />
+        <field name="user_id" ref="base.user_demo" />
+        <field name="fiscal_operation_type">out</field>
+    </record>
+
+    <record
+        id="demo_nfe_lr_natural_icms_18_red_51_11-1"
+        model="l10n_br_fiscal.document.line"
+    >
+        <field name="document_id" ref="demo_nfe_lr_natural_icms_18_red_51_11" />
+        <field name="name">Teste</field>
+        <field name="product_id" ref="product.product_product_20" />
+        <field name="uom_id" ref="uom.product_uom_kgm" />
+        <field name="quantity">1</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+    </record>
+
+    <!-- NFe Test - Empresa Lucro Real - Pessoa Física - ICMS 4% Imported for Resale -->
+    <record id="demo_nfe_lr_natural_icms_7_resale" model="l10n_br_fiscal.document">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
+        <field
+            name="document_serie_id"
+            ref="l10n_br_fiscal.empresa_lr_document_55_serie_1"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="document_number">13</field>
+        <field name="document_serie">1</field>
+        <field name="document_key">35200159594315000157550010000000032062777166</field>
+        <field name="document_date">2020-01-01 11:00:00</field>
+        <field name="date_in_out">2020-01-01 11:00:00</field>
+        <field name="nfe_environment">2</field>
+        <field name="processador_edoc">oca</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente4_am" />
+        <field name="user_id" ref="base.user_demo" />
+        <field name="fiscal_operation_type">out</field>
+    </record>
+
+    <record
+        id="demo_nfe_lr_natural_icms_7_resale-1"
+        model="l10n_br_fiscal.document.line"
+    >
+        <field name="document_id" ref="demo_nfe_lr_natural_icms_7_resale" />
+        <field name="name">Teste</field>
+        <field name="product_id" ref="product.product_product_9" />
+        <field name="uom_id" ref="uom.product_uom_kgm" />
+        <field name="quantity">2</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_revenda" />
+    </record>
+
+    <!-- NFCe Test - Empresa Lucro Real - Mesmo Estado -->
+    <record id="demo_nfce_lr_same_state" model="l10n_br_fiscal.document">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_65" />
+        <field
+            name="document_serie_id"
+            ref="l10n_br_fiscal.empresa_lr_document_65_serie_1"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="document_serie">1</field>
+        <field name="document_key">33230807984267003800650040000000321935136447</field>
+        <field name="document_date">2023-08-01 11:00:00</field>
+        <field name="date_in_out">2023-08-01 11:00:00</field>
+        <field name="nfe_environment">2</field>
+        <field name="nfe_version">4.00</field>
+        <field name="processador_edoc">oca</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
+        <field name="user_id" ref="base.user_demo" />
+        <field name="fiscal_operation_type">out</field>
+    </record>
+
+    <record id="demo_nfce_line_lr_same_state_1-1" model="l10n_br_fiscal.document.line">
+        <field name="document_id" ref="demo_nfce_lr_same_state" />
+        <field name="name">Teste</field>
+        <field name="product_id" ref="product.product_product_6" />
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="price_unit">100</field>
+        <field name="quantity">1</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda" />
+    </record>
+
 </odoo>

--- a/l10n_br_purchase/demo/company.xml
+++ b/l10n_br_purchase/demo/company.xml
@@ -10,4 +10,8 @@
         <field name="purchase_fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
     </record>
 
+    <record id="l10n_br_base.empresa_lucro_real" model="res.company">
+        <field name="purchase_fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+    </record>
+
 </odoo>

--- a/l10n_br_purchase/demo/l10n_br_purchase.xml
+++ b/l10n_br_purchase/demo/l10n_br_purchase.xml
@@ -263,6 +263,47 @@
         <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
     </record>
 
+    <!-- Empresa Lucro Real -->
+    <!-- Purchase Order with only products test -->
+    <record id="lr_po_only_products" model="purchase.order">
+        <field name="name">LR l10n_br_purchase - Produtos</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_akretion" />
+        <field name="state">draft</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field name="user_id" ref="base.user_admin" />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
+
+    <record id="lr_pl_only_products_1_2" model="purchase.order.line">
+        <field name="order_id" ref="lr_po_only_products" />
+        <field name="name">Office Chair Black</field>
+        <field name="product_id" ref="product.product_product_12" />
+        <field name="product_qty">4</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="price_unit">25.00</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_compras_compras"
+        />
+        <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
+    </record>
+
+    <record id="lr_pl_only_products_2_2" model="purchase.order.line">
+        <field name="order_id" ref="lr_po_only_products" />
+        <field name="name">Drawer Black</field>
+        <field name="product_id" ref="product.product_product_16" />
+        <field name="product_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="price_unit">50.00</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_compras_compras"
+        />
+        <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
+    </record>
+
     <!-- Empresa Simples Nacional -->
     <!-- Purchase Order with only products test -->
     <record id="sn_po_only_products" model="purchase.order">

--- a/l10n_br_purchase/hooks.py
+++ b/l10n_br_purchase/hooks.py
@@ -114,3 +114,34 @@ def purchase_set_journal_in_fiscal_operation(cr):
                     },
                 ],
             )
+
+        company_lr = env.ref(
+            "l10n_br_base.empresa_lucro_real", raise_if_not_found=False
+        )
+
+        # COA Generic Fiscal Operation properties
+        if company_lr and env["ir.module.module"].search_count(
+            [
+                ("name", "=", "l10n_br_coa_generic"),
+                ("state", "=", "installed"),
+            ]
+        ):
+            # Load Fiscal Operation for Lucro Real
+            set_journal_in_fiscal_operation(
+                cr,
+                company_lr,
+                [
+                    {
+                        "fiscal_operation": "l10n_br_fiscal.fo_compras",
+                        "journal": "l10n_br_coa_generic.purchase_journal_empresa_lr",
+                    },
+                    {
+                        "fiscal_operation": "l10n_br_fiscal.fo_devolucao_compras",
+                        "journal": "l10n_br_coa_generic.purchase_journal_empresa_lr",
+                    },
+                    {
+                        "fiscal_operation": "l10n_br_fiscal.fo_entrada_remessa",
+                        "journal": "l10n_br_coa_generic.purchase_journal_empresa_lr",
+                    },
+                ],
+            )

--- a/l10n_br_purchase_stock/demo/purchase_order.xml
+++ b/l10n_br_purchase_stock/demo/purchase_order.xml
@@ -281,6 +281,71 @@
         <field name="freight_value">10</field>
     </record>
 
+    <!-- Lucro Real -->
+    <!-- Purchase Order with only products test -->
+    <record id="lucro_real_po_only_products_1" model="purchase.order">
+        <field
+            name="name"
+        >l10n_br_purchase_stock - somente produtos (Lucro Real)</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_akretion" />
+        <field name="payment_term_id" ref="account.account_payment_term_advance" />
+        <field name="state">draft</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field name="user_id" ref="base.user_admin" />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="notes">TESTE - TERMOS E CONDIÇÕES</field>
+        <field
+            name="manual_customer_additional_data"
+        >TESTE - CUSTOMER ADDITIONAL DATA</field>
+        <field
+            name="manual_fiscal_additional_data"
+        >TESTE - FISCAL ADDITIONAL DATA</field>
+        <field name="ind_final">0</field>
+    </record>
+
+    <record id="lucro_real_pol_only_products_1_1" model="purchase.order.line">
+        <field name="order_id" ref="lucro_real_po_only_products_1" />
+        <field name="name">Office Chair Black</field>
+        <field name="product_id" ref="product.product_product_12" />
+        <field name="product_qty">4</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="price_unit">250</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_compras_compras"
+        />
+        <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
+        <field name="partner_order">999999</field>
+        <field name="partner_order_line">001</field>
+        <field name="manual_additional_data">Teste - Additional Data</field>
+        <field name="insurance_value">10</field>
+        <field name="other_value">10</field>
+        <field name="freight_value">10</field>
+        <field name="ind_final">0</field>
+    </record>
+
+    <record id="lucro_real_pol_only_products_1_2" model="purchase.order.line">
+        <field name="order_id" ref="lucro_real_po_only_products_1" />
+        <field name="name">Gaveta Preta</field>
+        <field name="product_id" ref="product.product_product_16" />
+        <field name="product_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="price_unit">500</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_compras_compras"
+        />
+        <field name="date_planned" eval="time.strftime('%Y-%m-%d')" />
+        <field name="partner_order">999999</field>
+        <field name="partner_order_line">002</field>
+        <field name="manual_additional_data">Teste - Additional Data</field>
+        <field name="insurance_value">10</field>
+        <field name="other_value">10</field>
+        <field name="freight_value">10</field>
+    </record>
+
     <!-- Purchase Order with only Service -->
     <!-- Necessario alterar o Metodo de Compra do Servico
          para evitar necessidade de Receber/Stock Picking-->

--- a/l10n_br_sale/demo/company.xml
+++ b/l10n_br_sale/demo/company.xml
@@ -10,4 +10,8 @@
         <field name="sale_fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
     </record>
 
+    <record id="l10n_br_base.empresa_lucro_real" model="res.company">
+        <field name="sale_fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+    </record>
+
 </odoo>

--- a/l10n_br_sale/demo/l10n_br_sale.xml
+++ b/l10n_br_sale/demo/l10n_br_sale.xml
@@ -462,4 +462,122 @@
         <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_servico" />
     </record>
 
+    <!-- Empresa Lucro Real -->
+    <!-- Sale Order with only products test -->
+    <record id="lr_so_only_products" model="sale.order">
+        <field name="name">LR l10n_br_sale - Produtos</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_akretion" />
+        <field name="partner_invoice_id" ref="l10n_br_base.res_partner_akretion" />
+        <field name="partner_shipping_id" ref="l10n_br_base.res_partner_akretion" />
+        <field name="user_id" ref="l10n_br_base.user_demo_real" />
+        <field name="pricelist_id" ref="product.list0" />
+        <field name="team_id" ref="sales_team.crm_team_1" />
+        <field name="state">draft</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="note">TESTE</field>
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
+
+    <record id="lr_sl_only_products_1_2" model="sale.order.line">
+        <field name="order_id" ref="lr_so_only_products" />
+        <field name="name">Laptop Customized</field>
+        <field name="product_id" ref="product.product_product_27" />
+        <field name="product_uom_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="price_unit">500</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda" />
+    </record>
+
+    <record id="lr_sl_only_products_2_2" model="sale.order.line">
+        <field name="order_id" ref="lr_so_only_products" />
+        <field name="name">Mouse, Wireless</field>
+        <field name="product_id" ref="product.product_product_12" />
+        <field name="product_uom_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="price_unit">500</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda" />
+    </record>
+
+    <!-- Sale Order with only services test -->
+    <record id="lr_so_only_services" model="sale.order">
+        <field name="name">LR l10n_br_sale - Serviços</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_akretion" />
+        <field name="partner_invoice_id" ref="l10n_br_base.res_partner_akretion" />
+        <field name="partner_shipping_id" ref="l10n_br_base.res_partner_akretion" />
+        <field name="user_id" ref="l10n_br_base.user_demo_real" />
+        <field name="pricelist_id" ref="product.list0" />
+        <field name="team_id" ref="sales_team.crm_team_1" />
+        <field name="state">draft</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="note">TESTE</field>
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
+
+    <record id="lr_sl_only_services_1_2" model="sale.order.line">
+        <field name="order_id" ref="lr_so_only_services" />
+        <field name="name">Customized Odoo Development</field>
+        <field name="product_id" ref="l10n_br_fiscal.customized_development_sale" />
+        <field name="product_uom_qty">15</field>
+        <field name="product_uom" ref="uom.product_uom_hour" />
+        <field name="price_unit">30.75</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_servico" />
+    </record>
+
+    <record id="lr_sl_only_services_2_2" model="sale.order.line">
+        <field name="order_id" ref="lr_so_only_services" />
+        <field name="name">Customized Odoo Development</field>
+        <field name="product_id" ref="l10n_br_fiscal.customized_development_sale" />
+        <field name="product_uom_qty">20</field>
+        <field name="product_uom" ref="uom.product_uom_hour" />
+        <field name="price_unit">38.25</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_servico" />
+    </record>
+
+    <!-- Sale Order with product and service test -->
+    <record id="lr_so_product_service" model="sale.order">
+        <field name="name">LR l10n_br_sale - Produtos e Serviços</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_akretion" />
+        <field name="partner_invoice_id" ref="l10n_br_base.res_partner_akretion" />
+        <field name="partner_shipping_id" ref="l10n_br_base.res_partner_akretion" />
+        <field name="user_id" ref="l10n_br_base.user_demo_real" />
+        <field name="pricelist_id" ref="product.list0" />
+        <field name="team_id" ref="sales_team.crm_team_1" />
+        <field name="state">draft</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="note">TESTE de criação de duas Notas de Serviço e Produto</field>
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
+
+    <record id="lr_sl_product_service_1_2" model="sale.order.line">
+        <field name="order_id" ref="lr_so_product_service" />
+        <field name="name">Laptop Customized</field>
+        <field name="product_id" ref="product.product_product_27" />
+        <field name="product_uom_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="price_unit">500</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda" />
+    </record>
+
+    <record id="lr_sl_product_service_2_2" model="sale.order.line">
+        <field name="order_id" ref="lr_so_product_service" />
+        <field name="name">Customized Odoo Development</field>
+        <field name="product_id" ref="l10n_br_fiscal.customized_development_sale" />
+        <field name="product_uom_qty">10</field>
+        <field name="product_uom" ref="uom.product_uom_hour" />
+        <field name="price_unit">100</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_servico" />
+    </record>
+
 </odoo>

--- a/l10n_br_sale/hooks.py
+++ b/l10n_br_sale/hooks.py
@@ -122,3 +122,37 @@ def sale_set_journal_in_fiscal_operation(cr):
                     },
                 ],
             )
+
+        company_lr = env.ref(
+            "l10n_br_base.empresa_lucro_real", raise_if_not_found=False
+        )
+
+        # COA Generic Fiscal Operation properties
+        if company_lr and env["ir.module.module"].search_count(
+            [
+                ("name", "=", "l10n_br_coa_generic"),
+                ("state", "=", "installed"),
+            ]
+        ):
+            set_journal_in_fiscal_operation(
+                cr,
+                company_lr,
+                [
+                    {
+                        "fiscal_operation": "l10n_br_fiscal.fo_venda",
+                        "journal": "l10n_br_coa_generic.sale_journal_empresa_lr",
+                    },
+                    {
+                        "fiscal_operation": "l10n_br_fiscal.fo_bonificacao",
+                        "journal": "l10n_br_coa_generic.sale_journal_empresa_lr",
+                    },
+                    {
+                        "fiscal_operation": "l10n_br_fiscal.fo_devolucao_venda",
+                        "journal": "l10n_br_coa_generic.sale_journal_empresa_lr",
+                    },
+                    {
+                        "fiscal_operation": "l10n_br_fiscal.fo_simples_remessa",
+                        "journal": "l10n_br_coa_generic.sale_journal_empresa_lr",
+                    },
+                ],
+            )

--- a/l10n_br_sale_stock/demo/sale_order_demo.xml
+++ b/l10n_br_sale_stock/demo/sale_order_demo.xml
@@ -459,4 +459,83 @@
         />
     </record>
 
+    <!-- Empresa Lucro Real -->
+    <!-- Sale Order with only products test -->
+    <record id="lucro_real-sale_order_1" model="sale.order">
+        <field name="name">LC l10n_br_sale - Produtos</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_akretion" />
+        <field name="partner_invoice_id" ref="l10n_br_base.res_partner_akretion" />
+        <field name="partner_shipping_id" ref="l10n_br_base.res_partner_akretion" />
+        <field name="user_id" ref="l10n_br_base.user_demo_real" />
+        <field name="pricelist_id" ref="product.list0" />
+        <field name="team_id" ref="sales_team.crm_team_1" />
+        <field name="state">draft</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <!-- Necessario para corrigir o campo ind_final, por padrão vem com o
+         valor Sim, o que está errado, porque deve ser Não -->
+        <field name="ind_final">0</field>
+        <field name="copy_note">True</field>
+        <field name="note">TESTE - TERMOS E CONDIÇÕES 1</field>
+        <field
+            name="manual_customer_additional_data"
+        >TESTE - CUSTOMER ADDITIONAL DATA 1</field>
+        <field
+            name="manual_fiscal_additional_data"
+        >TESTE - FISCAL ADDITIONAL DATA 1</field>
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="client_order_ref">Customer Ref Test 1</field>
+        <field name="campaign_id" ref="utm.utm_campaign_christmas_special" />
+        <field name="medium_id" ref="utm.utm_medium_banner" />
+        <field name="source_id" ref="utm.utm_source_monster" />
+        <field name="incoterm" ref="account.incoterm_FOB" />
+        <field name="tag_ids" eval="[Command.link(ref('sales_team.categ_oppor1'))]" />
+    </record>
+
+    <record id="lucro_real-sale_order_line_1_1" model="sale.order.line">
+        <field name="order_id" ref="lucro_real-sale_order_1" />
+        <field
+            name="name"
+            model="sale.order.line"
+            eval="obj().env.ref('product.product_product_12').get_product_multiline_description_sale()"
+        />
+        <field name="product_id" ref="product.product_product_12" />
+        <field name="product_uom_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="price_unit">500</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda" />
+    </record>
+
+    <record id="lucro_real-sale_order_line_1_2" model="sale.order.line">
+        <field name="order_id" ref="lucro_real-sale_order_1" />
+        <field name="name">This is a Note 1</field>
+        <field name="display_type">line_note</field>
+    </record>
+
+    <record id="lucro_real-sale_order_line_1_3" model="sale.order.line">
+        <field name="order_id" ref="lucro_real-sale_order_1" />
+        <field name="name">This is a Section 1</field>
+        <field name="display_type">line_section</field>
+    </record>
+
+    <record id="lucro_real-sale_order_line_1_4" model="sale.order.line">
+        <field name="order_id" ref="lucro_real-sale_order_1" />
+        <field
+            name="name"
+            model="sale.order.line"
+            eval="obj().env.ref('product.product_product_12').get_product_multiline_description_sale()"
+        />
+        <field name="product_id" ref="product.product_product_12" />
+        <field name="product_uom_qty">2</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="price_unit">500</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_bonificacao" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_bonificacao_bonificacao"
+        />
+    </record>
+
 </odoo>

--- a/l10n_br_stock/demo/stock_location_demo.xml
+++ b/l10n_br_stock/demo/stock_location_demo.xml
@@ -45,4 +45,26 @@
             <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
         </record>
 
+        <!-- Lucro Real -->
+
+        <record id="stock_location_lr_shelf_1" model="stock.location">
+            <field name="name">Shelf 1</field>
+            <field name="posx">0</field>
+            <field
+            name="location_id"
+            ref="l10n_br_stock.wh_empresa_lucro_real_loc_stock_id"
+        />
+            <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        </record>
+
+        <record id="stock_location_lr_shelf_2" model="stock.location">
+            <field name="name">Shelf 2</field>
+            <field name="posx">0</field>
+            <field
+            name="location_id"
+            ref="l10n_br_stock.wh_empresa_lucro_real_loc_stock_id"
+        />
+            <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        </record>
+
 </odoo>

--- a/l10n_br_stock/hooks.py
+++ b/l10n_br_stock/hooks.py
@@ -86,6 +86,7 @@ def pre_init_hook(cr):
         _logger.info(_("Loading l10n_br_stock warehouse external ids..."))
         set_stock_warehouse_external_ids(env, "l10n_br_base.empresa_simples_nacional")
         set_stock_warehouse_external_ids(env, "l10n_br_base.empresa_lucro_presumido")
+        set_stock_warehouse_external_ids(env, "l10n_br_base.empresa_lucro_real")
 
 
 def create_locations_quants(cr, locations, products):
@@ -121,6 +122,7 @@ def post_init_hook(cr, registry):
             [
                 env.ref("l10n_br_stock.wh_empresa_simples_nacional").lot_stock_id,
                 env.ref("l10n_br_stock.wh_empresa_lucro_presumido").lot_stock_id,
+                env.ref("l10n_br_stock.wh_empresa_lucro_real").lot_stock_id,
             ],
             [
                 env.ref("product.product_product_24"),

--- a/l10n_br_stock_account/demo/account_journal_demo.xml
+++ b/l10n_br_stock_account/demo/account_journal_demo.xml
@@ -46,6 +46,21 @@
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
     </record>
 
+    <!-- Account Journal for Lucro Real -->
+    <record id="simples_remessa_journal_lucro_real" model="account.journal">
+        <field name="name">Diário Simples Remessa</field>
+        <field name="code">DSR</field>
+        <field name="type">sale</field>
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
+
+    <record id="entrada_remessa_journal_lucro_real" model="account.journal">
+        <field name="name">Diário Entrada Remessa</field>
+        <field name="code">DER</field>
+        <field name="type">purchase</field>
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
+
     <!-- Account Journal for Simples Nacional -->
     <record id="simples_remessa_journal_simples_nacional" model="account.journal">
         <field name="name">Diário Simples Remessa</field>

--- a/l10n_br_stock_account/demo/company_demo.xml
+++ b/l10n_br_stock_account/demo/company_demo.xml
@@ -29,4 +29,13 @@
         />
   </record>
 
+  <record id="l10n_br_base.empresa_lucro_real" model="res.company">
+      <field name="stock_fiscal_operation_id" ref="l10n_br_fiscal.fo_simples_remessa" />
+      <field name="stock_in_fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+      <field
+            name="stock_out_fiscal_operation_id"
+            ref="l10n_br_fiscal.fo_simples_remessa"
+        />
+  </record>
+
 </odoo>

--- a/l10n_br_stock_account/demo/l10n_br_stock_account_demo.xml
+++ b/l10n_br_stock_account/demo/l10n_br_stock_account_demo.xml
@@ -925,6 +925,145 @@
         <field name="other_value">100</field>
     </record>
 
+    <!-- Picking Test - Lucro Presumido -->
+    <record model="stock.picking" id="lucro_real-picking_1">
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
+        <field
+            name="picking_type_id"
+            ref="l10n_br_stock.wh_empresa_lucro_real_picking_type_out"
+        />
+        <field
+            name="location_id"
+            ref="l10n_br_stock.wh_empresa_lucro_real_loc_stock_id"
+        />
+        <field name="location_dest_id" ref="stock.stock_location_customers" />
+        <field name="invoice_state">2binvoiced</field>
+        <field name="origin">Test - l10n_br_stock_account - Regime Normal</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_simples_remessa" />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
+
+    <record model="stock.move" id="lucro_real-move_1_1">
+        <field name="name">Test - l10n_br_stock_account - 1</field>
+        <!-- sem o campo abaixo falha o mapeamento de CFOP, erro não acontece na tela -->
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
+        <field name="product_id" ref="product.product_product_16" />
+        <field name="product_uom_qty">2</field>
+        <field name="price_unit">50.00</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="picking_id" ref="lucro_real-picking_1" />
+        <field
+            name="location_id"
+            ref="l10n_br_stock.wh_empresa_lucro_real_loc_stock_id"
+        />
+        <field name="location_dest_id" ref="stock.stock_location_customers" />
+        <field name="invoice_state">2binvoiced</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_simples_remessa" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_simples_remessa_simples_remessa"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="freight_value">100</field>
+        <field name="insurance_value">100</field>
+        <field name="other_value">100</field>
+    </record>
+
+    <record model="stock.move" id="lucro_real-move_1_2">
+        <field name="name">Test - l10n_br_stock_account - 1</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
+        <field name="product_id" ref="product.product_product_12" />
+        <field name="product_uom_qty">2</field>
+        <field name="price_unit">50.00</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="picking_id" ref="lucro_real-picking_1" />
+        <field
+            name="location_id"
+            ref="l10n_br_stock.wh_empresa_lucro_real_loc_stock_id"
+        />
+        <field name="location_dest_id" ref="stock.stock_location_customers" />
+        <field name="invoice_state">2binvoiced</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_simples_remessa" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_simples_remessa_simples_remessa"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="freight_value">100</field>
+        <field name="insurance_value">100</field>
+        <field name="other_value">100</field>
+    </record>
+
+    <!-- Picking Test - Lucro Presumido -->
+    <record model="stock.picking" id="lucro_real-picking_2">
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
+        <field
+            name="picking_type_id"
+            ref="l10n_br_stock.wh_empresa_lucro_real_picking_type_out"
+        />
+        <field
+            name="location_id"
+            ref="l10n_br_stock.wh_empresa_lucro_real_loc_stock_id"
+        />
+        <field name="location_dest_id" ref="stock.stock_location_customers" />
+        <field name="invoice_state">2binvoiced</field>
+        <field name="origin">Test - l10n_br_stock_account - Regime Normal</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_simples_remessa" />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+    </record>
+
+    <record model="stock.move" id="lucro_real-move_2_1">
+        <field name="name">Test - l10n_br_stock_account - 1</field>
+        <!-- sem o campo abaixo falha o mapeamento de CFOP, erro não acontece na tela -->
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
+        <field name="product_id" ref="product.product_product_16" />
+        <field name="product_uom_qty">2</field>
+        <field name="price_unit">50.00</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="picking_id" ref="lucro_real-picking_2" />
+        <field
+            name="location_id"
+            ref="l10n_br_stock.wh_empresa_lucro_real_loc_stock_id"
+        />
+        <field name="location_dest_id" ref="stock.stock_location_customers" />
+        <field name="invoice_state">2binvoiced</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_simples_remessa" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_simples_remessa_simples_remessa"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="freight_value">100</field>
+        <field name="insurance_value">100</field>
+        <field name="other_value">100</field>
+    </record>
+
+    <record model="stock.move" id="lucro_real-move_2_2">
+        <field name="name">Test - l10n_br_stock_account - 1</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
+        <field name="product_id" ref="product.product_product_12" />
+        <field name="product_uom_qty">2</field>
+        <field name="price_unit">50.00</field>
+        <field name="product_uom" ref="uom.product_uom_unit" />
+        <field name="picking_id" ref="lucro_real-picking_2" />
+        <field
+            name="location_id"
+            ref="l10n_br_stock.wh_empresa_lucro_real_loc_stock_id"
+        />
+        <field name="location_dest_id" ref="stock.stock_location_customers" />
+        <field name="invoice_state">2binvoiced</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_simples_remessa" />
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_simples_remessa_simples_remessa"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_real" />
+        <field name="freight_value">100</field>
+        <field name="insurance_value">100</field>
+        <field name="other_value">100</field>
+    </record>
+
+
     <!-- Picking Test - Simples Nacional -->
     <record model="stock.picking" id="simples_nacional-picking_1">
         <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />

--- a/l10n_br_stock_account/hooks.py
+++ b/l10n_br_stock_account/hooks.py
@@ -16,6 +16,7 @@ def post_init_hook(cr, registry):
                 env.ref("stock.warehouse0").lot_stock_id,
                 env.ref("l10n_br_stock.wh_empresa_simples_nacional").lot_stock_id,
                 env.ref("l10n_br_stock.wh_empresa_lucro_presumido").lot_stock_id,
+                env.ref("l10n_br_stock.wh_empresa_lucro_real").lot_stock_id,
             ],
             [
                 env.ref("product.product_product_12"),
@@ -86,6 +87,27 @@ def stock_account_set_journal_in_fiscal_operation(cr):
                     "fiscal_operation": "l10n_br_fiscal.fo_simples_remessa",
                     "journal": "l10n_br_stock_account."
                     "simples_remessa_journal_lucro_presumido",
+                },
+            ],
+        )
+
+        company_lr = env.ref(
+            "l10n_br_base.empresa_lucro_real", raise_if_not_found=False
+        )
+
+        set_journal_in_fiscal_operation(
+            cr,
+            company_lr,
+            [
+                {
+                    "fiscal_operation": "l10n_br_fiscal.fo_entrada_remessa",
+                    "journal": "l10n_br_stock_account."
+                    "entrada_remessa_journal_lucro_real",
+                },
+                {
+                    "fiscal_operation": "l10n_br_fiscal.fo_simples_remessa",
+                    "journal": "l10n_br_stock_account."
+                    "simples_remessa_journal_lucro_real",
                 },
             ],
         )


### PR DESCRIPTION
# Dados de demonstração para Empresa Lucro Real

Após o merge do PR #4729 que adicionou a empresa do Lucro Real nos dados de demonstração esse PR adiciona os registros de demo que faltavam para a empresa `l10n_br_base.empresa_lucro_real`, espelhando o que já existia para `empresa_simples_nacional` e `empresa_lucro_presumido` para o uso da empresa de lucro real em uma base de demonstração e auxiliar em futuros testes onde existe diferenças entre as outras duas empresas como a valorização de estoque, tributação e contabilizações.

## l10n_br_base

- `demo/res_users_demo.xml`: novo parceiro `partner_demo_real` e usuário `user_demo_real` (login/senha `real`), seguindo o mesmo padrão de `partner_demo_simples`/`user_demo_simples` e `partner_demo_presumido`/`user_demo_presumido`.

## l10n_br_fiscal

- `demo/product_demo.xml`: réplica das 51 `ir.property` de `fiscal_type` e `icms_origin` (uma por produto) para `empresa_lucro_real`.
- `demo/fiscal_document_demo.xml`: os 8 cenários de NF-e usados para testar o cálculo de impostos (mesmo estado, outro estado, exportação, não contribuinte PJ/PF, benefício fiscal, faturamento por Simples, compra mesmo estado) duplicados para lucro real, usando a série de documento `empresa_lr_document_55_serie_1`.

## l10n_br_stock

- `hooks.py`: o `pre_init_hook` agora também registra os xmlids do warehouse/localizações de `empresa_lucro_real` (antes só cobria simples nacional e lucro presumido), e o `post_init_hook` cria quants de estoque  também para esse warehouse.
- `demo/stock_location_demo.xml`: duas `stock.location` (Shelf 1 e 2) para lucro real, no padrão das já existentes para as outras duas empresas.

## l10n_br_coa_generic

- `hooks.py`: `post_init_hook` passou a carregar o plano de contas genérico também para `empresa_lucro_real` (antes só carregava para lucro presumido; simples nacional usa o plano simplificado de outro módulo).
- `demo/account_journal.xml`: xmlids dos diários de venda/compra/geral (`sale_journal_empresa_lr`, `purchase_journal_empresa_lr`, `general_journal_empresa_lr`).

## l10n_br_account_payment_order

- `demo/account_journal.xml`: diário bancário `lucro_real_bank_journal` (código `TPO3`) e seu método de pagamento.
- `demo/ir_sequence.xml`: sequência "Nosso número" para lucro real.
- `demo/res_partner_bank.xml`: as 11 contas bancárias de demonstração (Banco do Brasil, HSBC, Itaú, Santander, CEF, Bradesco, Nordeste, Banrisul, Banestes, Sicoob, Sicredi) replicadas para o parceiro/empresa lucro real.

## l10n_br_contract / l10n_br_purchase / l10n_br_sale

- `demo/company.xml` de cada módulo: fiscal operation padrão de contrato/compra/venda (`fo_venda`/`fo_compras`) configurada em `empresa_lucro_real`.
- `l10n_br_sale/hooks.py` e `l10n_br_purchase/hooks.py`: a rotina que vincula os diários da COA genérica às fiscal operations (`set_journal_in_fiscal_operation`) passou a rodar também para lucro real (antes só cobria simples nacional/COA simples e lucro presumido/COA genérica).
- `l10n_br_sale/demo/l10n_br_sale.xml`: 3 pedidos de venda de demo (só produtos, só serviços, produto+serviço) para lucro real, usando o novo `user_demo_real`.
- `l10n_br_purchase/demo/l10n_br_purchase.xml`: pedido de compra "somente produtos" com suas 2 linhas para lucro real.

## l10n_br_purchase_stock / l10n_br_sale_stock

- `l10n_br_purchase_stock/demo/purchase_order.xml`: pedido de compra "somente produtos" (com seção/nota/linhas extras) para lucro real, no padrão do já existente para lucro presumido.
- `l10n_br_sale_stock/demo/sale_order_demo.xml`: pedido de venda para lucro real, mesmo padrão do `lucro_presumido-sale_order_1`.

## l10n_br_cte

- `demo/company_demo.xml`: `processador_edoc` e `rntrc_code` do parceiro para lucro real.
- `demo/fiscal_document_demo.xml`: os 5 cenários de CT-e (modal rodoviário, aéreo, aquaviário, ferroviário e dutoviário), cada um com seu documento, infos de quantidade de carga, linha e documento relacionado — réplica completa do bloco de lucro presumido, com `document_number` deslocado (+10) para não colidir com os já existentes.

## l10n_br_mdfe

- `demo/company_demo.xml`: `processador_edoc` para lucro real.
- `demo/fiscal_document_demo.xml`: cenário de MDF-e modal rodoviário (documento + município de descarga + linha) para lucro real.

## l10n_br_nfe

- `demo/fiscal_document_demo.xml`: os 4 documentos (venda mesmo estado, ICMS 18% com redução de 51,11%, ICMS 4% importado para revenda, NFC-e mesmo estado) replicados para lucro real, com `document_number` ajustado para não colidir com os originais.

## l10n_br_fiscal_notification

- `demo/l10n_br_fiscal_document_email.xml`: as 2 definições de e-mail (mudança de estado do documento fiscal e NFS-e) para lucro real.

## l10n_br_stock_account

- `hooks.py`: `post_init_hook` passou a criar quants também no warehouse de lucro real e a vincular os diários de remessa às fiscal operations dessa empresa (mesma lacuna encontrada em `l10n_br_sale`/`l10n_br_purchase`).
- `demo/account_journal_demo.xml`: diários "Simples Remessa" e "Entrada Remessa" para lucro real.
- `demo/company_demo.xml`: fiscal operations de estoque (`stock_fiscal_operation_id`, `stock_in_fiscal_operation_id`, `stock_out_fiscal_operation_id`) para lucro real.
- `demo/l10n_br_stock_account_demo.xml`: os 2 pickings de teste (com 2 movimentos cada) usando o warehouse de lucro real.

## Fora do escopo

Alguns arquivos com dados só de uma empresa (sem par simples nacional/lucro presumido) foram deixados como estão, por parecerem fixtures de demonstração de um único cenário e não um template por empresa: `l10n_br_account_nfe/demo/account_invoice_sn_demo.xml` (documentado como exclusivo do Simples Nacional), `l10n_br_coa_simple` (plano de contas simplificado é conceito exclusivo do Simples Nacional), `l10n_br_pos/*`, `l10n_br_sale_blanket_order` e `l10n_br_sale_invoice_plan`.