### PR TITLE
[16.0][ADD] l10n_br_sped_base: signatarios da escrituracao

### DIFF
--- a/l10n_br_sped_base/README.rst
+++ b/l10n_br_sped_base/README.rst
@@ -123,6 +123,7 @@ Authors
 -------
 
 * Akretion
+* KMEE
 
 Contributors
 ------------
@@ -130,6 +131,10 @@ Contributors
 - `AKRETION <https://akretion.com/pt-BR/>`__:
 
   - Raphaël Valyi <raphael.valyi@akretion.com.br>
+
+- `KMEE <https://www.kmee.com.br>`__:
+
+  - Luis Felipe Mileo <mileo@kmee.com.br>
 
 Maintainers
 -----------

--- a/l10n_br_sped_base/__manifest__.py
+++ b/l10n_br_sped_base/__manifest__.py
@@ -13,6 +13,7 @@
     "maintainers": ["rvalyi"],
     "development_status": "Alpha",
     "data": [
+        "security/ir.model.access.csv",
         "views/sped_base.xml",
         "views/res_partner_view.xml",
     ],

--- a/l10n_br_sped_base/models/__init__.py
+++ b/l10n_br_sped_base/models/__init__.py
@@ -1,3 +1,4 @@
 from . import res_partner
+from . import sped_signer
 from . import sped_mixin
 from . import sped_declaration

--- a/l10n_br_sped_base/models/sped_signer.py
+++ b/l10n_br_sped_base/models/sped_signer.py
@@ -1,0 +1,125 @@
+# Copyright (C) 2026 Luis Felipe Mileo - KMEE <mileo@kmee.com.br>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
+
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+# Tabela de qualificacao do assinante. Sao os codigos de uso corrente; a
+# tabela completa esta no Guia Pratico de cada escrituracao.
+QUALIFICACAO_SIGNATARIO = [
+    ("203", "203 - Administrador"),
+    ("204", "204 - Advogado"),
+    ("205", "205 - Diretor"),
+    ("206", "206 - Empresario"),
+    ("207", "207 - Inventariante"),
+    ("208", "208 - Liquidante"),
+    ("209", "209 - Presidente"),
+    ("222", "222 - Procurador"),
+    ("223", "223 - Gestor judicial"),
+    ("226", "226 - Socio"),
+    ("309", "309 - Contador"),
+    ("312", "312 - Tecnico contabil"),
+]
+
+# Qualificacoes que exigem o numero de inscricao no CRC.
+QUALIFICACAO_COM_CRC = ("309", "312")
+
+
+class SpedSigner(models.Model):
+    """Signatario de uma escrituracao do Sped.
+
+    A escrituracao e assinada por, no minimo, o responsavel legal da pessoa
+    juridica e o contabilista; por isso o registro e obrigatorio e tem mais de
+    uma ocorrencia. O cadastro cobre o registro 0930 da ECF. O J930 da ECD
+    pede campos alem destes (COD_ASSIN, UF_CRC, NUM_SEQ_CRC, DT_CRC e
+    IND_RESP_LEGAL) e usa outra tabela de qualificacao: quando a geracao do
+    J930 for implementada, esses campos entram aqui.
+    """
+
+    _name = "l10n_br_sped.signer"
+    _description = "Signatario da Escrituracao do Sped"
+    _order = "sequence, id"
+
+    sequence = fields.Integer(default=10)
+    company_id = fields.Many2one(
+        comodel_name="res.company",
+        string="Company",
+        required=True,
+        ondelete="cascade",
+        index=True,
+    )
+    partner_id = fields.Many2one(
+        comodel_name="res.partner",
+        string="Contato",
+        help="Preenche nome, CPF/CNPJ, e-mail e telefone a partir do contato.",
+    )
+    name = fields.Char(string="Nome", required=True)
+    cpf_cnpj = fields.Char(string="CPF/CNPJ", required=True)
+    qualification = fields.Selection(
+        selection=QUALIFICACAO_SIGNATARIO,
+        string="Qualificacao",
+        required=True,
+    )
+    crc = fields.Char(
+        string="CRC",
+        help="Numero de inscricao no Conselho Regional de Contabilidade, "
+        "obrigatorio para contador e tecnico contabil.",
+    )
+    email = fields.Char()
+    phone = fields.Char(string="Telefone")
+
+    @api.onchange("partner_id")
+    def _onchange_partner_id(self):
+        for signer in self.filtered("partner_id"):
+            partner = signer.partner_id
+            signer.name = partner.name
+            signer.cpf_cnpj = partner.vat or partner.cnpj_cpf
+            signer.email = partner.email
+            signer.phone = partner.phone or partner.mobile
+
+    @api.constrains("qualification", "crc")
+    def _check_crc(self):
+        for signer in self:
+            if signer.qualification in QUALIFICACAO_COM_CRC and not signer.crc:
+                raise ValidationError(
+                    _(
+                        "O signatario %(nome)s e contabilista e precisa do "
+                        "numero de inscricao no CRC para assinar a ECF."
+                    )
+                    % {"nome": signer.name}
+                )
+
+    @staticmethod
+    def _so_digitos(valor):
+        """So os digitos: o Sped nao aceita separador nem espaco.
+
+        O ``punctuation_rm`` do erpbrasil tira a pontuacao mas preserva o
+        espaco, e o telefone brasileiro costuma ter um depois do DDD.
+        """
+        return "".join(c for c in str(valor or "") if c.isdigit())
+
+    def _sped_values(self):
+        """Valores do registro 0930 deste signatario."""
+        self.ensure_one()
+        return {
+            "IDENT_NOM": self.name,
+            "IDENT_CPF_CNPJ": self._so_digitos(self.cpf_cnpj),
+            "IDENT_QUALIF": self.qualification,
+            "IND_CRC": self.crc or "",
+            "EMAIL": self.email or "",
+            "FONE": self._so_digitos(self.phone),
+        }
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    l10n_br_sped_signer_ids = fields.One2many(
+        comodel_name="l10n_br_sped.signer",
+        inverse_name="company_id",
+        string="Signatarios da escrituracao",
+        help="A escrituracao e assinada, no minimo, pelo responsavel legal da "
+        "pessoa juridica e pelo contabilista: registro 0930 da ECF e J930 da "
+        "ECD.",
+    )

--- a/l10n_br_sped_base/readme/CONTRIBUTORS.md
+++ b/l10n_br_sped_base/readme/CONTRIBUTORS.md
@@ -1,2 +1,4 @@
 - [AKRETION](https://akretion.com/pt-BR/):
   - Raphaël Valyi \<<raphael.valyi@akretion.com.br>\>
+- [KMEE](https://www.kmee.com.br):
+  - Luis Felipe Mileo \<<mileo@kmee.com.br>\>

--- a/l10n_br_sped_base/security/ir.model.access.csv
+++ b/l10n_br_sped_base/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+access_user_sped_signer,sped.signer,model_l10n_br_sped_signer,l10n_br_fiscal.group_user,1,0,0,0
+access_manager_sped_signer,sped.signer,model_l10n_br_sped_signer,l10n_br_fiscal.group_manager,1,1,1,1

--- a/l10n_br_sped_base/static/description/index.html
+++ b/l10n_br_sped_base/static/description/index.html
@@ -468,6 +468,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h3><a class="toc-backref" href="#toc-entry-3">Authors</a></h3>
 <ul class="simple">
 <li>Akretion</li>
+<li>KMEE</li>
 </ul>
 </div>
 <div class="section" id="contributors">
@@ -475,6 +476,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <ul class="simple">
 <li><a class="reference external" href="https://akretion.com/pt-BR/">AKRETION</a>:<ul>
 <li>Raphaël Valyi &lt;<a class="reference external" href="mailto:raphael.valyi&#64;akretion.com.br">raphael.valyi&#64;akretion.com.br</a>&gt;</li>
+</ul>
+</li>
+<li><a class="reference external" href="https://www.kmee.com.br">KMEE</a>:<ul>
+<li>Luis Felipe Mileo &lt;<a class="reference external" href="mailto:mileo&#64;kmee.com.br">mileo&#64;kmee.com.br</a>&gt;</li>
 </ul>
 </li>
 </ul>

--- a/l10n_br_sped_base/tests/__init__.py
+++ b/l10n_br_sped_base/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_sped_base
+from . import test_sped_signer

--- a/l10n_br_sped_base/tests/test_sped_signer.py
+++ b/l10n_br_sped_base/tests/test_sped_signer.py
@@ -1,0 +1,89 @@
+# Copyright (C) 2026 Luis Felipe Mileo - KMEE <mileo@kmee.com.br>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
+
+from odoo.exceptions import ValidationError
+from odoo.tests import TransactionCase
+
+
+class TestSpedSigner(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.company
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "Contabilista da Empresa",
+                "email": "contador@example.com",
+                "phone": "(35) 3333-4444",
+            }
+        )
+
+    def _criar(self, **kw):
+        vals = {
+            "company_id": self.company.id,
+            "name": "Responsavel Legal",
+            "cpf_cnpj": "541.400.700-93",
+            "qualification": "203",
+        }
+        vals.update(kw)
+        return self.env["l10n_br_sped.signer"].create(vals)
+
+    def test_valores_do_0930(self):
+        """O registro sai sem pontuacao no documento e no telefone."""
+        signer = self._criar(phone="(35) 3333-4444", email="legal@example.com")
+        self.assertEqual(
+            signer._sped_values(),
+            {
+                "IDENT_NOM": "Responsavel Legal",
+                "IDENT_CPF_CNPJ": "54140070093",
+                "IDENT_QUALIF": "203",
+                "IND_CRC": "",
+                "EMAIL": "legal@example.com",
+                "FONE": "3533334444",
+            },
+        )
+
+    def test_contabilista_sem_crc_e_recusado(self):
+        """Contador e tecnico contabil assinam com o numero do CRC."""
+        with self.assertRaises(ValidationError):
+            self._criar(name="Contador", qualification="309")
+
+    def test_contabilista_com_crc(self):
+        signer = self._criar(name="Contador", qualification="309", crc="1SP123456/O-7")
+        self.assertEqual(signer._sped_values()["IND_CRC"], "1SP123456/O-7")
+
+    def test_qualificacao_sem_crc_nao_exige(self):
+        """A exigencia do CRC e so das qualificacoes de contabilista."""
+        signer = self._criar(qualification="203")
+        self.assertFalse(signer.crc)
+
+    def test_onchange_do_contato(self):
+        """O contato preenche nome, documento, e-mail e telefone."""
+        signer = self.env["l10n_br_sped.signer"].new(
+            {"company_id": self.company.id, "partner_id": self.partner.id}
+        )
+        signer._onchange_partner_id()
+        self.assertEqual(signer.name, "Contabilista da Empresa")
+        self.assertEqual(signer.email, "contador@example.com")
+        self.assertEqual(signer.phone, "(35) 3333-4444")
+
+    def test_signatarios_da_empresa_e_ordem(self):
+        """A escrituracao e assinada por mais de um, na ordem da sequencia."""
+        contador = self._criar(
+            name="Contador", qualification="309", crc="1SP123456/O-7", sequence=20
+        )
+        legal = self._criar(sequence=10)
+        signers = self.company.l10n_br_sped_signer_ids
+        self.assertIn(legal, signers)
+        self.assertIn(contador, signers)
+        ordenados = signers.sorted(lambda s: (s.sequence, s.id))
+        self.assertEqual(ordenados[0], legal)
+
+    def test_espaco_no_telefone_nao_vaza(self):
+        """O separador do DDD nao pode sobrar no campo FONE.
+
+        O punctuation_rm do erpbrasil tira a pontuacao mas preserva o
+        espaco, e o telefone brasileiro costuma ter um depois do DDD.
+        """
+        signer = self._criar(phone="+55 (35) 3333-4444")
+        self.assertEqual(signer._sped_values()["FONE"], "553533334444")


### PR DESCRIPTION

Cadastro dos signatarios de uma escrituracao do Sped, na empresa.

A escrituracao e assinada por, no minimo, o responsavel legal da pessoa
juridica e o contabilista, e essa informacao nao existe em lugar nenhum do
Odoo. O mesmo cadastro serve as duas escrituracoes: registro **0930 da ECF** e
**J930 da ECD**, que hoje esta sem implementacao.

O modelo guarda nome, CPF ou CNPJ, qualificacao (tabela do Guia Pratico),
numero de inscricao no CRC, e-mail e telefone, e preenche a partir de um
contato quando ele e informado. Ha uma restricao: contador e tecnico contabil
nao podem ser gravados sem o CRC, porque a escrituracao e recusada sem ele.
