### PR TITLE
[16.0][IMP] l10n_br_account_withholding: resolver a SEFAZ estadual

### DIFF
--- a/l10n_br_account_withholding/models/account_move.py
+++ b/l10n_br_account_withholding/models/account_move.py
@@ -78,18 +78,7 @@ class AccountMove(models.Model):
         wh_date_invoice = move_line.move_id.date
         wh_due_invoice = wh_date_invoice.replace(day=fiscal_group.wh_due_day)
 
-        if fiscal_group.tax_scope == "city":
-            city_id = (
-                self.invoice_line_ids[0].issqn_fg_city_id
-                if self.invoice_line_ids[0].issqn_fg_city_id
-                else self.partner_id.city_id
-            )
-            partner_wh = self.env["res.partner"].search(
-                [("city_id", "=", city_id.id), ("wh_cityhall", "=", True)], limit=1
-            )
-            partner_id = partner_wh if partner_wh else fiscal_group.partner_id
-        else:
-            partner_id = fiscal_group.partner_id
+        partner_id = fiscal_group._get_tax_authority_partner(self)
 
         values = {
             "partner_id": partner_id.id,

--- a/l10n_br_account_withholding/models/l10n_br_fiscal_tax_group.py
+++ b/l10n_br_account_withholding/models/l10n_br_fiscal_tax_group.py
@@ -27,3 +27,29 @@ class FiscalTaxGroup(models.Model):
         domain="[('account_type', 'in', ('asset_receivable', 'liability_payable'))]",
         company_dependent=True,
     )
+
+    def _get_tax_authority_partner(self, move):
+        """Return the partner that collects this tax group for a given move.
+
+        The lookup depends on ``tax_scope``: city taxes are collected by the
+        city hall of the taxable event, state taxes by the treasury of the
+        state where the goods are delivered. When no specific authority is
+        registered, fall back to the partner set on the tax group itself.
+
+        :param move: the account.move that originated the tax.
+        :return: a res.partner recordset, possibly empty.
+        """
+        self.ensure_one()
+        authority = self.env["res.partner"]
+        if self.tax_scope == "city":
+            city = move.invoice_line_ids[:1].issqn_fg_city_id or move.partner_id.city_id
+            authority = authority.search(
+                [("city_id", "=", city.id), ("wh_cityhall", "=", True)], limit=1
+            )
+        elif self.tax_scope == "state":
+            state = move.partner_shipping_id.state_id or move.partner_id.state_id
+            authority = authority.search(
+                [("state_id", "=", state.id), ("wh_state_treasury", "=", True)],
+                limit=1,
+            )
+        return authority or self.partner_id

--- a/l10n_br_account_withholding/models/res_partner.py
+++ b/l10n_br_account_withholding/models/res_partner.py
@@ -8,8 +8,35 @@ from odoo.exceptions import ValidationError
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
-    # TODO: Add WH fields for State and Country
+    # TODO: Add WH field for Country
     wh_cityhall = fields.Boolean(string="Is City Hall?", default=False)
+
+    wh_state_treasury = fields.Boolean(
+        string="Is State Treasury?",
+        default=False,
+        help="Partner that collects state taxes withheld in this state, "
+        "such as ICMS. Used to fill the vendor of the withholding invoice "
+        "when the fiscal tax group scope is 'State'.",
+    )
+
+    @api.constrains("state_id", "wh_state_treasury")
+    def _check_unique_state_treasury(self):
+        for record in self:
+            if record.wh_state_treasury:
+                existing_count = self.sudo().search_count(
+                    [
+                        ("state_id", "=", record.state_id.id),
+                        ("wh_state_treasury", "=", True),
+                        ("id", "!=", record.id),
+                    ]
+                )
+                if existing_count > 0:
+                    raise ValidationError(
+                        _(
+                            "Only one partner with the same State Treasury can "
+                            "exist in the same state."
+                        )
+                    )
 
     @api.constrains("city_id", "wh_cityhall")
     def _check_unique_cityhall(self):

--- a/l10n_br_account_withholding/readme/CONFIGURE.md
+++ b/l10n_br_account_withholding/readme/CONFIGURE.md
@@ -5,3 +5,5 @@ Configure a geração de faturas de retenção de impostos no Odoo seguindo este
 2. **Configure os Impostos Retidos:** Para cada imposto que requer uma fatura de retenção, garanta que esteja corretamente configurado. Defina um fornecedor, o diário e uma conta pagável para a geração da fatura do imposto se necessário. Se um diário não for especificado, o módulo usará o diário da fatura de compra original. A conta pagável é opicional, se não definida será utilizada a conta padrão do parceiro.
 
 3. **Definir uma Prefeitura para o ISSQN:** Crie ou edite um parceiro, vá até a aba "Fiscal" e marque a opção "É Prefeitura".
+
+4. **Definir uma Secretaria da Fazenda estadual:** para grupos de imposto com abrangência "Estado" (ICMS e derivados), crie ou edite um parceiro da SEFAZ, informe o estado e marque a opção "É Secretaria da Fazenda Estadual". Só pode existir um parceiro assim por estado. Se nenhum for encontrado, o módulo usa o fornecedor definido no grupo de imposto.

--- a/l10n_br_account_withholding/tests/test_account_wh_invoice.py
+++ b/l10n_br_account_withholding/tests/test_account_wh_invoice.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import Command, fields
+from odoo.exceptions import ValidationError
 from odoo.tests.common import tagged
 
 from odoo.addons.l10n_br_account.tests.common import AccountMoveBRCommon
@@ -533,3 +534,58 @@ class AccountMoveWithWhInvoice(AccountMoveBRCommon):
                 for pay_line in payable_line_ids
             )
         )
+
+    def _create_state_treasury(self, name, state_ref):
+        return self.env["res.partner"].create(
+            {
+                "name": name,
+                "state_id": self.env.ref(state_ref).id,
+                "country_id": self.env.ref("base.br").id,
+                "wh_state_treasury": True,
+            }
+        )
+
+    def test_state_scope_resolves_state_treasury(self):
+        """A state scoped tax group resolves the treasury of the delivery state."""
+        tax_group = self.env.ref("l10n_br_fiscal.tax_group_icmsst")
+        self.assertEqual(tax_group.tax_scope, "state")
+        treasury = self._create_state_treasury("SEFAZ SP", "base.state_br_sp")
+
+        move = self.move_in_compra_para_revenda
+        move.partner_id.state_id = self.env.ref("base.state_br_sp")
+
+        self.assertEqual(tax_group._get_tax_authority_partner(move), treasury)
+
+    def test_state_scope_uses_delivery_state(self):
+        """The delivery address wins over the invoice address."""
+        tax_group = self.env.ref("l10n_br_fiscal.tax_group_icmsst")
+        self._create_state_treasury("SEFAZ SP", "base.state_br_sp")
+        treasury_rj = self._create_state_treasury("SEFAZ RJ", "base.state_br_rj")
+
+        move = self.move_in_compra_para_revenda
+        move.partner_id.state_id = self.env.ref("base.state_br_sp")
+        move.partner_shipping_id = self.env["res.partner"].create(
+            {
+                "name": "Filial RJ",
+                "state_id": self.env.ref("base.state_br_rj").id,
+                "country_id": self.env.ref("base.br").id,
+            }
+        )
+
+        self.assertEqual(tax_group._get_tax_authority_partner(move), treasury_rj)
+
+    def test_state_scope_falls_back_to_tax_group_partner(self):
+        """Without a registered treasury, the tax group partner is used."""
+        tax_group = self.env.ref("l10n_br_fiscal.tax_group_icmsst")
+        tax_group.partner_id = self.test_partner
+
+        move = self.move_in_compra_para_revenda
+        move.partner_id.state_id = self.env.ref("base.state_br_ac")
+
+        self.assertEqual(tax_group._get_tax_authority_partner(move), self.test_partner)
+
+    def test_unique_state_treasury(self):
+        """Only one treasury partner may exist per state."""
+        self._create_state_treasury("SEFAZ SP", "base.state_br_sp")
+        with self.assertRaises(ValidationError):
+            self._create_state_treasury("SEFAZ SP duplicada", "base.state_br_sp")

--- a/l10n_br_account_withholding/views/res_partner.xml
+++ b/l10n_br_account_withholding/views/res_partner.xml
@@ -11,6 +11,7 @@
         <field name="arch" type="xml">
             <xpath expr="//group[@name='other_infos']" position="inside">
                 <field name="wh_cityhall" />
+                <field name="wh_state_treasury" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
## O que muda

O módulo já resolve o credor do tributo quando o escopo do grupo fiscal é a cidade: busca o parceiro marcado como "É Prefeitura" naquele município. Para o escopo estado, que é o caso do ICMS e derivados, ele caía no parceiro fixo do grupo e ignorava a UF, o que não serve para quem recolhe em mais de um estado.

Este PR fecha o `# TODO: Add WH fields for State and Country` que já estava no `res_partner.py`, acrescentando:

- o campo "É Secretaria da Fazenda Estadual" no parceiro, com constraint de um por estado, espelhando o que já existe para prefeitura;
- o ramo de resolução por UF, que usa o endereço de entrega e cai no de faturamento quando não houver;
- a extração da resolução para o método público `_get_tax_authority_partner(move)` no `l10n_br_fiscal.tax.group`, para que outros módulos reusem em vez de duplicar a busca.

O comportamento para cidade e o fallback para o parceiro do grupo não mudam.

## Por que

Os grupos `icmsst`, `icmsfcpst` e `icmsfcp` já vêm com `tax_scope = "state"` no `l10n_br_fiscal.tax.group.csv`, então o ramo estado já estava previsto nos dados e faltava no código.

Surgiu enquanto eu desenhava a emissão de GNRE, que precisa exatamente disso, mas o PR tem valor próprio e não depende de nada da GNRE: serve para qualquer retenção de tributo estadual.

## Testes

Quatro testes novos: resolução pela UF, precedência do endereço de entrega sobre o de faturamento, fallback para o parceiro do grupo, e a constraint de unicidade. Rodados em Odoo 16 com os 3 testes existentes do módulo, `0 failed, 0 error(s) of 7 tests`.

## Observação

No `_prepare_wh_invoice` original havia `self.invoice_line_ids[0]`, que levanta `IndexError` se a fatura não tiver linhas. Troquei por `[:1]`, que cai no fallback em vez de estourar. É mudança de comportamento num caso de borda, então avisem se preferirem que eu reverta.
