### PR TITLE
[18.0] l10n_br_portal, l10n_br_fiscal: Remove eslint warnings

### DIFF
--- a/l10n_br_fiscal/static/src/js/list_renderer_with_button.esm.js
+++ b/l10n_br_fiscal/static/src/js/list_renderer_with_button.esm.js
@@ -1,4 +1,3 @@
-/** @odoo-module **/
 // Copyright 2025-TODAY Akretion - Raphael Valyi <raphael.valyi@akretion.com>
 // License AGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
 

--- a/l10n_br_portal/static/src/js/l10n_br_portal.esm.js
+++ b/l10n_br_portal/static/src/js/l10n_br_portal.esm.js
@@ -1,5 +1,4 @@
-/** @odoo-module **/
-/* global Cleave, console */
+/* global Cleave */
 
 import publicWidget from "@web/legacy/js/public/public_widget";
 import {rpc} from "@web/core/network/rpc";

--- a/l10n_br_portal/static/src/js/l10n_br_portal_tour.esm.js
+++ b/l10n_br_portal/static/src/js/l10n_br_portal_tour.esm.js
@@ -1,5 +1,3 @@
-/** @odoo-module **/
-
 import {registry} from "@web/core/registry";
 
 registry.category("web_tour.tours").add("l10n_br_portal_tour", {


### PR DESCRIPTION
Ao executar o pre-commit está sendo apresentado as seguintes mensagens de aviso:

```bash
eslint...................................................................Passed
- hook id: eslint
- duration: 1.39s


/l10n-brazil/l10n_br_fiscal/static/src/js/list_renderer_with_button.esm.js
  1:1  warning  Invalid JSDoc tag name "odoo-module"  jsdoc/check-tag-names

/l10n-brazil/l10n_br_portal/static/src/js/l10n_br_portal.esm.js
  1:1   warning  Invalid JSDoc tag name "odoo-module"                        jsdoc/check-tag-names
  2:19  warning  'console' is already defined as a built-in global variable  no-redeclare

/l10n-brazil/l10n_br_portal/static/src/js/l10n_br_portal_tour.esm.js
  1:1  warning  Invalid JSDoc tag name "odoo-module"  jsdoc/check-tag-names

✖ 4 problems (0 errors, 4 warnings)
```

Port do commit 901fd3026b6b2d4928888ff90d6c8f1c0f27e41a do PR #4852 e feito mais um commit para corrigir as mensagens de aviso do módulo l10n_br_fiscal