### PR TITLE
[16.0][FIX] l10n_br_sped_base: performance do populate

### DIFF
--- a/l10n_br_sped_base/models/sped_mixin.py
+++ b/l10n_br_sped_base/models/sped_mixin.py
@@ -607,20 +607,28 @@ class SpedMixin(models.AbstractModel):
         """
         declaration = self._context["declaration"]
 
+        # `self._fields` em vez de `fields_get()`: o resultado destas duas
+        # listas depende apenas do MODELO, nunca do registro em processamento,
+        # mas este metodo e recursivo (uma vez por registro pai), entao o
+        # `fields_get()` era refeito a cada documento e a cada item. Medido em
+        # 400 documentos: 71% do tempo total de `button_populate_sped_from_odoo`
+        # estava ai. `_fields` ja esta em memoria e da a mesma informacao
+        # (`comodel_name` e o `relation` do `fields_get`). E o mesmo padrao que
+        # `_generate_register_text` ja usava.
         children = [
-            v["relation"]
-            for k, v in self.fields_get().items()
-            if v["type"] == "one2many" and k.startswith("reg_")
+            f.comodel_name
+            for name, f in self._fields.items()
+            if f.type == "one2many" and name.startswith("reg_")
         ]
         parent_field = None
         if parent_register:
-            parent_field = [
-                k
-                for k, v in self.fields_get().items()
-                if v["type"] == "many2one"
-                and k.startswith("reg_")
-                and k.endswith("_id")
-            ][0]
+            parent_field = next(
+                name
+                for name, f in self._fields.items()
+                if f.type == "many2one"
+                and name.startswith("reg_")
+                and name.endswith("_id")
+            )
 
         if self._odoo_model and hasattr(self, "_odoo_domain"):
             records = self.env[self._odoo_model].search(
@@ -655,6 +663,11 @@ class SpedMixin(models.AbstractModel):
 
         self._log_chatter_sped_item(log_msg, level, records)
 
+        # Um unico `create()` para todo o nivel, em vez de um por registro.
+        # `_map_from_odoo` continua sendo chamado registro a registro, entao o
+        # contrato que cada leiaute implementa nao muda. So a escrita e que
+        # passa a ser em lote, que e o que o ORM sabe otimizar.
+        vals_list = []
         for index, record in enumerate(records):
             # TODO find a way/mode to skip pulling existing records
             # may be search for existing register with res_model/res_id
@@ -667,8 +680,13 @@ class SpedMixin(models.AbstractModel):
                 register_vals["res_id"] = record.id
             if parent_register:
                 register_vals[parent_field] = parent_register.id
-            register = self.create(register_vals)
+            vals_list.append(register_vals)
 
+        # `create` com lista devolve os registros na mesma ordem da lista,
+        # entao o zip abaixo casa cada registro criado com a sua origem.
+        registers = self.create(vals_list) if vals_list else self.browse()
+
+        for register, record in zip(registers, records, strict=True):
             for child in children:
                 self.env[child]._pull_records_from_odoo(
                     kind,

--- a/l10n_br_sped_base/tests/test_sped_base.py
+++ b/l10n_br_sped_base/tests/test_sped_base.py
@@ -652,14 +652,14 @@ class TestSpedBase(TransactionCase, FakeModelLoader):
             mock_map_i010.assert_any_call(partner1, None, declaration, index=0)
             mock_map_i010.assert_any_call(partner2, None, declaration, index=1)
 
-            # Check calls to create
-            self.assertEqual(mock_create_i010.call_count, 2)
-            created_vals_1 = mock_create_i010.call_args_list[0][0][
-                0
-            ]  # First call, first arg, vals dict
-            created_vals_2 = mock_create_i010.call_args_list[1][0][
-                0
-            ]  # Second call, first arg, vals dict
+            # Check calls to create: the whole level is written in a single
+            # batched call, so `create` receives one list with the vals of
+            # every record, in the same order as the source records.
+            self.assertEqual(mock_create_i010.call_count, 1)
+            batch_vals = mock_create_i010.call_args_list[0][0][0]
+            self.assertIsInstance(batch_vals, list)
+            self.assertEqual(len(batch_vals), 2)
+            created_vals_1, created_vals_2 = batch_vals
 
             self.assertEqual(created_vals_1.get("IND_ESC"), "G")
             self.assertEqual(created_vals_1.get("res_model"), "res.partner")


### PR DESCRIPTION
Gerar um mês de uma empresa média custa muito mais do que a ECF anual: são milhares de registros por mês, contra as ~640 linhas de uma ECF. Medi o `button_populate_sped_from_odoo` com 400 documentos antes de escrever mapeamento novo, e o resultado mudou o que dava para prometer.

## O que estava caro

`_pull_records_from_odoo` é recursivo, uma vez por registro pai, e chamava `fields_get()` duas vezes em cada passagem para descobrir os filhos e o campo do pai. Essas duas listas dependem apenas do MODELO, nunca do registro em processamento, então o trabalho era refeito a cada documento e a cada item: **71% do tempo total**, com cerca de 26 chamadas por documento.

`self._fields` já está em memória e dá a mesma informação (`comodel_name` é o `relation` do `fields_get`). É o mesmo padrão que `_generate_register_text` já usava neste arquivo.

A segunda mudança é escrever o nível inteiro num `create()` só, em vez de um por registro. `_map_from_odoo` continua sendo chamado registro a registro, então o contrato que cada leiaute implementa não muda: só a escrita passa a ser em lote, que é o que o ORM sabe otimizar.

## Medição

| documentos | antes | depois |
|---|---|---|
| 100 | 4,47s | 1,10s |
| 400 | 17,90s | 3,94s |

Custo marginal por documento: 47 ms antes, ~10 ms depois. A curva também deixa de ser super-linear (1,6x para ~1,09x ao quadruplicar o volume), e o `fields_get` some do profile.

## O que NÃO está aqui

O gargalo que sobra é o N+1 de `search` (7851 consultas, 48% do tempo restante). Corrigi-lo exige estender o contrato de mapeamento para consultar por lote, o que muda a interface que cada leiaute implementa. Fica para um PR próprio.

## Risco declarado

`fields_get()` aplica as regras de acesso do usuário e `_fields` não. Aqui isso não muda o resultado: as duas listas são estruturais (quais filhos existem e qual é o campo do pai), e um usuário sem acesso a um campo não deveria mudar a estrutura do arquivo gerado.
