### PR TITLE
[16.0][IMP] l10n_br_fiscal: operações de bonificação, brinde, doação, amostra e comodato

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -51,6 +51,8 @@
         "data/l10n_br_fiscal.operation.indicator.csv",
         "data/simplified_tax_data.xml",
         "data/operation_data.xml",
+        "data/fiscal_operation_bonificacao.xml",
+        "data/fiscal_operation_comodato.xml",
         "data/l10n_br_fiscal_tax_icms_data.xml",
         # the following csv data files will be loaded as noupdate=True
         # and will be trimmed down when demo mode is True (faster):

--- a/l10n_br_fiscal/data/fiscal_operation_bonificacao.xml
+++ b/l10n_br_fiscal/data/fiscal_operation_bonificacao.xml
@@ -1,0 +1,481 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Família BONIFICAÇÃO / BRINDE / DOAÇÃO / AMOSTRA GRÁTIS.
+
+  Tributação (caso geral): há circulação de mercadoria em nota própria, então o
+  ICMS INCIDE (CST 00) — exceto amostra grátis, isenta (CST 40, Conv. ICM 29/90).
+  Não há receita, então PIS/COFINS NÃO incidem (CST 08). IPI: industrial destaca
+  (CST 50); amostra é isenta (CST 52, art. 54 RIPI).
+
+  O core tem fo_bonificacao (5910/6910) SEM tributação. Aqui: (a) acrescenta as
+  tax.definition de PIS/COFINS à linha do core (aditivo); (b) cria brinde, doação
+  e amostra como operações próprias (granularidade do catálogo); (c) cria as
+  entradas dedicadas e religa os returns.
+-->
+<odoo noupdate="1">
+
+    <!-- infCpl (a da bonificação-core é consolidada no PR de saneamento) -->
+    <record id="comment_brinde" model="l10n_br_fiscal.comment">
+        <field name="name">Brinde</field>
+        <field
+            name="comment"
+        >Remessa de brinde, sem valor comercial. Operação sem receita; PIS/COFINS sem incidência.</field>
+        <field name="comment_type">fiscal</field>
+        <field name="object">l10n_br_fiscal.document.mixin</field>
+    </record>
+    <record id="comment_doacao" model="l10n_br_fiscal.comment">
+        <field name="name">Doação</field>
+        <field
+            name="comment"
+        >Doação de mercadoria. Sem receita; ICMS destacado por haver circulação.</field>
+        <field name="comment_type">fiscal</field>
+        <field name="object">l10n_br_fiscal.document.mixin</field>
+    </record>
+    <record id="comment_amostra" model="l10n_br_fiscal.comment">
+        <field name="name">Amostra grátis</field>
+        <field
+            name="comment"
+        >Amostra grátis - isenção de IPI (art. 54, I, RIPI) e de ICMS (Conv. ICM 29/90 e RICMS); produto identificado indelevelmente como amostra grátis.</field>
+        <field name="comment_type">fiscal</field>
+        <field name="object">l10n_br_fiscal.document.mixin</field>
+    </record>
+
+    <!-- (a) Tributação PIS/COFINS na bonificação do core (aditivo à linha existente) -->
+    <record id="fo_bonificacao_pis" model="l10n_br_fiscal.tax.definition">
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_bonificacao_bonificacao"
+        />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_08" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_bonificacao_cofins" model="l10n_br_fiscal.tax.definition">
+        <field
+            name="fiscal_operation_line_id"
+            ref="l10n_br_fiscal.fo_bonificacao_bonificacao"
+        />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_08" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- Entrada de bonificação/doação/brinde (destinatário) — sem crédito PIS/COFINS -->
+    <record id="fo_ent_bonif" model="l10n_br_fiscal.operation">
+        <field name="code">ENT-BONIF</field>
+        <field name="name">Entrada de bonificação, doação ou brinde</field>
+        <field name="fiscal_operation_type">in</field>
+        <field name="fiscal_type">other</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ent_bonif_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_ent_bonif" />
+        <field name="name">Entrada de bonificação, doação ou brinde</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1910" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2910" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ent_bonif_pis" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_ent_bonif_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_70" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ent_bonif_cofins" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_ent_bonif_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_70" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- Brinde (saída) -->
+    <record id="fo_brinde" model="l10n_br_fiscal.operation">
+        <field name="code">BRINDE</field>
+        <field name="name">Remessa de brinde</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">other</field>
+        <field name="return_fiscal_operation_id" ref="fo_ent_bonif" />
+        <field name="state">approved</field>
+        <field name="comment_ids" eval="[(6, 0, [ref('comment_brinde')])]" />
+    </record>
+    <record id="fo_brinde_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_brinde" />
+        <field name="name">Remessa de brinde</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5910" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6910" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_brinde_pis" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_brinde_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_08" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_brinde_cofins" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_brinde_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_08" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- Doação (saída) -->
+    <record id="fo_doacao" model="l10n_br_fiscal.operation">
+        <field name="code">DOACAO</field>
+        <field name="name">Doação de mercadoria</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">other</field>
+        <field name="return_fiscal_operation_id" ref="fo_ent_bonif" />
+        <field name="state">approved</field>
+        <field name="comment_ids" eval="[(6, 0, [ref('comment_doacao')])]" />
+    </record>
+    <record id="fo_doacao_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_doacao" />
+        <field name="name">Doação de mercadoria</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5910" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6910" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_doacao_pis" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_doacao_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_08" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_doacao_cofins" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_doacao_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_08" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- Entrada de amostra grátis (antes da saída, alvo do return) -->
+    <record id="fo_ent_amostra" model="l10n_br_fiscal.operation">
+        <field name="code">ENT-AMOSTRA</field>
+        <field name="name">Entrada de amostra grátis</field>
+        <field name="fiscal_operation_type">in</field>
+        <field name="fiscal_type">other</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ent_amostra_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_ent_amostra" />
+        <field name="name">Entrada de amostra grátis</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1911" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2911" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+
+    <!-- Amostra grátis (saída) — ICMS e IPI isentos; PIS/COFINS sem incidência -->
+    <record id="fo_amostra" model="l10n_br_fiscal.operation">
+        <field name="code">AMOSTRA</field>
+        <field name="name">Remessa de amostra grátis</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">other</field>
+        <field name="return_fiscal_operation_id" ref="fo_ent_amostra" />
+        <field name="state">approved</field>
+        <field name="comment_ids" eval="[(6, 0, [ref('comment_amostra')])]" />
+    </record>
+    <record id="fo_amostra_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_amostra" />
+        <field name="name">Remessa de amostra grátis</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5911" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6911" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_amostra_icms" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_amostra_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icms" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_isento" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icms_40" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_amostra_ipi" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_amostra_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_isento" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_52" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_amostra_pis" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_amostra_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_08" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_amostra_cofins" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_amostra_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_08" />
+        <field name="state">approved</field>
+    </record>
+
+
+
+    <!-- ================= Simples Nacional =================
+         Linhas irmãs para empresa do Simples (company_tax_framework=1): o
+         seletor de linha prefere a mais específica, então a empresa SN casa
+         estas (CSOSN via grupo icmssn) e os demais regimes casam as genéricas
+         (CST). Empresa em excesso de sublimite (framework=2) recolhe ICMS fora
+         do DAS e cai na genérica com CST — correto. Regra geral: movimento sem
+         receita/titularidade = CSOSN 400; ajuste/simbólica = 900; linha de
+         receita não fixa ICMS (herda a tributação SN da empresa). Mapa a
+         ratificar com contador (transferência de mercadoria: ADC 49). -->
+    <record id="fo_ent_bonif_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_ent_bonif" />
+        <field
+            name="name"
+        >Entrada de bonificação, doação ou brinde - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1910" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2910" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ent_bonif_pis_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_ent_bonif_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_70" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ent_bonif_cofins_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_ent_bonif_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_70" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ent_bonif_line_sn_icmssn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_ent_bonif_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_brinde_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_brinde" />
+        <field name="name">Remessa de brinde - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5910" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6910" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_brinde_pis_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_brinde_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_08" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_brinde_cofins_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_brinde_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_08" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_brinde_line_sn_icmssn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_brinde_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_doacao_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_doacao" />
+        <field name="name">Doação de mercadoria - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5910" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6910" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_doacao_pis_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_doacao_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_08" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_doacao_cofins_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_doacao_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_08" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_doacao_line_sn_icmssn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_doacao_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ent_amostra_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_ent_amostra" />
+        <field name="name">Entrada de amostra grátis - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1911" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2911" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ent_amostra_line_sn_icmssn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_ent_amostra_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_amostra_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_amostra" />
+        <field name="name">Remessa de amostra grátis - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5911" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6911" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_amostra_ipi_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_amostra_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_isento" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_52" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_amostra_pis_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_amostra_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_08" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_amostra_cofins_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_amostra_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_08" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_amostra_line_sn_icmssn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_amostra_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+
+</odoo>

--- a/l10n_br_fiscal/data/fiscal_operation_comodato.xml
+++ b/l10n_br_fiscal/data/fiscal_operation_comodato.xml
@@ -1,0 +1,425 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Família COMODATO / LOCAÇÃO (empréstimo gratuito de bem infungível, CC art. 579).
+  NÃO existe no core. Não incidência de ICMS (sem transferência de titularidade,
+  STF Súmula 573), IPI (CST 53/03), PIS/COFINS (CST 08) e ISS (Súmula Vinculante
+  31 — locação pura de bem móvel). product_type=08 (ativo) no caso geral.
+  IPI do fabricante que dá saída do próprio produto em comodato = override por
+  perfil (não default). Ciclo: comodante remete/recebe de volta; comodatário
+  recebe/devolve.
+-->
+<odoo noupdate="1">
+
+    <record id="comment_comodato_remessa" model="l10n_br_fiscal.comment">
+        <field name="name">Remessa em comodato</field>
+        <field
+            name="comment"
+        >Remessa em comodato conforme contrato (CC art. 579). Não incidência de ICMS/IPI/PIS/COFINS; bem deve retornar ao remetente.</field>
+        <field name="comment_type">fiscal</field>
+        <field name="object">l10n_br_fiscal.document.mixin</field>
+    </record>
+    <record id="comment_comodato_devolucao" model="l10n_br_fiscal.comment">
+        <field name="name">Devolução de comodato</field>
+        <field
+            name="comment"
+        >Devolução de bem recebido em comodato. Não incidência de ICMS/IPI/PIS/COFINS.</field>
+        <field name="comment_type">fiscal</field>
+        <field name="object">l10n_br_fiscal.document.mixin</field>
+    </record>
+
+    <!-- COMODANTE: entrada do retorno (alvo do return da remessa) -->
+    <record id="fo_entrada_retorno_comodato" model="l10n_br_fiscal.operation">
+        <field name="code">ER-COM</field>
+        <field name="name">Entrada de retorno de comodato/locação</field>
+        <field name="fiscal_operation_type">in</field>
+        <field name="fiscal_type">return_in</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_entrada_retorno_comodato_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_entrada_retorno_comodato" />
+        <field name="name">Entrada de retorno de comodato</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1909" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2909" />
+        <field name="product_type">08</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_er_comodato_icms" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_entrada_retorno_comodato_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icms" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icms_41" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_er_comodato_ipi" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_entrada_retorno_comodato_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_03" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_er_comodato_pis" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_entrada_retorno_comodato_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_08" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_er_comodato_cofins" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_entrada_retorno_comodato_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_08" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- COMODANTE: remessa em comodato -->
+    <record id="fo_remessa_comodato" model="l10n_br_fiscal.operation">
+        <field name="code">REM-COM</field>
+        <field name="name">Remessa em comodato/locação</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">other</field>
+        <field name="return_fiscal_operation_id" ref="fo_entrada_retorno_comodato" />
+        <field name="state">approved</field>
+        <field name="comment_ids" eval="[(6, 0, [ref('comment_comodato_remessa')])]" />
+    </record>
+    <record id="fo_remessa_comodato_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_remessa_comodato" />
+        <field name="name">Remessa em comodato/locação</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5908" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6908" />
+        <field name="product_type">08</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rem_comodato_icms" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_comodato_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icms" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icms_41" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rem_comodato_ipi" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_comodato_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_53" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rem_comodato_pis" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_comodato_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_08" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rem_comodato_cofins" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_comodato_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_08" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- COMODATÁRIO: devolução (alvo do return da entrada) -->
+    <record id="fo_devolucao_comodato" model="l10n_br_fiscal.operation">
+        <field name="code">DEV-COM</field>
+        <field name="name">Devolução de comodato/locação</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">return_out</field>
+        <field name="state">approved</field>
+        <field
+            name="comment_ids"
+            eval="[(6, 0, [ref('comment_comodato_devolucao')])]"
+        />
+    </record>
+    <record id="fo_devolucao_comodato_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_devolucao_comodato" />
+        <field name="name">Devolução de comodato/locação</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5909" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6909" />
+        <field name="product_type">08</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_dev_comodato_icms" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_devolucao_comodato_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icms" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icms_41" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_dev_comodato_pis" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_devolucao_comodato_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_08" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_dev_comodato_cofins" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_devolucao_comodato_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_08" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- COMODATÁRIO: entrada do bem recebido em comodato -->
+    <record id="fo_entrada_comodato" model="l10n_br_fiscal.operation">
+        <field name="code">ENT-COM</field>
+        <field name="name">Entrada de bem em comodato/locação</field>
+        <field name="fiscal_operation_type">in</field>
+        <field name="fiscal_type">return_in</field>
+        <field name="return_fiscal_operation_id" ref="fo_devolucao_comodato" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_entrada_comodato_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_entrada_comodato" />
+        <field name="name">Entrada de bem em comodato/locação</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1908" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2908" />
+        <field name="product_type">08</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+
+
+    <!-- ================= Simples Nacional =================
+         Linhas irmãs para empresa do Simples (company_tax_framework=1): o
+         seletor de linha prefere a mais específica, então a empresa SN casa
+         estas (CSOSN via grupo icmssn) e os demais regimes casam as genéricas
+         (CST). Empresa em excesso de sublimite (framework=2) recolhe ICMS fora
+         do DAS e cai na genérica com CST — correto. Regra geral: movimento sem
+         receita/titularidade = CSOSN 400; ajuste/simbólica = 900; linha de
+         receita não fixa ICMS (herda a tributação SN da empresa). Mapa a
+         ratificar com contador (transferência de mercadoria: ADC 49). -->
+    <record
+        id="fo_entrada_retorno_comodato_line_sn"
+        model="l10n_br_fiscal.operation.line"
+    >
+        <field name="fiscal_operation_id" ref="fo_entrada_retorno_comodato" />
+        <field name="name">Entrada de retorno de comodato - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1909" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2909" />
+        <field name="product_type">08</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_er_comodato_ipi_sn" model="l10n_br_fiscal.tax.definition">
+        <field
+            name="fiscal_operation_line_id"
+            ref="fo_entrada_retorno_comodato_line_sn"
+        />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_03" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_er_comodato_pis_sn" model="l10n_br_fiscal.tax.definition">
+        <field
+            name="fiscal_operation_line_id"
+            ref="fo_entrada_retorno_comodato_line_sn"
+        />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_08" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_er_comodato_cofins_sn" model="l10n_br_fiscal.tax.definition">
+        <field
+            name="fiscal_operation_line_id"
+            ref="fo_entrada_retorno_comodato_line_sn"
+        />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_08" />
+        <field name="state">approved</field>
+    </record>
+    <record
+        id="fo_entrada_retorno_comodato_line_sn_icmssn"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field
+            name="fiscal_operation_line_id"
+            ref="fo_entrada_retorno_comodato_line_sn"
+        />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_remessa_comodato_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_remessa_comodato" />
+        <field name="name">Remessa em comodato/locação - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5908" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6908" />
+        <field name="product_type">08</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rem_comodato_ipi_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_comodato_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_53" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rem_comodato_pis_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_comodato_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_08" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rem_comodato_cofins_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_comodato_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_08" />
+        <field name="state">approved</field>
+    </record>
+    <record
+        id="fo_remessa_comodato_line_sn_icmssn"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="fiscal_operation_line_id" ref="fo_remessa_comodato_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_devolucao_comodato_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_devolucao_comodato" />
+        <field name="name">Devolução de comodato/locação - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5909" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6909" />
+        <field name="product_type">08</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_dev_comodato_pis_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_devolucao_comodato_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_08" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_dev_comodato_cofins_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_devolucao_comodato_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_08" />
+        <field name="state">approved</field>
+    </record>
+    <record
+        id="fo_devolucao_comodato_line_sn_icmssn"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="fiscal_operation_line_id" ref="fo_devolucao_comodato_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_entrada_comodato_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_entrada_comodato" />
+        <field name="name">Entrada de bem em comodato/locação - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1908" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2908" />
+        <field name="product_type">08</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record
+        id="fo_entrada_comodato_line_sn_icmssn"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="fiscal_operation_line_id" ref="fo_entrada_comodato_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+
+</odoo>

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -17,4 +17,5 @@ from . import (
     test_service_type,
     test_operation,
     test_tax_framework,
+    test_catalog_bonificacao_comodato,
 )

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -16,4 +16,5 @@ from . import (
     test_partner_profile,
     test_service_type,
     test_operation,
+    test_catalog_bonificacao_comodato,
 )

--- a/l10n_br_fiscal/tests/operation_catalog_common.py
+++ b/l10n_br_fiscal/tests/operation_catalog_common.py
@@ -1,0 +1,86 @@
+# Copyright (C) 2026 KMEE
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo.tests.common import TransactionCase
+
+
+class OperationCatalogCommon(TransactionCase):
+    """Base para os testes do catálogo de operações fiscais.
+
+    Fornece uma empresa em SP e três parceiros (interno, interestadual e
+    exterior) para exercitar a resolução de CFOP por destino
+    (``operation.line._get_cfop``), além de helpers de asserção.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.br = cls.env.ref("base.br")
+        cls.state_sp = cls.env.ref("base.state_br_sp")
+        cls.state_mg = cls.env.ref("base.state_br_mg")
+
+        cls.company = cls.env.ref("base.main_company")
+        cls.company.write({"country_id": cls.br.id, "state_id": cls.state_sp.id})
+
+        Partner = cls.env["res.partner"]
+        cls.partner_interno = Partner.create(
+            {
+                "name": "Parceiro Interno SP",
+                "country_id": cls.br.id,
+                "state_id": cls.state_sp.id,
+            }
+        )
+        cls.partner_interestadual = Partner.create(
+            {
+                "name": "Parceiro Interestadual MG",
+                "country_id": cls.br.id,
+                "state_id": cls.state_mg.id,
+            }
+        )
+        cls.partner_exterior = Partner.create(
+            {
+                "name": "Parceiro Exterior",
+                "country_id": cls.env.ref("base.us").id,
+            }
+        )
+
+    def _cfop_code(self, operation_line, partner):
+        return operation_line._get_cfop(self.company, partner).code
+
+    def assert_operation_cfops(
+        self, operation_line_xmlid, internal, external, export=None
+    ):
+        """Confere que a linha de operação resolve o CFOP esperado por destino.
+
+        :param operation_line_xmlid: xmlid completo da l10n_br_fiscal.operation.line
+        :param internal: código CFOP esperado para operação interna (mesmo estado)
+        :param external: código CFOP esperado para operação interestadual
+        :param export: código CFOP esperado para exportação (opcional)
+        """
+        line = self.env.ref(operation_line_xmlid)
+        self.assertEqual(
+            self._cfop_code(line, self.partner_interno),
+            internal,
+            "CFOP interno incorreto em %s" % operation_line_xmlid,
+        )
+        self.assertEqual(
+            self._cfop_code(line, self.partner_interestadual),
+            external,
+            "CFOP interestadual incorreto em %s" % operation_line_xmlid,
+        )
+        if export:
+            self.assertEqual(
+                self._cfop_code(line, self.partner_exterior),
+                export,
+                "CFOP de exportação incorreto em %s" % operation_line_xmlid,
+            )
+
+    def assert_return_link(self, operation_xmlid, return_operation_xmlid):
+        """Confere o encadeamento remessa/retorno via return_fiscal_operation_id."""
+        operation = self.env.ref(operation_xmlid)
+        expected = self.env.ref(return_operation_xmlid)
+        self.assertEqual(
+            operation.return_fiscal_operation_id,
+            expected,
+            "Encadeamento de retorno incorreto em %s" % operation_xmlid,
+        )

--- a/l10n_br_fiscal/tests/test_catalog_bonificacao_comodato.py
+++ b/l10n_br_fiscal/tests/test_catalog_bonificacao_comodato.py
@@ -1,0 +1,63 @@
+# Copyright (C) 2026 KMEE
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+"""Testes data-driven do catálogo de operações: bonificacao / comodato."""
+
+from odoo.tests import tagged
+
+from .operation_catalog_common import OperationCatalogCommon
+
+M = "l10n_br_fiscal"
+
+CFOP_CASES = [
+    ("fo_brinde_line", "5910", "6910", None),
+    ("fo_doacao_line", "5910", "6910", None),
+    ("fo_amostra_line", "5911", "6911", None),
+    ("fo_ent_bonif_line", "1910", "2910", None),
+    ("fo_ent_amostra_line", "1911", "2911", None),
+    ("fo_remessa_comodato_line", "5908", "6908", None),
+    ("fo_entrada_retorno_comodato_line", "1909", "2909", None),
+    ("fo_entrada_comodato_line", "1908", "2908", None),
+    ("fo_devolucao_comodato_line", "5909", "6909", None),
+]
+
+RETURN_LINKS = [
+    ("fo_brinde", "fo_ent_bonif"),
+    ("fo_amostra", "fo_ent_amostra"),
+    ("fo_remessa_comodato", "fo_entrada_retorno_comodato"),
+    ("fo_entrada_comodato", "fo_devolucao_comodato"),
+]
+
+TAX_DEF_CASES = [
+    ("fo_brinde_line", {"PIS": "08", "COFINS": "08"}, ["ICMS"], []),
+    ("fo_amostra_line", {"ICMS": "40", "IPI": "52", "PIS": "08"}, [], []),
+    ("fo_bonificacao_bonificacao", {"PIS": "08", "COFINS": "08"}, [], []),
+    ("fo_remessa_comodato_line", {"ICMS": "41", "PIS": "08"}, [], ["ICMS"]),
+]
+
+
+@tagged("post_install", "-at_install", "op_catalog")
+class TestCatalogBonificacaoComodato(OperationCatalogCommon):
+    def test_cfops(self):
+        """CFOP resolvido por destino (interno/interestadual/exportação)."""
+        for line, internal, external, export in CFOP_CASES:
+            with self.subTest(line=line):
+                self.assert_operation_cfops(f"{M}.{line}", internal, external, export)
+
+    def test_return_links(self):
+        """Encadeamento remessa/retorno via return_fiscal_operation_id."""
+        for op, ret in RETURN_LINKS:
+            with self.subTest(op=op):
+                self.assert_return_link(f"{M}.{op}", f"{M}.{ret}")
+
+    def test_tax_definitions(self):
+        """CST por grupo, ausência de definition (default) e não incidência."""
+        for line, csts, absent, not_taxed in TAX_DEF_CASES:
+            with self.subTest(line=line):
+                rec = self.env.ref(f"{M}.{line}")
+                defs = {d.tax_group_id.name: d for d in rec.tax_definition_ids}
+                for group, cst in csts.items():
+                    self.assertEqual(defs[group].cst_id.code, cst, f"{line}/{group}")
+                for group in absent:
+                    self.assertNotIn(group, defs, f"{line}/{group}")
+                for group in not_taxed:
+                    self.assertFalse(defs[group].is_taxed, f"{line}/{group}")


### PR DESCRIPTION
Parte da série do catálogo de operações fiscais:

- Bonificação: tributação PIS/COFINS (CST 08) na linha do core, que não tinha nenhuma
- Brinde, doação e amostra grátis (ICMS/IPI isentos na amostra), com entradas dedicadas e encadeamento de retorno
- Comodato/locação: não incidência, ciclo completo (remessa, retorno, entrada, devolução)

Com linhas irmãs Simples Nacional (CSOSN 400) para os movimentos sem receita. Testes data-driven.
