### PR TITLE
[16.0][IMP] l10n_br_fiscal: operações de entrega futura e venda fora do estabelecimento

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -51,6 +51,8 @@
         "data/l10n_br_fiscal.operation.indicator.csv",
         "data/simplified_tax_data.xml",
         "data/operation_data.xml",
+        "data/fiscal_operation_entrega_futura.xml",
+        "data/fiscal_operation_venda_fora_estabelecimento.xml",
         "data/l10n_br_fiscal_tax_icms_data.xml",
         # the following csv data files will be loaded as noupdate=True
         # and will be trimmed down when demo mode is True (faster):

--- a/l10n_br_fiscal/data/fiscal_operation_entrega_futura.xml
+++ b/l10n_br_fiscal/data/fiscal_operation_entrega_futura.xml
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Família ENTREGA FUTURA — parte ADITIVA sobre o core.
+
+  ⚠ DEPENDÊNCIA: só fica correta em produção APÓS o PR de saneamento dos flags
+  finance_move/stock_move do CFOP (ver data/AUDITORIA_CFOP_FLAGS.md). Modela a
+  ESCOLA A (faturamento antecipado): PIS/COFINS incidem no FATURAMENTO (receita);
+  ICMS/IPI na REMESSA (circulação). Com os flags corrigidos (5922→1/0
+  faturamento; 5116/5117→0/1 remessa), o financeiro nasce no faturamento e o
+  estoque sai na remessa.
+
+  O core já tem o lado venda parcial (fo_simples_faturamento 5922, fo_entrega_
+  futura 5116 produção) — porém com bugs (fo_entrega_futura zera IPI/PIS-COFINS
+  indevidamente; falta zerar IPI no faturamento). Essas CORREÇÕES do lado venda
+  existente entram no PR de saneamento de core, não aqui. Este arquivo adiciona
+  só o que falta: lado COMPRA (recebimento futuro) e a remessa de REVENDA (5117).
+-->
+<odoo noupdate="1">
+
+    <!-- Remessa de entrega futura — mercadoria de terceiros (revenda). O core só
+         tem a de produção (5116); esta complementa. PIS/COFINS já foram no
+         faturamento (CST 49); IPI não destaca (comerciante); ICMS destaca. -->
+    <record id="fo_entrega_futura_remessa_revenda" model="l10n_br_fiscal.operation">
+        <field name="code">EF-REM-REV</field>
+        <field name="name">Remessa de entrega futura - mercadoria de terceiros</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">sale</field>
+        <field
+            name="return_fiscal_operation_id"
+            ref="l10n_br_fiscal.fo_devolucao_venda"
+        />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ef_remessa_revenda_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_entrega_futura_remessa_revenda" />
+        <field name="name">Remessa de entrega futura (revenda)</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5117" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6117" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ef_remessa_revenda_ipi" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_ef_remessa_revenda_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_53" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ef_remessa_revenda_pis" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_ef_remessa_revenda_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ef_remessa_revenda_cofins" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_ef_remessa_revenda_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- LADO COMPRA: faturamento antecipado recebido (1922). PIS/COFINS creditam
+         (espelham o débito do vendedor); ICMS/IPI sem crédito (crédito vem na
+         entrada física). -->
+    <record id="fo_entrega_futura_compra" model="l10n_br_fiscal.operation">
+        <field name="code">EF-COMPRA</field>
+        <field name="name">Simples faturamento - compra para recebimento futuro</field>
+        <field name="fiscal_operation_type">in</field>
+        <field name="fiscal_type">other</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ef_compra_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_entrega_futura_compra" />
+        <field name="name">Faturamento de compra para recebimento futuro</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1922" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2922" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ef_compra_icms" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_ef_compra_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icms" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_0" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icms_90" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ef_compra_ipi" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_ef_compra_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_49" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- LADO COMPRA: entrada física - industrialização (1116). ICMS/IPI creditam
+         (default); PIS/COFINS sem novo crédito (CST 98, já creditados no fat.). -->
+    <record id="fo_entrega_futura_entrada_ind" model="l10n_br_fiscal.operation">
+        <field name="code">EF-ENT-IND</field>
+        <field
+            name="name"
+        >Entrada de compra p/ industrialização - recebimento futuro</field>
+        <field name="fiscal_operation_type">in</field>
+        <field name="fiscal_type">purchase</field>
+        <field
+            name="return_fiscal_operation_id"
+            ref="l10n_br_fiscal.fo_devolucao_compras"
+        />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ef_entrada_ind_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_entrega_futura_entrada_ind" />
+        <field
+            name="name"
+        >Entrada física - industrialização (recebimento futuro)</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1116" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2116" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ef_entrada_ind_pis" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_ef_entrada_ind_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_98" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ef_entrada_ind_cofins" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_ef_entrada_ind_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_98" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- LADO COMPRA: entrada física - comercialização (1117). ICMS credita; IPI
+         não creditável (revenda); PIS/COFINS CST 98. -->
+    <record id="fo_entrega_futura_entrada_com" model="l10n_br_fiscal.operation">
+        <field name="code">EF-ENT-COM</field>
+        <field
+            name="name"
+        >Entrada de compra p/ comercialização - recebimento futuro</field>
+        <field name="fiscal_operation_type">in</field>
+        <field name="fiscal_type">purchase</field>
+        <field
+            name="return_fiscal_operation_id"
+            ref="l10n_br_fiscal.fo_devolucao_compras"
+        />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ef_entrada_com_line" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_entrega_futura_entrada_com" />
+        <field name="name">Entrada física - comercialização (recebimento futuro)</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1117" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2117" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ef_entrada_com_ipi" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_ef_entrada_com_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ef_entrada_com_pis" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_ef_entrada_com_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_98" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ef_entrada_com_cofins" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_ef_entrada_com_line" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_98" />
+        <field name="state">approved</field>
+    </record>
+
+
+    <!-- ================= Simples Nacional =================
+         Linhas irmãs para empresa do Simples (company_tax_framework=1): o
+         seletor de linha prefere a mais específica, então a empresa SN casa
+         estas (CSOSN via grupo icmssn) e os demais regimes casam as genéricas
+         (CST). Empresa em excesso de sublimite (framework=2) recolhe ICMS fora
+         do DAS e cai na genérica com CST — correto. Regra geral: movimento sem
+         receita/titularidade = CSOSN 400; ajuste/simbólica = 900; linha de
+         receita não fixa ICMS (herda a tributação SN da empresa). Mapa a
+         ratificar com contador (transferência de mercadoria: ADC 49). -->
+    <record id="fo_ef_remessa_revenda_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_entrega_futura_remessa_revenda" />
+        <field
+            name="name"
+        >Remessa de entrega futura (revenda) - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5117" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6117" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ef_remessa_revenda_ipi_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_ef_remessa_revenda_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_53" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ef_remessa_revenda_pis_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_ef_remessa_revenda_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ef_remessa_revenda_cofins_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_ef_remessa_revenda_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+    <record
+        id="fo_ef_remessa_revenda_line_sn_icmssn"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="fiscal_operation_line_id" ref="fo_ef_remessa_revenda_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ef_compra_line_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_entrega_futura_compra" />
+        <field
+            name="name"
+        >Faturamento de compra para recebimento futuro - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1922" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2922" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ef_compra_ipi_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_ef_compra_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_ef_compra_line_sn_icmssn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_ef_compra_line_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_900" />
+        <field name="state">approved</field>
+    </record>
+
+</odoo>

--- a/l10n_br_fiscal/data/fiscal_operation_venda_fora_estabelecimento.xml
+++ b/l10n_br_fiscal/data/fiscal_operation_venda_fora_estabelecimento.xml
@@ -1,0 +1,522 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Família VENDA FORA DO ESTABELECIMENTO (venda ambulante / em veículo).
+  Não existe no core. Mesma dissociação de fato gerador da consignação:
+  ICMS/IPI (circulação) na REMESSA (5904); PIS/COFINS (receita) na VENDA
+  EFETIVA (5103/5104). A venda efetiva NÃO destaca ICMS de novo (já debitado na
+  remessa — evita bis in idem); o retorno das não vendidas (1904) credita o
+  ICMS proporcional.
+
+  Caso geral (RICMS-SP clássico): remessa destaca ICMS integral / venda efetiva
+  sem destaque (CST 90). Variante por UF (venda destaca, remessa não) e destinos
+  ind_ie_dest 2/9 (DIFAL na camada de imposto) e ST/Simples = parametrizável,
+  fora do default (readme).
+-->
+<odoo noupdate="1">
+
+    <record id="comment_vfe_remessa" model="l10n_br_fiscal.comment">
+        <field name="name">Remessa para venda fora do estabelecimento</field>
+        <field
+            name="comment"
+        >Remessa de mercadoria para realização de vendas fora do estabelecimento, sem destinatário certo, por meio de veículo. ICMS destacado sobre o total da carga.</field>
+        <field name="comment_type">fiscal</field>
+        <field name="object">l10n_br_fiscal.document.mixin</field>
+    </record>
+    <record id="comment_vfe_venda" model="l10n_br_fiscal.comment">
+        <field name="name">Venda efetuada fora do estabelecimento</field>
+        <field
+            name="comment"
+        >Venda de mercadoria efetuada fora do estabelecimento. ICMS integralmente debitado na NF-e de remessa; sem novo destaque para evitar duplicidade.</field>
+        <field name="comment_type">fiscal</field>
+        <field name="object">l10n_br_fiscal.document.mixin</field>
+    </record>
+    <record id="comment_vfe_retorno" model="l10n_br_fiscal.comment">
+        <field name="name">Retorno de venda fora do estabelecimento</field>
+        <field
+            name="comment"
+        >Retorno de mercadoria remetida para venda fora do estabelecimento e não comercializada. Crédito do ICMS proporcional às mercadorias retornadas. Ref. NF-e de remessa.</field>
+        <field name="comment_type">fiscal</field>
+        <field name="object">l10n_br_fiscal.document.mixin</field>
+    </record>
+
+    <!-- OP-2: retorno das não vendidas (alvo do return da remessa) -->
+    <record id="fo_vfe_retorno" model="l10n_br_fiscal.operation">
+        <field name="code">VFE-RET</field>
+        <field name="name">Retorno de venda fora do estabelecimento</field>
+        <field name="fiscal_operation_type">in</field>
+        <field name="fiscal_type">other</field>
+        <field name="state">approved</field>
+        <field name="comment_ids" eval="[(6, 0, [ref('comment_vfe_retorno')])]" />
+    </record>
+    <record id="fo_vfe_retorno_producao" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_vfe_retorno" />
+        <field name="name">Retorno de venda fora do estabelecimento (produção)</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1904" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2904" />
+        <field name="product_type">04</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_retorno_producao_pis" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_vfe_retorno_producao" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_retorno_producao_cofins" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_vfe_retorno_producao" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_retorno_revenda" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_vfe_retorno" />
+        <field name="name">Retorno de venda fora do estabelecimento (revenda)</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1904" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2904" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_retorno_revenda_ipi" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_vfe_retorno_revenda" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_retorno_revenda_pis" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_vfe_retorno_revenda" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_retorno_revenda_cofins" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_vfe_retorno_revenda" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- OP-1: remessa para venda fora do estabelecimento -->
+    <record id="fo_vfe_remessa" model="l10n_br_fiscal.operation">
+        <field name="code">VFE-REM</field>
+        <field name="name">Remessa para venda fora do estabelecimento</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">other</field>
+        <field name="return_fiscal_operation_id" ref="fo_vfe_retorno" />
+        <field name="state">approved</field>
+        <field name="comment_ids" eval="[(6, 0, [ref('comment_vfe_remessa')])]" />
+    </record>
+    <record id="fo_vfe_remessa_producao" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_vfe_remessa" />
+        <field name="name">Remessa para venda fora do estabelecimento (produção)</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5904" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6904" />
+        <field name="product_type">04</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_remessa_producao_pis" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_vfe_remessa_producao" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_remessa_producao_cofins" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_vfe_remessa_producao" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_remessa_revenda" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_vfe_remessa" />
+        <field name="name">Remessa para venda fora do estabelecimento (revenda)</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5904" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6904" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_remessa_revenda_ipi" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_vfe_remessa_revenda" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_53" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_remessa_revenda_pis" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_vfe_remessa_revenda" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_remessa_revenda_cofins" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_vfe_remessa_revenda" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- OP-3: venda efetuada fora do estabelecimento (receita) -->
+    <record id="fo_vfe_venda" model="l10n_br_fiscal.operation">
+        <field name="code">VFE-VDA</field>
+        <field name="name">Venda efetuada fora do estabelecimento</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_type">sale</field>
+        <field
+            name="return_fiscal_operation_id"
+            ref="l10n_br_fiscal.fo_devolucao_venda"
+        />
+        <field name="state">approved</field>
+        <field name="comment_ids" eval="[(6, 0, [ref('comment_vfe_venda')])]" />
+    </record>
+    <record id="fo_vfe_venda_producao" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_vfe_venda" />
+        <field name="name">Venda fora do estabelecimento (produção)</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5103" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6103" />
+        <field name="product_type">04</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_venda_producao_icms" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_vfe_venda_producao" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icms" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_0" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icms_90" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_venda_producao_ipi" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_vfe_venda_producao" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_53" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_venda_revenda" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_vfe_venda" />
+        <field name="name">Venda fora do estabelecimento (revenda)</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5104" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6104" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_venda_revenda_icms" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_vfe_venda_revenda" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icms" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_0" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icms_90" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_venda_revenda_ipi" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_vfe_venda_revenda" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_53" />
+        <field name="state">approved</field>
+    </record>
+
+
+    <!-- ================= Simples Nacional =================
+         Linhas irmãs para empresa do Simples (company_tax_framework=1): o
+         seletor de linha prefere a mais específica, então a empresa SN casa
+         estas (CSOSN via grupo icmssn) e os demais regimes casam as genéricas
+         (CST). Empresa em excesso de sublimite (framework=2) recolhe ICMS fora
+         do DAS e cai na genérica com CST — correto. Regra geral: movimento sem
+         receita/titularidade = CSOSN 400; ajuste/simbólica = 900; linha de
+         receita não fixa ICMS (herda a tributação SN da empresa). Mapa a
+         ratificar com contador (transferência de mercadoria: ADC 49). -->
+    <record id="fo_vfe_retorno_producao_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_vfe_retorno" />
+        <field
+            name="name"
+        >Retorno de venda fora do estabelecimento (produção) - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1904" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2904" />
+        <field name="product_type">04</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_retorno_producao_pis_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_vfe_retorno_producao_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record
+        id="fo_vfe_retorno_producao_cofins_sn"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="fiscal_operation_line_id" ref="fo_vfe_retorno_producao_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+    <record
+        id="fo_vfe_retorno_producao_sn_icmssn"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="fiscal_operation_line_id" ref="fo_vfe_retorno_producao_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_retorno_revenda_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_vfe_retorno" />
+        <field
+            name="name"
+        >Retorno de venda fora do estabelecimento (revenda) - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_1904" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_2904" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_retorno_revenda_ipi_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_vfe_retorno_revenda_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_retorno_revenda_pis_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_vfe_retorno_revenda_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_retorno_revenda_cofins_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_vfe_retorno_revenda_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_retorno_revenda_sn_icmssn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_vfe_retorno_revenda_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_remessa_producao_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_vfe_remessa" />
+        <field
+            name="name"
+        >Remessa para venda fora do estabelecimento (produção) - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5904" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6904" />
+        <field name="product_type">04</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_remessa_producao_pis_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_vfe_remessa_producao_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record
+        id="fo_vfe_remessa_producao_cofins_sn"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="fiscal_operation_line_id" ref="fo_vfe_remessa_producao_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+    <record
+        id="fo_vfe_remessa_producao_sn_icmssn"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="fiscal_operation_line_id" ref="fo_vfe_remessa_producao_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_remessa_revenda_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_vfe_remessa" />
+        <field
+            name="name"
+        >Remessa para venda fora do estabelecimento (revenda) - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5904" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6904" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_remessa_revenda_ipi_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_vfe_remessa_revenda_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_53" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_remessa_revenda_pis_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_vfe_remessa_revenda_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_pis" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_pis_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_pis_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_remessa_revenda_cofins_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_vfe_remessa_revenda_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cofins" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cofins_outros" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cofins_49" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_remessa_revenda_sn_icmssn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_vfe_remessa_revenda_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmssn" />
+        <field name="is_taxed" eval="False" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_400" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_venda_producao_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_vfe_venda" />
+        <field
+            name="name"
+        >Venda fora do estabelecimento (produção) - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5103" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6103" />
+        <field name="product_type">04</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_venda_producao_ipi_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_vfe_venda_producao_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_53" />
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_venda_revenda_sn" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="fo_vfe_venda" />
+        <field
+            name="name"
+        >Venda fora do estabelecimento (revenda) - Simples Nacional</field>
+        <field name="company_tax_framework">1</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5104" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6104" />
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field name="state">approved</field>
+    </record>
+    <record id="fo_vfe_venda_revenda_ipi_sn" model="l10n_br_fiscal.tax.definition">
+        <field name="fiscal_operation_line_id" ref="fo_vfe_venda_revenda_sn" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ipi" />
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_nt" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_53" />
+        <field name="state">approved</field>
+    </record>
+
+</odoo>

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -17,4 +17,5 @@ from . import (
     test_service_type,
     test_operation,
     test_tax_framework,
+    test_catalog_entrega_futura_vfe,
 )

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -16,4 +16,5 @@ from . import (
     test_partner_profile,
     test_service_type,
     test_operation,
+    test_catalog_entrega_futura_vfe,
 )

--- a/l10n_br_fiscal/tests/operation_catalog_common.py
+++ b/l10n_br_fiscal/tests/operation_catalog_common.py
@@ -1,0 +1,86 @@
+# Copyright (C) 2026 KMEE
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo.tests.common import TransactionCase
+
+
+class OperationCatalogCommon(TransactionCase):
+    """Base para os testes do catálogo de operações fiscais.
+
+    Fornece uma empresa em SP e três parceiros (interno, interestadual e
+    exterior) para exercitar a resolução de CFOP por destino
+    (``operation.line._get_cfop``), além de helpers de asserção.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.br = cls.env.ref("base.br")
+        cls.state_sp = cls.env.ref("base.state_br_sp")
+        cls.state_mg = cls.env.ref("base.state_br_mg")
+
+        cls.company = cls.env.ref("base.main_company")
+        cls.company.write({"country_id": cls.br.id, "state_id": cls.state_sp.id})
+
+        Partner = cls.env["res.partner"]
+        cls.partner_interno = Partner.create(
+            {
+                "name": "Parceiro Interno SP",
+                "country_id": cls.br.id,
+                "state_id": cls.state_sp.id,
+            }
+        )
+        cls.partner_interestadual = Partner.create(
+            {
+                "name": "Parceiro Interestadual MG",
+                "country_id": cls.br.id,
+                "state_id": cls.state_mg.id,
+            }
+        )
+        cls.partner_exterior = Partner.create(
+            {
+                "name": "Parceiro Exterior",
+                "country_id": cls.env.ref("base.us").id,
+            }
+        )
+
+    def _cfop_code(self, operation_line, partner):
+        return operation_line._get_cfop(self.company, partner).code
+
+    def assert_operation_cfops(
+        self, operation_line_xmlid, internal, external, export=None
+    ):
+        """Confere que a linha de operação resolve o CFOP esperado por destino.
+
+        :param operation_line_xmlid: xmlid completo da l10n_br_fiscal.operation.line
+        :param internal: código CFOP esperado para operação interna (mesmo estado)
+        :param external: código CFOP esperado para operação interestadual
+        :param export: código CFOP esperado para exportação (opcional)
+        """
+        line = self.env.ref(operation_line_xmlid)
+        self.assertEqual(
+            self._cfop_code(line, self.partner_interno),
+            internal,
+            "CFOP interno incorreto em %s" % operation_line_xmlid,
+        )
+        self.assertEqual(
+            self._cfop_code(line, self.partner_interestadual),
+            external,
+            "CFOP interestadual incorreto em %s" % operation_line_xmlid,
+        )
+        if export:
+            self.assertEqual(
+                self._cfop_code(line, self.partner_exterior),
+                export,
+                "CFOP de exportação incorreto em %s" % operation_line_xmlid,
+            )
+
+    def assert_return_link(self, operation_xmlid, return_operation_xmlid):
+        """Confere o encadeamento remessa/retorno via return_fiscal_operation_id."""
+        operation = self.env.ref(operation_xmlid)
+        expected = self.env.ref(return_operation_xmlid)
+        self.assertEqual(
+            operation.return_fiscal_operation_id,
+            expected,
+            "Encadeamento de retorno incorreto em %s" % operation_xmlid,
+        )

--- a/l10n_br_fiscal/tests/test_catalog_entrega_futura_vfe.py
+++ b/l10n_br_fiscal/tests/test_catalog_entrega_futura_vfe.py
@@ -1,0 +1,62 @@
+# Copyright (C) 2026 KMEE
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+"""Testes data-driven do catálogo de operações: entrega / futura / vfe."""
+
+from odoo.tests import tagged
+
+from .operation_catalog_common import OperationCatalogCommon
+
+M = "l10n_br_fiscal"
+
+CFOP_CASES = [
+    ("fo_ef_remessa_revenda_line", "5117", "6117", None),
+    ("fo_ef_compra_line", "1922", "2922", None),
+    ("fo_ef_entrada_ind_line", "1116", "2116", None),
+    ("fo_ef_entrada_com_line", "1117", "2117", None),
+    ("fo_vfe_remessa_producao", "5904", "6904", None),
+    ("fo_vfe_retorno_producao", "1904", "2904", None),
+    ("fo_vfe_venda_producao", "5103", "6103", None),
+    ("fo_vfe_venda_revenda", "5104", "6104", None),
+]
+
+RETURN_LINKS = [
+    ("fo_entrega_futura_entrada_ind", "fo_devolucao_compras"),
+    ("fo_vfe_remessa", "fo_vfe_retorno"),
+    ("fo_vfe_venda", "fo_devolucao_venda"),
+]
+
+TAX_DEF_CASES = [
+    ("fo_ef_remessa_revenda_line", {"IPI": "53", "PIS": "49"}, ["ICMS"], []),
+    ("fo_ef_compra_line", {"ICMS": "90"}, ["PIS"], []),
+    ("fo_ef_entrada_ind_line", {"PIS": "98", "COFINS": "98"}, [], []),
+    ("fo_vfe_remessa_producao", {"PIS": "49", "COFINS": "49"}, ["ICMS"], []),
+    ("fo_vfe_venda_producao", {"ICMS": "90"}, ["PIS"], ["ICMS"]),
+]
+
+
+@tagged("post_install", "-at_install", "op_catalog")
+class TestCatalogEntregaFuturaVfe(OperationCatalogCommon):
+    def test_cfops(self):
+        """CFOP resolvido por destino (interno/interestadual/exportação)."""
+        for line, internal, external, export in CFOP_CASES:
+            with self.subTest(line=line):
+                self.assert_operation_cfops(f"{M}.{line}", internal, external, export)
+
+    def test_return_links(self):
+        """Encadeamento remessa/retorno via return_fiscal_operation_id."""
+        for op, ret in RETURN_LINKS:
+            with self.subTest(op=op):
+                self.assert_return_link(f"{M}.{op}", f"{M}.{ret}")
+
+    def test_tax_definitions(self):
+        """CST por grupo, ausência de definition (default) e não incidência."""
+        for line, csts, absent, not_taxed in TAX_DEF_CASES:
+            with self.subTest(line=line):
+                rec = self.env.ref(f"{M}.{line}")
+                defs = {d.tax_group_id.name: d for d in rec.tax_definition_ids}
+                for group, cst in csts.items():
+                    self.assertEqual(defs[group].cst_id.code, cst, f"{line}/{group}")
+                for group in absent:
+                    self.assertNotIn(group, defs, f"{line}/{group}")
+                for group in not_taxed:
+                    self.assertFalse(defs[group].is_taxed, f"{line}/{group}")


### PR DESCRIPTION
Parte da série do catálogo de operações fiscais:

- Entrega futura: remessa de mercadoria de terceiros (5117) e o lado compra (faturamento 1922 e entradas físicas 1116/1117); o comportamento financeiro/estoque do simples faturamento fica completo com o saneamento dos flags de CFOP (PR dos fixes)
- Venda fora do estabelecimento: remessa (5904, ICMS destacado), venda efetiva (5103/5104, sem novo destaque) e retorno das não vendidas (1904)

Com linhas irmãs Simples Nacional (a venda efetiva SN herda a tributação da empresa; remessas com CSOSN 400). Testes data-driven.
