### PR TITLE
[18.0][FIX] l10n_br_coa: sudo() on tax repartition line update during CoA load

### DIFF
--- a/l10n_br_coa/models/template_br_oca.py
+++ b/l10n_br_coa/models/template_br_oca.py
@@ -281,7 +281,9 @@ class AccountChartTemplate(models.AbstractModel):
             refund_account = (
                 created_accounts_refs.get(ref_rep_acc_key) if ref_rep_acc_key else False
             )
-            company_tax._update_repartition_lines(invoice_account.id, refund_account.id)
+            company_tax.sudo()._update_repartition_lines(
+                invoice_account.id, refund_account.id
+            )
 
         # Void default company sale/purchase taxes:
         company.account_sale_tax_id = None


### PR DESCRIPTION
## Problem

Creating a new `res.company` with `chart_template = 'br_oca'` fails with
an `AccessError` on `account.tax` whenever the requesting user is not
the superuser (i.e. any real admin using `base.group_system` +
`account.group_account_manager`, which is the normal case).

Core Odoo (`account/models/company.py`) registers
`account.chart.template.try_loading()` as a pre-commit hook whenever a
company's `chart_template` field is set. This hook runs **before** the
new company is committed, so it is not yet part of the requesting
user's `allowed_company_ids`.

`_populate_default_br_tax_accounts()` reads
`company_tax.invoice_repartition_line_ids` on the newly created
company's tax record without `sudo()`. Odoo's multi-company `ir.rule`
on `account.tax` blocks that read because the new company isn't yet
visible to the user in that transaction, and the whole company
creation fails.

## Steps to reproduce

1. Install `l10n_br_fiscal` + `l10n_br_coa`.
2. In a database that already has at least one company, as a
   non-superuser internal user with `base.group_system` +
   `account.group_account_manager`, create a new `res.company`
   (Settings > Users & Companies > Companies > New) and save.

Expected: company is created, CoA populated.
Actual:

```
odoo.exceptions.AccessError: ...
- Imposto (account.tax)
...
```

Traceback bottoms out in `AccountTax._update_repartition_lines()` -> `tax.invoice_repartition_line_ids` field access -> `check_access('read')`.

## Fix

Add `.sudo()` on `company_tax` before calling
`_update_repartition_lines()`. This is a system-level provisioning
step, same pattern already used a few lines above in the same method
for `ir.model.data` (`self.env["ir.model.data"].sudo()`) - it
shouldn't be gated by the requesting user's per-record multi-company
access.