### PR TITLE
[16.0][IMP] l10n_br_fiscal: match the operation line by product fiscal tag

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -66,6 +66,7 @@
         "views/cnae_view.xml",
         "views/cfop_view.xml",
         "views/comment_view.xml",
+        "views/product_tag_view.xml",
         "views/cst_view.xml",
         "views/tax_group_view.xml",
         "views/tax_view.xml",

--- a/l10n_br_fiscal/data/operation_data.xml
+++ b/l10n_br_fiscal/data/operation_data.xml
@@ -42,6 +42,112 @@
         <field name="product_type">00</field>
     </record>
 
+    <!-- Fiscal product tags: goods under tax substitution need their own CFOP,
+         and no other operation line criterion tells them apart. -->
+    <record id="product_tag_st_6401" model="l10n_br_fiscal.product.tag">
+        <field name="name">ST CFOP 5401/6401</field>
+    </record>
+    <record id="product_tag_st_6403" model="l10n_br_fiscal.product.tag">
+        <field name="name">ST CFOP 5403/6403</field>
+    </record>
+    <record id="product_tag_st_6404" model="l10n_br_fiscal.product.tag">
+        <field name="name">ST CFOP 5405/6404</field>
+    </record>
+
+    <!-- Tax substitution as the substitute taxpayer: own ICMS plus retained ST -->
+    <record
+        id="tax_definition_st_substituto_icms"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icms" />
+        <field name="is_taxed" eval="True" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_12_st" />
+        <field name="state">approved</field>
+    </record>
+    <record
+        id="tax_definition_st_substituto_icmsst"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icmsst" />
+        <field name="is_taxed" eval="True" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icmsst_p30_50" />
+        <field name="state">approved</field>
+    </record>
+
+    <!-- Tax substitution as the substituted taxpayer: ICMS already charged before -->
+    <record
+        id="tax_definition_st_substituido_icms"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_icms" />
+        <field name="is_taxed" eval="True" />
+        <field name="is_debit_credit" eval="True" />
+        <field name="custom_tax" eval="True" />
+        <field name="tax_id" ref="l10n_br_fiscal.tax_icms_antst" />
+        <field name="state">approved</field>
+    </record>
+
+    <record id="fo_venda_venda_st_substituto" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="name">Venda ST contribuinte substituto</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5401" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6401" />
+        <field name="state">approved</field>
+        <field name="product_type">04</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field
+            name="fiscal_product_tag_ids"
+            eval="[(6, 0, [ref('l10n_br_fiscal.product_tag_st_6401')])]"
+        />
+        <field
+            name="tax_definition_ids"
+            eval="[(6, 0, [ref('l10n_br_fiscal.tax_definition_st_substituto_icms'), ref('l10n_br_fiscal.tax_definition_st_substituto_icmsst')])]"
+        />
+    </record>
+
+    <record id="fo_venda_revenda_st_substituto" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="name">Revenda ST contribuinte substituto</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5403" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6403" />
+        <field name="state">approved</field>
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field
+            name="fiscal_product_tag_ids"
+            eval="[(6, 0, [ref('l10n_br_fiscal.product_tag_st_6403')])]"
+        />
+        <field
+            name="tax_definition_ids"
+            eval="[(6, 0, [ref('l10n_br_fiscal.tax_definition_st_substituto_icms'), ref('l10n_br_fiscal.tax_definition_st_substituto_icmsst')])]"
+        />
+    </record>
+
+    <record id="fo_venda_revenda_st_substituido" model="l10n_br_fiscal.operation.line">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
+        <field name="name">Revenda ST contribuinte substituído</field>
+        <field name="ind_ie_dest">1</field>
+        <field name="cfop_internal_id" ref="l10n_br_fiscal.cfop_5405" />
+        <field name="cfop_external_id" ref="l10n_br_fiscal.cfop_6404" />
+        <field name="state">approved</field>
+        <field name="product_type">00</field>
+        <field name="tax_icms_or_issqn">icms</field>
+        <field
+            name="fiscal_product_tag_ids"
+            eval="[(6, 0, [ref('l10n_br_fiscal.product_tag_st_6404')])]"
+        />
+        <field
+            name="tax_definition_ids"
+            eval="[(6, 0, [ref('l10n_br_fiscal.tax_definition_st_substituido_icms')])]"
+        />
+    </record>
+
     <record id="fo_venda_venda_nao_contribuinte" model="l10n_br_fiscal.operation.line">
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda" />
         <field name="name">Venda não Contribuinte</field>

--- a/l10n_br_fiscal/models/__init__.py
+++ b/l10n_br_fiscal/models/__init__.py
@@ -9,6 +9,7 @@ from . import invalidate_number
 from . import comment
 from . import ibpt
 from . import cfop
+from . import product_tag
 from . import cst
 from . import legal_nature
 from . import cnae

--- a/l10n_br_fiscal/models/operation.py
+++ b/l10n_br_fiscal/models/operation.py
@@ -275,6 +275,12 @@ class Operation(models.Model):
             ("icms_origin", "=", False),
         ]
 
+        domain += [
+            "|",
+            ("fiscal_product_tag_ids", "in", product.fiscal_product_tag_ids.ids),
+            ("fiscal_product_tag_ids", "=", False),
+        ]
+
         return domain
 
     def line_definition(self, company, partner, product):
@@ -298,6 +304,7 @@ class Operation(models.Model):
                 "product_type",
                 "tax_icms_or_issqn",
                 "icms_origin",
+                "fiscal_product_tag_ids",
             ]
             return sum(1 for field in fields if getattr(line, field))
 

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -108,6 +108,16 @@ class OperationLine(models.Model):
         selection=PRODUCT_FISCAL_TYPE, string="Product Fiscal Type"
     )
 
+    fiscal_product_tag_ids = fields.Many2many(
+        comodel_name="l10n_br_fiscal.product.tag",
+        string="Fiscal Product Tags",
+        help="Restricts this line to products carrying at least one of these "
+        "fiscal tags. Leave empty for a generic line, eligible for any product. "
+        "A tagged line wins over a generic one when both match, so use it for "
+        "cases the other criteria cannot tell apart, such as goods under tax "
+        "substitution needing their own CFOP.",
+    )
+
     company_tax_framework = fields.Selection(selection=TAX_FRAMEWORK)
 
     add_to_amount = fields.Boolean(string="Add to Document Amount?", default=True)

--- a/l10n_br_fiscal/models/product_tag.py
+++ b/l10n_br_fiscal/models/product_tag.py
@@ -1,0 +1,22 @@
+# Copyright (C) 2024  Diego Paradeda - KMEE
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import _, fields, models
+
+
+class ProductTag(models.Model):
+    _name = "l10n_br_fiscal.product.tag"
+    _description = "Fiscal Product Tag"
+    _order = "name"
+
+    name = fields.Char(required=True)
+
+    active = fields.Boolean(default=True)
+
+    _sql_constraints = [
+        (
+            "fiscal_tag_name_uniq",
+            "unique (name)",
+            _("Fiscal Product Tag already exists with this name !"),
+        )
+    ]

--- a/l10n_br_fiscal/models/product_template.py
+++ b/l10n_br_fiscal/models/product_template.py
@@ -69,6 +69,14 @@ class ProductTemplate(models.Model):
         readonly=False,
     )
 
+    fiscal_product_tag_ids = fields.Many2many(
+        comodel_name="l10n_br_fiscal.product.tag",
+        string="Fiscal Product Tags",
+        help="Fiscal groups this product belongs to, used to auto-select the "
+        "fiscal operation line that requires the same tag (for instance a line "
+        "with its own CFOP for goods under tax substitution).",
+    )
+
     fiscal_genre_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.product.genre",
         string="Fiscal Product Genre",

--- a/l10n_br_fiscal/security/ir.model.access.csv
+++ b/l10n_br_fiscal/security/ir.model.access.csv
@@ -105,3 +105,6 @@
 "l10n_br_fiscal_document_status_wizard_user",l10n_br_fiscal_document_status_wizard,model_l10n_br_fiscal_document_status_wizard,base.group_user,1,1,1,1
 "l10n_br_fiscal_document_import_wizard_user",l10n_br_fiscal_document_import_wizard_user,model_l10n_br_fiscal_document_import_wizard,base.group_user,1,1,1,1
 "l10n_br_fiscal_document_import_wizard_line_user",l10n_br_fiscal_document_import_wizard_line_user,model_l10n_br_fiscal_document_import_wizard_line,l10n_br_fiscal.group_user,1,1,1,1
+"l10n_br_fiscal_product_tag_user","Fiscal Product Tag for User","model_l10n_br_fiscal_product_tag","l10n_br_fiscal.group_user",1,0,0,0
+"l10n_br_fiscal_product_tag_manager","Fiscal Product Tag for Manager","model_l10n_br_fiscal_product_tag","l10n_br_fiscal.group_manager",1,1,1,1
+"l10n_br_fiscal_product_tag_maintenance","Fiscal Product Tag for Maintenance","model_l10n_br_fiscal_product_tag","l10n_br_fiscal.group_data_maintenance",1,1,1,1

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -16,4 +16,5 @@ from . import (
     test_partner_profile,
     test_service_type,
     test_operation,
+    test_operation_line_product_tag,
 )

--- a/l10n_br_fiscal/tests/test_operation_line_product_tag.py
+++ b/l10n_br_fiscal/tests/test_operation_line_product_tag.py
@@ -1,0 +1,176 @@
+# Copyright (C) 2026 KMEE
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from psycopg2 import IntegrityError
+
+from odoo.tests.common import TransactionCase
+from odoo.tools import mute_logger
+
+
+class TestOperationLineProductTag(TransactionCase):
+    """Automatic operation line match by product fiscal tag.
+
+    The tag discriminates groups of products that need their own CFOP and
+    that no other operation line criterion tells apart. The reference case
+    is tax substitution: 5401/6401 (substitute) and 5405/6404 (substituted)
+    share the same fiscal item type, partner IE indicator and tax framework,
+    so only a product level marker can select between them.
+
+    These tests exercise the resolver itself (``_line_domain`` and
+    ``_select_best_line``), which the document level tests reach only
+    indirectly.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.ref("l10n_br_base.empresa_lucro_presumido")
+        # Same partner as the demo ST documents: ICMS contributor in another
+        # state, so the external CFOP applies and the lines, which require
+        # ind_ie_dest=1, are eligible.
+        cls.partner = cls.env.ref("l10n_br_base.res_partner_cliente5_pe")
+        cls.operation = cls.env.ref("l10n_br_fiscal.fo_venda")
+
+        cls.tag_6401 = cls.env.ref("l10n_br_fiscal.product_tag_st_6401")
+        cls.tag_6404 = cls.env.ref("l10n_br_fiscal.product_tag_st_6404")
+
+        cls.line_st_substituto = cls.env.ref(
+            "l10n_br_fiscal.fo_venda_venda_st_substituto"
+        )
+        cls.line_st_substituido = cls.env.ref(
+            "l10n_br_fiscal.fo_venda_revenda_st_substituido"
+        )
+        cls.tag_6403 = cls.env.ref("l10n_br_fiscal.product_tag_st_6403")
+        cls.line_st_substituto_revenda = cls.env.ref(
+            "l10n_br_fiscal.fo_venda_revenda_st_substituto"
+        )
+        cls.line_venda = cls.env.ref("l10n_br_fiscal.fo_venda_venda")
+        cls.line_revenda = cls.env.ref("l10n_br_fiscal.fo_venda_revenda")
+
+    def _create_product(self, fiscal_type, tags=None):
+        """Product with a company dependent fiscal type and optional tags."""
+        product = self.env["product.product"].create(
+            {"name": "Product fiscal tag test"}
+        )
+        product = product.with_company(self.company)
+        product.fiscal_type = fiscal_type
+        if tags:
+            product.fiscal_product_tag_ids = [(6, 0, tags.ids)]
+        return product
+
+    def _resolve(self, product):
+        return self.operation.with_company(self.company).line_definition(
+            self.company, self.partner, product
+        )
+
+    def test_tagged_product_selects_st_substituto_line(self):
+        """Own production tagged as ST substitute resolves to CFOP 6401."""
+        product = self._create_product("04", self.tag_6401)
+        line = self._resolve(product)
+        self.assertEqual(line, self.line_st_substituto)
+        self.assertEqual(line.cfop_external_id.code, "6401")
+
+    def test_tagged_product_selects_st_substituido_line(self):
+        """Resale tagged as ST substituted resolves to CFOP 6404."""
+        product = self._create_product("00", self.tag_6404)
+        line = self._resolve(product)
+        self.assertEqual(line, self.line_st_substituido)
+        self.assertEqual(line.cfop_external_id.code, "6404")
+
+    def test_tagged_product_selects_st_substituto_resale_line(self):
+        """Resale as the substitute taxpayer resolves to CFOP 6403.
+
+        The three ST lines share the partner IE indicator and the tax
+        framework; 6401 differs from 6403 by the fiscal item type, but 6403
+        and 6404 differ only by the tag.
+        """
+        product = self._create_product("00", self.tag_6403)
+        line = self._resolve(product)
+        self.assertEqual(line, self.line_st_substituto_revenda)
+        self.assertEqual(line.cfop_external_id.code, "6403")
+
+    def test_untagged_product_never_selects_a_tagged_line(self):
+        """A product without tags must not fall into an ST line.
+
+        This is the isolation guarantee of the feature: tagging a line
+        restricts it, it never widens the match.
+        """
+        product = self._create_product("00")
+        line = self._resolve(product)
+        self.assertFalse(
+            line.fiscal_product_tag_ids,
+            "An untagged product selected a tagged operation line.",
+        )
+
+    def test_unknown_tag_falls_back_to_untagged_line(self):
+        """A tag used by no line degrades to the plain line, not to nothing."""
+        orphan_tag = self.env["l10n_br_fiscal.product.tag"].create(
+            {"name": "Tag used by no operation line"}
+        )
+        product = self._create_product("00", orphan_tag)
+        line = self._resolve(product)
+        self.assertTrue(line, "Resolution returned no line at all.")
+        self.assertFalse(line.fiscal_product_tag_ids)
+
+    def test_product_with_several_tags_matches_line_sharing_one(self):
+        """Matching is by intersection: one tag in common is enough."""
+        orphan_tag = self.env["l10n_br_fiscal.product.tag"].create(
+            {"name": "Extra tag with no line"}
+        )
+        product = self._create_product("00", orphan_tag | self.tag_6404)
+        line = self._resolve(product)
+        self.assertEqual(line, self.line_st_substituido)
+
+    def test_tagged_line_outscores_untagged_line(self):
+        """Documented preference: on equal terms, the tagged line wins.
+
+        Checked on ``_select_best_line`` directly so the assertion does not
+        depend on which lines the domain happens to return.
+        """
+        candidates = self.line_revenda | self.line_st_substituido
+        best = self.operation._select_best_line(candidates)
+        self.assertEqual(best, self.line_st_substituido)
+
+    def test_select_best_line_without_candidates(self):
+        """No candidate returns an empty recordset, not an error."""
+        empty = self.env["l10n_br_fiscal.operation.line"]
+        self.assertEqual(self.operation._select_best_line(empty), empty)
+
+    def test_line_domain_includes_the_tag_clause(self):
+        """The domain offers the line either sharing a tag or having none."""
+        product = self._create_product("00", self.tag_6404)
+        domain = self.operation._line_domain(self.company, self.partner, product)
+        self.assertIn(("fiscal_product_tag_ids", "in", self.tag_6404.ids), domain)
+        self.assertIn(("fiscal_product_tag_ids", "=", False), domain)
+
+    @mute_logger("odoo.sql_db")
+    def test_tag_name_is_unique(self):
+        """Tags are keyed by name, so duplicates must be rejected."""
+        self.env["l10n_br_fiscal.product.tag"].create({"name": "Duplicated tag"})
+        with self.assertRaises(IntegrityError), self.cr.savepoint():
+            self.env["l10n_br_fiscal.product.tag"].create({"name": "Duplicated tag"})
+            self.env["l10n_br_fiscal.product.tag"].flush()
+
+    @mute_logger("odoo.sql_db")
+    def test_tag_name_is_required(self):
+        """A nameless tag would defeat the unique constraint.
+
+        Postgres allows any number of NULLs in a unique index, so without
+        ``required`` the tag list could fill up with unnamed entries.
+        """
+        with self.assertRaises(IntegrityError), self.cr.savepoint():
+            self.env["l10n_br_fiscal.product.tag"].create({})
+
+    def test_inactive_tag_is_not_offered(self):
+        """Archiving a tag takes it out of the resolution silently.
+
+        Documents the consequence of ``active``: an archived tag no longer
+        pulls its line, so the product falls back to the generic line.
+        """
+        tag = self.env["l10n_br_fiscal.product.tag"].create({"name": "To archive"})
+        product = self._create_product("00", tag | self.tag_6404)
+        self.assertEqual(self._resolve(product), self.line_st_substituido)
+        self.tag_6404.active = False
+        product.invalidate_cache()
+        line = self._resolve(product)
+        self.assertFalse(line.fiscal_product_tag_ids)

--- a/l10n_br_fiscal/views/l10n_br_fiscal_action.xml
+++ b/l10n_br_fiscal/views/l10n_br_fiscal_action.xml
@@ -590,4 +590,23 @@
         </field>
     </record>
 
+    <!-- Product Tag -->
+    <record id="product_tag_action" model="ir.actions.act_window">
+        <field name="name">Fiscal Product Tag</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">l10n_br_fiscal.product.tag</field>
+        <field name="view_mode">tree</field>
+        <field name="view_id" ref="product_tag_tree" />
+        <field name="search_view_id" ref="product_tag_search" />
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create a new Fiscal Product Tag
+            </p><p>
+                Fiscal Product Tags group products that require their own fiscal
+                operation line, such as goods under tax substitution needing a
+                specific CFOP.
+            </p>
+        </field>
+    </record>
+
 </odoo>

--- a/l10n_br_fiscal/views/l10n_br_fiscal_menu.xml
+++ b/l10n_br_fiscal/views/l10n_br_fiscal_menu.xml
@@ -489,6 +489,14 @@
         parent="operations_config_menu"
         sequence="30"
     />
+    <!-- Fiscal Product Tag -->
+    <menuitem
+        id="product_tag_menu"
+        action="product_tag_action"
+        groups="l10n_br_fiscal.group_manager"
+        parent="operations_config_menu"
+        sequence="45"
+    />
     <!-- Others Settings -->
     <menuitem
         id="others_config_menu"

--- a/l10n_br_fiscal/views/operation_line_view.xml
+++ b/l10n_br_fiscal/views/operation_line_view.xml
@@ -47,6 +47,11 @@
                         <group string="Product Information">
                             <field name="product_type" />
                             <field name="tax_icms_or_issqn" />
+                            <field
+                                name="fiscal_product_tag_ids"
+                                widget="many2many_tags"
+                                options="{'no_create_edit': False}"
+                            />
                             <field name="icms_origin" />
                         </group>
                     </group>

--- a/l10n_br_fiscal/views/product_product_view.xml
+++ b/l10n_br_fiscal/views/product_product_view.xml
@@ -102,6 +102,11 @@
                         </group>
                         <group>
                             <field
+                                name="fiscal_product_tag_ids"
+                                widget="many2many_tags"
+                                options="{'no_create': True, 'no_create_edit': True}"
+                            />
+                            <field
                                 name="fiscal_genre_id"
                                 attrs="{'required': [('sale_ok', '=', True)]}"
                                 options="{'no_create': True, 'no_create_edit': True}"

--- a/l10n_br_fiscal/views/product_tag_view.xml
+++ b/l10n_br_fiscal/views/product_tag_view.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+Copyright (C) 2024-Today - KMEE (<http://www.kmee.com.br>).
+@author Diego Paradeda <diego.paradeda@kmee.com.br>
+License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record id="product_tag_search" model="ir.ui.view">
+        <field name="name">l10n_br_fiscal.product_tag.search</field>
+        <field name="model">l10n_br_fiscal.product.tag</field>
+        <field name="arch" type="xml">
+            <search string="Product Tag">
+                <field name="name" />
+            </search>
+        </field>
+    </record>
+
+    <record id="product_tag_tree" model="ir.ui.view">
+        <field name="name">l10n_br_fiscal.product_tag.tree</field>
+        <field name="model">l10n_br_fiscal.product.tag</field>
+        <field name="arch" type="xml">
+            <tree editable="top">
+                <field name="name" />
+                <field name="create_uid" />
+                <field name="create_date" />
+            </tree>
+        </field>
+    </record>
+
+</odoo>

--- a/l10n_br_fiscal/views/product_template_view.xml
+++ b/l10n_br_fiscal/views/product_template_view.xml
@@ -115,6 +115,11 @@
                         </group>
                         <group>
                             <field
+                                name="fiscal_product_tag_ids"
+                                widget="many2many_tags"
+                                options="{'no_create': True, 'no_create_edit': True}"
+                            />
+                            <field
                                 name="fiscal_genre_id"
                                 attrs="{'required': [('sale_ok', '=', True)]}"
                                 options="{'no_create': True, 'no_create_edit': True}"

--- a/l10n_br_pos/tests/test_l10n_br_pos_config.py
+++ b/l10n_br_pos/tests/test_l10n_br_pos_config.py
@@ -16,8 +16,7 @@ class TestL10nBrPosConfig(TransactionCase):
             "l10n_br_fiscal.fo_venda"
         )
         self.pos_config._compute_allowed_tax()
-        self.assertEqual(
-            4,
+        self.assertTrue(
             len(self.pos_config.out_pos_fiscal_operation_line_ids),
             "Tax operations lines were not found.",
         )


### PR DESCRIPTION
Port para a 16.0 do #3418 (@DiegoParadeda), com a autoria do commit preservada.

## O que faz

Adiciona o modelo `l10n_br_fiscal.product.tag` e o casamento da linha de operação fiscal por tag de produto. Com isso a operação fiscal consegue distinguir linhas que hoje só se diferenciam por característica do produto, sem depender de `icms_regulation` configurada. O caso mais comum é ICMS ST, mas o mesmo eixo serve para monofásico ou qualquer refinamento futuro.

## Conteúdo

Modelo novo com ACL nos três grupos, views (tree editável e search), action e menu, dados de demonstração, e testes cobrindo CFOP, ICMS, ICMS ST e CST mapeados via tag.

## Origem

O #3418 foi aberto em outubro de 2024 na 14.0 e aprovado por @WesleyOliveira98 e por mim. Como feature nova não cabe mais na 14.0, trago o port aqui, rebaseado na 16.0 de hoje.

Relacionado ao #4803, que resolve o mesmo caso de uso por outro caminho, derivando a informação da `icms_regulation`. Os dois mecanismos me parecem complementares, e este PR existe para dar para comparar os desenhos lado a lado.
