### PR TITLE
[16.0][FIX] l10n_br_account: recalcula os valores fiscais defasados ao criar a fatura

### DIFF
--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -183,7 +183,65 @@ class AccountMoveLine(models.Model):
         sorted_result = self.env["account.move.line"]
         for idx in inverted_index:
             sorted_result |= result[idx]
+
+        # The marking has to happen here, inside create: account.move.create
+        # keeps _sync_dynamic_lines open around it and runs line_ids._sync_invoice
+        # again afterwards, which is the pass that reads the recomputed fiscal
+        # amounts. Moving this call out of the create window silently brings the
+        # unbalanced entry back.
+        sorted_result._mark_stale_fiscal_taxes_for_recompute()
         return sorted_result
+
+    def _lines_from_source_document(self):
+        """Lines whose values were copied from another document.
+
+        The link fields are added by the sale and purchase modules, which
+        l10n_br_account does not depend on, so they are looked up dynamically:
+        the same invoice line may carry either, or neither when it was typed
+        in by hand.
+        """
+        link_fields = [
+            name
+            for name in ("purchase_line_id", "sale_line_ids")
+            if name in self._fields
+        ]
+        if not link_fields:
+            return self.browse()
+        return self.filtered(lambda line: any(line[name] for name in link_fields))
+
+    def _mark_stale_fiscal_taxes_for_recompute(self):
+        """Put the tax fields back in the compute queue for these lines.
+
+        The tax fields of the fiscal document line are stored compute fields
+        with readonly=False. When the invoice is built from another document
+        (sale order, purchase order, receipt) they arrive already written, and
+        the ORM keeps the explicit value and skips the compute even though
+        `quantity` is in their `depends`. If the invoiced quantity differs from
+        the one they were calculated on - the usual partial receipt or partial
+        invoicing - the fiscal amounts stay on the old quantity while
+        _compute_all_tax builds the journal entry tax lines from the real one.
+        The two sides stop adding up and _check_balanced rejects the invoice.
+
+        Marking the delegated fiscal document line as modified puts those
+        fields back in the compute queue, so both sides end up reading values
+        calculated on the same quantity. It is idempotent: for an invoice that
+        was already consistent the recompute gives the same values back.
+        """
+        stale = self.filtered(
+            lambda line: line.display_type == "product"
+            # Refunds keep the values of the document being reversed, and a
+            # fiscal document coming from an XML must keep the imported ones.
+            and line.move_id.move_type in ("in_invoice", "out_invoice")
+            and line.move_id.fiscal_operation_id
+            and line.fiscal_document_line_id
+            and not line.fiscal_document_line_id._is_imported()
+        )._lines_from_source_document()
+        if stale:
+            # Only `quantity` is declared: by transitivity it already puts
+            # fiscal_quantity and the whole _compute_tax_fields group back in
+            # the queue, while leaving fiscal_price alone - the picking wizard
+            # sets it explicitly and it must not be re-derived from price_unit.
+            stale.fiscal_document_line_id.modified(["quantity"])
 
     def unlink(self):
         unlink_fiscal_lines = self.env["l10n_br_fiscal.document.line"]

--- a/l10n_br_purchase_stock/tests/test_l10n_br_purchase_stock.py
+++ b/l10n_br_purchase_stock/tests/test_l10n_br_purchase_stock.py
@@ -452,6 +452,127 @@ class L10nBrPurchaseStockBase(TestBrPickingInvoicingCommon):
             "The Invoice Partner and Partner to Shipping should be the same.",
         )
 
+    TAX_FIELDS = (
+        "icms_base",
+        "icms_value",
+        "icmssn_base",
+        "icmssn_credit_value",
+        "ipi_base",
+        "ipi_value",
+        "pis_base",
+        "pis_value",
+        "cofins_base",
+        "cofins_value",
+        "amount_tax_included",
+        "amount_tax_not_included",
+        "amount_tax_withholding",
+    )
+
+    def _assert_tax_fields_match_recompute(self, invoice_lines):
+        """Assert the stored tax fields match a fresh recompute.
+
+        They are stored compute fields with readonly=False, so a value given
+        explicitly at create() is kept and the compute is skipped. When that
+        value was calculated on another quantity, the fiscal amounts and the
+        journal entry tax lines stop matching each other.
+        """
+        for invoice_line in invoice_lines:
+            fiscal_line = invoice_line.fiscal_document_line_id
+            stored = {name: fiscal_line[name] for name in self.TAX_FIELDS}
+            fiscal_line._compute_tax_fields()
+            for name, value in stored.items():
+                self.assertAlmostEqual(
+                    fiscal_line[name],
+                    value,
+                    2,
+                    f"{name} differs after recompute: stored={value}, "
+                    f"recomputed={fiscal_line[name]}",
+                )
+
+    def _receive_half(self, purchase):
+        """Confirm the order and receive half of every line."""
+        purchase.button_confirm()
+        picking = purchase.picking_ids
+        picking.set_to_be_invoiced()
+        self._run_picking_onchanges(picking)
+        picking.action_confirm()
+        picking.action_assign()
+        for move in picking.move_ids_without_package:
+            self._run_line_onchanges(move)
+            move.quantity_done = move.product_uom_qty / 2.0
+        self.create_backorder_wizard(picking)
+        self.assertEqual(picking.state, "done")
+        return picking
+
+    def test_partial_receipt_invoice_from_picking(self):
+        """Invoice a partial receipt: taxes must follow the received quantity.
+
+        The values copied from the purchase order line stay on the ordered
+        quantity, leaving the fiscal amounts and the journal entry tax lines
+        calculated on different quantities, so the entry did not balance.
+        """
+        self._change_user_company(self.env.ref("l10n_br_base.empresa_lucro_presumido"))
+        purchase = self.env.ref(
+            "l10n_br_purchase_stock.lucro_presumido_po_only_products_1"
+        )
+        picking = self._receive_half(purchase)
+
+        invoice = self.create_invoice_wizard(picking)
+        invoice_lines = invoice.invoice_line_ids.filtered(
+            lambda line: line.display_type == "product"
+        )
+        self.assertTrue(invoice_lines, "Invoice must have product lines")
+        for invoice_line in invoice_lines:
+            self.assertLess(
+                invoice_line.quantity,
+                invoice_line.purchase_line_id.product_qty,
+                "The invoice must hold the received quantity, not the ordered one.",
+            )
+        self._assert_tax_fields_match_recompute(invoice_lines)
+        self.assertAlmostEqual(
+            sum(invoice.line_ids.mapped("balance")),
+            0.0,
+            2,
+            "The journal entry must be balanced.",
+        )
+
+        if hasattr(invoice, "document_serie"):
+            invoice.document_serie = "1"
+            invoice.document_number = "4321"
+        invoice.action_post()
+        self.assertEqual(invoice.state, "posted", "Invoice should be in state Posted")
+
+    def test_partial_receipt_bill_from_purchase_order(self):
+        """Bill on received quantities: taxes must follow the received one."""
+        self._change_user_company(self.env.ref("l10n_br_base.empresa_lucro_presumido"))
+        purchase = self.env.ref(
+            "l10n_br_purchase_stock.lucro_presumido_po_only_products_1"
+        )
+        purchase.order_line.product_id.purchase_method = "receive"
+        self._receive_half(purchase)
+
+        order_lines = purchase.order_line.filtered(lambda line: not line.display_type)
+        for order_line in order_lines:
+            self.assertLess(
+                order_line.qty_to_invoice,
+                order_line.product_qty,
+                "Only the received quantity should be pending invoicing.",
+            )
+
+        purchase.action_create_invoice()
+        invoice = purchase.invoice_ids
+        invoice_lines = invoice.invoice_line_ids.filtered(
+            lambda line: line.display_type == "product"
+        )
+        self.assertTrue(invoice_lines, "Bill must have product lines")
+        self._assert_tax_fields_match_recompute(invoice_lines)
+        self.assertAlmostEqual(
+            sum(invoice.line_ids.mapped("balance")),
+            0.0,
+            2,
+            "The journal entry must be balanced.",
+        )
+
     def test_form_stock_picking(self):
         """Test Stock Picking with Form"""
         purchase = self.env.ref("l10n_br_purchase_stock.main_po_only_products_1")


### PR DESCRIPTION
## Problema

Ao criar uma fatura com localização brasileira a partir de outro documento — pedido de
venda, pedido de compra ou recebimento — o lançamento é recusado:

> A operação (Fatura de Rascunho ...) não fecha. O total de débitos é igual a R$ X e o
> total de créditos é igual a R$ Y.

Acontece tipicamente quando a quantidade faturada é diferente daquela do documento de
origem: recebimento parcial, faturamento parcial, `stock.move` agrupadas.

## Causa

Os campos de imposto de `l10n_br_fiscal.document.line` (`icms_value`, `ipi_value`,
`amount_tax_not_included`, `amount_tax_withholding`, bases e percentuais) são `compute`
com `store=True`, `precompute=True` e `readonly=False`.

Quando a fatura nasce de outro documento, o `_prepare_br_fiscal_dict` copia esses valores
já calculados para o `vals` da linha. Por serem `readonly=False`, o ORM aceita o valor
explícito no `create()` e **pula o compute**, mesmo com `quantity` no `depends` deles.

A partir daí os dois lados do lançamento passam a usar bases diferentes:

- o passivo, via `_sync_invoice`, consome `fiscal_amount_total`, `amount_tax_included` e
  `amount_tax_not_included` — os valores gravados, da quantidade antiga;
- o razão, via `_compute_all_tax`, recalcula sempre pela `quantity` real da linha.

Medido num recebimento parcial (3 de 7 un., IPI): passivo com R$ 5,04 (base 7 un.) e linha
de imposto do razão com R$ 2,16 (base 3 un.). A diferença de R$ 2,88 é exatamente o
desbalanceamento.

## Correção

Um único ponto: no `create` de `account.move.line`, marcar a linha do documento fiscal
delegada como `modified()` nos campos de que os impostos dependem. Isso devolve os campos
de imposto para a fila de recompute, e passivo e razão passam a ler valores calculados na
mesma quantidade.

É idempotente — numa fatura que já estava coerente o recálculo devolve os mesmos valores —
e cobre venda, compra e recebimento num só lugar, sem tocar nos módulos de origem.

### Por que aqui e não nos pontos de cópia

A alternativa natural seria recalcular no `_prepare_br_fiscal_dict` de cada origem,
generalizando o que a fb628f97d fez no `l10n_br_sale`. Cheguei a implementar e medir isso
(#4842). Nos dados reais de um recebimento parcial ela **não é suficiente**: os valores
fiscais gravados ficam corretos, mas o `_sync_invoice` ainda produz um `amount_currency`
defasado e o lançamento continua não fechando.

| | débitos × créditos | diferença |
| --- | --- | --- |
| sem correção | 7.673,32 × 8.096,63 | 423,31 |
| corrigindo os pontos de cópia (#4842) | 7.684,76 × 7.954,66 | 269,90 |
| esta correção | fecha | 0,00 |

Com a correção nos pontos de cópia os valores gravados ficaram idênticos aos desta PR, e
ainda assim o `amount_currency` das linhas saiu R$ 269,90 menor. Ou seja: além do valor
existe um efeito de ordem/cache no momento em que o `_sync_invoice` roda, e só o recompute
no `create` o resolve.

### Escopo

O recálculo é disparado apenas para linhas que reúnem todas estas condições:

- `display_type == "product"`;
- `move_type` em `in_invoice` / `out_invoice`, o que deixa **devoluções** de fora;
- move com `fiscal_operation_id` e linha com `fiscal_document_line_id`;
- documento fiscal **não importado**, para preservar os valores vindos do XML;
- linha **originada de outro documento**.

Os campos que ligam a linha à origem (`purchase_line_id`, `sale_line_ids`) pertencem aos
módulos `sale` e `purchase`, dos quais o `l10n_br_account` não depende, e por isso são
procurados dinamicamente em `_fields`. Assim faturas fiscais avulsas, digitadas na
interface, não são tocadas.

## Testes

Em `l10n_br_purchase_stock`, onde o cenário de recebimento parcial existe:

- `test_partial_receipt_invoice_from_picking` — recebimento parcial com backorder,
  faturado pelo picking;
- `test_partial_receipt_bill_from_purchase_order` — `purchase_method='receive'`,
  recebimento parcial, faturado pelo pedido.

Os dois verificam que cada valor de imposto armazenado é igual ao que um novo cálculo
devolve e que o lançamento fecha. Sem a correção,
`test_partial_receipt_bill_from_purchase_order` falha com
`icms_base differs after recompute: stored=1081.5, recomputed=556.5`.

Suítes de `l10n_br_account`, `l10n_br_sale`, `l10n_br_purchase`, `l10n_br_stock_account` e
`l10n_br_purchase_stock` rodadas antes e depois, sem diferença de resultado.

## Validação em produção

Esta correção roda como módulo interno numa base de produção desde 2026-07-24, cobrindo os
três fluxos. Rodei o antes/depois num recebimento parcial real dessa base: sem ela a
fatura é recusada com R$ 423,31 de diferença; com ela fecha em zero e todos os valores
fiscais ficam coerentes com um novo cálculo.

## Limitações conhecidas

Declarando o que medi, para o revisor decidir:

- O recompute é **incondicional** para linha vinda de pedido: se um valor fiscal
  foi ajustado à mão na linha de origem e a quantidade faturada é a mesma, o
  ajuste não é preservado. Condicionar a marcação a uma divergência real de
  quantidade resolveria, ao custo de comparar contra a quantidade da origem.
- **Devolução parcial** tem a mesma causa raiz e fica de fora, porque o filtro
  aceita só `in_invoice`/`out_invoice`.
- `l10n_br_contract` copia o dicionário fiscal do mesmo jeito e também fica fora
  do filtro.
- Uso `modified()`. O idioma mais comum no core é `env.add_to_compute`; optei
  pelo primeiro porque é o que está validado em produção há dez dias, mas troco
  se preferirem.
- Sobreposição com a fb628f97d: no faturamento de venda pelo pedido o recálculo
  passa a acontecer duas vezes. Se preferirem, esta PR pode simplificar a
  fb628f97d num commit adicional.

## Escopo medido

Corrige o faturamento de **compra** pelo pedido e pelo recebimento. Os dois
fluxos de venda já estavam corretos (pelo pedido desde a fb628f97d; pelo picking
porque a `stock.move` recalcula seus valores ao ser dividida e nada os
sobrescreve) — a correção os cobre, sem alterar o resultado.

Refs #4704, #4455. Substitui a #4709 e a #4842, ambas fechadas.
