### PR TITLE
[16.0][FIX] l10n_br_fiscal: show CST tab and fields for IBS, CBS, IS

### DIFF
--- a/l10n_br_fiscal/views/tax_definition_view.xml
+++ b/l10n_br_fiscal/views/tax_definition_view.xml
@@ -89,7 +89,7 @@
                         <field
                             name="cst_id"
                             force_save="1"
-                            attrs="{'invisible': ['|', ('custom_tax', '=', False), ('tax_domain', 'not in', ('icmssn', 'icms', 'ipi', 'pis', 'pisst', 'cofins', 'cofinsst'))], 'required': [('custom_tax', '=', True), ('tax_domain', 'in', ('icms', 'ipi', 'pis', 'pisst', 'cofins', 'cofinsst'))]}"
+                            attrs="{'invisible': ['|', ('custom_tax', '=', False), ('tax_domain', 'not in', ('icms','icmssn', 'icmsst', 'ipi', 'pis', 'pisst', 'cofins', 'cofinsst', 'ibs', 'cbs', 'is'))], 'required': [('custom_tax', '=', True), ('tax_domain', 'in', ('icms','icmssn', 'icmsst', 'ipi', 'pis', 'pisst', 'cofins', 'cofinsst', 'ibs', 'cbs', 'is'))]}"
                             options="{'no_create': True, 'no_create_edit': True}"
                         />
                         <field

--- a/l10n_br_fiscal/views/tax_group_view.xml
+++ b/l10n_br_fiscal/views/tax_group_view.xml
@@ -63,7 +63,7 @@
                         <page
                             name="csts"
                             string="CSTs"
-                            attrs="{'invisible': [('tax_domain', 'not in', ('icms', 'ipi', 'pis', 'cofins'))]}"
+                            attrs="{'invisible': [('tax_domain', 'not in', ('icms', 'ipi', 'pis', 'cofins', 'ibs', 'cbs', 'is'))]}"
                         >
                             <field name="cst_ids" nolabel="1" />
                         </page>


### PR DESCRIPTION
Atualmente o grupo de impostos (Fiscal > Configuração > Impostos > Grupo de Imposto, a aba CST não está visível para os novos impostos IBS, CBS, IS:

<img width="1144" height="637" alt="Captura de Tela 2026-08-04 às 12 08 56" src="https://github.com/user-attachments/assets/0fb270aa-908b-4af8-8f69-e48bf0e8eb86" />

<br><br>
Nesse PR é corrigido para que a aba CSTs seja apresentada para esses impostos:


<img width="1144" height="637" alt="Captura de Tela 2026-08-04 às 12 16 45" src="https://github.com/user-attachments/assets/844fa920-c023-4e18-8e78-04afa75721e0" />

Também foi feito uma correção na tela da definição fiscal

<img width="977" height="795" alt="Captura de Tela 2026-08-04 às 14 49 45" src="https://github.com/user-attachments/assets/e4189655-de6e-4b38-86ed-4535be05795e" />
