### PR TITLE
[16.0][ADD] l10n_br_account: test import_fiscal_document into a new move

### DIFF
--- a/l10n_br_account/tests/__init__.py
+++ b/l10n_br_account/tests/__init__.py
@@ -9,3 +9,4 @@ from . import test_payment_status
 from . import test_move_workflow
 from . import test_cancel_move_ids
 from . import test_document_import_check
+from . import test_import_fiscal_document

--- a/l10n_br_account/tests/__init__.py
+++ b/l10n_br_account/tests/__init__.py
@@ -7,3 +7,4 @@ from . import test_invoice_refund
 from . import test_multi_localizations_invoice
 from . import test_payment_status
 from . import test_move_workflow
+from . import test_import_fiscal_document

--- a/l10n_br_account/tests/test_import_fiscal_document.py
+++ b/l10n_br_account/tests/test_import_fiscal_document.py
@@ -1,0 +1,68 @@
+# Copyright 2026 - TODAY KMEE - Luis Felipe Mileo <mileo@kmee.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests.common import tagged
+
+from .common import AccountMoveBRCommon
+
+
+@tagged("post_install", "-at_install")
+class TestImportFiscalDocument(AccountMoveBRCommon):
+    """Import an existing fiscal document into a brand new account.move.
+
+    This is the code path used when the fiscal document exists before its
+    invoice: imported XML, DUIMP declarations, service invoices captured
+    from a PDF. It differs from button_import_fiscal_document, which
+    imports into an existing move and is already covered by
+    test_account_move_lc.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.configure_normal_company_taxes()
+        cls.company = cls.company_data["company"]
+
+    def _create_fiscal_document(self):
+        document = self.env["l10n_br_fiscal.document"].create(
+            {
+                "company_id": self.company.id,
+                "fiscal_operation_id": self.env.ref("l10n_br_fiscal.fo_compras").id,
+                "fiscal_operation_type": "in",
+                "document_type_id": self.env.ref("l10n_br_fiscal.document_55").id,
+                "document_number": "123",
+                "document_serie": "1",
+                "issuer": "partner",
+                "partner_id": self.partner_a.id,
+            }
+        )
+        self.env["l10n_br_fiscal.document.line"].create(
+            {
+                "document_id": document.id,
+                "name": "Import Test",
+                "product_id": self.product_a.id,
+                "fiscal_operation_id": document.fiscal_operation_id.id,
+                "fiscal_operation_line_id": self.env.ref(
+                    "l10n_br_fiscal.fo_compras_compras"
+                ).id,
+                "fiscal_operation_type": "in",
+                "quantity": 1,
+                "price_unit": 100.0,
+            }
+        )
+        return document
+
+    def test_import_into_a_new_vendor_bill(self):
+        """A vendor fiscal document is imported into a new vendor bill."""
+        document = self._create_fiscal_document()
+        move_form = self.env["account.move"].import_fiscal_document(document)
+        move = self.env["account.move"].browse(move_form.id)
+        self.assertEqual(move.move_type, "in_invoice")
+        self.assertEqual(move.fiscal_document_id, document)
+        self.assertEqual(move.partner_id, self.partner_a)
+        self.assertEqual(move.document_serie, "1")
+        self.assertEqual(len(move.invoice_line_ids), 1)
+        self.assertEqual(
+            move.invoice_line_ids.fiscal_document_line_id,
+            document.fiscal_line_ids,
+        )


### PR DESCRIPTION
## What

Adds `TestImportFiscalDocument`: it imports a vendor fiscal document into
a brand new vendor bill through `account.move.import_fiscal_document()`
and asserts the move type, the partner, the document serie and the
imported line.

## Why

`import_fiscal_document` has two code paths and only one of them was
covered. `test_account_move_lc` calls `button_import_fiscal_document`,
which imports into an already existing move. Importing into a move that
does not exist yet is the path used by the XML import wizard, by the
DUIMP module and by any service invoice importer, and it had no test at
all.

That gap let a real crash live in 16.0 until #4494: `_compute_amount`
called `move._compute_fiscal_amount()` under the
`force_fiscal_amount_recompute` context key, but `account.move` reaches
the fiscal document through `_inherits`, which delegates fields and not
methods, so the import always raised

    AttributeError: 'account.move' object has no attribute '_compute_fiscal_amount'

#4494 removed that block and fixed the crash. This PR adds the test that
would have caught it, so the path stays covered from now on.

## Test

The test passes on current 16.0 and fails with the AttributeError above
if reverted to the state before #4494.
