### PR TITLE
[18.0[FIX] l10n_br_fiscal: rm product_type hack

### DIFF
--- a/l10n_br_fiscal/models/product_template.py
+++ b/l10n_br_fiscal/models/product_template.py
@@ -22,18 +22,6 @@ class ProductTemplate(models.Model):
         if fiscal_type == PRODUCT_FISCAL_TYPE_SERVICE:
             return self.env.ref(NCM_FOR_SERVICE_REF)
 
-    # Some modules of the repo depend on stock and have
-    # demo products of type 'product' (this type is added to product.template
-    # in the stock module).
-    # For some reason when running the tests, some inverse method fields then fail when
-    # reading 'product' value for the product type. It seems it is because
-    # l10n_br_fiscal doesn't depend on stock. But we don't want such a dependency.
-    # So a workaround to avoid the bug we add the 'product' value to the selection.
-    type = fields.Selection(
-        selection_add=[("product", "Storable Product")],
-        ondelete={"product": "set consu"},
-    )
-
     fiscal_type = fields.Selection(
         selection=PRODUCT_FISCAL_TYPE,
         company_dependent=True,


### PR DESCRIPTION
Na epoca da 12 ou da 14 foi preciso desse hack pro testes passarem mas hoje o tipo que adicionamos não é mais usado e como limpamos muito os computes,  não deve precisar mais desse hack.