### PR TITLE
[16.0][FIX] l10n_br_fiscal: cfop.destination check in tax compute for operation without CFOP

### DIFF
--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -691,7 +691,8 @@ class Tax(models.Model):
         tax_dict_pis = taxes_dict.get("pis", {})
         tax_dict_cofins = taxes_dict.get("cofins", {})
         if (
-            cfop.destination == CFOP_DESTINATION_EXPORT
+            cfop
+            and cfop.destination == CFOP_DESTINATION_EXPORT
             and fiscal_operation_type == FISCAL_IN
         ):
             tax_dict["add_to_base"] += (
@@ -722,7 +723,8 @@ class Tax(models.Model):
         tax_dict_pis = taxes_dict.get("pis", {})
         tax_dict_cofins = taxes_dict.get("cofins", {})
         if (
-            cfop.destination == CFOP_DESTINATION_EXPORT
+            cfop
+            and cfop.destination == CFOP_DESTINATION_EXPORT
             and fiscal_operation_type == FISCAL_IN
         ):
             tax_dict["add_to_base"] += (
@@ -752,7 +754,8 @@ class Tax(models.Model):
         tax_dict_pis = taxes_dict.get("pis", {})
         tax_dict_cofins = taxes_dict.get("cofins", {})
         if (
-            cfop.destination == CFOP_DESTINATION_EXPORT
+            cfop
+            and cfop.destination == CFOP_DESTINATION_EXPORT
             and fiscal_operation_type == FISCAL_IN
         ):
             tax_dict["add_to_base"] += tax_dict_ii.get("tax_value", 0.00) + kwargs.get(


### PR DESCRIPTION
## Adiciona a verificação do CFOP para evitar erro nas linhas de documentos fiscais que não tem CFOP como NFS-e.

`_compute_ibs`, `_compute_cbs` e `_compute_is` em `l10n_br_fiscal/models/tax.py` começam com:

```python
if (
    cfop.destination == CFOP_DESTINATION_EXPORT
    and fiscal_operation_type == FISCAL_IN
):
```

cfop é None para qualquer linha sem CFOP definido — o que acontece em linhas de fatura de serviço tributadas pelo ISSQN, já que account_move_line.py (em l10n_br_account) passa cfop=line.cfop_id or None, e um recordset de CFOP vazio vira None em Python.

Então None.destination levanta AttributeError. Essa exceção é silenciosamente engolida pelo loop de dispatch em Tax.compute_taxes():

```python
try:
    compute_method = getattr(self, f"_compute_{tax.tax_domain}")
    taxes[tax.tax_domain].update(compute_method(tax, taxes, **kwargs))
except AttributeError:
    taxes[tax.tax_domain].update(tax._compute_tax(tax, taxes, **kwargs))
```

Esse `except AttributeError` existe para capturar o caso de "não existe método `_compute_<domain>` para este domínio de imposto" e cair no cálculo genérico `_compute_tax`. Só que ele também captura o crash acima — então, para qualquer linha de serviço, IBS/CBS/IS caem silenciosamente no cálculo genérico, pulando o ajuste de base específico daquele domínio (por exemplo, remover o ISS da base do IBS/CBS), sem nenhum erro aparecer em lugar nenhum. `_compute_icms` e `_compute_ipi` já têm essa proteção correta (`if cfop and cfop.destination == ...`); os métodos mais novos de IBS/CBS/IS simplesmente não tinham a mesma proteção.

## Impacto
Isso se manifestou como uma falha no teste `test_picking_sale_order_product_and_service` do `l10n_br_sale_stock`, com fatura desbalanceada:

```
The move (Draft Invoice (* 363) (Customer Ref Test 2)) is not balanced.
The total of debits equals R$ 1,000.00 and the total of credits equals R$ 1,000.50.
```

O IBS/CBS da linha de serviço estava sendo calculado sobre a base cheia de R$ 1.000, em vez da base reduzida pelo ISS (R$ 950, já que ISS de 5% = R$ 50). A diferença de R$ 0,50 bate exatamente com IBS+CBS (~0,1%+0,9%) sobre esse gap de R$ 50.

O bug em si é anterior a esta correção e não foi introduzido pela lógica de remoção do ISS da base — ele só era invisível antes, porque sem essa lógica o fallback genérico e o cálculo pretendido davam o mesmo resultado para linhas de serviço.

# Correção
Adiciona a mesma proteção cfop and já usada em _compute_icms/_compute_ipi aos métodos _compute_ibs, _compute_cbs e _compute_is, para que a ausência de CFOP não gere mais um crash que cai no fallback genérico.
