### PR TITLE
[16.0][FIX] l10n_br_sped_base: indicador de movimento conta só a declaração

### DIFF
--- a/l10n_br_sped_base/models/sped_declaration.py
+++ b/l10n_br_sped_base/models/sped_declaration.py
@@ -350,11 +350,16 @@ class SpedDeclaration(models.AbstractModel):
         self._generate_register_text(sped, version, line_count, count_by_register)
         count_by_register["0990"] = 1  # for some reason it is needed
 
+        domain = [("declaration_id", "=", self.id)]
         for register_class in top_register_classes:
             bloco = register_class._name[-4:][0].upper()
-            count_by_bloco[bloco] += register_class.search_count([])
-
-        domain = [("declaration_id", "=", self.id)]
+            # Contar com o dominio da declaracao, e nao `[]`: sem ele o
+            # indicador de movimento do bloco enxerga os registros de TODAS as
+            # escrituracoes da base e abre como "com dados" um bloco que nesta
+            # declaracao esta vazio. O PVA recusa a importacao com "registro de
+            # abertura do bloco informa que o bloco tem movimento, no entanto
+            # nenhum registro foi informado no bloco".
+            count_by_bloco[bloco] += register_class.search_count(domain)
         for register_class in top_register_classes:
             bloco = register_class._name[-4:][0].upper()
             registers = register_class.search(domain)

--- a/l10n_br_sped_base/tests/test_sped_base.py
+++ b/l10n_br_sped_base/tests/test_sped_base.py
@@ -119,6 +119,55 @@ class TestSpedBase(TransactionCase, FakeModelLoader):
         cls.loader.restore_registry()
         super().tearDownClass()
 
+    def test_block_movement_counts_only_this_declaration(self):
+        """The block movement indicator looks at this declaration alone.
+
+        With `search_count([])` a second, empty declaration opened its blocks
+        as "has data" because the count saw the registers of the first one, and
+        the PVA rejects the import in that case with "the block opening record
+        states the block has movement, however no record was reported in the
+        block".
+        """
+        source = self.declaration
+        other = self.env["l10n_br_sped.fake.0000"].create(
+            {
+                "company_id": source.company_id.id,
+                "DT_INI": "2022-01-01",
+                "DT_FIN": "2022-12-31",
+                "LECD": source.LECD,
+                "NOME": source.NOME,
+                "CNPJ": source.CNPJ,
+                "UF": source.UF,
+                "IND_SIT_INI_PER": source.IND_SIT_INI_PER,
+                "IND_NIRE": source.IND_NIRE,
+                "IND_FIN_ESC": source.IND_FIN_ESC,
+                "IND_GRANDE_PORTE": source.IND_GRANDE_PORTE,
+                "TIP_ECD": source.TIP_ECD,
+                "IDENT_MF": source.IDENT_MF,
+                "IND_ESC_CONS": source.IND_ESC_CONS,
+                "IND_CENTRALIZADA": source.IND_CENTRALIZADA,
+                "IND_MUDANC_PC": source.IND_MUDANC_PC,
+            }
+        )
+        # the guard that makes this test meaningful: without a register of
+        # block I somewhere else in the database, a naive count would also
+        # report "no movement" and the test would pass either way
+        self.assertTrue(
+            self.env["l10n_br_sped.fake.i010"].search_count([]),
+            "the fixture must have block I registers for this test to mean " "anything",
+        )
+        sped = other._generate_sped_text()
+
+        # the fixture declaration does have I and J registers, so a count
+        # without the declaration domain would open both blocks here
+        for bloco in ("I", "J"):
+            self.assertIn(
+                f"|{bloco}001|1|",
+                sped,
+                f"block {bloco} is empty in this declaration and must open "
+                f"with no movement",
+            )
+
     def test_generate_sped(self):
         sped = self.declaration._generate_sped_text()
         with open(self.file_path) as f:


### PR DESCRIPTION
O registro de abertura de cada bloco informa se o bloco tem dados (`IND_MOV` = 0) ou não (`IND_MOV` = 1). A contagem usava `search_count([])`, sem filtrar a declaração, então enxergava os registros de TODAS as escriturações da base.

Na prática: numa base com mais de uma declaração, um bloco vazio na declaração corrente é aberto como "com dados" porque outra declaração tem registros daquele bloco.

O PVA da EFD ICMS/IPI 6.1.1 recusa a importação com

> Registro de abertura do bloco informa que o bloco tem movimento, no entanto
> nenhum registro foi informado no bloco.

Aconteceu com `C001` e `1001` num arquivo real: a base tinha a escrituração de demonstração importada pelo `post_init_hook` além da declaração que eu estava gerando.

Vale notar que em banco de teste com uma declaração só o defeito é invisível, que é por isso que ele sobreviveu.

## Teste

O teste novo cria uma segunda declaração vazia e exige que os blocos dela abram sem movimento. Ele distingue: com o código anterior o arquivo sai `|0001|0|`, `|I001|0|` e `|J001|0|` mesmo sem nenhum registro naquela declaração.
