### PR TITLE
[16.0][IMP] l10n_br_fiscal: operações de venda à ordem e industrialização por encomenda

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -51,6 +51,8 @@
         "data/l10n_br_fiscal.operation.indicator.csv",
         "data/simplified_tax_data.xml",
         "data/operation_data.xml",
+        "data/fiscal_operation_triangular.xml",
+        "data/fiscal_operation_industrializacao.xml",
         "data/l10n_br_fiscal_tax_icms_data.xml",
         # the following csv data files will be loaded as noupdate=True
         # and will be trimmed down when demo mode is True (faster):

--- a/l10n_br_fiscal/data/fiscal_operation_industrializacao.xml
+++ b/l10n_br_fiscal/data/fiscal_operation_industrializacao.xml
@@ -1,0 +1,436 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Família INDUSTRIALIZAÇÃO POR ENCOMENDA — completa o core (que só tem a remessa
+  do encomendante 5901/6901 e a entrada do industrializador 1901/2901).
+
+  Acrescenta: (a) retorno do INDUSTRIALIZADOR (5902/6902 insumo aplicado +
+  5903/6903 não aplicado + 5124/6124 cobrança da industrialização); (b) entrada
+  do retorno no ENCOMENDANTE (1902/2902 + 1903/2903 + 1124/2124 crédito da MO);
+  (c) variante "não transita pelo encomendante" (conta e ordem, 5924/1924 e
+  5925/1925).
+
+  Tributação: remessa/retorno do INSUMO têm SUSPENSÃO (ICMS CST 50, IPI CST
+  55-saída/05-entrada, PIS/COFINS CST 08). A parcela de industrialização
+  (5124/6124) é TRIBUTADA no caso geral (default). A suspensão do ICMS sobre a
+  MO+materiais (Conv. AE-15/74) é override por UF — não default.
+
+  ADITIVO: NÃO altera os return do core. O core tem um pareamento
+  remessa↔entrada de industrialização questionável (1901/2901 é entrada do
+  industrializador, não retorno do encomendante) — correção fica como PR de core
+  separado (ver ESTADO). Aqui as operações novas apontam para as do core.
+-->
+<odoo noupdate="1">
+
+    <!-- (b) ENCOMENDANTE: entrada do retorno da industrialização -->
+    <record id="fo_entrada_retorno_industrializacao" model="l10n_br_fiscal.operation">
+        <field name="code">ER-IND</field>
+        <field name="name">Entrada de retorno de industrialização por encomenda</field>
+        <field name="fiscal_operation_type">in</field>
+        <field name="fiscal_type">return_in</field>
+        <field
+            name="return_fiscal_operation_id"
+            ref="l10n_br_fiscal.fo_remessa_industrializacao"
+        />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_eri_insumo" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_entrada_retorno_industrializacao" />
+        <field name="name">Retorno de insumo aplicado (suspensão)</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1902" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2902" />
+        <field name="product_type">01</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_eri_insumo_icms" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_eri_insumo" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icms" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_suspensao" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icms_50" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_eri_insumo_ipi" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_eri_insumo" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_suspensao" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_05" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_eri_mo" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_entrada_retorno_industrializacao" />
+        <field name="name">Crédito da industrialização (mão de obra)</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1124" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2124" />
+        <field name="product_type">09</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+
+    <!-- (a) INDUSTRIALIZADOR: retorno da industrialização -->
+    <record id="fo_retorno_industrializacao" model="l10n_br_fiscal.operation">
+        <field name="code">RT-IND</field>
+        <field name="name">Retorno de industrialização por encomenda</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">return_out</field>
+        <field
+            name="return_fiscal_operation_id"
+            ref="l10n_br_fiscal.fo_entrada_industrializacao"
+        />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rti_insumo" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_retorno_industrializacao" />
+        <field name="name">Retorno de insumo aplicado (suspensão)</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5902" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6902" />
+        <field name="product_type">01</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rti_insumo_icms" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_rti_insumo" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icms" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_suspensao" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icms_50" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rti_insumo_ipi" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_rti_insumo" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_suspensao" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_55" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rti_mo" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_retorno_industrializacao" />
+        <field
+            name="name"
+        >Cobrança da industrialização (mão de obra e materiais)</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5124" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6124" />
+        <field name="product_type">09</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+
+    <!-- (c) Variante "não transita pelo encomendante" (conta e ordem) -->
+    <!-- Encomendante: entrada do retorno (alvo do return) -->
+    <record id="fo_entrada_retorno_ind_conta_ordem" model="l10n_br_fiscal.operation">
+        <field name="code">ER-IND-CO</field>
+        <field
+            name="name"
+        >Entrada de retorno de industrialização por conta e ordem (não transita)</field>
+        <field name="fiscal_operation_type">in</field>
+        <field name="fiscal_type">return_in</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_eri_co_insumo" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_entrada_retorno_ind_conta_ordem" />
+        <field name="name">Retorno de insumo por conta e ordem (suspensão)</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1925" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2925" />
+        <field name="product_type">01</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_eri_co_insumo_icms" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_eri_co_insumo" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icms" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_suspensao" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icms_50" />
+        <field name="state">approved</field>
+    </record>
+
+    <record id="fo_remessa_ind_conta_ordem" model="l10n_br_fiscal.operation">
+        <field name="code">REM-IND-CO</field>
+        <field
+            name="name"
+        >Remessa simbólica para industrialização por conta e ordem (não transita)</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">return_out</field>
+        <field
+            name="return_fiscal_operation_id"
+            ref="fo_entrada_retorno_ind_conta_ordem"
+        />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rem_ind_co_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_remessa_ind_conta_ordem" />
+        <field name="name">Remessa simbólica por conta e ordem (suspensão)</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5924" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6924" />
+        <field name="product_type">01</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rem_ind_co_icms" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_rem_ind_co_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icms" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_suspensao" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icms_50" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- Industrializador: retorno por conta e ordem (alvo do return) -->
+    <record id="fo_retorno_ind_conta_ordem" model="l10n_br_fiscal.operation">
+        <field name="code">RT-IND-CO</field>
+        <field
+            name="name"
+        >Retorno de industrialização por conta e ordem (não transita)</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">return_out</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rti_co_insumo" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_retorno_ind_conta_ordem" />
+        <field name="name">Retorno de insumo por conta e ordem (suspensão)</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5925" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6925" />
+        <field name="product_type">01</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rti_co_mo" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_retorno_ind_conta_ordem" />
+        <field name="name">Cobrança da industrialização por conta e ordem</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5124" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6124" />
+        <field name="product_type">09</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+
+    <record id="fo_entrada_ind_conta_ordem" model="l10n_br_fiscal.operation">
+        <field name="code">ENT-IND-CO</field>
+        <field
+            name="name"
+        >Entrada para industrialização por conta e ordem (não transita)</field>
+        <field name="fiscal_operation_type">in</field>
+        <field name="fiscal_type">return_in</field>
+        <field name="return_fiscal_operation_id" ref="fo_retorno_ind_conta_ordem" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ent_ind_co_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_entrada_ind_conta_ordem" />
+        <field name="name">Entrada por conta e ordem (suspensão)</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1924" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2924" />
+        <field name="product_type">01</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+
+    <!-- Correção do pareamento de return do core (SANEAMENTO). O core apontava
+         fo_remessa_industrializacao.return -> fo_entrada_industrializacao (1901),
+         mas 1901 é a ENTRADA do industrializador (a inversa), não o RETORNO do
+         encomendante (1902). Corrige para as operações certas. Estes records
+         atualizam só o campo return e vivem aqui porque referenciam operações
+         definidas acima (carregam após operation_data.xml). Bases existentes:
+         ver migração pós-saneamento. -->
+    <record id="fo_remessa_industrializacao" model="l10n_br_fiscal.operation">
+        <field
+            name="return_fiscal_operation_id"
+            ref="fo_entrada_retorno_industrializacao"
+        />
+    </record>
+    <record id="fo_entrada_industrializacao" model="l10n_br_fiscal.operation">
+        <field name="return_fiscal_operation_id" ref="fo_retorno_industrializacao" />
+    </record>
+
+
+    <!-- ================= Simples Nacional =================
+         Linhas irmãs para empresa do Simples (company_tax_framework=1): o
+         seletor de linha prefere a mais específica, então a empresa SN casa
+         estas (CSOSN via grupo icmssn) e os demais regimes casam as genéricas
+         (CST). Empresa em excesso de sublimite (framework=2) recolhe ICMS fora
+         do DAS e cai na genérica com CST — correto. Regra geral: movimento sem
+         receita/titularidade = CSOSN 400; ajuste/simbólica = 900; linha de
+         receita não fixa ICMS (herda a tributação SN da empresa). Mapa a
+         ratificar com contador (transferência de mercadoria: ADC 49). -->
+    <record id="fo_eri_insumo_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_entrada_retorno_industrializacao" />
+        <field
+            name="name"
+        >Retorno de insumo aplicado (suspensão) - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1902" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2902" />
+        <field name="product_type">01</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_eri_insumo_ipi_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_eri_insumo_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_suspensao" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_05" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_eri_insumo_sn_icmssn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_eri_insumo_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rti_insumo_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_retorno_industrializacao" />
+        <field
+            name="name"
+        >Retorno de insumo aplicado (suspensão) - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5902" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6902" />
+        <field name="product_type">01</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rti_insumo_ipi_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_rti_insumo_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_suspensao" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_55" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rti_insumo_sn_icmssn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_rti_insumo_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_eri_co_insumo_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_entrada_retorno_ind_conta_ordem" />
+        <field
+            name="name"
+        >Retorno de insumo por conta e ordem (suspensão) - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1925" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2925" />
+        <field name="product_type">01</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_eri_co_insumo_sn_icmssn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_eri_co_insumo_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rem_ind_co_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_remessa_ind_conta_ordem" />
+        <field
+            name="name"
+        >Remessa simbólica por conta e ordem (suspensão) - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5924" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6924" />
+        <field name="product_type">01</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rem_ind_co_line_sn_icmssn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_rem_ind_co_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rti_co_insumo_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_retorno_ind_conta_ordem" />
+        <field
+            name="name"
+        >Retorno de insumo por conta e ordem (suspensão) - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5925" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6925" />
+        <field name="product_type">01</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rti_co_insumo_sn_icmssn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_rti_co_insumo_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ent_ind_co_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_entrada_ind_conta_ordem" />
+        <field
+            name="name"
+        >Entrada por conta e ordem (suspensão) - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1924" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2924" />
+        <field name="product_type">01</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ent_ind_co_line_sn_icmssn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_ent_ind_co_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+
+</odoo>

--- a/l10n_br_fiscal/data/fiscal_operation_triangular.xml
+++ b/l10n_br_fiscal/data/fiscal_operation_triangular.xml
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Família VENDA À ORDEM / TRIANGULAR (caso geral: 3 contribuintes no país).
+  Três papéis, três notas:
+    NF1 (AO→D)  venda à ordem, COM ICMS        → papel AO (adquirente originário)
+    NF2 (VR→AO) faturamento, COM ICMS          → papel VR (vendedor remetente)
+    NF3 (VR→D)  remessa por conta e ordem, SEM destaque de ICMS/PIS/COFINS
+
+  Drop shipping B2B doméstico = venda à ordem. Variantes B2C (DIFAL) e importação
+  ficam fora (famílias próprias). ICMS na remessa NF3: CST 41 no caso geral,
+  parametrizável por UF (41/90/suspensão) — ver readme.
+-->
+<odoo noupdate="1">
+
+    <!-- ===== Papel AO (adquirente originário / trader) ===== -->
+
+    <!-- A3: devolução da venda à ordem (alvo do return da A1) -->
+    <record id="fo_venda_ordem_dev" model="l10n_br_fiscal.operation">
+        <field name="code">VO-DEV</field>
+        <field name="name">Devolução de venda à ordem</field>
+        <field name="fiscal_operation_type">in</field>
+        <field name="fiscal_type">return_in</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_venda_ordem_dev_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_venda_ordem_dev" />
+        <field name="name">Devolução de venda à ordem</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1202" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2202" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+
+    <!-- A1: venda à ordem (AO → D) — NF1, com ICMS -->
+    <record id="fo_venda_ordem" model="l10n_br_fiscal.operation">
+        <field name="code">VO-VENDA</field>
+        <field name="name">Venda à ordem (adquirente originário)</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">sale</field>
+        <field name="return_fiscal_operation_id" ref="fo_venda_ordem_dev" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_venda_ordem_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_venda_ordem" />
+        <field name="name">Venda à ordem</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5102" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6102" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <!-- ICMS/PIS/COFINS incidem (default). IPI não destacado (AO comercial). -->
+    <record id="fo_venda_ordem_ipi" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_venda_ordem_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_49" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- A2: entrada do faturamento em venda à ordem (AO recebe a NF2 do VR) -->
+    <record id="fo_venda_ordem_compra" model="l10n_br_fiscal.operation">
+        <field name="code">VO-COMPRA</field>
+        <field name="name">Compra em venda à ordem (entrada de faturamento)</field>
+        <field name="fiscal_operation_type">in</field>
+        <field name="fiscal_type">purchase</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_venda_ordem_compra_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_venda_ordem_compra" />
+        <field name="name">Compra em venda à ordem</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1118" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2118" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+
+    <!-- ===== Papel VR (vendedor remetente / fornecedor) ===== -->
+
+    <!-- B3: retorno de remessa por conta e ordem (alvo do return da B2) -->
+    <record id="fo_conta_ordem_retorno" model="l10n_br_fiscal.operation">
+        <field name="code">CO-RET</field>
+        <field name="name">Retorno de remessa por conta e ordem</field>
+        <field name="fiscal_operation_type">in</field>
+        <field name="fiscal_type">other</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_conta_ordem_retorno_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_conta_ordem_retorno" />
+        <field name="name">Retorno de remessa por conta e ordem</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1923" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2923" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+
+    <!-- B2: remessa por conta e ordem de terceiros (VR → D) — NF3, sem destaque -->
+    <record id="fo_remessa_conta_ordem" model="l10n_br_fiscal.operation">
+        <field name="code">CO-REMESSA</field>
+        <field
+            name="name"
+        >Remessa por conta e ordem de terceiros (venda à ordem)</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">other</field>
+        <field name="return_fiscal_operation_id" ref="fo_conta_ordem_retorno" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_remessa_conta_ordem_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_remessa_conta_ordem" />
+        <field name="name">Remessa por conta e ordem de terceiros</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5923" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6923" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <!-- Sem destaque: ICMS CST 41 (parametrizável por UF), IPI 49, PIS/COFINS 49. -->
+    <record id="fo_remessa_conta_ordem_icms" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_conta_ordem_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icms" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icms_41" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_remessa_conta_ordem_ipi" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_conta_ordem_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_remessa_conta_ordem_pis" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_conta_ordem_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_remessa_conta_ordem_cofins" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_conta_ordem_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- B1: faturamento em venda à ordem (VR → AO) — NF2, com ICMS -->
+    <record id="fo_faturamento_ordem" model="l10n_br_fiscal.operation">
+        <field name="code">VO-FAT</field>
+        <field name="name">Faturamento em venda à ordem (vendedor remetente)</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">sale</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_faturamento_ordem_producao" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_faturamento_ordem" />
+        <field name="name">Faturamento venda à ordem (produção própria)</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5118" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6118" />
+        <field name="product_type">04</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_faturamento_ordem_revenda" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_faturamento_ordem" />
+        <field name="name">Faturamento venda à ordem (mercadoria de terceiros)</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5119" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6119" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+
+    <!-- ===== Papel D (destinatário final) ===== -->
+
+    <!-- C1: compra em venda à ordem (D recebe a NF1 do AO) -->
+    <record id="fo_compra_ordem_destinatario" model="l10n_br_fiscal.operation">
+        <field name="code">VO-ENTRADA</field>
+        <field name="name">Compra em venda à ordem (destinatário)</field>
+        <field name="fiscal_operation_type">in</field>
+        <field name="fiscal_type">purchase</field>
+        <field name="state">approved</field>
+    </record>
+    <record
+        id="fo_compra_ordem_destinatario_line"
+        model="l10n_br_fiscal.operation.line"
+    >
+        <field name="fiscal_operation_id" ref="fo_compra_ordem_destinatario" />
+        <field name="name">Compra em venda à ordem</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1102" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2102" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+
+
+    <!-- ================= Simples Nacional =================
+         Linhas irmãs para empresa do Simples (company_tax_framework=1): o
+         seletor de linha prefere a mais específica, então a empresa SN casa
+         estas (CSOSN via grupo icmssn) e os demais regimes casam as genéricas
+         (CST). Empresa em excesso de sublimite (framework=2) recolhe ICMS fora
+         do DAS e cai na genérica com CST — correto. Regra geral: movimento sem
+         receita/titularidade = CSOSN 400; ajuste/simbólica = 900; linha de
+         receita não fixa ICMS (herda a tributação SN da empresa). Mapa a
+         ratificar com contador (transferência de mercadoria: ADC 49). -->
+    <record id="fo_remessa_conta_ordem_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_remessa_conta_ordem" />
+        <field
+            name="name"
+        >Remessa por conta e ordem de terceiros - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5923" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6923" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_remessa_conta_ordem_ipi_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_conta_ordem_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_remessa_conta_ordem_pis_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_conta_ordem_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_remessa_conta_ordem_cofins_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_conta_ordem_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+    <record
+        id="fo_remessa_conta_ordem_line_sn_icmssn"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="fiscal_operation_line_id" ref="fo_remessa_conta_ordem_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_conta_ordem_retorno_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_conta_ordem_retorno" />
+        <field
+            name="name"
+        >Retorno de remessa por conta e ordem - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1923" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2923" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record
+        id="fo_conta_ordem_retorno_line_sn_icmssn"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="fiscal_operation_line_id" ref="fo_conta_ordem_retorno_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+
+</odoo>

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -17,4 +17,5 @@ from . import (
     test_service_type,
     test_operation,
     test_tax_framework,
+    test_catalog_triangular_industrializacao,
 )

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -16,4 +16,5 @@ from . import (
     test_partner_profile,
     test_service_type,
     test_operation,
+    test_catalog_triangular_industrializacao,
 )

--- a/l10n_br_fiscal/tests/operation_catalog_common.py
+++ b/l10n_br_fiscal/tests/operation_catalog_common.py
@@ -1,0 +1,86 @@
+# Copyright (C) 2026 KMEE
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo.tests.common import TransactionCase
+
+
+class OperationCatalogCommon(TransactionCase):
+    """Base para os testes do catálogo de operações fiscais.
+
+    Fornece uma empresa em SP e três parceiros (interno, interestadual e
+    exterior) para exercitar a resolução de CFOP por destino
+    (``operation.line._get_cfop``), além de helpers de asserção.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.br = cls.env.ref("base.br")
+        cls.state_sp = cls.env.ref("base.state_br_sp")
+        cls.state_mg = cls.env.ref("base.state_br_mg")
+
+        cls.company = cls.env.ref("base.main_company")
+        cls.company.write({"country_id": cls.br.id, "state_id": cls.state_sp.id})
+
+        Partner = cls.env["res.partner"]
+        cls.partner_interno = Partner.create(
+            {
+                "name": "Parceiro Interno SP",
+                "country_id": cls.br.id,
+                "state_id": cls.state_sp.id,
+            }
+        )
+        cls.partner_interestadual = Partner.create(
+            {
+                "name": "Parceiro Interestadual MG",
+                "country_id": cls.br.id,
+                "state_id": cls.state_mg.id,
+            }
+        )
+        cls.partner_exterior = Partner.create(
+            {
+                "name": "Parceiro Exterior",
+                "country_id": cls.env.ref("base.us").id,
+            }
+        )
+
+    def _cfop_code(self, operation_line, partner):
+        return operation_line._get_cfop(self.company, partner).code
+
+    def assert_operation_cfops(
+        self, operation_line_xmlid, internal, external, export=None
+    ):
+        """Confere que a linha de operação resolve o CFOP esperado por destino.
+
+        :param operation_line_xmlid: xmlid completo da l10n_br_fiscal.operation.line
+        :param internal: código CFOP esperado para operação interna (mesmo estado)
+        :param external: código CFOP esperado para operação interestadual
+        :param export: código CFOP esperado para exportação (opcional)
+        """
+        line = self.env.ref(operation_line_xmlid)
+        self.assertEqual(
+            self._cfop_code(line, self.partner_interno),
+            internal,
+            "CFOP interno incorreto em %s" % operation_line_xmlid,
+        )
+        self.assertEqual(
+            self._cfop_code(line, self.partner_interestadual),
+            external,
+            "CFOP interestadual incorreto em %s" % operation_line_xmlid,
+        )
+        if export:
+            self.assertEqual(
+                self._cfop_code(line, self.partner_exterior),
+                export,
+                "CFOP de exportação incorreto em %s" % operation_line_xmlid,
+            )
+
+    def assert_return_link(self, operation_xmlid, return_operation_xmlid):
+        """Confere o encadeamento remessa/retorno via return_fiscal_operation_id."""
+        operation = self.env.ref(operation_xmlid)
+        expected = self.env.ref(return_operation_xmlid)
+        self.assertEqual(
+            operation.return_fiscal_operation_id,
+            expected,
+            "Encadeamento de retorno incorreto em %s" % operation_xmlid,
+        )

--- a/l10n_br_fiscal/tests/test_catalog_triangular_industrializacao.py
+++ b/l10n_br_fiscal/tests/test_catalog_triangular_industrializacao.py
@@ -1,0 +1,73 @@
+# Copyright (C) 2026 KMEE
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+"""Testes data-driven do catálogo de operações: triangular / industrializacao."""
+
+from odoo.tests import tagged
+
+from .operation_catalog_common import OperationCatalogCommon
+
+M = "l10n_br_fiscal"
+
+CFOP_CASES = [
+    ("fo_venda_ordem_line", "5102", "6102", None),
+    ("fo_venda_ordem_compra_line", "1118", "2118", None),
+    ("fo_faturamento_ordem_producao", "5118", "6118", None),
+    ("fo_faturamento_ordem_revenda", "5119", "6119", None),
+    ("fo_remessa_conta_ordem_line", "5923", "6923", None),
+    ("fo_compra_ordem_destinatario_line", "1102", "2102", None),
+    ("fo_rti_insumo", "5902", "6902", None),
+    ("fo_rti_mo", "5124", "6124", None),
+    ("fo_eri_insumo", "1902", "2902", None),
+    ("fo_eri_mo", "1124", "2124", None),
+    ("fo_rem_ind_co_line", "5924", "6924", None),
+    ("fo_ent_ind_co_line", "1924", "2924", None),
+]
+
+RETURN_LINKS = [
+    ("fo_venda_ordem", "fo_venda_ordem_dev"),
+    ("fo_remessa_conta_ordem", "fo_conta_ordem_retorno"),
+    ("fo_remessa_ind_conta_ordem", "fo_entrada_retorno_ind_conta_ordem"),
+]
+
+TAX_DEF_CASES = [
+    (
+        "fo_remessa_conta_ordem_line",
+        {"ICMS": "41", "PIS": "49", "COFINS": "49"},
+        [],
+        ["ICMS"],
+    ),
+    ("fo_rti_insumo", {"ICMS": "50", "IPI": "55"}, [], []),
+]
+
+
+@tagged("post_install", "-at_install", "op_catalog")
+class TestCatalogTriangularIndustrializacao(OperationCatalogCommon):
+    def test_cfops(self):
+        """CFOP resolvido por destino (interno/interestadual/exportação)."""
+        for line, internal, external, export in CFOP_CASES:
+            with self.subTest(line=line):
+                self.assert_operation_cfops(f"{M}.{line}", internal, external, export)
+
+    def test_return_links(self):
+        """Encadeamento remessa/retorno via return_fiscal_operation_id."""
+        for op, ret in RETURN_LINKS:
+            with self.subTest(op=op):
+                self.assert_return_link(f"{M}.{op}", f"{M}.{ret}")
+
+    def test_tax_definitions(self):
+        """CST por grupo, ausência de definition (default) e não incidência."""
+        for line, csts, absent, not_taxed in TAX_DEF_CASES:
+            with self.subTest(line=line):
+                rec = self.env.ref(f"{M}.{line}")
+                defs = {d.tax_group_id.name: d for d in rec.tax_definition_ids}
+                for group, cst in csts.items():
+                    self.assertEqual(defs[group].cst_id.code, cst, f"{line}/{group}")
+                for group in absent:
+                    self.assertNotIn(group, defs, f"{line}/{group}")
+                for group in not_taxed:
+                    self.assertFalse(defs[group].is_taxed, f"{line}/{group}")
+
+    def test_mo_industrializacao_tributada(self):
+        """A cobrança da industrialização (5124) não tem definition: tributa
+        pelo default (é a receita do industrializador)."""
+        self.assertFalse(self.env.ref(f"{M}.fo_rti_mo").tax_definition_ids)


### PR DESCRIPTION
Parte da série do catálogo de operações fiscais:

- Venda à ordem/triangular: os três papéis (adquirente originário, vendedor remetente, destinatário), com a remessa por conta e ordem (5923) sem destaque
- Industrialização por encomenda: retorno do industrializador (5902 + cobrança 5124), entrada do retorno no encomendante (1902) e a variante por conta e ordem (não transita); insumos com suspensão (CST 50/55), mão de obra tributada
- Corrige o pareamento de return das operações de industrialização do core (1901/2901 é a entrada do industrializador, não o retorno do encomendante)

Com linhas irmãs Simples Nacional (CSOSN 400). Testes data-driven.
