### PR TITLE
[16.0][IMP] l10n_br_sped_ecf: cenario de teste e arquivo de exemplo

### DIFF
--- a/l10n_br_sped_ecf/demo/demo_ecf.txt
+++ b/l10n_br_sped_ecf/demo/demo_ecf.txt
@@ -1,0 +1,671 @@
+|0000|LECF|0009|91827364000103|ECF Comercio e Servicos Ltda|0|0|||01012022|31122022|N||0||
+|0001|0|
+|0010||N|5|T|01|PPPP||C||||2|
+|0020|1|0|N|N|N|N|N|N|N|N|N|N|N|N|N|N|N|N|N|N|N|N|N|N|N|N|N|N|N|
+|0030|1015|0111301|Rua das Escrituracoes|1000||Centro|SP|3500105|01310100|11 33334444|contato@exemplo.com.br|
+|0930|Maria de Souza|19180847005|203||diretoria@exemplo.com.br|1133334444|
+|0930|Joao Pereira|74685175093|309|1SP123456/O-1|contabilidade@exemplo.com.br|1133335555|
+|0990|8|
+|J001|0|
+|J050|01012022|01|S|1|1||ATIVO|
+|J050|01012022|01|S|2|1.01|1|ATIVO CIRCULANTE|
+|J050|01012022|01|S|3|1.01.01|1.01|DISPONIBILIDADES|
+|J050|01012022|01|A|4|1.01.01.01|1.01.01|Bancos Conta Movimento|
+|J051||1.01.01.02.01|
+|J050|01012022|01|S|3|1.01.02|1.01|CREDITOS|
+|J050|01012022|01|A|4|1.01.02.01|1.01.02|Duplicatas a Receber|
+|J051||1.01.02.02.01|
+|J050|01012022|01|S|3|1.01.03|1.01|ESTOQUES|
+|J050|01012022|01|A|4|1.01.03.01|1.01.03|Mercadorias para Revenda|
+|J051||1.01.03.01.01|
+|J050|01012022|01|A|3|1.01.04.01|1.01|IRRF a Compensar|
+|J051||1.01.02.04.01|
+|J050|01012022|01|A|3|1.01.04.02|1.01|CSLL Retida a Compensar|
+|J051||1.01.02.04.04|
+|J050|01012022|02|S|1|2||PASSIVO|
+|J050|01012022|02|S|2|2.01|2|PASSIVO CIRCULANTE|
+|J050|01012022|02|S|3|2.01.01|2.01|FORNECEDORES|
+|J050|01012022|02|A|4|2.01.01.01|2.01.01|Fornecedores|
+|J051||2.01.01.03.01|
+|J050|01012022|02|S|3|2.01.02|2.01|OBRIGACOES FISCAIS|
+|J050|01012022|02|A|4|2.01.02.01|2.01.02|IRPJ a Recolher|
+|J051||2.01.01.09.13|
+|J050|01012022|02|A|4|2.01.02.02|2.01.02|CSLL a Recolher|
+|J051||2.01.01.09.14|
+|J050|01012022|03|S|2|2.03|2|PATRIMONIO LIQUIDO|
+|J050|01012022|03|S|3|2.03.01|2.03|CAPITAL SOCIAL|
+|J050|01012022|03|A|4|2.03.01.01|2.03.01|Capital Social|
+|J051||2.03.01.01.01|
+|J050|01012022|03|S|3|2.03.02|2.03|LUCROS ACUMULADOS|
+|J050|01012022|03|A|4|2.03.02.01|2.03.02|Lucros Acumulados|
+|J051||2.03.04.01.01|
+|J050|01012022|04|S|1|3||RECEITAS|
+|J050|01012022|04|S|2|3.01|3|RECEITA OPERACIONAL|
+|J050|01012022|04|S|3|3.01.01|3.01|RECEITA BRUTA|
+|J050|01012022|04|A|4|3.01.01.01|3.01.01|Receita de Revenda|
+|J051||3.01.01.01.01.05|
+|J050|01012022|04|A|4|3.01.01.02|3.01.01|Receita de Servicos|
+|J051||3.01.01.01.01.06|
+|J050|01012022|04|S|3|3.01.02|3.01|OUTRAS RECEITAS|
+|J050|01012022|04|A|4|3.01.02.01|3.01.02|Rendimentos de Aplicacoes|
+|J051||3.01.01.05.01.05|
+|J050|01012022|04|S|1|4||CUSTOS E DESPESAS|
+|J050|01012022|04|S|2|4.01|4|CUSTOS E DESPESAS OPERACIONAIS|
+|J050|01012022|04|S|3|4.01.01|4.01|CUSTO DAS MERCADORIAS|
+|J050|01012022|04|A|4|4.01.01.01|4.01.01|Custo das Mercadorias|
+|J051||3.01.01.03.01.02|
+|J050|01012022|04|S|3|4.01.02|4.01|DESPESAS OPERACIONAIS|
+|J050|01012022|04|A|4|4.01.02.01|4.01.02|Despesas Operacionais|
+|J051||3.01.01.09.01.99|
+|J990|52|
+|K001|0|
+|K030|01012022|31032022|T01|
+|K155|1.01.01.01||0|D|504000,00|0|504000,00|D|
+|K156|1.01.01.02.01|0|D|504000,00|0|504000,00|D|
+|K155|1.01.02.01||0|D|417000,00|0|417000,00|D|
+|K156|1.01.02.02.01|0|D|417000,00|0|417000,00|D|
+|K155|1.01.03.01||0|D|180000,00|180000,00|0|D|
+|K156|1.01.03.01.01|0|D|180000,00|180000,00|0|D|
+|K155|1.01.04.01||0|D|1800,00|0|1800,00|D|
+|K156|1.01.02.04.01|0|D|1800,00|0|1800,00|D|
+|K155|1.01.04.02||0|D|1200,00|0|1200,00|D|
+|K156|1.01.02.04.04|0|D|1200,00|0|1200,00|D|
+|K155|2.01.01.01||0|D|0|240000,00|240000,00|C|
+|K156|2.01.01.03.01|0|D|0|240000,00|240000,00|C|
+|K155|2.03.01.01||0|D|0|500000,00|500000,00|C|
+|K156|2.03.01.01.01|0|D|0|500000,00|500000,00|C|
+|K355|3.01.01.01||300000,00|C|
+|K356|3.01.01.01.01.05|300000,00|C|
+|K355|3.01.01.02||120000,00|C|
+|K356|3.01.01.01.01.06|120000,00|C|
+|K355|3.01.02.01||4000,00|C|
+|K356|3.01.01.05.01.05|4000,00|C|
+|K355|4.01.01.01||180000,00|D|
+|K356|3.01.01.03.01.02|180000,00|D|
+|K355|4.01.02.01||60000,00|D|
+|K356|3.01.01.09.01.99|60000,00|D|
+|K030|01042022|30062022|T02|
+|K155|1.01.01.01||504000,00|D|5000,00|0|509000,00|D|
+|K156|1.01.01.02.01|504000,00|D|5000,00|0|509000,00|D|
+|K155|1.01.02.01||417000,00|D|506250,00|0|923250,00|D|
+|K156|1.01.02.02.01|417000,00|D|506250,00|0|923250,00|D|
+|K155|1.01.03.01||0|D|210000,00|210000,00|0|D|
+|K156|1.01.03.01.01|0|D|210000,00|210000,00|0|D|
+|K155|1.01.04.01||1800,00|D|2250,00|0|4050,00|D|
+|K156|1.01.02.04.01|1800,00|D|2250,00|0|4050,00|D|
+|K155|1.01.04.02||1200,00|D|1500,00|0|2700,00|D|
+|K156|1.01.02.04.04|1200,00|D|1500,00|0|2700,00|D|
+|K155|2.01.01.01||240000,00|C|0|280000,00|520000,00|C|
+|K156|2.01.01.03.01|240000,00|C|0|280000,00|520000,00|C|
+|K355|3.01.01.01||360000,00|C|
+|K356|3.01.01.01.01.05|360000,00|C|
+|K355|3.01.01.02||150000,00|C|
+|K356|3.01.01.01.01.06|150000,00|C|
+|K355|3.01.02.01||5000,00|C|
+|K356|3.01.01.05.01.05|5000,00|C|
+|K355|4.01.01.01||210000,00|D|
+|K356|3.01.01.03.01.02|210000,00|D|
+|K355|4.01.02.01||70000,00|D|
+|K356|3.01.01.09.01.99|70000,00|D|
+|K030|01072022|30092022|T03|
+|K155|1.01.01.01||509000,00|D|6000,00|0|515000,00|D|
+|K156|1.01.01.02.01|509000,00|D|6000,00|0|515000,00|D|
+|K155|1.01.02.01||923250,00|D|595500,00|0|1518750,00|D|
+|K156|1.01.02.02.01|923250,00|D|595500,00|0|1518750,00|D|
+|K155|1.01.03.01||0|D|250000,00|250000,00|0|D|
+|K156|1.01.03.01.01|0|D|250000,00|250000,00|0|D|
+|K155|1.01.04.01||4050,00|D|2700,00|0|6750,00|D|
+|K156|1.01.02.04.01|4050,00|D|2700,00|0|6750,00|D|
+|K155|1.01.04.02||2700,00|D|1800,00|0|4500,00|D|
+|K156|1.01.02.04.04|2700,00|D|1800,00|0|4500,00|D|
+|K155|2.01.01.01||520000,00|C|0|330000,00|850000,00|C|
+|K156|2.01.01.03.01|520000,00|C|0|330000,00|850000,00|C|
+|K355|3.01.01.01||420000,00|C|
+|K356|3.01.01.01.01.05|420000,00|C|
+|K355|3.01.01.02||180000,00|C|
+|K356|3.01.01.01.01.06|180000,00|C|
+|K355|3.01.02.01||6000,00|C|
+|K356|3.01.01.05.01.05|6000,00|C|
+|K355|4.01.01.01||250000,00|D|
+|K356|3.01.01.03.01.02|250000,00|D|
+|K355|4.01.02.01||80000,00|D|
+|K356|3.01.01.09.01.99|80000,00|D|
+|K030|01102022|31122022|T04|
+|K155|1.01.01.01||515000,00|D|7000,00|0|522000,00|D|
+|K156|1.01.01.02.01|515000,00|D|7000,00|0|522000,00|D|
+|K155|1.01.02.01||1518750,00|D|695000,00|0|2213750,00|D|
+|K156|1.01.02.02.01|1518750,00|D|695000,00|0|2213750,00|D|
+|K155|1.01.03.01||0|D|300000,00|300000,00|0|D|
+|K156|1.01.03.01.01|0|D|300000,00|300000,00|0|D|
+|K155|1.01.04.01||6750,00|D|3000,00|0|9750,00|D|
+|K156|1.01.02.04.01|6750,00|D|3000,00|0|9750,00|D|
+|K155|1.01.04.02||4500,00|D|2000,00|0|6500,00|D|
+|K156|1.01.02.04.04|4500,00|D|2000,00|0|6500,00|D|
+|K155|2.01.01.01||850000,00|C|0|390000,00|1240000,00|C|
+|K156|2.01.01.03.01|850000,00|C|0|390000,00|1240000,00|C|
+|K355|3.01.01.01||500000,00|C|
+|K356|3.01.01.01.01.05|500000,00|C|
+|K355|3.01.01.02||200000,00|C|
+|K356|3.01.01.01.01.06|200000,00|C|
+|K355|3.01.02.01||7000,00|C|
+|K356|3.01.01.05.01.05|7000,00|C|
+|K355|4.01.01.01||300000,00|D|
+|K356|3.01.01.03.01.02|300000,00|D|
+|K355|4.01.02.01||90000,00|D|
+|K356|3.01.01.09.01.99|90000,00|D|
+|K990|96|
+|P001|0|
+|P030|01012022|31032022|T01|
+|P100|1|1|S|1|01||0|D|1104000,00|180000,00|924000,00|D|
+|P100|1.01|1.01|S|2|01|1|0|D|1104000,00|180000,00|924000,00|D|
+|P100|1.01.01|1.01.01|S|3|01|1.01|0|D|504000,00|0|504000,00|D|
+|P100|1.01.01.02|1.01.01.02|S|4|01|1.01.01|0|D|504000,00|0|504000,00|D|
+|P100|1.01.01.02.01|Bancos Conta Movimento|A|5|01|1.01.01.02|0|D|504000,00|0|504000,00|D|
+|P100|1.01.02|1.01.02|S|3|01|1.01|0|D|420000,00|0|420000,00|D|
+|P100|1.01.02.02|1.01.02.02|S|4|01|1.01.02|0|D|417000,00|0|417000,00|D|
+|P100|1.01.02.02.01|Duplicatas a Receber|A|5|01|1.01.02.02|0|D|417000,00|0|417000,00|D|
+|P100|1.01.02.04|1.01.02.04|S|4|01|1.01.02|0|D|3000,00|0|3000,00|D|
+|P100|1.01.02.04.01|IRRF a Compensar|A|5|01|1.01.02.04|0|D|1800,00|0|1800,00|D|
+|P100|1.01.02.04.04|CSLL Retida a Compensar|A|5|01|1.01.02.04|0|D|1200,00|0|1200,00|D|
+|P100|1.01.03|1.01.03|S|3|01|1.01|0|D|180000,00|180000,00|0,00|D|
+|P100|1.01.03.01|1.01.03.01|S|4|01|1.01.03|0|D|180000,00|180000,00|0,00|D|
+|P100|1.01.03.01.01|Mercadorias para Revenda|A|5|01|1.01.03.01|0|D|180000,00|180000,00|0,00|D|
+|P100|2|2|S|1|02||0|D|0|740000,00|740000,00|C|
+|P100|2.01|2.01|S|2|02|2|0|D|0|240000,00|240000,00|C|
+|P100|2.01.01|2.01.01|S|3|02|2.01|0|D|0|240000,00|240000,00|C|
+|P100|2.01.01.03|2.01.01.03|S|4|02|2.01.01|0|D|0|240000,00|240000,00|C|
+|P100|2.01.01.03.01|Fornecedores|A|5|02|2.01.01.03|0|D|0|240000,00|240000,00|C|
+|P100|2.03|2.03|S|2|03|2|0|D|0|500000,00|500000,00|C|
+|P100|2.03.01|2.03.01|S|3|03|2.03|0|D|0|500000,00|500000,00|C|
+|P100|2.03.01.01|2.03.01.01|S|4|03|2.03.01|0|D|0|500000,00|500000,00|C|
+|P100|2.03.01.01.01|Capital Social|A|5|03|2.03.01.01|0|D|0|500000,00|500000,00|C|
+|P150|3|3|S|1|04||184000,00|C|
+|P150|3.01|3.01|S|2|04|3|184000,00|C|
+|P150|3.01.01|3.01.01|S|3|04|3.01|184000,00|C|
+|P150|3.01.01.01|3.01.01.01|S|4|04|3.01.01|420000,00|C|
+|P150|3.01.01.01.01|3.01.01.01.01|S|5|04|3.01.01.01|420000,00|C|
+|P150|3.01.01.01.01.05|Receita de Revenda|A|6|04|3.01.01.01.01|300000,00|C|
+|P150|3.01.01.01.01.06|Receita de Servicos|A|6|04|3.01.01.01.01|120000,00|C|
+|P150|3.01.01.03|3.01.01.03|S|4|04|3.01.01|180000,00|D|
+|P150|3.01.01.03.01|3.01.01.03.01|S|5|04|3.01.01.03|180000,00|D|
+|P150|3.01.01.03.01.02|Custo das Mercadorias|A|6|04|3.01.01.03.01|180000,00|D|
+|P150|3.01.01.05|3.01.01.05|S|4|04|3.01.01|4000,00|C|
+|P150|3.01.01.05.01|3.01.01.05.01|S|5|04|3.01.01.05|4000,00|C|
+|P150|3.01.01.05.01.05|Rendimentos de Aplicacoes|A|6|04|3.01.01.05.01|4000,00|C|
+|P150|3.01.01.09|3.01.01.09|S|4|04|3.01.01|60000,00|D|
+|P150|3.01.01.09.01|3.01.01.09.01|S|5|04|3.01.01.09|60000,00|D|
+|P150|3.01.01.09.01.99|Despesas Operacionais|A|6|04|3.01.01.09.01|60000,00|D|
+|P200|1|DISCRIMINAÇÃO DA RECEITA BRUTA||
+|P200|2|Receita Bruta Sujeita ao Percentual de 1,6%|0,00|
+|P200|4|Receita Bruta Sujeita ao Percentual de 8%|300000,00|
+|P200|6|Receita Bruta Sujeita ao Percentual de 16%|0,00|
+|P200|8|Receita Bruta Sujeita ao Percentual de 32%|120000,00|
+|P200|9|Receita Bruta Sujeita ao Percentual de 38,4%|0,00|
+|P200|10|RESULTADO DA APLICAÇÃO DOS PERCENTUAIS SOBRE A RECEITA BRUTA AJUSTADO|62400,00|
+|P200|11|Rendimentos e Ganhos Líquidos de Aplicações de Renda Fixa e Renda Variável|4000,00|
+|P200|12|Juros sobre o Capital Próprio|0,00|
+|P200|13|Realização de Valores cuja Tributação Tenha Sido Diferida|0,00|
+|P200|14|Recuperação de Custos e Despesas|0,00|
+|P200|15|Ajustes Decorrentes de Métodos - Preços de Transferências|0,00|
+|P200|16|Multas e Vantagens Decorrentes de Rescisão Contratual|0,00|
+|P200|17|Lucros Disponibilizados no Exterior|0,00|
+|P200|18|Rendimentos e Ganhos de Capital Auferidos no Exterior|0,00|
+|P200|19|Variações Cambiais Ativas - Operações Liquidadas (MP nº 1.858-10/1999, art. 30)|0,00|
+|P200|20|Demais Receitas e Ganhos de Capital|0,00|
+|P200|20.01|Valor da Contraprestação de Arrendamento Mercantil (Art. 46, § 4º, da Lei nº 12.973/2014).|0,00|
+|P200|22|(-) Excedente de Variação Cambial (MP nº 1.858-10/1999, art. 31)|0,00|
+|P200|23|(-) Variações Cambiais Ativas (MP nº 1.858-10/1999, art. 30)|0,00|
+|P200|24|(-) Resultados Não Tributáveis de Sociedades Cooperativas|0,00|
+|P200|25|(-) Divulgação Eleitoral e Partidária Gratuita|0,00|
+|P200|25.01|(-) Receitas Financeiras Relativas às Variações Monetárias dos Direitos de Crédito e Obrigações do Contribuinte Decorrentes de Ajuste a Valor Presente (Art. 8º da Lei nº 12.973/2014)|0,00|
+|P200|25.02|(-) Receita Reconhecida pela Construção, Recuperação, Reforma, Ampliação ou Melhoramento da Infraestrutura, cuja Contrapartida Seja Ativo Intangível Representativo do Direito de Exploração (Art. 44 da Lei nº 12.973/2014)|0,00|
+|P200|26|BASE DE CÁLCULO DO IMPOSTO SOBRE O LUCRO PRESUMIDO|66400,00|
+|P300|1|BASE DE CÁLCULO DO IMPOSTO SOBRE O LUCRO PRESUMIDO|66400,00|
+|P300|2|IMPOSTO APURADO COM BASE NO LUCRO PRESUMIDO||
+|P300|3|À Alíquota de 15%|9960,00|
+|P300|4|Adicional|640,00|
+|P300|5|Diferença de IR Devida pela Mudança de Coeficiente sobre a Receita Bruta|0,00|
+|P300|6|DEDUÇÕES||
+|P300|7|(-) Isenção de Empresas Estrangeiras de Transporte|0,00|
+|P300|8|(-) Isenção e Redução do Imposto|0,00|
+|P300|9|(-) Redução por Reinvestimento|0,00|
+|P300|10|(-) Imposto de Renda Retido na Fonte|1800,00|
+|P300|11|(-) Imposto Pago no Exterior sobre Lucros, Rendimentos e Ganhos de Capital|0,00|
+|P300|11.20|(-) Programa Emergencial de Retomada do Setor de Eventos (Perse) e o Programa de Garantia aos Setores Críticos (PGSC) (Art. 4º, Lei nº 14.148/2021).|0,00|
+|P300|12|(-) Imposto de Renda Retido na Fonte por Órgãos, Autarquias e Fundações Federais (Lei nº 9.430/1996, art. 64)|0,00|
+|P300|13|(-) Imposto de Renda Retido na Fonte pelas Demais Entidades da Administração Pública Federal (Lei n° 10.833/2003, art. 34)|0,00|
+|P300|14|(-) Imposto Pago Incidente sobre Ganhos no Mercado de Renda Variável|0,00|
+|P300|15|IMPOSTO DE RENDA A PAGAR|8800,00|
+|P300|16|RECEITAS DA ATIVIDADE IMOBILIÁRIA TRIBUTADAS PELO RET|0,00|
+|P300|17|IMPOSTO DE RENDA POSTERGADO DE PERÍODOS DE APURAÇÃO ANTERIORES|0,00|
+|P400|1|CÁLCULO DA CSLL||
+|P400|2|Receita Bruta Sujeita ao Percentual de 12%|300000,00|
+|P400|4|Receita Bruta Sujeita ao Percentual de 32%|120000,00|
+|P400|5|Receita Bruta Sujeita ao Percentual de 38,4%|0,00|
+|P400|6|RESULTADO DA APLICAÇÃO DOS PERCENTUAIS SOBRE A RECEITA BRUTA AJUSTADO|74400,00|
+|P400|7|Rendimentos e Ganhos Líquidos de Aplicações de Renda Fixa e Renda Variável|4000,00|
+|P400|8|Juros sobre o Capital Próprio|0,00|
+|P400|9|Realização de Valores cuja Tributação Tenha Sido Diferida|0,00|
+|P400|10|Recuperação de Custos e Despesas|0,00|
+|P400|11|Ajustes Decorrentes de Métodos - Preços de Transferências|0,00|
+|P400|12|Multas e Vantagens Decorrentes de Rescisão Contratual|0,00|
+|P400|13|Lucros Disponibilizados no Exterior|0,00|
+|P400|14|Rendimentos e Ganhos de Capital Auferidos no Exterior|0,00|
+|P400|15|Variações Cambiais Ativas - Operações Liquidadas (MP nº 1.858-10/1999, art. 30)|0,00|
+|P400|16|Demais Receitas e Ganhos de Capital|0,00|
+|P400|16.01|Valor da Contraprestação de Arrendamento Mercantil (Art. 46, § 4º, da Lei nº 12.973/2014)|0,00|
+|P400|18|(-) Excedente de Variação Cambial (MP nº 1.858-10/1999, art. 31)|0,00|
+|P400|19|(-) Variações Cambiais Ativas (MP nº 1.858-10/1999, art. 30)|0,00|
+|P400|19.01|(-) Receitas Financeiras Relativas às Variações Monetárias dos Direitos de Crédito e Obrigações do Contribuinte Decorrentes de Ajuste a Valor Presente (Art. 8º da Lei nº 12.973/2014)|0,00|
+|P400|19.02|(-) Receita Reconhecida pela Construção, Recuperação, Reforma, Ampliação ou Melhoramento da Infraestrutura, cuja Contrapartida Seja Ativo Intangível Representativo do Direito de Exploração (Art. 44 da Lei nº 12.973/2014)|0,00|
+|P400|20|(-) Resultados Não Tributáveis de Sociedades Cooperativas|0,00|
+|P400|21|BASE DE CÁLCULO DA CSLL|78400,00|
+|P500|1|BASE DE CÁLCULO DA CSLL|78400,00|
+|P500|2|CSLL Apurada|7056,00|
+|P500|3|Adição de Créditos de CSLL sobre Depreciação Utilizados no Regime de Lucro Real (Lei nº 11.051/2004, art. 1º, § 9º)|0,00|
+|P500|4|TOTAL DA CONTRIBUIÇÃO SOCIAL SOBRE O LUCRO LÍQUIDO|7056,00|
+|P500|5|DEDUÇÕES||
+|P500|6|(-) Bônus de Adimplência Fiscal (Lei nº 10.637/2002, art. 38)|0,00|
+|P500|7|(-) Isenção sobre o Lucro Relativo ao Prouni|0,00|
+|P500|8|(-) Imposto Pago no Exterior sobre Lucros, Rendimentos e Ganhos de Capital (MP nº 1.858-6/1999, art. 19)|0,00|
+|P500|9|(-) CSLL Retida na Fonte por Órgãos, Autarquias e Fundações Federais (Lei nº 9.430/1996, art. 64)|0,00|
+|P500|10|(-) CSLL Retida na Fonte pelas Demais Entidades da Administração Pública Federal (Lei n° 10.833/2003, art. 34)|0,00|
+|P500|11|(-) CSLL Retida na Fonte por Pessoas Jurídicas de Direito Privado (Lei n° 10.833/2003, art. 30)|1200,00|
+|P500|11.20|(-) Programa Emergencial de Retomada do Setor de Eventos (Perse) e o Programa de Garantia aos Setores Críticos (PGSC) (Art. 4º, Lei nº 14.148/2021).|0,00|
+|P500|12|(-) CSLL Retida na Fonte por Órgãos, Autarquias e Fundações dos Estados, Distrito Federal e Municípios (Lei n° 10.833/2003, art. 33)|0,00|
+|P500|13|CSLL A PAGAR|5856,00|
+|P500|14|RECEITAS DA ATIVIDADE IMOBILIÁRIA TRIBUTADAS PELO RET|0,00|
+|P500|15|CSLL POSTERGADA DE PERÍODOS DE APURAÇÃO ANTERIORES|0,00|
+|P030|01042022|30062022|T02|
+|P100|1|1|S|1|01||924000,00|D|725000,00|210000,00|1439000,00|D|
+|P100|1.01|1.01|S|2|01|1|924000,00|D|725000,00|210000,00|1439000,00|D|
+|P100|1.01.01|1.01.01|S|3|01|1.01|504000,00|D|5000,00|0|509000,00|D|
+|P100|1.01.01.02|1.01.01.02|S|4|01|1.01.01|504000,00|D|5000,00|0|509000,00|D|
+|P100|1.01.01.02.01|Bancos Conta Movimento|A|5|01|1.01.01.02|504000,00|D|5000,00|0|509000,00|D|
+|P100|1.01.02|1.01.02|S|3|01|1.01|420000,00|D|510000,00|0|930000,00|D|
+|P100|1.01.02.02|1.01.02.02|S|4|01|1.01.02|417000,00|D|506250,00|0|923250,00|D|
+|P100|1.01.02.02.01|Duplicatas a Receber|A|5|01|1.01.02.02|417000,00|D|506250,00|0|923250,00|D|
+|P100|1.01.02.04|1.01.02.04|S|4|01|1.01.02|3000,00|D|3750,00|0|6750,00|D|
+|P100|1.01.02.04.01|IRRF a Compensar|A|5|01|1.01.02.04|1800,00|D|2250,00|0|4050,00|D|
+|P100|1.01.02.04.04|CSLL Retida a Compensar|A|5|01|1.01.02.04|1200,00|D|1500,00|0|2700,00|D|
+|P100|1.01.03|1.01.03|S|3|01|1.01|0|D|210000,00|210000,00|0,00|D|
+|P100|1.01.03.01|1.01.03.01|S|4|01|1.01.03|0|D|210000,00|210000,00|0,00|D|
+|P100|1.01.03.01.01|Mercadorias para Revenda|A|5|01|1.01.03.01|0|D|210000,00|210000,00|0,00|D|
+|P100|2|2|S|1|02||240000,00|C|0|280000,00|520000,00|C|
+|P100|2.01|2.01|S|2|02|2|240000,00|C|0|280000,00|520000,00|C|
+|P100|2.01.01|2.01.01|S|3|02|2.01|240000,00|C|0|280000,00|520000,00|C|
+|P100|2.01.01.03|2.01.01.03|S|4|02|2.01.01|240000,00|C|0|280000,00|520000,00|C|
+|P100|2.01.01.03.01|Fornecedores|A|5|02|2.01.01.03|240000,00|C|0|280000,00|520000,00|C|
+|P150|3|3|S|1|04||235000,00|C|
+|P150|3.01|3.01|S|2|04|3|235000,00|C|
+|P150|3.01.01|3.01.01|S|3|04|3.01|235000,00|C|
+|P150|3.01.01.01|3.01.01.01|S|4|04|3.01.01|510000,00|C|
+|P150|3.01.01.01.01|3.01.01.01.01|S|5|04|3.01.01.01|510000,00|C|
+|P150|3.01.01.01.01.05|Receita de Revenda|A|6|04|3.01.01.01.01|360000,00|C|
+|P150|3.01.01.01.01.06|Receita de Servicos|A|6|04|3.01.01.01.01|150000,00|C|
+|P150|3.01.01.03|3.01.01.03|S|4|04|3.01.01|210000,00|D|
+|P150|3.01.01.03.01|3.01.01.03.01|S|5|04|3.01.01.03|210000,00|D|
+|P150|3.01.01.03.01.02|Custo das Mercadorias|A|6|04|3.01.01.03.01|210000,00|D|
+|P150|3.01.01.05|3.01.01.05|S|4|04|3.01.01|5000,00|C|
+|P150|3.01.01.05.01|3.01.01.05.01|S|5|04|3.01.01.05|5000,00|C|
+|P150|3.01.01.05.01.05|Rendimentos de Aplicacoes|A|6|04|3.01.01.05.01|5000,00|C|
+|P150|3.01.01.09|3.01.01.09|S|4|04|3.01.01|70000,00|D|
+|P150|3.01.01.09.01|3.01.01.09.01|S|5|04|3.01.01.09|70000,00|D|
+|P150|3.01.01.09.01.99|Despesas Operacionais|A|6|04|3.01.01.09.01|70000,00|D|
+|P200|1|DISCRIMINAÇÃO DA RECEITA BRUTA||
+|P200|2|Receita Bruta Sujeita ao Percentual de 1,6%|0,00|
+|P200|4|Receita Bruta Sujeita ao Percentual de 8%|360000,00|
+|P200|6|Receita Bruta Sujeita ao Percentual de 16%|0,00|
+|P200|8|Receita Bruta Sujeita ao Percentual de 32%|150000,00|
+|P200|9|Receita Bruta Sujeita ao Percentual de 38,4%|0,00|
+|P200|10|RESULTADO DA APLICAÇÃO DOS PERCENTUAIS SOBRE A RECEITA BRUTA AJUSTADO|76800,00|
+|P200|11|Rendimentos e Ganhos Líquidos de Aplicações de Renda Fixa e Renda Variável|5000,00|
+|P200|12|Juros sobre o Capital Próprio|0,00|
+|P200|13|Realização de Valores cuja Tributação Tenha Sido Diferida|0,00|
+|P200|14|Recuperação de Custos e Despesas|0,00|
+|P200|15|Ajustes Decorrentes de Métodos - Preços de Transferências|0,00|
+|P200|16|Multas e Vantagens Decorrentes de Rescisão Contratual|0,00|
+|P200|17|Lucros Disponibilizados no Exterior|0,00|
+|P200|18|Rendimentos e Ganhos de Capital Auferidos no Exterior|0,00|
+|P200|19|Variações Cambiais Ativas - Operações Liquidadas (MP nº 1.858-10/1999, art. 30)|0,00|
+|P200|20|Demais Receitas e Ganhos de Capital|0,00|
+|P200|20.01|Valor da Contraprestação de Arrendamento Mercantil (Art. 46, § 4º, da Lei nº 12.973/2014).|0,00|
+|P200|22|(-) Excedente de Variação Cambial (MP nº 1.858-10/1999, art. 31)|0,00|
+|P200|23|(-) Variações Cambiais Ativas (MP nº 1.858-10/1999, art. 30)|0,00|
+|P200|24|(-) Resultados Não Tributáveis de Sociedades Cooperativas|0,00|
+|P200|25|(-) Divulgação Eleitoral e Partidária Gratuita|0,00|
+|P200|25.01|(-) Receitas Financeiras Relativas às Variações Monetárias dos Direitos de Crédito e Obrigações do Contribuinte Decorrentes de Ajuste a Valor Presente (Art. 8º da Lei nº 12.973/2014)|0,00|
+|P200|25.02|(-) Receita Reconhecida pela Construção, Recuperação, Reforma, Ampliação ou Melhoramento da Infraestrutura, cuja Contrapartida Seja Ativo Intangível Representativo do Direito de Exploração (Art. 44 da Lei nº 12.973/2014)|0,00|
+|P200|26|BASE DE CÁLCULO DO IMPOSTO SOBRE O LUCRO PRESUMIDO|81800,00|
+|P300|1|BASE DE CÁLCULO DO IMPOSTO SOBRE O LUCRO PRESUMIDO|81800,00|
+|P300|2|IMPOSTO APURADO COM BASE NO LUCRO PRESUMIDO||
+|P300|3|À Alíquota de 15%|12270,00|
+|P300|4|Adicional|2180,00|
+|P300|5|Diferença de IR Devida pela Mudança de Coeficiente sobre a Receita Bruta|0,00|
+|P300|6|DEDUÇÕES||
+|P300|7|(-) Isenção de Empresas Estrangeiras de Transporte|0,00|
+|P300|8|(-) Isenção e Redução do Imposto|0,00|
+|P300|9|(-) Redução por Reinvestimento|0,00|
+|P300|10|(-) Imposto de Renda Retido na Fonte|2250,00|
+|P300|11|(-) Imposto Pago no Exterior sobre Lucros, Rendimentos e Ganhos de Capital|0,00|
+|P300|11.20|(-) Programa Emergencial de Retomada do Setor de Eventos (Perse) e o Programa de Garantia aos Setores Críticos (PGSC) (Art. 4º, Lei nº 14.148/2021).|0,00|
+|P300|12|(-) Imposto de Renda Retido na Fonte por Órgãos, Autarquias e Fundações Federais (Lei nº 9.430/1996, art. 64)|0,00|
+|P300|13|(-) Imposto de Renda Retido na Fonte pelas Demais Entidades da Administração Pública Federal (Lei n° 10.833/2003, art. 34)|0,00|
+|P300|14|(-) Imposto Pago Incidente sobre Ganhos no Mercado de Renda Variável|0,00|
+|P300|15|IMPOSTO DE RENDA A PAGAR|12200,00|
+|P300|16|RECEITAS DA ATIVIDADE IMOBILIÁRIA TRIBUTADAS PELO RET|0,00|
+|P300|17|IMPOSTO DE RENDA POSTERGADO DE PERÍODOS DE APURAÇÃO ANTERIORES|0,00|
+|P400|1|CÁLCULO DA CSLL||
+|P400|2|Receita Bruta Sujeita ao Percentual de 12%|360000,00|
+|P400|4|Receita Bruta Sujeita ao Percentual de 32%|150000,00|
+|P400|5|Receita Bruta Sujeita ao Percentual de 38,4%|0,00|
+|P400|6|RESULTADO DA APLICAÇÃO DOS PERCENTUAIS SOBRE A RECEITA BRUTA AJUSTADO|91200,00|
+|P400|7|Rendimentos e Ganhos Líquidos de Aplicações de Renda Fixa e Renda Variável|5000,00|
+|P400|8|Juros sobre o Capital Próprio|0,00|
+|P400|9|Realização de Valores cuja Tributação Tenha Sido Diferida|0,00|
+|P400|10|Recuperação de Custos e Despesas|0,00|
+|P400|11|Ajustes Decorrentes de Métodos - Preços de Transferências|0,00|
+|P400|12|Multas e Vantagens Decorrentes de Rescisão Contratual|0,00|
+|P400|13|Lucros Disponibilizados no Exterior|0,00|
+|P400|14|Rendimentos e Ganhos de Capital Auferidos no Exterior|0,00|
+|P400|15|Variações Cambiais Ativas - Operações Liquidadas (MP nº 1.858-10/1999, art. 30)|0,00|
+|P400|16|Demais Receitas e Ganhos de Capital|0,00|
+|P400|16.01|Valor da Contraprestação de Arrendamento Mercantil (Art. 46, § 4º, da Lei nº 12.973/2014)|0,00|
+|P400|18|(-) Excedente de Variação Cambial (MP nº 1.858-10/1999, art. 31)|0,00|
+|P400|19|(-) Variações Cambiais Ativas (MP nº 1.858-10/1999, art. 30)|0,00|
+|P400|19.01|(-) Receitas Financeiras Relativas às Variações Monetárias dos Direitos de Crédito e Obrigações do Contribuinte Decorrentes de Ajuste a Valor Presente (Art. 8º da Lei nº 12.973/2014)|0,00|
+|P400|19.02|(-) Receita Reconhecida pela Construção, Recuperação, Reforma, Ampliação ou Melhoramento da Infraestrutura, cuja Contrapartida Seja Ativo Intangível Representativo do Direito de Exploração (Art. 44 da Lei nº 12.973/2014)|0,00|
+|P400|20|(-) Resultados Não Tributáveis de Sociedades Cooperativas|0,00|
+|P400|21|BASE DE CÁLCULO DA CSLL|96200,00|
+|P500|1|BASE DE CÁLCULO DA CSLL|96200,00|
+|P500|2|CSLL Apurada|8658,00|
+|P500|3|Adição de Créditos de CSLL sobre Depreciação Utilizados no Regime de Lucro Real (Lei nº 11.051/2004, art. 1º, § 9º)|0,00|
+|P500|4|TOTAL DA CONTRIBUIÇÃO SOCIAL SOBRE O LUCRO LÍQUIDO|8658,00|
+|P500|5|DEDUÇÕES||
+|P500|6|(-) Bônus de Adimplência Fiscal (Lei nº 10.637/2002, art. 38)|0,00|
+|P500|7|(-) Isenção sobre o Lucro Relativo ao Prouni|0,00|
+|P500|8|(-) Imposto Pago no Exterior sobre Lucros, Rendimentos e Ganhos de Capital (MP nº 1.858-6/1999, art. 19)|0,00|
+|P500|9|(-) CSLL Retida na Fonte por Órgãos, Autarquias e Fundações Federais (Lei nº 9.430/1996, art. 64)|0,00|
+|P500|10|(-) CSLL Retida na Fonte pelas Demais Entidades da Administração Pública Federal (Lei n° 10.833/2003, art. 34)|0,00|
+|P500|11|(-) CSLL Retida na Fonte por Pessoas Jurídicas de Direito Privado (Lei n° 10.833/2003, art. 30)|1500,00|
+|P500|11.20|(-) Programa Emergencial de Retomada do Setor de Eventos (Perse) e o Programa de Garantia aos Setores Críticos (PGSC) (Art. 4º, Lei nº 14.148/2021).|0,00|
+|P500|12|(-) CSLL Retida na Fonte por Órgãos, Autarquias e Fundações dos Estados, Distrito Federal e Municípios (Lei n° 10.833/2003, art. 33)|0,00|
+|P500|13|CSLL A PAGAR|7158,00|
+|P500|14|RECEITAS DA ATIVIDADE IMOBILIÁRIA TRIBUTADAS PELO RET|0,00|
+|P500|15|CSLL POSTERGADA DE PERÍODOS DE APURAÇÃO ANTERIORES|0,00|
+|P030|01072022|30092022|T03|
+|P100|1|1|S|1|01||1439000,00|D|856000,00|250000,00|2045000,00|D|
+|P100|1.01|1.01|S|2|01|1|1439000,00|D|856000,00|250000,00|2045000,00|D|
+|P100|1.01.01|1.01.01|S|3|01|1.01|509000,00|D|6000,00|0|515000,00|D|
+|P100|1.01.01.02|1.01.01.02|S|4|01|1.01.01|509000,00|D|6000,00|0|515000,00|D|
+|P100|1.01.01.02.01|Bancos Conta Movimento|A|5|01|1.01.01.02|509000,00|D|6000,00|0|515000,00|D|
+|P100|1.01.02|1.01.02|S|3|01|1.01|930000,00|D|600000,00|0|1530000,00|D|
+|P100|1.01.02.02|1.01.02.02|S|4|01|1.01.02|923250,00|D|595500,00|0|1518750,00|D|
+|P100|1.01.02.02.01|Duplicatas a Receber|A|5|01|1.01.02.02|923250,00|D|595500,00|0|1518750,00|D|
+|P100|1.01.02.04|1.01.02.04|S|4|01|1.01.02|6750,00|D|4500,00|0|11250,00|D|
+|P100|1.01.02.04.01|IRRF a Compensar|A|5|01|1.01.02.04|4050,00|D|2700,00|0|6750,00|D|
+|P100|1.01.02.04.04|CSLL Retida a Compensar|A|5|01|1.01.02.04|2700,00|D|1800,00|0|4500,00|D|
+|P100|1.01.03|1.01.03|S|3|01|1.01|0|D|250000,00|250000,00|0,00|D|
+|P100|1.01.03.01|1.01.03.01|S|4|01|1.01.03|0|D|250000,00|250000,00|0,00|D|
+|P100|1.01.03.01.01|Mercadorias para Revenda|A|5|01|1.01.03.01|0|D|250000,00|250000,00|0,00|D|
+|P100|2|2|S|1|02||520000,00|C|0|330000,00|850000,00|C|
+|P100|2.01|2.01|S|2|02|2|520000,00|C|0|330000,00|850000,00|C|
+|P100|2.01.01|2.01.01|S|3|02|2.01|520000,00|C|0|330000,00|850000,00|C|
+|P100|2.01.01.03|2.01.01.03|S|4|02|2.01.01|520000,00|C|0|330000,00|850000,00|C|
+|P100|2.01.01.03.01|Fornecedores|A|5|02|2.01.01.03|520000,00|C|0|330000,00|850000,00|C|
+|P150|3|3|S|1|04||276000,00|C|
+|P150|3.01|3.01|S|2|04|3|276000,00|C|
+|P150|3.01.01|3.01.01|S|3|04|3.01|276000,00|C|
+|P150|3.01.01.01|3.01.01.01|S|4|04|3.01.01|600000,00|C|
+|P150|3.01.01.01.01|3.01.01.01.01|S|5|04|3.01.01.01|600000,00|C|
+|P150|3.01.01.01.01.05|Receita de Revenda|A|6|04|3.01.01.01.01|420000,00|C|
+|P150|3.01.01.01.01.06|Receita de Servicos|A|6|04|3.01.01.01.01|180000,00|C|
+|P150|3.01.01.03|3.01.01.03|S|4|04|3.01.01|250000,00|D|
+|P150|3.01.01.03.01|3.01.01.03.01|S|5|04|3.01.01.03|250000,00|D|
+|P150|3.01.01.03.01.02|Custo das Mercadorias|A|6|04|3.01.01.03.01|250000,00|D|
+|P150|3.01.01.05|3.01.01.05|S|4|04|3.01.01|6000,00|C|
+|P150|3.01.01.05.01|3.01.01.05.01|S|5|04|3.01.01.05|6000,00|C|
+|P150|3.01.01.05.01.05|Rendimentos de Aplicacoes|A|6|04|3.01.01.05.01|6000,00|C|
+|P150|3.01.01.09|3.01.01.09|S|4|04|3.01.01|80000,00|D|
+|P150|3.01.01.09.01|3.01.01.09.01|S|5|04|3.01.01.09|80000,00|D|
+|P150|3.01.01.09.01.99|Despesas Operacionais|A|6|04|3.01.01.09.01|80000,00|D|
+|P200|1|DISCRIMINAÇÃO DA RECEITA BRUTA||
+|P200|2|Receita Bruta Sujeita ao Percentual de 1,6%|0,00|
+|P200|4|Receita Bruta Sujeita ao Percentual de 8%|420000,00|
+|P200|6|Receita Bruta Sujeita ao Percentual de 16%|0,00|
+|P200|8|Receita Bruta Sujeita ao Percentual de 32%|180000,00|
+|P200|9|Receita Bruta Sujeita ao Percentual de 38,4%|0,00|
+|P200|10|RESULTADO DA APLICAÇÃO DOS PERCENTUAIS SOBRE A RECEITA BRUTA AJUSTADO|91200,00|
+|P200|11|Rendimentos e Ganhos Líquidos de Aplicações de Renda Fixa e Renda Variável|6000,00|
+|P200|12|Juros sobre o Capital Próprio|0,00|
+|P200|13|Realização de Valores cuja Tributação Tenha Sido Diferida|0,00|
+|P200|14|Recuperação de Custos e Despesas|0,00|
+|P200|15|Ajustes Decorrentes de Métodos - Preços de Transferências|0,00|
+|P200|16|Multas e Vantagens Decorrentes de Rescisão Contratual|0,00|
+|P200|17|Lucros Disponibilizados no Exterior|0,00|
+|P200|18|Rendimentos e Ganhos de Capital Auferidos no Exterior|0,00|
+|P200|19|Variações Cambiais Ativas - Operações Liquidadas (MP nº 1.858-10/1999, art. 30)|0,00|
+|P200|20|Demais Receitas e Ganhos de Capital|0,00|
+|P200|20.01|Valor da Contraprestação de Arrendamento Mercantil (Art. 46, § 4º, da Lei nº 12.973/2014).|0,00|
+|P200|22|(-) Excedente de Variação Cambial (MP nº 1.858-10/1999, art. 31)|0,00|
+|P200|23|(-) Variações Cambiais Ativas (MP nº 1.858-10/1999, art. 30)|0,00|
+|P200|24|(-) Resultados Não Tributáveis de Sociedades Cooperativas|0,00|
+|P200|25|(-) Divulgação Eleitoral e Partidária Gratuita|0,00|
+|P200|25.01|(-) Receitas Financeiras Relativas às Variações Monetárias dos Direitos de Crédito e Obrigações do Contribuinte Decorrentes de Ajuste a Valor Presente (Art. 8º da Lei nº 12.973/2014)|0,00|
+|P200|25.02|(-) Receita Reconhecida pela Construção, Recuperação, Reforma, Ampliação ou Melhoramento da Infraestrutura, cuja Contrapartida Seja Ativo Intangível Representativo do Direito de Exploração (Art. 44 da Lei nº 12.973/2014)|0,00|
+|P200|26|BASE DE CÁLCULO DO IMPOSTO SOBRE O LUCRO PRESUMIDO|97200,00|
+|P300|1|BASE DE CÁLCULO DO IMPOSTO SOBRE O LUCRO PRESUMIDO|97200,00|
+|P300|2|IMPOSTO APURADO COM BASE NO LUCRO PRESUMIDO||
+|P300|3|À Alíquota de 15%|14580,00|
+|P300|4|Adicional|3720,00|
+|P300|5|Diferença de IR Devida pela Mudança de Coeficiente sobre a Receita Bruta|0,00|
+|P300|6|DEDUÇÕES||
+|P300|7|(-) Isenção de Empresas Estrangeiras de Transporte|0,00|
+|P300|8|(-) Isenção e Redução do Imposto|0,00|
+|P300|9|(-) Redução por Reinvestimento|0,00|
+|P300|10|(-) Imposto de Renda Retido na Fonte|2700,00|
+|P300|11|(-) Imposto Pago no Exterior sobre Lucros, Rendimentos e Ganhos de Capital|0,00|
+|P300|11.20|(-) Programa Emergencial de Retomada do Setor de Eventos (Perse) e o Programa de Garantia aos Setores Críticos (PGSC) (Art. 4º, Lei nº 14.148/2021).|0,00|
+|P300|12|(-) Imposto de Renda Retido na Fonte por Órgãos, Autarquias e Fundações Federais (Lei nº 9.430/1996, art. 64)|0,00|
+|P300|13|(-) Imposto de Renda Retido na Fonte pelas Demais Entidades da Administração Pública Federal (Lei n° 10.833/2003, art. 34)|0,00|
+|P300|14|(-) Imposto Pago Incidente sobre Ganhos no Mercado de Renda Variável|0,00|
+|P300|15|IMPOSTO DE RENDA A PAGAR|15600,00|
+|P300|16|RECEITAS DA ATIVIDADE IMOBILIÁRIA TRIBUTADAS PELO RET|0,00|
+|P300|17|IMPOSTO DE RENDA POSTERGADO DE PERÍODOS DE APURAÇÃO ANTERIORES|0,00|
+|P400|1|CÁLCULO DA CSLL||
+|P400|2|Receita Bruta Sujeita ao Percentual de 12%|420000,00|
+|P400|4|Receita Bruta Sujeita ao Percentual de 32%|180000,00|
+|P400|5|Receita Bruta Sujeita ao Percentual de 38,4%|0,00|
+|P400|6|RESULTADO DA APLICAÇÃO DOS PERCENTUAIS SOBRE A RECEITA BRUTA AJUSTADO|108000,00|
+|P400|7|Rendimentos e Ganhos Líquidos de Aplicações de Renda Fixa e Renda Variável|6000,00|
+|P400|8|Juros sobre o Capital Próprio|0,00|
+|P400|9|Realização de Valores cuja Tributação Tenha Sido Diferida|0,00|
+|P400|10|Recuperação de Custos e Despesas|0,00|
+|P400|11|Ajustes Decorrentes de Métodos - Preços de Transferências|0,00|
+|P400|12|Multas e Vantagens Decorrentes de Rescisão Contratual|0,00|
+|P400|13|Lucros Disponibilizados no Exterior|0,00|
+|P400|14|Rendimentos e Ganhos de Capital Auferidos no Exterior|0,00|
+|P400|15|Variações Cambiais Ativas - Operações Liquidadas (MP nº 1.858-10/1999, art. 30)|0,00|
+|P400|16|Demais Receitas e Ganhos de Capital|0,00|
+|P400|16.01|Valor da Contraprestação de Arrendamento Mercantil (Art. 46, § 4º, da Lei nº 12.973/2014)|0,00|
+|P400|18|(-) Excedente de Variação Cambial (MP nº 1.858-10/1999, art. 31)|0,00|
+|P400|19|(-) Variações Cambiais Ativas (MP nº 1.858-10/1999, art. 30)|0,00|
+|P400|19.01|(-) Receitas Financeiras Relativas às Variações Monetárias dos Direitos de Crédito e Obrigações do Contribuinte Decorrentes de Ajuste a Valor Presente (Art. 8º da Lei nº 12.973/2014)|0,00|
+|P400|19.02|(-) Receita Reconhecida pela Construção, Recuperação, Reforma, Ampliação ou Melhoramento da Infraestrutura, cuja Contrapartida Seja Ativo Intangível Representativo do Direito de Exploração (Art. 44 da Lei nº 12.973/2014)|0,00|
+|P400|20|(-) Resultados Não Tributáveis de Sociedades Cooperativas|0,00|
+|P400|21|BASE DE CÁLCULO DA CSLL|114000,00|
+|P500|1|BASE DE CÁLCULO DA CSLL|114000,00|
+|P500|2|CSLL Apurada|10260,00|
+|P500|3|Adição de Créditos de CSLL sobre Depreciação Utilizados no Regime de Lucro Real (Lei nº 11.051/2004, art. 1º, § 9º)|0,00|
+|P500|4|TOTAL DA CONTRIBUIÇÃO SOCIAL SOBRE O LUCRO LÍQUIDO|10260,00|
+|P500|5|DEDUÇÕES||
+|P500|6|(-) Bônus de Adimplência Fiscal (Lei nº 10.637/2002, art. 38)|0,00|
+|P500|7|(-) Isenção sobre o Lucro Relativo ao Prouni|0,00|
+|P500|8|(-) Imposto Pago no Exterior sobre Lucros, Rendimentos e Ganhos de Capital (MP nº 1.858-6/1999, art. 19)|0,00|
+|P500|9|(-) CSLL Retida na Fonte por Órgãos, Autarquias e Fundações Federais (Lei nº 9.430/1996, art. 64)|0,00|
+|P500|10|(-) CSLL Retida na Fonte pelas Demais Entidades da Administração Pública Federal (Lei n° 10.833/2003, art. 34)|0,00|
+|P500|11|(-) CSLL Retida na Fonte por Pessoas Jurídicas de Direito Privado (Lei n° 10.833/2003, art. 30)|1800,00|
+|P500|11.20|(-) Programa Emergencial de Retomada do Setor de Eventos (Perse) e o Programa de Garantia aos Setores Críticos (PGSC) (Art. 4º, Lei nº 14.148/2021).|0,00|
+|P500|12|(-) CSLL Retida na Fonte por Órgãos, Autarquias e Fundações dos Estados, Distrito Federal e Municípios (Lei n° 10.833/2003, art. 33)|0,00|
+|P500|13|CSLL A PAGAR|8460,00|
+|P500|14|RECEITAS DA ATIVIDADE IMOBILIÁRIA TRIBUTADAS PELO RET|0,00|
+|P500|15|CSLL POSTERGADA DE PERÍODOS DE APURAÇÃO ANTERIORES|0,00|
+|P030|01102022|31122022|T04|
+|P100|1|1|S|1|01||2045000,00|D|1007000,00|300000,00|2752000,00|D|
+|P100|1.01|1.01|S|2|01|1|2045000,00|D|1007000,00|300000,00|2752000,00|D|
+|P100|1.01.01|1.01.01|S|3|01|1.01|515000,00|D|7000,00|0|522000,00|D|
+|P100|1.01.01.02|1.01.01.02|S|4|01|1.01.01|515000,00|D|7000,00|0|522000,00|D|
+|P100|1.01.01.02.01|Bancos Conta Movimento|A|5|01|1.01.01.02|515000,00|D|7000,00|0|522000,00|D|
+|P100|1.01.02|1.01.02|S|3|01|1.01|1530000,00|D|700000,00|0|2230000,00|D|
+|P100|1.01.02.02|1.01.02.02|S|4|01|1.01.02|1518750,00|D|695000,00|0|2213750,00|D|
+|P100|1.01.02.02.01|Duplicatas a Receber|A|5|01|1.01.02.02|1518750,00|D|695000,00|0|2213750,00|D|
+|P100|1.01.02.04|1.01.02.04|S|4|01|1.01.02|11250,00|D|5000,00|0|16250,00|D|
+|P100|1.01.02.04.01|IRRF a Compensar|A|5|01|1.01.02.04|6750,00|D|3000,00|0|9750,00|D|
+|P100|1.01.02.04.04|CSLL Retida a Compensar|A|5|01|1.01.02.04|4500,00|D|2000,00|0|6500,00|D|
+|P100|1.01.03|1.01.03|S|3|01|1.01|0|D|300000,00|300000,00|0,00|D|
+|P100|1.01.03.01|1.01.03.01|S|4|01|1.01.03|0|D|300000,00|300000,00|0,00|D|
+|P100|1.01.03.01.01|Mercadorias para Revenda|A|5|01|1.01.03.01|0|D|300000,00|300000,00|0,00|D|
+|P100|2|2|S|1|02||850000,00|C|0|390000,00|1240000,00|C|
+|P100|2.01|2.01|S|2|02|2|850000,00|C|0|390000,00|1240000,00|C|
+|P100|2.01.01|2.01.01|S|3|02|2.01|850000,00|C|0|390000,00|1240000,00|C|
+|P100|2.01.01.03|2.01.01.03|S|4|02|2.01.01|850000,00|C|0|390000,00|1240000,00|C|
+|P100|2.01.01.03.01|Fornecedores|A|5|02|2.01.01.03|850000,00|C|0|390000,00|1240000,00|C|
+|P150|3|3|S|1|04||317000,00|C|
+|P150|3.01|3.01|S|2|04|3|317000,00|C|
+|P150|3.01.01|3.01.01|S|3|04|3.01|317000,00|C|
+|P150|3.01.01.01|3.01.01.01|S|4|04|3.01.01|700000,00|C|
+|P150|3.01.01.01.01|3.01.01.01.01|S|5|04|3.01.01.01|700000,00|C|
+|P150|3.01.01.01.01.05|Receita de Revenda|A|6|04|3.01.01.01.01|500000,00|C|
+|P150|3.01.01.01.01.06|Receita de Servicos|A|6|04|3.01.01.01.01|200000,00|C|
+|P150|3.01.01.03|3.01.01.03|S|4|04|3.01.01|300000,00|D|
+|P150|3.01.01.03.01|3.01.01.03.01|S|5|04|3.01.01.03|300000,00|D|
+|P150|3.01.01.03.01.02|Custo das Mercadorias|A|6|04|3.01.01.03.01|300000,00|D|
+|P150|3.01.01.05|3.01.01.05|S|4|04|3.01.01|7000,00|C|
+|P150|3.01.01.05.01|3.01.01.05.01|S|5|04|3.01.01.05|7000,00|C|
+|P150|3.01.01.05.01.05|Rendimentos de Aplicacoes|A|6|04|3.01.01.05.01|7000,00|C|
+|P150|3.01.01.09|3.01.01.09|S|4|04|3.01.01|90000,00|D|
+|P150|3.01.01.09.01|3.01.01.09.01|S|5|04|3.01.01.09|90000,00|D|
+|P150|3.01.01.09.01.99|Despesas Operacionais|A|6|04|3.01.01.09.01|90000,00|D|
+|P200|1|DISCRIMINAÇÃO DA RECEITA BRUTA||
+|P200|2|Receita Bruta Sujeita ao Percentual de 1,6%|0,00|
+|P200|4|Receita Bruta Sujeita ao Percentual de 8%|500000,00|
+|P200|6|Receita Bruta Sujeita ao Percentual de 16%|0,00|
+|P200|8|Receita Bruta Sujeita ao Percentual de 32%|200000,00|
+|P200|9|Receita Bruta Sujeita ao Percentual de 38,4%|0,00|
+|P200|10|RESULTADO DA APLICAÇÃO DOS PERCENTUAIS SOBRE A RECEITA BRUTA AJUSTADO|104000,00|
+|P200|11|Rendimentos e Ganhos Líquidos de Aplicações de Renda Fixa e Renda Variável|7000,00|
+|P200|12|Juros sobre o Capital Próprio|0,00|
+|P200|13|Realização de Valores cuja Tributação Tenha Sido Diferida|0,00|
+|P200|14|Recuperação de Custos e Despesas|0,00|
+|P200|15|Ajustes Decorrentes de Métodos - Preços de Transferências|0,00|
+|P200|16|Multas e Vantagens Decorrentes de Rescisão Contratual|0,00|
+|P200|17|Lucros Disponibilizados no Exterior|0,00|
+|P200|18|Rendimentos e Ganhos de Capital Auferidos no Exterior|0,00|
+|P200|19|Variações Cambiais Ativas - Operações Liquidadas (MP nº 1.858-10/1999, art. 30)|0,00|
+|P200|20|Demais Receitas e Ganhos de Capital|0,00|
+|P200|20.01|Valor da Contraprestação de Arrendamento Mercantil (Art. 46, § 4º, da Lei nº 12.973/2014).|0,00|
+|P200|22|(-) Excedente de Variação Cambial (MP nº 1.858-10/1999, art. 31)|0,00|
+|P200|23|(-) Variações Cambiais Ativas (MP nº 1.858-10/1999, art. 30)|0,00|
+|P200|24|(-) Resultados Não Tributáveis de Sociedades Cooperativas|0,00|
+|P200|25|(-) Divulgação Eleitoral e Partidária Gratuita|0,00|
+|P200|25.01|(-) Receitas Financeiras Relativas às Variações Monetárias dos Direitos de Crédito e Obrigações do Contribuinte Decorrentes de Ajuste a Valor Presente (Art. 8º da Lei nº 12.973/2014)|0,00|
+|P200|25.02|(-) Receita Reconhecida pela Construção, Recuperação, Reforma, Ampliação ou Melhoramento da Infraestrutura, cuja Contrapartida Seja Ativo Intangível Representativo do Direito de Exploração (Art. 44 da Lei nº 12.973/2014)|0,00|
+|P200|26|BASE DE CÁLCULO DO IMPOSTO SOBRE O LUCRO PRESUMIDO|111000,00|
+|P300|1|BASE DE CÁLCULO DO IMPOSTO SOBRE O LUCRO PRESUMIDO|111000,00|
+|P300|2|IMPOSTO APURADO COM BASE NO LUCRO PRESUMIDO||
+|P300|3|À Alíquota de 15%|16650,00|
+|P300|4|Adicional|5100,00|
+|P300|5|Diferença de IR Devida pela Mudança de Coeficiente sobre a Receita Bruta|0,00|
+|P300|6|DEDUÇÕES||
+|P300|7|(-) Isenção de Empresas Estrangeiras de Transporte|0,00|
+|P300|8|(-) Isenção e Redução do Imposto|0,00|
+|P300|9|(-) Redução por Reinvestimento|0,00|
+|P300|10|(-) Imposto de Renda Retido na Fonte|3000,00|
+|P300|11|(-) Imposto Pago no Exterior sobre Lucros, Rendimentos e Ganhos de Capital|0,00|
+|P300|11.20|(-) Programa Emergencial de Retomada do Setor de Eventos (Perse) e o Programa de Garantia aos Setores Críticos (PGSC) (Art. 4º, Lei nº 14.148/2021).|0,00|
+|P300|12|(-) Imposto de Renda Retido na Fonte por Órgãos, Autarquias e Fundações Federais (Lei nº 9.430/1996, art. 64)|0,00|
+|P300|13|(-) Imposto de Renda Retido na Fonte pelas Demais Entidades da Administração Pública Federal (Lei n° 10.833/2003, art. 34)|0,00|
+|P300|14|(-) Imposto Pago Incidente sobre Ganhos no Mercado de Renda Variável|0,00|
+|P300|15|IMPOSTO DE RENDA A PAGAR|18750,00|
+|P300|16|RECEITAS DA ATIVIDADE IMOBILIÁRIA TRIBUTADAS PELO RET|0,00|
+|P300|17|IMPOSTO DE RENDA POSTERGADO DE PERÍODOS DE APURAÇÃO ANTERIORES|0,00|
+|P400|1|CÁLCULO DA CSLL||
+|P400|2|Receita Bruta Sujeita ao Percentual de 12%|500000,00|
+|P400|4|Receita Bruta Sujeita ao Percentual de 32%|200000,00|
+|P400|5|Receita Bruta Sujeita ao Percentual de 38,4%|0,00|
+|P400|6|RESULTADO DA APLICAÇÃO DOS PERCENTUAIS SOBRE A RECEITA BRUTA AJUSTADO|124000,00|
+|P400|7|Rendimentos e Ganhos Líquidos de Aplicações de Renda Fixa e Renda Variável|7000,00|
+|P400|8|Juros sobre o Capital Próprio|0,00|
+|P400|9|Realização de Valores cuja Tributação Tenha Sido Diferida|0,00|
+|P400|10|Recuperação de Custos e Despesas|0,00|
+|P400|11|Ajustes Decorrentes de Métodos - Preços de Transferências|0,00|
+|P400|12|Multas e Vantagens Decorrentes de Rescisão Contratual|0,00|
+|P400|13|Lucros Disponibilizados no Exterior|0,00|
+|P400|14|Rendimentos e Ganhos de Capital Auferidos no Exterior|0,00|
+|P400|15|Variações Cambiais Ativas - Operações Liquidadas (MP nº 1.858-10/1999, art. 30)|0,00|
+|P400|16|Demais Receitas e Ganhos de Capital|0,00|
+|P400|16.01|Valor da Contraprestação de Arrendamento Mercantil (Art. 46, § 4º, da Lei nº 12.973/2014)|0,00|
+|P400|18|(-) Excedente de Variação Cambial (MP nº 1.858-10/1999, art. 31)|0,00|
+|P400|19|(-) Variações Cambiais Ativas (MP nº 1.858-10/1999, art. 30)|0,00|
+|P400|19.01|(-) Receitas Financeiras Relativas às Variações Monetárias dos Direitos de Crédito e Obrigações do Contribuinte Decorrentes de Ajuste a Valor Presente (Art. 8º da Lei nº 12.973/2014)|0,00|
+|P400|19.02|(-) Receita Reconhecida pela Construção, Recuperação, Reforma, Ampliação ou Melhoramento da Infraestrutura, cuja Contrapartida Seja Ativo Intangível Representativo do Direito de Exploração (Art. 44 da Lei nº 12.973/2014)|0,00|
+|P400|20|(-) Resultados Não Tributáveis de Sociedades Cooperativas|0,00|
+|P400|21|BASE DE CÁLCULO DA CSLL|131000,00|
+|P500|1|BASE DE CÁLCULO DA CSLL|131000,00|
+|P500|2|CSLL Apurada|11790,00|
+|P500|3|Adição de Créditos de CSLL sobre Depreciação Utilizados no Regime de Lucro Real (Lei nº 11.051/2004, art. 1º, § 9º)|0,00|
+|P500|4|TOTAL DA CONTRIBUIÇÃO SOCIAL SOBRE O LUCRO LÍQUIDO|11790,00|
+|P500|5|DEDUÇÕES||
+|P500|6|(-) Bônus de Adimplência Fiscal (Lei nº 10.637/2002, art. 38)|0,00|
+|P500|7|(-) Isenção sobre o Lucro Relativo ao Prouni|0,00|
+|P500|8|(-) Imposto Pago no Exterior sobre Lucros, Rendimentos e Ganhos de Capital (MP nº 1.858-6/1999, art. 19)|0,00|
+|P500|9|(-) CSLL Retida na Fonte por Órgãos, Autarquias e Fundações Federais (Lei nº 9.430/1996, art. 64)|0,00|
+|P500|10|(-) CSLL Retida na Fonte pelas Demais Entidades da Administração Pública Federal (Lei n° 10.833/2003, art. 34)|0,00|
+|P500|11|(-) CSLL Retida na Fonte por Pessoas Jurídicas de Direito Privado (Lei n° 10.833/2003, art. 30)|2000,00|
+|P500|11.20|(-) Programa Emergencial de Retomada do Setor de Eventos (Perse) e o Programa de Garantia aos Setores Críticos (PGSC) (Art. 4º, Lei nº 14.148/2021).|0,00|
+|P500|12|(-) CSLL Retida na Fonte por Órgãos, Autarquias e Fundações dos Estados, Distrito Federal e Municípios (Lei n° 10.833/2003, art. 33)|0,00|
+|P500|13|CSLL A PAGAR|9790,00|
+|P500|14|RECEITAS DA ATIVIDADE IMOBILIÁRIA TRIBUTADAS PELO RET|0,00|
+|P500|15|CSLL POSTERGADA DE PERÍODOS DE APURAÇÃO ANTERIORES|0,00|
+|P990|474|
+|Y001|0|
+|Y600|01012022||105|01|19180847005|Maria de Souza|01|60|60|||120000,00|||||
+|Y600|01012022||105|01|52899431021|Carlos Lima|01|40|40|||90000,00|||||
+|Y990|4|
+|9001|0|
+|9900|0000|1|
+|9900|0001|1|
+|9900|0010|1|
+|9900|0020|1|
+|9900|0030|1|
+|9900|0930|2|
+|9900|0990|1|
+|9900|J001|1|
+|9900|J050|35|
+|9900|J051|15|
+|9900|J990|1|
+|9900|K001|1|
+|9900|K030|4|
+|9900|K155|25|
+|9900|K156|25|
+|9900|K355|20|
+|9900|K356|20|
+|9900|K990|1|
+|9900|P001|1|
+|9900|P030|4|
+|9900|P100|80|
+|9900|P150|64|
+|9900|P200|100|
+|9900|P300|72|
+|9900|P400|88|
+|9900|P500|64|
+|9900|P990|1|
+|9900|Y001|1|
+|9900|Y600|2|
+|9900|Y990|1|
+|9900|9001|1|
+|9900|9900|34|
+|9900|9990|1|
+|9900|9999|1|
+|9990|37|
+|9999|671|

--- a/l10n_br_sped_ecf/hooks.py
+++ b/l10n_br_sped_ecf/hooks.py
@@ -1,0 +1,20 @@
+# Copyright 2023 - TODAY, Akretion - Raphael Valyi <raphael.valyi@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
+
+from pathlib import Path
+
+from odoo import SUPERUSER_ID, api
+
+
+def post_init_hook(cr, registry):
+    """Importa a ECF de exemplo, para quem instala o modulo com dados demo.
+
+    O arquivo e gerado pela propria escrituracao (ver o teste
+    ``test_gerar_arquivo_de_exemplo``), e nao escrito a mao: importa-lo aqui
+    exercita o caminho de leitura logo na instalacao.
+    """
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    if env.ref("base.module_l10n_br_sped_ecf").demo:
+        caminho = Path(__file__).resolve().parent / "demo" / "demo_ecf.txt"
+        env["l10n_br_sped.mixin"]._flush_registers("ecf")
+        env["l10n_br_sped.mixin"]._import_file(caminho, "ecf")

--- a/l10n_br_sped_ecf/models/apuracao_presumido.py
+++ b/l10n_br_sped_ecf/models/apuracao_presumido.py
@@ -1,0 +1,335 @@
+# Copyright (C) 2026 Luis Felipe Mileo - KMEE <mileo@kmee.com.br>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
+"""Apuracao do IRPJ e da CSLL pelo lucro presumido (bloco P da ECF).
+
+O calculo e Python puro, sem Odoo, para poder ser testado isoladamente: recebe
+a receita bruta separada por percentual de presuncao mais as adicoes e
+exclusoes do periodo, e devolve o valor de cada linha dos registros P200, P300,
+P400 e P500.
+
+Cada metodo de linha calculada traz no docstring a FORMULA oficial publicada
+pela RFB na tabela dinamica do registro (ver ``tabelas_dinamicas.py``), copiada
+literalmente, para que a conferencia contra o Guia seja direta.
+
+As linhas da Lei Complementar 224/25 (P200 "25.100" em diante, P400 "20.100" em
+diante e as linhas 18.x do P300/P500) valem a partir de 2026 e sao geradas
+apenas quando o periodo alcanca a vigencia; o leiaute 9 desta escrituracao nao
+as contempla.
+"""
+
+from . import tabelas_dinamicas
+
+# Percentuais de presuncao do lucro para o IRPJ, por linha do P200.
+PERCENTUAL_IRPJ = {
+    "2": 0.016,
+    "4": 0.08,
+    "6": 0.16,
+    "8": 0.32,
+    "9": 0.384,
+}
+
+# Percentuais de presuncao do lucro para a CSLL, por linha do P400.
+PERCENTUAL_CSLL = {
+    "2": 0.12,
+    "4": 0.32,
+    "5": 0.384,
+}
+
+# Aliquotas da CSLL por 0020.IND_ALIQ_CSLL (P500 linha 2).
+ALIQUOTA_CSLL = {
+    "1": 0.09,
+    "2": 0.15,
+    "3": 0.20,
+}
+
+# Parcela mensal isenta do adicional de IRPJ (P300 linha 4).
+LIMITE_MENSAL_ADICIONAL = 20000.0
+
+ALIQUOTA_IRPJ = 0.15
+ALIQUOTA_ADICIONAL_IRPJ = 0.10
+
+
+def chave_ordem(codigo):
+    """Ordem oficial de um codigo de linha: "2" < "20.01" < "25.110" < "26"."""
+    partes = str(codigo).split(".")
+    inteiro = int(partes[0]) if partes[0].isdigit() else 0
+    decimal = int(partes[1]) if len(partes) > 1 and partes[1].isdigit() else 0
+    return (inteiro, decimal)
+
+
+def soma(valores, primeiro, ultimo):
+    """SOMA(Pxxx(primeiro:ultimo)) da linguagem de formulas da RFB.
+
+    Soma todas as linhas cujo codigo esta no intervalo, inclusive, seguindo a
+    ordem oficial dos codigos e nao a ordem alfabetica. Limite superior sem
+    parte decimal ("14") abrange as proprias sublinhas ("14.10"): a sublinha
+    pertence a linha, e a RFB escreve o limite pela linha-mae. Limite com
+    parte decimal ("25.99") e exato.
+    """
+    inicio = chave_ordem(primeiro)
+    partes_fim = str(ultimo).split(".")
+    if len(partes_fim) > 1:
+        fim = chave_ordem(ultimo)
+    else:
+        fim = (int(partes_fim[0]), float("inf"))
+    return sum(
+        valor
+        for codigo, valor in valores.items()
+        if inicio <= chave_ordem(codigo) <= fim
+    )
+
+
+def arredonda(valor):
+    """Arredondamento contabil de duas casas usado na escrituracao.
+
+    O epsilon acompanha o sinal: sem isso o meio centavo negativo
+    arredondaria em direcao ao zero (-0,125 viraria -0,12).
+    """
+    epsilon = 1e-9 if valor >= 0 else -1e-9
+    return round(valor + epsilon, 2)
+
+
+class ApuracaoPresumido:
+    """Apuracao trimestral do lucro presumido de um periodo do registro P030.
+
+    :param receita_irpj: receita bruta por linha do P200 ("2", "4", "6", "8",
+        "9"), ja separada pelo percentual de presuncao aplicavel.
+    :param receita_csll: receita bruta por linha do P400 ("2", "4", "5").
+    :param adicoes: demais receitas e ganhos do P200 (linhas 11 a 21), por
+        codigo de linha.
+    :param exclusoes: exclusoes do P200 (linhas 22 a "25.02"), por codigo de
+        linha, informadas em valor positivo.
+    :param meses_periodo: meses do periodo de apuracao, usado no limite do
+        adicional de IRPJ.
+    :param ind_aliquota_csll: 0020.IND_ALIQ_CSLL da declaracao.
+    :param retencoes_irpj: retencoes na fonte deduziveis do IRPJ, por linha do
+        P300 (10, 12, 13, 14).
+    :param retencoes_csll: retencoes na fonte deduziveis da CSLL, por linha do
+        P500 (9, 10, 11, 12).
+    """
+
+    def __init__(
+        self,
+        receita_irpj=None,
+        receita_csll=None,
+        adicoes=None,
+        exclusoes=None,
+        meses_periodo=3,
+        ind_aliquota_csll="1",
+        retencoes_irpj=None,
+        retencoes_csll=None,
+    ):
+        self.receita_irpj = dict(receita_irpj or {})
+        self.receita_csll = dict(receita_csll or {})
+        self.adicoes = dict(adicoes or {})
+        self.exclusoes = dict(exclusoes or {})
+        self.meses_periodo = meses_periodo
+        self.ind_aliquota_csll = ind_aliquota_csll
+        self.retencoes_irpj = dict(retencoes_irpj or {})
+        self.retencoes_csll = dict(retencoes_csll or {})
+
+    # ------------------------------------------------------------------
+    # P200 - Apuracao da Base de Calculo do Lucro Presumido
+    # ------------------------------------------------------------------
+
+    def p200(self):
+        """Valores das linhas do P200."""
+        valores = {}
+        for codigo in PERCENTUAL_IRPJ:
+            valores[codigo] = arredonda(self.receita_irpj.get(codigo, 0.0))
+        valores["10"] = self._p200_10(valores)
+        for codigo, valor in self.adicoes.items():
+            valores[codigo] = arredonda(valor)
+        for codigo, valor in self.exclusoes.items():
+            valores[codigo] = arredonda(valor)
+        valores["26"] = self._p200_26(valores)
+        return valores
+
+    def _p200_10(self, valores):
+        """RESULTADO DA APLICACAO DOS PERCENTUAIS SOBRE A RECEITA BRUTA.
+
+        SE (((P200(2)*0,016) + (P200(4)*0,08) + (P200(6)*0,16) +
+        (P200(8)*0,32) + (P200(9)*0,384)) > 0) ENTAO ((P200(2)*0,016) +
+        (P200(4)*0,08) + (P200(6)*0,16) + (P200(8)*0,32) + (P200(9)*0,384))
+        SENAO 0 FIM_SE
+        """
+        resultado = sum(
+            valores.get(codigo, 0.0) * percentual
+            for codigo, percentual in PERCENTUAL_IRPJ.items()
+        )
+        return arredonda(resultado) if resultado > 0 else 0.0
+
+    def _p200_26(self, valores):
+        """BASE DE CALCULO DO IMPOSTO SOBRE O LUCRO PRESUMIDO.
+
+        SE (SOMA(P200(10:21)) - SOMA(P200(22:"25.99")) > 0) ENTAO
+        (SOMA(P200(10:21)) - SOMA(P200(22:"25.99"))) SENAO 0 FIM_SE
+        """
+        base = soma(valores, "10", "21") - soma(valores, "22", "25.99")
+        return arredonda(base) if base > 0 else 0.0
+
+    # ------------------------------------------------------------------
+    # P300 - Calculo do IRPJ com Base no Lucro Presumido
+    # ------------------------------------------------------------------
+
+    def p300(self, valores_p200):
+        """Valores das linhas do P300."""
+        valores = {"1": valores_p200.get("26", 0.0)}
+        valores["3"] = self._p300_3(valores)
+        valores["4"] = self._p300_4(valores)
+        for codigo, valor in self.retencoes_irpj.items():
+            valores[codigo] = arredonda(valor)
+        valores["15"] = self._p300_15(valores)
+        return valores
+
+    def _p300_3(self, valores):
+        """A Aliquota de 15%.
+
+        SE (P300(1) > 0) ENTAO P300(1) * 0,15 SENAO 0 FIM_SE
+        """
+        base = valores.get("1", 0.0)
+        return arredonda(base * ALIQUOTA_IRPJ) if base > 0 else 0.0
+
+    def _p300_4(self, valores):
+        """Adicional.
+
+        SE (P300(1) <= (20000 * MESES_PERIODO())) ENTAO 0 SENAO
+        (P300(1) - (20000 * MESES_PERIODO())) * 0,10 FIM_SE
+        """
+        base = valores.get("1", 0.0)
+        limite = LIMITE_MENSAL_ADICIONAL * self.meses_periodo
+        if base <= limite:
+            return 0.0
+        return arredonda((base - limite) * ALIQUOTA_ADICIONAL_IRPJ)
+
+    def _p300_15(self, valores):
+        """IMPOSTO DE RENDA A PAGAR.
+
+        SOMA(P300(3:5)) - SOMA(P300(7:14))
+        """
+        return arredonda(soma(valores, "3", "5") - soma(valores, "7", "14"))
+
+    # ------------------------------------------------------------------
+    # P400 - Apuracao da Base de Calculo da CSLL
+    # ------------------------------------------------------------------
+
+    # Linhas do P400 que sao transporte de uma linha do P200 (tipo CA).
+    TRANSPORTE_P200 = {
+        "7": "11",
+        "8": "12",
+        "10": "14",
+        "12": "16",
+        "13": "17",
+        "14": "18",
+        "15": "19",
+        "16": "20",
+        "16.01": "20.01",
+        "18": "22",
+        "19": "23",
+        "19.01": "25.01",
+        "19.02": "25.02",
+    }
+
+    def p400(self, valores_p200):
+        """Valores das linhas do P400."""
+        valores = {}
+        for codigo in PERCENTUAL_CSLL:
+            valores[codigo] = arredonda(self.receita_csll.get(codigo, 0.0))
+        valores["6"] = self._p400_6(valores)
+        for destino, origem in self.TRANSPORTE_P200.items():
+            if origem in valores_p200:
+                valores[destino] = valores_p200[origem]
+        valores["21"] = self._p400_21(valores)
+        return valores
+
+    def _p400_6(self, valores):
+        """RESULTADO DA APLICACAO DOS PERCENTUAIS SOBRE A RECEITA BRUTA.
+
+        SE ((P400(2) * 0,12) + (P400(4) * 0,32) + (P400(5) * 0,384) > 0) ENTAO
+        (P400(2) * 0,12) + (P400(4) * 0,32) + (P400(5) * 0,384) SENAO 0 FIM_SE
+        """
+        resultado = sum(
+            valores.get(codigo, 0.0) * percentual
+            for codigo, percentual in PERCENTUAL_CSLL.items()
+        )
+        return arredonda(resultado) if resultado > 0 else 0.0
+
+    def _p400_21(self, valores):
+        """BASE DE CALCULO DA CSLL.
+
+        SOMA(P400(6:17)) - SOMA(P400(18:20))
+        """
+        return arredonda(soma(valores, "6", "17") - soma(valores, "18", "20"))
+
+    # ------------------------------------------------------------------
+    # P500 - Calculo da CSLL
+    # ------------------------------------------------------------------
+
+    def p500(self, valores_p400):
+        """Valores das linhas do P500."""
+        valores = {"1": valores_p400.get("21", 0.0)}
+        valores["2"] = self._p500_2(valores)
+        valores["4"] = self._p500_4(valores)
+        for codigo, valor in self.retencoes_csll.items():
+            valores[codigo] = arredonda(valor)
+        valores["13"] = self._p500_13(valores)
+        return valores
+
+    def _p500_2(self, valores):
+        """CSLL Apurada.
+
+        SE (P500(1) < 0) ENTAO 0 SENAO SE (0000.DT_INI()>="2022-01-01") ENTAO
+        SE(0020.IND_ALIQ_CSLL()="1") ENTAO P500(1)*0,09 SENAO
+        SE(0020.IND_ALIQ_CSLL()="3") ENTAO P500(1)*0,20 SENAO P500(1)*0,15
+        FIM_SE FIM_SE FIM_SE FIM_SE
+        """
+        base = valores.get("1", 0.0)
+        if base < 0:
+            return 0.0
+        # a condicao 0000.DT_INI >= 2022-01-01 da formula nao e testada aqui
+        # de proposito: o leiaute 9 desta escrituracao e do ano-calendario
+        # 2022 em diante, entao ela e sempre verdadeira
+        aliquota = ALIQUOTA_CSLL.get(self.ind_aliquota_csll, ALIQUOTA_CSLL["2"])
+        return arredonda(base * aliquota)
+
+    def _p500_4(self, valores):
+        """TOTAL DA CONTRIBUICAO SOCIAL SOBRE O LUCRO LIQUIDO.
+
+        SOMA(P500(2:3))
+        """
+        return arredonda(soma(valores, "2", "3"))
+
+    def _p500_13(self, valores):
+        """CSLL A PAGAR.
+
+        P500(4) - SOMA(P500(6:12))
+        """
+        return arredonda(valores.get("4", 0.0) - soma(valores, "6", "12"))
+
+    # ------------------------------------------------------------------
+
+    def apurar(self):
+        """Todos os registros do bloco P, por codigo de linha."""
+        valores_p200 = self.p200()
+        valores_p400 = self.p400(valores_p200)
+        return {
+            "P200": valores_p200,
+            "P300": self.p300(valores_p200),
+            "P400": valores_p400,
+            "P500": self.p500(valores_p400),
+        }
+
+    def linhas(self, registro, data_inicio, data_fim, valores):
+        """Linhas do registro a escriturar, na ordem e com a descricao oficiais.
+
+        Devolve ``(codigo, descricao, valor)`` para cada linha vigente no
+        periodo; o valor e ``None`` nas linhas de rotulo, que a RFB escritura
+        sem valor.
+        """
+        escrituradas = []
+        for codigo, descricao, tipo in tabelas_dinamicas.linhas_vigentes(
+            registro, data_inicio, data_fim
+        ):
+            valor = None if tipo == "R" else valores.get(codigo, 0.0)
+            escrituradas.append((codigo, descricao, valor))
+        return escrituradas

--- a/l10n_br_sped_ecf/models/ecf_validator.py
+++ b/l10n_br_sped_ecf/models/ecf_validator.py
@@ -1,0 +1,174 @@
+# Copyright (C) 2026 Luis Felipe Mileo - KMEE <mileo@kmee.com.br>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
+"""ECF validation: what the generic SPED validator cannot reach.
+
+Adds to the structural validator of ``l10n_br_sped_base`` the rules that
+belong to this declaration: the registers required by the tax regime
+declared in the 0010, and the **block P arithmetic**, where every computed
+line is recomputed with the official formula published by the Brazilian
+Federal Revenue from the editable lines of the file itself.
+"""
+
+from odoo.addons.l10n_br_sped_base.models.validator import SpedValidator, _decimal
+
+from .apuracao_presumido import ApuracaoPresumido, arredonda
+
+# Registers required from companies under the presumed profit regime with
+# accounting bookkeeping (0010.FORMA_TRIB = 5 and 0010.TIP_ESC_PRE = "C").
+PRESUMIDO_REQUIRED = [
+    "0000",
+    "0010",
+    "0020",
+    "0030",
+    "0930",
+    "J050",
+    "K030",
+    "P030",
+]
+
+# Block P registers that carry dynamic table lines.
+VALUE_REGISTERS = ["P200", "P300", "P400", "P500"]
+
+
+class EcfValidator(SpedValidator):
+    """The SPED validator with the rules specific to the ECF."""
+
+    def _validate_specific(self, structure):
+        self._validate_required(structure)
+        self._validate_block_p(structure)
+
+    def _validate_block_p(self, structure):
+        """The computed block P lines match the official formulas."""
+        # the engine parameters come from the file ITSELF: the period from
+        # the P030 (company opened or split mid-quarter has a broken period,
+        # and the IRPJ surtax threshold is per month) and the CSLL rate from
+        # the 0020; guessing a full quarter and a 9% rate would reject a
+        # correct file
+        csll_rate = "1"
+        for _number, code, fields in structure:
+            if code == "0020" and len(fields) > 1 and fields[1]:
+                csll_rate = fields[1]
+                break
+        periods = self._group_block_p(structure)
+        for period, data in periods.items():
+            registers = data["registers"]
+            values = {
+                name: {code: value for code, value, _number in lines}
+                for name, lines in registers.items()
+            }
+            positions = {
+                name: {code: number for code, _value, number in lines}
+                for name, lines in registers.items()
+            }
+            engine = ApuracaoPresumido(
+                meses_periodo=data["months"], ind_aliquota_csll=csll_rate
+            )
+            checks = [
+                ("P200", "10", engine._p200_10, "P200"),
+                ("P200", "26", engine._p200_26, "P200"),
+                ("P300", "3", engine._p300_3, "P300"),
+                ("P300", "4", engine._p300_4, "P300"),
+                ("P300", "15", engine._p300_15, "P300"),
+                ("P400", "6", engine._p400_6, "P400"),
+                ("P400", "21", engine._p400_21, "P400"),
+                ("P500", "2", engine._p500_2, "P500"),
+                ("P500", "4", engine._p500_4, "P500"),
+                ("P500", "13", engine._p500_13, "P500"),
+            ]
+            for register, line, formula, source in checks:
+                if register not in values or line not in values[register]:
+                    continue
+                expected = arredonda(formula(values[source]))
+                found = values[register][line]
+                if abs(expected - found) > 0.005:
+                    self._error(
+                        positions[register][line],
+                        register,
+                        f"line {line} of period {period} states {found:.2f} "
+                        f"and the official formula yields {expected:.2f}",
+                    )
+            self._check_transport(period, values, positions)
+
+    def _check_transport(self, period, values, positions):
+        """Lines that only carry over the value of another line (CA type)."""
+        transports = [("P300", "1", "P200", "26"), ("P500", "1", "P400", "21")]
+        for target, target_line, source, source_line in transports:
+            if target not in values or target_line not in values[target]:
+                continue
+            if source not in values or source_line not in values[source]:
+                continue
+            expected = values[source][source_line]
+            found = values[target][target_line]
+            if abs(expected - found) > 0.005:
+                self._error(
+                    positions[target][target_line],
+                    target,
+                    f"line {target_line} of period {period} must carry over "
+                    f"{source}({source_line}) = {expected:.2f} and states "
+                    f"{found:.2f}",
+                )
+
+    def _group_block_p(self, structure):
+        """Block P lines grouped by the P030 assessment period.
+
+        Returns ``{period: {"registers": {...}, "months": n}}``, with the
+        months computed from the dates of the P030 itself
+        (|P030|DT_INI|DT_FIN|...).
+        """
+        periods = {}
+        current = None
+        for number, code, fields in structure:
+            if code == "P030":
+                current = fields[3] if len(fields) > 3 else str(number)
+                periods[current] = {
+                    "registers": {},
+                    "months": self._months_from_p030(fields),
+                }
+            elif code in VALUE_REGISTERS and current is not None:
+                if len(fields) < 4:
+                    continue
+                line, value = fields[1], fields[3]
+                if not value:
+                    continue
+                periods[current]["registers"].setdefault(code, []).append(
+                    (line, _decimal(value), number)
+                )
+        return periods
+
+    @staticmethod
+    def _months_from_p030(fields):
+        """Months elapsed between DT_INI and DT_FIN of the P030 (ddmmyyyy)."""
+        try:
+            start, end = fields[1], fields[2]
+            years = int(end[4:8]) - int(start[4:8])
+            return years * 12 + int(end[2:4]) - int(start[2:4]) + 1
+        except (IndexError, ValueError):
+            return 3
+
+    def _validate_required(self, structure):
+        """Registers required by the tax regime declared in the 0010."""
+        codes = {code for _number, code, _fields in structure}
+        register_0010 = [f for _n, code, f in structure if code == "0010"]
+        if not register_0010:
+            self._error(0, "0010", "the tax parameters register is missing")
+            return
+        # |0010|HASH_ECF_ANTERIOR|OPT_REFIS|FORMA_TRIB|...
+        fields_0010 = register_0010[0]
+        forma_trib = fields_0010[3] if len(fields_0010) > 3 else ""
+        if forma_trib not in ("5", "6", "7", "8"):
+            # only the presumed profit regime has its register set checked
+            return
+        for required in PRESUMIDO_REQUIRED:
+            if required not in codes:
+                self._error(
+                    0,
+                    required,
+                    "register required for the presumed profit regime is " "missing",
+                )
+        for register in VALUE_REGISTERS:
+            if register not in codes:
+                self._error(
+                    0,
+                    register,
+                    "the presumed profit assessment requires this register",
+                )

--- a/l10n_br_sped_ecf/tests/__init__.py
+++ b/l10n_br_sped_ecf/tests/__init__.py
@@ -1,0 +1,3 @@
+from . import test_sped_ecf
+from . import test_sped_ecf_generate
+from . import test_sped_ecf_presumido

--- a/l10n_br_sped_ecf/tests/cenario_presumido.py
+++ b/l10n_br_sped_ecf/tests/cenario_presumido.py
@@ -1,0 +1,426 @@
+# Copyright (C) 2026 Luis Felipe Mileo - KMEE <mileo@kmee.com.br>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
+"""Cenario de uma empresa do lucro presumido com escrituracao contabil.
+
+E o caso mais comum do regime: uma empresa que revende mercadoria e presta
+servico, sem atividade incentivada e sem operacao com o exterior. O mesmo
+cenario alimenta o teste da escrituracao e a geracao do arquivo de exemplo
+(``demo/demo_ecf.txt``), para que o exemplo do modulo seja sempre um arquivo
+que a propria escrituracao produz.
+
+Os codigos do plano de contas referencial sao os do pacote oficial de tabelas
+dinamicas do Sped (abas P100A e P150A).
+"""
+
+from datetime import date
+
+# Ano-calendario coerente com o leiaute 9 implementado pelo spec do modulo.
+ANO = 2022
+
+# Grupos sinteticos do plano do contribuinte. A Resolucao CFC 1299/2010 exige
+# no minimo quatro niveis, e o PVA critica a conta analitica de nivel menor:
+# tres grupos mais a conta dao os quatro.
+GRUPOS = [
+    ("1", "ATIVO", None),
+    ("1.01", "ATIVO CIRCULANTE", "1"),
+    ("1.01.01", "DISPONIBILIDADES", "1.01"),
+    ("1.01.02", "CREDITOS", "1.01"),
+    ("1.01.03", "ESTOQUES", "1.01"),
+    ("2", "PASSIVO", None),
+    ("2.01", "PASSIVO CIRCULANTE", "2"),
+    ("2.01.01", "FORNECEDORES", "2.01"),
+    ("2.01.02", "OBRIGACOES FISCAIS", "2.01"),
+    ("2.03", "PATRIMONIO LIQUIDO", "2"),
+    ("2.03.01", "CAPITAL SOCIAL", "2.03"),
+    ("2.03.02", "LUCROS ACUMULADOS", "2.03"),
+    ("3", "RECEITAS", None),
+    ("3.01", "RECEITA OPERACIONAL", "3"),
+    ("3.01.01", "RECEITA BRUTA", "3.01"),
+    ("3.01.02", "OUTRAS RECEITAS", "3.01"),
+    ("4", "CUSTOS E DESPESAS", None),
+    ("4.01", "CUSTOS E DESPESAS OPERACIONAIS", "4"),
+    ("4.01.01", "CUSTO DAS MERCADORIAS", "4.01"),
+    ("4.01.02", "DESPESAS OPERACIONAIS", "4.01"),
+]
+
+# (codigo, nome, tipo do Odoo, conta referencial da RFB, linha do P200,
+#  linha da retencao no P300/P500)
+PLANO = [
+    (
+        "1.01.01.01",
+        "Bancos Conta Movimento",
+        "asset_cash",
+        "1.01.01.02.01",
+        False,
+        False,
+    ),
+    (
+        "1.01.02.01",
+        "Duplicatas a Receber",
+        "asset_receivable",
+        "1.01.02.02.01",
+        False,
+        False,
+    ),
+    (
+        "1.01.03.01",
+        "Mercadorias para Revenda",
+        "asset_current",
+        "1.01.03.01.01",
+        False,
+        False,
+    ),
+    ("2.01.01.01", "Fornecedores", "liability_payable", "2.01.01.03.01", False, False),
+    (
+        "2.01.02.01",
+        "IRPJ a Recolher",
+        "liability_current",
+        "2.01.01.09.13",
+        False,
+        False,
+    ),
+    (
+        "2.01.02.02",
+        "CSLL a Recolher",
+        "liability_current",
+        "2.01.01.09.14",
+        False,
+        False,
+    ),
+    ("2.03.01.01", "Capital Social", "equity", "2.03.01.01.01", False, False),
+    ("2.03.02.01", "Lucros Acumulados", "equity", "2.03.04.01.01", False, False),
+    ("3.01.01.01", "Receita de Revenda", "income", "3.01.01.01.01.05", "4", False),
+    ("3.01.01.02", "Receita de Servicos", "income", "3.01.01.01.01.06", "8", False),
+    (
+        "3.01.02.01",
+        "Rendimentos de Aplicacoes",
+        "income",
+        "3.01.01.05.01.05",
+        "11",
+        False,
+    ),
+    (
+        "4.01.01.01",
+        "Custo das Mercadorias",
+        "expense",
+        "3.01.01.03.01.02",
+        False,
+        False,
+    ),
+    (
+        "4.01.02.01",
+        "Despesas Operacionais",
+        "expense",
+        "3.01.01.09.01.99",
+        False,
+        False,
+    ),
+    # o prestador de servico sofre IRRF de 1,5% e CSRF de 1% do tomador:
+    # a retencao e um credito a compensar, e o de-para diz em que linha
+    # do P300 e do P500 ela e deduzida do imposto devido
+    (
+        "1.01.04.01",
+        "IRRF a Compensar",
+        "asset_current",
+        "1.01.02.04.01",
+        False,
+        "P300-10",
+    ),
+    (
+        "1.01.04.02",
+        "CSLL Retida a Compensar",
+        "asset_current",
+        "1.01.02.04.04",
+        False,
+        "P500-11",
+    ),
+]
+
+# Movimento de cada trimestre: revenda, servicos, rendimentos financeiros,
+# custo da revenda e despesas operacionais.
+MOVIMENTO = {
+    1: (300000.00, 120000.00, 4000.00, 180000.00, 60000.00),
+    2: (360000.00, 150000.00, 5000.00, 210000.00, 70000.00),
+    3: (420000.00, 180000.00, 6000.00, 250000.00, 80000.00),
+    4: (500000.00, 200000.00, 7000.00, 300000.00, 90000.00),
+}
+
+# Retencao na fonte que o tomador faz sobre o servico prestado:
+# IRRF de 1,5% (Lei 7.450/1985, art. 52) e CSLL de 1% dentro da CSRF de
+# 4,65% (Lei 10.833/2003, art. 30).
+ALIQUOTA_IRRF_SERVICO = 0.015
+ALIQUOTA_CSLL_RETIDA_SERVICO = 0.01
+
+ULTIMO_MES_DO_TRIMESTRE = {1: 3, 2: 6, 3: 9, 4: 12}
+
+CAPITAL_INTEGRALIZADO = 500000.00
+
+# Cada combinacao de regime e apuracao monta sua propria empresa, para que as
+# variantes possam conviver no mesmo banco.
+EMPRESAS = {
+    ("presumed", "T"): ("ECF Comercio e Servicos Ltda", "91.827.364/0001-03"),
+    ("real", "T"): ("ECF Lucro Real Trimestral Ltda", "82.736.451/0001-56"),
+    ("real", "A"): ("ECF Lucro Real Anual Ltda", "73.645.182/0001-21"),
+}
+
+
+class CenarioPresumido:
+    """Monta a empresa, o plano de contas, os cadastros e o movimento do ano."""
+
+    def __init__(self, env, regime="presumed", apuracao="T"):
+        """:param regime: ``presumed`` ou ``real``.
+        :param apuracao: ``T`` trimestral ou ``A`` anual (so vale no real).
+        """
+        self.env = env
+        self.regime = regime
+        self.apuracao = apuracao
+        self.company = None
+        self.contas = {}
+        self.journal = None
+
+    def montar(self):
+        self._empresa()
+        self._endereco()
+        self._plano_de_contas()
+        self._diario()
+        self._signatarios()
+        self._socios()
+        self._movimento()
+        return self
+
+    # ------------------------------------------------------------------
+
+    def _empresa(self):
+        nome, cnpj = EMPRESAS[(self.regime, self.apuracao)]
+        self.company = self.env["res.company"].create(
+            {
+                "name": nome,
+                "legal_name": nome,
+                "vat": cnpj,
+                "profit_calculation": self.regime,
+                "l10n_br_ecf_profit_period": self.apuracao,
+            }
+        )
+        self.env.user.company_ids |= self.company
+        self.env = self.env(
+            context=dict(self.env.context, allowed_company_ids=[self.company.id])
+        )
+        self.company.legal_nature_id = self.env["l10n_br_fiscal.legal.nature"].search(
+            [], limit=1
+        )
+        # o registro 0030 escritura o CNAE sem pontuacao, com sete digitos
+        self.company.cnae_main_id = self.env["l10n_br_fiscal.cnae"].search(
+            [("internal_type", "=", "normal")], limit=1
+        )
+
+    def _endereco(self):
+        """O registro 0030 exige endereco, municipio e CEP da matriz."""
+        cidade = self.env["res.city"].search(
+            [("ibge_code", "!=", False), ("state_id.code", "=", "SP")], limit=1
+        )
+        self.company.partner_id.write(
+            {
+                "street_name": "Rua das Escrituracoes",
+                "street_number": "1000",
+                "district": "Centro",
+                "zip": "01310-100",
+                "city_id": cidade.id,
+                "state_id": cidade.state_id.id,
+                "country_id": cidade.state_id.country_id.id,
+                "phone": "11 3333-4444",
+                "email": "contato@exemplo.com.br",
+            }
+        )
+
+    def _plano_de_contas(self):
+        grupos = {}
+        for codigo, nome, pai in GRUPOS:
+            grupos[codigo] = (
+                self.env["account.group"]
+                .with_company(self.company)
+                .create(
+                    {
+                        "name": nome,
+                        "code_prefix_start": codigo,
+                        "code_prefix_end": codigo,
+                        "parent_id": grupos[pai].id if pai else False,
+                        "company_id": self.company.id,
+                    }
+                )
+            )
+        for codigo, nome, tipo, referencial, linha_p200, linha_wh in PLANO:
+            self.contas[codigo] = (
+                self.env["account.account"]
+                .with_company(self.company)
+                .create(
+                    {
+                        "code": codigo,
+                        "name": nome,
+                        "account_type": tipo,
+                        "company_id": self.company.id,
+                        "l10n_br_sped_referential_code": referencial,
+                        "l10n_br_ecf_revenue_line": linha_p200,
+                        "l10n_br_ecf_withholding_line": linha_wh,
+                    }
+                )
+            )
+
+    def _diario(self):
+        self.journal = (
+            self.env["account.journal"]
+            .with_company(self.company)
+            .create(
+                {
+                    "name": "Diario ECF",
+                    "code": "ECF",
+                    "type": "general",
+                    "company_id": self.company.id,
+                }
+            )
+        )
+
+    def _signatarios(self):
+        signer = self.env["l10n_br_sped.signer"]
+        signer.create(
+            {
+                "company_id": self.company.id,
+                "name": "Maria de Souza",
+                "cpf_cnpj": "191.808.470-05",
+                "qualification": "203",
+                "email": "diretoria@exemplo.com.br",
+                "phone": "11 3333-4444",
+            }
+        )
+        signer.create(
+            {
+                "company_id": self.company.id,
+                "name": "Joao Pereira",
+                "cpf_cnpj": "746.851.750-93",
+                "qualification": "309",
+                "crc": "1SP123456/O-1",
+                "email": "contabilidade@exemplo.com.br",
+                "phone": "11 3333-5555",
+            }
+        )
+
+    def _socios(self):
+        socio = self.env["l10n_br_ecf.shareholder"]
+        socio.create(
+            {
+                "company_id": self.company.id,
+                "name": "Maria de Souza",
+                "cpf_cnpj": "191.808.470-05",
+                "qualification": "01",
+                "capital_share": 60.0,
+                "voting_share": 60.0,
+                "work_income": 120000.00,
+            }
+        )
+        socio.create(
+            {
+                "company_id": self.company.id,
+                "name": "Carlos Lima",
+                "cpf_cnpj": "528.994.310-21",
+                "qualification": "01",
+                "capital_share": 40.0,
+                "voting_share": 40.0,
+                "work_income": 90000.00,
+            }
+        )
+
+    def _lancar(self, data, linhas, referencia):
+        move = (
+            self.env["account.move"]
+            .with_company(self.company)
+            .create(
+                {
+                    "move_type": "entry",
+                    "date": data,
+                    "ref": referencia,
+                    "journal_id": self.journal.id,
+                    "company_id": self.company.id,
+                    "line_ids": [
+                        (
+                            0,
+                            0,
+                            {
+                                "account_id": self.contas[codigo].id,
+                                "debit": debito,
+                                "credit": credito,
+                                "name": referencia,
+                            },
+                        )
+                        for codigo, debito, credito in linhas
+                    ],
+                }
+            )
+        )
+        move.action_post()
+        return move
+
+    def _movimento(self):
+        self._lancar(
+            date(ANO, 1, 1),
+            [
+                ("1.01.01.01", CAPITAL_INTEGRALIZADO, 0.0),
+                ("2.03.01.01", 0.0, CAPITAL_INTEGRALIZADO),
+            ],
+            "Integralizacao de capital",
+        )
+        for trimestre, valores in MOVIMENTO.items():
+            revenda, servicos, rendimentos, custo, despesas = valores
+            data = date(ANO, ULTIMO_MES_DO_TRIMESTRE[trimestre], 20)
+            irrf = round(servicos * ALIQUOTA_IRRF_SERVICO, 2)
+            csll_retida = round(servicos * ALIQUOTA_CSLL_RETIDA_SERVICO, 2)
+            self._lancar(
+                data,
+                [
+                    # o tomador retem na fonte, entao o valor a receber e
+                    # liquido e a retencao vira credito a compensar
+                    ("1.01.02.01", revenda + servicos - irrf - csll_retida, 0.0),
+                    ("1.01.04.01", irrf, 0.0),
+                    ("1.01.04.02", csll_retida, 0.0),
+                    ("3.01.01.01", 0.0, revenda),
+                    ("3.01.01.02", 0.0, servicos),
+                ],
+                f"Receitas do {trimestre}o trimestre",
+            )
+            self._lancar(
+                data,
+                [("1.01.01.01", rendimentos, 0.0), ("3.01.02.01", 0.0, rendimentos)],
+                f"Rendimentos financeiros do {trimestre}o trimestre",
+            )
+            # a mercadoria entra antes de sair: sem a compra o estoque fecha
+            # negativo e o registro Y672 sai com saldo invertido
+            self._lancar(
+                data,
+                [("1.01.03.01", custo, 0.0), ("2.01.01.01", 0.0, custo)],
+                f"Compra de mercadorias do {trimestre}o trimestre",
+            )
+            self._lancar(
+                data,
+                [("4.01.01.01", custo, 0.0), ("1.01.03.01", 0.0, custo)],
+                f"Custo das mercadorias do {trimestre}o trimestre",
+            )
+            self._lancar(
+                data,
+                [("4.01.02.01", despesas, 0.0), ("2.01.01.01", 0.0, despesas)],
+                f"Despesas do {trimestre}o trimestre",
+            )
+
+    # ------------------------------------------------------------------
+
+    def declaracao(self):
+        """Cria a declaracao do ano-calendario e a preenche a partir do Odoo."""
+        modelo = self.env["l10n_br_sped.ecf.0000"].with_company(self.company)
+        vals = modelo._map_from_odoo(self.company, None, None)
+        vals.update(
+            {
+                "company_id": self.company.id,
+                "DT_INI": date(ANO, 1, 1),
+                "DT_FIN": date(ANO, 12, 31),
+            }
+        )
+        declaracao = modelo.create(vals)
+        declaracao.button_populate_sped_from_odoo()
+        return declaracao

--- a/l10n_br_sped_ecf/tests/test_sped_ecf.py
+++ b/l10n_br_sped_ecf/tests/test_sped_ecf.py
@@ -1,0 +1,27 @@
+# Copyright 2023 - TODAY, Akretion - Raphael Valyi <raphael.valyi@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
+
+from os import path
+
+from odoo.tests import common
+
+from odoo.addons import l10n_br_sped_ecf
+from odoo.addons.l10n_br_sped_base.models.sped_mixin import SPED_ENCODING
+
+
+class SpedTest(common.TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.demo_path = path.join(l10n_br_sped_ecf.__path__[0], "demo")
+
+    def test_import_ecf(self):
+        self.env["l10n_br_sped.mixin"]._flush_registers("ecf")
+        file_path = path.join(self.demo_path, "demo_ecf.txt")
+        sped_mixin = self.env["l10n_br_sped.mixin"]
+        declaration = sped_mixin._import_file(file_path, "ecf")
+        sped = declaration._generate_sped_text()
+        with open(file_path, encoding=SPED_ENCODING) as f:
+            target_content = f.read()
+            # print(sped)
+            self.assertEqual(sped.strip(), target_content.strip())

--- a/l10n_br_sped_ecf/tests/test_sped_ecf_generate.py
+++ b/l10n_br_sped_ecf/tests/test_sped_ecf_generate.py
@@ -1,0 +1,58 @@
+# Copyright (C) 2026 Luis Felipe Mileo - KMEE <mileo@kmee.com.br>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
+
+from datetime import date
+
+from odoo.tests import common
+
+
+class SpedEcfGenerateTest(common.TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env["res.company"].search(
+            [("name", "=", "Empresa Lucro Presumido")], limit=1
+        )
+
+    def _fiscal_year(self):
+        lines = self.env["account.move.line"].search(
+            [
+                ("company_id", "=", self.company.id),
+                ("parent_state", "=", "posted"),
+                ("account_id", "!=", False),
+                ("date", "!=", False),
+            ]
+        )
+        dates = lines.mapped("date")
+        if not dates:
+            return None, None
+        return date(min(dates).year, 1, 1), date(max(dates).year, 12, 31)
+
+    def test_generate_ecf(self):
+        if not self.company:
+            self.skipTest("demo company 'Empresa Lucro Presumido' not available")
+        if not self.company.legal_nature_id:
+            self.company.legal_nature_id = self.env[
+                "l10n_br_fiscal.legal.nature"
+            ].search([], limit=1)
+        if not self.company.cnae_main_id:
+            self.company.cnae_main_id = self.env["l10n_br_fiscal.cnae"].search(
+                [], limit=1
+            )
+        dt_ini, dt_fin = self._fiscal_year()
+        if not dt_ini:
+            self.skipTest("no posted account moves in demo data")
+
+        model = self.env["l10n_br_sped.ecf.0000"].with_company(self.company)
+        vals = model._map_from_odoo(self.company, None, None)
+        vals.update({"company_id": self.company.id, "DT_INI": dt_ini, "DT_FIN": dt_fin})
+        declaration = model.create(vals)
+        declaration.button_populate_sped_from_odoo()
+        text = declaration._generate_sped_text()
+
+        self.assertTrue(text.startswith("|0000|"))
+        # identification, chart of accounts, balances and apuration periods
+        self.assertIn("\n|0010|", text)
+        self.assertIn("\n|J050|", text)
+        self.assertIn("\n|K155|", text)
+        self.assertIn("\n|P030|", text)

--- a/l10n_br_sped_ecf/tests/test_sped_ecf_presumido.py
+++ b/l10n_br_sped_ecf/tests/test_sped_ecf_presumido.py
@@ -1,0 +1,287 @@
+# Copyright (C) 2026 Luis Felipe Mileo - KMEE <mileo@kmee.com.br>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
+"""Escrituracao completa de uma ECF de lucro presumido, do Odoo ao arquivo.
+
+O cenario esta em ``cenario_presumido.py``, compartilhado com a geracao do
+arquivo de exemplo do modulo. O teste vai ate o fim: gera a ECF e a submete ao
+validador estrutural, que confere blocos, hierarquia, campos, contagens do
+bloco 9 e a aritmetica das linhas calculadas do bloco P contra as formulas
+oficiais da RFB.
+"""
+
+import os
+
+from odoo.tests import common, tagged
+
+from odoo.addons.l10n_br_sped_ecf.models.ecf_validator import EcfValidator
+
+from .cenario_presumido import CenarioPresumido
+
+# Modelos do modulo que nao sao registros da escrituracao.
+NAO_REGISTROS = ("MIXIN", "VALORES")
+
+
+@tagged("post_install", "-at_install")
+class TestEcfPresumido(common.TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.cenario = CenarioPresumido(cls.env).montar()
+        cls.company = cls.cenario.company
+
+    # ------------------------------------------------------------------
+
+    def _definicoes_de_registro(self):
+        """``{codigo: [(campo, obrigatorio, tipo)]}`` a partir do spec."""
+        definicoes = {}
+        for modelo in self.env["ir.model"].search(
+            [("model", "=like", "l10n_br_sped.ecf.%")]
+        ):
+            codigo = modelo.model.split(".")[-1].upper()
+            if not codigo or codigo in NAO_REGISTROS:
+                continue
+            registro = self.env[modelo.model]
+            if not hasattr(registro, "_ordered_fields"):
+                continue
+            campos = [
+                (nome, bool(campo.required), campo.type)
+                for nome, campo in registro._ordered_fields()
+                if nome.isupper()
+            ]
+            if campos:
+                definicoes[codigo] = campos
+        return definicoes
+
+    def test_arquivo_valido(self):
+        """A ECF gerada passa no validador estrutural, sem nenhum apontamento."""
+        texto = self.cenario.declaracao()._generate_sped_text()
+        erros = EcfValidator(texto, self._definicoes_de_registro()).validate()
+        self.assertEqual(
+            erros,
+            [],
+            "a ECF gerada tem inconformidades:\n"
+            + "\n".join(str(erro) for erro in erros),
+        )
+
+    def test_blocos_obrigatorios_preenchidos(self):
+        """O arquivo carrega identificacao, plano, saldos e apuracao."""
+        texto = self.cenario.declaracao()._generate_sped_text()
+        obrigatorios = (
+            "0000",
+            "0010",
+            "0020",
+            "0030",
+            "0930",
+            "J050",
+            "J051",
+            "K030",
+            "K155",
+            "K156",
+            "K355",
+            "K356",
+            "P030",
+            "P100",
+            "P150",
+            "P200",
+            "P300",
+            "P400",
+            "P500",
+            "Y600",
+        )
+        for registro in obrigatorios:
+            self.assertIn(f"|{registro}|", texto, f"falta o registro {registro}")
+        self.assertTrue(texto.startswith("|0000|LECF|0009|"))
+        # o bloco sem dados nao entra no arquivo, e o Y672 nao vale para quem
+        # apresentou escrituracao contabil
+        for ausente in ("E001", "L001", "M001", "N001", "T001", "U001", "Y672"):
+            self.assertNotIn(f"|{ausente}|", texto, f"{ausente} nao deveria sair")
+
+    def test_apuracao_do_primeiro_trimestre(self):
+        """Os valores apurados batem com o calculo do lucro presumido.
+
+        Primeiro trimestre: 300.000,00 de revenda (presuncao de 8%) e
+        120.000,00 de servicos (presuncao de 32%), mais 4.000,00 de
+        rendimentos de aplicacoes financeiras, que entram integralmente.
+        """
+        declaracao = self.cenario.declaracao()
+        p030 = self.env["l10n_br_sped.ecf.p030"].search(
+            [("declaration_id", "=", declaracao.id), ("PER_APUR", "=", "T01")]
+        )
+        self.assertTrue(p030, "o primeiro trimestre nao foi escriturado")
+
+        p200 = {r.CODIGO: r.VALOR for r in p030.reg_P200_ids}
+        self.assertEqual(p200["4"], "300000,00")
+        self.assertEqual(p200["8"], "120000,00")
+        # 300.000 x 8% + 120.000 x 32% = 24.000 + 38.400
+        self.assertEqual(p200["10"], "62400,00")
+        self.assertEqual(p200["11"], "4000,00")
+        # base = 62.400 + 4.000
+        self.assertEqual(p200["26"], "66400,00")
+
+        p300 = {r.CODIGO: r.VALOR for r in p030.reg_P300_ids}
+        self.assertEqual(p300["1"], "66400,00")
+        # 66.400 x 15%
+        self.assertEqual(p300["3"], "9960,00")
+        # (66.400 - 3 x 20.000) x 10%
+        self.assertEqual(p300["4"], "640,00")
+        # IRRF de 1,5% sobre os 120.000 de servico, retido pelo tomador
+        self.assertEqual(p300["10"], "1800,00")
+        # 9.960 + 640 - 1.800
+        self.assertEqual(p300["15"], "8800,00")
+
+        p400 = {r.CODIGO: r.VALOR for r in p030.reg_P400_ids}
+        # a revenda presume 12% para a CSLL e o servico 32%
+        self.assertEqual(p400["2"], "300000,00")
+        self.assertEqual(p400["4"], "120000,00")
+        # 300.000 x 12% + 120.000 x 32% = 36.000 + 38.400
+        self.assertEqual(p400["6"], "74400,00")
+        self.assertEqual(p400["21"], "78400,00")
+
+        p500 = {r.CODIGO: r.VALOR for r in p030.reg_P500_ids}
+        self.assertEqual(p500["1"], "78400,00")
+        # 78.400 x 9%
+        self.assertEqual(p500["2"], "7056,00")
+        # CSLL de 1% retida na fonte pelo tomador do servico
+        self.assertEqual(p500["11"], "1200,00")
+        # 7.056 - 1.200
+        self.assertEqual(p500["13"], "5856,00")
+
+    def test_validador_reprova_arquivo_adulterado(self):
+        """O validador nao passa a mao: valor calculado errado e reprovado."""
+        texto = self.cenario.declaracao()._generate_sped_text()
+        adulterado = "\n".join(
+            linha.replace("|9960,00|", "|1,00|")
+            if linha.startswith("|P300|3|")
+            else linha
+            for linha in texto.split("\n")
+        )
+        self.assertNotEqual(adulterado, texto, "o arquivo nao foi adulterado")
+        erros = EcfValidator(adulterado).validate()
+        self.assertTrue(
+            any("line 3 of period" in str(erro) for erro in erros),
+            "o validador aceitou um IRPJ calculado errado: "
+            + "; ".join(str(erro) for erro in erros),
+        )
+
+    def test_validador_reprova_contagem_errada(self):
+        """Contagem do bloco 9 fora do que o arquivo tem e reprovada."""
+        texto = self.cenario.declaracao()._generate_sped_text()
+        adulterado = texto.replace("|9900|0930|2|", "|9900|0930|7|", 1)
+        erros = EcfValidator(adulterado).validate()
+        self.assertTrue(
+            any("occurrence(s) of register 0930" in str(erro) for erro in erros),
+            "o validador aceitou uma contagem do bloco 9 errada",
+        )
+
+    def test_gerar_arquivo_de_exemplo(self):
+        """Escreve a ECF gerada no caminho de ``ECF_GERAR_DEMO``.
+
+        O arquivo de exemplo do modulo (``demo/demo_ecf.txt``) deve ser a ECF
+        que esta escrituracao produz, e nao um arquivo escrito a mao: e o que
+        da valor ao teste de ida e volta ``test_import_ecf``. Roda sob demanda
+        porque escreve em disco, e o destino vem da variavel porque o
+        diretorio do modulo costuma estar montado somente para leitura.
+        """
+        destino = os.environ.get("ECF_GERAR_DEMO")
+        if not destino:
+            self.skipTest("defina ECF_GERAR_DEMO=<arquivo> para gerar o exemplo")
+        regime = os.environ.get("ECF_REGIME", "presumed")
+        apuracao = os.environ.get("ECF_APURACAO", "T")
+        if regime != "presumed" or apuracao != "T":
+            cenario = CenarioPresumido(self.env, regime, apuracao).montar()
+            texto = cenario.declaracao()._generate_sped_text()
+            with open(destino, "w") as arquivo:
+                arquivo.write(texto.strip() + "\n")
+            return
+        texto = self.cenario.declaracao()._generate_sped_text()
+        self.assertEqual(EcfValidator(texto).validate(), [])
+        with open(destino, "w") as arquivo:
+            arquivo.write(texto.strip() + "\n")
+
+    def test_soma_e_arredondamento_do_motor(self):
+        """Casos de borda da linguagem de formulas da RFB.
+
+        O limite superior sem parte decimal abrange as sublinhas (a linha
+        14.10 pertence a linha 14); o limite com parte decimal e exato. O
+        arredondamento de meio centavo vai para longe do zero nos dois
+        sinais.
+        """
+        from odoo.addons.l10n_br_sped_ecf.models.apuracao_presumido import (
+            arredonda,
+            soma,
+        )
+
+        valores = {"7": 100.0, "14": 50.0, "14.10": 30.0, "15": 1.0}
+        self.assertEqual(soma(valores, "7", "14"), 180.0)
+        exatos = {"25.02": 5.0, "25.100": 7.0}
+        self.assertEqual(soma(exatos, "22", "25.99"), 5.0)
+        self.assertEqual(arredonda(0.125), 0.13)
+        self.assertEqual(arredonda(-0.125), -0.13)
+
+    def test_csll_nao_deriva_da_linha_do_irpj(self):
+        """Servico do art. 40 da Lei 9.250/1995: IRPJ a 16%, CSLL segue a 32%.
+
+        A presuncao da CSLL nao deriva da do IRPJ: sem o campo proprio, o
+        de-para usual mandaria o servico com IRPJ reduzido para a linha de
+        12% da CSLL, recolhendo a menor.
+        """
+        declaracao = self.cenario.declaracao()
+        p030 = self.env["l10n_br_sped.ecf.p030"].search(
+            [("declaration_id", "=", declaracao.id), ("PER_APUR", "=", "T01")]
+        )
+        conta_servico = self.env["account.account"].search(
+            [
+                ("company_id", "=", self.company.id),
+                ("l10n_br_ecf_revenue_line", "=", "8"),
+            ],
+            limit=1,
+        )
+        self.assertTrue(conta_servico, "o cenario nao tem conta de servico")
+        # a empresa passa a se enquadrar no art. 40: IRPJ presume 16%...
+        conta_servico.l10n_br_ecf_revenue_line = "6"
+        valores = p030._apurar()
+        # ...e SEM o campo proprio o de-para usual manda a CSLL para 12%
+        # (que e o certo para transporte de passageiros, nao para servico):
+        # a linha 2 do P400 soma a revenda (300.000) e o servico (120.000)
+        self.assertEqual(valores["P400"].get("2", 0.0), 420000.0)
+        # com a linha propria declarada, a CSLL do servico fica nos 32%
+        conta_servico.l10n_br_ecf_csll_line = "4"
+        valores = p030._apurar()
+        self.assertEqual(valores["P400"].get("4", 0.0), 120000.0)
+        self.assertEqual(valores["P400"].get("2", 0.0), 300000.0)
+
+    def test_criterio_de_reconhecimento_e_competencia(self):
+        """O 0010 declara competencia (2), que e o que a apuracao faz.
+
+        Na tabela do leiaute o valor 1 e o regime de CAIXA e o 2 e o de
+        COMPETENCIA. O modulo apura por competencia, entao declarar 1 seria
+        afirmar a Receita uma opcao que a empresa nao exerceu (a inversao
+        passou pelo PVA, que aceita os dois valores para o presumido).
+        """
+        texto = self.cenario.declaracao()._generate_sped_text()
+        linha_0010 = next(
+            linha for linha in texto.split("\n") if linha.startswith("|0010|")
+        )
+        campos = linha_0010.split("|")
+        self.assertEqual(campos[-2], "2", linha_0010)
+
+    def test_optante_pelo_caixa_nao_gera(self):
+        """Quem optou pelo caixa nao pode sair com uma ECF de competencia.
+
+        A opcao e exercida no primeiro DARF do ano e vale para IRPJ, CSLL,
+        PIS e COFINS ao mesmo tempo (IN RFB 1700/2017, art. 224; MP
+        2.158-35/2001, art. 20). O arquivo declarando competencia
+        contradiria os recolhimentos, e o PVA nao cruza nada disso: o erro
+        so apareceria na malha (art. 223, par. 4: juros e multa).
+        """
+        from odoo.exceptions import UserError
+
+        declaracao = self.cenario.declaracao()
+        self.company.l10n_br_ecf_revenue_recognition = "cash"
+        self.addCleanup(
+            setattr, self.company, "l10n_br_ecf_revenue_recognition", "accrual"
+        )
+        with self.assertRaisesRegex(UserError, "regime de caixa"):
+            self.env["l10n_br_sped.ecf.0010"].with_context(
+                declaration=declaracao
+            )._map_from_odoo(None, None, declaracao)


### PR DESCRIPTION
Depends on #4876, #4874 e #4878 (o validador confere a apuracao do bloco P)

> **Sobre o CI:** este PR carrega apenas o seu delta. O `__manifest__.py` do modulo vive no #4876, entao ate ele mesclar o modulo nao e reconhecido pelo CI e **os testes daqui nao rodam** (o check verde nao prova nada neste momento). Depois do merge do #4876, um rebase torna o CI informativo. E a estrategia combinada para que o diff de cada PR nao contenha o anterior.


O arquivo de exemplo do modulo (`demo/demo_ecf.txt`) e invalido, e o proprio
`hooks.py` reconhece isso e desliga a importacao com um FIXME. Ele tem datas em
formato ISO no registro L100, falta o campo `NOME_ESC` no 0000 e nao tem bloco
de apuracao nenhum: nao e um arquivo que a escrituracao poderia produzir.

Este PR troca o exemplo por uma ECF que a **propria escrituracao gera**, a
partir de um cenario de teste compartilhado: uma empresa do lucro presumido com
escrituracao contabil, que revende mercadoria e presta servico, com movimento
nos quatro trimestres. O mesmo cenario alimenta o teste e a geracao do exemplo,
entao o arquivo nunca mais fica defasado do codigo.

Com o exemplo valido, a importacao volta a ser ligada no `post_init_hook` e o
teste de ida e volta (importar e regerar identico) passa a ter valor: hoje ele
compara a saida com um arquivo escrito a mao.

Traz tambem a validacao das formulas do bloco P, que e a parte do validador
especifica desta escrituracao: cada linha calculada e recalculada pela formula
oficial da RFB a partir das linhas editaveis do proprio arquivo. Ha teste que
adultera o arquivo (IRPJ calculado errado, contagem do bloco 9 errada) e exige
que o validador reprove.