### PR TITLE
[18.0][REM] l10n_br_account: remove field fiscal_document_line_id

### DIFF
--- a/l10n_br_account/views/account_move_view.xml
+++ b/l10n_br_account/views/account_move_view.xml
@@ -500,7 +500,6 @@
                     <page name="fiscal_line_extra_info" string="Extra Info" />
                     <page name="accounting" string="Accounting">
                         <group>
-                            <field name="fiscal_document_line_id" />
                             <field
                                 name="tax_ids"
                                 context="{'move_type': parent.move_type}"


### PR DESCRIPTION
Esse campo já tem na aba de Outros

https://github.com/OCA/l10n-brazil/blob/18.0/l10n_br_account/views/account_move_view.xml#L499