### PR TITLE
[16.0][IMP] l10n_br_fiscal: operações de exportação, baixa de estoque, armazém geral e vasilhames

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -51,6 +51,8 @@
         "data/l10n_br_fiscal.operation.indicator.csv",
         "data/simplified_tax_data.xml",
         "data/operation_data.xml",
+        "data/fiscal_operation_comex_ajustes.xml",
+        "data/fiscal_operation_armazem_vasilhame.xml",
         "data/l10n_br_fiscal_tax_icms_data.xml",
         # the following csv data files will be loaded as noupdate=True
         # and will be trimmed down when demo mode is True (faster):

--- a/l10n_br_fiscal/data/fiscal_operation_armazem_vasilhame.xml
+++ b/l10n_br_fiscal/data/fiscal_operation_armazem_vasilhame.xml
@@ -1,0 +1,484 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Famílias ARMAZÉM GERAL / DEPÓSITO FECHADO e EMBALAGENS RETORNÁVEIS (vasilhame/
+  sacaria). Não existem no core.
+
+  ARMAZÉM (lado depositante): remessa (5905/6905) e retorno (1906/2906) — não
+  incidência de ICMS na mesma UF (CST 41); interestadual pode tributar
+  (parametrizável). Lado armazém (entrada/retorno real/simbólico/conta-e-ordem)
+  e venda de mercadoria depositada = bloco opcional (3PL), não incluído no base.
+
+  VASILHAME/SACARIA: ciclo completo (remessa/retorno/entrada/devolução). Não
+  incidência de ICMS (CST 41; variante isenção CST 40 Conv. ICMS 88/91,
+  parametrizável), IPI NT, PIS/COFINS sem incidência (CST 08).
+
+  IPI: usa NT (revenda, caso geral). Depositante industrial → suspensão (variante).
+-->
+<odoo noupdate="1">
+
+    <record id="comment_deposito" model="l10n_br_fiscal.comment">
+        <field name="name">Remessa para depósito/armazém geral</field>
+        <field
+            name="comment"
+        >Remessa para depósito fechado ou armazém geral. Não incidência de ICMS na mesma UF (art. 7º do RICMS; Convênio SINIEF).</field>
+        <field name="comment_type">fiscal</field>
+        <field name="object">l10n_br_fiscal.document.mixin</field>
+    </record>
+    <record id="comment_vasilhame" model="l10n_br_fiscal.comment">
+        <field name="name">Vasilhame/sacaria retornável</field>
+        <field
+            name="comment"
+        >Vasilhame ou sacaria retornável. Não incidência de ICMS (ou isenção Conv. ICMS 88/91). Sem incidência de IPI/PIS/COFINS.</field>
+        <field name="comment_type">fiscal</field>
+        <field name="object">l10n_br_fiscal.document.mixin</field>
+    </record>
+
+    <!-- ARMAZÉM: retorno (alvo do return da remessa) -->
+    <record id="fo_retorno_deposito" model="l10n_br_fiscal.operation">
+        <field name="code">RT-DEP</field>
+        <field
+            name="name"
+        >Retorno de mercadoria depositada em depósito/armazém geral</field>
+        <field name="fiscal_operation_type">in</field>
+        <field name="fiscal_type">return_in</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_retorno_deposito_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_retorno_deposito" />
+        <field name="name">Retorno de mercadoria depositada</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1906" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2906" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ret_dep_icms" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_retorno_deposito_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icms" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icms_41" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- ARMAZÉM: remessa para depósito -->
+    <record id="fo_remessa_deposito" model="l10n_br_fiscal.operation">
+        <field name="code">REM-DEP</field>
+        <field name="name">Remessa para depósito fechado ou armazém geral</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">other</field>
+        <field name="return_fiscal_operation_id" ref="fo_retorno_deposito" />
+        <field name="state">approved</field>
+        <field name="comment_ids" eval="[(6, 0, [ref('comment_deposito')])]" />
+    </record>
+    <record id="fo_remessa_deposito_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_remessa_deposito" />
+        <field name="name">Remessa para depósito/armazém geral</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5905" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6905" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rem_dep_icms" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_deposito_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icms" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icms_41" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rem_dep_ipi" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_deposito_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_53" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rem_dep_pis" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_deposito_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_08" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rem_dep_cofins" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_deposito_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_08" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- VASILHAME: retorno (alvo do return da remessa) -->
+    <record id="fo_retorno_vasilhame" model="l10n_br_fiscal.operation">
+        <field name="code">RT-VAS</field>
+        <field name="name">Retorno de vasilhame ou sacaria</field>
+        <field name="fiscal_operation_type">in</field>
+        <field name="fiscal_type">return_in</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_retorno_vasilhame_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_retorno_vasilhame" />
+        <field name="name">Retorno de vasilhame ou sacaria</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1921" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2921" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ret_vas_icms" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_retorno_vasilhame_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icms" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icms_41" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- VASILHAME: remessa -->
+    <record id="fo_remessa_vasilhame" model="l10n_br_fiscal.operation">
+        <field name="code">REM-VAS</field>
+        <field name="name">Remessa de vasilhame ou sacaria</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">other</field>
+        <field name="return_fiscal_operation_id" ref="fo_retorno_vasilhame" />
+        <field name="state">approved</field>
+        <field name="comment_ids" eval="[(6, 0, [ref('comment_vasilhame')])]" />
+    </record>
+    <record id="fo_remessa_vasilhame_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_remessa_vasilhame" />
+        <field name="name">Remessa de vasilhame ou sacaria</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5920" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6920" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rem_vas_icms" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_vasilhame_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icms" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icms_41" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rem_vas_ipi" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_vasilhame_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_53" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rem_vas_pis" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_vasilhame_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_08" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rem_vas_cofins" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_vasilhame_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_08" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- VASILHAME: devolução (alvo do return da entrada) -->
+    <record id="fo_devolucao_vasilhame" model="l10n_br_fiscal.operation">
+        <field name="code">DEV-VAS</field>
+        <field name="name">Devolução de vasilhame ou sacaria</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">return_out</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_devolucao_vasilhame_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_devolucao_vasilhame" />
+        <field name="name">Devolução de vasilhame ou sacaria</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5921" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6921" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_dev_vas_icms" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_devolucao_vasilhame_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icms" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icms_41" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- VASILHAME: entrada -->
+    <record id="fo_entrada_vasilhame" model="l10n_br_fiscal.operation">
+        <field name="code">ENT-VAS</field>
+        <field name="name">Entrada de vasilhame ou sacaria</field>
+        <field name="fiscal_operation_type">in</field>
+        <field name="fiscal_type">other</field>
+        <field name="return_fiscal_operation_id" ref="fo_devolucao_vasilhame" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_entrada_vasilhame_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_entrada_vasilhame" />
+        <field name="name">Entrada de vasilhame ou sacaria</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1920" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2920" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+
+
+    <!-- ================= Simples Nacional =================
+         Linhas irmãs para empresa do Simples (company_tax_framework=1): o
+         seletor de linha prefere a mais específica, então a empresa SN casa
+         estas (CSOSN via grupo icmssn) e os demais regimes casam as genéricas
+         (CST). Empresa em excesso de sublimite (framework=2) recolhe ICMS fora
+         do DAS e cai na genérica com CST — correto. Regra geral: movimento sem
+         receita/titularidade = CSOSN 400; ajuste/simbólica = 900; linha de
+         receita não fixa ICMS (herda a tributação SN da empresa). Mapa a
+         ratificar com contador (transferência de mercadoria: ADC 49). -->
+    <record id="fo_retorno_deposito_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_retorno_deposito" />
+        <field name="name">Retorno de mercadoria depositada - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1906" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2906" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record
+        id="fo_retorno_deposito_line_sn_icmssn"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="fiscal_operation_line_id" ref="fo_retorno_deposito_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_remessa_deposito_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_remessa_deposito" />
+        <field
+            name="name"
+        >Remessa para depósito/armazém geral - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5905" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6905" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rem_dep_ipi_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_deposito_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_53" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rem_dep_pis_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_deposito_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_08" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rem_dep_cofins_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_deposito_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_08" />
+        <field name="state">approved</field>
+    </record>
+    <record
+        id="fo_remessa_deposito_line_sn_icmssn"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="fiscal_operation_line_id" ref="fo_remessa_deposito_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_retorno_vasilhame_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_retorno_vasilhame" />
+        <field name="name">Retorno de vasilhame ou sacaria - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1921" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2921" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record
+        id="fo_retorno_vasilhame_line_sn_icmssn"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="fiscal_operation_line_id" ref="fo_retorno_vasilhame_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_remessa_vasilhame_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_remessa_vasilhame" />
+        <field name="name">Remessa de vasilhame ou sacaria - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5920" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6920" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rem_vas_ipi_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_vasilhame_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_53" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rem_vas_pis_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_vasilhame_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_08" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rem_vas_cofins_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_vasilhame_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_seminc" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_08" />
+        <field name="state">approved</field>
+    </record>
+    <record
+        id="fo_remessa_vasilhame_line_sn_icmssn"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="fiscal_operation_line_id" ref="fo_remessa_vasilhame_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_devolucao_vasilhame_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_devolucao_vasilhame" />
+        <field name="name">Devolução de vasilhame ou sacaria - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5921" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6921" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record
+        id="fo_devolucao_vasilhame_line_sn_icmssn"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="fiscal_operation_line_id" ref="fo_devolucao_vasilhame_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_entrada_vasilhame_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_entrada_vasilhame" />
+        <field name="name">Entrada de vasilhame ou sacaria - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1920" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2920" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record
+        id="fo_entrada_vasilhame_line_sn_icmssn"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="fiscal_operation_line_id" ref="fo_entrada_vasilhame_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+
+</odoo>

--- a/l10n_br_fiscal/data/fiscal_operation_comex_ajustes.xml
+++ b/l10n_br_fiscal/data/fiscal_operation_comex_ajustes.xml
@@ -1,0 +1,402 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Famílias COMÉRCIO EXTERIOR (exportação) e AJUSTES/OUTRAS.
+
+  COMEX: remessa com fim específico de exportação (5501/5502, suspensão de ICMS
+  até efetivar a exportação — LC 87/96) + retorno (1501/2501). A exportação
+  direta (7101/7102) já está como cfop_export nas linhas de venda do core — a
+  imunidade (ICMS 41/IPI 54/PIS-COFINS 08) para parceiro no exterior é resolvida
+  na camada de código (detecção de país), não duplicada aqui. DUIMP/DI é frente
+  própria (fora).
+
+  AJUSTES: só a BAIXA DE ESTOQUE (5927) é nova. "Outras saídas/entradas" 5949/
+  1949 já são fo_simples_remessa / fo_entrada_remessa no core — não duplicadas.
+  A baixa não destaca imposto; o efeito é ESTORNO DE CRÉDITO na apuração (SPED
+  bloco E/M) — fora do escopo do catálogo de operações, sinalizado no infCpl.
+-->
+<odoo noupdate="1">
+
+    <record id="comment_remessa_export" model="l10n_br_fiscal.comment">
+        <field name="name">Remessa com fim específico de exportação</field>
+        <field
+            name="comment"
+        >Remessa com fim específico de exportação. ICMS suspenso (LC 87/96, art. 3º, parágrafo único). Prazo de 180 dias para efetivar a exportação por comercial exportadora/trading, sob pena de recolhimento do imposto suspenso.</field>
+        <field name="comment_type">fiscal</field>
+        <field name="object">l10n_br_fiscal.document.mixin</field>
+    </record>
+    <record id="comment_baixa_estoque" model="l10n_br_fiscal.comment">
+        <field name="name">Baixa de estoque</field>
+        <field
+            name="comment"
+        >Baixa de estoque por perda, roubo ou deterioração. Estorno de crédito de ICMS nos termos do art. 21, I, da LC 87/96. Nota emitida exclusivamente para regularização de estoque.</field>
+        <field name="comment_type">fiscal</field>
+        <field name="object">l10n_br_fiscal.document.mixin</field>
+    </record>
+
+    <!-- Retorno de remessa com fim específico de exportação (alvo do return) -->
+    <record id="fo_retorno_remessa_export" model="l10n_br_fiscal.operation">
+        <field name="code">RRE</field>
+        <field name="name">Retorno de remessa com fim específico de exportação</field>
+        <field name="fiscal_operation_type">in</field>
+        <field name="fiscal_type">other</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_retorno_remessa_export_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_retorno_remessa_export" />
+        <field name="name">Retorno de remessa com fim específico de exportação</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1501" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2501" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_rre_icms" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_retorno_remessa_export_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icms" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_suspensao" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icms_50" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- Remessa com fim específico de exportação -->
+    <record id="fo_remessa_export" model="l10n_br_fiscal.operation">
+        <field name="code">REE</field>
+        <field name="name">Remessa com fim específico de exportação</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">other</field>
+        <field name="return_fiscal_operation_id" ref="fo_retorno_remessa_export" />
+        <field name="state">approved</field>
+        <field name="comment_ids" eval="[(6, 0, [ref('comment_remessa_export')])]" />
+    </record>
+    <record id="fo_remessa_export_producao" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_remessa_export" />
+        <field name="name">Remessa p/ exportação (produção própria)</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5501" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6501" />
+        <field name="product_type">04</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ree_prod_icms" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_export_producao" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icms" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_suspensao" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icms_50" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ree_prod_ipi" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_export_producao" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_suspensao" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_55" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ree_prod_pis" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_export_producao" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ree_prod_cofins" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_export_producao" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_remessa_export_revenda" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_remessa_export" />
+        <field name="name">Remessa p/ exportação (mercadoria de terceiros)</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5502" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6502" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ree_rev_icms" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_export_revenda" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icms" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_suspensao" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icms_50" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ree_rev_pis" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_export_revenda" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ree_rev_cofins" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_export_revenda" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- Baixa de estoque por perda/roubo/deterioração (5927, sem par interestadual) -->
+    <record id="fo_baixa_estoque" model="l10n_br_fiscal.operation">
+        <field name="code">BXE</field>
+        <field name="name">Baixa de estoque por perda, roubo ou deterioração</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">other</field>
+        <field name="state">approved</field>
+        <field name="comment_ids" eval="[(6, 0, [ref('comment_baixa_estoque')])]" />
+    </record>
+    <record id="fo_baixa_estoque_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_baixa_estoque" />
+        <field name="name">Baixa de estoque por perda, roubo ou deterioração</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5927" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_bxe_icms" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_baixa_estoque_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icms" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_outras" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icms_90" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_bxe_pis" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_baixa_estoque_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_bxe_cofins" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_baixa_estoque_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+
+
+    <!-- ================= Simples Nacional =================
+         Linhas irmãs para empresa do Simples (company_tax_framework=1): o
+         seletor de linha prefere a mais específica, então a empresa SN casa
+         estas (CSOSN via grupo icmssn) e os demais regimes casam as genéricas
+         (CST). Empresa em excesso de sublimite (framework=2) recolhe ICMS fora
+         do DAS e cai na genérica com CST — correto. Regra geral: movimento sem
+         receita/titularidade = CSOSN 400; ajuste/simbólica = 900; linha de
+         receita não fixa ICMS (herda a tributação SN da empresa). Mapa a
+         ratificar com contador (transferência de mercadoria: ADC 49). -->
+    <record
+        id="fo_retorno_remessa_export_line_sn"
+        model="l10n_br_fiscal.operation.line"
+    >
+        <field name="fiscal_operation_id" ref="fo_retorno_remessa_export" />
+        <field
+            name="name"
+        >Retorno de remessa com fim específico de exportação - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1501" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2501" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record
+        id="fo_retorno_remessa_export_line_sn_icmssn"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field
+            name="fiscal_operation_line_id"
+            ref="fo_retorno_remessa_export_line_sn"
+        />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_remessa_export_producao_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_remessa_export" />
+        <field
+            name="name"
+        >Remessa p/ exportação (produção própria) - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5501" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6501" />
+        <field name="product_type">04</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ree_prod_ipi_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_export_producao_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_suspensao" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_55" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ree_prod_pis_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_export_producao_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ree_prod_cofins_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_export_producao_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+    <record
+        id="fo_remessa_export_producao_sn_icmssn"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="fiscal_operation_line_id" ref="fo_remessa_export_producao_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_remessa_export_revenda_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_remessa_export" />
+        <field
+            name="name"
+        >Remessa p/ exportação (mercadoria de terceiros) - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5502" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6502" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ree_rev_pis_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_export_revenda_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ree_rev_cofins_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_remessa_export_revenda_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+    <record
+        id="fo_remessa_export_revenda_sn_icmssn"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="fiscal_operation_line_id" ref="fo_remessa_export_revenda_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_baixa_estoque_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_baixa_estoque" />
+        <field
+            name="name"
+        >Baixa de estoque por perda, roubo ou deterioração - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5927" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_bxe_pis_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_baixa_estoque_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_bxe_cofins_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_baixa_estoque_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_baixa_estoque_line_sn_icmssn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_baixa_estoque_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_900" />
+        <field name="state">approved</field>
+    </record>
+
+</odoo>

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -17,4 +17,5 @@ from . import (
     test_service_type,
     test_operation,
     test_tax_framework,
+    test_catalog_comex_armazem,
 )

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -16,4 +16,5 @@ from . import (
     test_partner_profile,
     test_service_type,
     test_operation,
+    test_catalog_comex_armazem,
 )

--- a/l10n_br_fiscal/tests/operation_catalog_common.py
+++ b/l10n_br_fiscal/tests/operation_catalog_common.py
@@ -1,0 +1,86 @@
+# Copyright (C) 2026 KMEE
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo.tests.common import TransactionCase
+
+
+class OperationCatalogCommon(TransactionCase):
+    """Base para os testes do catálogo de operações fiscais.
+
+    Fornece uma empresa em SP e três parceiros (interno, interestadual e
+    exterior) para exercitar a resolução de CFOP por destino
+    (``operation.line._get_cfop``), além de helpers de asserção.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.br = cls.env.ref("base.br")
+        cls.state_sp = cls.env.ref("base.state_br_sp")
+        cls.state_mg = cls.env.ref("base.state_br_mg")
+
+        cls.company = cls.env.ref("base.main_company")
+        cls.company.write({"country_id": cls.br.id, "state_id": cls.state_sp.id})
+
+        Partner = cls.env["res.partner"]
+        cls.partner_interno = Partner.create(
+            {
+                "name": "Parceiro Interno SP",
+                "country_id": cls.br.id,
+                "state_id": cls.state_sp.id,
+            }
+        )
+        cls.partner_interestadual = Partner.create(
+            {
+                "name": "Parceiro Interestadual MG",
+                "country_id": cls.br.id,
+                "state_id": cls.state_mg.id,
+            }
+        )
+        cls.partner_exterior = Partner.create(
+            {
+                "name": "Parceiro Exterior",
+                "country_id": cls.env.ref("base.us").id,
+            }
+        )
+
+    def _cfop_code(self, operation_line, partner):
+        return operation_line._get_cfop(self.company, partner).code
+
+    def assert_operation_cfops(
+        self, operation_line_xmlid, internal, external, export=None
+    ):
+        """Confere que a linha de operação resolve o CFOP esperado por destino.
+
+        :param operation_line_xmlid: xmlid completo da l10n_br_fiscal.operation.line
+        :param internal: código CFOP esperado para operação interna (mesmo estado)
+        :param external: código CFOP esperado para operação interestadual
+        :param export: código CFOP esperado para exportação (opcional)
+        """
+        line = self.env.ref(operation_line_xmlid)
+        self.assertEqual(
+            self._cfop_code(line, self.partner_interno),
+            internal,
+            "CFOP interno incorreto em %s" % operation_line_xmlid,
+        )
+        self.assertEqual(
+            self._cfop_code(line, self.partner_interestadual),
+            external,
+            "CFOP interestadual incorreto em %s" % operation_line_xmlid,
+        )
+        if export:
+            self.assertEqual(
+                self._cfop_code(line, self.partner_exterior),
+                export,
+                "CFOP de exportação incorreto em %s" % operation_line_xmlid,
+            )
+
+    def assert_return_link(self, operation_xmlid, return_operation_xmlid):
+        """Confere o encadeamento remessa/retorno via return_fiscal_operation_id."""
+        operation = self.env.ref(operation_xmlid)
+        expected = self.env.ref(return_operation_xmlid)
+        self.assertEqual(
+            operation.return_fiscal_operation_id,
+            expected,
+            "Encadeamento de retorno incorreto em %s" % operation_xmlid,
+        )

--- a/l10n_br_fiscal/tests/test_catalog_comex_armazem.py
+++ b/l10n_br_fiscal/tests/test_catalog_comex_armazem.py
@@ -1,0 +1,64 @@
+# Copyright (C) 2026 KMEE
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+"""Testes data-driven do catálogo de operações: comex / armazem."""
+
+from odoo.tests import tagged
+
+from .operation_catalog_common import OperationCatalogCommon
+
+M = "l10n_br_fiscal"
+
+CFOP_CASES = [
+    ("fo_remessa_export_producao", "5501", "6501", None),
+    ("fo_remessa_export_revenda", "5502", "6502", None),
+    ("fo_retorno_remessa_export_line", "1501", "2501", None),
+    ("fo_remessa_deposito_line", "5905", "6905", None),
+    ("fo_retorno_deposito_line", "1906", "2906", None),
+    ("fo_remessa_vasilhame_line", "5920", "6920", None),
+    ("fo_retorno_vasilhame_line", "1921", "2921", None),
+    ("fo_entrada_vasilhame_line", "1920", "2920", None),
+    ("fo_devolucao_vasilhame_line", "5921", "6921", None),
+]
+
+RETURN_LINKS = [
+    ("fo_remessa_export", "fo_retorno_remessa_export"),
+]
+
+TAX_DEF_CASES = [
+    ("fo_remessa_export_producao", {"ICMS": "50", "IPI": "55", "PIS": "49"}, [], []),
+    ("fo_baixa_estoque_line", {"ICMS": "90", "PIS": "49"}, [], []),
+]
+
+
+@tagged("post_install", "-at_install", "op_catalog")
+class TestCatalogComexArmazem(OperationCatalogCommon):
+    def test_cfops(self):
+        """CFOP resolvido por destino (interno/interestadual/exportação)."""
+        for line, internal, external, export in CFOP_CASES:
+            with self.subTest(line=line):
+                self.assert_operation_cfops(f"{M}.{line}", internal, external, export)
+
+    def test_return_links(self):
+        """Encadeamento remessa/retorno via return_fiscal_operation_id."""
+        for op, ret in RETURN_LINKS:
+            with self.subTest(op=op):
+                self.assert_return_link(f"{M}.{op}", f"{M}.{ret}")
+
+    def test_tax_definitions(self):
+        """CST por grupo, ausência de definition (default) e não incidência."""
+        for line, csts, absent, not_taxed in TAX_DEF_CASES:
+            with self.subTest(line=line):
+                rec = self.env.ref(f"{M}.{line}")
+                defs = {d.tax_group_id.name: d for d in rec.tax_definition_ids}
+                for group, cst in csts.items():
+                    self.assertEqual(defs[group].cst_id.code, cst, f"{line}/{group}")
+                for group in absent:
+                    self.assertNotIn(group, defs, f"{line}/{group}")
+                for group in not_taxed:
+                    self.assertFalse(defs[group].is_taxed, f"{line}/{group}")
+
+    def test_baixa_estoque_so_interna(self):
+        """Baixa de estoque (5927) não tem CFOP interestadual: é sempre interna."""
+        line = self.env.ref(f"{M}.fo_baixa_estoque_line")
+        self.assertEqual(self._cfop_code(line, self.partner_interno), "5927")
+        self.assertFalse(line.cfop_external_id)


### PR DESCRIPTION
Parte da série do catálogo de operações fiscais:

- Remessa com fim específico de exportação (5501/5502, suspensão) e retorno (1501)
- Baixa de estoque por perda/roubo/deterioração (5927, apenas interna)
- Armazém geral/depósito fechado (remessa e retorno do depositante, não incidência)
- Embalagens retornáveis/vasilhames (ciclo completo)

Com linhas irmãs Simples Nacional (CSOSN 400/900). Testes data-driven.
