### PR TITLE
[14.0][IMP] l10n_br_account_payment_brcobranca: enable Itau CNAB 240 cobranca

### DIFF
--- a/l10n_br_account_payment_brcobranca/constants/br_cobranca.py
+++ b/l10n_br_account_payment_brcobranca/constants/br_cobranca.py
@@ -32,7 +32,7 @@ DICT_BRCOBRANCA_BANK = {
     "104": BankRecord("caixa", retorno=["240"], remessa=["240"]),
     "136": BankRecord("unicred", retorno=["400"], remessa=["240", "400"]),
     "237": BankRecord("bradesco", retorno=["400"], remessa=["400"]),
-    "341": BankRecord("itau", retorno=["400"], remessa=["400"]),
+    "341": BankRecord("itau", retorno=["400", "240"], remessa=["400", "240"]),
     "399": BankRecord("hsbc", retorno=[], remessa=[]),
     "745": BankRecord("citibank", retorno=[], remessa=["400"]),
     "748": BankRecord("sicredi", retorno=["240"], remessa=["240"]),

--- a/l10n_br_account_payment_brcobranca/parser/cnab_file_parser.py
+++ b/l10n_br_account_payment_brcobranca/parser/cnab_file_parser.py
@@ -105,8 +105,12 @@ class CNABFileParser(FileParser):
     def _get_date_format(self, bank_name_brcobranca):
         # TODO: Idealmente o JSON de Retorno do BRCobranca deveria vir
         #  padronizado para não ser necessário ser feito esse tratamento aqui
-        if bank_name_brcobranca in ("ailos", "santander"):
-            # No Banco AILOS e Santander o formato da Data é completo com os 4 digitos.
+        if bank_name_brcobranca in ("ailos", "santander") or (
+            bank_name_brcobranca == "itau" and self.parser_name == "cnab240"
+        ):
+            # No Banco AILOS, Santander, e no Itau no CNAB 240 (o CNAB 400
+            # do Itau continua com 2 digitos), o formato da Data é completo
+            # com os 4 digitos.
             zeros_date = "00000000"
             date_format = "%d%m%Y"
         else:
@@ -115,6 +119,24 @@ class CNABFileParser(FileParser):
             date_format = "%d%m%y"
 
         return zeros_date, date_format
+
+    def _get_registration_code_allowed(self, bank_name_brcobranca):
+        if bank_name_brcobranca in ("ailos", "santander"):
+            # No AILOS e Santander o código de registro onde ficam as linhas CNAB é o 3.
+            return 3
+        if bank_name_brcobranca == "itau" and self.parser_name == "cnab240":
+            # No CNAB 240 o codigo de registro (posicao 8 do arquivo, padrao
+            # Febraban) e sempre 3 para os registros de detalhe (segmentos
+            # T e U). O CNAB 400 do Itau continua com o codigo de registro 1.
+            return 3
+        if bank_name_brcobranca == "banco_brasil":
+            # No Banco do Brasil o código do registro principal é o 7.
+            # existem registros opcionais porém como não estão mapeados no BRCobrança
+            # e serão ignorados aqui. Teoricamente a verificação do código do registro
+            # nem deveria se feita aqui, cada dict retornado da lib era pra representar
+            # um registro completo do boleto. Esse tratamento deveria estar lá.
+            return 7
+        return 1
 
     def process_return_file(self, data):
         #          Forma de Lançamento do Retorno
@@ -183,18 +205,9 @@ class CNABFileParser(FileParser):
 
         bank_name_brcobranca = dict_brcobranca_bank[self.bank.code_bc]
 
-        if bank_name_brcobranca in ("ailos", "santander"):
-            # No AILOS e Santander o código de registro onde ficam as linhas CNAB é o 3.
-            registration_code_allowed = 3
-        elif bank_name_brcobranca == "banco_brasil":
-            # No Banco do Brasil o código do registro principal é o 7.
-            # existem registros opcionais porém como não estão mapeados no BRCobrança
-            # e serão ignorados aqui. Teoricamente a verificação do código do registro
-            # nem deveria se feita aqui, cada dict retornado da lib era pra representar
-            # um registro completo do boleto. Esse tratamento deveria estar lá.
-            registration_code_allowed = 7
-        else:
-            registration_code_allowed = 1
+        registration_code_allowed = self._get_registration_code_allowed(
+            bank_name_brcobranca
+        )
 
         for linha_cnab in data:
             if int(linha_cnab["codigo_registro"]) != registration_code_allowed:


### PR DESCRIPTION
@Escodoo 

[SO868-3]

cc @marcelsavegnago @CristianoMafraJunior @WesleyOliveira98

O Itaú estava fixado apenas em CNAB 400 no DICT_BRCOBRANCA_BANK, bloqueando remessa/retorno CNAB 240 mesmo depois que o brcobranca ganhar suporte a isso (ver [kivanio/brcobranca#280](https://github.com/kivanio/brcobranca/pull/280), que adiciona a remessa e o retorno CNAB 240 de cobrança do Itaú).

Também estende dois trechos de parsing específicos do CNAB 240 no CNABFileParser (já com tratamento especial para Ailos/Santander) para cobrir o CNAB 240 do Itaú, condicionado ao parser_name para não afetar o retorno CNAB 400 do Itaú (que continua no formato atual):

- As datas do CNAB 240 do Itaú usam ano com 4 dígitos (DDMMAAAA), diferente do CNAB 400 (ano com 2 dígitos).
- O registration_code_allowed precisa ser 3 para os registros de detalhe do CNAB 240 (o "tipo de registro" padrão Febraban dos segmentos T/U), e não o valor padrão 1 usado no CNAB 400.

Depende do serviço boleto_cnab_api rodar uma versão do brcobranca que inclua o suporte a CNAB 240 do Itaú (ainda não publicado no repositório oficial — acompanhar a PR #280 acima).