### PR TITLE
[16.0][FIX] l10n_br_sped_base: obrigatoriedade declarada no mapeamento vale no arquivo

### DIFF
--- a/l10n_br_sped_base/models/sped_mixin.py
+++ b/l10n_br_sped_base/models/sped_mixin.py
@@ -537,7 +537,13 @@ class SpedMixin(models.AbstractModel):
             if not fname.isupper():
                 continue
 
-            val = self._format_field_value(register_spec._fields[fname], value)
+            # A ORDEM dos campos vem do spec, que e o leiaute; os ATRIBUTOS
+            # vem do modelo concreto, que herda tudo do spec e pode refinar.
+            # E o que permite a camada de mapping declarar a obrigatoriedade
+            # que o spec gerado nao carrega, e sem a qual o campo zerado sai
+            # em branco e o PVA recusa o registro.
+            field = self._fields.get(fname) or register_spec._fields[fname]
+            val = self._format_field_value(field, value)
             sped.write(f"{val}|")
 
     def _format_field_value(self, field, value):

--- a/l10n_br_sped_base/tests/test_sped_base.py
+++ b/l10n_br_sped_base/tests/test_sped_base.py
@@ -2,6 +2,7 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
 
 import base64
+from collections import defaultdict
 from datetime import date
 from io import StringIO
 from os import path
@@ -168,6 +169,42 @@ class TestSpedBase(TransactionCase, FakeModelLoader):
                 f"block {bloco} is empty in this declaration and must open "
                 f"with no movement",
             )
+
+    def test_register_line_uses_the_concrete_field(self):
+        """Field attributes come from the concrete model, not from the spec.
+
+        The field ORDER must keep coming from the spec, which is the layout,
+        but the attributes must not: the generated spec does not carry the
+        mandatoriness the Guia Pratico defines, so the mapping layer declares
+        it. While the writer read the spec, a field declared `required=True`
+        in the mapping was ignored and every zeroed amount came out blank,
+        which the PVA rejects with "mandatory field".
+        """
+        register = self.declaration
+        spec = self.env["l10n_br_sped.fake.9.0000"]
+        seen = []
+        original = type(register)._format_field_value
+
+        def spy(self_, field, value):
+            seen.append(field)
+            return original(self_, field, value)
+
+        with mock.patch.object(
+            type(register), "_format_field_value", autospec=True, side_effect=spy
+        ):
+            register._generate_register_text(StringIO(), "9", [0], defaultdict(int))
+
+        self.assertTrue(seen, "no field was written")
+        for field in seen:
+            name = field.name
+            self.assertIs(
+                field,
+                register._fields[name],
+                f"{name} was taken from the spec instead of the concrete model",
+            )
+            # the spec holds a different Field instance for the same name, so
+            # the assertion above really distinguishes the two
+            self.assertIsNot(field, spec._fields[name])
 
     def test_generate_sped(self):
         sped = self.declaration._generate_sped_text()


### PR DESCRIPTION
`_write_register_line` lia os atributos do campo no modelo de SPEC (`...20.e110`) e não no modelo concreto que o implementa (`...e110`). A ordem dos campos deve mesmo vir do spec, porque ela é o leiaute, mas os atributos não: o spec é gerado e não carrega a obrigatoriedade que o Guia Prático define.

Consequência: um campo declarado `required=True` na camada de mapeamento era ignorado na hora de escrever a linha. Como a regra de formatação escreve zero como `0` apenas quando o campo é obrigatório (#4871), todo campo zerado saía em branco.

O PVA 6.1.1 recusa o `E110` com "campo obrigatório" em cada um dos dez campos zerados que vieram vazios. Com esta mudança o mesmo registro sai `|E110|0|0|100,00|0|0|0|0|0|0|100,00|0|100,00|0|0|` e o PVA aceita.

Depende de #4871, que é quem define a regra do zero.

## Teste

O teste novo confere que todo campo entregue ao formatador é o do modelo concreto, e não o do spec. Ele distingue: com o código anterior falha com `'l10n_br_sped.fake.9.0000.LECD' is not 'l10n_br_sped.fake.0000.LECD'`.
