### PR TITLE
[16.0][IMP] l10n_br_fiscal: operações de consignação mercantil

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -51,6 +51,7 @@
         "data/l10n_br_fiscal.operation.indicator.csv",
         "data/simplified_tax_data.xml",
         "data/operation_data.xml",
+        "data/fiscal_operation_consignacao.xml",
         "data/l10n_br_fiscal_tax_icms_data.xml",
         # the following csv data files will be loaded as noupdate=True
         # and will be trimmed down when demo mode is True (faster):
@@ -129,6 +130,7 @@
         "demo/res_users_demo.xml",
         "demo/icms_tax_definition_demo.xml",
         "demo/fiscal_document_demo.xml",
+        "demo/fiscal_document_consignacao_demo.xml",
     ],
     "installable": True,
     "application": True,

--- a/l10n_br_fiscal/data/fiscal_operation_consignacao.xml
+++ b/l10n_br_fiscal/data/fiscal_operation_consignacao.xml
@@ -1,0 +1,809 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Família: Consignação mercantil (Ajuste SINIEF 02/93).
+
+  Princípio que rege o desenho: o fato gerador do ICMS/IPI (circulação física)
+  ocorre na REMESSA; o do PIS/COFINS (receita) ocorre no FATURAMENTO/venda. Por
+  isso PIS/COFINS são zerados (CST 49) na remessa/devolução e o ICMS é sem
+  destaque (CST 90) no faturamento — os tax.definition abaixo materializam essa
+  dissociação; onde o tributo incide normalmente, usa-se o default de venda.
+
+  Caso geral modelado: consignação MERCANTIL (product_type=00), regime NORMAL
+  (CST, não CSOSN), SEM ICMS-ST. Variantes industrial/Simples/ST são sub-famílias
+  próprias (ver readme). Mecânica B (devolução simbólica, CFOPs 5919/1919) está
+  incluída como operações à parte — ativar conforme a prática do fisco.
+-->
+<odoo noupdate="1">
+
+    <!-- ============ Informações complementares (infCpl) ============ -->
+    <record id="comment_consig_remessa" model="l10n_br_fiscal.comment">
+        <field name="name">Remessa em consignação mercantil</field>
+        <field
+            name="comment"
+        >Mercadoria remetida em consignação mercantil - Ajuste SINIEF 02/93.</field>
+        <field name="comment_type">fiscal</field>
+        <field name="object">l10n_br_fiscal.document.mixin</field>
+    </record>
+
+    <record id="comment_consig_reajuste" model="l10n_br_fiscal.comment">
+        <field name="name">Reajuste de preço em consignação</field>
+        <field
+            name="comment"
+        >Reajuste de preço de mercadoria em consignação mercantil - Ajuste SINIEF 02/93.</field>
+        <field name="comment_type">fiscal</field>
+        <field name="object">l10n_br_fiscal.document.mixin</field>
+    </record>
+
+    <record id="comment_consig_faturamento" model="l10n_br_fiscal.comment">
+        <field name="name">Faturamento de consignação</field>
+        <field
+            name="comment"
+        >Simples faturamento de mercadoria remetida em consignação mercantil, sem novo destaque de ICMS (débito ocorrido na remessa) - Ajuste SINIEF 02/93.</field>
+        <field name="comment_type">fiscal</field>
+        <field name="object">l10n_br_fiscal.document.mixin</field>
+    </record>
+
+    <record id="comment_consig_devolucao" model="l10n_br_fiscal.comment">
+        <field name="name">Devolução de consignação</field>
+        <field
+            name="comment"
+        >Devolução de mercadoria em consignação mercantil, não comercializada - Ajuste SINIEF 02/93.</field>
+        <field name="comment_type">fiscal</field>
+        <field name="object">l10n_br_fiscal.document.mixin</field>
+    </record>
+
+    <record id="comment_consig_devsimb" model="l10n_br_fiscal.comment">
+        <field name="name">Devolução simbólica de consignação</field>
+        <field
+            name="comment"
+        >Devolução simbólica de mercadoria vendida, recebida em consignação mercantil - Ajuste SINIEF 02/93.</field>
+        <field name="comment_type">fiscal</field>
+        <field name="object">l10n_br_fiscal.document.mixin</field>
+    </record>
+
+    <record id="comment_consig_entrada" model="l10n_br_fiscal.comment">
+        <field name="name">Entrada em consignação mercantil</field>
+        <field
+            name="comment"
+        >Entrada de mercadoria recebida em consignação mercantil - Ajuste SINIEF 02/93.</field>
+        <field name="comment_type">fiscal</field>
+        <field name="object">l10n_br_fiscal.document.mixin</field>
+    </record>
+
+    <record id="comment_consig_venda" model="l10n_br_fiscal.comment">
+        <field name="name">Venda de mercadoria em consignação</field>
+        <field
+            name="comment"
+        >Venda de mercadoria recebida em consignação mercantil - Ajuste SINIEF 02/93.</field>
+        <field name="comment_type">fiscal</field>
+        <field name="object">l10n_br_fiscal.document.mixin</field>
+    </record>
+
+    <!-- ============ LADO CONSIGNANTE ============ -->
+
+    <!-- OP-4: Devolução recebida (entrada) — definida antes por ser alvo do return da OP-1 -->
+    <record id="fo_consig_ret" model="l10n_br_fiscal.operation">
+        <field name="code">CONSIG_RET</field>
+        <field name="name">Devolução de mercadoria remetida em consignação</field>
+        <field name="fiscal_operation_type">in</field>
+        <field name="fiscal_type">other</field>
+        <field name="state">approved</field>
+        <field name="comment_ids" eval="[(6, 0, [ref('comment_consig_devolucao')])]" />
+    </record>
+
+    <record id="fo_consig_ret_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_consig_ret" />
+        <field name="name">Devolução de mercadoria remetida em consignação</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1918" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2918" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <!-- ICMS/IPI: default de entrada (crédito, espelhando a remessa). PIS/COFINS não incidem. -->
+    <record id="fo_consig_ret_pis" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_ret_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_ret_cofins" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_ret_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- OP-1: Remessa em consignação -->
+    <record id="fo_consig_rem" model="l10n_br_fiscal.operation">
+        <field name="code">CONSIG_REM</field>
+        <field name="name">Remessa em consignação mercantil</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">other</field>
+        <field name="return_fiscal_operation_id" ref="fo_consig_ret" />
+        <field name="state">approved</field>
+        <field name="comment_ids" eval="[(6, 0, [ref('comment_consig_remessa')])]" />
+    </record>
+
+    <record id="fo_consig_rem_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_consig_rem" />
+        <field name="name">Remessa em consignação mercantil</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5917" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6917" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <!-- ICMS/IPI: default de venda (destaque normal). PIS/COFINS não incidem (sem receita). -->
+    <record id="fo_consig_rem_pis" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_rem_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_rem_cofins" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_rem_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- OP-2: Reajuste de preço em consignação (NF complementar) -->
+    <record id="fo_consig_rem_reaj" model="l10n_br_fiscal.operation">
+        <field name="code">CONSIG_REM_REAJ</field>
+        <field name="name">Reajuste de preço em consignação mercantil</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">other</field>
+        <field name="state">approved</field>
+        <field name="comment_ids" eval="[(6, 0, [ref('comment_consig_reajuste')])]" />
+    </record>
+
+    <record id="fo_consig_rem_reaj_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_consig_rem_reaj" />
+        <field name="name">Reajuste de preço em consignação mercantil</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5917" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6917" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_rem_reaj_pis" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_rem_reaj_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_rem_reaj_cofins" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_rem_reaj_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- OP-3: Faturamento (venda) de mercadoria em consignação -->
+    <record id="fo_consig_fat" model="l10n_br_fiscal.operation">
+        <field name="code">CONSIG_FAT</field>
+        <field
+            name="name"
+        >Venda de mercadoria remetida em consignação (faturamento)</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">sale</field>
+        <field name="state">approved</field>
+        <field
+            name="comment_ids"
+            eval="[(6, 0, [ref('comment_consig_faturamento')])]"
+        />
+    </record>
+
+    <record id="fo_consig_fat_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_consig_fat" />
+        <field
+            name="name"
+        >Venda de mercadoria remetida em consignação (faturamento)</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5114" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6114" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <!-- ICMS sem novo destaque (CST 90, já debitado na remessa). PIS/COFINS: default de venda (incide). -->
+    <record id="fo_consig_fat_icms" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_fat_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icms" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_0" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icms_90" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_fat_ipi" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_fat_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_49" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- OP-5: Entrada por devolução simbólica (Mecânica B) -->
+    <record id="fo_consig_devsimb_ent" model="l10n_br_fiscal.operation">
+        <field name="code">CONSIG_DEVSIMB_ENT</field>
+        <field name="name">Entrada de devolução simbólica de consignação</field>
+        <field name="fiscal_operation_type">in</field>
+        <field name="fiscal_type">other</field>
+        <field name="state">approved</field>
+        <field name="comment_ids" eval="[(6, 0, [ref('comment_consig_devsimb')])]" />
+    </record>
+
+    <record id="fo_consig_devsimb_ent_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_consig_devsimb_ent" />
+        <field name="name">Entrada de devolução simbólica de consignação</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1919" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2919" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <!-- Operação simbólica: todos os tributos zerados. -->
+    <record id="fo_consig_devsimb_ent_icms" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_devsimb_ent_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icms" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_0" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icms_90" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_devsimb_ent_ipi" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_devsimb_ent_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_devsimb_ent_pis" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_devsimb_ent_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_devsimb_ent_cofins" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_devsimb_ent_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- ============ LADO CONSIGNATÁRIO ============ -->
+
+    <!-- OP-8: Devolução ao consignante (saída) — definida antes por ser alvo do return da OP-6 -->
+    <record id="fo_consig_dev" model="l10n_br_fiscal.operation">
+        <field name="code">CONSIG_DEV</field>
+        <field name="name">Devolução de mercadoria recebida em consignação</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">other</field>
+        <field name="state">approved</field>
+        <field name="comment_ids" eval="[(6, 0, [ref('comment_consig_devolucao')])]" />
+    </record>
+
+    <record id="fo_consig_dev_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_consig_dev" />
+        <field name="name">Devolução de mercadoria recebida em consignação</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5918" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6918" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <!-- ICMS espelha a remessa recebida (para o consignante se creditar). IPI replicado. PIS/COFINS não incidem. -->
+    <record id="fo_consig_dev_ipi" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_dev_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_dev_pis" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_dev_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_dev_cofins" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_dev_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- OP-6: Entrada de mercadoria em consignação -->
+    <record id="fo_consig_ent" model="l10n_br_fiscal.operation">
+        <field name="code">CONSIG_ENT</field>
+        <field name="name">Entrada de mercadoria em consignação mercantil</field>
+        <field name="fiscal_operation_type">in</field>
+        <field name="fiscal_type">other</field>
+        <field name="return_fiscal_operation_id" ref="fo_consig_dev" />
+        <field name="state">approved</field>
+        <field name="comment_ids" eval="[(6, 0, [ref('comment_consig_entrada')])]" />
+    </record>
+
+    <record id="fo_consig_ent_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_consig_ent" />
+        <field name="name">Entrada de mercadoria em consignação mercantil</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1917" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2917" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <!-- ICMS/IPI: default de entrada (crédito quando permitido). PIS/COFINS não incidem. -->
+    <record id="fo_consig_ent_pis" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_ent_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_ent_cofins" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_ent_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- OP-7: Venda de mercadoria recebida em consignação (ao cliente final) -->
+    <record id="fo_consig_venda" model="l10n_br_fiscal.operation">
+        <field name="code">CONSIG_VENDA</field>
+        <field name="name">Venda de mercadoria recebida em consignação</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">sale</field>
+        <field
+            name="return_fiscal_operation_id"
+            ref="l10n_br_fiscal.fo_devolucao_venda"
+        />
+        <field name="state">approved</field>
+        <field name="comment_ids" eval="[(6, 0, [ref('comment_consig_venda')])]" />
+    </record>
+
+    <record id="fo_consig_venda_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_consig_venda" />
+        <field name="name">Venda de mercadoria recebida em consignação</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5115" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6115" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <!-- Venda normal: ICMS e PIS/COFINS default (incidem). IPI não destacado (comerciante). -->
+    <record id="fo_consig_venda_ipi" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_venda_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_49" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- OP-9: Devolução simbólica na venda (Mecânica B) -->
+    <record id="fo_consig_devsimb" model="l10n_br_fiscal.operation">
+        <field name="code">CONSIG_DEVSIMB</field>
+        <field
+            name="name"
+        >Devolução simbólica de mercadoria vendida em consignação</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">other</field>
+        <field name="state">approved</field>
+        <field name="comment_ids" eval="[(6, 0, [ref('comment_consig_devsimb')])]" />
+    </record>
+
+    <record id="fo_consig_devsimb_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_consig_devsimb" />
+        <field
+            name="name"
+        >Devolução simbólica de mercadoria vendida em consignação</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5919" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6919" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <!-- Operação simbólica: todos os tributos zerados. -->
+    <record id="fo_consig_devsimb_icms" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_devsimb_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icms" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_0" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icms_90" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_devsimb_ipi" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_devsimb_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_devsimb_pis" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_devsimb_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_devsimb_cofins" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_devsimb_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+
+
+    <!-- ================= Simples Nacional =================
+         Linhas irmãs para empresa do Simples (company_tax_framework=1): o
+         seletor de linha prefere a mais específica, então a empresa SN casa
+         estas (CSOSN via grupo icmssn) e os demais regimes casam as genéricas
+         (CST). Empresa em excesso de sublimite (framework=2) recolhe ICMS fora
+         do DAS e cai na genérica com CST — correto. Regra geral: movimento sem
+         receita/titularidade = CSOSN 400; ajuste/simbólica = 900; linha de
+         receita não fixa ICMS (herda a tributação SN da empresa). Mapa a
+         ratificar com contador (transferência de mercadoria: ADC 49). -->
+    <record id="fo_consig_ret_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_consig_ret" />
+        <field
+            name="name"
+        >Devolução de mercadoria remetida em consignação - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1918" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2918" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_ret_pis_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_ret_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_ret_cofins_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_ret_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_ret_line_sn_icmssn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_ret_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_rem_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_consig_rem" />
+        <field name="name">Remessa em consignação mercantil - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5917" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6917" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_rem_pis_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_rem_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_rem_cofins_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_rem_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_rem_line_sn_icmssn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_rem_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_rem_reaj_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_consig_rem_reaj" />
+        <field
+            name="name"
+        >Reajuste de preço em consignação mercantil - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5917" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6917" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_rem_reaj_pis_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_rem_reaj_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_rem_reaj_cofins_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_rem_reaj_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+    <record
+        id="fo_consig_rem_reaj_line_sn_icmssn"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="fiscal_operation_line_id" ref="fo_consig_rem_reaj_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_dev_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_consig_dev" />
+        <field
+            name="name"
+        >Devolução de mercadoria recebida em consignação - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5918" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6918" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_dev_ipi_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_dev_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_dev_pis_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_dev_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_dev_cofins_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_dev_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_dev_line_sn_icmssn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_dev_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_ent_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_consig_ent" />
+        <field
+            name="name"
+        >Entrada de mercadoria em consignação mercantil - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1917" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2917" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_ent_pis_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_ent_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_ent_cofins_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_ent_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_ent_line_sn_icmssn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_ent_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_devsimb_ent_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_consig_devsimb_ent" />
+        <field
+            name="name"
+        >Entrada de devolução simbólica de consignação - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1919" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2919" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_devsimb_ent_ipi_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_devsimb_ent_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_devsimb_ent_pis_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_devsimb_ent_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_devsimb_ent_cofins_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_devsimb_ent_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+    <record
+        id="fo_consig_devsimb_ent_line_sn_icmssn"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="fiscal_operation_line_id" ref="fo_consig_devsimb_ent_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_900" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_devsimb_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_consig_devsimb" />
+        <field
+            name="name"
+        >Devolução simbólica de mercadoria vendida em consignação - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5919" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6919" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_devsimb_ipi_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_devsimb_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_devsimb_pis_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_devsimb_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_devsimb_cofins_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_devsimb_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_devsimb_line_sn_icmssn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_devsimb_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_900" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_fat_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_consig_fat" />
+        <field
+            name="name"
+        >Venda de mercadoria remetida em consignação (faturamento) - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5114" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6114" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_consig_fat_ipi_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_consig_fat_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_49" />
+        <field name="state">approved</field>
+    </record>
+
+</odoo>

--- a/l10n_br_fiscal/demo/fiscal_document_consignacao_demo.xml
+++ b/l10n_br_fiscal/demo/fiscal_document_consignacao_demo.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  História ponta-a-ponta da consignação (lado consignante), Empresa Lucro Presumido:
+  1) remete 10 un em consignação ao cliente contribuinte de SP;
+  2) fatura 6 un efetivamente vendidas pelo consignatário (sem novo ICMS);
+  3) recebe de volta 4 un não vendidas (crédito de ICMS espelhando a remessa).
+-->
+<odoo noupdate="1">
+
+    <!-- 1) Remessa em consignação -->
+    <record id="demo_consig_remessa" model="l10n_br_fiscal.document">
+        <field name="fiscal_operation_id" ref="fo_consig_rem" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
+        <field
+            name="document_serie_id"
+            ref="l10n_br_fiscal.empresa_lc_document_55_serie_1"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+        <field name="document_serie">1</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
+        <field name="user_id" ref="base.user_demo" />
+        <field name="fiscal_operation_type">out</field>
+    </record>
+
+    <record id="demo_consig_remessa_line" model="l10n_br_fiscal.document.line">
+        <field name="document_id" ref="demo_consig_remessa" />
+        <field name="name">Mercadoria remetida em consignação</field>
+        <field name="product_id" ref="product.product_product_6" />
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="quantity">10</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="fo_consig_rem" />
+        <field name="fiscal_operation_line_id" ref="fo_consig_rem_line" />
+    </record>
+
+    <!-- 2) Faturamento da venda (6 un) -->
+    <record id="demo_consig_faturamento" model="l10n_br_fiscal.document">
+        <field name="fiscal_operation_id" ref="fo_consig_fat" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
+        <field
+            name="document_serie_id"
+            ref="l10n_br_fiscal.empresa_lc_document_55_serie_1"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+        <field name="document_serie">1</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
+        <field name="user_id" ref="base.user_demo" />
+        <field name="fiscal_operation_type">out</field>
+    </record>
+
+    <record id="demo_consig_faturamento_line" model="l10n_br_fiscal.document.line">
+        <field name="document_id" ref="demo_consig_faturamento" />
+        <field name="name">Faturamento de mercadoria em consignação</field>
+        <field name="product_id" ref="product.product_product_6" />
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="quantity">6</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="fo_consig_fat" />
+        <field name="fiscal_operation_line_id" ref="fo_consig_fat_line" />
+    </record>
+
+    <!-- 3) Devolução recebida (4 un não vendidas) -->
+    <record id="demo_consig_devolucao" model="l10n_br_fiscal.document">
+        <field name="fiscal_operation_id" ref="fo_consig_ret" />
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
+        <field
+            name="document_serie_id"
+            ref="l10n_br_fiscal.empresa_lc_document_55_serie_1"
+        />
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+        <field name="document_serie">1</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp" />
+        <field name="user_id" ref="base.user_demo" />
+        <field name="fiscal_operation_type">in</field>
+    </record>
+
+    <record id="demo_consig_devolucao_line" model="l10n_br_fiscal.document.line">
+        <field name="document_id" ref="demo_consig_devolucao" />
+        <field name="name">Devolução de mercadoria em consignação</field>
+        <field name="product_id" ref="product.product_product_6" />
+        <field name="uom_id" ref="uom.product_uom_unit" />
+        <field name="quantity">4</field>
+        <field name="fiscal_operation_type">in</field>
+        <field name="fiscal_operation_id" ref="fo_consig_ret" />
+        <field name="fiscal_operation_line_id" ref="fo_consig_ret_line" />
+    </record>
+
+</odoo>

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -17,4 +17,6 @@ from . import (
     test_service_type,
     test_operation,
     test_tax_framework,
+    test_catalog_consignacao,
+    test_regime,
 )

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -16,4 +16,6 @@ from . import (
     test_partner_profile,
     test_service_type,
     test_operation,
+    test_catalog_consignacao,
+    test_regime,
 )

--- a/l10n_br_fiscal/tests/operation_catalog_common.py
+++ b/l10n_br_fiscal/tests/operation_catalog_common.py
@@ -1,0 +1,86 @@
+# Copyright (C) 2026 KMEE
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo.tests.common import TransactionCase
+
+
+class OperationCatalogCommon(TransactionCase):
+    """Base para os testes do catálogo de operações fiscais.
+
+    Fornece uma empresa em SP e três parceiros (interno, interestadual e
+    exterior) para exercitar a resolução de CFOP por destino
+    (``operation.line._get_cfop``), além de helpers de asserção.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.br = cls.env.ref("base.br")
+        cls.state_sp = cls.env.ref("base.state_br_sp")
+        cls.state_mg = cls.env.ref("base.state_br_mg")
+
+        cls.company = cls.env.ref("base.main_company")
+        cls.company.write({"country_id": cls.br.id, "state_id": cls.state_sp.id})
+
+        Partner = cls.env["res.partner"]
+        cls.partner_interno = Partner.create(
+            {
+                "name": "Parceiro Interno SP",
+                "country_id": cls.br.id,
+                "state_id": cls.state_sp.id,
+            }
+        )
+        cls.partner_interestadual = Partner.create(
+            {
+                "name": "Parceiro Interestadual MG",
+                "country_id": cls.br.id,
+                "state_id": cls.state_mg.id,
+            }
+        )
+        cls.partner_exterior = Partner.create(
+            {
+                "name": "Parceiro Exterior",
+                "country_id": cls.env.ref("base.us").id,
+            }
+        )
+
+    def _cfop_code(self, operation_line, partner):
+        return operation_line._get_cfop(self.company, partner).code
+
+    def assert_operation_cfops(
+        self, operation_line_xmlid, internal, external, export=None
+    ):
+        """Confere que a linha de operação resolve o CFOP esperado por destino.
+
+        :param operation_line_xmlid: xmlid completo da l10n_br_fiscal.operation.line
+        :param internal: código CFOP esperado para operação interna (mesmo estado)
+        :param external: código CFOP esperado para operação interestadual
+        :param export: código CFOP esperado para exportação (opcional)
+        """
+        line = self.env.ref(operation_line_xmlid)
+        self.assertEqual(
+            self._cfop_code(line, self.partner_interno),
+            internal,
+            "CFOP interno incorreto em %s" % operation_line_xmlid,
+        )
+        self.assertEqual(
+            self._cfop_code(line, self.partner_interestadual),
+            external,
+            "CFOP interestadual incorreto em %s" % operation_line_xmlid,
+        )
+        if export:
+            self.assertEqual(
+                self._cfop_code(line, self.partner_exterior),
+                export,
+                "CFOP de exportação incorreto em %s" % operation_line_xmlid,
+            )
+
+    def assert_return_link(self, operation_xmlid, return_operation_xmlid):
+        """Confere o encadeamento remessa/retorno via return_fiscal_operation_id."""
+        operation = self.env.ref(operation_xmlid)
+        expected = self.env.ref(return_operation_xmlid)
+        self.assertEqual(
+            operation.return_fiscal_operation_id,
+            expected,
+            "Encadeamento de retorno incorreto em %s" % operation_xmlid,
+        )

--- a/l10n_br_fiscal/tests/test_catalog_consignacao.py
+++ b/l10n_br_fiscal/tests/test_catalog_consignacao.py
@@ -1,0 +1,85 @@
+# Copyright (C) 2026 KMEE
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+"""Testes data-driven do catálogo de operações: consignacao."""
+
+from odoo.tests import tagged
+
+from .operation_catalog_common import OperationCatalogCommon
+
+M = "l10n_br_fiscal"
+
+CFOP_CASES = [
+    ("fo_consig_rem_line", "5917", "6917", None),
+    ("fo_consig_rem_reaj_line", "5917", "6917", None),
+    ("fo_consig_fat_line", "5114", "6114", None),
+    ("fo_consig_ret_line", "1918", "2918", None),
+    ("fo_consig_devsimb_ent_line", "1919", "2919", None),
+    ("fo_consig_ent_line", "1917", "2917", None),
+    ("fo_consig_venda_line", "5115", "6115", None),
+    ("fo_consig_dev_line", "5918", "6918", None),
+    ("fo_consig_devsimb_line", "5919", "6919", None),
+]
+
+RETURN_LINKS = [
+    ("fo_consig_rem", "fo_consig_ret"),
+    ("fo_consig_ent", "fo_consig_dev"),
+    ("fo_consig_venda", "fo_devolucao_venda"),
+]
+
+TAX_DEF_CASES = [
+    ("fo_consig_rem_line", {"PIS": "49", "COFINS": "49"}, ["ICMS"], []),
+    ("fo_consig_fat_line", {"ICMS": "90"}, ["PIS", "COFINS"], []),
+]
+
+
+@tagged("post_install", "-at_install", "op_catalog")
+class TestCatalogConsignacao(OperationCatalogCommon):
+    def test_cfops(self):
+        """CFOP resolvido por destino (interno/interestadual/exportação)."""
+        for line, internal, external, export in CFOP_CASES:
+            with self.subTest(line=line):
+                self.assert_operation_cfops(f"{M}.{line}", internal, external, export)
+
+    def test_return_links(self):
+        """Encadeamento remessa/retorno via return_fiscal_operation_id."""
+        for op, ret in RETURN_LINKS:
+            with self.subTest(op=op):
+                self.assert_return_link(f"{M}.{op}", f"{M}.{ret}")
+
+    def test_tax_definitions(self):
+        """CST por grupo, ausência de definition (default) e não incidência."""
+        for line, csts, absent, not_taxed in TAX_DEF_CASES:
+            with self.subTest(line=line):
+                rec = self.env.ref(f"{M}.{line}")
+                defs = {d.tax_group_id.name: d for d in rec.tax_definition_ids}
+                for group, cst in csts.items():
+                    self.assertEqual(defs[group].cst_id.code, cst, f"{line}/{group}")
+                for group in absent:
+                    self.assertNotIn(group, defs, f"{line}/{group}")
+                for group in not_taxed:
+                    self.assertFalse(defs[group].is_taxed, f"{line}/{group}")
+
+    def test_operations_loaded(self):
+        """As 9 operações da família carregam aprovadas."""
+        codes = [
+            "CONSIG_REM",
+            "CONSIG_REM_REAJ",
+            "CONSIG_FAT",
+            "CONSIG_RET",
+            "CONSIG_DEVSIMB_ENT",
+            "CONSIG_ENT",
+            "CONSIG_VENDA",
+            "CONSIG_DEV",
+            "CONSIG_DEVSIMB",
+        ]
+        ops = self.env["l10n_br_fiscal.operation"].search([("code", "in", codes)])
+        self.assertEqual(len(ops), 9)
+        self.assertTrue(all(op.state == "approved" for op in ops))
+
+    def test_simbolicas_zeradas(self):
+        """Devolução simbólica (Mecânica B): todos os grupos zerados."""
+        line = self.env.ref(f"{M}.fo_consig_devsimb_line")
+        groups = {d.tax_group_id.name for d in line.tax_definition_ids}
+        self.assertEqual(groups, {"ICMS", "IPI", "PIS", "COFINS"})
+        for d in line.tax_definition_ids:
+            self.assertEqual(d.tax_id.percent_amount, 0.0)

--- a/l10n_br_fiscal/tests/test_regime.py
+++ b/l10n_br_fiscal/tests/test_regime.py
@@ -1,0 +1,106 @@
+# Copyright (C) 2026 KMEE
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo.tests import tagged
+
+from .operation_catalog_common import OperationCatalogCommon
+
+MODULE = "l10n_br_fiscal"
+SN_GROUP = "ICMS - Simples Nacional"
+
+
+@tagged("post_install", "-at_install", "op_catalog")
+class TestRegime(OperationCatalogCommon):
+    """O catálogo é neutro de regime: a empresa é o único ponto de configuração.
+
+    A mesma fiscal.operation resolve CST (regime normal) ou CSOSN (Simples)
+    conforme o tax_framework da empresa — trocar a empresa de regime não exige
+    reconfigurar nenhuma operação.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company_sn = cls.env.ref("l10n_br_base.empresa_simples_nacional")
+        cls.company_lp = cls.env.ref("l10n_br_base.empresa_lucro_presumido")
+        # Parceiro demo com IE: o ind_ie_dest é computado (sem IE vira
+        # não-contribuinte), então é preciso um contribuinte real.
+        cls.partner_contribuinte = cls.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        cls.product_00 = cls.env["product.product"].create(
+            {
+                "name": "Produto Teste Regime",
+                "fiscal_type": "00",
+                "tax_icms_or_issqn": "icms",
+            }
+        )
+
+    def _line_for(self, op_xmlid, company):
+        operation = self.env.ref(op_xmlid)
+        return operation.line_definition(
+            company, self.partner_contribuinte, self.product_00
+        )
+
+    def test_simples_casa_linha_csosn(self):
+        """Empresa SN casa a linha irmã SN (CSOSN 400); regime normal, a genérica."""
+        op = f"{MODULE}.fo_consig_rem"
+        line_sn = self._line_for(op, self.company_sn)
+        self.assertEqual(line_sn.company_tax_framework, "1")
+        defs = {d.tax_group_id.name: d for d in line_sn.tax_definition_ids}
+        self.assertEqual(defs[SN_GROUP].cst_id.code, "400")
+        self.assertNotIn("ICMS", defs)
+
+        line_lp = self._line_for(op, self.company_lp)
+        self.assertFalse(line_lp.company_tax_framework)
+        defs_lp = {d.tax_group_id.name: d for d in line_lp.tax_definition_ids}
+        # na remessa em consignação o ICMS destaca pelo default (sem definition)
+        self.assertNotIn("ICMS", defs_lp)
+        self.assertEqual(defs_lp["PIS"].cst_id.code, "49")
+
+    def test_troca_de_regime_sem_reconfigurar(self):
+        """Simples -> Presumido -> Real trocando só o cadastro da empresa."""
+        company = self.company_lp
+        op = f"{MODULE}.fo_consig_rem"
+
+        # Presumido (regime normal): linha genérica com CST.
+        self.assertFalse(self._line_for(op, company).company_tax_framework)
+
+        # Empresa "entra" no Simples: muda só o tax_framework no cadastro.
+        company.tax_framework = "1"
+        self.assertEqual(self._line_for(op, company).company_tax_framework, "1")
+
+        # Sai do Simples para o Presumido: volta à linha genérica. Nenhuma
+        # operação foi reconfigurada em nenhum momento.
+        company.tax_framework = "3"
+        self.assertFalse(self._line_for(op, company).company_tax_framework)
+
+        # Presumido -> Real: muda só o profit_calculation no cadastro; a
+        # linha da operação é a mesma (a diferença de PIS/COFINS vem do
+        # default da empresa, não do catálogo).
+        line_before = self._line_for(op, company)
+        company.profit_calculation = "real"
+        line_after = self._line_for(op, company)
+        self.assertEqual(line_before, line_after)
+        company.profit_calculation = "presumed"
+
+    def test_excesso_sublimite_usa_cst(self):
+        """Empresa framework=2 (excesso de sublimite) recolhe ICMS fora do DAS:
+        cai na linha genérica com CST, não na linha SN."""
+        company = self.company_lp
+        company.tax_framework = "2"
+        line = self._line_for(f"{MODULE}.fo_consig_rem", company)
+        self.assertFalse(line.company_tax_framework)
+        company.tax_framework = "3"
+
+    def test_receita_sn_nao_fixa_csosn(self):
+        """Linhas de receita (faturamento de consignação) na variante SN não
+        fixam ICMS/CSOSN — herdam a tributação SN default da empresa."""
+        line_sn = self.env.ref(f"{MODULE}.fo_consig_fat_line_sn")
+        groups = {d.tax_group_id.name for d in line_sn.tax_definition_ids}
+        self.assertNotIn("ICMS", groups)
+        self.assertNotIn(SN_GROUP, groups)
+
+    def test_simbolica_sn_usa_900(self):
+        """Simbólicas/ajustes na variante SN usam CSOSN 900."""
+        line = self.env.ref(f"{MODULE}.fo_consig_devsimb_line_sn")
+        defs = {d.tax_group_id.name: d for d in line.tax_definition_ids}
+        self.assertEqual(defs[SN_GROUP].cst_id.code, "900")


### PR DESCRIPTION
Primeira família de um catálogo de operações fiscais curadas (série de PRs, uma família por PR).

Adiciona a consignação mercantil (Ajuste SINIEF 02/93): remessa, reajuste, faturamento, venda pelo consignatário, devoluções e simbólicas, com a dissociação do fato gerador (ICMS/IPI na remessa; PIS/COFINS no faturamento), CFOPs por destino e encadeamento remessa/retorno.

O catálogo é neutro de regime tributário: linhas irmãs Simples Nacional (company_tax_framework=1) emitem com CSOSN e os demais regimes com CST, pela mesma operação. Mudar a empresa de regime (Simples <-> Presumido <-> Real, inclusive excesso de sublimite) exige apenas alterar o cadastro da empresa; test_regime cobre as transições.

Inclui demo com o ciclo encadeado e a base de testes data-driven (operation_catalog_common), reutilizada pelas demais famílias da série.
