### PR TITLE
[16.0][FIX] l10n_br_fiscal_edi: chama o gancho público de denegação, e a fatura é cancelada

### DIFF
--- a/l10n_br_account/tests/test_move_workflow.py
+++ b/l10n_br_account/tests/test_move_workflow.py
@@ -44,7 +44,14 @@ class TestMoveWorkflow(AccountMoveBRCommon):
             self.assertEqual(document_id.state, "em_digitacao")
 
     def test_document_deny(self):
+        """A denied document cancels the invoice it belongs to.
+
+        The state change is what has to trigger the cancellation: calling the
+        hook by hand passed even while the dispatch never reached it, which is
+        how the cancellation stayed broken.
+        """
         document_id = self.move_out_venda.fiscal_document_id
         self.assertEqual(self.move_out_venda.state, "draft")
-        document_id.exec_after_SITUACAO_EDOC_DENEGADA("em_digitacao", "denegada")
+        document_id._change_state("denegada", force_change=True)
+        self.assertEqual(document_id.state_edoc, "denegada")
         self.assertEqual(self.move_out_venda.state, "cancel")

--- a/l10n_br_fiscal_edi/models/document_workflow.py
+++ b/l10n_br_fiscal_edi/models/document_workflow.py
@@ -182,7 +182,13 @@ class DocumentWorkflow(models.AbstractModel):
         elif new_state == SITUACAO_EDOC_CANCELADA:
             self._exec_after_SITUACAO_EDOC_CANCELADA(old_state, new_state)
         elif new_state == SITUACAO_EDOC_DENEGADA:
-            self._exec_after_SITUACAO_EDOC_DENEGADA(old_state, new_state)
+            # The public method is the extension point of the denial (see
+            # https://github.com/OCA/l10n-brazil/pull/3272): it chains to the
+            # overrides of the other modules and then to the private hook of
+            # this one. Calling the private hook straight from here left every
+            # override of exec_after_SITUACAO_EDOC_DENEGADA dead, l10n_br_account
+            # included, so a denied document never cancelled its invoice.
+            self.exec_after_SITUACAO_EDOC_DENEGADA(old_state, new_state)
         elif new_state == SITUACAO_EDOC_INUTILIZADA:
             self._exec_after_SITUACAO_EDOC_INUTILIZADA(old_state, new_state)
 


### PR DESCRIPTION
O par de métodos em torno da denegação foi introduzido pelo #3272 tendo o
público `exec_after_SITUACAO_EDOC_DENEGADA` como ponto de extensão: ele
encadeia para os overrides dos outros módulos e depois para o gancho privado
deste. O despacho em `_after_change_state` chamava direto o privado, então
todo override do público era código morto.

A consequência visível está no `l10n_br_account`, que sobrescreve o público
para cancelar a fatura de um documento denegado: uma NF-e ou um CT-e denegado
deixava a fatura postada.

O teste desse comportamento chamava o gancho na mão, então passava enquanto o
despacho nunca chegava nele. Agora ele muda o estado do documento e verifica
que a fatura terminou cancelada.

Verificação: 83 testes de `l10n_br_account` mais `l10n_br_fiscal_edi` passando
em Odoo 16 com dados de demonstração.

Depende funcionalmente do #4562. O `_document_deny` do `l10n_br_account`
cancela a fatura por `cancel_move_ids()`, que é justamente o método que aquele
PR corrige para desfazer a conciliação antes de cancelar. Enquanto o gancho de
denegação era código morto, o defeito só aparecia no cancelamento manual; com
esta correção, a denegação passa a percorrer o mesmo caminho. Sugiro mesclar o
#4562 antes deste, ou os dois na mesma leva.

Achado durante a revisão do #4629, onde a correção equivalente aparece
misturada à refatoração da máquina de estados. Aqui vai isolada, para poder
entrar na 16.0 independente daquela discussão. Não conflita com o #4796, que
trata do outro lado do mesmo gatilho, no l10n_br_fiscal_subsequent_document.
