### PR TITLE
[16.0][FIX] l10n_br_nfse_focus: indicador_total_tributacao

### DIFF
--- a/l10n_br_nfse_focus/models/nfse_nacional.py
+++ b/l10n_br_nfse_focus/models/nfse_nacional.py
@@ -370,7 +370,11 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
             "percentual_total_tributos_municipais": service_basic[
                 "percentual_total_tributos_municipais"
             ],
-            "indicador_total_tributacao": 0,
+            **(
+                {"indicador_total_tributacao": 0}
+                if provider_data["codigo_opcao_simples_nacional"] != 2
+                else {}
+            ),
             "informacoes_complementares": (
                 rps_info.get("customer_additional_data", False)[:2000]
                 if rps_info.get("customer_additional_data")


### PR DESCRIPTION
@Escodoo SO848-6
o campo indTotTrib (mapeado de indicador_total_tributacao) nunca pode ser informado quando o prestador é optante pelo Simples Nacional (ME/EPP) — esse é justamente o erro E0712 da NFSe Nacional.

Não achei fontes da Focus mas usei de base isso aqui
https://www.projetoacbr.com.br/forum/topic/88669-acbr-8698-rejei%C3%A7%C3%A3o-e0712-para-meepp-indtottrib-nunca-poder%C3%A1-ser-informado/