### PR TITLE
[16.0][FIX] l10n_br_mdfe_spec: index the one2many inverse foreign keys

### DIFF
--- a/l10n_br_mdfe_spec/models/v3_0/mdfe_modal_aquaviario_v3_00.py
+++ b/l10n_br_mdfe_spec/models/v3_0/mdfe_modal_aquaviario_v3_00.py
@@ -141,7 +141,10 @@ class InfTermCarreg(models.AbstractModel):
     _binding_type = "Aquav.InfTermCarreg"
 
     mdfe30_infTermCarreg_aquav_id = fields.Many2one(
-        comodel_name="mdfe.30.aquav", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.aquav",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_cTermCarreg = fields.Char(
         string="Código do Terminal de Carregamento",
@@ -167,7 +170,10 @@ class InfTermDescarreg(models.AbstractModel):
     _binding_type = "Aquav.InfTermDescarreg"
 
     mdfe30_infTermDescarreg_aquav_id = fields.Many2one(
-        comodel_name="mdfe.30.aquav", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.aquav",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_cTermDescarreg = fields.Char(
         string="Código do Terminal de Descarregamento",
@@ -193,7 +199,10 @@ class InfEmbComb(models.AbstractModel):
     _binding_type = "Aquav.InfEmbComb"
 
     mdfe30_infEmbComb_aquav_id = fields.Many2one(
-        comodel_name="mdfe.30.aquav", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.aquav",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_cEmbComb = fields.Char(
         string="Código da embarcação do comboio", xsd_required=True
@@ -211,7 +220,10 @@ class InfUnidCargaVazia(models.AbstractModel):
     _binding_type = "Aquav.InfUnidCargaVazia"
 
     mdfe30_infUnidCargaVazia_aquav_id = fields.Many2one(
-        comodel_name="mdfe.30.aquav", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.aquav",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_idUnidCargaVazia = fields.Char(
         string="Identificação da unidades de carga vazia",
@@ -239,7 +251,10 @@ class InfUnidTranspVazia(models.AbstractModel):
     _binding_type = "Aquav.InfUnidTranspVazia"
 
     mdfe30_infUnidTranspVazia_aquav_id = fields.Many2one(
-        comodel_name="mdfe.30.aquav", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.aquav",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_idUnidTranspVazia = fields.Char(
         string="Identificação da unidades",

--- a/l10n_br_mdfe_spec/models/v3_0/mdfe_modal_ferroviario_v3_00.py
+++ b/l10n_br_mdfe_spec/models/v3_0/mdfe_modal_ferroviario_v3_00.py
@@ -70,7 +70,10 @@ class Vag(models.AbstractModel):
     _binding_type = "Ferrov.Vag"
 
     mdfe30_vag_ferrov_id = fields.Many2one(
-        comodel_name="mdfe.30.ferrov", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.ferrov",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_pesoBC = fields.Float(
         string="Peso Base de Cálculo de Frete",

--- a/l10n_br_mdfe_spec/models/v3_0/mdfe_modal_rodoviario_v3_00.py
+++ b/l10n_br_mdfe_spec/models/v3_0/mdfe_modal_rodoviario_v3_00.py
@@ -207,7 +207,10 @@ class InfCiot(models.AbstractModel):
     _binding_type = "Rodo.InfAntt.InfCiot"
 
     mdfe30_infCIOT_infANTT_id = fields.Many2one(
-        comodel_name="mdfe.30.infantt", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.infantt",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_CIOT = fields.Char(
         string="Código Identificador da Operação",
@@ -282,7 +285,10 @@ class Disp(models.AbstractModel):
     _binding_type = "Rodo.InfAntt.ValePed.Disp"
 
     mdfe30_disp_valePed_id = fields.Many2one(
-        comodel_name="mdfe.30.valeped", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.valeped",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_CNPJForn = fields.Char(
         string="CNPJ da empresa fornecedora",
@@ -353,7 +359,10 @@ class InfContratante(models.AbstractModel):
     _binding_type = "Rodo.InfAntt.InfContratante"
 
     mdfe30_infContratante_infANTT_id = fields.Many2one(
-        comodel_name="mdfe.30.infantt", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.infantt",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_xNome = fields.Char(string="Razão social ou Nome do contratante")
 
@@ -427,7 +436,10 @@ class RodoInfPag(models.AbstractModel):
     _binding_type = "Rodo.InfAntt.InfPag"
 
     mdfe30_infPag_infANTT_id = fields.Many2one(
-        comodel_name="mdfe.30.infantt", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.infantt",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_xNome = fields.Char(
         string="Razão social ou Nome do respnsável",
@@ -548,7 +560,10 @@ class RodoComp(models.AbstractModel):
     _binding_type = "Rodo.InfAntt.InfPag.Comp"
 
     mdfe30_Comp_infPag_id = fields.Many2one(
-        comodel_name="mdfe.30.rodo_infpag", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.rodo_infpag",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_tpComp = fields.Selection(
         COMP_TPCOMP_2,
@@ -581,7 +596,10 @@ class RodoInfPrazo(models.AbstractModel):
     _binding_type = "Rodo.InfAntt.InfPag.InfPrazo"
 
     mdfe30_infPrazo_infPag_id = fields.Many2one(
-        comodel_name="mdfe.30.rodo_infpag", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.rodo_infpag",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_nParcela = fields.Char(string="Número da Parcela", xsd_required=True)
 
@@ -781,7 +799,10 @@ class RodoCondutor(models.AbstractModel):
     _binding_type = "Rodo.VeicTracao.Condutor"
 
     mdfe30_condutor_veicTracao_id = fields.Many2one(
-        comodel_name="mdfe.30.veictracao", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.veictracao",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_xNome = fields.Char(string="Nome do Condutor", xsd_required=True)
 
@@ -799,7 +820,10 @@ class VeicReboque(models.AbstractModel):
     _binding_type = "Rodo.VeicReboque"
 
     mdfe30_veicReboque_rodo_id = fields.Many2one(
-        comodel_name="mdfe.30.rodo", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.rodo",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_cInt = fields.Char(string="Código interno do veículo")
 
@@ -914,6 +938,9 @@ class LacRodo(models.AbstractModel):
     _binding_type = "Rodo.LacRodo"
 
     mdfe30_lacRodo_rodo_id = fields.Many2one(
-        comodel_name="mdfe.30.rodo", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.rodo",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_nLacre = fields.Char(string="Número do Lacre", xsd_required=True)

--- a/l10n_br_mdfe_spec/models/v3_0/mdfe_tipos_basico_v3_00.py
+++ b/l10n_br_mdfe_spec/models/v3_0/mdfe_tipos_basico_v3_00.py
@@ -802,7 +802,10 @@ class TunidCarga(models.AbstractModel):
     _binding_type = "TunidCarga"
 
     mdfe30_infUnidCarga_TUnidadeTransp_id = fields.Many2one(
-        comodel_name="mdfe.30.tunidadetransp", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.tunidadetransp",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_tpUnidCarga = fields.Selection(
         TTIPOUNIDCARGA,
@@ -843,7 +846,10 @@ class LacUnidCarga(models.AbstractModel):
     _binding_type = "TunidCarga.LacUnidCarga"
 
     mdfe30_lacUnidCarga_TUnidCarga_id = fields.Many2one(
-        comodel_name="mdfe.30.tunidcarga", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.tunidcarga",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_nLacre = fields.Char(string="Número do lacre", xsd_required=True)
 
@@ -901,13 +907,22 @@ class TunidadeTransp(models.AbstractModel):
     _binding_type = "TunidadeTransp"
 
     mdfe30_infUnidTransp_infCTe_id = fields.Many2one(
-        comodel_name="mdfe.30.infcte", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.infcte",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_infUnidTransp_infNFe_id = fields.Many2one(
-        comodel_name="mdfe.30.tmdfe_infnfe", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.tmdfe_infnfe",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_infUnidTransp_infMDFeTransp_id = fields.Many2one(
-        comodel_name="mdfe.30.infmdfetransp", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.infmdfetransp",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_tpUnidTransp = fields.Selection(
         TTIPOUNIDTRANSP,
@@ -969,7 +984,10 @@ class LacUnidTransp(models.AbstractModel):
     _binding_type = "TunidadeTransp.LacUnidTransp"
 
     mdfe30_lacUnidTransp_TUnidadeTransp_id = fields.Many2one(
-        comodel_name="mdfe.30.tunidadetransp", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.tunidadetransp",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_nLacre = fields.Char(string="Número do lacre", xsd_required=True)
 
@@ -1322,7 +1340,10 @@ class InfMunCarrega(models.AbstractModel):
     _binding_type = "Tmdfe.InfMdfe.Ide.InfMunCarrega"
 
     mdfe30_infMunCarrega_ide_id = fields.Many2one(
-        comodel_name="mdfe.30.ide", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.ide",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_cMunCarrega = fields.Char(
         string="Código do Município de Carregamento",
@@ -1344,7 +1365,10 @@ class InfPercurso(models.AbstractModel):
     _binding_type = "Tmdfe.InfMdfe.Ide.InfPercurso"
 
     mdfe30_infPercurso_ide_id = fields.Many2one(
-        comodel_name="mdfe.30.ide", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.ide",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_UFPer = fields.Selection(
         TUF,
@@ -1443,7 +1467,10 @@ class InfMunDescarga(models.AbstractModel):
     _binding_type = "Tmdfe.InfMdfe.InfDoc.InfMunDescarga"
 
     mdfe30_infMunDescarga_infDoc_id = fields.Many2one(
-        comodel_name="mdfe.30.tmdfe_infdoc", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.tmdfe_infdoc",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_cMunDescarga = fields.Char(
         string="Código do Município de Descarregamento",
@@ -1492,7 +1519,10 @@ class InfCte(models.AbstractModel):
     _binding_type = "Tmdfe.InfMdfe.InfDoc.InfMunDescarga.InfCte"
 
     mdfe30_infCTe_infMunDescarga_id = fields.Many2one(
-        comodel_name="mdfe.30.infmundescarga", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.infmundescarga",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_chCTe = fields.Char(
         string="Conhecimento Eletrônico",
@@ -1559,7 +1589,10 @@ class InfCtePeri(models.AbstractModel):
     _binding_type = "Tmdfe.InfMdfe.InfDoc.InfMunDescarga.InfCte.Peri"
 
     mdfe30_peri_infCTe_id = fields.Many2one(
-        comodel_name="mdfe.30.infcte", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.infcte",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_nONU = fields.Char(
         string="Número ONU/UN",
@@ -1656,7 +1689,10 @@ class InfNfePrestParcial(models.AbstractModel):
     _binding_type = "Tmdfe.InfMdfe.InfDoc.InfMunDescarga.InfCte.InfNfePrestParcial"
 
     mdfe30_infNFePrestParcial_infCTe_id = fields.Many2one(
-        comodel_name="mdfe.30.infcte", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.infcte",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_chNFe = fields.Char(
         string="Nota Fiscal Eletrônica", xsd_required=True, xsd_type="TChCTe"
@@ -1672,7 +1708,10 @@ class TmdfeInfNfe(models.AbstractModel):
     _binding_type = "Tmdfe.InfMdfe.InfDoc.InfMunDescarga.InfNfe"
 
     mdfe30_infNFe_infMunDescarga_id = fields.Many2one(
-        comodel_name="mdfe.30.infmundescarga", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.infmundescarga",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_chNFe = fields.Char(
         string="Nota Fiscal Eletrônica", xsd_required=True, xsd_type="TChNFe"
@@ -1719,7 +1758,10 @@ class InfNfePeri(models.AbstractModel):
     _binding_type = "Tmdfe.InfMdfe.InfDoc.InfMunDescarga.InfNfe.Peri"
 
     mdfe30_peri_infNFe_id = fields.Many2one(
-        comodel_name="mdfe.30.tmdfe_infnfe", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.tmdfe_infnfe",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_nONU = fields.Char(
         string="Número ONU/UN",
@@ -1788,7 +1830,10 @@ class InfMdfeTransp(models.AbstractModel):
     _binding_type = "Tmdfe.InfMdfe.InfDoc.InfMunDescarga.InfMdfeTransp"
 
     mdfe30_infMDFeTransp_infMunDescarga_id = fields.Many2one(
-        comodel_name="mdfe.30.infmundescarga", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.infmundescarga",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_chMDFe = fields.Char(
         string="Manifesto Eletrônico",
@@ -1836,7 +1881,10 @@ class InfMdfeTranspPeri(models.AbstractModel):
     _binding_type = "Tmdfe.InfMdfe.InfDoc.InfMunDescarga.InfMdfeTransp.Peri"
 
     mdfe30_peri_infMDFeTransp_id = fields.Many2one(
-        comodel_name="mdfe.30.infmdfetransp", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.infmdfetransp",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_nONU = fields.Char(
         string="Número ONU/UN",
@@ -1904,7 +1952,10 @@ class Seg(models.AbstractModel):
     _binding_type = "Tmdfe.InfMdfe.Seg"
 
     mdfe30_seg_infMDFe_id = fields.Many2one(
-        comodel_name="mdfe.30.tmdfe_infmdfe", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.tmdfe_infmdfe",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_infResp = fields.Many2one(
         comodel_name="mdfe.30.infresp",
@@ -2196,7 +2247,10 @@ class Lacres(models.AbstractModel):
     _binding_type = "Tmdfe.InfMdfe.Lacres"
 
     mdfe30_lacres_infMDFe_id = fields.Many2one(
-        comodel_name="mdfe.30.tmdfe_infmdfe", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.tmdfe_infmdfe",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_nLacre = fields.Char(string="número do lacre", xsd_required=True)
 
@@ -2211,7 +2265,10 @@ class AutXml(models.AbstractModel):
     _binding_type = "Tmdfe.InfMdfe.AutXml"
 
     mdfe30_autXML_infMDFe_id = fields.Many2one(
-        comodel_name="mdfe.30.tmdfe_infmdfe", xsd_implicit=True, ondelete="cascade"
+        comodel_name="mdfe.30.tmdfe_infmdfe",
+        xsd_implicit=True,
+        ondelete="cascade",
+        index=True,
     )
     mdfe30_CNPJ = fields.Char(
         string="CNPJ do autorizado",


### PR DESCRIPTION
## Problem

The generated spec models declare no index on the many2one fields that serve as
the inverse key of a one2many (`xsd_implicit=True` + `ondelete="cascade"`).

In Odoo 16 a `Many2one` does not create an index by default, and PostgreSQL does
not index foreign key columns automatically. Reading such a one2many issues
`SELECT ... WHERE <inverse_fk> = X` against an unindexed column, which is a
sequential scan of the whole child table.

`l10n_br_mdfe_spec` has 34 one2many and, before this PR, **0** fields with `index=True`.
This PR indexes 34 of them.

## Measured on a production database

Restored production database of a Brazilian customer (82,214 fiscal documents,
587 new documents per month, PostgreSQL 15):

| relation | rows | plan | time |
|---|---|---|---|
| `res.partner.nfe40_autXML_infNFe_id` | 73,359 | Seq Scan | **106 ms** |
| the same after this change | 73,359 | Index Scan | **0.064 ms** |
| for reference, `l10n_br_fiscal.document.line.document_id` (already indexed) | 204,698 | Index Scan | 1.3 ms |

## Honest scope

I also measured the end-to-end invoice flow (create + post) on that database,
before and after adding these indexes: **no significant change** (2.339s -> 2.337s,
median of 3 runs). The test invoice does not populate those groups, so the scans
do not run in that path.

The gain shows up where many documents are read at once: batch XML export,
reports, DF-e import, and any `search()` on those relations. So this is a
correctness/hygiene fix with a clear worst case, **not an invoice speed-up** -
flagging it explicitly so it is not oversold.

## Why applied to the generated files instead of regenerating

The change mirrors exactly what the generator emits after
akretion/xsdata-odoo#22 (`index=True` in `odoo_implicit_many2ones`).

I did try a full regeneration first, and verified by comparing field definitions
semantically (not textually) that it would be **destructive** with the current
toolchain:

- the output is not even valid Python (`from __future__ import annotationsfrom
  .tipos_basico_v4_00 import (`);
- nfelib 2.5.2 does not carry the tax reform types, so 6 IBS/CBS and IS fields
  would degrade from `Many2one`/`Selection` to `Char`, **losing** support that is
  already committed here;
- 74 fields would disappear.

So this PR touches only the implicit many2one fields and nothing else. The diff is
`index=True` plus the line rewrapping it causes. Whoever regenerates the specs
next with the fixed generator will produce the same result.

## Verification

- the number of modified fields matches the number of one2many in the module;
- every file still compiles;
- pre-commit (ruff, ruff-format, pylint_odoo) passes.
