### PR TITLE
[16.0][FIX] l10n_br_fiscal: tax engine must not swallow compute errors

### DIFF
--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -561,7 +561,7 @@ class Tax(models.Model):
         tax_dict = taxes_dict.get(tax.tax_domain)
         partner = kwargs.get("partner")
         company = kwargs.get("company")
-        icms_cst_id = kwargs.get("icms_cst_id")
+        icms_cst_id = kwargs.get("icms_cst_id") or self.env["l10n_br_fiscal.cst"]
 
         if taxes_dict.get("icms"):
             if company.state_id != partner.state_id:
@@ -835,11 +835,14 @@ class Tax(models.Model):
             operation_line = kwargs.get("operation_line")
             fiscal_operation_type = operation_line.fiscal_operation_type or FISCAL_OUT
             kwargs.update({"cst": tax.cst_from_tax(fiscal_operation_type)})
-            try:
-                compute_method = getattr(self, f"_compute_{tax.tax_domain}")
+            # getattr with a default instead of try/except AttributeError: the
+            # previous form also caught AttributeError raised INSIDE the compute
+            # method, silently replacing a specialized computation that crashed
+            # with the generic formula.
+            compute_method = getattr(self, f"_compute_{tax.tax_domain}", None)
+            if compute_method is not None:
                 taxes[tax.tax_domain].update(compute_method(tax, taxes, **kwargs))
-
-            except AttributeError:
+            else:
                 taxes[tax.tax_domain].update(tax._compute_tax(tax, taxes, **kwargs))
 
             tax_domain = taxes[tax.tax_domain]

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -1,6 +1,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import (
+    test_tax_engine_contract,
     test_cnae,
     test_fiscal_document_serie,
     test_fiscal_document_generic,

--- a/l10n_br_fiscal/tests/test_tax_engine_contract.py
+++ b/l10n_br_fiscal/tests/test_tax_engine_contract.py
@@ -1,0 +1,149 @@
+# Copyright 2026 KMEE INFORMATICA LTDA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+"""Contract of the tax engine entry point.
+
+These tests pin two properties of `compute_taxes` and its per-domain compute
+methods that the current code does not hold. They are deliberately independent
+of any fiscal configuration: they call the compute methods directly with a
+well-formed tax dictionary, so a failure points at the engine and not at a
+missing tax definition in the data.
+
+Why this matters: `l10n_br_fiscal.document.line` and `account.tax.compute_all`
+are two entry points into the same engine, and they do not pass the same
+arguments. `compute_all` has no `icms_cst_id` parameter at all, so every call
+coming from the accounting side reaches the compute methods without it.
+"""
+
+from unittest.mock import patch
+
+from odoo.tests import TransactionCase
+
+from ..models.tax import TAX_DICT_VALUES
+
+
+class TestTaxEngineContract(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Resolved by search instead of by xml id on purpose: these tests exercise
+        # the engine contract, so they must run on a database with or without demo
+        # data.
+        cls.company = cls.env.company
+        cls.partner = cls.env["res.partner"].search(
+            [("country_id.code", "=", "BR"), ("state_id", "!=", False)], limit=1
+        )
+        cls.product = cls.env["product.product"].search(
+            [("type", "!=", "service")], limit=1
+        )
+        cls.operation_line = cls.env["l10n_br_fiscal.operation.line"].search(
+            [], limit=1
+        )
+        cls.tax_icmsfcp = cls.env["l10n_br_fiscal.tax"].search(
+            [("tax_domain", "=", "icmsfcp")], limit=1
+        )
+        cls.tax_icms = cls.env["l10n_br_fiscal.tax"].search(
+            [("tax_domain", "=", "icms"), ("percent_amount", ">", 0)], limit=1
+        )
+
+    def setUp(self):
+        super().setUp()
+        if not (self.partner and self.product and self.operation_line):
+            self.skipTest("database without the minimum fiscal records")
+
+    def _kwargs(self, **extra):
+        """The arguments both entry points share."""
+        values = {
+            "company": self.company,
+            "partner": self.partner,
+            "product": self.product,
+            "price_unit": 100.0,
+            "quantity": 10.0,
+            "fiscal_price": 100.0,
+            "fiscal_quantity": 10.0,
+            "operation_line": self.operation_line,
+            "ncm": self.product.ncm_id,
+        }
+        values.update(extra)
+        return values
+
+    def _taxes_dict(self, domain, **overrides):
+        """A tax dictionary shaped like the one `compute_taxes` builds."""
+        entry = dict(TAX_DICT_VALUES)
+        entry.update(overrides)
+        return {domain: entry}
+
+    def test_icmsfcp_without_icms_cst_id(self):
+        """_compute_icmsfcp must not require `icms_cst_id` to be passed.
+
+        `account.tax.compute_all` cannot pass it: the parameter does not exist in
+        its signature. Today `kwargs.get("icms_cst_id")` returns None and the
+        method dereferences `.code` on it, so the accounting entry point raises
+        AttributeError inside the engine.
+        """
+        if not self.tax_icmsfcp:
+            self.skipTest("no icmsfcp tax in the database")
+        taxes_dict = self._taxes_dict("icmsfcp")
+        taxes_dict["icms"] = dict(TAX_DICT_VALUES, base=1000.0)
+        try:
+            self.tax_icmsfcp._compute_icmsfcp(
+                self.tax_icmsfcp, taxes_dict, **self._kwargs()
+            )
+        except AttributeError as error:
+            self.fail(
+                "_compute_icmsfcp requires icms_cst_id, which the accounting "
+                "entry point cannot provide: %s" % error
+            )
+
+    def test_icmsfcp_with_and_without_icms_cst_id_agree(self):
+        """The two entry points must compute the same FCP for the same line.
+
+        One passes `icms_cst_id` (the fiscal line does), the other cannot (the
+        accounting side does not have the parameter). A tax value that depends on
+        which entry point was used means the fiscal document and the accounting
+        entries disagree on the same line.
+        """
+        if not self.tax_icmsfcp:
+            self.skipTest("no icmsfcp tax in the database")
+        cst = self.env["l10n_br_fiscal.cst"].search(
+            [("code", "=", "00"), ("tax_domain", "=", "icms")], limit=1
+        )
+        base_dict = {"icms": dict(TAX_DICT_VALUES, base=1000.0)}
+
+        with_cst = self._taxes_dict("icmsfcp")
+        with_cst.update({k: dict(v) for k, v in base_dict.items()})
+        self.tax_icmsfcp._compute_icmsfcp(
+            self.tax_icmsfcp, with_cst, **self._kwargs(icms_cst_id=cst)
+        )
+
+        without_cst = self._taxes_dict("icmsfcp")
+        without_cst.update({k: dict(v) for k, v in base_dict.items()})
+        self.tax_icmsfcp._compute_icmsfcp(
+            self.tax_icmsfcp, without_cst, **self._kwargs()
+        )
+
+        self.assertEqual(
+            with_cst["icmsfcp"].get("fcpst_value"),
+            without_cst["icmsfcp"].get("fcpst_value"),
+            "FCP-ST value depends on which entry point called the engine",
+        )
+
+    def test_compute_taxes_does_not_hide_programming_errors(self):
+        """An AttributeError raised inside a compute method must propagate.
+
+        `compute_taxes` wraps both the `getattr` lookup and the call to the
+        compute method in the same `try`, so any AttributeError raised while
+        computing a tax is caught and the generic formula is used instead. The
+        document is then posted with a plausible but wrong tax value, with
+        nothing in the log.
+        """
+        if not self.tax_icms:
+            self.skipTest("no icms tax with a percentage in the database")
+        marker = "raised on purpose by the test"
+
+        def boom(*args, **kwargs):
+            raise AttributeError(marker)
+
+        with patch.object(
+            type(self.tax_icms), "_compute_icms", side_effect=boom, create=True
+        ), self.assertRaises(AttributeError, msg=marker):
+            self.tax_icms.compute_taxes(**self._kwargs())


### PR DESCRIPTION
## Two related defects, pinned by tests

### 1. `compute_taxes` silently replaces a crashed computation with the generic formula

`l10n_br_fiscal/models/tax.py` wrapped both the `getattr` lookup and the call to
the per-domain compute method in the same `try`:

```python
try:
    compute_method = getattr(self, f"_compute_{tax.tax_domain}")
    taxes[tax.tax_domain].update(compute_method(tax, taxes, **kwargs))
except AttributeError:
    taxes[tax.tax_domain].update(tax._compute_tax(tax, taxes, **kwargs))
```

The intent is a fallback for tax domains that have no specialized method. But the
`except` also catches any `AttributeError` raised INSIDE `_compute_icms`,
`_compute_icmssn`, etc. (a `None` dereference, a typo, a field renamed in a
migration). When that happens the engine posts a plausible but wrong tax value
computed by the generic formula, with nothing in the log.

Fixed with `getattr(self, ..., None)`: the fallback behavior for domains without
a specialized method is unchanged, and programming errors now propagate.

### 2. The accounting entry point cannot provide `icms_cst_id`, and FCP crashes on it

`_compute_icmsfcp` did:

```python
icms_cst_id = kwargs.get("icms_cst_id")   # None when absent
...
if icms_cst_id.code in ICSM_CST_CSOSN_ST_BASE:   # AttributeError on None
```

`account.tax.compute_all` (l10n_br_account) has no `icms_cst_id` parameter in its
signature, so every call coming from the accounting side reaches this line with
`None` and raises. Combined with defect 1, the crash was invisible: on the
accounting side FCP silently fell back to the generic formula, while the fiscal
document side (which passes `icms_cst_id`) used the specialized one. Same line,
two different computations, depending on the entry point.

Fixed by defaulting to an empty recordset, the exact pattern `_compute_icms`
already uses:

```python
cst = kwargs.get("icms_cst_id", self.env["l10n_br_fiscal.cst"])
```

## The tests

`test_tax_engine_contract.py` pins the engine contract itself, on purpose without
relying on fiscal configuration or demo data (records are resolved by `search`,
and the compute methods are called directly with a well-formed tax dictionary):

- `test_icmsfcp_without_icms_cst_id`: the accounting entry point must be able to
  compute FCP;
- `test_icmsfcp_with_and_without_icms_cst_id_agree`: the two entry points must
  agree on the same line;
- `test_compute_taxes_does_not_hide_programming_errors`: an `AttributeError`
  raised inside a compute method must propagate (asserted by injecting one).

All three fail on current 16.0 and pass with this PR.

## Behavior change to be aware of

On the accounting side, FCP for CST/CSOSN in `ICSM_CST_CSOSN_ST_BASE` is now
computed by the specialized method instead of the silent generic fallback. That
is the intended correction, but databases that relied on the previous accounting
values will see them change. Flagging it for reviewers rather than hiding it.

## How this was found

Reviewing the engine after a performance investigation on a restored production
database: the `except AttributeError` showed up as the reason a crash in the FCP
path had never surfaced. Full module test suite runs with no new failures
relative to the same database without this change.