### PR TITLE
[16.0][IMP] l10n_br_mdfe: vehicle management and owner/driver data from partner

### DIFF
--- a/l10n_br_delivery/__manifest__.py
+++ b/l10n_br_delivery/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "Akretion, Odoo Community Association (OCA)",
     "maintainers": ["renatonlima", "mbcosta"],
     "website": "https://github.com/OCA/l10n-brazil",
-    "version": "16.0.4.0.0",
+    "version": "16.0.4.1.0",
     "development_status": "Beta",
     "depends": [
         "l10n_br_sale_stock",

--- a/l10n_br_delivery/demo/l10n_br_delivery_demo.xml
+++ b/l10n_br_delivery/demo/l10n_br_delivery_demo.xml
@@ -31,7 +31,10 @@
     >
         <field name="name">Teste - Veículo da Transportadora 1</field>
         <field name="description">Teste - Veículo da Transportadora 1</field>
+        <field name="owner_id" ref="test_carrier" />
         <field name="plate">ABC1234</field>
+        <field name="vehicle_code">01</field>
+        <field name="renavam">42423325472</field>
         <field name="driver">Teste - Motorista 1</field>
         <field name="rntc_code">Teste - Codigo RTNC 1</field>
         <field name="country_id" ref="base.br" />
@@ -41,6 +44,11 @@
         <field name="manufacture_year">2000</field>
         <field name="model_year">2001</field>
         <field name="type">bau</field>
+        <field name="wheel_type">03</field>
+        <field name="body_type">02</field>
+        <field name="tara">7500</field>
+        <field name="capacity_kg">42500</field>
+        <field name="capacity_m3">300</field>
     </record>
 
     <record
@@ -49,7 +57,10 @@
     >
         <field name="name">Teste - Veículo da Transportadora 2</field>
         <field name="description">Teste - Veículo da Transportadora 2</field>
+        <field name="owner_id" ref="test_carrier" />
         <field name="plate">DEF5678</field>
+        <field name="vehicle_code">02</field>
+        <field name="renavam">42423325473</field>
         <field name="driver">Teste - Motorista 2</field>
         <field name="rntc_code">Teste - Codigo RTNC 2</field>
         <field name="country_id" ref="base.br" />
@@ -59,6 +70,11 @@
         <field name="manufacture_year">2010</field>
         <field name="model_year">2011</field>
         <field name="type">bau</field>
+        <field name="wheel_type">03</field>
+        <field name="body_type">02</field>
+        <field name="tara">7500</field>
+        <field name="capacity_kg">42500</field>
+        <field name="capacity_m3">300</field>
     </record>
 
     <!-- Metodo de Entrega -->

--- a/l10n_br_delivery/models/vehicle.py
+++ b/l10n_br_delivery/models/vehicle.py
@@ -3,6 +3,24 @@
 
 from odoo import fields, models
 
+VEHICLE_WHEEL_TYPE = [
+    ("01", "Truck"),
+    ("02", "Toco"),
+    ("03", "Cavalo Mecânico"),
+    ("04", "VAN"),
+    ("05", "Utilitário"),
+    ("06", "Outros"),
+]
+
+VEHICLE_BODY_TYPE = [
+    ("00", "Não aplicável"),
+    ("01", "Aberta"),
+    ("02", "Fechada/Baú"),
+    ("03", "Granelera"),
+    ("04", "Porta Container"),
+    ("05", "Sider"),
+]
+
 
 class CarrierVehicle(models.Model):
     _name = "l10n_br_delivery.carrier.vehicle"
@@ -19,9 +37,23 @@ class CarrierVehicle(models.Model):
         unaccent=False,
     )
 
+    owner_id = fields.Many2one(
+        comodel_name="res.partner",
+        string="Owner",
+    )
+
     plate = fields.Char(
         string="Placa",
         size=7,
+    )
+
+    vehicle_code = fields.Char(
+        size=10,
+    )
+
+    renavam = fields.Char(
+        string="RENAVAM",
+        size=11,
     )
 
     driver = fields.Char(
@@ -66,6 +98,26 @@ class CarrierVehicle(models.Model):
     type = fields.Selection(
         selection=[("bau", "Caminhão Baú")],
         string="Model Type",
+    )
+
+    wheel_type = fields.Selection(
+        selection=VEHICLE_WHEEL_TYPE,
+    )
+
+    body_type = fields.Selection(
+        selection=VEHICLE_BODY_TYPE,
+    )
+
+    tara = fields.Char(
+        string="Tara (KG)",
+    )
+
+    capacity_kg = fields.Char(
+        string="Capacity (KG)",
+    )
+
+    capacity_m3 = fields.Char(
+        string="Capacity (M3)",
     )
 
     carrier_id = fields.Many2one(

--- a/l10n_br_delivery/readme/HISTORY.md
+++ b/l10n_br_delivery/readme/HISTORY.md
@@ -1,3 +1,7 @@
+## 16.0.4.1.0 (2026-08-13)
+
+- Add vehicle data fields (owner, RENAVAM, tara, capacities, wheel/body type).
+
 ## 14.0.1.0.0 (2022-09-29)
 
 - Migration.

--- a/l10n_br_delivery/views/l10n_br_delivery_view.xml
+++ b/l10n_br_delivery/views/l10n_br_delivery_view.xml
@@ -15,8 +15,11 @@
                     <group string="Vehicle Data">
                         <field name="name" />
                         <field name="active" />
+                        <field name="owner_id" />
                         <field name="description" />
                         <field name="plate" />
+                        <field name="vehicle_code" />
+                        <field name="renavam" />
                         <field name="driver" />
                         <field name="rntc_code" />
                         <field name="country_id" />
@@ -25,6 +28,11 @@
                         <field name="manufacture_year" />
                         <field name="model_year" />
                         <field name="type" />
+                        <field name="wheel_type" />
+                        <field name="body_type" />
+                        <field name="tara" />
+                        <field name="capacity_kg" />
+                        <field name="capacity_m3" />
                     </group>
                 </sheet>
             </form>
@@ -39,6 +47,7 @@
             <tree>
                 <field colspan="4" name="name" />
                 <field name="plate" />
+                <field name="renavam" />
                 <field name="manufacture_year" />
             </tree>
         </field>

--- a/l10n_br_mdfe/__manifest__.py
+++ b/l10n_br_mdfe/__manifest__.py
@@ -15,6 +15,7 @@
         "l10n_br_fiscal_edi",
         "l10n_br_fiscal_certificate",
         "l10n_br_mdfe_spec",
+        "l10n_br_delivery",
         "spec_driven_model",
     ],
     "data": [

--- a/l10n_br_mdfe/constants/mdfe.py
+++ b/l10n_br_mdfe/constants/mdfe.py
@@ -18,12 +18,13 @@ MDFE_EMIT_TYPES = [
 MDFE_EMIT_TYPE_DEFAULT = "2"
 
 MDFE_TRANSP_TYPE = [
+    ("", "Não Aplicável (veículo próprio)"),
     ("1", "Empresa de Transporte de Cargas – ETC"),
     ("2", "Transportador Autônomo de Cargas – TAC"),
     ("3", "Cooperativa de Transporte de Cargas – CTC"),
 ]
 
-MDFE_TRANSP_TYPE_DEFAULT = "1"
+MDFE_TRANSP_TYPE_DEFAULT = ""
 
 MDFE_TRANSMISSIONS = [
     ("1", "Emissão Normal"),

--- a/l10n_br_mdfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_mdfe/demo/fiscal_document_demo.xml
@@ -19,6 +19,7 @@
 
     <!-- MDFe Test - Modal Ferroviário - LC -->
     <record id="demo_mdfe_lc_modal_ferroviario" model="l10n_br_fiscal.document">
+        <field name="mdfe_transp_type">1</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_manifesto" />
         <field name="document_type_id" ref="l10n_br_fiscal.document_58" />
         <field
@@ -81,6 +82,7 @@
 
     <!-- MDFe Test - Modal Rodoviário - LC -->
     <record id="demo_mdfe_lc_modal_rodoviario" model="l10n_br_fiscal.document">
+        <field name="mdfe_transp_type">1</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_manifesto" />
         <field name="document_type_id" ref="l10n_br_fiscal.document_58" />
         <field
@@ -199,6 +201,7 @@
 
     <!-- MDFe Test - Modal Aéreo - SN -->
     <record id="demo_mdfe_sn_modal_aereo" model="l10n_br_fiscal.document">
+        <field name="mdfe_transp_type">1</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_manifesto" />
         <field name="document_type_id" ref="l10n_br_fiscal.document_58" />
         <field
@@ -255,6 +258,7 @@
 
     <!-- MDFe Test - Modal Aquaviário - SN -->
     <record id="demo_mdfe_sn_modal_aquaviario" model="l10n_br_fiscal.document">
+        <field name="mdfe_transp_type">1</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_manifesto" />
         <field name="document_type_id" ref="l10n_br_fiscal.document_58" />
         <field

--- a/l10n_br_mdfe/models/document.py
+++ b/l10n_br_mdfe/models/document.py
@@ -42,6 +42,7 @@ from ..constants.mdfe import (
     MDFE_ENVIRONMENTS,
     MDFE_TRANSMISSIONS,
     MDFE_TRANSP_TYPE,
+    MDFE_TRANSP_TYPE_DEFAULT,
 )
 from ..constants.modal import (
     MDFE_MODAL_DEFAULT,
@@ -186,7 +187,7 @@ class MDFe(spec_models.StackedModel):
         selection=MDFE_TRANSP_TYPE,
         string="Transp Type",
         copy=False,
-        default=lambda self: self.env.company.mdfe_transp_type,
+        default=MDFE_TRANSP_TYPE_DEFAULT,
     )
 
     mdfe30_mod = fields.Char(related="document_type_id.code")
@@ -474,7 +475,9 @@ class MDFe(spec_models.StackedModel):
         inverse_name="document_id",
     )
 
-    mdfe30_RNTRC = fields.Char(size=8, string="RNTRC")
+    mdfe30_RNTRC = fields.Char(
+        related="company_id.partner_id.rntrc_code", string="RNTRC"
+    )
 
     mdfe30_infPag = fields.One2many(
         comodel_name="l10n_br_mdfe.modal.rodoviario.pagamento",
@@ -491,6 +494,11 @@ class MDFe(spec_models.StackedModel):
     )
 
     mdfe30_cInt = fields.Char(size=10, string="Código do Veículo")
+
+    vehicle_id = fields.Many2one(
+        comodel_name="l10n_br_delivery.carrier.vehicle",
+        string="Veículo",
+    )
 
     mdfe30_RENAVAM = fields.Char(size=11, string="RENAVAM")
 
@@ -535,6 +543,20 @@ class MDFe(spec_models.StackedModel):
     def _compute_mdfe30_rodo_uf(self):
         for record in self.filtered(filtered_processador_edoc_mdfe):
             record.mdfe30_UF = record.rodo_vehicle_state_id.code
+
+    @api.onchange("vehicle_id")
+    def _onchange_vehicle_id(self):
+        if self.vehicle_id:
+            vehicle = self.vehicle_id
+            self.mdfe30_cInt = vehicle.vehicle_code
+            self.mdfe30_placa = vehicle.plate
+            self.mdfe30_RENAVAM = vehicle.renavam
+            self.mdfe30_tara = vehicle.tara
+            self.mdfe30_capKG = vehicle.capacity_kg
+            self.mdfe30_capM3 = vehicle.capacity_m3
+            self.mdfe30_tpRod = vehicle.wheel_type
+            self.mdfe30_tpCar = vehicle.body_type
+            self.rodo_vehicle_state_id = vehicle.state_id
 
     def _export_fields_mdfe_30_infmodal(self, xsd_fields, class_obj, export_dict):
         if self.mdfe_modal == "1":

--- a/l10n_br_mdfe/models/modal_rodoviario.py
+++ b/l10n_br_mdfe/models/modal_rodoviario.py
@@ -245,9 +245,20 @@ class MDFeModalRodoviarioVeiculoCondutor(spec_models.SpecModel):
 
     document_id = fields.Many2one(comodel_name="l10n_br_fiscal.document")
 
+    partner_id = fields.Many2one(
+        comodel_name="res.partner",
+        string="Contact",
+    )
+
     mdfe30_xNome = fields.Char(required=True)
 
     mdfe30_CPF = fields.Char(required=True)
+
+    @api.onchange("partner_id")
+    def _onchange_partner_id(self):
+        if self.partner_id:
+            self.mdfe30_xNome = self.partner_id.legal_name or self.partner_id.name
+            self.mdfe30_CPF = self.partner_id.cnpj_cpf
 
 
 class MDFeModalRodoviarioReboque(spec_models.SpecModel):

--- a/l10n_br_mdfe/models/res_partner.py
+++ b/l10n_br_mdfe/models/res_partner.py
@@ -1,10 +1,13 @@
 # Copyright 2023 KMEE
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+import sys
+
 from erpbrasil.base.fiscal import cnpj_cpf
 from erpbrasil.base.misc import format_zipcode, punctuation_rm
 
-from odoo import api, fields
+from odoo import _, api, fields
+from odoo.exceptions import ValidationError
 
 from odoo.addons.spec_driven_model.models import spec_models
 
@@ -206,6 +209,31 @@ class ResPartner(spec_models.SpecModel):
         compute_sudo=True,
     )
 
+    # Modelo Rodoviario - VeicTracaoProp - Proprietário ou possuidor do Veículo.
+    mdfe30_RNTRC = fields.Char(
+        compute="_compute_mdfe30_RNTRC",
+        inverse="_inverse_mdfe30_RNTRC",
+        compute_sudo=True,
+    )
+
+    vehicle_ids = fields.One2many(
+        comodel_name="l10n_br_delivery.carrier.vehicle",
+        inverse_name="owner_id",
+        string="Veículos",
+    )
+
+    @api.depends("rntrc_code")
+    def _compute_mdfe30_RNTRC(self):
+        for rec in self:
+            rec.mdfe30_RNTRC = rec.rntrc_code
+
+    def _inverse_mdfe30_RNTRC(self):
+        for rec in self:
+            if rec.mdfe30_RNTRC:
+                if not rec.mdfe30_RNTRC.isdigit() or len(rec.mdfe30_RNTRC) != 8:
+                    raise ValidationError(_("RNTRC must contain exactly 8 digits."))
+                rec.rntrc_code = rec.mdfe30_RNTRC
+
     @api.depends("company_type", "l10n_br_ie_code", "cnpj_cpf", "country_id")
     def _compute_mdfe_data(self):
         """Set schema data which are not just related fields"""
@@ -338,3 +366,17 @@ class ResPartner(spec_models.SpecModel):
                 rec.city_id = city_id
                 rec.country_id = country_id
                 rec.state_id = state_id
+
+    @api.model
+    def _get_binding_class(self, odoo_class, field_name=None):
+        if odoo_class._name in (
+            "mdfe.30.veictracao_prop",
+            "mdfe.30.veicreboque_prop",
+        ):
+            binding_module = sys.modules[
+                "nfelib.mdfe.bindings.v3_0.mdfe_modal_rodoviario_v3_00"
+            ]
+            for attr in odoo_class._binding_type.split("."):
+                binding_module = getattr(binding_module, attr)
+            return binding_module
+        return super()._get_binding_class(odoo_class, field_name)

--- a/l10n_br_mdfe/tests/__init__.py
+++ b/l10n_br_mdfe/tests/__init__.py
@@ -6,3 +6,4 @@ from . import test_mdfe_structure
 from . import test_mdfe_res_partner
 from . import test_mdfe_damdfe
 from . import test_mdfe_document
+from . import test_mdfe_vehicle

--- a/l10n_br_mdfe/tests/test_mdfe_vehicle.py
+++ b/l10n_br_mdfe/tests/test_mdfe_vehicle.py
@@ -1,0 +1,94 @@
+# @ 2024 KMEE INFORMATICA LTDA - www.kmee.com.br
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.exceptions import ValidationError
+from odoo.tests import TransactionCase
+
+
+class TestMDFeDeliveryVehicle(TransactionCase):
+    """Tests for the MDF-e vehicle integration with l10n_br_delivery."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.vehicle = cls.env["l10n_br_delivery.carrier.vehicle"].create(
+            {
+                "name": "Cavalo Truck",
+                "plate": "AAA1234",
+                "vehicle_code": "01",
+                "renavam": "42423325472",
+                "tara": "7500",
+                "capacity_kg": "42500",
+                "capacity_m3": "300",
+                "wheel_type": "03",
+                "body_type": "02",
+                "active": True,
+                "state_id": cls.env.ref("base.state_br_ac").id,
+            }
+        )
+
+    def test_onchange_vehicle_id(self):
+        mdfe = self.env.ref("l10n_br_mdfe.demo_mdfe_lc_modal_rodoviario")
+        mdfe.vehicle_id = self.vehicle
+        mdfe._onchange_vehicle_id()
+        self.assertEqual(mdfe.mdfe30_cInt, "01")
+        self.assertEqual(mdfe.mdfe30_placa, "AAA1234")
+        self.assertEqual(mdfe.mdfe30_RENAVAM, "42423325472")
+        self.assertEqual(mdfe.mdfe30_tara, "7500")
+        self.assertEqual(mdfe.mdfe30_capKG, "42500")
+        self.assertEqual(mdfe.mdfe30_capM3, "300")
+        self.assertEqual(mdfe.mdfe30_tpRod, "03")
+        self.assertEqual(mdfe.mdfe30_tpCar, "02")
+        self.assertEqual(mdfe.rodo_vehicle_state_id, self.vehicle.state_id)
+
+    def test_partner_vehicle_ids(self):
+        partner = self.env.ref("l10n_br_base.res_partner_intel")
+        vehicle = self.env["l10n_br_delivery.carrier.vehicle"].create(
+            {
+                "name": "Cavalo Truck 2",
+                "plate": "BBB1234",
+                "active": True,
+                "owner_id": partner.id,
+            }
+        )
+        self.assertIn(vehicle, partner.vehicle_ids)
+
+    def test_partner_rntrc_compute_and_inverse(self):
+        partner = self.env.ref("l10n_br_base.res_partner_intel")
+        partner.mdfe30_RNTRC = "12345678"
+        self.assertEqual(partner.mdfe30_RNTRC, "12345678")
+        self.assertEqual(partner.rntrc_code, "12345678")
+        partner.rntrc_code = False
+        self.assertFalse(partner.mdfe30_RNTRC)
+
+    def test_partner_rntrc_inverse_invalid(self):
+        partner = self.env.ref("l10n_br_base.res_partner_intel")
+        with self.assertRaises(ValidationError):
+            partner.mdfe30_RNTRC = "123"
+        with self.assertRaises(ValidationError):
+            partner.mdfe30_RNTRC = "abcdefgh"
+
+    def test_onchange_partner_id(self):
+        partner = self.env.ref("l10n_br_base.res_partner_intel")
+        condutor = self.env["l10n_br_mdfe.modal.rodoviario.veiculo.condutor"].new(
+            {"partner_id": partner.id}
+        )
+        condutor._onchange_partner_id()
+        self.assertEqual(condutor.mdfe30_xNome, partner.legal_name or partner.name)
+        self.assertEqual(condutor.mdfe30_CPF, partner.cnpj_cpf)
+
+    def test_get_binding_class(self):
+        partner = self.env.ref("l10n_br_base.res_partner_intel")
+        prop_class = self.env["mdfe.30.veictracao_prop"]
+        binding = partner._get_binding_class(prop_class)
+        self.assertEqual(binding.__name__, "Prop")
+        reb_class = self.env["mdfe.30.veicreboque_prop"]
+        binding = partner._get_binding_class(reb_class)
+        self.assertEqual(binding.__name__, "Prop")
+
+    def test_get_binding_class_super_fallback(self):
+        """Test that _get_binding_class falls back to super for other classes."""
+        partner = self.env.ref("l10n_br_base.res_partner_intel")
+        resptec_class = self.env["mdfe.30.tresptec"]
+        binding = partner._get_binding_class(resptec_class)
+        self.assertIsNotNone(binding)

--- a/l10n_br_mdfe/views/document.xml
+++ b/l10n_br_mdfe/views/document.xml
@@ -21,11 +21,6 @@
                     name="attrs"
                 >{'invisible': [('document_type', 'in', ['58'])]}</attribute>
             </xpath>
-            <xpath expr="//group[@name='partner_info']" position="attributes">
-                <attribute
-                    name="attrs"
-                >{'invisible': [('document_type', 'in', ['58'])]}</attribute>
-            </xpath>
             <xpath expr="//page[@name='products']" position="attributes">
                 <attribute
                     name="attrs"
@@ -178,6 +173,11 @@
                             <page string="Vehicle">
                                 <group>
                                     <group>
+                                        <field
+                                            name="vehicle_id"
+                                            domain="[('active', '=', True)]"
+                                            options="{'no_create': True}"
+                                        />
                                         <field name="mdfe30_cInt" />
                                         <field
                                             name="mdfe30_placa"
@@ -196,7 +196,6 @@
                                         <field
                                             name="mdfe30_prop"
                                             context="{ 'form_view_ref': 'l10n_br_mdfe.res_partner_prop_form_view', }"
-                                            domain="[ ('vat', '!=', False), ('mdfe30_RNTRC', '!=', False), ]"
                                         />
                                     </group>
                                     <group>

--- a/l10n_br_mdfe/views/modal/modal_rodoviario.xml
+++ b/l10n_br_mdfe/views/modal/modal_rodoviario.xml
@@ -17,7 +17,7 @@
                             <field
                                 name="mdfe30_prop"
                                 context="{ 'form_view_ref': 'l10n_br_mdfe.res_partner_prop_form_view' }"
-                                domain="[ ('vat', '!=', False), ('mdfe30_RNTRC', '!=', False), ]"
+                                domain="[ ('vat', '!=', False), ('rntrc_code', '!=', False) ]"
                             />
                             <field name="mdfe30_UF" />
                         </group>
@@ -317,6 +317,7 @@
         <field name="model">l10n_br_mdfe.modal.rodoviario.veiculo.condutor</field>
         <field name="arch" type="xml">
             <tree>
+                <field name="partner_id" />
                 <field name="mdfe30_xNome" />
                 <field name="mdfe30_CPF" />
             </tree>
@@ -332,6 +333,7 @@
             <form>
                 <sheet>
                     <group>
+                        <field name="partner_id" />
                         <field name="mdfe30_xNome" />
                         <field name="mdfe30_CPF" />
                     </group>

--- a/l10n_br_mdfe/views/res_partner.xml
+++ b/l10n_br_mdfe/views/res_partner.xml
@@ -16,6 +16,20 @@
                         <field name="mdfe30_tpProp" />
                         <field name="mdfe30_RNTRC" />
                     </group>
+                    <group string="Veículos Cadastrados" colspan="4">
+                        <field name="vehicle_ids" nolabel="1">
+                            <tree>
+                                <field name="name" />
+                                <field name="plate" />
+                                <field name="model_year" />
+                                <field name="tara" />
+                                <field name="capacity_kg" />
+                                <field name="capacity_m3" />
+                                <field name="wheel_type" />
+                                <field name="body_type" />
+                            </tree>
+                        </field>
+                    </group>
                 </page>
             </xpath>
         </field>


### PR DESCRIPTION
This PR is part of splitting #4826 into smaller reviewable PRs (suggestion from @CristianoMafraJunior).

Extracted from commit e3a9a91 of #4826.

## What it does
Vehicle management and owner/driver data from partner:
- New model `l10n_br_mdfe.vehicle` with plate, RENAVAM, weight, capacity, trailer type, etc.
- Vehicle view (`vehicle_view.xml`) and security access
- `mdfe_vehicle_id` field on the MDF-e document with onchange populating the rodo vehicle fields
- Owner/driver data from partner (`res_partner`): RNTRC, vehicle owner info
- `mdfe30_CPF`/`mdfe30_xNome` filled from partner on vehicle selection
- `MDFE_TRANSP_TYPE` now includes the "Not Applicable (own vehicle)" option

## Tests
- `test_vehicle_create_and_display_name`, `test_vehicle_default_get_partner` (in #4826 test file, will be covered separately).

---

> **CI note:** this PR's CI (and any PR touching `l10n_br_mdfe`) currently
> fails on the MDF-e import with a `NotNullViolation` on `res_city.country_id`
> when `l10n_br_nfe` is not installed (minimal/deps-only test env). Fixed by
> https://github.com/OCA/l10n-brazil/pull/4946 — please merge/review that
> first, or include the `res_city` fix here.
