### PR TITLE
[18.0][FIX] l10n_br_fiscal: check cnpj_cpf only when filled

### DIFF
--- a/l10n_br_fiscal/models/document_related.py
+++ b/l10n_br_fiscal/models/document_related.py
@@ -85,7 +85,8 @@ class DocumentRelated(models.Model):
     @api.constrains("cnpj_cpf")
     def _check_cnpj_cpf(self):
         for record in self:
-            check_cnpj_cpf(record.env, record.vat, self.env.ref("base.br"))
+            if record.vat:
+                check_cnpj_cpf(record.env, record.vat, self.env.ref("base.br"))
 
     @api.constrains("l10n_br_ie_code", "state_id")
     def _check_ie(self):
@@ -144,4 +145,5 @@ class DocumentRelated(models.Model):
 
     @api.onchange("cnpj_cpf", "cpfcnpj_type")
     def _onchange_mask_cnpj_cpf(self):
-        self.vat = cnpj_cpf.formata(str(self.vat))
+        if self.vat:
+            self.vat = cnpj_cpf.formata(self.vat)


### PR DESCRIPTION
Port of #4823 to 18.0. Adapted to the vat field currently used by this branch. Cherry-picked from 3518f9171a9a27d7077e23e9f7923786b395f2ba. Local syntax and diff checks passed. Note: #4671 changes the same methods back to cnpj_cpf, so this PR may require a small rebase if #4671 is merged first.