### PR TITLE
[16.0][FIX] l10n_br_base: falso positivo de CNPJ/CPF duplicado com cnpj_cpf_stripped vazio

### DIFF
--- a/l10n_br_base/__manifest__.py
+++ b/l10n_br_base/__manifest__.py
@@ -10,7 +10,7 @@
     "maintainers": ["renatonlima", "rvalyi"],
     "website": "https://github.com/OCA/l10n-brazil",
     "depends": ["base", "base_setup", "base_address_extended"],
-    "version": "16.0.6.5.3",
+    "version": "16.0.6.6.0",
     "data": [
         "security/ir.model.access.csv",
         "data/res.city.csv",

--- a/l10n_br_base/migrations/16.0.6.6.0/post-migration.py
+++ b/l10n_br_base/migrations/16.0.6.6.0/post-migration.py
@@ -1,0 +1,61 @@
+# Copyright (C) 2026 - Felipe Motter Pereira - Trento Química
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import logging
+
+from openupgradelib import openupgrade
+
+_logger = logging.getLogger(__name__)
+
+MODELS = ("res.partner", "res.company")
+
+
+def recompute_cnpj_cpf_stripped(env):
+    """Repopulate ``cnpj_cpf_stripped`` where it got out of sync with ``vat``.
+
+    ``cnpj_cpf_stripped`` is a stored computed field depending on ``vat``, but
+    the 16.0.2.0.0 pre-migration copied the legacy ``cnpj_cpf`` column into
+    ``vat`` with a raw UPDATE:
+
+        UPDATE res_partner SET vat = cnpj_cpf
+         WHERE vat IS NULL AND cnpj_cpf IS NOT NULL;
+
+    Raw SQL does not trigger a recompute, so every record it touched kept
+    ``vat`` filled and ``cnpj_cpf_stripped`` NULL. Until now that was harmless
+    because the duplicate check was dead code; it started reporting unrelated
+    partners as duplicates once the check was revived.
+
+    Recompute through the ORM rather than a SQL regexp: the compute uses
+    ``str.isalnum()``, which keeps the alphanumeric CNPJ of NT 2025.001.
+    """
+    for model_name in MODELS:
+        model = env[model_name].with_context(active_test=False)
+        # Both fields are Char, so "empty" may be NULL or an empty string --
+        # and ("vat", "!=", False) alone only maps to `vat IS NOT NULL`, which
+        # would wrongly pick up records whose vat is '' (empty stripped is
+        # correct for those).
+        records = model.search(
+            [
+                ("vat", "not in", [False, ""]),
+                "|",
+                ("cnpj_cpf_stripped", "=", False),
+                ("cnpj_cpf_stripped", "=", ""),
+            ]
+        )
+        if not records:
+            continue
+
+        records.modified(["vat"])
+        records._compute_cnpj_cpf_stripped()
+        records.flush_recordset()
+        _logger.info(
+            "%s: recomputed cnpj_cpf_stripped on %d record(s)",
+            model_name,
+            len(records),
+        )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if not version:
+        return
+    recompute_cnpj_cpf_stripped(env)

--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -103,8 +103,12 @@ class Partner(models.Model):
         for record in self:
             domain = []
 
+            # `continue`, not `return`: this is a per-record check, and
+            # returning would silently skip every remaining record of the
+            # recordset -- on a batch create, a single partner without a vat
+            # would disable the check for all the ones after it.
             if not record.vat:
-                return
+                continue
 
             if self.env.context.get(
                 "disable_allow_cnpj_multi_ie"

--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -158,8 +158,19 @@ class Partner(models.Model):
             if not stripped_vat:
                 continue
 
+            # Match the raw `vat` as well: normalizing from `vat` only fixes
+            # this side of the comparison, and the searched column is still the
+            # stored `cnpj_cpf_stripped`. A *counterpart* left out of sync by a
+            # raw SQL write would otherwise be invisible here, so a real
+            # duplicate would go through. `vat` is indexed in `base`, and both
+            # spellings are needed because the counterpart may hold the
+            # document either as typed or already unmasked. A counterpart
+            # out of sync *and* holding a different mask is only reachable
+            # through raw SQL, and is what the 16.0.6.6.0 migration repairs.
             domain += [
+                "|",
                 ("cnpj_cpf_stripped", "=", stripped_vat),
+                ("vat", "in", [record.vat, stripped_vat]),
                 ("id", "!=", record.id),
                 ("parent_id", "!=", record.id),
             ]

--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -143,6 +143,14 @@ class Partner(models.Model):
             # out of sync. An empty value would turn the clause below into
             # ("cnpj_cpf_stripped", "=", False) and match every *other*
             # out-of-sync record, reporting an unrelated partner as a duplicate.
+            #
+            # An empty normalized document is not only an out-of-sync value:
+            # `base` documents `vat = "/"` as "this partner is not subject to
+            # tax", and no character of it is alphanumeric, so the compute
+            # legitimately stores an empty string. The clause would then read
+            # ("cnpj_cpf_stripped", "=", "") and match every *other* tax-exempt
+            # partner, reporting two of them as duplicates of each other. Skip
+            # the record instead of searching for an empty document.
             # NOTE for the v19 migration: once `vat` is stored unformatted and
             # `cnpj_cpf_stripped` is retired, comparing by `vat` directly here is
             # enough.

--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -127,16 +127,27 @@ class Partner(models.Model):
                     ("parent_id", "not in", record.parent_id.ids),
                 ]
 
-            # Compare by the normalized CNPJ/CPF (cnpj_cpf_stripped, without mask)
-            # so the same number typed with a different mask is still detected as
-            # a duplicate: `vat` is only normalized when written through the
+            # Compare by the normalized CNPJ/CPF (without mask) so the same
+            # number typed with a different mask is still detected as a
+            # duplicate: `vat` is only normalized when written through the
             # `cnpj_cpf` alias, so a direct `vat` write could store a different
             # mask and slip past a raw `vat` comparison.
+            #
+            # Normalize from `vat` instead of reading the stored
+            # `cnpj_cpf_stripped`: the latter is a stored computed field, so a
+            # raw SQL write on `vat` (a data migration, a bulk import) leaves it
+            # out of sync. An empty value would turn the clause below into
+            # ("cnpj_cpf_stripped", "=", False) and match every *other*
+            # out-of-sync record, reporting an unrelated partner as a duplicate.
             # NOTE for the v19 migration: once `vat` is stored unformatted and
             # `cnpj_cpf_stripped` is retired, comparing by `vat` directly here is
             # enough.
+            stripped_vat = "".join(char for char in record.vat if char.isalnum())
+            if not stripped_vat:
+                continue
+
             domain += [
-                ("cnpj_cpf_stripped", "=", record.cnpj_cpf_stripped),
+                ("cnpj_cpf_stripped", "=", stripped_vat),
                 ("id", "!=", record.id),
                 ("parent_id", "!=", record.id),
             ]

--- a/l10n_br_base/tests/test_duplicate_cnpj.py
+++ b/l10n_br_base/tests/test_duplicate_cnpj.py
@@ -146,3 +146,30 @@ class DuplicateCnpjTest(TransactionCase):
         # the old code the empty domain matched any record with an empty stored
         # value, so the error was raised for the wrong partner.
         self.assertIn(original.name, capture.exception.args[0])
+
+    def test_tax_exempt_partners_are_not_duplicates(self):
+        """Two partners "not subject to tax" are not duplicates of each other.
+
+        ``base`` documents ``vat = "/"`` as "the partner is not subject to
+        tax", and ``_compute_cnpj_cpf_stripped`` only keeps alphanumeric
+        characters, so the stored document is legitimately an empty string --
+        with the compute perfectly in sync, no raw SQL write involved. Without
+        the guard the clause degrades to ("cnpj_cpf_stripped", "=", "") and
+        every other tax-exempt partner matches.
+
+        Note this is a distinct state from a partner with no ``vat`` at all,
+        which stores NULL and is therefore never matched by that clause.
+        """
+        # is_company=False: for a document that is not a valid CNPJ, the check
+        # only reports duplicates on individuals (the CPF/RG branch).
+        exempt_vals = {
+            "is_company": False,
+            "country_id": self.env.ref("base.us").id,
+            "vat": "/",
+        }
+        self.partner_model.create(dict(exempt_vals, name="Tax exempt 1"))
+        second = self.partner_model.create(dict(exempt_vals, name="Tax exempt 2"))
+
+        # Must not raise, neither on the create above nor on an explicit
+        # re-check.
+        second._check_cnpj_l10n_br_ie_code()

--- a/l10n_br_base/tests/test_duplicate_cnpj.py
+++ b/l10n_br_base/tests/test_duplicate_cnpj.py
@@ -147,6 +147,23 @@ class DuplicateCnpjTest(TransactionCase):
         # value, so the error was raised for the wrong partner.
         self.assertIn(original.name, capture.exception.args[0])
 
+    def test_out_of_sync_counterpart_still_detects_duplicate(self):
+        """A real duplicate is still caught when the *counterpart* -- the
+        record already stored -- is the one out of sync.
+
+        Normalizing from ``vat`` only fixes the side being validated: the
+        searched column remains the stored ``cnpj_cpf_stripped``, which is
+        empty on the counterpart, so the duplicate would go through unnoticed.
+        The domain matches the raw ``vat`` as well to cover it.
+        """
+        original = self._create_partner("Google 1", self.google_cnpj)
+        self._desync_stripped(original)
+
+        with self.assertRaises(ValidationError) as capture:
+            self._create_partner("Google 2", self.google_cnpj)
+
+        self.assertIn(original.name, capture.exception.args[0])
+
     def test_tax_exempt_partners_are_not_duplicates(self):
         """Two partners "not subject to tax" are not duplicates of each other.
 

--- a/l10n_br_base/tests/test_duplicate_cnpj.py
+++ b/l10n_br_base/tests/test_duplicate_cnpj.py
@@ -88,3 +88,61 @@ class DuplicateCnpjTest(TransactionCase):
         self._create_partner_with_ie("Branch 1", self.google_cnpj, "111111111")
         with self.assertRaises(ValidationError):
             self._create_partner_with_ie("Branch 2", self.google_cnpj, "111111111")
+
+    def _desync_stripped(self, partner):
+        """Reproduce the effect of a raw SQL write on ``vat``.
+
+        ``cnpj_cpf_stripped`` is a stored computed field, so a plain UPDATE
+        (a data migration, a bulk import) leaves it behind. This is the state
+        the 16.0.2.0.0 pre-migration left on every record it touched.
+        """
+        # Flush first: right after create the computed value is still pending,
+        # and the ORM would write it back over the raw UPDATE below.
+        partner.flush_recordset(["cnpj_cpf_stripped"])
+        self.env.cr.execute(
+            "UPDATE res_partner SET cnpj_cpf_stripped = NULL WHERE id = %s",
+            (partner.id,),
+        )
+        partner.invalidate_recordset(["cnpj_cpf_stripped"])
+        self.assertFalse(
+            partner.cnpj_cpf_stripped, "setup failed: the field is still in sync"
+        )
+
+    def test_out_of_sync_stripped_is_not_a_duplicate(self):
+        """Records with an out-of-sync ``cnpj_cpf_stripped`` and *distinct*
+        CNPJs must not be reported as duplicates of each other.
+
+        Before the fix the domain was built from the stored (empty) value, so
+        it became ("cnpj_cpf_stripped", "=", False) and matched every other
+        out-of-sync record -- flagging a completely unrelated partner.
+        """
+        first = self._create_partner("Google", self.google_cnpj)
+        second = self._create_partner("Other Co", self.other_cnpj)
+        self._desync_stripped(first)
+        self._desync_stripped(second)
+
+        # Must not raise: the two hold different CNPJs.
+        second._check_cnpj_l10n_br_ie_code()
+
+    def test_out_of_sync_stripped_still_detects_duplicate(self):
+        """A real duplicate is still caught when the stored value is empty,
+        because the comparison normalizes from ``vat`` itself."""
+        original = self._create_partner("Google 1", self.google_cnpj)
+        # allow_vat_duplicate bypasses the check on create so the test can set
+        # up the duplicate it wants to assert on.
+        duplicate = self.partner_model.with_context(allow_vat_duplicate=True).create(
+            dict(self.base_vals, name="Google 2", vat=self.google_cnpj)
+        )
+        self._desync_stripped(duplicate)
+
+        # Drop allow_vat_duplicate before asserting: the recordset carries the
+        # context it was created with, and the check bails out early on it.
+        with self.assertRaises(ValidationError) as capture:
+            duplicate.with_context(
+                allow_vat_duplicate=False
+            )._check_cnpj_l10n_br_ie_code()
+
+        # Assert *which* record is reported. Raising alone is not enough: with
+        # the old code the empty domain matched any record with an empty stored
+        # value, so the error was raised for the wrong partner.
+        self.assertIn(original.name, capture.exception.args[0])


### PR DESCRIPTION
## Resumo

A validação de CNPJ/CPF duplicado acusa duplicidade contra um cadastro **sem relação nenhuma** quando o campo `cnpj_cpf_stripped` está dessincronizado do `vat`. Em produção isso trava a edição de qualquer contato afetado — no nosso caso, abrir a condição comercial de um cliente que tem "comprador" cadastrado.

## Como reproduzir

Cliente com contato-filho cujo `cnpj_cpf_stripped` está vazio mas o `vat` está preenchido. Ao editar qualquer campo que toque `vat`/`l10n_br_ie_code`:

```
There is already a partner COMPRAS (ID 524) with this CPF/RG! 27.390.622/0001-20
```

O `COMPRAS (ID 524)` não tem relação com o cliente editado. Dois sinais de que a mensagem está errada:

- o partner citado é apenas o **primeiro do `_order`** (`display_name ASC, id DESC`) entre os registros dessincronizados;
- o documento exibido é o do *match*, não o do registro validado — por isso a mensagem fala em "CPF/RG" e mostra um CNPJ.

## Causa raiz

`_check_cnpj_l10n_br_ie_code` compara pelo `cnpj_cpf_stripped` **armazenado**, sem guarda para valor vazio. Com o campo vazio a cláusula degrada para:

```python
("cnpj_cpf_stripped", "=", False)
```

que casa com todos os *outros* registros igualmente dessincronizados.

`cnpj_cpf_stripped` é `store=True` com `@api.depends("vat")`, então qualquer escrita SQL crua em `vat` o deixa para trás. Foi exatamente o que fez `l10n_br_base/migrations/16.0.2.0.0/pre-migration.py`:

```sql
UPDATE res_partner SET vat = cnpj_cpf
 WHERE vat IS NULL AND cnpj_cpf IS NOT NULL;
```

Na nossa base isso atingiu **698 cadastros** — 693 deles contatos-filhos, o que faz sentido: `_commercial_sync_from_company` exclui o `vat` da sincronização pai→filho, então esses contatos tinham `cnpj_cpf` legado do v14 e `vat` vazio, justamente o alvo do UPDATE.

A inconsistência era inofensiva enquanto a validação era código morto. Ela passou a aparecer com `4e41408dce` (`[FIX] l10n_br_base: detecta CNPJ/CPF duplicado ignorando a formatação`), que removeu o `return` que matava o check e trocou a comparação para `cnpj_cpf_stripped`. **O commit não introduziu o problema** — apenas acordou a validação, que passou a tropeçar num dado já inconsistente desde a migration.

### Por que não apareceu antes

O falso positivo **não reproduz em base limpa**: exige registros com `vat` preenchido e `cnpj_cpf_stripped` vazio, estado que só existe onde a pre-migration da 16.0.2.0.0 passou — ou seja, bases migradas da v14. Num banco novo, ou no runboat, os dois campos sempre nascem em sincronia e a validação se comporta corretamente. É por isso que o problema passou pelo review da #4628 e só apareceu em produção.

## Solução

**1. Normalizar a partir do `vat` no momento da checagem**, em vez de confiar no valor armazenado, e pular o registro se o documento normalizado for vazio. A validação deixa de depender de um campo que pode estar defasado.

> **Isto não desfaz a #4628.** O objetivo dela — detectar o mesmo documento digitado com formatação diferente — continua atendido: seguimos comparando pelo número normalizado, com a mesma regra (`str.isalnum()`), apenas calculada a partir do `vat` em vez de lida do campo armazenado. Os testes dela (`test_dup_same_format`, `test_dup_different_format`, `test_distinct_cnpj_allowed`, os dois de `multi_ie`) continuam passando sem alteração. A mudança é de *fonte* do valor, não de critério.

**2. Post-migration** repopulando o campo em `res.partner` e `res.company` (ambos herdam `l10n_br_base.party.mixin`, logo ambos têm o campo e a mesma exposição). Recomputa pelo ORM, não por SQL: o compute usa `str.isalnum()`, que preserva o **CNPJ alfanumérico da NT 2025.001** — um `regexp_replace` não seria equivalente.

**3. `return` → `continue`** (commit separado). O método itera o recordset mas retornava quando um registro não tinha `vat`, pulando silenciosamente a validação de todos os seguintes num create/write em lote. É um defeito adjacente e independente; se preferirem, dá para removê-lo desta PR.

## Testes

Dois testes de regressão em `test_duplicate_cnpj.py`, verificados nos dois sentidos:

**Sem o fix:**
```
ERROR: DuplicateCnpjTest.test_out_of_sync_stripped_is_not_a_duplicate
  ValidationError: There is already a partner Acme Corporation (ID 10) with this CNPJ 02.960.895/0001-31!
FAIL:  DuplicateCnpjTest.test_out_of_sync_stripped_still_detects_duplicate
1 failed, 1 error(s) of 56 tests
```

**Com o fix:**
```
0 failed, 0 error(s) of 56 tests
```

Dois cuidados no fixture que valem menção, porque sem eles os testes passavam sem testar nada:

- o helper **dá flush antes** do UPDATE cru — logo após o `create` o valor computado ainda está pendente e o ORM o regravaria por cima — e **afirma** que o campo realmente ficou vazio, para o teste não passar sobre um setup silenciosamente inválido;
- o segundo teste afirma **qual** duplicado é apontado, não apenas que levanta: com o código antigo o domínio degradado casava qualquer registro de valor vazio, então ele levantava — pelo partner errado.

## Convergência com a #4671 (18.0)

A [#4671](https://github.com/OCA/l10n-brazil/pull/4671) (`[18.0][REF] armazenar CNPJ/CPF sem formatação`) ataca a mesma raiz e chega à mesma conclusão no constraint:

```diff
-                ("cnpj_cpf_stripped", "=", record.cnpj_cpf_stripped),
+            cnpj_cpf_stripped = punctuation_rm(str(rec_dict["cnpj_cpf"]))
+                ("vat", "=", cnpj_cpf_stripped),
```

Ou seja: parar de confiar no valor armazenado e normalizar o documento na hora da checagem. Chegamos a isso de forma independente, partindo de um bug em produção — a convergência sugere que é a direção correta.

A diferença é o alcance: a #4671 é um `[REF]` de base 18.0, com migration própria e 6 arquivos. A **16.0 fica sem correção**, e não localizamos backport nem qualquer outra PR (aberta ou fechada) tratando do falso positivo. Esta PR é deliberadamente mínima para caber numa série estável.

## Ressalva: duplicidades reais que o bug mascarava

Depois de repopular o campo, alguns cadastros **continuam** acusando duplicidade — na nossa base, 17 de 3791, formando ~8 pares genuinamente duplicados (quatro contatos com o CNPJ da mesma empresa, dois cadastros da mesma pessoa física, etc.).

Isso é esperado e desejável: são duplicidades verdadeiras que o domínio degradado escondia. Elas passam a ser reportadas com a mensagem correta, apontando o duplicado de verdade. Vale registrar para quem aplicar a migration não interpretar esses casos como efeito colateral.

## Nota operacional

A correção de dado já foi aplicada por script na base onde o problema apareceu; a post-migration cobre quem atualizar o módulo sem ter feito isso.


## Uso de IA

Esta contribuição foi desenvolvida com assistência de IA, conforme a [política de IA da OCA](https://github.com/OCA/.github/blob/master/AI_POLICY.md). Os três commits trazem o trailer correspondente:

```
Assisted-by: Claude Opus 5
```

O diagnóstico da causa raiz, o fix e os testes foram revisados e são de minha responsabilidade integral.

