### PR TITLE
[18.0][FIX] l10n_br_base: sync street_number2 with the company partner

### DIFF
--- a/l10n_br_base/models/res_company.py
+++ b/l10n_br_base/models/res_company.py
@@ -21,6 +21,7 @@ class Company(models.Model):
             "state_tax_number_ids",
             "street_number",
             "street_name",
+            "street_number2",
         ]
 
     def _inverse_legal_name(self):
@@ -38,6 +39,10 @@ class Company(models.Model):
     def _inverse_street_number(self):
         for company in self:
             company.partner_id.street_number = company.street_number
+
+    def _inverse_street_number2(self):
+        for company in self:
+            company.partner_id.street_number2 = company.street_number2
 
     def _inverse_l10n_br_ie_code(self):
         for company in self:
@@ -88,6 +93,10 @@ class Company(models.Model):
     street_number = fields.Char(
         compute="_compute_address",
         inverse="_inverse_street_number",
+    )
+
+    street_number2 = fields.Char(
+        compute="_compute_address", inverse="_inverse_street_number2"
     )
 
     city_id = fields.Many2one(


### PR DESCRIPTION
Substitui o #4344, mantendo a autoria do @EdnilsonMonteiro e apenas a parte que ainda é necessária na 18.0.

Das correções propostas lá, o domain do `parent.tax_framework` (issues #4213/#4565) já foi resolvido pelo #4566 e o erro de view da issue #4328 pelo #4379. O que ainda faltava: o `base_address_extended` (dependência do `l10n_br_base`) adiciona `street_number2` ao `res.partner`, mas o espelhamento de endereço do `res.company` só cobria `street_name` e `street_number`, então o complemento não era gravado no partner ao editar o endereço da empresa.

Este PR adiciona somente o espelhamento de `street_number2`, com o mesmo mecanismo compute/inverse dos demais campos.