### PR TITLE
[16.0][FIX] l10n_br_fiscal: migracao 16.0.22.2.0 falha com definicao de imposto aprovada

### DIFF
--- a/l10n_br_fiscal/migrations/16.0.22.2.0/post-migration.py
+++ b/l10n_br_fiscal/migrations/16.0.22.2.0/post-migration.py
@@ -48,6 +48,11 @@ def migrate(env, version):
     # ele, a definição some do arquivo mas continua viva na base.
     ipi_ef = _ref(env, "tax_ipi_definition_entrega_futura")
     if ipi_ef:
+        # A definição precisa estar em rascunho: o unlink do modelo recusa
+        # registros aprovados (UserError). Numa base ja em uso o registro
+        # costuma estar 'approved', e sem este passo a migracao inteira aborta
+        # e o registry nao carrega (issue #4857).
+        ipi_ef.action_draft()
         ipi_ef.unlink()  # IPI passa a destacar pelo default (remessa de produção)
 
     # --- Entrada de reparo: IPI 00->49; PIS/COFINS 99->98 ---


### PR DESCRIPTION
Corrige a issue #4857.

## Problema

A migração `16.0.22.2.0` do `l10n_br_fiscal` aborta em bases já em uso, e o
registry nao carrega (o banco nao sobe):

```
ERROR OpenUpgrade: l10n_br_fiscal: error in migration script
  .../migrations/16.0.22.2.0/post-migration.py: Voce nao pode excluir uma
  Definicao de Imposto que nao e rascunho !
CRITICAL odoo.service.server: Failed to initialize database
```

## Causa

O script remove a definicao `tax_ipi_definition_entrega_futura` com `unlink()`,
mas o `unlink()` de `l10n_br_fiscal.tax.definition` recusa registros no estado
`approved`:

```python
def unlink(self):
    operations = self.filtered(lambda line: line.state == "approved")
    if operations:
        raise UserError(_("You cannot delete an Tax Definition which is not draft !"))
```

Numa base nova a definicao nasce em `draft` e o unlink passa. Numa base em uso
ela normalmente ja foi aprovada (fluxo draft -> review -> approved), e ai a
migracao inteira falha.

## Correcao

Colocar a definicao em rascunho antes de remover, usando o `action_draft()` do
proprio modelo:

```python
ipi_ef = _ref(env, "tax_ipi_definition_entrega_futura")
if ipi_ef:
    ipi_ef.action_draft()
    ipi_ef.unlink()
```

O `unlink()` continua necessario (nao e redundante): o arquivo de dados e
`noupdate`, entao o cleanup de xml_ids orfaos do Odoo nao remove o registro.

Este e o unico `unlink()` nas migrations do `l10n_br_fiscal`, entao nao ha
outros pontos com o mesmo problema.

## Como reproduzir

Numa base com o `l10n_br_fiscal` instalado, aprovar a definicao
`tax_ipi_definition_entrega_futura` (estado `approved`) e rodar o upgrade do
modulo. Sem o patch a migracao aborta com o UserError acima; com o patch ela
completa e a definicao e removida.
