### PR TITLE
[16.0][IMP] spec_driven_model: disambiguate dup labels

### DIFF
--- a/l10n_br_cte/models/document.py
+++ b/l10n_br_cte/models/document.py
@@ -212,8 +212,8 @@ class CTe(spec_models.StackedModel):
                 and record.document_type_id.prefix
                 and record.document_key
             ):
-                record.cte40_Id = "{}{}".format(
-                    record.document_type_id.prefix, record.document_key
+                record.cte40_Id = (
+                    f"{record.document_type_id.prefix}{record.document_key}"
                 )
 
     ##########################
@@ -711,14 +711,14 @@ class CTe(spec_models.StackedModel):
             icms["vICMSSTRet"] += line.icmsst_wh_value
 
         # Formatar os valores acumulados
-        icms["vBC"] = str("%.02f" % icms["vBC"])
-        icms["vICMS"] = str("%.02f" % icms["vICMS"])
-        icms["vICMSSubstituto"] = str("%.02f" % icms["vICMSSubstituto"])
-        icms["vBCSTRet"] = str("%.02f" % icms["vBCSTRet"])
-        icms["vICMSSTRet"] = str("%.02f" % icms["vICMSSTRet"])
-        icms["pRedBC"] = str("%.04f" % icms["pRedBC"])
-        icms["pICMS"] = str("%.02f" % icms["pICMS"])
-        icms["pICMSSTRet"] = str("%.02f" % icms["pICMSSTRet"])
+        icms["vBC"] = f"{icms['vBC']:.02f}"
+        icms["vICMS"] = f"{icms['vICMS']:.02f}"
+        icms["vICMSSubstituto"] = f"{icms['vICMSSubstituto']:.02f}"
+        icms["vBCSTRet"] = f"{icms['vBCSTRet']:.02f}"
+        icms["vICMSSTRet"] = f"{icms['vICMSSTRet']:.02f}"
+        icms["pRedBC"] = f"{icms['pRedBC']:.04f}"
+        icms["pICMS"] = f"{icms['pICMS']:.02f}"
+        icms["pICMSSTRet"] = f"{icms['pICMSSTRet']:.02f}"
 
         return icms
 
@@ -1019,8 +1019,6 @@ class CTe(spec_models.StackedModel):
     ##########################
 
     cte40_modal = fields.Selection(related="transport_modal")
-
-    cte_modal = fields.Selection(related="transport_modal")
 
     cte40_versaoModal = fields.Char(default=CTE_MODAL_VERSION_DEFAULT)
 
@@ -1611,7 +1609,7 @@ class CTe(spec_models.StackedModel):
         else:
             state = SITUACAO_EDOC_REJEITADA
         if self.authorization_event_id and infProt.nProt:
-            if type(infProt.dhRecbto) == datetime:
+            if isinstance(infProt.dhRecbto, datetime):
                 protocol_date = fields.Datetime.to_string(infProt.dhRecbto)
             else:
                 protocol_date = fields.Datetime.to_string(

--- a/l10n_br_cte/models/res_config_settings.py
+++ b/l10n_br_cte/models/res_config_settings.py
@@ -16,7 +16,7 @@ class ResConfigSettings(models.TransientModel):
     )
 
     cte_transmission = fields.Selection(
-        string="NFe Transmission",
+        string="CTe Transmission",
         related="company_id.cte_transmission",
         readonly=False,
     )

--- a/l10n_br_cte/tests/test_cte_serialize.py
+++ b/l10n_br_cte/tests/test_cte_serialize.py
@@ -47,15 +47,15 @@ class TestCTeSerialize(TransactionCase):
         )
         cte.cte40_cCT = "57000111"
 
-        if cte.cte_modal == "01":
+        if cte.cte40_modal == "01":
             self.prepare_modal_rodoviario_data(cte)
-        elif cte.cte_modal == "02":
+        elif cte.cte40_modal == "02":
             self.prepare_modal_aereo_data(cte)
-        elif cte.cte_modal == "03":
+        elif cte.cte40_modal == "03":
             self.prepare_modal_aquaviario_data(cte)
-        elif cte.cte_modal == "04":
+        elif cte.cte40_modal == "04":
             self.prepare_modal_ferroviario_data(cte)
-        elif cte.cte_modal == "05":
+        elif cte.cte40_modal == "05":
             self.prepare_modal_dutoviario_data(cte)
 
         cte._document_export()

--- a/spec_driven_model/models/__init__.py
+++ b/spec_driven_model/models/__init__.py
@@ -1,6 +1,7 @@
 from . import spec_export
 from . import spec_import
 from . import spec_mixin
+from . import ir_model
 
 # from . import spec_view
 from . import spec_models

--- a/spec_driven_model/models/ir_model.py
+++ b/spec_driven_model/models/ir_model.py
@@ -1,0 +1,83 @@
+# Copyright 2025-TODAY Akretion - Raphael Valyi <raphael.valyi@akretion.com>
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
+
+import re
+from collections import defaultdict
+
+from odoo import models
+
+SPEC_FIELD_PREFIX_RE = re.compile(r"^([a-z]+)\d{2}_")
+
+
+def disambiguate_spec_labels(cls):
+    """Dynamically disambiguate the labels of spec fields that would
+    otherwise be duplicates.
+
+    NFe, CTe, MDFe... XSD schemas share many tags with the same label
+    and those spec fields tend to be injected into the same Odoo models
+    (res.partner, l10n_br_fiscal.document...). Odoo then emits a
+    "Two fields ... have the same label" warning for each such pair of
+    fields. These warnings are not legit in the spec_driven_model
+    context: the labels come from the XSD schemas and cannot be changed
+    without diverging from the spec. So instead we dynamically
+    disambiguate the labels of the spec fields that would be duplicate
+    by appending their schema and XSD tag, e.g. "Nome do município
+    (cte_xMun)" or "Dados do endereço (cte_enderExped)".
+    """
+    by_label = defaultdict(list)
+    for name, field in cls._fields.items():
+        if not field.string:
+            continue
+        match = SPEC_FIELD_PREFIX_RE.match(name)
+        if not match:
+            # regular field: tracked to detect collisions with spec
+            # fields, but its label is never changed
+            by_label[field.string].append((name, field, None, None))
+            continue
+        schema = match.group(1)
+        tag = name[match.end() :]
+        suffix = f"({schema}_{tag})"
+        # strip our own suffix if already applied in a previous registry
+        # build (direct field objects may be shared between builds)
+        base_label = field.string
+        if base_label.endswith(f" {suffix}"):
+            base_label = base_label[: -len(suffix) - 1]
+        by_label[base_label].append((name, field, schema, tag))
+
+    for fields in by_label.values():
+        if len(fields) < 2:
+            continue
+        for _name, field, schema, tag in fields:
+            if schema is None:
+                continue
+            suffix = f"({schema}_{tag})"
+            # idempotent: a direct field object may already have been
+            # disambiguated in a previous registry build of this process
+            if field.string.endswith(f" {suffix}"):
+                continue
+            field.string = f"{field.string} {suffix}"
+
+
+class IrModelFields(models.Model):
+    """
+    When NFe, CTe, MDFe... XSD spec fields are injected into the same
+    Odoo model (either directly as a SpecModel or StackedModel, either
+    through the _inherits delegation mechanism used by l10n_br_account
+    for instance), many of them share the same label coming from the XSD
+    schemas. Odoo then emits a "Two fields ... have the same label"
+    warning in _reflect_fields for each such pair of fields.
+
+    These warnings are not legit in the spec_driven_model context: the
+    labels come from the XSD schemas and cannot be changed without
+    diverging from the spec. So we dynamically disambiguate the labels
+    of the spec fields that would be duplicate right before the label
+    check of _reflect_fields, whatever the way (direct or delegated)
+    the spec fields were injected.
+    """
+
+    _inherit = "ir.model.fields"
+
+    def _reflect_fields(self, model_names):
+        for model_name in model_names:
+            disambiguate_spec_labels(self.env[model_name])
+        return super()._reflect_fields(model_names)

--- a/spec_driven_model/models/spec_models.py
+++ b/spec_driven_model/models/spec_models.py
@@ -10,6 +10,8 @@ from inspect import getmembers, isclass
 from odoo import SUPERUSER_ID, _, api, models
 from odoo.tools import mute_logger
 
+from .ir_model import disambiguate_spec_labels
+
 SPEC_MIXIN_MAPPINGS = defaultdict(dict)  # by db
 
 _logger = logging.getLogger(__name__)
@@ -169,7 +171,9 @@ class SpecModel(models.Model):
                             f.args["original_comodel_name"] = f.args["comodel_name"]
                             f.args["comodel_name"] = self._name
 
-        return super()._setup_fields()
+        res = super()._setup_fields()
+        disambiguate_spec_labels(cls)
+        return res
 
     @classmethod
     def _map_concrete(cls, dbname, key, target, quiet=False):


### PR DESCRIPTION
    [FIX] spec_driven_model: disambiguate duplicate spec field labels

    When NFe, CTe, MDFe... XSD spec fields are injected into the same Odoo
    model (res.partner, l10n_br_fiscal.document...), many of them share the
    same label coming from the XSD schema, making Odoo emit a
    'Two fields ... have the same label' warning for each such pair of
    fields. These warnings are not legit in the spec_driven_model context:
    the labels come from the XSD schemas and cannot be changed without
    diverging from the spec.

    So we now dynamically disambiguate the labels of the spec fields that
    would be duplicate by appending their schema and XSD tag, e.g. 'Nome do
    município (cte_xMun)' or 'Dados do endereço (cte_enderExped)'. Only
    spec fields involved in a duplicate get disambiguated, regular fields
    keep their labels untouched.

    The disambiguation runs in SpecModel._setup_fields for the spec models
    proper, and right before the duplicate label check of
    ir.model.fields._reflect_fields for any model receiving spec fields
    through another mechanism (typically the _inherits delegation used by
    l10n_br_account for account.move, account.payment or
    account.bank.statement.line), because the label of a delegated field is
    copied from its parent model during the child setup, possibly before
    the parent _setup_fields disambiguation, depending on the model setup
    order. _reflect_fields runs after all model setup, whatever the way the
    spec fields were injected.


**antes**: mais de 1300 WARNING como odoo odoo.addons.base.models.ir_model: Two fields (cte40_toma, service_provider) of l10n_br_fiscal.document() have the same label: Tomador do Serviço. [Modules: l10n_br_cte and l10n_br_fiscal] 
**depois**: 11 casos de warning de same labels que nao tem a ver com os modulos que usam spec_driven_model

remover esses warnings eh necessario para mesclar a migraçao dos modulos l10n_br_mdfe e l10n_br_cte na branch 18.0 onde warnings nao sao mais permitidos.