### PR TITLE
[16.0][IMP] l10n_br_fiscal: add MEI fiscal regime

### DIFF
--- a/l10n_br_fiscal/constants/fiscal.py
+++ b/l10n_br_fiscal/constants/fiscal.py
@@ -150,13 +150,14 @@ TAX_FRAMEWORK = [
     ("1", "1 - Simples Nacional"),
     ("2", "2 - Simples Nacional – excesso de sublimite da receita bruta"),
     ("3", "3 - Regime Normal"),
+    ("4", "4 - Simples Nacional - Microempreendedor Individual (MEI)"),
 ]
 
 
 TAX_FRAMEWORK_SIMPLES = "1"
 TAX_FRAMEWORK_SIMPLES_EX = "2"
 TAX_FRAMEWORK_NORMAL = "3"
-TAX_FRAMEWORK_SIMPLES_ALL = ("1", "2")
+TAX_FRAMEWORK_SIMPLES_ALL = ("1", "2", "4")
 
 
 PROFIT_CALCULATION = [

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -16,4 +16,5 @@ from . import (
     test_partner_profile,
     test_service_type,
     test_operation,
+    test_tax_framework,
 )

--- a/l10n_br_fiscal/tests/test_tax_framework.py
+++ b/l10n_br_fiscal/tests/test_tax_framework.py
@@ -1,0 +1,29 @@
+# Copyright 2026 KMEE INFORMATICA LTDA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import TransactionCase
+
+from ..constants.fiscal import TAX_FRAMEWORK_SIMPLES_ALL
+
+
+class TestTaxFramework(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.company = cls.env.company
+
+    def test_mei_is_simples_nacional_all(self):
+        self.assertIn("4", TAX_FRAMEWORK_SIMPLES_ALL)
+
+    def test_mei_gets_simples_nacional_taxes_onchange(self):
+        self.company.tax_framework = "4"
+        self.company._onchange_profit_calculation()
+        self.assertEqual(
+            self.company.tax_icms_id,
+            self.env.ref("l10n_br_fiscal.tax_icms_sn_com_credito"),
+        )
+        self.assertEqual(
+            self.company.piscofins_id,
+            self.env.ref("l10n_br_fiscal.tax_pis_cofins_simples_nacional"),
+        )


### PR DESCRIPTION
Adiciona o regime tributário "4 - Simples Nacional - MEI" e inclui na `TAX_FRAMEWORK_SIMPLES_ALL`, então empresa MEI passa a receber os mesmos padrões de ICMS/PIS-COFINS que as demais do Simples Nacional em toda a localização.