### PR TITLE
[16.0][FIX] l10n_br_purchase, l10n_br_stock_account: recalcula impostos pela quantidade faturada

### DIFF
--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -277,7 +277,16 @@ class FiscalDocumentLineMixin(models.AbstractModel):
             else:
                 line.allow_csll_irpj = False  # No tax charges expected
 
-    def _prepare_br_fiscal_dict(self, default=False):
+    def _prepare_br_fiscal_dict(self, default=False, quantity=None):
+        """Return the fiscal fields of this record as a write dict.
+
+        When `quantity` is given and differs from the record quantity, the
+        stored compute fields depending on it (tax bases and values,
+        fiscal_quantity...) are recomputed for that quantity. Otherwise they
+        would be copied frozen and, since they are readonly=False, the ORM
+        would accept them as explicit values at create() and skip the compute
+        even though `quantity` is in their `depends`.
+        """
         self.ensure_one()
         fields = self.env["l10n_br_fiscal.document.line.mixin"]._fields.keys()
 
@@ -286,6 +295,22 @@ class FiscalDocumentLineMixin(models.AbstractModel):
 
         # remove id field to avoid conflicts
         vals.pop("id", None)
+
+        if quantity is not None and quantity != vals.get("quantity"):
+            # Simulate the quantity change on a virtual record: the depends
+            # fire and every stored compute field is recomputed by the ORM
+            # itself, the same way it would happen if the quantity was edited
+            # in a form. This makes the recompute independent from knowing
+            # which field is populated by which compute method.
+            # Read-back goes through the cache (convert_to_write per field) to
+            # avoid the ACL check that read() would trigger on the virtual
+            # record.
+            virtual = self.env["l10n_br_fiscal.document.line"].new(vals)
+            virtual.quantity = quantity
+            vals = {
+                fname: virtual._fields[fname].convert_to_write(virtual[fname], virtual)
+                for fname in vals
+            }
 
         if default:  # in case you want to use new rather than write later
             return {f"default_{k}": vals[k] for k in vals.keys()}

--- a/l10n_br_purchase/models/purchase_order_line.py
+++ b/l10n_br_purchase/models/purchase_order_line.py
@@ -125,12 +125,12 @@ class PurchaseOrderLine(models.Model):
             )
             if line.fiscal_operation_id:
                 # O caso Brasil se caracteriza por ter a Operação Fiscal
-                fiscal_values = line._prepare_br_fiscal_dict()
-                # fiscal_quantity must not be copied from PO line because
-                # the invoice quantity may differ (e.g. partial receipt).
-                # Let _compute_fiscal_quantity recompute it from the
-                # invoice line quantity, same approach as l10n_br_sale.
-                fiscal_values.pop("fiscal_quantity", None)
+                # The invoiced quantity may differ from the ordered one
+                # (partial receipt, partial invoicing), so the tax fields must
+                # be recomputed for it instead of copied from the PO line.
+                fiscal_values = line._prepare_br_fiscal_dict(
+                    quantity=values.get("quantity")
+                )
                 fiscal_values.update(values)
                 values.update(fiscal_values)
 

--- a/l10n_br_purchase/tests/test_l10n_br_purchase.py
+++ b/l10n_br_purchase/tests/test_l10n_br_purchase.py
@@ -299,14 +299,17 @@ class L10nBrPurchaseBaseTest(TransactionCase):
 
         self.po_products.with_context(tracking_disable=True).button_confirm()
 
-        # 1) _prepare_account_move_line must NOT contain fiscal_quantity
+        # 1) _prepare_account_move_line must carry a fiscal_quantity matching
+        #    the quantity being invoiced, not the ordered one
         for po_line in self.po_products.order_line:
             vals = po_line._prepare_account_move_line(False)
-            self.assertNotIn(
-                "fiscal_quantity",
-                vals,
-                "fiscal_quantity should not be in the prepared invoice line "
-                "values — it must be recomputed from the invoice quantity.",
+            uot_factor = po_line.product_id.uot_factor or 1.0
+            self.assertAlmostEqual(
+                vals["fiscal_quantity"],
+                vals["quantity"] * uot_factor,
+                2,
+                "fiscal_quantity in the prepared invoice line values must "
+                "follow the invoiced quantity, not the PO line quantity.",
             )
 
         # 2) Create the invoice the same way the existing helper does

--- a/l10n_br_purchase_stock/tests/test_l10n_br_purchase_stock.py
+++ b/l10n_br_purchase_stock/tests/test_l10n_br_purchase_stock.py
@@ -452,6 +452,92 @@ class L10nBrPurchaseStockBase(TestBrPickingInvoicingCommon):
             "The Invoice Partner and Partner to Shipping should be the same.",
         )
 
+    def _receive_half(self, purchase):
+        """Confirm the order and receive half of every line."""
+        purchase.button_confirm()
+        picking = purchase.picking_ids
+        picking.set_to_be_invoiced()
+        self._run_picking_onchanges(picking)
+        picking.action_confirm()
+        picking.action_assign()
+        for move in picking.move_ids_without_package:
+            self._run_line_onchanges(move)
+            move.quantity_done = move.product_uom_qty / 2.0
+        self.create_backorder_wizard(picking)
+        self.assertEqual(picking.state, "done")
+        return picking
+
+    def test_partial_receipt_invoice_from_picking(self):
+        """Invoice a partial receipt: taxes must follow the received quantity.
+
+        The stock.move has its tax values recomputed on the quantity left
+        after the backorder split, but the PO line ones stay on the ordered
+        quantity. Taking them from the PO line left the fiscal amounts and the
+        journal entry tax lines calculated on different quantities, so the
+        entry did not balance.
+        """
+        self._change_user_company(self.env.ref("l10n_br_base.empresa_lucro_presumido"))
+        purchase = self.env.ref(
+            "l10n_br_purchase_stock.lucro_presumido_po_only_products_1"
+        )
+        picking = self._receive_half(purchase)
+
+        invoice = self.create_invoice_wizard(picking)
+        invoice_lines = invoice.invoice_line_ids.filtered(
+            lambda line: line.display_type == "product"
+        )
+        self.assertTrue(invoice_lines, "Invoice must have product lines")
+        for invoice_line in invoice_lines:
+            self.assertLess(
+                invoice_line.quantity,
+                invoice_line.purchase_line_id.product_qty,
+                "The invoice must hold the received quantity, not the ordered one.",
+            )
+        self._assert_tax_fields_match_recompute(invoice_lines)
+        self.assertAlmostEqual(
+            sum(invoice.line_ids.mapped("balance")),
+            0.0,
+            2,
+            "The journal entry must be balanced.",
+        )
+
+        if hasattr(invoice, "document_serie"):
+            invoice.document_serie = "1"
+            invoice.document_number = "4321"
+        invoice.action_post()
+        self.assertEqual(invoice.state, "posted", "Invoice should be in state Posted")
+
+    def test_partial_receipt_bill_from_purchase_order(self):
+        """Bill on received quantities: taxes must follow the received one."""
+        self._change_user_company(self.env.ref("l10n_br_base.empresa_lucro_presumido"))
+        purchase = self.env.ref(
+            "l10n_br_purchase_stock.lucro_presumido_po_only_products_1"
+        )
+        purchase.order_line.product_id.purchase_method = "receive"
+        self._receive_half(purchase)
+
+        order_lines = purchase.order_line.filtered(lambda line: not line.display_type)
+        for order_line in order_lines:
+            self.assertLess(
+                order_line.qty_to_invoice,
+                order_line.product_qty,
+                "Only the received quantity should be pending invoicing.",
+            )
+
+        purchase.action_create_invoice()
+        invoice = purchase.invoice_ids
+        invoice_lines = invoice.invoice_line_ids.filtered(
+            lambda line: line.display_type == "product"
+        )
+        self.assertTrue(invoice_lines, "Bill must have product lines")
+        self._assert_tax_fields_match_recompute(invoice_lines)
+        self.assertAlmostEqual(
+            sum(invoice.line_ids.mapped("balance")),
+            0.0,
+            2,
+            "The journal entry must be balanced.",
+        )
+
     def test_form_stock_picking(self):
         """Test Stock Picking with Form"""
         purchase = self.env.ref("l10n_br_purchase_stock.main_po_only_products_1")

--- a/l10n_br_purchase_stock/wizards/stock_invocing_onshipping.py
+++ b/l10n_br_purchase_stock/wizards/stock_invocing_onshipping.py
@@ -154,6 +154,16 @@ class StockInvoiceOnshipping(models.TransientModel):
                     "display_name",
                 }
 
+                # The quantity and the price of the invoice line come from the
+                # moves, and l10n_br_stock_account already fills the tax fields
+                # from the stock.move for them. The PO line ones are frozen on
+                # the ordered quantity, so they must not win here: mixing the
+                # two sources would leave the stored tax values and the inputs
+                # _compute_all_tax uses on different bases.
+                vals_to_remove |= set(
+                    self.env["l10n_br_fiscal.document.line"]._build_null_mask_dict()
+                ) | {"fiscal_quantity", "fiscal_price"}
+
                 purchase_line_values_rm = {
                     k: purchase_line_values[k]
                     for k in set(purchase_line_values) - vals_to_remove

--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -198,18 +198,8 @@ class SaleOrderLine(models.Model):
         result = {}
         super_result = super()._prepare_invoice_line(**optional_values)
         if not self.display_type and self.fiscal_operation_id:
-            result = self._prepare_br_fiscal_dict()
-            invoice_qty = super_result["quantity"]
-            if invoice_qty != result["quantity"]:
-                # Tax fields must be recomputed for the invoiced quantity.
-                virtual = self.env["l10n_br_fiscal.document.line"].new(result)
-                virtual.quantity = invoice_qty
-                result = {
-                    fname: virtual._fields[fname].convert_to_write(
-                        virtual[fname], virtual
-                    )
-                    for fname in result
-                }
+            # Tax fields must be recomputed for the invoiced quantity.
+            result = self._prepare_br_fiscal_dict(quantity=super_result["quantity"])
         result.update(super_result)
         return result
 

--- a/l10n_br_stock_account/tests/common.py
+++ b/l10n_br_stock_account/tests/common.py
@@ -13,3 +13,39 @@ class TestBrPickingInvoicingCommon(TestPickingInvoicingCommon):
         result = super()._run_line_onchanges(record)
         record._onchange_product_quantity()
         return result
+
+    def _assert_tax_fields_match_recompute(self, invoice_lines):
+        """Assert the stored tax fields match a fresh recompute.
+
+        They are stored compute fields with readonly=False, so an explicit
+        value given at create() is kept as is and the compute is skipped.
+        When such a value was calculated on another quantity, the fiscal
+        amounts and the journal entry tax lines stop matching each other.
+        """
+        tax_fields = (
+            "icms_base",
+            "icms_value",
+            "icmssn_base",
+            "icmssn_credit_value",
+            "ipi_base",
+            "ipi_value",
+            "pis_base",
+            "pis_value",
+            "cofins_base",
+            "cofins_value",
+            "amount_tax_included",
+            "amount_tax_not_included",
+            "amount_tax_withholding",
+        )
+        for invoice_line in invoice_lines:
+            fiscal_line = invoice_line.fiscal_document_line_id
+            stored = {name: fiscal_line[name] for name in tax_fields}
+            fiscal_line._compute_tax_fields()
+            for name, value in stored.items():
+                self.assertAlmostEqual(
+                    fiscal_line[name],
+                    value,
+                    2,
+                    f"{name} differs after recompute: stored={value}, "
+                    f"recomputed={fiscal_line[name]}",
+                )

--- a/l10n_br_stock_account/wizards/stock_invoice_onshipping.py
+++ b/l10n_br_stock_account/wizards/stock_invoice_onshipping.py
@@ -149,7 +149,10 @@ class StockInvoiceOnshipping(models.TransientModel):
             # Caso Brasileiro se caracteriza pela Operação Fiscal
             return values
 
-        fiscal_values = move._prepare_br_fiscal_dict()
+        # A quantidade da linha da fatura é a soma das stock.move agrupadas e
+        # pode ser diferente da quantidade da move usada aqui, por isso os
+        # valores fiscais são recalculados para ela.
+        fiscal_values = move._prepare_br_fiscal_dict(quantity=values["quantity"])
 
         # A Fatura não pode ser criada com os campos price_unit e fiscal_price
         # negativos, o metodo _prepare_br_fiscal_dict retorna o price_unit
@@ -159,15 +162,9 @@ class StockInvoiceOnshipping(models.TransientModel):
         del fiscal_values["price_unit"]
         fiscal_values["fiscal_price"] = abs(fiscal_values.get("fiscal_price"))
 
-        # Como é usada apenas uma move para chamar o _prepare_br_fiscal_dict
-        # a quantidade/quantity do dicionario traz a quantidade referente a
-        # apenas a essa linha por isso é removido aqui.
+        # A quantidade da linha da fatura já vem do super, calculada com as
+        # moves agrupadas.
         del fiscal_values["quantity"]
-
-        # Mesmo a quantidade estando errada por ser chamada apenas por uma move
-        # no caso das stock.move agrupadas e os valores fiscais e de totais
-        # retornados poderem estar errados ao criar o documento fiscal isso
-        # será recalculado já com a quantidade correta.
 
         values.update(fiscal_values)
 


### PR DESCRIPTION
## Problema

Ao criar a fatura a partir de um pedido de compra ou de um recebimento, quando a
quantidade faturada é diferente da quantidade do documento de origem
(recebimento parcial, faturamento parcial, `stock.move` agrupadas), o
lançamento é recusado:

> A operação (Fatura de Rascunho ...) não fecha. O total de débitos é igual a
> R$ X e o total de créditos é igual a R$ Y.

## Causa

Os campos de imposto da linha do documento fiscal (`icms_base`, `icms_value`,
`ipi_value`, `amount_tax_not_included`, `amount_tax_withholding` etc.) são
`compute` com `store=True` e `readonly=False`. Quando um valor chega explícito
no `create()`, o ORM aceita esse valor e não roda o compute, mesmo com
`quantity` no `depends`.

O `_prepare_br_fiscal_dict` copia todos os campos do mixin, inclusive esses
valores já calculados. Se a quantidade da fatura for diferente da do documento
de origem, a linha fica com os impostos da quantidade antiga enquanto o
`_compute_all_tax` monta as linhas de imposto do razão pela quantidade real da
linha. Os dois lados deixam de fechar e o `_check_balanced` recusa a fatura.

Medido em produção (recebimento de 3 de 7 un., IPI 6,5%): o passivo usa
R$ 5,04 (base 7 un.) e a linha de imposto do razão R$ 2,16 (base 3 un.) —
R$ 2,88, que é exatamente o desbalanceamento relatado.

O `l10n_br_sale` já resolve essa variante desde a fb628f97d, recalculando os
campos num registro virtual. Os outros fluxos ficaram de fora:

- `l10n_br_purchase`: a a82be38ca removeu apenas o `fiscal_quantity` do
  dicionário; os demais valores continuam vindo congelados do pedido.
- `l10n_br_stock_account`: o comentário no `_get_invoice_line_values` assume que
  "ao criar o documento fiscal isso será recalculado já com a quantidade
  correta" — não é o que acontece.
- `l10n_br_purchase_stock`: na fatura por recebimento os valores do pedido
  sobrescrevem os da `stock.move`, que estavam corretos.

## Solução

O recálculo do `l10n_br_sale` sai de dentro do `_prepare_invoice_line` e passa a
ser um argumento opcional `quantity` do `_prepare_br_fiscal_dict`, no mixin. Os
três fluxos passam a usá-lo. Sem o argumento o dicionário é montado exatamente
como antes.

No `l10n_br_purchase_stock`, os campos calculados pelo `_compute_tax_fields` (e
o `fiscal_quantity`) passam a vir da `stock.move`, que o `l10n_br_stock_account`
já recalcula pela quantidade faturada.

Como o recálculo é feito pelo próprio ORM — simula a mudança de quantidade num
registro virtual e deixa os `depends` dispararem — não há lista de campos para
manter: só recalcula o que depende de `quantity` (`_compute_tax_fields` e
`_compute_fiscal_quantity`), e campo novo entra automaticamente. É o mesmo
mecanismo já aceito na fb628f97d.

## Testes

Em `l10n_br_purchase_stock`:

- `test_partial_receipt_invoice_from_picking` — recebimento parcial com
  backorder e fatura pelo picking.
- `test_partial_receipt_bill_from_purchase_order` — `purchase_method='receive'`,
  recebimento parcial e fatura pelo pedido.

Os dois verificam que cada valor de imposto armazenado é igual ao que um
recálculo devolve e que o lançamento fecha. Sem a correção,
`test_partial_receipt_bill_from_purchase_order` falha com
`icms_base differs after recompute: stored=1081.5, recomputed=556.5`.

O `test_invoice_fiscal_quantity_not_from_po` do `l10n_br_purchase` foi ajustado:
os valores preparados voltam a trazer `fiscal_quantity` e o que o teste precisa
checar é que ele segue a quantidade faturada.

Os testes de recebimento parcial ficam em `l10n_br_purchase_stock` porque é lá
que o cenário existe; o auxiliar de asserção fica no
`l10n_br_stock_account/tests/common.py`.

## Escopo, e o que fica de fora

Esta PR cobre a variante em que a **quantidade faturada difere** da quantidade do
documento de origem. A #4704 descreve outra variante do mesmo sintoma (serviço
com retenções, quantidade igual à do pedido), com causa diferente — não é
corrigida aqui e por isso não estou marcando `Closes`.

Sobre a #4709, que eu abri: ela propunha propagar
`force_fiscal_amount_recompute` no faturamento de vendas. Esse caminho foi
refeito no upstream — hoje o contexto só protege o `_inverse_tax_totals` da
importação — então o patch dela não se aplica mais como estava. Vou fechá-la em
favor desta.

Refs #4704, #4455.
