### PR TITLE
[16.0][IMP] l10n_br_fiscal: operações de venda de ativo, notas complementares e compra para serviço

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -51,6 +51,9 @@
         "data/l10n_br_fiscal.operation.indicator.csv",
         "data/simplified_tax_data.xml",
         "data/operation_data.xml",
+        "data/fiscal_operation_venda.xml",
+        "data/fiscal_operation_compras.xml",
+        "data/fiscal_operation_devolucao.xml",
         "data/l10n_br_fiscal_tax_icms_data.xml",
         # the following csv data files will be loaded as noupdate=True
         # and will be trimmed down when demo mode is True (faster):

--- a/l10n_br_fiscal/data/fiscal_operation_compras.xml
+++ b/l10n_br_fiscal/data/fiscal_operation_compras.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Família COMPRAS — acrescenta apenas as linhas de compra para prestação de
+  serviço, que faltam no core.
+
+  A matriz de crédito por destinação (PIS/COFINS/IPI por regime) NÃO entra aqui:
+  fixar tax.definition nas linhas de fo_compras sobrescreve o imposto que vem do
+  produto/regulamento e quebra o comportamento por regime (Simples/Presumido/
+  Real) — é decisão de regime, deve morar num módulo/config próprio, não no
+  catálogo base. Ver SANEAMENTO_OPERACOES_BASE.md.
+-->
+<odoo noupdate="1">
+
+    <!-- Compra para prestação de serviço (linhas novas em fo_compras) -->
+    <record id="fo_compras_servico_icms" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field name="name">Compra para prestação de serviço (ICMS)</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1126" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2126" />
+        <field name="product_type">09</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_compras_servico_iss" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_compras" />
+        <field name="name">Compra para prestação de serviço (ISS)</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1128" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2128" />
+        <field name="product_type">09</field>
+        <field name="tax_icms_or_issqn">issqn</field>
+        <field name="state">approved</field>
+    </record>
+
+</odoo>

--- a/l10n_br_fiscal/data/fiscal_operation_devolucao.xml
+++ b/l10n_br_fiscal/data/fiscal_operation_devolucao.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Família DEVOLUÇÕES — o core já tem fo_devolucao_venda e fo_devolucao_compras
+  com as linhas principais (produção/revenda/ativo/uso-consumo). O espelhamento
+  dos impostos da nota de origem é comportamento de runtime (copiado via
+  return_fiscal_operation_id), não dado fixo — por isso não há tax.definition
+  aqui.
+
+  Nesta fase entra apenas a linha que fecha o par da compra para prestação de
+  serviço (1126/2126 → devolução 5210/6210).
+
+  A DEVOLUÇÃO DE TRANSFERÊNCIA (5208/5209·6208/6209 / 1208/1209·2208/2209) fica
+  para a fase 2, junto com a família Transferências — o core 16.0 atual NÃO tem
+  operações de transferência (só existiam no snapshot antigo), então a ida
+  precisa ser criada primeiro para o retorno ter par.
+-->
+<odoo noupdate="1">
+
+    <!-- Devolução de compra para prestação de serviço (par de fo_compras_servico_icms) -->
+    <record id="fo_devolucao_compras_servico" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_devolucao_compras" />
+        <field name="name">Devolução de compra para prestação de serviço</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5210" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6210" />
+        <field name="product_type">09</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+
+</odoo>

--- a/l10n_br_fiscal/data/fiscal_operation_venda.xml
+++ b/l10n_br_fiscal/data/fiscal_operation_venda.xml
@@ -1,0 +1,229 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Família VENDA — operações NOVAS complementares ao core (que já tem fo_venda).
+  NÃO estende fo_venda (para não quebrar módulos que dependem da sua estrutura,
+  ex. l10n_br_pos conta as linhas). Cobre: (a) venda de ativo imobilizado (não
+  incidência); (b) nota complementar de valor e de imposto (edoc_purpose=2 /
+  finNFe=2, mesmo CFOP da origem).
+
+  FORA daqui (sub-famílias/PRs próprios): destinatário isento de IE (ind_ie_dest=2,
+  exige ajustar a contagem testada pelo l10n_br_pos); Substituição Tributária;
+  DIFAL (camada de imposto). Decisões default a validar com contador.
+-->
+<odoo noupdate="1">
+
+    <!-- (a) Venda de ativo imobilizado (desincorporação): não incidência de
+         ICMS (art. 3º LC 87/96), IPI, PIS e COFINS. -->
+    <record id="fo_venda_ativo" model="l10n_br_fiscal.operation">
+        <field name="code">VD-ATIVO</field>
+        <field name="name">Venda de ativo imobilizado</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">other</field>
+        <field name="state">approved</field>
+    </record>
+
+    <record id="fo_venda_ativo_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_venda_ativo" />
+        <field name="name">Venda de ativo imobilizado</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5551" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6551" />
+        <field name="product_type">04</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_venda_ativo_icms" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_venda_ativo_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icms" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icms_41" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_venda_ativo_ipi" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_venda_ativo_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_53" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_venda_ativo_pis" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_venda_ativo_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_08" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_venda_ativo_cofins" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_venda_ativo_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_08" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- (c) Nota complementar de VALOR/PREÇO: edoc_purpose=2 (finNFe=2), mesmo
+         CFOP da venda; todos os impostos incidem sobre a diferença de valor. -->
+    <record id="fo_complementar_valor" model="l10n_br_fiscal.operation">
+        <field name="code">COMPL-VALOR</field>
+        <field name="name">NF-e complementar de valor/preço</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">sale</field>
+        <field name="edoc_purpose">2</field>
+        <field name="state">approved</field>
+    </record>
+
+    <record id="fo_complementar_valor_producao" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_complementar_valor" />
+        <field name="name">Complemento de venda (produção)</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5101" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6101" />
+        <field name="cfop_export_id" ref="l10n_br_fiscal.cfop_7101" />
+        <field name="product_type">04</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+
+    <record id="fo_complementar_valor_revenda" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_complementar_valor" />
+        <field name="name">Complemento de revenda</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5102" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6102" />
+        <field name="cfop_export_id" ref="l10n_br_fiscal.cfop_7102" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record
+        id="fo_complementar_valor_revenda_ipi_nt"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="fiscal_operation_line_id" ref="fo_complementar_valor_revenda" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_53" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- (c) Nota complementar de IMPOSTO (ICMS): edoc_purpose=2; só o ICMS é
+         destacado (a diferença); IPI/PIS/COFINS não incidem no complemento. -->
+    <record id="fo_complementar_icms" model="l10n_br_fiscal.operation">
+        <field name="code">COMPL-ICMS</field>
+        <field name="name">NF-e complementar de imposto (ICMS)</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">other</field>
+        <field name="edoc_purpose">2</field>
+        <field name="state">approved</field>
+    </record>
+
+    <record id="fo_complementar_icms_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_complementar_icms" />
+        <field name="name">Complemento de ICMS</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5101" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6101" />
+        <field name="product_type">04</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <!-- ICMS: default (destaca o complemento). IPI/PIS/COFINS: não incidem. -->
+    <record id="fo_complementar_icms_ipi" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_complementar_icms_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_53" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_complementar_icms_pis" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_complementar_icms_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_08" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_complementar_icms_cofins" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_complementar_icms_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_08" />
+        <field name="state">approved</field>
+    </record>
+
+
+    <!-- ================= Simples Nacional =================
+         Linhas irmãs para empresa do Simples (company_tax_framework=1): o
+         seletor de linha prefere a mais específica, então a empresa SN casa
+         estas (CSOSN via grupo icmssn) e os demais regimes casam as genéricas
+         (CST). Empresa em excesso de sublimite (framework=2) recolhe ICMS fora
+         do DAS e cai na genérica com CST — correto. Regra geral: movimento sem
+         receita/titularidade = CSOSN 400; ajuste/simbólica = 900; linha de
+         receita não fixa ICMS (herda a tributação SN da empresa). Mapa a
+         ratificar com contador (transferência de mercadoria: ADC 49). -->
+    <record id="fo_venda_ativo_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_venda_ativo" />
+        <field name="name">Venda de ativo imobilizado - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5551" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6551" />
+        <field name="product_type">04</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_venda_ativo_ipi_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_venda_ativo_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_53" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_venda_ativo_pis_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_venda_ativo_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_08" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_venda_ativo_cofins_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_venda_ativo_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_08" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_venda_ativo_line_sn_icmssn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_venda_ativo_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+
+</odoo>

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -17,4 +17,5 @@ from . import (
     test_service_type,
     test_operation,
     test_tax_framework,
+    test_catalog_venda_compras,
 )

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -16,4 +16,5 @@ from . import (
     test_partner_profile,
     test_service_type,
     test_operation,
+    test_catalog_venda_compras,
 )

--- a/l10n_br_fiscal/tests/operation_catalog_common.py
+++ b/l10n_br_fiscal/tests/operation_catalog_common.py
@@ -1,0 +1,86 @@
+# Copyright (C) 2026 KMEE
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo.tests.common import TransactionCase
+
+
+class OperationCatalogCommon(TransactionCase):
+    """Base para os testes do catálogo de operações fiscais.
+
+    Fornece uma empresa em SP e três parceiros (interno, interestadual e
+    exterior) para exercitar a resolução de CFOP por destino
+    (``operation.line._get_cfop``), além de helpers de asserção.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.br = cls.env.ref("base.br")
+        cls.state_sp = cls.env.ref("base.state_br_sp")
+        cls.state_mg = cls.env.ref("base.state_br_mg")
+
+        cls.company = cls.env.ref("base.main_company")
+        cls.company.write({"country_id": cls.br.id, "state_id": cls.state_sp.id})
+
+        Partner = cls.env["res.partner"]
+        cls.partner_interno = Partner.create(
+            {
+                "name": "Parceiro Interno SP",
+                "country_id": cls.br.id,
+                "state_id": cls.state_sp.id,
+            }
+        )
+        cls.partner_interestadual = Partner.create(
+            {
+                "name": "Parceiro Interestadual MG",
+                "country_id": cls.br.id,
+                "state_id": cls.state_mg.id,
+            }
+        )
+        cls.partner_exterior = Partner.create(
+            {
+                "name": "Parceiro Exterior",
+                "country_id": cls.env.ref("base.us").id,
+            }
+        )
+
+    def _cfop_code(self, operation_line, partner):
+        return operation_line._get_cfop(self.company, partner).code
+
+    def assert_operation_cfops(
+        self, operation_line_xmlid, internal, external, export=None
+    ):
+        """Confere que a linha de operação resolve o CFOP esperado por destino.
+
+        :param operation_line_xmlid: xmlid completo da l10n_br_fiscal.operation.line
+        :param internal: código CFOP esperado para operação interna (mesmo estado)
+        :param external: código CFOP esperado para operação interestadual
+        :param export: código CFOP esperado para exportação (opcional)
+        """
+        line = self.env.ref(operation_line_xmlid)
+        self.assertEqual(
+            self._cfop_code(line, self.partner_interno),
+            internal,
+            "CFOP interno incorreto em %s" % operation_line_xmlid,
+        )
+        self.assertEqual(
+            self._cfop_code(line, self.partner_interestadual),
+            external,
+            "CFOP interestadual incorreto em %s" % operation_line_xmlid,
+        )
+        if export:
+            self.assertEqual(
+                self._cfop_code(line, self.partner_exterior),
+                export,
+                "CFOP de exportação incorreto em %s" % operation_line_xmlid,
+            )
+
+    def assert_return_link(self, operation_xmlid, return_operation_xmlid):
+        """Confere o encadeamento remessa/retorno via return_fiscal_operation_id."""
+        operation = self.env.ref(operation_xmlid)
+        expected = self.env.ref(return_operation_xmlid)
+        self.assertEqual(
+            operation.return_fiscal_operation_id,
+            expected,
+            "Encadeamento de retorno incorreto em %s" % operation_xmlid,
+        )

--- a/l10n_br_fiscal/tests/test_catalog_venda_compras.py
+++ b/l10n_br_fiscal/tests/test_catalog_venda_compras.py
@@ -1,0 +1,74 @@
+# Copyright (C) 2026 KMEE
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+"""Testes data-driven do catálogo de operações: venda / compras."""
+
+from odoo.tests import tagged
+
+from .operation_catalog_common import OperationCatalogCommon
+
+M = "l10n_br_fiscal"
+
+CFOP_CASES = [
+    ("fo_venda_ativo_line", "5551", "6551", None),
+    ("fo_complementar_valor_producao", "5101", "6101", "7101"),
+    ("fo_compras_servico_icms", "1126", "2126", None),
+    ("fo_compras_servico_iss", "1128", "2128", None),
+    ("fo_devolucao_compras_servico", "5210", "6210", None),
+]
+
+TAX_DEF_CASES = [
+    (
+        "fo_venda_ativo_line",
+        {"ICMS": "41", "PIS": "08", "COFINS": "08"},
+        [],
+        ["ICMS", "PIS"],
+    ),
+    (
+        "fo_complementar_icms_line",
+        {"PIS": "08", "COFINS": "08"},
+        ["ICMS"],
+        ["PIS", "COFINS"],
+    ),
+]
+
+ATTR_CASES = [
+    ("fo_venda_ativo", "fiscal_type", "other"),
+    ("fo_complementar_valor", "edoc_purpose", "2"),
+    ("fo_complementar_valor", "fiscal_type", "sale"),
+    ("fo_complementar_icms", "edoc_purpose", "2"),
+    ("fo_complementar_icms", "fiscal_type", "other"),
+    ("fo_compras_servico_iss", "tax_icms_or_issqn", "issqn"),
+    ("fo_devolucao_compras_servico", "product_type", "09"),
+    ("fo_devolucao_compras_servico", "fiscal_operation_id.code", "DVC"),
+]
+
+
+@tagged("post_install", "-at_install", "op_catalog")
+class TestCatalogVendaCompras(OperationCatalogCommon):
+    def test_cfops(self):
+        """CFOP resolvido por destino (interno/interestadual/exportação)."""
+        for line, internal, external, export in CFOP_CASES:
+            with self.subTest(line=line):
+                self.assert_operation_cfops(f"{M}.{line}", internal, external, export)
+
+    def test_tax_definitions(self):
+        """CST por grupo, ausência de definition (default) e não incidência."""
+        for line, csts, absent, not_taxed in TAX_DEF_CASES:
+            with self.subTest(line=line):
+                rec = self.env.ref(f"{M}.{line}")
+                defs = {d.tax_group_id.name: d for d in rec.tax_definition_ids}
+                for group, cst in csts.items():
+                    self.assertEqual(defs[group].cst_id.code, cst, f"{line}/{group}")
+                for group in absent:
+                    self.assertNotIn(group, defs, f"{line}/{group}")
+                for group in not_taxed:
+                    self.assertFalse(defs[group].is_taxed, f"{line}/{group}")
+
+    def test_attrs(self):
+        """Atributos pontuais (finalidade de emissão, tipo fiscal, ISSQN...)."""
+        for xmlid, path, expected in ATTR_CASES:
+            with self.subTest(xmlid=xmlid, attr=path):
+                value = self.env.ref(f"{M}.{xmlid}")
+                for part in path.split("."):
+                    value = getattr(value, part)
+                self.assertEqual(value, expected)


### PR DESCRIPTION
Parte da série do catálogo de operações fiscais:

- Venda de ativo imobilizado (5551, não incidência de ICMS/IPI/PIS/COFINS)
- Notas complementares de valor e de imposto (edoc_purpose=2, mesmo CFOP da operação de origem)
- Compra para prestação de serviço (1126 ICMS / 1128 ISS) e sua devolução (5210)

Com linhas irmãs Simples Nacional (CSOSN) onde o CST fixo do regime normal não se aplica. Não estende fo_venda/fo_compras de forma que altere a estrutura testada por outros módulos. Testes data-driven de CFOP, CST e atributos.
