### PR TITLE
[16.0][FIX] l10n_br_cte_spec: index the one2many inverse foreign keys

### DIFF
--- a/l10n_br_cte_spec/models/v4_0/cte_modal_aereo_v4_00.py
+++ b/l10n_br_cte_spec/models/v4_0/cte_modal_aereo_v4_00.py
@@ -186,7 +186,10 @@ class Peri(models.AbstractModel):
     _binding_type = "Aereo.Peri"
 
     cte40_peri_aereo_id = fields.Many2one(
-        comodel_name="cte.40.aereo", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.aereo",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_nONU = fields.Char(
         string="Número ONU/UN",

--- a/l10n_br_cte_spec/models/v4_0/cte_modal_aquaviario_v4_00.py
+++ b/l10n_br_cte_spec/models/v4_0/cte_modal_aquaviario_v4_00.py
@@ -97,7 +97,10 @@ class Balsa(models.AbstractModel):
     _binding_type = "Aquav.Balsa"
 
     cte40_balsa_aquav_id = fields.Many2one(
-        comodel_name="cte.40.aquav", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.aquav",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_xBalsa = fields.Char(string="Identificador da Balsa", xsd_required=True)
 
@@ -112,7 +115,10 @@ class DetCont(models.AbstractModel):
     _binding_type = "Aquav.DetCont"
 
     cte40_detCont_aquav_id = fields.Many2one(
-        comodel_name="cte.40.aquav", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.aquav",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_nCont = fields.Char(
         string="Identificação do Container", xsd_required=True, xsd_type="TContainer"
@@ -141,7 +147,10 @@ class Lacre(models.AbstractModel):
     _binding_type = "Aquav.DetCont.Lacre"
 
     cte40_lacre_detCont_id = fields.Many2one(
-        comodel_name="cte.40.detcont", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.detcont",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_nLacre = fields.Char(string="Lacre", xsd_required=True)
 
@@ -180,7 +189,10 @@ class AquavInfNf(models.AbstractModel):
     _binding_type = "Aquav.DetCont.InfDoc.InfNf"
 
     cte40_infNF_infDoc_id = fields.Many2one(
-        comodel_name="cte.40.aquav_infdoc", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.aquav_infdoc",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_serie = fields.Char(string="Série", xsd_required=True)
 
@@ -203,7 +215,10 @@ class AquavInfNfe(models.AbstractModel):
     _binding_type = "Aquav.DetCont.InfDoc.InfNfe"
 
     cte40_infNFe_infDoc_id = fields.Many2one(
-        comodel_name="cte.40.aquav_infdoc", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.aquav_infdoc",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_chave = fields.Char(
         string="Chave de acesso da NF-e", xsd_required=True, xsd_type="TChDFe"

--- a/l10n_br_cte_spec/models/v4_0/cte_modal_ferroviario_v4_00.py
+++ b/l10n_br_cte_spec/models/v4_0/cte_modal_ferroviario_v4_00.py
@@ -168,7 +168,10 @@ class FerroEnv(models.AbstractModel):
     _binding_type = "Ferrov.TrafMut.FerroEnv"
 
     cte40_ferroEnv_trafMut_id = fields.Many2one(
-        comodel_name="cte.40.trafmut", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.trafmut",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_CNPJ = fields.Char(
         string="Número do CNPJ",

--- a/l10n_br_cte_spec/models/v4_0/cte_modal_rodoviario_v4_00.py
+++ b/l10n_br_cte_spec/models/v4_0/cte_modal_rodoviario_v4_00.py
@@ -44,7 +44,10 @@ class Occ(models.AbstractModel):
     _binding_type = "Rodo.Occ"
 
     cte40_occ_rodo_id = fields.Many2one(
-        comodel_name="cte.40.rodo", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.rodo",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_serie = fields.Char(string="Série da OCC")
 

--- a/l10n_br_cte_spec/models/v4_0/cte_tipos_basico_v4_00.py
+++ b/l10n_br_cte_spec/models/v4_0/cte_tipos_basico_v4_00.py
@@ -1387,19 +1387,34 @@ class TunidCarga(models.AbstractModel):
     _binding_type = "TunidCarga"
 
     cte40_infUnidCarga_infNFe_id = fields.Many2one(
-        comodel_name="cte.40.tctesimp_infnfe", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tctesimp_infnfe",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_infUnidCarga_infNF_id = fields.Many2one(
-        comodel_name="cte.40.tcte_infnf", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcte_infnf",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_infUnidCarga_infNFe_id = fields.Many2one(
-        comodel_name="cte.40.tcte_infnfe", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcte_infnfe",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_infUnidCarga_infOutros_id = fields.Many2one(
-        comodel_name="cte.40.infoutros", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.infoutros",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_infUnidCarga_TUnidadeTransp_id = fields.Many2one(
-        comodel_name="cte.40.tunidadetransp", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tunidadetransp",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_tpUnidCarga = fields.Selection(
         TTIPOUNIDCARGA,
@@ -1443,7 +1458,10 @@ class LacUnidCarga(models.AbstractModel):
     _binding_type = "TunidCarga.LacUnidCarga"
 
     cte40_lacUnidCarga_TUnidCarga_id = fields.Many2one(
-        comodel_name="cte.40.tunidcarga", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tunidcarga",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_nLacre = fields.Char(string="Número do lacre", xsd_required=True)
 
@@ -1855,7 +1873,10 @@ class InfPercurso(models.AbstractModel):
     _binding_type = "TcteOs.InfCte.Ide.InfPercurso"
 
     cte40_infPercurso_ide_id = fields.Many2one(
-        comodel_name="cte.40.tcteos_ide", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcteos_ide",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_UFPer = fields.Selection(
         TUF,
@@ -1929,7 +1950,10 @@ class TcteOsObsCont(models.AbstractModel):
     _binding_type = "TcteOs.InfCte.Compl.ObsCont"
 
     cte40_ObsCont_compl_id = fields.Many2one(
-        comodel_name="cte.40.tcteos_compl", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcteos_compl",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_xTexto = fields.Char(string="Conteúdo do campo", xsd_required=True)
 
@@ -1946,7 +1970,10 @@ class TcteOsObsFisco(models.AbstractModel):
     _binding_type = "TcteOs.InfCte.Compl.ObsFisco"
 
     cte40_ObsFisco_compl_id = fields.Many2one(
-        comodel_name="cte.40.tcteos_compl", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcteos_compl",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_xTexto = fields.Char(string="Conteúdo do campo", xsd_required=True)
 
@@ -2101,7 +2128,10 @@ class TcteOsVPrestComp(models.AbstractModel):
     _binding_type = "TcteOs.InfCte.VPrest.Comp"
 
     cte40_Comp_vPrest_id = fields.Many2one(
-        comodel_name="cte.40.tcteos_vprest", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcteos_vprest",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_xNome = fields.Char(
         string="Nome do componente",
@@ -2328,7 +2358,10 @@ class TcteOsAutXml(models.AbstractModel):
     _binding_type = "TcteOs.InfCte.AutXml"
 
     cte40_autXML_infCte_id = fields.Many2one(
-        comodel_name="cte.40.tcteos_infcte", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcteos_infcte",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_CNPJ = fields.Char(
         string="CNPJ do autorizado",
@@ -2459,7 +2492,10 @@ class InfDocRef(models.AbstractModel):
     _binding_type = "TcteOs.InfCte.InfCteNorm.InfDocRef"
 
     cte40_infDocRef_infCTeNorm_id = fields.Many2one(
-        comodel_name="cte.40.tcteos_infctenorm", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcteos_infctenorm",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_nDoc = fields.Char(
         string="Número", choice="infdocref", xsd_choice_required=True
@@ -2506,7 +2542,10 @@ class TcteOsSeg(models.AbstractModel):
     _binding_type = "TcteOs.InfCte.InfCteNorm.Seg"
 
     cte40_seg_infCTeNorm_id = fields.Many2one(
-        comodel_name="cte.40.tcteos_infctenorm", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcteos_infctenorm",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_respSeg = fields.Selection(
         SEG_RESPSEG,
@@ -2611,7 +2650,10 @@ class TcteOsDup(models.AbstractModel):
     _binding_type = "TcteOs.InfCte.InfCteNorm.Cobr.Dup"
 
     cte40_dup_cobr_id = fields.Many2one(
-        comodel_name="cte.40.tcteos_cobr", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcteos_cobr",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_nDup = fields.Char(string="Número da duplicata")
 
@@ -2637,7 +2679,10 @@ class InfGtve(models.AbstractModel):
     _binding_type = "TcteOs.InfCte.InfCteNorm.InfGtve"
 
     cte40_infGTVe_infCTeNorm_id = fields.Many2one(
-        comodel_name="cte.40.tcteos_infctenorm", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcteos_infctenorm",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_chCTe = fields.Char(string="Chave de acesso da GTV-e", xsd_required=True)
 
@@ -2657,7 +2702,10 @@ class TcteOsInfCteNormComp(models.AbstractModel):
     _binding_type = "TcteOs.InfCte.InfCteNorm.InfGtve.Comp"
 
     cte40_Comp_infGTVe_id = fields.Many2one(
-        comodel_name="cte.40.infgtve", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.infgtve",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_tpComp = fields.Selection(
         COMP_TPCOMP,
@@ -2694,7 +2742,10 @@ class TcteOsInfCteComp(models.AbstractModel):
     _binding_type = "TcteOs.InfCte.InfCteComp"
 
     cte40_infCteComp_infCte_id = fields.Many2one(
-        comodel_name="cte.40.tcteos_infcte", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcteos_infcte",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_chCTe = fields.Char(
         string="Chave do CT-e complementado", xsd_required=True, xsd_type="TChDFe"
@@ -3192,7 +3243,10 @@ class TgtveObsCont(models.AbstractModel):
     _binding_type = "Tgtve.InfCte.Compl.ObsCont"
 
     cte40_ObsCont_compl_id = fields.Many2one(
-        comodel_name="cte.40.tgtve_compl", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tgtve_compl",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_xTexto = fields.Char(string="Conteúdo do campo", xsd_required=True)
 
@@ -3209,7 +3263,10 @@ class TgtveObsFisco(models.AbstractModel):
     _binding_type = "Tgtve.InfCte.Compl.ObsFisco"
 
     cte40_ObsFisco_compl_id = fields.Many2one(
-        comodel_name="cte.40.tgtve_compl", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tgtve_compl",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_xTexto = fields.Char(string="Conteúdo do campo", xsd_required=True)
 
@@ -3416,7 +3473,10 @@ class TgtveInfEspecie(models.AbstractModel):
     _binding_type = "Tgtve.InfCte.DetGtv.InfEspecie"
 
     cte40_infEspecie_detGTV_id = fields.Many2one(
-        comodel_name="cte.40.detgtv", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.detgtv",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
 
     cte40_vEspecie = fields.Monetary(
@@ -3450,7 +3510,10 @@ class InfVeiculo(models.AbstractModel):
     _binding_type = "Tgtve.InfCte.DetGtv.InfVeiculo"
 
     cte40_infVeiculo_detGTV_id = fields.Many2one(
-        comodel_name="cte.40.detgtv", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.detgtv",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_placa = fields.Char(
         string="Placa do veículo", xsd_required=True, xsd_type="TPlaca"
@@ -3479,7 +3542,10 @@ class TgtveAutXml(models.AbstractModel):
     _binding_type = "Tgtve.InfCte.AutXml"
 
     cte40_autXML_infCte_id = fields.Many2one(
-        comodel_name="cte.40.tgtve_infcte", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tgtve_infcte",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_CNPJ = fields.Char(
         string="CNPJ do autorizado",
@@ -3727,16 +3793,28 @@ class TunidadeTransp(models.AbstractModel):
     _binding_type = "TunidadeTransp"
 
     cte40_infUnidTransp_infNFe_id = fields.Many2one(
-        comodel_name="cte.40.tctesimp_infnfe", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tctesimp_infnfe",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_infUnidTransp_infNF_id = fields.Many2one(
-        comodel_name="cte.40.tcte_infnf", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcte_infnf",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_infUnidTransp_infNFe_id = fields.Many2one(
-        comodel_name="cte.40.tcte_infnfe", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcte_infnfe",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_infUnidTransp_infOutros_id = fields.Many2one(
-        comodel_name="cte.40.infoutros", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.infoutros",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_tpUnidTransp = fields.Selection(
         TTIPOUNIDTRANSP,
@@ -3798,7 +3876,10 @@ class LacUnidTransp(models.AbstractModel):
     _binding_type = "TunidadeTransp.LacUnidTransp"
 
     cte40_lacUnidTransp_TUnidadeTransp_id = fields.Many2one(
-        comodel_name="cte.40.tunidadetransp", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tunidadetransp",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_nLacre = fields.Char(string="Número do lacre", xsd_required=True)
 
@@ -4475,7 +4556,10 @@ class TctePass(models.AbstractModel):
     _binding_type = "Tcte.InfCte.Compl.Fluxo.Pass"
 
     cte40_pass_fluxo_id = fields.Many2one(
-        comodel_name="cte.40.tcte_fluxo", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcte_fluxo",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_xPass = fields.Char(
         string="Sigla ou código interno",
@@ -4703,7 +4787,10 @@ class TcteObsCont(models.AbstractModel):
     _binding_type = "Tcte.InfCte.Compl.ObsCont"
 
     cte40_ObsCont_compl_id = fields.Many2one(
-        comodel_name="cte.40.tcte_compl", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcte_compl",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_xTexto = fields.Char(string="Conteúdo do campo", xsd_required=True)
 
@@ -4720,7 +4807,10 @@ class TcteObsFisco(models.AbstractModel):
     _binding_type = "Tcte.InfCte.Compl.ObsFisco"
 
     cte40_ObsFisco_compl_id = fields.Many2one(
-        comodel_name="cte.40.tcte_compl", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcte_compl",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_xTexto = fields.Char(string="Conteúdo do campo", xsd_required=True)
 
@@ -5065,7 +5155,10 @@ class TcteVPrestComp(models.AbstractModel):
     _binding_type = "Tcte.InfCte.VPrest.Comp"
 
     cte40_Comp_vPrest_id = fields.Many2one(
-        comodel_name="cte.40.tcte_vprest", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcte_vprest",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_xNome = fields.Char(
         string="Nome do componente",
@@ -5249,7 +5342,10 @@ class TcteAutXml(models.AbstractModel):
     _binding_type = "Tcte.InfCte.AutXml"
 
     cte40_autXML_infCte_id = fields.Many2one(
-        comodel_name="cte.40.tcte_infcte", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcte_infcte",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_CNPJ = fields.Char(
         string="CNPJ do autorizado",
@@ -5469,7 +5565,10 @@ class TcteInfQ(models.AbstractModel):
     _binding_type = "Tcte.InfCte.InfCteNorm.InfCarga.InfQ"
 
     cte40_infQ_infCarga_id = fields.Many2one(
-        comodel_name="cte.40.tcte_infcarga", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcte_infcarga",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_cUnid = fields.Selection(
         INFQ_CUNID,
@@ -5564,7 +5663,10 @@ class TcteInfNf(models.AbstractModel):
     _binding_type = "Tcte.InfCte.InfCteNorm.InfDoc.InfNf"
 
     cte40_infNF_infDoc_id = fields.Many2one(
-        comodel_name="cte.40.tcte_infdoc", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcte_infdoc",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_nRoma = fields.Char(string="Número do Romaneio da NF")
 
@@ -5704,7 +5806,10 @@ class TcteInfNfe(models.AbstractModel):
     _binding_type = "Tcte.InfCte.InfCteNorm.InfDoc.InfNfe"
 
     cte40_infNFe_infDoc_id = fields.Many2one(
-        comodel_name="cte.40.tcte_infdoc", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcte_infdoc",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_chave = fields.Char(
         string="Chave de acesso da NF-e", xsd_required=True, xsd_type="TChDFe"
@@ -5761,7 +5866,10 @@ class InfOutros(models.AbstractModel):
     _binding_type = "Tcte.InfCte.InfCteNorm.InfDoc.InfOutros"
 
     cte40_infOutros_infDoc_id = fields.Many2one(
-        comodel_name="cte.40.tcte_infdoc", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcte_infdoc",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_tpDoc = fields.Selection(
         INFOUTROS_TPDOC,
@@ -5841,6 +5949,7 @@ class InfDce(models.AbstractModel):
         comodel_name="cte.40.tcte_infdoc",
         xsd_implicit=True,
         ondelete="cascade",
+        index=True,
     )
     cte40_chave = fields.Char(
         string="Chave de acesso da DCe", xsd_required=True, xsd_type="TChDFe"
@@ -5871,7 +5980,10 @@ class EmiDocAnt(models.AbstractModel):
     _binding_type = "Tcte.InfCte.InfCteNorm.DocAnt.EmiDocAnt"
 
     cte40_emiDocAnt_docAnt_id = fields.Many2one(
-        comodel_name="cte.40.docant", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.docant",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_CNPJ = fields.Char(
         string="Número do CNPJ",
@@ -5924,7 +6036,10 @@ class IdDocAnt(models.AbstractModel):
     _binding_type = "Tcte.InfCte.InfCteNorm.DocAnt.EmiDocAnt.IdDocAnt"
 
     cte40_idDocAnt_emiDocAnt_id = fields.Many2one(
-        comodel_name="cte.40.emidocant", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.emidocant",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_idDocAntPap = fields.One2many(
         "cte.40.iddocantpap",
@@ -5954,7 +6069,10 @@ class IdDocAntPap(models.AbstractModel):
     _binding_type = "Tcte.InfCte.InfCteNorm.DocAnt.EmiDocAnt.IdDocAnt.IdDocAntPap"
 
     cte40_idDocAntPap_idDocAnt_id = fields.Many2one(
-        comodel_name="cte.40.iddocant", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.iddocant",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_tpDoc = fields.Selection(
         TDOCASSOC,
@@ -5990,7 +6108,10 @@ class IdDocAntEle(models.AbstractModel):
     _binding_type = "Tcte.InfCte.InfCteNorm.DocAnt.EmiDocAnt.IdDocAnt.IdDocAntEle"
 
     cte40_idDocAntEle_idDocAnt_id = fields.Many2one(
-        comodel_name="cte.40.iddocant", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.iddocant",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_chCTe = fields.Char(
         string="Chave de acesso do CT-e", xsd_required=True, xsd_type="TChDFe"
@@ -6021,7 +6142,10 @@ class VeicNovos(models.AbstractModel):
     _binding_type = "Tcte.InfCte.InfCteNorm.VeicNovos"
 
     cte40_veicNovos_infCTeNorm_id = fields.Many2one(
-        comodel_name="cte.40.tcte_infctenorm", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcte_infctenorm",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_chassi = fields.Char(string="Chassi do veículo", xsd_required=True)
 
@@ -6109,7 +6233,10 @@ class TcteDup(models.AbstractModel):
     _binding_type = "Tcte.InfCte.InfCteNorm.Cobr.Dup"
 
     cte40_dup_cobr_id = fields.Many2one(
-        comodel_name="cte.40.tcte_cobr", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcte_cobr",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_nDup = fields.Char(string="Número da duplicata")
 
@@ -6184,7 +6311,10 @@ class InfCteMultimodal(models.AbstractModel):
     _binding_type = "Tcte.InfCte.InfCteNorm.InfServVinc.InfCteMultimodal"
 
     cte40_infCTeMultimodal_infServVinc_id = fields.Many2one(
-        comodel_name="cte.40.infservvinc", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.infservvinc",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_chCTeMultimodal = fields.Char(
         string="Chave de acesso do CT-e Multimodal",
@@ -6202,7 +6332,10 @@ class TcteInfCteComp(models.AbstractModel):
     _binding_type = "Tcte.InfCte.InfCteComp"
 
     cte40_infCteComp_infCte_id = fields.Many2one(
-        comodel_name="cte.40.tcte_infcte", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tcte_infcte",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_chCTe = fields.Char(
         string="Chave do CT-e complementado", xsd_required=True, xsd_type="TChDFe"
@@ -6697,7 +6830,10 @@ class TcteSimpPass(models.AbstractModel):
     _binding_type = "TcteSimp.InfCte.Compl.Fluxo.Pass"
 
     cte40_pass_fluxo_id = fields.Many2one(
-        comodel_name="cte.40.tctesimp_fluxo", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tctesimp_fluxo",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_xPass = fields.Char(
         string="Sigla ou código interno",
@@ -6723,7 +6859,10 @@ class TcteSimpObsCont(models.AbstractModel):
     _binding_type = "TcteSimp.InfCte.Compl.ObsCont"
 
     cte40_ObsCont_compl_id = fields.Many2one(
-        comodel_name="cte.40.tctesimp_compl", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tctesimp_compl",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_xTexto = fields.Char(string="Conteúdo do campo", xsd_required=True)
 
@@ -6740,7 +6879,10 @@ class TcteSimpObsFisco(models.AbstractModel):
     _binding_type = "TcteSimp.InfCte.Compl.ObsFisco"
 
     cte40_ObsFisco_compl_id = fields.Many2one(
-        comodel_name="cte.40.tctesimp_compl", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tctesimp_compl",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_xTexto = fields.Char(string="Conteúdo do campo", xsd_required=True)
 
@@ -6968,7 +7110,10 @@ class TcteSimpInfQ(models.AbstractModel):
     _binding_type = "TcteSimp.InfCte.InfCarga.InfQ"
 
     cte40_infQ_infCarga_id = fields.Many2one(
-        comodel_name="cte.40.tctesimp_infcarga", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tctesimp_infcarga",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_cUnid = fields.Selection(
         INFQ_CUNID,
@@ -7015,7 +7160,10 @@ class Det(models.AbstractModel):
     _binding_type = "TcteSimp.InfCte.Det"
 
     cte40_det_infCte_id = fields.Many2one(
-        comodel_name="cte.40.tctesimp_infcte", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tctesimp_infcte",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_cMunIni = fields.Char(
         string="Código do Município de início",
@@ -7111,7 +7259,10 @@ class TcteSimpDetComp(models.AbstractModel):
     _binding_type = "TcteSimp.InfCte.Det.Comp"
 
     cte40_Comp_det_id = fields.Many2one(
-        comodel_name="cte.40.det", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.det",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_xNome = fields.Char(
         string="Nome do componente",
@@ -7139,7 +7290,10 @@ class TcteSimpInfNfe(models.AbstractModel):
     _binding_type = "TcteSimp.InfCte.Det.InfNfe"
 
     cte40_infNFe_det_id = fields.Many2one(
-        comodel_name="cte.40.det", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.det",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_chNFe = fields.Char(string="Chave de acesso da NF-e", xsd_required=True)
 
@@ -7194,7 +7348,10 @@ class InfDocAnt(models.AbstractModel):
     _binding_type = "TcteSimp.InfCte.Det.InfDocAnt"
 
     cte40_infDocAnt_det_id = fields.Many2one(
-        comodel_name="cte.40.det", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.det",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_chCTe = fields.Char(
         string="Chave de acesso do CT-e", xsd_required=True, xsd_type="TChDFe"
@@ -7224,7 +7381,10 @@ class InfNfeTranspParcial(models.AbstractModel):
     _binding_type = "TcteSimp.InfCte.Det.InfDocAnt.InfNfeTranspParcial"
 
     cte40_infNFeTranspParcial_infDocAnt_id = fields.Many2one(
-        comodel_name="cte.40.infdocant", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.infdocant",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_chNFe = fields.Char(
         string="Chave de acesso da NF-e",
@@ -7308,7 +7468,10 @@ class TcteSimpDup(models.AbstractModel):
     _binding_type = "TcteSimp.InfCte.Cobr.Dup"
 
     cte40_dup_cobr_id = fields.Many2one(
-        comodel_name="cte.40.tctesimp_cobr", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tctesimp_cobr",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_nDup = fields.Char(string="Número da duplicata")
 
@@ -7536,7 +7699,10 @@ class TcteSimpAutXml(models.AbstractModel):
     _binding_type = "TcteSimp.InfCte.AutXml"
 
     cte40_autXML_infCte_id = fields.Many2one(
-        comodel_name="cte.40.tctesimp_infcte", xsd_implicit=True, ondelete="cascade"
+        comodel_name="cte.40.tctesimp_infcte",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     cte40_CNPJ = fields.Char(
         string="CNPJ do autorizado",


### PR DESCRIPTION
## Problem

The generated spec models declare no index on the many2one fields that serve as
the inverse key of a one2many (`xsd_implicit=True` + `ondelete="cascade"`).

In Odoo 16 a `Many2one` does not create an index by default, and PostgreSQL does
not index foreign key columns automatically. Reading such a one2many issues
`SELECT ... WHERE <inverse_fk> = X` against an unindexed column, which is a
sequential scan of the whole child table.

`l10n_br_cte_spec` has 64 one2many and, before this PR, **0** fields with `index=True`.
This PR indexes 64 of them.

## Measured on a production database

Restored production database of a Brazilian customer (82,214 fiscal documents,
587 new documents per month, PostgreSQL 15):

| relation | rows | plan | time |
|---|---|---|---|
| `res.partner.nfe40_autXML_infNFe_id` | 73,359 | Seq Scan | **106 ms** |
| the same after this change | 73,359 | Index Scan | **0.064 ms** |
| for reference, `l10n_br_fiscal.document.line.document_id` (already indexed) | 204,698 | Index Scan | 1.3 ms |

## Honest scope

I also measured the end-to-end invoice flow (create + post) on that database,
before and after adding these indexes: **no significant change** (2.339s -> 2.337s,
median of 3 runs). The test invoice does not populate those groups, so the scans
do not run in that path.

The gain shows up where many documents are read at once: batch XML export,
reports, DF-e import, and any `search()` on those relations. So this is a
correctness/hygiene fix with a clear worst case, **not an invoice speed-up** -
flagging it explicitly so it is not oversold.

## Why applied to the generated files instead of regenerating

The change mirrors exactly what the generator emits after
akretion/xsdata-odoo#22 (`index=True` in `odoo_implicit_many2ones`).

I did try a full regeneration first, and verified by comparing field definitions
semantically (not textually) that it would be **destructive** with the current
toolchain:

- the output is not even valid Python (`from __future__ import annotationsfrom
  .tipos_basico_v4_00 import (`);
- nfelib 2.5.2 does not carry the tax reform types, so 6 IBS/CBS and IS fields
  would degrade from `Many2one`/`Selection` to `Char`, **losing** support that is
  already committed here;
- 74 fields would disappear.

So this PR touches only the implicit many2one fields and nothing else. The diff is
`index=True` plus the line rewrapping it causes. Whoever regenerates the specs
next with the fixed generator will produce the same result.

## Verification

- the number of modified fields matches the number of one2many in the module;
- every file still compiles;
- pre-commit (ruff, ruff-format, pylint_odoo) passes.
