### PR TITLE
[16.0] l10n_br_portal, l10n_br_pos: Remove eslint warnings

### DIFF
--- a/l10n_br_portal/static/src/js/l10n_br_portal.js
+++ b/l10n_br_portal/static/src/js/l10n_br_portal.js
@@ -11,7 +11,7 @@ odoo.define("l10n_br_portal.l10n_br_portal", function (require) {
     }
 
     if ($(".input-vat").length) {
-        new Cleave(".input-vat", {
+        var vat_cleave = new Cleave(".input-vat", {
             blocks: [2, 3, 3, 4, 2],
             delimiters: [".", ".", "-"],
             numericOnly: true,
@@ -29,7 +29,7 @@ odoo.define("l10n_br_portal.l10n_br_portal", function (require) {
 
     if ($(".input-zipcode").length) {
         // Apply ZIP code mask only when the field exists.
-        new Cleave(".input-zipcode", {
+        var zipcode_cleave = new Cleave(".input-zipcode", {
             blocks: [5, 3],
             delimiter: "-",
             numericOnly: true,

--- a/l10n_br_pos/static/src/js/Screens/PaymentScreen/PaymentScreen.esm.js
+++ b/l10n_br_pos/static/src/js/Screens/PaymentScreen/PaymentScreen.esm.js
@@ -8,10 +8,10 @@ Copyright (C) 2016-Today KMEE (https://kmee.com.br)
  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 */
 
-import {validate_cnpj_cpf} from "@l10n_br_pos/js/util.esm";
-import {_t} from "@web/core/l10n/translation";
 import PaymentScreen from "point_of_sale.PaymentScreen";
 import Registries from "point_of_sale.Registries";
+import {_t} from "@web/core/l10n/translation";
+import {validate_cnpj_cpf} from "@l10n_br_pos/js/util.esm";
 
 const L10nBrPosPaymentScreen = (OriginalPaymentScreen) =>
     class extends OriginalPaymentScreen {

--- a/l10n_br_pos/static/src/js/Screens/TicketScreen/TicketScreen.esm.js
+++ b/l10n_br_pos/static/src/js/Screens/TicketScreen/TicketScreen.esm.js
@@ -6,9 +6,9 @@ Copyright (C) 2026-Today Escodoo (https://www.escodoo.com.br)
 License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 */
 
-import {_t} from "@web/core/l10n/translation";
 import Registries from "point_of_sale.Registries";
 import TicketScreen from "point_of_sale.TicketScreen";
+import {_t} from "@web/core/l10n/translation";
 
 export const TicketScreenPatch = (OriginalTicketScreen) =>
     class extends OriginalTicketScreen {

--- a/l10n_br_pos/static/src/js/models.esm.js
+++ b/l10n_br_pos/static/src/js/models.esm.js
@@ -10,11 +10,11 @@ Copyright (C) 2016-Today KMEE (https://kmee.com.br)
 */
 
 import {Order, Orderline, Paymentline, PosGlobalState} from "point_of_sale.models";
-import {validate_cnpj_cpf} from "@l10n_br_pos/js/util.esm";
-import {_t} from "@web/core/l10n/translation";
-import {patch} from "@web/core/utils/patch";
 import {Gui} from "point_of_sale.Gui";
 import Registries from "point_of_sale.Registries";
+import {_t} from "@web/core/l10n/translation";
+import {patch} from "@web/core/utils/patch";
+import {validate_cnpj_cpf} from "@l10n_br_pos/js/util.esm";
 
 const SITUACAO_EDOC = {
     em_digitacao: "Em digitação",
@@ -47,7 +47,7 @@ if (PosGlobalState) {
 }
 
 const L10nBrOrder = (BaseOrder) =>
-    class L10nBrOrder extends BaseOrder {
+    class extends BaseOrder {
         setup(_default_attributes, options) {
             super.setup(...arguments);
             this.state_edoc = this.state_edoc || "em_digitacao";
@@ -143,7 +143,7 @@ if (Order) {
 }
 
 const L10nBrOrderline = (BaseOrderline) =>
-    class L10nBrOrderline extends BaseOrderline {
+    class extends BaseOrderline {
         export_as_JSON() {
             const json = super.export_as_JSON(...arguments);
             const product = this.get_product();
@@ -171,7 +171,7 @@ if (Orderline) {
 }
 
 const L10nBrPaymentline = (BasePaymentline) =>
-    class L10nBrPaymentline extends BasePaymentline {
+    class extends BasePaymentline {
         export_as_JSON() {
             const json = super.export_as_JSON(...arguments);
             json.payment_status = this.payment_status;


### PR DESCRIPTION
Ao executar o pre-commit está sendo apresentado as seguintes mensagens de aviso:

```bash
/l10n-brazil/l10n_br_portal/static/src/js/l10n_br_portal.js
  14:9  warning  Do not use 'new' for side effects  no-new
  32:9  warning  Do not use 'new' for side effects  no-new

/l10n-brazil/l10n_br_pos/static/src/js/models.esm.js
   14:1   warning  Imports should be sorted alphabetically                                          sort-imports
   16:1   warning  Imports should be sorted alphabetically                                          sort-imports
   50:11  warning  'L10nBrOrder' is already declared in the upper scope on line 49 column 7         no-shadow
  146:11  warning  'L10nBrOrderline' is already declared in the upper scope on line 145 column 7    no-shadow
  174:11  warning  'L10nBrPaymentline' is already declared in the upper scope on line 173 column 7  no-shadow

✖ 7 problems (0 errors, 7 warnings)


/l10n-brazil/l10n_br_pos/static/src/js/Screens/PaymentScreen/PaymentScreen.esm.js
  12:1  warning  Imports should be sorted alphabetically  sort-imports
  13:1  warning  Imports should be sorted alphabetically  sort-imports

/l10n-brazil/l10n_br_pos/static/src/js/Screens/TicketScreen/TicketScreen.esm.js
  10:1  warning  Imports should be sorted alphabetically  sort-imports

✖ 3 problems (0 errors, 3 warnings)

```

Esse PR faz as correções necessárias para remover essas menagens de aviso