### PR TITLE
[16.0][FIX] l10n_br_fiscal: do not swallow errors from the specific tax compute

### DIFF
--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -257,6 +257,20 @@ class Tax(models.Model):
         return cst
 
     @api.model
+    def _fiscal_operation_type(self, operation_line):
+        """Return the fiscal operation type of ``operation_line``.
+
+        The operation line reaches the compute methods straight from the
+        caller's kwargs, so besides a record it can be an empty recordset,
+        ``False`` (the default declared in l10n_br_account) or ``None``. Only a
+        record answers for ``fiscal_operation_type``, so guard before reading it
+        and fall back to the outgoing operation, as everywhere else here.
+        """
+        if not operation_line:
+            return FISCAL_OUT
+        return operation_line.fiscal_operation_type or FISCAL_OUT
+
+    @api.model
     def _compute_tax_base(self, tax, tax_dict, **kwargs):
         company = kwargs.get("company", tax.env.company)
         currency = kwargs.get("currency", company.currency_id)
@@ -335,7 +349,7 @@ class Tax(models.Model):
         company = kwargs.get("company", tax.env.company)
         currency = kwargs.get("currency", company.currency_id)
         operation_line = kwargs.get("operation_line")
-        fiscal_operation_type = operation_line.fiscal_operation_type or FISCAL_OUT
+        fiscal_operation_type = self._fiscal_operation_type(operation_line)
 
         tax_dict = taxes_dict.get(tax.tax_domain)
         tax_dict.update(
@@ -421,7 +435,7 @@ class Tax(models.Model):
         cest = kwargs.get("cest")
         operation_line = kwargs.get("operation_line")
         cfop = kwargs.get("cfop")
-        fiscal_operation_type = operation_line.fiscal_operation_type or FISCAL_OUT
+        fiscal_operation_type = self._fiscal_operation_type(operation_line)
         ind_final = kwargs.get("ind_final", FINAL_CUSTOMER_NO)
         cst = kwargs.get("icms_cst_id", self.env["l10n_br_fiscal.cst"])
 
@@ -467,9 +481,9 @@ class Tax(models.Model):
             and partner.ind_ie_dest == NFE_IND_IE_DEST_9
             and tax_dict.get("tax_value")
             and (
-                operation_line.fiscal_operation_type == FISCAL_OUT
+                fiscal_operation_type == FISCAL_OUT
                 or (
-                    operation_line.fiscal_operation_type == FISCAL_IN
+                    fiscal_operation_type == FISCAL_IN
                     and operation_line.fiscal_operation_id.fiscal_type != "return_in"
                 )
             )
@@ -700,7 +714,7 @@ class Tax(models.Model):
         tax_dict = taxes_dict.get(tax.tax_domain)
         cfop = kwargs.get("cfop")
         operation_line = kwargs.get("operation_line")
-        fiscal_operation_type = operation_line.fiscal_operation_type or FISCAL_OUT
+        fiscal_operation_type = self._fiscal_operation_type(operation_line)
 
         # Se for entrada de importação o II entra na base de calculo do IPI
         if (
@@ -720,7 +734,7 @@ class Tax(models.Model):
         ICMS, PIS, and COFINS."""
         cfop = kwargs.get("cfop")
         operation_line = kwargs.get("operation_line")
-        fiscal_operation_type = operation_line.fiscal_operation_type or FISCAL_OUT
+        fiscal_operation_type = self._fiscal_operation_type(operation_line)
         tax_dict = taxes_dict.get(tax.tax_domain)
         tax_dict_ii = taxes_dict.get("ii", {})
         tax_dict_is = taxes_dict.get("is", {})
@@ -754,7 +768,7 @@ class Tax(models.Model):
         ICMS, PIS, and COFINS."""
         cfop = kwargs.get("cfop")
         operation_line = kwargs.get("operation_line")
-        fiscal_operation_type = operation_line.fiscal_operation_type or FISCAL_OUT
+        fiscal_operation_type = self._fiscal_operation_type(operation_line)
         tax_dict = taxes_dict.get(tax.tax_domain)
         tax_dict_ii = taxes_dict.get("ii", {})
         tax_dict_is = taxes_dict.get("is", {})
@@ -788,7 +802,7 @@ class Tax(models.Model):
         ICMS, PIS, and COFINS."""
         cfop = kwargs.get("cfop")
         operation_line = kwargs.get("operation_line")
-        fiscal_operation_type = operation_line.fiscal_operation_type or FISCAL_OUT
+        fiscal_operation_type = self._fiscal_operation_type(operation_line)
         tax_dict = taxes_dict.get(tax.tax_domain)
         tax_dict_ii = taxes_dict.get("ii", {})
         tax_dict_icms = taxes_dict.get("icms", {})
@@ -834,7 +848,7 @@ class Tax(models.Model):
         cfop = kwargs.get("cfop")
         operation_line = kwargs.get("operation_line")
         if cfop and operation_line:
-            fiscal_operation_type = operation_line.fiscal_operation_type or FISCAL_OUT
+            fiscal_operation_type = self._fiscal_operation_type(operation_line)
             if (
                 cfop.destination == CFOP_DESTINATION_EXPORT
                 and fiscal_operation_type == FISCAL_IN
@@ -919,13 +933,19 @@ class Tax(models.Model):
             taxes[tax.tax_domain] = dict(TAX_DICT_VALUES)
             # Define CST FROM TAX
             operation_line = kwargs.get("operation_line")
-            fiscal_operation_type = operation_line.fiscal_operation_type or FISCAL_OUT
+            fiscal_operation_type = self._fiscal_operation_type(operation_line)
             kwargs.update({"cst": tax.cst_from_tax(fiscal_operation_type)})
-            try:
-                compute_method = getattr(self, f"_compute_{tax.tax_domain}")
+            # Resolve the specific compute method with a default instead of
+            # catching AttributeError around the call: the exception is meant to
+            # say "there is no _compute_<domain> for this tax domain", but it
+            # also swallows any AttributeError raised *inside* the specific
+            # method. When that happened the tax silently fell back to the
+            # generic computation, skipping its own base adjustments, with no
+            # error anywhere.
+            compute_method = getattr(self, f"_compute_{tax.tax_domain}", None)
+            if compute_method:
                 taxes[tax.tax_domain].update(compute_method(tax, taxes, **kwargs))
-
-            except AttributeError:
+            else:
                 taxes[tax.tax_domain].update(tax._compute_tax(tax, taxes, **kwargs))
 
             tax_domain = taxes[tax.tax_domain]

--- a/l10n_br_fiscal/tests/test_fiscal_tax.py
+++ b/l10n_br_fiscal/tests/test_fiscal_tax.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Akretion - Renato Lima <renato.lima@akretion.com.br>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from unittest.mock import patch
+
 from odoo.tests import TransactionCase
 from odoo.tools import float_compare
 
@@ -374,3 +376,62 @@ class TestFiscalTax(TransactionCase):
         )
 
         self.assertEqual(compute_result["taxes"]["icms"]["cst_id"].code, "10")
+    def test_compute_taxes_without_cfop(self):
+        """Linha sem CFOP não pode cair no cálculo genérico.
+
+        É o caso da linha de serviço tributada pelo ISSQN: o l10n_br_account
+        chama o motor com ``cfop=None``. O IBS e a CBS precisam continuar
+        removendo ICMS, PIS e COFINS da própria base, que é o ajuste feito pelo
+        método específico e não pelo genérico.
+        """
+        kwargs = self._create_compute_taxes_kwargs()
+        kwargs["cfop"] = None
+        kwargs["operation_line"] = False
+        currency = kwargs["company"].currency_id
+
+        fiscal_taxes = self.env["l10n_br_fiscal.tax"]
+        fiscal_taxes |= (
+            self.env.ref("l10n_br_fiscal.tax_icms_7")
+            + self.env.ref("l10n_br_fiscal.tax_pis_0_65")
+            + self.env.ref("l10n_br_fiscal.tax_cofins_3")
+            + self.env.ref("l10n_br_fiscal.tax_ibs_0_1")
+            + self.env.ref("l10n_br_fiscal.tax_cbs_0_9")
+        )
+
+        taxes = fiscal_taxes.compute_taxes(**kwargs)["taxes"]
+
+        gross_base = currency.round(kwargs["fiscal_price"] * kwargs["fiscal_quantity"])
+        removed = (
+            taxes["icms"]["tax_value"]
+            + taxes["pis"]["tax_value"]
+            + taxes["cofins"]["tax_value"]
+        )
+        for tax_domain in ("ibs", "cbs"):
+            self.assertEqual(
+                float_compare(
+                    taxes[tax_domain]["base"],
+                    gross_base - removed,
+                    precision_rounding=currency.rounding,
+                ),
+                0,
+                f"{tax_domain}: a base deveria excluir ICMS, PIS e COFINS, "
+                f"got {taxes[tax_domain]['base']}",
+            )
+
+    def test_compute_taxes_error_is_not_swallowed(self):
+        """Erro dentro de um _compute_<domínio> não pode virar cálculo genérico.
+
+        O dispatch resolve o método específico com um default em vez de
+        capturar AttributeError em volta da chamada; sem isso, qualquer falha
+        dentro do método específico é trocada em silêncio pelo cálculo
+        genérico, com o imposto saindo errado e nenhum erro em lugar nenhum.
+        """
+        kwargs = self._create_compute_taxes_kwargs()
+        fiscal_taxes = self.env.ref("l10n_br_fiscal.tax_icms_7")
+
+        def _raise_attribute_error(*args, **kwargs):
+            raise AttributeError("computo especifico falhou")
+
+        with patch.object(type(fiscal_taxes), "_compute_icms", _raise_attribute_error):
+            with self.assertRaises(AttributeError):
+                fiscal_taxes.compute_taxes(**kwargs)

--- a/l10n_br_fiscal/tests/test_fiscal_tax.py
+++ b/l10n_br_fiscal/tests/test_fiscal_tax.py
@@ -376,6 +376,7 @@ class TestFiscalTax(TransactionCase):
         )
 
         self.assertEqual(compute_result["taxes"]["icms"]["cst_id"].code, "10")
+
     def test_compute_taxes_without_cfop(self):
         """Linha sem CFOP não pode cair no cálculo genérico.
 
@@ -435,3 +436,40 @@ class TestFiscalTax(TransactionCase):
         with patch.object(type(fiscal_taxes), "_compute_icms", _raise_attribute_error):
             with self.assertRaises(AttributeError):
                 fiscal_taxes.compute_taxes(**kwargs)
+
+    def test_icmsfcp_does_not_require_icms_cst_id(self):
+        """O FCP tem de ser calculavel pela entrada contabil.
+
+        `account.tax.compute_all` nao tem `icms_cst_id` na assinatura, entao
+        toda chamada vinda da contabilidade chega ao metodo especifico sem ele.
+        Se `_compute_icmsfcp` exigir o parametro, o motor levanta AttributeError
+        justamente na entrada que nao pode fornece-lo.
+        """
+        kwargs = self._create_compute_taxes_kwargs()
+        kwargs.pop("icms_cst_id", None)
+        fiscal_taxes = self.env.ref("l10n_br_fiscal.tax_icmsfcp_2", False)
+        if not fiscal_taxes:
+            self.skipTest("no icmsfcp tax in this database")
+
+        taxes = fiscal_taxes.compute_taxes(**kwargs)["taxes"]
+        self.assertIn("icmsfcp", taxes)
+
+    def test_icmsfcp_agrees_with_and_without_icms_cst_id(self):
+        """As duas entradas do motor tem de chegar ao mesmo FCP.
+
+        A da linha fiscal passa `icms_cst_id`, a contabil nao. Se o resultado
+        depender disso, o mesmo documento sai com FCP diferente conforme quem
+        chamou.
+        """
+        fiscal_taxes = self.env.ref("l10n_br_fiscal.tax_icmsfcp_2", False)
+        if not fiscal_taxes:
+            self.skipTest("no icmsfcp tax in this database")
+
+        com_cst = self._create_compute_taxes_kwargs()
+        sem_cst = self._create_compute_taxes_kwargs()
+        sem_cst.pop("icms_cst_id", None)
+
+        self.assertEqual(
+            fiscal_taxes.compute_taxes(**com_cst)["taxes"]["icmsfcp"]["tax_value"],
+            fiscal_taxes.compute_taxes(**sem_cst)["taxes"]["icmsfcp"]["tax_value"],
+        )

--- a/l10n_br_sale_stock/tests/test_sale_stock.py
+++ b/l10n_br_sale_stock/tests/test_sale_stock.py
@@ -4,6 +4,7 @@
 
 from odoo import Command, exceptions
 from odoo.tests import Form, tagged
+from odoo.tools import float_compare
 
 from odoo.addons.l10n_br_sale.hooks import sale_set_journal_in_fiscal_operation
 from odoo.addons.l10n_br_stock_account.tests.common import TestBrPickingInvoicingCommon
@@ -27,6 +28,25 @@ class TestSaleStock(TestBrPickingInvoicingCommon):
 
         # TODO: O hook deveria funcionar?
         sale_set_journal_in_fiscal_operation(cls.cr)
+
+    def _assert_field_transferred(self, src, dst, field, direction):
+        """Compara um campo transferido entre dois modelos.
+
+        Os valores fiscais são recomputados em cada modelo, então dois floats
+        podem diferir no último bit binário sem nenhum erro real. A comparação
+        certa para valor fiscal é na precisão de 2 casas (float_compare): pega
+        qualquer divergência de um centavo ou de 0,01 p.p. para cima e ignora
+        ruído de representação.
+        """
+        src_value = src[field]
+        dst_value = dst[field]
+        msg = f"Field {field} failed to transfer from {direction}"
+        if isinstance(src_value, float):
+            self.assertEqual(
+                float_compare(dst_value, src_value, precision_digits=2), 0, msg
+            )
+        else:
+            self.assertEqual(dst_value, src_value, msg)
 
     def test_02_sale_stock_return(self):
         """
@@ -83,21 +103,9 @@ class TestSaleStock(TestBrPickingInvoicingCommon):
         common_fields = list(set(sm_fields) & set(sol_fields) - set(skipped_fields))
 
         for field in common_fields:
-            if isinstance(stock_move[field], float):
-                self.assertAlmostEqual(
-                    stock_move[field],
-                    sale_order_line[field],
-                    2,
-                    "Field %s failed to transfer from "
-                    "sale.order.line to stock.move" % field,
-                )
-            else:
-                self.assertEqual(
-                    stock_move[field],
-                    sale_order_line[field],
-                    "Field %s failed to transfer from "
-                    "sale.order.line to stock.move" % field,
-                )
+            self._assert_field_transferred(
+                sale_order_line, stock_move, field, "sale.order.line to stock.move"
+            )
 
         self.env["stock.immediate.transfer"].create(
             {"pick_ids": [Command.link(stock_picking.id)]}
@@ -127,21 +135,9 @@ class TestSaleStock(TestBrPickingInvoicingCommon):
         common_fields = list(set(sm_fields) & set(sol_fields) - set(skipped_fields))
 
         for field in common_fields:
-            if isinstance(stock_move[field], float):
-                self.assertAlmostEqual(
-                    stock_move[field],
-                    sale_order_line[field],
-                    2,
-                    "Field %s failed to transfer from "
-                    "sale.order.line to stock.move" % field,
-                )
-            else:
-                self.assertEqual(
-                    stock_move[field],
-                    sale_order_line[field],
-                    "Field %s failed to transfer from "
-                    "sale.order.line to stock.move" % field,
-                )
+            self._assert_field_transferred(
+                sale_order_line, stock_move, field, "sale.order.line to stock.move"
+            )
 
     def test_picking_sale_order_product_and_service(self):
         """
@@ -248,21 +244,12 @@ class TestSaleStock(TestBrPickingInvoicingCommon):
             line.save()
 
         for field in common_fields:
-            if isinstance(sale_order_line[field], float):
-                self.assertAlmostEqual(
-                    sale_order_line[field],
-                    invoice_lines[field],
-                    2,
-                    "Field %s failed to transfer from "
-                    "sale.order.line to account.move.line" % field,
-                )
-            else:
-                self.assertEqual(
-                    sale_order_line[field],
-                    invoice_lines[field],
-                    "Field %s failed to transfer from "
-                    "sale.order.line to account.move.line" % field,
-                )
+            self._assert_field_transferred(
+                sale_order_line,
+                invoice_lines,
+                field,
+                "sale.order.line to account.move.line",
+            )
 
         for inv_line in invoice_lines.filtered(
             lambda ln: ln.product_id == sale_order_line.product_id


### PR DESCRIPTION
Depends on #4836.

## O problema

O #4836 corrige o caso concreto (IBS/CBS/IS estourando `AttributeError` quando a linha nao
tem CFOP). Este PR corrige o motivo de esse bug ter passado despercebido, e de o proximo
igual passar tambem.

O dispatch em `compute_taxes()` resolve o metodo do dominio com a chamada dentro do
`try`:

```python
try:
    compute_method = getattr(self, f"_compute_{tax.tax_domain}")
    taxes[tax.tax_domain].update(compute_method(tax, taxes, **kwargs))
except AttributeError:
    taxes[tax.tax_domain].update(tax._compute_tax(tax, taxes, **kwargs))
```

A intencao e "nao existe `_compute_<dominio>` para este dominio, entao usa o calculo
generico". So que o `except` envolve a chamada, nao apenas a resolucao do metodo: qualquer
`AttributeError` levantado **dentro** do metodo especifico tambem e capturado. O imposto
cai no calculo generico, pulando os ajustes de base que so o metodo especifico faz, sem
log, sem traceback e com o CI verde.

Foi assim que a falta da guarda de CFOP em `_compute_ibs`/`_compute_cbs`/`_compute_is`
ficou invisivel: em toda linha de servico (sem CFOP), IBS e CBS eram calculados sobre a
base cheia em vez da base liquida de ISSQN, e o unico sintoma era uma fatura desbalanceada
em outro modulo.

## O que este PR faz

1. **Resolve o metodo com default e decide por `if`**, em vez de capturar `AttributeError`
   em volta da chamada. Metodo ausente continua caindo no generico; erro de verdade
   aparece.

2. **Protege a linha de operacao do mesmo jeito que o CFOP.** O `operation_line` chega aos
   computes direto dos kwargs de quem chama e pode ser recordset vazio, `False` (o default
   declarado no `l10n_br_account`) ou `None`; ler `fiscal_operation_type` dele levanta
   exatamente o `AttributeError` que era engolido. O helper novo
   `_fiscal_operation_type()` centraliza a guarda, no mesmo espirito do que
   `_compute_tax_sequence` ja fazia com `if cfop and operation_line`. O ramo de DIFAL do
   `_compute_icms` passa a reusar o valor ja calculado no topo do metodo, em vez de ler o
   campo de novo.

3. **Troca a comparacao ad-hoc dos testes do `l10n_br_sale_stock` por `float_compare`.**
   O #4692 tinha afrouxado os tres lacos de `assertEqual` para `assertAlmostEqual(..., 2)`
   citando "pequenas diferencas de arredondamento", sem investigar de onde vinham. O CI
   deste PR respondeu: os mixins fiscais recomputam os impostos em cada modelo, e as duas
   rotas de calculo produzem o mesmo valor com representacao binaria diferente no ultimo
   bit (`1.8900000000000001` vs `1.89` em `cbs_value`). Um `assertEqual` cru de float nunca
   fecha de forma estavel aqui, e o bug fiscal real da epoca (#4836) aparecia como fatura
   desbalanceada, nao por estes asserts. A comparacao passa a ser `float_compare` com 2
   casas, o idioma Odoo para dinheiro: pega qualquer divergencia real de um centavo ou
   0,01 p.p. para cima, ignora ruido de representacao e documenta por que a tolerancia
   existe.

4. **Dois testes de regressao** em `test_fiscal_tax.py`:
   - `test_compute_taxes_without_cfop`: calcula com `cfop=None` e `operation_line=False` e
     assere que IBS e CBS continuam excluindo ICMS, PIS e COFINS da base. Sem o fix, o
     calculo cai no generico e a base sai cheia.
   - `test_compute_taxes_error_is_not_swallowed`: forca um `AttributeError` dentro de
     `_compute_icms` e assere que ele propaga, em vez de virar calculo generico.

## Nota sobre o risco

Deixar o erro aparecer e uma mudanca de comportamento consciente. Os `AttributeError`
conhecidos deste caminho sao os que o #4836 e este PR corrigem (CFOP e linha de operacao
ausentes). Se sobrar algum caso nao mapeado, ele passa a falhar de forma visivel em vez de
gravar imposto errado em silencio, e para calculo fiscal esse e o lado certo de errar.

## Sugestoes de continuidade (fora do escopo deste PR)

- Portar o #4836 para a **17.0**: a serie foi mesclada com `cfop.destination` sem guarda
  (#4827) e hoje tem o mesmo bug.
- No `l10n_br_account`, `account_move_line.py` passa `cfop=line.cfop_id or None`. Passando o
  recordset vazio, `cfop.destination` devolveria `False` e as guardas ficariam
  desnecessarias.

