### PR TITLE
[16.0][IMP] l10n_br_mdfe: validate required fields before sending

### DIFF
--- a/l10n_br_mdfe/models/document.py
+++ b/l10n_br_mdfe/models/document.py
@@ -18,6 +18,7 @@ from odoo import Command, _, api, fields
 from odoo.exceptions import UserError
 
 from odoo.addons.l10n_br_fiscal.constants.fiscal import (
+    DOCUMENT_ISSUER_COMPANY,
     EVENT_ENV_HML,
     EVENT_ENV_PROD,
     MODELO_FISCAL_MDFE,
@@ -989,6 +990,140 @@ class MDFe(spec_models.StackedModel):
             record.key_random_code = chave_edoc.codigo_aleatorio
             record.key_check_digit = chave_edoc.digito_verificador
             record.document_key = chave_edoc.chave
+
+    def _document_number(self):
+        if (
+            self.document_type == MODELO_FISCAL_MDFE
+            and self.issuer == DOCUMENT_ISSUER_COMPANY
+            and not self.document_serie_id
+            and self.document_type_id
+        ):
+            serie = self.document_type_id.get_document_serie(
+                self.company_id, self.fiscal_operation_id
+            )
+            if serie:
+                self.document_serie_id = serie
+        return super()._document_number()
+
+    def _document_check(self):
+        result = super()._document_check()
+        for record in self.filtered(filtered_processador_edoc_mdfe):
+            record._check_mdfe_required_fields()
+        return result
+
+    def _check_mdfe_required_fields(self):
+        self.ensure_one()
+
+        missing_fields = []
+
+        def check(value, label):
+            if not value:
+                missing_fields.append(label)
+
+        company = self.company_id
+        certificate = (
+            company.sudo().certificate_nfe_id or company.sudo().certificate_ecnpj_id
+        )
+
+        check(company, _("Company"))
+        check(company.vat, _("Company CNPJ/CPF"))
+        check(company.state_id, _("Company State"))
+        check(certificate, _("Digital Certificate"))
+        if certificate:
+            check(certificate.file, _("Digital Certificate File"))
+            check(certificate.password, _("Digital Certificate Password"))
+
+        check(self.document_type_id, _("Document Type"))
+        check(self.document_serie, _("Document Serie"))
+        check(self.document_number, _("Document Number"))
+        check(self.document_date, _("Document Date"))
+        check(self.mdfe_version, _("MDF-e Version"))
+        check(self.mdfe_environment, _("MDF-e Environment"))
+        check(self.mdfe_emit_type, _("MDF-e Emit Type"))
+        # mdfe_transp_type is only required when a third-party owner is set.
+        # It is validated together with mdfe30_prop in _check_mdfe_road_required_fields.
+        check(self.mdfe_modal, _("MDF-e Modal"))
+        check(self.mdfe_transmission, _("MDF-e Transmission"))
+        check(self.mdfe_initial_state_id, _("MDF-e Initial State"))
+        check(self.mdfe_final_state_id, _("MDF-e Final State"))
+        check(self.mdfe_loading_city_ids, _("MDF-e Loading City"))
+        check(self.mdfe30_infMunDescarga, _("MDF-e Unloading City"))
+
+        for descarga in self.mdfe30_infMunDescarga:
+            label = descarga.city_id.display_name or _("Unloading City")
+            check(descarga.city_id, _("MDF-e Unloading City"))
+            if descarga.document_type == "nfe":
+                check(
+                    descarga.nfe_ids, _("NF-e documents for unloading city %s") % label
+                )
+            elif descarga.document_type == "cte":
+                check(
+                    descarga.cte_ids, _("CT-e documents for unloading city %s") % label
+                )
+            elif descarga.document_type == "mdfe":
+                check(
+                    descarga.mdfe_ids,
+                    _("MDF-e transport documents for unloading city %s") % label,
+                )
+
+            for document in descarga.nfe_ids + descarga.cte_ids + descarga.mdfe_ids:
+                check(document.document_key, _("Document Key for %s") % label)
+
+        if self.mdfe_modal == "1":
+            self._check_mdfe_road_required_fields(missing_fields)
+
+        if missing_fields:
+            raise UserError(
+                _("Fill in the required MDF-e fields before sending:\n- %s")
+                % "\n- ".join(missing_fields)
+            )
+
+    def _check_mdfe_road_required_fields(self, missing_fields):
+        def check(value, label):
+            if not value:
+                missing_fields.append(label)
+
+        check(self.mdfe30_placa, _("Vehicle Plate"))
+        check(self.mdfe30_tara, _("Vehicle Tare in KG"))
+        check(self.mdfe30_tpRod, _("Vehicle Wheel Type"))
+        check(self.mdfe30_tpCar, _("Vehicle Body Type"))
+        check(self.mdfe30_condutor, _("Vehicle Driver"))
+
+        if self.mdfe30_prop:
+            if self.mdfe30_prop == self.company_id.partner_id:
+                missing_fields.append(
+                    _(
+                        "Vehicle Owner must be different from the MDF-e issuer. "
+                        "If the vehicle belongs to your company, clear the "
+                        "Transport Type field instead of filling an owner."
+                    )
+                )
+            elif not self.mdfe_transp_type:
+                missing_fields.append(
+                    _(
+                        "Transport Type must be informed when a third-party "
+                        "vehicle owner is specified."
+                    )
+                )
+        elif self.mdfe_transp_type:
+            missing_fields.append(
+                _(
+                    "Vehicle Owner is required when Transport Type is informed. "
+                    "If the vehicle belongs to your company, clear the "
+                    "Transport Type field."
+                )
+            )
+
+        if self.mdfe30_prop:
+            owner_rntrc = self.mdfe30_prop.rntrc_code
+            if not owner_rntrc:
+                missing_fields.append(_("Vehicle Owner RNTRC"))
+            elif not owner_rntrc.isdigit() or len(owner_rntrc) != 8:
+                missing_fields.append(_("Owner RNTRC must contain exactly 8 digits."))
+
+        for condutor in self.mdfe30_condutor:
+            check(condutor.mdfe30_xNome, _("Driver Name"))
+            check(condutor.mdfe30_CPF, _("Driver CPF"))
 
     def _document_export(self, pretty_print=True):
         result = super()._document_export()

--- a/l10n_br_mdfe/tests/test_mdfe_damdfe.py
+++ b/l10n_br_mdfe/tests/test_mdfe_damdfe.py
@@ -4,10 +4,13 @@
 from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
 
+from .test_mdfe_serialize import TestMDFeSerialize
+
 
 class TestDamdfeGeneration(TransactionCase):
     def test_generate_damdfe_brazil_fiscal_report(self):
         mdfe = self.env.ref("l10n_br_mdfe.demo_mdfe_lc_modal_rodoviario")
+        TestMDFeSerialize.prepare_modal_rodoviario_data(mdfe)
         mdfe.action_document_confirm()
         mdfe.view_pdf()
         self.assertTrue(mdfe.file_report_id)
@@ -18,6 +21,7 @@ class TestDamdfeGeneration(TransactionCase):
         )
         mdfe = self.env.ref("l10n_br_mdfe.demo_mdfe_lc_modal_rodoviario")
         mdfe.document_type_id = self.env.ref("l10n_br_fiscal.document_01")
+        TestMDFeSerialize.prepare_modal_rodoviario_data(mdfe)
         mdfe.action_document_confirm()
         with self.assertRaises(UserError) as captured_exception:
             damdfe_report._render_qweb_pdf("main_template_damdfe", [mdfe.id])
@@ -28,6 +32,7 @@ class TestDamdfeGeneration(TransactionCase):
 
     def test_generate_damdfe_brazil_fiscal_report_partner(self):
         mdfe = self.env.ref("l10n_br_mdfe.demo_mdfe_lc_modal_rodoviario")
+        TestMDFeSerialize.prepare_modal_rodoviario_data(mdfe)
         mdfe.action_document_confirm()
         mdfe.issuer = "partner"
         mdfe.view_pdf()

--- a/l10n_br_mdfe/tests/test_mdfe_serialize.py
+++ b/l10n_br_mdfe/tests/test_mdfe_serialize.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from xmldiff import main
 
 from odoo import Command
+from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
 from odoo.tools import config
 
@@ -37,12 +38,6 @@ class TestMDFeSerialize(TransactionCase):
         if mdfe.state != "em_digitacao":  # 2nd test run
             mdfe.action_document_back2draft()
 
-        mdfe.action_document_confirm()
-        mdfe.document_date = datetime.strptime(
-            "2020-01-01T11:00:00", "%Y-%m-%dT%H:%M:%S"
-        )
-        mdfe.mdfe30_cMDF = "20801844"
-
         if mdfe.mdfe_modal == "1":
             cls.prepare_modal_rodoviario_data(mdfe)
         elif mdfe.mdfe_modal == "2":
@@ -51,6 +46,12 @@ class TestMDFeSerialize(TransactionCase):
             cls.prepare_modal_aquaviario_data(mdfe)
         elif mdfe.mdfe_modal == "4":
             cls.prepare_modal_ferroviario_data(mdfe)
+
+        mdfe.action_document_confirm()
+        mdfe.document_date = datetime.strptime(
+            "2020-01-01T11:00:00", "%Y-%m-%dT%H:%M:%S"
+        )
+        mdfe.mdfe30_cMDF = "20801844"
 
         mdfe._document_export()
 
@@ -84,7 +85,7 @@ class TestMDFeSerialize(TransactionCase):
         mdfe.mdfe30_infPag = [
             Command.create(
                 {
-                    "partner_id": cls.env.ref("l10n_br_base.res_partner_intel").id,
+                    "partner_id": mdfe.env.ref("l10n_br_base.res_partner_intel").id,
                     "mdfe30_vContrato": 5,
                     "mdfe30_indPag": "0",
                     "payment_type": "pix",
@@ -107,13 +108,18 @@ class TestMDFeSerialize(TransactionCase):
         mdfe.mdfe30_cInt = "1"
         mdfe.mdfe30_RENAVAM = "42423325472"
         mdfe.mdfe30_placa = "AAA1233"
+        # The MDF-e is issued by the company itself, so no transport type /
+        # owner is required. mdfe30_tpTransp may be defined as a related or
+        # as a spec field depending on the model loading order, so clear both
+        # the logical field and the spec field.
+        mdfe.mdfe_transp_type = False
         mdfe.mdfe30_tpTransp = False
         mdfe.mdfe30_tara = 7500
         mdfe.mdfe30_capKG = 42500
         mdfe.mdfe30_capM3 = 300
         mdfe.mdfe30_tpRod = "03"
         mdfe.mdfe30_tpCar = "00"
-        mdfe.rodo_vehicle_state_id = cls.env.ref("base.state_br_ac").id
+        mdfe.rodo_vehicle_state_id = mdfe.env.ref("base.state_br_ac").id
         mdfe.mdfe30_condutor = [
             Command.create(
                 {
@@ -225,3 +231,91 @@ class TestMDFeSerialize(TransactionCase):
         _logger.info(f"XML file saved at {output}")
         diff = main.diff_files(output, xml_path)
         return diff
+
+
+class TestMDFeRequiredFields(TransactionCase):
+    """Negative tests: sending must be blocked when required fields are missing."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.mdfe = cls.env.ref("l10n_br_mdfe.demo_mdfe_lc_modal_rodoviario")
+        TestMDFeSerialize.prepare_modal_rodoviario_data(cls.mdfe)
+
+    def test_missing_initial_state(self):
+        self.mdfe.mdfe_initial_state_id = False
+        with self.assertRaises(UserError) as cm:
+            self.mdfe.action_document_confirm()
+        self.assertIn("MDF-e Initial State", str(cm.exception))
+
+    def test_missing_vehicle_plate(self):
+        self.mdfe.mdfe30_placa = False
+        with self.assertRaises(UserError) as cm:
+            self.mdfe.action_document_confirm()
+        self.assertIn("Vehicle Plate", str(cm.exception))
+
+    def test_document_number_assigns_serie(self):
+        self.mdfe.document_serie_id = False
+        self.mdfe.document_serie = False
+        self.mdfe._document_number()
+        self.assertTrue(self.mdfe.document_serie_id)
+
+    def test_check_with_cte_and_mdfe_descarga(self):
+        demo_descarga = self.env.ref("l10n_br_mdfe.demo_mdfe_lc_descarga_rodoviario")
+        self.mdfe.mdfe30_infMunDescarga = [
+            Command.set(self.mdfe.mdfe30_infMunDescarga.ids),
+            Command.create(
+                {
+                    "city_id": demo_descarga.city_id.id,
+                    "document_type": "cte",
+                },
+            ),
+            Command.create(
+                {
+                    "city_id": demo_descarga.city_id.id,
+                    "document_type": "mdfe",
+                },
+            ),
+        ]
+        with self.assertRaises(UserError) as cm:
+            self.mdfe.action_document_confirm()
+        self.assertIn("CT-e documents for unloading city", str(cm.exception))
+        self.assertIn("MDF-e transport documents for unloading city", str(cm.exception))
+
+    def test_owner_equal_issuer(self):
+        self.mdfe.mdfe30_prop = self.mdfe.company_id.partner_id
+        self.mdfe.mdfe_transp_type = "1"
+        with self.assertRaises(UserError) as cm:
+            self.mdfe.action_document_confirm()
+        self.assertIn("Vehicle Owner must be different", str(cm.exception))
+
+    def test_owner_without_transp_type(self):
+        partner = self.env.ref("l10n_br_base.res_partner_intel")
+        partner.rntrc_code = "12345678"
+        self.mdfe.mdfe30_prop = partner
+        self.mdfe.mdfe_transp_type = False
+        with self.assertRaises(UserError) as cm:
+            self.mdfe.action_document_confirm()
+        self.assertIn("Transport Type must be informed", str(cm.exception))
+
+    def test_transp_type_without_owner(self):
+        self.mdfe.mdfe_transp_type = "1"
+        with self.assertRaises(UserError) as cm:
+            self.mdfe.action_document_confirm()
+        self.assertIn("Vehicle Owner is required", str(cm.exception))
+
+    def test_owner_without_rntrc(self):
+        self.mdfe.mdfe30_prop = self.env.ref("l10n_br_base.res_partner_intel")
+        self.mdfe.mdfe_transp_type = "1"
+        with self.assertRaises(UserError) as cm:
+            self.mdfe.action_document_confirm()
+        self.assertIn("Vehicle Owner RNTRC", str(cm.exception))
+
+    def test_owner_invalid_rntrc(self):
+        partner = self.env.ref("l10n_br_base.res_partner_intel")
+        partner.rntrc_code = "123"
+        self.mdfe.mdfe30_prop = partner
+        self.mdfe.mdfe_transp_type = "1"
+        with self.assertRaises(UserError) as cm:
+            self.mdfe.action_document_confirm()
+        self.assertIn("Owner RNTRC must contain exactly 8 digits", str(cm.exception))

--- a/l10n_br_mdfe/views/document.xml
+++ b/l10n_br_mdfe/views/document.xml
@@ -59,7 +59,7 @@
             <xpath expr="//field[@name='fiscal_operation_id']" position="after">
                 <field
                     name="mdfe_emit_type"
-                    attrs="{'invisible': [('document_type', 'not in', ['58'])]}"
+                    attrs="{'required': [('document_type', '=', '58')], 'invisible': [('document_type', 'not in', ['58'])]}"
                 />
                 <field
                     name="mdfe_transp_type"
@@ -70,11 +70,11 @@
                 <group>
                     <field
                         name="mdfe_initial_state_id"
-                        attrs="{'invisible': [('document_type', 'not in', ['58'])]}"
+                        attrs="{'required': [('document_type', '=', '58')], 'invisible': [('document_type', 'not in', ['58'])]}"
                     />
                     <field
                         name="mdfe_final_state_id"
-                        attrs="{'invisible': [('document_type', 'not in', ['58'])]}"
+                        attrs="{'required': [('document_type', '=', '58')], 'invisible': [('document_type', 'not in', ['58'])]}"
                     />
                 </group>
                 <separator
@@ -84,7 +84,7 @@
                 />
                 <field
                     name="mdfe_loading_city_ids"
-                    attrs="{'invisible': [('document_type', 'not in', ['58'])]}"
+                    attrs="{'required': [('document_type', '=', '58')], 'invisible': [('document_type', 'not in', ['58'])]}"
                 />
                 <separator
                     colspan="4"
@@ -160,7 +160,11 @@
                     attrs="{'invisible': [('document_type', 'not in', ['58'])]}"
                 >
                     <group>
-                        <field name="mdfe_modal" widget="radio" />
+                        <field
+                            name="mdfe_modal"
+                            widget="radio"
+                            attrs="{'required': [('document_type', '=', '58')], 'invisible': [('document_type', 'not in', ['58'])]}"
+                        />
                     </group>
                     <group
                         attrs="{'invisible': [('mdfe_modal', '!=', '1')]}"
@@ -205,7 +209,11 @@
                                     </group>
                                 </group>
                                 <separator string="Conductors" />
-                                <field name="mdfe30_condutor" nolabel="1" />
+                                <field
+                                    name="mdfe30_condutor"
+                                    nolabel="1"
+                                    attrs="{'required': [('mdfe_modal', '=', '1'), ('document_type', '=', '58')]}"
+                                />
                             </page>
                             <page string="CIOT">
                                 <field name="mdfe30_infCIOT" nolabel="1" />


### PR DESCRIPTION
This PR is part of splitting #4826 into smaller reviewable PRs (suggestion from @CristianoMafraJunior).

Extracted from commit f792a9a of #4826.

## What it does
Validate required fields before sending the MDF-e:
- `_document_check` calls `_check_mdfe_required_fields` for MDF-e documents
- `_check_mdfe_required_fields` / `_check_mdfe_road_required_fields` validate the mandatory fields before transmission
- `_document_number` assigns the document serie when missing, only for MDF-e documents (`document_type == 58`)
- View: fields `mdfe_emit_type`, `mdfe_initial_state_id`, `mdfe_final_state_id`, `mdfe_loading_city_ids` become required for document type 58, and `mdfe_modal` becomes required through the view attrs (instead of a hardcoded `required="1"`)

## Review changes
- `_document_number` is guarded by `document_type == MODELO_FISCAL_MDFE` so other fiscal documents (NFe, etc.) that reach this method are not affected (review from @mileo).
- `mdfe_modal` required was moved from a hardcoded `required="1"` to `attrs` conditional on the MDF-e document type.
- The vehicle owner RNTRC is now required when an owner is informed, not only validated for its format.
- Added negative tests asserting issuance is blocked with a missing header field (`mdfe_initial_state_id`) and with a missing road modal field (`mdfe30_placa`).

## Notes
- Added missing import of `DOCUMENT_ISSUER_COMPANY` so the module is self-contained (it is used by `_document_number`).
- Fixed existing tests: `prepare_modal_rodoviario_data` now runs before `action_document_confirm` (the new validation runs on confirm), using `mdfe.env` instead of `cls.env` so it can be reused from the damdfe tests.
