### PR TITLE
[16.0][FIX]l10n_br_purchase_blanket_order: fix taxes

### DIFF
--- a/l10n_br_purchase_blanket_order/models/purchase_blanket_order_line.py
+++ b/l10n_br_purchase_blanket_order/models/purchase_blanket_order_line.py
@@ -86,6 +86,29 @@ class PurchaseBlanketOrderLine(models.Model):
         domain=lambda self: self._cnae_domain(),
     )
 
+    def _setup_complete(self):
+        # Same approach as l10n_br_purchase: mixin fields use precompute=True but
+        # blanket lines do not have all dependencies ready at create time.
+        res = super()._setup_complete()
+        mixin = self.env["l10n_br_fiscal.document.line.mixin"]
+        mixin_fields = mixin._fields
+        for name, field in self._fields.items():
+            mixin_field = mixin_fields.get(name)
+            if not mixin_field:
+                continue
+            if mixin_field.compute in (
+                "_compute_price_unit_fiscal",
+                "_compute_product_fiscal_fields",
+                "_compute_fiscal_quantity",
+                "_compute_fiscal_price",
+                "_compute_fiscal_tax_ids",
+                "_compute_tax_fields",
+                "_compute_fiscal_operation_line_id",
+                "_compute_comment_ids",
+            ) and getattr(mixin_field, "precompute", False):
+                field.precompute = False
+        return res
+
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:
@@ -95,7 +118,12 @@ class PurchaseBlanketOrderLine(models.Model):
                 vals["product_uom"] = product.uom_po_id.id or product.uom_id.id
                 vals["uom_id"] = vals["product_uom"]
                 vals["uot_id"] = vals["product_uom"]
-        return super().create(vals_list)
+        # Like l10n_br_purchase / sale blanket: ensure taxes_id after create when
+        # onchange path did not run (e.g. Command.create from parent).
+        lines = super().create(vals_list)
+        for line in lines.filtered("fiscal_operation_line_id"):
+            line._onchange_fiscal_tax_ids()
+        return lines
 
     def _get_protected_fields(self):
         protected_fields = super()._get_protected_fields()
@@ -140,6 +168,26 @@ class PurchaseBlanketOrderLine(models.Model):
             line.company_id = line.order_id.company_id
             line.currency_id = line.order_id.currency_id
         return super()._compute_tax_fields()
+
+    @api.onchange("product_id", "original_uom_qty")
+    def onchange_product(self):
+        """OCA onchange_product sets taxes_id from supplier_taxes_id (empty on BR).
+
+        Re-sync like l10n_br_purchase after the OCA onchange.
+        """
+        res = super().onchange_product()
+        self._onchange_fiscal_tax_ids()
+        return res
+
+    @api.onchange("fiscal_tax_ids")
+    def _onchange_fiscal_tax_ids(self):
+        # Same hook used by l10n_br_purchase / purchase_request / requisition.
+        if self.fiscal_operation_line_id:
+            self.taxes_id = self.fiscal_tax_ids.account_taxes(
+                user_type="purchase",
+                fiscal_operation=self.fiscal_operation_id,
+                company=self.company_id or self.order_id.company_id,
+            )
 
     @api.depends(
         "quantity",

--- a/l10n_br_purchase_blanket_order/models/purchase_blanket_order_line.py
+++ b/l10n_br_purchase_blanket_order/models/purchase_blanket_order_line.py
@@ -3,6 +3,8 @@
 
 from odoo import api, fields, models
 
+from odoo.addons.l10n_br_fiscal.constants.fiscal import FISCAL_TAX_ID_FIELDS
+
 
 class PurchaseBlanketOrderLine(models.Model):
     _name = "purchase.blanket.order.line"
@@ -106,6 +108,15 @@ class PurchaseBlanketOrderLine(models.Model):
                 field.precompute = False
         return res
 
+    def _needs_fiscal_tax_recompute(self, vals):
+        return "fiscal_tax_ids" in vals or any(
+            fname in vals for fname in FISCAL_TAX_ID_FIELDS
+        )
+
+    def _recompute_fiscal_tax_fields(self):
+        # _compute_tax_fields writes tax outputs; skip re-entry via write().
+        self.with_context(skip_fiscal_tax_recompute=True)._compute_tax_fields()
+
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:
@@ -120,7 +131,23 @@ class PurchaseBlanketOrderLine(models.Model):
         lines = super().create(vals_list)
         for line in lines.filtered("fiscal_operation_line_id"):
             line._onchange_fiscal_tax_ids()
+        # Form save often creates with fiscal_tax_ids + *_tax_id together;
+        # the mixin compute can run before both values settle and leave
+        # amount_tax_withholding at 0. Force a final recompute.
+        if any(self._needs_fiscal_tax_recompute(vals) for vals in vals_list):
+            lines._recompute_fiscal_tax_fields()
         return lines
+
+    def write(self, vals):
+        res = super().write(vals)
+        if self.env.context.get("skip_fiscal_tax_recompute"):
+            return res
+        # Same race as create: writing inss_wh_tax_id together with
+        # fiscal_tax_ids can make _compute_tax_fields run on stale taxes
+        # and persist amount_tax_withholding=0 after an onchange showed 11.
+        if self._needs_fiscal_tax_recompute(vals):
+            self._recompute_fiscal_tax_fields()
+        return res
 
     def _get_protected_fields(self):
         protected_fields = super()._get_protected_fields()

--- a/l10n_br_purchase_blanket_order/models/purchase_blanket_order_line.py
+++ b/l10n_br_purchase_blanket_order/models/purchase_blanket_order_line.py
@@ -47,9 +47,6 @@ class PurchaseBlanketOrderLine(models.Model):
         related="order_id.partner_id",
         string="Partner",
     )
-    price_gross = fields.Monetary(
-        compute="_compute_amount", string="Gross Amount", compute_sudo=True
-    )
     comment_ids = fields.Many2many(
         comodel_name="l10n_br_fiscal.comment",
         relation="purchase_blanket_order_line_comment_rel",
@@ -199,11 +196,13 @@ class PurchaseBlanketOrderLine(models.Model):
     def _compute_amount(self):
         result = super()._compute_amount()
         for line in self:
+            # Mirror l10n_br_purchase: map commercial totals from fiscal amounts.
+            # Keep price_gross on the mixin (price_unit * quantity); rebinding it
+            # here creates a circular dependency when withholdings are present.
             line.update(
                 {
                     "price_subtotal": line.fiscal_amount_untaxed,
                     "price_tax": line.fiscal_amount_tax,
-                    "price_gross": line.fiscal_amount_untaxed,
                     "price_total": line.fiscal_amount_total,
                 }
             )

--- a/l10n_br_purchase_blanket_order/tests/test_l10n_br_purchase_blanket_order.py
+++ b/l10n_br_purchase_blanket_order/tests/test_l10n_br_purchase_blanket_order.py
@@ -24,6 +24,7 @@ class L10nBrPurchaseBlanketOrderTest(TransactionCase):
 
         cls.product = cls.env.ref("product.product_product_27")
         cls.product_uom = cls.env.ref("uom.product_uom_unit")
+        cls.fiscal_operation = cls.env.ref("l10n_br_fiscal.fo_compras")
 
         cls.company.cnae_secondary_ids = [(6, 0, [cls.cnae_secondary.id])]
         cls.env.company = cls.company
@@ -35,18 +36,23 @@ class L10nBrPurchaseBlanketOrderTest(TransactionCase):
             "date_schedule": self.date_schedule,
             "original_uom_qty": 20.0,
             "price_unit": 25.0,
+            "fiscal_operation_id": self.fiscal_operation.id,
         }
         if line_values:
             line_vals.update(line_values)
 
         values = {
             "partner_id": self.partner.id,
+            "company_id": self.company.id,
             "validity_date": self.validity_date,
             "payment_term_id": self.payment_term.id,
+            "fiscal_operation_id": self.fiscal_operation.id,
             "line_ids": [Command.create(line_vals)],
         }
         values.update(extra_values)
-        blanket_order = self.env["purchase.blanket.order"].create(values)
+        blanket_order = (
+            self.env["purchase.blanket.order"].with_company(self.company).create(values)
+        )
         blanket_order.sudo().onchange_partner_id()
         return blanket_order
 
@@ -108,6 +114,25 @@ class L10nBrPurchaseBlanketOrderTest(TransactionCase):
             [("order_id", "=", blanket_order.id)]
         )
         self.assertEqual(len(blanket_lines), 1)
+        bo_line = blanket_lines[0]
+        self.assertTrue(
+            bo_line.fiscal_operation_line_id,
+            "Error: Blanket Order line has no fiscal operation line.",
+        )
+        self.assertTrue(
+            bo_line.fiscal_tax_ids,
+            "Error: Blanket Order line has no fiscal taxes.",
+        )
+        expected_account_taxes = bo_line.fiscal_tax_ids.account_taxes(
+            user_type="purchase",
+            fiscal_operation=bo_line.fiscal_operation_id,
+            company=bo_line.company_id,
+        )
+        self.assertTrue(
+            bo_line.taxes_id,
+            "Error: Blanket Order line taxes_id was not filled from fiscal taxes.",
+        )
+        self.assertEqual(bo_line.taxes_id, expected_account_taxes)
 
         wizard = self._create_wizard(blanket_order)
         result = wizard.create_purchase_order()
@@ -128,10 +153,11 @@ class L10nBrPurchaseBlanketOrderTest(TransactionCase):
         )
 
         for order_line in purchase_order.order_line:
-            order_line.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_compras")
-            order_line.fiscal_operation_line_id = self.env.ref(
-                "l10n_br_fiscal.fo_compras_compras"
+            self.assertTrue(
+                order_line.taxes_id,
+                "Error: Purchase Order line taxes_id was not filled from blanket.",
             )
+            self.assertEqual(order_line.taxes_id, expected_account_taxes)
 
         purchase_order.button_confirm()
 
@@ -158,14 +184,7 @@ class L10nBrPurchaseBlanketOrderTest(TransactionCase):
 
         bo_line = blanket_order.line_ids[0]
         self.assertEqual(bo_line.quantity, 20.0)
-        bo_line.write(
-            {
-                "fiscal_operation_id": self.env.ref("l10n_br_fiscal.fo_compras").id,
-                "fiscal_operation_line_id": self.env.ref(
-                    "l10n_br_fiscal.fo_compras_compras"
-                ).id,
-            }
-        )
+        self.assertTrue(bo_line.taxes_id)
 
         full_price_subtotal = bo_line.price_subtotal
         self.assertTrue(full_price_subtotal)
@@ -289,6 +308,30 @@ class L10nBrPurchaseBlanketOrderTest(TransactionCase):
         blanket_line.fiscal_operation_id = False
         blanket_line._compute_price_unit_fiscal()
         self.assertEqual(blanket_line.price_unit, 0.0)
+
+    def test_onchange_product_keeps_taxes_id_from_fiscal(self):
+        """Inline tree product onchange must not leave taxes_id empty on BR CoA.
+
+        OCA onchange_product sets taxes_id from supplier_taxes_id (usually empty);
+        the BR override re-syncs from fiscal_tax_ids afterwards.
+        """
+        blanket_order = self._create_blanket_order()
+        blanket_order._onchange_fiscal_operation_id()
+        line = blanket_order.line_ids[0]
+        self.assertTrue(line.fiscal_tax_ids)
+
+        line.taxes_id = False
+        line.onchange_product()
+        expected = line.fiscal_tax_ids.account_taxes(
+            user_type="purchase",
+            fiscal_operation=line.fiscal_operation_id,
+            company=line.company_id or line.order_id.company_id,
+        )
+        self.assertTrue(line.taxes_id)
+        self.assertEqual(line.taxes_id, expected)
+
+        line._onchange_fiscal_tax_ids()
+        self.assertEqual(line.taxes_id, expected)
 
     def test_cnae_domain(self):
         domain = self.env["purchase.blanket.order.line"]._cnae_domain()

--- a/l10n_br_purchase_blanket_order/tests/test_l10n_br_purchase_blanket_order.py
+++ b/l10n_br_purchase_blanket_order/tests/test_l10n_br_purchase_blanket_order.py
@@ -333,6 +333,48 @@ class L10nBrPurchaseBlanketOrderTest(TransactionCase):
         line._onchange_fiscal_tax_ids()
         self.assertEqual(line.taxes_id, expected)
 
+    def test_withholding_tax_keeps_fiscal_totals(self):
+        """Adding a withholding tax must keep totals after form save.
+
+        The line form onchange computes amount_tax_withholding correctly, but
+        saving sends fiscal_tax_ids together with *_tax_id. That write used to
+        recompute taxes on stale values and persist withholding=0.
+        """
+        blanket_order = self._create_blanket_order()
+        blanket_order._onchange_fiscal_operation_id()
+        line = blanket_order.line_ids[0]
+        line.write({"original_uom_qty": 1.0, "price_unit": 100.0})
+
+        inss_wh = self.env["l10n_br_fiscal.tax"].search(
+            [("tax_domain", "=", "inss_wh")], limit=1
+        )
+        if not inss_wh:
+            self.skipTest("No inss_wh fiscal tax found in demo data.")
+
+        # Reproduce UI save: both fiscal_tax_ids and the specific tax field.
+        taxes = line.fiscal_tax_ids | inss_wh
+        line.write(
+            {
+                "inss_wh_tax_id": inss_wh.id,
+                "fiscal_tax_ids": [Command.set(taxes.ids)],
+            }
+        )
+        line.invalidate_recordset()
+
+        # Gross stays on the mixin (qty * price_unit), not rebound to untaxed.
+        self.assertAlmostEqual(line.price_gross, 100.0, places=2)
+        self.assertTrue(
+            line.amount_tax_withholding,
+            "amount_tax_withholding must persist after saving fiscal taxes.",
+        )
+        self.assertAlmostEqual(
+            line.fiscal_amount_total,
+            line.fiscal_amount_untaxed
+            + line.fiscal_amount_tax
+            - line.amount_tax_withholding,
+            places=2,
+        )
+
     def test_cnae_domain(self):
         domain = self.env["purchase.blanket.order.line"]._cnae_domain()
         expected_domain = [

--- a/l10n_br_purchase_blanket_order/views/purchase_blanket_order.xml
+++ b/l10n_br_purchase_blanket_order/views/purchase_blanket_order.xml
@@ -84,10 +84,16 @@
                     name="context"
                 >{'default_fiscal_operation_id': fiscal_operation_id, 'default_partner_id': partner_id, 'default_company_id': company_id}</attribute>
             </xpath>
+            <!-- Keep taxes_id in the list datapoint but hide the column: in tree,
+                 invisible="1" becomes modifiers.column_invisible (column_invisible
+                 XML attr alone is ignored). Visible only on the line form
+                 Accounting tab; fiscal_tax_ids stays visible in the tree. -->
             <xpath
                 expr="//field[@name='line_ids']/tree/field[@name='taxes_id']"
                 position="replace"
-            />
+            >
+                <field name="taxes_id" invisible="1" force_save="1" />
+            </xpath>
             <xpath
                 expr="//field[@name='line_ids']/tree/field[@name='price_unit']"
                 position="after"

--- a/l10n_br_purchase_blanket_order/wizards/create_purchase_orders.py
+++ b/l10n_br_purchase_blanket_order/wizards/create_purchase_orders.py
@@ -30,7 +30,7 @@ class PurchaseBlanketOrderWizard(models.TransientModel):
         fiscal_vals = self._simulate_onchange_price_subtotal(fiscal_vals)
 
         date_planned = line.blanket_line_id.date_schedule
-        return {
+        vals = {
             "product_id": line.product_id.id,
             "name": line.product_id.name,
             "date_planned": date_planned
@@ -44,6 +44,24 @@ class PurchaseBlanketOrderWizard(models.TransientModel):
             "taxes_id": [(6, 0, line.taxes_id.ids)],
             **fiscal_vals,
         }
+        # OCA copies taxes_id from the wizard related field (blanket taxes_id),
+        # which may still be empty on BR CoA. Force account taxes from fiscal
+        # after fiscal_vals so it is not overwritten.
+        blanket_line = line.blanket_line_id
+        if blanket_line.fiscal_operation_line_id:
+            company = blanket_line.company_id or self.blanket_order_id.company_id
+            vals["taxes_id"] = [
+                (
+                    6,
+                    0,
+                    blanket_line.fiscal_tax_ids.account_taxes(
+                        user_type="purchase",
+                        fiscal_operation=blanket_line.fiscal_operation_id,
+                        company=company,
+                    ).ids,
+                )
+            ]
+        return vals
 
     def _simulate_onchange_price_subtotal(self, values):
         line = self.env["account.move.line"].new(values.copy())

--- a/l10n_br_purchase_blanket_order/wizards/create_purchase_orders.py
+++ b/l10n_br_purchase_blanket_order/wizards/create_purchase_orders.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 
 from odoo import _, models
 from odoo.exceptions import UserError
+from odoo.fields import Command
 
 
 class PurchaseBlanketOrderWizard(models.TransientModel):
@@ -41,7 +42,7 @@ class PurchaseBlanketOrderWizard(models.TransientModel):
             "price_unit": line.blanket_line_id.price_unit,
             "blanket_order_line": line.blanket_line_id.id,
             "product_qty": line.qty,
-            "taxes_id": [(6, 0, line.taxes_id.ids)],
+            "taxes_id": [Command.set(line.taxes_id.ids)],
             **fiscal_vals,
         }
         # OCA copies taxes_id from the wizard related field (blanket taxes_id),
@@ -51,14 +52,12 @@ class PurchaseBlanketOrderWizard(models.TransientModel):
         if blanket_line.fiscal_operation_line_id:
             company = blanket_line.company_id or self.blanket_order_id.company_id
             vals["taxes_id"] = [
-                (
-                    6,
-                    0,
+                Command.set(
                     blanket_line.fiscal_tax_ids.account_taxes(
                         user_type="purchase",
                         fiscal_operation=blanket_line.fiscal_operation_id,
                         company=company,
-                    ).ids,
+                    ).ids
                 )
             ]
         return vals


### PR DESCRIPTION
## Resumo

Corrige o preenchimento de `taxes_id` no **Pedido Guarda-Chuva de Compra** (`l10n_br_purchase_blanket_order`), alinhando o comportamento a `l10n_br_purchase` e ao fix equivalente em `l10n_br_sale_blanket_order`.

### `taxes_id` vazio na linha do blanket

No plano de contas BR, `product.supplier_taxes_id` costuma estar vazio. O `onchange_product` do OCA deixava `taxes_id` em branco na linha do guarda-chuva, e o wizard gerava PO sem `taxes_id`.

**Solução:**
- Mapear `taxes_id` a partir de `fiscal_tax_ids.account_taxes(user_type="purchase", ...)` (mesmo padrão de `l10n_br_purchase`)
- Re-sincronizar após `onchange_product` e no `create`
- Manter `taxes_id` no datapoint da tree (oculto + `force_save`)
- Desabilitar `precompute` dos campos do mixin na linha do blanket
- Forçar `taxes_id` no prepare da linha da PO gerada pelo wizard

## Testes

- Asserts de `taxes_id` no blanket (antes da PO) e na PO gerada
- Regressão de `onchange_product` mantendo `taxes_id` a partir de `fiscal_tax_ids`

## Como validar

1. Criar Pedido Guarda-Chuva de Compra e incluir produto com operação fiscal  
   → Contabilidade / `taxes_id` já preenchidos **antes** de criar a PO
2. No formulário da linha (aba Contabilidade), conferir os impostos contábeis
3. Gerar PO pelo wizard  
   → linhas com `taxes_id` preenchido a partir dos impostos fiscais do blanket