### PR TITLE
[16.0][IMP] l10n_br_fiscal: indicador de consumidor final na linha de operação

### DIFF
--- a/l10n_br_account/models/fiscal_operation.py
+++ b/l10n_br_account/models/fiscal_operation.py
@@ -39,8 +39,10 @@ class Operation(models.Model):
         company_dependent=True,
     )
 
-    def _line_domain(self, company, partner, product):
-        domain = super()._line_domain(company=company, partner=partner, product=product)
+    def _line_domain(self, company, partner, product, ind_final=None):
+        domain = super()._line_domain(
+            company=company, partner=partner, product=product, ind_final=ind_final
+        )
 
         domain += [
             "|",

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -291,7 +291,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
             return {f"default_{k}": vals[k] for k in vals.keys()}
         return vals
 
-    @api.depends("fiscal_operation_id", "partner_id", "product_id")
+    @api.depends("fiscal_operation_id", "partner_id", "product_id", "ind_final")
     def _compute_fiscal_operation_line_id(self):
         for line in self:
             if line.fiscal_operation_id:
@@ -300,6 +300,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
                         company=line.company_id,
                         partner=line.partner_id,
                         product=line.product_id,
+                        ind_final=line.ind_final,
                     )
                 )
 

--- a/l10n_br_fiscal/models/operation.py
+++ b/l10n_br_fiscal/models/operation.py
@@ -223,7 +223,7 @@ class Operation(models.Model):
 
         return serie
 
-    def _line_domain(self, company, partner, product):
+    def _line_domain(self, company, partner, product, ind_final=None):
         domain = [
             ("fiscal_operation_id", "=", self.id),
             ("fiscal_operation_type", "=", self.fiscal_operation_type),
@@ -275,14 +275,23 @@ class Operation(models.Model):
             ("icms_origin", "=", False),
         ]
 
+        if ind_final:
+            domain += [
+                "|",
+                ("ind_final", "=", ind_final),
+                ("ind_final", "=", False),
+            ]
+
         return domain
 
-    def line_definition(self, company, partner, product):
+    def line_definition(self, company, partner, product, ind_final=None):
         self.ensure_one()
         if not company:
             company = self.env.company
 
-        lines = self.line_ids.search(self._line_domain(company, partner, product))
+        lines = self.line_ids.search(
+            self._line_domain(company, partner, product, ind_final)
+        )
 
         return self._select_best_line(lines)
 
@@ -298,6 +307,7 @@ class Operation(models.Model):
                 "product_type",
                 "tax_icms_or_issqn",
                 "icms_origin",
+                "ind_final",
             ]
             return sum(1 for field in fields if getattr(line, field))
 

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -6,6 +6,7 @@ from odoo.exceptions import UserError
 
 from ..constants.fiscal import (
     CFOP_DESTINATION_EXPORT,
+    FINAL_CUSTOMER,
     FISCAL_COMMENT_LINE,
     FISCAL_IN,
     NFE_IND_IE_DEST,
@@ -106,6 +107,14 @@ class OperationLine(models.Model):
     ind_ie_dest = fields.Selection(
         selection=NFE_IND_IE_DEST,
         string="ICMS Taxpayer",
+    )
+
+    ind_final = fields.Selection(
+        selection=FINAL_CUSTOMER,
+        string="Final Consumption Operation",
+        help="Restricts this operation line to documents whose final consumer "
+        "indicator matches the selected value. When empty the line applies to "
+        "any operation.",
     )
 
     product_type = fields.Selection(

--- a/l10n_br_fiscal/tests/test_operation.py
+++ b/l10n_br_fiscal/tests/test_operation.py
@@ -3,6 +3,8 @@
 
 from odoo.tests.common import TransactionCase
 
+from ..constants.fiscal import FINAL_CUSTOMER_NO, FINAL_CUSTOMER_YES
+
 
 class TestOperation(TransactionCase):
     def test_copy(self):
@@ -11,3 +13,70 @@ class TestOperation(TransactionCase):
         operation_venda_copy = operation_venda.copy()
         self.assertEqual(operation_venda_copy.name, "Venda")
         self.assertEqual(operation_venda_copy.code, "VD (Copy)")
+
+
+class TestOperationLineIndFinal(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env["res.partner"].create({"name": "Partner Ind Final"})
+        cls.product = cls.env["product.product"].create({"name": "Product Ind Final"})
+
+        cls.operation = cls._create_operation("IND FINAL", "Operation Ind Final")
+        cls.line_any = cls._create_line(cls.operation, "Any", False)
+        cls.line_final = cls._create_line(cls.operation, "Final", FINAL_CUSTOMER_YES)
+        cls.line_resale = cls._create_line(cls.operation, "Resale", FINAL_CUSTOMER_NO)
+
+    @classmethod
+    def _create_operation(cls, code, name):
+        return cls.env["l10n_br_fiscal.operation"].create(
+            {
+                "code": code,
+                "name": name,
+                "fiscal_operation_type": "out",
+                "state": "approved",
+            }
+        )
+
+    @classmethod
+    def _create_line(cls, operation, name, ind_final):
+        return cls.env["l10n_br_fiscal.operation.line"].create(
+            {
+                "fiscal_operation_id": operation.id,
+                "name": name,
+                "ind_final": ind_final,
+                "state": "approved",
+            }
+        )
+
+    def _line_definition(self, operation, ind_final=None):
+        return operation.line_definition(
+            company=self.env.company,
+            partner=self.partner,
+            product=self.product,
+            ind_final=ind_final,
+        )
+
+    def test_line_ind_final_yes(self):
+        """A final consumption operation picks the line set to Yes"""
+        self.assertEqual(
+            self._line_definition(self.operation, FINAL_CUSTOMER_YES),
+            self.line_final,
+        )
+
+    def test_line_ind_final_no(self):
+        """An operation that is not for final consumption picks the line set
+        to No, instead of the generic line that comes first"""
+        self.assertEqual(
+            self._line_definition(self.operation, FINAL_CUSTOMER_NO),
+            self.line_resale,
+        )
+
+    def test_line_without_ind_final(self):
+        """Lines that leave the indicator empty keep matching any operation,
+        as they did before the criterion existed"""
+        operation = self._create_operation("IND FINAL 2", "Operation Any Ind Final")
+        line_any = self._create_line(operation, "Any", False)
+
+        for ind_final in (FINAL_CUSTOMER_YES, FINAL_CUSTOMER_NO, None):
+            self.assertEqual(self._line_definition(operation, ind_final), line_any)

--- a/l10n_br_fiscal/views/operation_line_view.xml
+++ b/l10n_br_fiscal/views/operation_line_view.xml
@@ -43,6 +43,7 @@
                             <field name="company_tax_framework" />
                             <field name="partner_tax_framework" />
                             <field name="ind_ie_dest" />
+                            <field name="ind_final" />
                         </group>
                         <group string="Product Information">
                             <field name="product_type" />


### PR DESCRIPTION
A linha de operação fiscal é escolhida por `line_definition()`, que filtra as
linhas aprovadas da operação por enquadramento da empresa e do parceiro,
indicador da IE do destinatário, tipo fiscal do produto, ICMS/ISSQN e origem, e
desempata pela linha com mais critérios preenchidos.

O indicador de consumidor final não está entre esses critérios, embora seja
usado logo em seguida no cálculo — `_compute_icms()` soma o IPI na base do ICMS
quando `ind_final` é Sim — e já seja aceito como critério nas definições de
imposto do regulamento de ICMS, ainda mais depois da #4790.

Nos dados padrão do módulo (`data/operation_data.xml`), a operação de Venda
separa duas linhas por `product_type`: "Produto Acabado" na linha Venda e
"Mercadoria para Revenda" na linha Revenda. Esse critério descreve a natureza fiscal do produto de quem
emite, não a destinação que o adquirente vai dar a ele. Quando a empresa vende
um maquinário de produção própria, portanto Produto Acabado, as duas situações
caem na mesma linha: o adquirente que vai usar o equipamento em uso e consumo e
o que vai revendê-lo. O tratamento do ICMS, porém, é diferente nos dois casos,
porque o IPI integra a base em um e não no outro.

Esta mudança acrescenta `ind_final` na linha de operação e passa a considerá-lo
no domínio e no desempate, na mesma convenção dos demais critérios: a linha casa
quando o valor é igual ao do documento ou quando está em branco. Documento sem
indicador definido não restringe nada, para não reduzir o conjunto de linhas em
bases já existentes. Como o campo nasce vazio, nada muda até que alguém o
preencha — é mais uma opção de parametrização, não uma alteração de
comportamento.

`_line_domain()` e `line_definition()` passaram a receber `ind_final`, e o
override do `l10n_br_account` foi ajustado para repassar o argumento.

Para validar: em uma operação de saída, crie duas linhas iguais e marque
"Operação de consumo final" com Sim em uma e Não na outra. Em um documento cujo
parceiro seja contribuinte de ICMS, alternar o indicador de consumidor final
passa a alternar a linha de operação. Sem preencher o campo nas linhas, a
seleção continua como antes.

Refs #4790
