### PR TITLE
[16.0][FIX] l10n_br_sale_commission: apura comissao no fuso do usuario

### DIFF
--- a/l10n_br_sale_commission/tests/test_l10n_br_sale_commission.py
+++ b/l10n_br_sale_commission/tests/test_l10n_br_sale_commission.py
@@ -5,11 +5,9 @@
 # @author Felipe Motter Pereira <felipe@engenere.one>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from datetime import date
-
 from dateutil.relativedelta import relativedelta
 
-from odoo import Command
+from odoo import Command, fields
 from odoo.tests import Form, TransactionCase, tagged
 
 
@@ -70,7 +68,12 @@ class TestL10nBrSalesCommission(TransactionCase):
     def _get_settlements_invoice(self):
         # Cria o Settlements
         with Form(self.env["commission.make.settle"]) as wiz_form:
-            wiz_form.date_to = date.today() + relativedelta(months=1)
+            # A data precisa vir do mesmo fuso usado pelo action_post ao gravar
+            # a invoice_date, senao na virada do mes a fatura nasce no mes
+            # seguinte e fica fora do periodo apurado pelo assistente.
+            wiz_form.date_to = fields.Date.context_today(self.env.user) + relativedelta(
+                months=1
+            )
             wiz_form.settlement_type = "sale_invoice"
             wiz = wiz_form.save()
             wiz.action_settle()


### PR DESCRIPTION
O teste `test_sale_order_commission_br` falha de forma intermitente, sempre na virada do mês.

A causa é uma comparação entre duas referências de data diferentes. O assistente de apuração recebe `date_to` montado com `date.today()`, que usa o fuso do servidor, enquanto a `invoice_date` da fatura é gravada no `action_post` com `fields.Date.context_today`, que usa o fuso do usuário. O demo do `base` carimba Europe/Brussels nos usuários de demonstração.

No último dia do mês, depois das 22:00 UTC, a fatura nasce já no mês seguinte enquanto `date.today()` ainda está no mês corrente. Como `_get_period_start` devolve o dia 1 do mês de `date_to` para agente mensal, e o domínio em `_get_account_settle_domain` filtra `invoice_date < date_to_agent`, a fatura fica de fora do período e nenhum settlement é criado.

Evidência no CI: o #4833 rodou quatro vezes entre 22:33 e 23:32 UTC de 31/07 e falhou em todas, enquanto o mesmo código-base passou às 17:50 UTC daquele dia e à 01:51 UTC do dia seguinte. Há precedente anterior no #4526, vermelho em 30/04 às 23:00 UTC e verde no mesmo commit em 20/05.

A correção usa `fields.Date.context_today` nos dois lados da comparação. Simulando a lógica do wizard, o cenário das 22:33 UTC passa a produzir corte em 2026-09-01 contra `invoice_date` 2026-08-01, e os cenários de dia comum e de fuso negativo seguem inalterados. A mesma falha existia na virada de ano e no fim de fevereiro.

@renatonlima @mileo
