### PR TITLE
[16.0][FIX] l10n_br_fiscal: correção no mapeamento do ICMS

### DIFF
--- a/l10n_br_fiscal/models/icms_regulation.py
+++ b/l10n_br_fiscal/models/icms_regulation.py
@@ -1932,12 +1932,16 @@ class ICMSRegulation(models.Model):
         ncm=None,
         nbm=None,
         cest=None,
+        ind_final=None,
     ):
         self.ensure_one()
         domain = [
             ("icms_regulation_id", "=", self.id),
             ("state", "=", "approved"),
             ("tax_group_id", "=", tax_group_icms.id),
+            "|",
+            ("ind_final", "=", ind_final),
+            ("ind_final", "=", False),
         ]
 
         if tax_group_icms.tax_domain in (TAX_DOMAIN_ICMS, TAX_DOMAIN_ICMS_ST):
@@ -2050,7 +2054,7 @@ class ICMSRegulation(models.Model):
         else:
             # ICMS
             domain = self._build_map_tax_def_domain(
-                company, partner, tax_group_icms, ncm, nbm, cest
+                company, partner, tax_group_icms, ncm, nbm, cest, ind_final
             )
 
             tax_definitions = self._tax_definition_search(
@@ -2074,7 +2078,7 @@ class ICMSRegulation(models.Model):
 
         # ICMS ST
         domain = self._build_map_tax_def_domain(
-            company, partner, tax_group_icmsst, ncm, nbm, cest
+            company, partner, tax_group_icmsst, ncm, nbm, cest, ind_final
         )
 
         tax_definitions = self._tax_definition_search(
@@ -2105,7 +2109,7 @@ class ICMSRegulation(models.Model):
             and operation_line.fiscal_operation_type == FISCAL_IN
         ):
             domain = self._build_map_tax_def_domain(
-                partner, partner, tax_group_icms, ncm, nbm, cest
+                partner, partner, tax_group_icms, ncm, nbm, cest, ind_final
             )
 
             tax_definitions = self._tax_definition_search(
@@ -2137,7 +2141,7 @@ class ICMSRegulation(models.Model):
             and operation_line.fiscal_operation_type == FISCAL_IN
         ):
             domain = self._build_map_tax_def_domain(
-                partner, partner, tax_group_icmsfcp, ncm, nbm, cest
+                partner, partner, tax_group_icmsfcp, ncm, nbm, cest, ind_final
             )
 
             tax_definitions = self._tax_definition_search(
@@ -2163,7 +2167,7 @@ class ICMSRegulation(models.Model):
 
         # FCP ST
         domain = self._build_map_tax_def_domain(
-            company, partner, tax_group_icmsfcpst, ncm, nbm, cest
+            company, partner, tax_group_icmsfcpst, ncm, nbm, cest, ind_final
         )
 
         tax_definitions = self._tax_definition_search(

--- a/l10n_br_fiscal/models/icms_regulation.py
+++ b/l10n_br_fiscal/models/icms_regulation.py
@@ -1482,7 +1482,7 @@ class ICMSRegulation(models.Model):
         domain=[
             ("state_from_id.code", "in", ("RJ", False)),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS),
-            ("is_benefit", "=", False),
+            ("is_benefit", "=", True),
         ],
     )
 
@@ -1494,7 +1494,7 @@ class ICMSRegulation(models.Model):
             ("state_from_id.code", "=", "RO"),
             ("state_to_ids.code", "=", "RO"),
             ("tax_group_id.tax_domain", "=", TAX_DOMAIN_ICMS),
-            ("is_benefit", "=", True),
+            ("is_benefit", "=", False),
         ],
     )
 

--- a/l10n_br_fiscal/tests/test_icms_regulation.py
+++ b/l10n_br_fiscal/tests/test_icms_regulation.py
@@ -1,6 +1,7 @@
 # Copyright 2019 Akretion - Renato Lima <renato.lima@akretion.com.br>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from odoo import Command
 from odoo.tests import TransactionCase, tagged
 
 from ..constants.fiscal import FINAL_CUSTOMER_NO, FINAL_CUSTOMER_YES, TAX_DOMAIN_ICMS
@@ -22,6 +23,11 @@ class TestICMSRegulation(TransactionCase):
         cls.venda_operation_line_id = cls.env.ref("l10n_br_fiscal.fo_venda_venda")
         cls.ncm_48191000_id = cls.env.ref("l10n_br_fiscal.ncm_48191000")
         cls.ncm_energia_id = cls.env.ref("l10n_br_fiscal.ncm_27160000")
+        # Dedicated NCM (not used by demo data) so a tax definition can be
+        # attached to it in the tests below without impacting other tests.
+        cls.ncm_test_id = cls.env["l10n_br_fiscal.ncm"].create(
+            {"code": "9999.99.99", "name": "NCM Teste ind_final"}
+        )
 
     def test_icms_sc_sc_ind_final_yes_default(self):
         tax_icms = self.find_icms_tax(
@@ -56,6 +62,57 @@ class TestICMSRegulation(TransactionCase):
             out_state_id=self.sp_state_id,
             ncm_id=self.ncm_48191000_id,
             ind_final=FINAL_CUSTOMER_YES,
+        )
+        self.assertEqual(tax_icms.percent_amount, 12.00)
+
+    def _create_ncm_specific_ind_final_yes_definition(self):
+        """Create a tax definition restricted to a specific NCM that only
+        applies to final consumer operations (ind_final = Yes), while the
+        generic SC -> SC tax definitions (ind_final Yes = 17%, No = 12%)
+        remain available for every other NCM.
+
+        This reproduces the scenario fixed by commit a6a586bac5: before the
+        fix, ``_build_map_tax_def_domain`` did not filter by ``ind_final``,
+        so this NCM-specific definition was returned by the domain search
+        for *any* ``ind_final`` value. Since it only matches
+        ``ind_final = Yes``, requesting the tax for ``ind_final = No``
+        ended up with an empty result instead of falling back to the
+        generic 12% definition.
+        """
+        return self.env["l10n_br_fiscal.tax.definition"].create(
+            {
+                "icms_regulation_id": self.icms_regulation.id,
+                "state_from_id": self.sc_state_id.id,
+                "state_to_ids": [Command.set([self.sc_state_id.id])],
+                "ncm_ids": [Command.set([self.ncm_test_id.id])],
+                "ind_final": FINAL_CUSTOMER_YES,
+                "is_taxed": True,
+                "is_debit_credit": True,
+                "custom_tax": True,
+                "tax_id": self.env.ref("l10n_br_fiscal.tax_icms_18").id,
+                "cst_id": self.env.ref("l10n_br_fiscal.cst_icms_00").id,
+                "tax_group_id": self.env.ref("l10n_br_fiscal.tax_group_icms").id,
+                "state": "approved",
+            }
+        )
+
+    def test_icms_sc_sc_ind_final_yes_ncm_specific(self):
+        self._create_ncm_specific_ind_final_yes_definition()
+        tax_icms = self.find_icms_tax(
+            in_state_id=self.sc_state_id,
+            out_state_id=self.sc_state_id,
+            ncm_id=self.ncm_test_id,
+            ind_final=FINAL_CUSTOMER_YES,
+        )
+        self.assertEqual(tax_icms.percent_amount, 18.00)
+
+    def test_icms_sc_sc_ind_final_no_ncm_specific_fallback_to_generic(self):
+        self._create_ncm_specific_ind_final_yes_definition()
+        tax_icms = self.find_icms_tax(
+            in_state_id=self.sc_state_id,
+            out_state_id=self.sc_state_id,
+            ncm_id=self.ncm_test_id,
+            ind_final=FINAL_CUSTOMER_NO,
         )
         self.assertEqual(tax_icms.percent_amount, 12.00)
 


### PR DESCRIPTION
Correção no mapeamento dos impostos do ICMS (ICMS, ICMS ST, ICMS FCP...) para adicionar a informação de consumidor final (ind_final) e correção dos campos `tax_benefit_rj_ids` e `icms_internal_ro_ids` que estavam com o atributo domain incorretos. 