### PR TITLE
[16.0][IMP] l10n_br_base: trigram indexes for partner search

### DIFF
--- a/l10n_br_base/models/party_mixin.py
+++ b/l10n_br_base/models/party_mixin.py
@@ -26,13 +26,21 @@ class PartyMixin(models.AbstractModel):
         help="CNPJ/CPF without special characters",
         compute="_compute_cnpj_cpf_stripped",
         store=True,
-        index=True,
+        # trigram GIN index to speed up the leading-wildcard ilike issued by
+        # name_search (see _rec_names_search on res.partner). unaccent=False
+        # keeps both the index and the query on the raw column (the value is
+        # alphanumeric and never accented), so the index is always used.
+        index="trigram",
+        unaccent=False,
     )
 
     l10n_br_ie_code = fields.Char(
         string="State Tax Number",
         size=17,
+        # unaccent=False + trigram: alphanumeric value, index and query stay on
+        # the raw column so the GIN index accelerates the ilike unconditionally.
         unaccent=False,
+        index="trigram",
     )
 
     # compat with legacy code:
@@ -66,6 +74,15 @@ class PartyMixin(models.AbstractModel):
     legal_name = fields.Char(
         size=128,
         help="Used in fiscal documents",
+        # trigram GIN index to speed up the name_search ilike on legal_name.
+        # legal_name keeps the default unaccent=True (names carry accents and
+        # must match accent-insensitively), so this index is only effective
+        # when the database `unaccent` function is IMMUTABLE (INDEXABLE): only
+        # then does Odoo build the index on unaccent(legal_name), matching the
+        # unaccent(col) like unaccent(%s) query. On a stock PostgreSQL the
+        # contrib unaccent is STABLE, not immutable, so the index is built on
+        # the raw column and the planner cannot use it. See the PR body.
+        index="trigram",
     )
 
     city_id = fields.Many2one(


### PR DESCRIPTION
## Problem

Partner lookups in the Brazilian localization search the extra fields added by
`res.partner._rec_names_search`:

```python
names += ["cnpj_cpf_stripped", "legal_name", "l10n_br_ie_code"]
```

On top of that, `l10n_br_base.party.mixin.search()` injects an extra
`("cnpj_cpf_stripped", "ilike", term)` leaf whenever a `vat ilike` term is
present. So a typical `name_search` (autocomplete on a many2one, the global
search, an import that matches partners by name/CNPJ) issues, for each of these
fields, a leading-wildcard match:

```sql
field ilike '%term%'
```

A leading wildcard cannot be accelerated by a btree index, so today the
`index=True` (btree) on `cnpj_cpf_stripped` is useless for these queries and
`legal_name` / `l10n_br_ie_code` are not indexed at all. Every autocomplete or
partner-matching import degrades to a sequential scan over `res_partner`.

## Change

Use a trigram GIN index (PostgreSQL `pg_trgm`, `gin_trgm_ops`), which is the
index type PostgreSQL can use for `LIKE` / `ILIKE` with a leading wildcard, on
the three searched Char fields:

- `cnpj_cpf_stripped`: `index=True` becomes `index="trigram"` and `unaccent=False`
  is added.
- `l10n_br_ie_code`: `index="trigram"` added (it already had `unaccent=False`).
- `legal_name`: `index="trigram"` added.

No behavior change for callers: `name_search` keeps returning the same rows,
the indexes only change the query plan.

## Finding: trigram indexes and the unaccent wrapper

Whether a trigram index is actually used depends on how Odoo 16 builds the index
versus how it builds the WHERE clause, and both depend on the field `unaccent`
flag and on the database `unaccent` function status. The relevant core code:

- `odoo/modules/registry.py` (index creation): for `index == 'trigram'`, the
  indexed expression is wrapped in `unaccent(...)` only when the field has
  `unaccent=True` AND the database `unaccent` function is IMMUTABLE
  (`FunctionStatus.INDEXABLE`). If `unaccent` is present but not immutable, Odoo
  logs `PostgreSQL function 'unaccent' is present but not immutable, therefore
  trigram indexes may not be effective.` and builds the index on the RAW column.
- `odoo/osv/expression.py` `_unaccent` / generic like path: for a non-translate
  Char field, the WHERE is `unaccent(col) like unaccent(%s)` when the field has
  `unaccent=True` and the database has an `unaccent` function, otherwise the raw
  `col like %s`.
- `odoo/modules/db.py` `has_unaccent`: returns INDEXABLE only when the
  `unaccent(text)` function has `provolatile = 'i'` (immutable). The stock
  PostgreSQL contrib `unaccent` is STABLE (`provolatile = 's'`), so a default
  install reports PRESENT, not INDEXABLE.

Match matrix for a non-translate Char field indexed with `index="trigram"`:

| field.unaccent | database unaccent | index built on | query uses | index used |
| --- | --- | --- | --- | --- |
| False | any | raw column | `col like %s` | yes, always |
| True | IMMUTABLE | `unaccent(col)` | `unaccent(col) like unaccent(%s)` | yes |
| True | PRESENT (not immutable) | raw column (with warning) | `unaccent(col) like unaccent(%s)` | no (mismatch) |
| True | MISSING | raw column | `col like %s` | yes |

Consequence:

- `cnpj_cpf_stripped` and `l10n_br_ie_code` hold alphanumeric values that never
  carry accents. Setting `unaccent=False` keeps BOTH the index and the query on
  the raw column, so the GIN index is used unconditionally, independent of the
  database `unaccent` configuration. This is why `unaccent=False` is added to
  `cnpj_cpf_stripped`.
- `legal_name` is a human name and must keep accent-insensitive matching, so it
  keeps the default `unaccent=True`. Its trigram index is only effective when the
  database `unaccent` function is IMMUTABLE (or absent). On a default PostgreSQL
  where `unaccent` is installed but STABLE, Odoo builds the index on the raw
  column and the `unaccent(legal_name)` query cannot use it.

### Empirical confirmation

Isolated Odoo 16 + PostgreSQL 15, module installed, `res_partner` inspected:

Indexes created (all three, on the raw column, as expected):

```
res_partner_cnpj_cpf_stripped_index  gin (cnpj_cpf_stripped gin_trgm_ops)
res_partner_l10n_br_ie_code_index    gin (l10n_br_ie_code gin_trgm_ops)
res_partner_legal_name_index         gin (legal_name gin_trgm_ops)
```

On a database where `unaccent` is present but STABLE (the default), install logs:

```
UserWarning: PostgreSQL function 'unaccent' is present but not immutable,
therefore trigram indexes may not be effective.
```

EXPLAIN on that same database:

- `cnpj_cpf_stripped ilike '%0001%'` (query Odoo emits, raw) uses
  `res_partner_cnpj_cpf_stripped_index` (Bitmap Index Scan).
- `unaccent(legal_name) ilike unaccent('%ret%')` (query Odoo emits for
  legal_name) falls back to a Seq Scan (even with `enable_seqscan=off`), the raw
  legal_name index is not usable.
- raw `legal_name ilike '%ret%'` would use the index, but Odoo never emits that
  form for a unaccent field.

## Decision on legal_name

legal_name is kept in this PR, with the caveat above, because:

1. It is consistent with Odoo core, which ships `index='trigram'` on name-like
   Char fields in many modules (product, stock, purchase, project, hr, repair).
2. Name is the dominant partner search term. Dropping it would leave the most
   common partner lookup unaccelerated and gut the value of the change.
3. On databases with an IMMUTABLE `unaccent` (the recommended Odoo production
   tuning) or with no `unaccent` at all, the legal_name index is used. Only the
   specific present-but-stable configuration leaves it unused, and that is
   exactly the configuration Odoo tells administrators to fix.

To make the legal_name index effective on a deployment, the DBA should register
`unaccent` as IMMUTABLE (the well known Odoo trigram-search setup), which also
benefits every core trigram index on a unaccent field.

## Validation

Isolated Odoo 16 + PostgreSQL 15 (containers separate from any dev database):

- `pg_trgm` enabled, all three GIN trigram indexes created (see above).
- Planner confirmed to use the GIN index for the alphanumeric fields.
- Full `l10n_br_base` test suite: 0 failed, 0 error(s) of 54 tests, including the
  partner-related tests test_duplicate_cnpj, test_cnpj_alfanumerico,
  test_base_onchange and test_other_ie.
