### PR TITLE
[16.0][FIX] l10n_br_account: pula impostos sem XML ID no load_fiscal_taxes

### DIFF
--- a/l10n_br_account/models/account_chart_template.py
+++ b/l10n_br_account/models/account_chart_template.py
@@ -57,8 +57,8 @@ class AccountChartTemplate(models.Model):
                 )
 
                 for tax in taxes:
-                    if tax.get_external_id():
-                        tax_ref = tax.get_external_id().get(tax.id)
+                    tax_ref = tax.get_external_id().get(tax.id)
+                    if tax_ref:
                         ref_module, ref_name = tax_ref.split(".")
                         ref_name = ref_name.replace(str(company.id) + "_", "")
                         template_source_ref = ".".join(["l10n_br_coa", ref_name])

--- a/l10n_br_account/tests/test_account_taxes.py
+++ b/l10n_br_account/tests/test_account_taxes.py
@@ -41,3 +41,32 @@ class TestAccountTaxes(TransactionCase):
                     is_fiscal_taxes = True
 
             assert is_fiscal_taxes, "There are not fiscal taxes related"
+
+    def test_load_fiscal_taxes_manual_tax(self):
+        """Taxes created by hand have no XML ID and must be skipped"""
+        coa_template = self.env["account.chart.template"].create(
+            {
+                "name": "Plano de Contas Teste",
+                "parent_id": self.env.ref("l10n_br_coa.l10n_br_coa_template").id,
+                "currency_id": self.env.ref("base.BRL").id,
+                "bank_account_code_prefix": "1.1.1.2",
+                "cash_account_code_prefix": "1.1.1.1",
+                "transfer_account_code_prefix": "1.1.1.3",
+            }
+        )
+        self.l10n_br_company.chart_template_id = coa_template
+        manual_tax = self.env["account.tax"].create(
+            {
+                "name": "IRRF Manual",
+                "amount": 1.5,
+                "amount_type": "percent",
+                "type_tax_use": "sale",
+                "company_id": self.l10n_br_company.id,
+            }
+        )
+
+        self.assertFalse(manual_tax.get_external_id().get(manual_tax.id))
+
+        coa_template.load_fiscal_taxes()
+
+        self.assertFalse(manual_tax.fiscal_tax_ids)


### PR DESCRIPTION
Instalar o `l10n_br_account` num banco que tenha algum `account.tax` criado na mão quebra o `post_init_hook`.

Para reproduzir:

1. Instalar o `l10n_br_coa` e carregar um plano brasileiro numa empresa.
2. Criar um `account.tax` na mão pela interface nessa empresa.
3. Instalar o `l10n_br_account`.

O install estoura em `account_chart_template.py:62` com `ValueError: not enough values to unpack (expected 2, got 1)`.

O `load_fiscal_taxes` passa a ler o external ID antes de testar e pula os impostos que não têm. Imposto criado na mão não veio de `account.tax.template`, então não tem `fiscal_tax_ids` pra herdar. Na 17.0 e na 18.0 o método já foi reescrito no `template_br_oca.py` e resolve tudo com `raise_if_not_found=False`.

O mesmo erro já tinha sido reportado em #2462, na 14.0, quando o código ainda estava no `hooks.py`. A issue foi fechada por inatividade.
