### PR TITLE
[16.0][IMP] l10n_br_coa: conta referencial da RFB no plano de contas

### DIFF
--- a/l10n_br_coa/__manifest__.py
+++ b/l10n_br_coa/__manifest__.py
@@ -22,6 +22,7 @@
         "data/account.tax.group.csv",
         "data/account.tax.template.csv",
         # Views
+        "views/account_account.xml",
         "views/account_tax_template.xml",
         "views/account_tax.xml",
     ],

--- a/l10n_br_coa/models/__init__.py
+++ b/l10n_br_coa/models/__init__.py
@@ -1,5 +1,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from . import account_account
 from . import account_tax_mixin
 from . import account_tax_template
 from . import account_tax

--- a/l10n_br_coa/models/account_account.py
+++ b/l10n_br_coa/models/account_account.py
@@ -1,0 +1,18 @@
+# Copyright (C) 2026 Luis Felipe Mileo - KMEE <mileo@kmee.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class AccountAccount(models.Model):
+    _inherit = "account.account"
+
+    l10n_br_sped_referential_code = fields.Char(
+        string="Conta referencial da RFB",
+        size=60,
+        help="Codigo da conta no plano de contas referencial da Receita "
+        "Federal em que esta conta desagua. E o mesmo de-para nas duas "
+        "escrituracoes: alimenta o registro I051 da ECD e os registros J051, "
+        "K156, K356, P100 e P150 da ECF. Quem tem o plano referencial "
+        "carregado num modulo de de-para preenche este campo por la.",
+    )

--- a/l10n_br_coa/views/account_account.xml
+++ b/l10n_br_coa/views/account_account.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    Copyright (C) 2026 Luis Felipe Mileo - KMEE <mileo@kmee.com.br>
+    License AGPL-3 or later (http://www.gnu.org/licenses/agpl)
+-->
+<odoo>
+
+    <record id="view_account_form" model="ir.ui.view">
+        <field name="name">account.account.form.l10n.br.coa</field>
+        <field name="model">account.account</field>
+        <field name="inherit_id" ref="account.view_account_form" />
+        <field name="arch" type="xml">
+            <field name="group_id" position="after">
+                <field name="l10n_br_sped_referential_code" />
+            </field>
+        </field>
+    </record>
+
+    <record id="view_account_list" model="ir.ui.view">
+        <field name="name">account.account.list.l10n.br.coa</field>
+        <field name="model">account.account</field>
+        <field name="inherit_id" ref="account.view_account_list" />
+        <field name="arch" type="xml">
+            <xpath expr="//tree" position="inside">
+                <field name="l10n_br_sped_referential_code" optional="hide" />
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
O de-para entre a conta do plano da empresa e a conta do plano referencial da Receita Federal e o mesmo nas duas escrituracoes: alimenta o registro I051 da ECD e os registros J051, K156, K356, P100 e P150 da ECF.

Cinco linhas no `l10n_br_coa`, que ja esta na cadeia de dependencia das duas escrituracoes pelo `l10n_br_account`, mais a view para o usuario conseguir preencher.

Quem tem o plano referencial oficial da RFB carregado num modulo de de-para preenche o campo por la; quem tem poucas contas preenche a mao na propria conta.