### PR TITLE
[17.0][FIX] l10n_br_fiscal: do not swallow errors from the specific tax compute

### DIFF
--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -241,6 +241,20 @@ class Tax(models.Model):
         return cst
 
     @api.model
+    def _fiscal_operation_type(self, operation_line):
+        """Return the fiscal operation type of ``operation_line``.
+
+        The operation line reaches the compute methods straight from the
+        caller's kwargs, so besides a record it can be an empty recordset,
+        ``False`` (the default declared in l10n_br_account) or ``None``. Only a
+        record answers for ``fiscal_operation_type``, so guard before reading it
+        and fall back to the outgoing operation, as everywhere else here.
+        """
+        if not operation_line:
+            return FISCAL_OUT
+        return operation_line.fiscal_operation_type or FISCAL_OUT
+
+    @api.model
     def _compute_tax_base(self, tax, tax_dict, **kwargs):
         company = kwargs.get("company") or tax.env.company
         currency = kwargs.get("currency") or company.currency_id
@@ -319,7 +333,7 @@ class Tax(models.Model):
         company = kwargs.get("company") or tax.env.company
         currency = kwargs.get("currency") or company.currency_id
         operation_line = kwargs.get("operation_line")
-        fiscal_operation_type = operation_line.fiscal_operation_type or FISCAL_OUT
+        fiscal_operation_type = self._fiscal_operation_type(operation_line)
 
         tax_dict = taxes_dict.get(tax.tax_domain)
         tax_dict.update(
@@ -405,7 +419,7 @@ class Tax(models.Model):
         cest = kwargs.get("cest")
         operation_line = kwargs.get("operation_line")
         cfop = kwargs.get("cfop")
-        fiscal_operation_type = operation_line.fiscal_operation_type or FISCAL_OUT
+        fiscal_operation_type = self._fiscal_operation_type(operation_line)
         ind_final = kwargs.get("ind_final", FINAL_CUSTOMER_NO)
         cst = kwargs.get("icms_cst_id", self.env["l10n_br_fiscal.cst"])
 
@@ -451,9 +465,9 @@ class Tax(models.Model):
             and partner.ind_ie_dest == NFE_IND_IE_DEST_9
             and tax_dict.get("tax_value")
             and (
-                operation_line.fiscal_operation_type == FISCAL_OUT
+                fiscal_operation_type == FISCAL_OUT
                 or (
-                    operation_line.fiscal_operation_type == FISCAL_IN
+                    fiscal_operation_type == FISCAL_IN
                     and operation_line.fiscal_operation_id.fiscal_type != "return_in"
                 )
             )
@@ -663,7 +677,7 @@ class Tax(models.Model):
         tax_dict = taxes_dict.get(tax.tax_domain)
         cfop = kwargs.get("cfop")
         operation_line = kwargs.get("operation_line")
-        fiscal_operation_type = operation_line.fiscal_operation_type or FISCAL_OUT
+        fiscal_operation_type = self._fiscal_operation_type(operation_line)
 
         # Se for entrada de importação o II entra na base de calculo do IPI
         if (
@@ -683,7 +697,7 @@ class Tax(models.Model):
         ICMS, PIS, and COFINS."""
         cfop = kwargs.get("cfop")
         operation_line = kwargs.get("operation_line")
-        fiscal_operation_type = operation_line.fiscal_operation_type or FISCAL_OUT
+        fiscal_operation_type = self._fiscal_operation_type(operation_line)
         tax_dict = taxes_dict.get(tax.tax_domain)
         tax_dict_ii = taxes_dict.get("ii", {})
         tax_dict_is = taxes_dict.get("is", {})
@@ -692,7 +706,8 @@ class Tax(models.Model):
         tax_dict_pis = taxes_dict.get("pis", {})
         tax_dict_cofins = taxes_dict.get("cofins", {})
         if (
-            cfop.destination == CFOP_DESTINATION_EXPORT
+            cfop
+            and cfop.destination == CFOP_DESTINATION_EXPORT
             and fiscal_operation_type == FISCAL_IN
         ):
             tax_dict["add_to_base"] += (
@@ -716,7 +731,7 @@ class Tax(models.Model):
         ICMS, PIS, and COFINS."""
         cfop = kwargs.get("cfop")
         operation_line = kwargs.get("operation_line")
-        fiscal_operation_type = operation_line.fiscal_operation_type or FISCAL_OUT
+        fiscal_operation_type = self._fiscal_operation_type(operation_line)
         tax_dict = taxes_dict.get(tax.tax_domain)
         tax_dict_ii = taxes_dict.get("ii", {})
         tax_dict_is = taxes_dict.get("is", {})
@@ -725,7 +740,8 @@ class Tax(models.Model):
         tax_dict_pis = taxes_dict.get("pis", {})
         tax_dict_cofins = taxes_dict.get("cofins", {})
         if (
-            cfop.destination == CFOP_DESTINATION_EXPORT
+            cfop
+            and cfop.destination == CFOP_DESTINATION_EXPORT
             and fiscal_operation_type == FISCAL_IN
         ):
             tax_dict["add_to_base"] += (
@@ -749,14 +765,15 @@ class Tax(models.Model):
         ICMS, PIS, and COFINS."""
         cfop = kwargs.get("cfop")
         operation_line = kwargs.get("operation_line")
-        fiscal_operation_type = operation_line.fiscal_operation_type or FISCAL_OUT
+        fiscal_operation_type = self._fiscal_operation_type(operation_line)
         tax_dict = taxes_dict.get(tax.tax_domain)
         tax_dict_ii = taxes_dict.get("ii", {})
         tax_dict_icms = taxes_dict.get("icms", {})
         tax_dict_pis = taxes_dict.get("pis", {})
         tax_dict_cofins = taxes_dict.get("cofins", {})
         if (
-            cfop.destination == CFOP_DESTINATION_EXPORT
+            cfop
+            and cfop.destination == CFOP_DESTINATION_EXPORT
             and fiscal_operation_type == FISCAL_IN
         ):
             tax_dict["add_to_base"] += tax_dict_ii.get("tax_value", 0.00) + kwargs.get(
@@ -794,7 +811,7 @@ class Tax(models.Model):
         cfop = kwargs.get("cfop")
         operation_line = kwargs.get("operation_line")
         if cfop and operation_line:
-            fiscal_operation_type = operation_line.fiscal_operation_type or FISCAL_OUT
+            fiscal_operation_type = self._fiscal_operation_type(operation_line)
             if (
                 cfop.destination == CFOP_DESTINATION_EXPORT
                 and fiscal_operation_type == FISCAL_IN
@@ -879,13 +896,19 @@ class Tax(models.Model):
             taxes[tax.tax_domain] = dict(TAX_DICT_VALUES)
             # Define CST FROM TAX
             operation_line = kwargs.get("operation_line")
-            fiscal_operation_type = operation_line.fiscal_operation_type or FISCAL_OUT
+            fiscal_operation_type = self._fiscal_operation_type(operation_line)
             kwargs.update({"cst": tax.cst_from_tax(fiscal_operation_type)})
-            try:
-                compute_method = getattr(self, f"_compute_{tax.tax_domain}")
+            # Resolve the specific compute method with a default instead of
+            # catching AttributeError around the call: the exception is meant to
+            # say "there is no _compute_<domain> for this tax domain", but it
+            # also swallows any AttributeError raised *inside* the specific
+            # method. When that happened the tax silently fell back to the
+            # generic computation, skipping its own base adjustments, with no
+            # error anywhere.
+            compute_method = getattr(self, f"_compute_{tax.tax_domain}", None)
+            if compute_method:
                 taxes[tax.tax_domain].update(compute_method(tax, taxes, **kwargs))
-
-            except AttributeError:
+            else:
                 taxes[tax.tax_domain].update(tax._compute_tax(tax, taxes, **kwargs))
 
             tax_domain = taxes[tax.tax_domain]

--- a/l10n_br_fiscal/tests/test_fiscal_tax.py
+++ b/l10n_br_fiscal/tests/test_fiscal_tax.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Akretion - Renato Lima <renato.lima@akretion.com.br>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from unittest.mock import patch
+
 from odoo.tests import TransactionCase
 from odoo.tools import float_compare
 
@@ -303,3 +305,63 @@ class TestFiscalTax(TransactionCase):
         }
 
         self._check_compute_taxes_result(test_result, compute_result, currency)
+
+    def test_compute_taxes_without_cfop(self):
+        """Linha sem CFOP não pode cair no cálculo genérico.
+
+        É o caso da linha de serviço tributada pelo ISSQN: o l10n_br_account
+        chama o motor com ``cfop=None``. O IBS e a CBS precisam continuar
+        removendo ICMS, PIS e COFINS da própria base, que é o ajuste feito pelo
+        método específico e não pelo genérico.
+        """
+        kwargs = self._create_compute_taxes_kwargs()
+        kwargs["cfop"] = None
+        kwargs["operation_line"] = False
+        currency = kwargs["company"].currency_id
+
+        fiscal_taxes = self.env["l10n_br_fiscal.tax"]
+        fiscal_taxes |= (
+            self.env.ref("l10n_br_fiscal.tax_icms_7")
+            + self.env.ref("l10n_br_fiscal.tax_pis_0_65")
+            + self.env.ref("l10n_br_fiscal.tax_cofins_3")
+            + self.env.ref("l10n_br_fiscal.tax_ibs_0_1")
+            + self.env.ref("l10n_br_fiscal.tax_cbs_0_9")
+        )
+
+        taxes = fiscal_taxes.compute_taxes(**kwargs)["taxes"]
+
+        gross_base = currency.round(kwargs["fiscal_price"] * kwargs["fiscal_quantity"])
+        removed = (
+            taxes["icms"]["tax_value"]
+            + taxes["pis"]["tax_value"]
+            + taxes["cofins"]["tax_value"]
+        )
+        for tax_domain in ("ibs", "cbs"):
+            self.assertEqual(
+                float_compare(
+                    taxes[tax_domain]["base"],
+                    gross_base - removed,
+                    precision_rounding=currency.rounding,
+                ),
+                0,
+                f"{tax_domain}: a base deveria excluir ICMS, PIS e COFINS, "
+                f"got {taxes[tax_domain]['base']}",
+            )
+
+    def test_compute_taxes_error_is_not_swallowed(self):
+        """Erro dentro de um _compute_<domínio> não pode virar cálculo genérico.
+
+        O dispatch resolve o método específico com um default em vez de
+        capturar AttributeError em volta da chamada; sem isso, qualquer falha
+        dentro do método específico é trocada em silêncio pelo cálculo
+        genérico, com o imposto saindo errado e nenhum erro em lugar nenhum.
+        """
+        kwargs = self._create_compute_taxes_kwargs()
+        fiscal_taxes = self.env.ref("l10n_br_fiscal.tax_icms_7")
+
+        def _raise_attribute_error(*args, **kwargs):
+            raise AttributeError("computo especifico falhou")
+
+        with patch.object(type(fiscal_taxes), "_compute_icms", _raise_attribute_error):
+            with self.assertRaises(AttributeError):
+                fiscal_taxes.compute_taxes(**kwargs)


### PR DESCRIPTION
Forward port do #4838 (16.0). Nesta serie o port carrega tambem a guarda do #4836, porque a
17.0 foi mesclada com o `cfop.destination` desprotegido em `_compute_ibs`, `_compute_cbs` e
`_compute_is` (pelo #4827): o bug esta vivo aqui.

## O problema

O dispatch em `compute_taxes()` resolve o metodo do dominio com a chamada dentro do `try`:

```python
try:
    compute_method = getattr(self, f"_compute_{tax.tax_domain}")
    taxes[tax.tax_domain].update(compute_method(tax, taxes, **kwargs))
except AttributeError:
    taxes[tax.tax_domain].update(tax._compute_tax(tax, taxes, **kwargs))
```

A intencao e "nao existe `_compute_<dominio>` para este dominio, entao usa o calculo
generico". So que o `except` envolve a chamada, nao apenas a resolucao do metodo: qualquer
`AttributeError` levantado dentro do metodo especifico tambem e capturado. O imposto cai no
calculo generico, pulando os ajustes de base que so o metodo especifico faz, sem log e com
o CI verde.

Na 16.0 isso escondeu um erro de imposto real: em toda linha de servico (sem CFOP), IBS e
CBS eram calculados sobre a base cheia em vez da base liquida de ISSQN, e o unico sintoma
era uma fatura desbalanceada em outro modulo. Ver #4836 e #4838.

## O que este PR faz

1. resolve o metodo com default e decide por `if`, para que metodo ausente continue caindo
   no generico e erro de verdade apareca;
2. adiciona a guarda `cfop and` em `_compute_ibs`, `_compute_cbs` e `_compute_is`, alinhando
   com `_compute_icms` e `_compute_ipi`, que ja a tinham;
3. protege a linha de operacao do mesmo jeito, pelo helper novo `_fiscal_operation_type()`:
   ela tambem chega direto dos kwargs de quem chama e pode ser recordset vazio, `False` (o
   default declarado no `l10n_br_account`) ou `None`. O ramo de DIFAL do `_compute_icms`
   passa a reusar o valor ja calculado no topo do metodo;
4. dois testes de regressao: um calcula com `cfop=None` e `operation_line=False` e assere
   que IBS e CBS continuam excluindo ICMS, PIS e COFINS da base; outro forca um
   `AttributeError` dentro de `_compute_icms` e assere que ele propaga.

## Nota sobre o risco

Deixar o erro aparecer e uma mudanca de comportamento consciente. Os `AttributeError`
conhecidos deste caminho sao os que este PR corrige. Se sobrar algum caso nao mapeado, ele
passa a falhar de forma visivel em vez de gravar imposto errado em silencio, e para calculo
fiscal esse e o lado certo de errar.
