### PR TITLE
[16.0][FIX] l10n_br_fiscal: transferencia nao e devolucao de saida

### DIFF
--- a/l10n_br_fiscal/data/operation_data.xml
+++ b/l10n_br_fiscal/data/operation_data.xml
@@ -630,7 +630,7 @@
         <field name="code">TR</field>
         <field name="name">Transferência</field>
         <field name="fiscal_operation_type">out</field>
-        <field name="fiscal_type">return_out</field>
+        <field name="fiscal_type">other</field>
         <field name="default_price_unit">cost_price</field>
         <field name="state">approved</field>
     </record>

--- a/l10n_br_fiscal/migrations/16.0.22.3.2/post-migration.py
+++ b/l10n_br_fiscal/migrations/16.0.22.3.2/post-migration.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2026 KMEE
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+"""Corrige o `fiscal_type` da operacao fiscal de Transferencia.
+
+A operacao `fo_transferencia` foi criada com `fiscal_type = "return_out"`
+(devolucao de saida). Em `l10n_br_account/models/fiscal_operation.py` o
+mapeamento `FISCAL_TYPE_INVOICE` traduz `return_out` para `out_refund`, entao a
+transferencia geraria nota de credito de saida em vez de nota de saida.
+
+O registro vive em `data/operation_data.xml`, que e carregado com
+`noupdate="1"`: corrigir o XML resolve so para instalacoes novas, e por isso
+este script existe.
+
+Defensivo de proposito: so escreve se o valor ainda for o errado, para nao
+desfazer ajuste manual de quem ja tiver corrigido na propria base.
+"""
+
+import logging
+
+from openupgradelib import openupgrade
+
+_logger = logging.getLogger(__name__)
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    operation = env.ref("l10n_br_fiscal.fo_transferencia", raise_if_not_found=False)
+    if not operation:
+        return
+    if operation.fiscal_type != "return_out":
+        return
+    operation.write({"fiscal_type": "other"})
+    _logger.info(
+        "l10n_br_fiscal: fo_transferencia teve fiscal_type corrigido de "
+        "'return_out' para 'other'."
+    )


### PR DESCRIPTION
## Problema

A operacao fiscal `fo_transferencia`, adicionada pelo #4762, esta com
`fiscal_type = "return_out"` (devolucao de saida):

```xml
<record id="fo_transferencia" model="l10n_br_fiscal.operation">
    <field name="code">TR</field>
    <field name="name">Transferência</field>
    <field name="fiscal_operation_type">out</field>
    <field name="fiscal_type">return_out</field>
```

Em `l10n_br_account/models/fiscal_operation.py:15` o mapeamento e:

```python
FISCAL_TYPE_INVOICE = {
    ...
    "return_out": "out_refund",
    ...
}
```

Ou seja, uma **transferencia** passa a gerar **nota de credito de saida**
(`out_refund`) em vez de nota de saida. As demais operacoes da base que nao sao
devolucao usam `fiscal_type = "other"`, que mapeia para `out_invoice`.

## Correcao

Duas partes, porque o dado e `noupdate`:

1. `data/operation_data.xml`: `return_out` -> `other`. Resolve para instalacoes
   novas. As outras 6 ocorrencias de `return_out` no arquivo sao devolucoes
   legitimas e ficam intactas.
2. `migrations/16.0.22.3.2/post-migration.py`: o arquivo e carregado com
   `<odoo noupdate="1">`, entao o `-u` nao atualiza o registro nas bases que ja
   receberam a operacao. O script corrige essas bases, e **so escreve quando o
   valor ainda e `return_out`**, para nao desfazer ajuste de quem ja corrigiu na
   propria base.

## Nota sobre a versao do diretorio de migracao

A versao do manifest hoje e `16.0.22.3.1` e o diretorio criado e
`16.0.22.3.2`, assumindo o bump de patch que o ocabot faz num `[FIX]`. Se outro
PR for mesclado antes deste e mudar a versao, o diretorio precisa ser renomeado
para a versao correspondente, senao o script nao roda.

## Relacionado

O port para a 18.0 (#4834) traz o mesmo registro e ainda nao foi mesclado: la da
para corrigir antes de entrar, sem precisar de script de migracao.
