### PR TITLE
[17.0][FIX] spec_driven_model: cleanup on hook failure

### DIFF
--- a/spec_driven_model/models/spec_mixin.py
+++ b/spec_driven_model/models/spec_mixin.py
@@ -104,8 +104,6 @@ class SpecMixin(models.AbstractModel):
             return
         setattr(self.env.registry, load_key, True)
 
-        access_data = []
-        access_fields = []
         field_prefix = f"{spec_schema}{spec_version}"
         relation_prefix = f"{spec_schema}.{spec_version}.%"
         self.env.cr.execute(
@@ -128,6 +126,46 @@ class SpecMixin(models.AbstractModel):
         # concrete classes we build below, tracked so we can drop them
         # from module_to_models at the end of this method
         concrete_models = []
+        try:
+            self._build_remaining_schema_models(
+                remaining_models,
+                spec_module,
+                odoo_module,
+                spec_schema,
+                spec_version,
+                field_prefix,
+                concrete_models,
+            )
+        finally:
+            # The concrete classes we built above are rebuilt from scratch every
+            # time this hook runs, but Odoo's MetaModel registered them in
+            # module_to_models, which persists across registry rebuilds. Leaving
+            # them there would make the next Registry.new() -- triggered by any
+            # module install/update -- rebuild these *stale* classes as extra
+            # bases of their model; being subclasses of the downstream classes
+            # that extend the model via _inherit, they break the C3
+            # linearization and crash setup_models() with an inconsistent MRO
+            # (#4668). This runs in a finally block because an exception raised
+            # anywhere above -- init_models recomputing a broken field, for
+            # instance -- would otherwise leak the classes and poison every
+            # later registry build in the process.
+            registered = models.MetaModel.module_to_models[odoo_module]
+            models.MetaModel.module_to_models[odoo_module] = [
+                cls for cls in registered if cls not in concrete_models
+            ]
+
+    def _build_remaining_schema_models(
+        self,
+        remaining_models,
+        spec_module,
+        odoo_module,
+        spec_schema,
+        spec_version,
+        field_prefix,
+        concrete_models,
+    ):
+        access_data = []
+        access_fields = []
         for name in remaining_models:
             spec_class = StackedModel._odoo_name_to_class(name, spec_module)
             if spec_class is None:

--- a/spec_driven_model/tests/test_spec_model.py
+++ b/spec_driven_model/tests/test_spec_model.py
@@ -259,6 +259,70 @@ class TestSpecModel(TransactionCase, FakeModelLoader):
         assert actual_calls == expected_model_suffixes
         assert mock_get_concrete_model.call_count == len(expected_model_suffixes)
 
+    def test_remaining_model_cleanup_survives_an_exception(self):
+        """The module_to_models cleanup must run even when the hook raises.
+
+        The cleanup that fixes #4668 sits at the end of
+        _register_remaining_schema_models_hook, after init_models. Any exception
+        raised in that window -- init_models recomputing a field that a
+        downstream module broke, for instance -- used to skip the cleanup and
+        leave the synthesized concrete class in MetaModel.module_to_models. From
+        then on every registry build in the process fed that class back as a
+        base of (SpecModel, ...) and died with an inconsistent MRO, so a single
+        transient error turned into a server that could not rebuild its registry
+        until the process was restarted.
+        """
+        from unittest import mock
+
+        from odoo.models import MetaModel, is_definition_class
+        from odoo.modules.registry import Registry
+
+        from odoo.addons.spec_driven_model.models.spec_models import SpecModel
+
+        from .fake_mixin import PoXsdMixin
+        from .spec_poxsd import Comment
+
+        registry = self.env.registry
+        cr = self.env.cr
+        module_to_models = MetaModel.module_to_models
+
+        def concrete_classes_left():
+            return [
+                cls
+                for cls in module_to_models["spec_driven_model"]
+                if is_definition_class(cls)
+                and issubclass(cls, SpecModel)
+                and cls._name == "poxsd.10.comment"
+            ]
+
+        original_init_models = Registry.init_models
+
+        def failing_init_models(self, cr, model_names, context, install=True):
+            if any(name.startswith("poxsd.10.") for name in model_names):
+                raise AttributeError("simulated failure inside the hook window")
+            return original_init_models(self, cr, model_names, context, install)
+
+        ready = registry.ready
+        saved_module_classes = list(module_to_models["spec_driven_model"])
+        try:
+            registry.__dict__.pop("_poxsd_register_hook_loaded", None)
+            self.loader.update_registry((PoXsdMixin, Comment))
+            registry.ready = True
+            with mock.patch.object(Registry, "init_models", failing_init_models):
+                with self.assertRaises(AttributeError):
+                    registry.setup_models(cr)
+
+            self.assertEqual(
+                concrete_classes_left(),
+                [],
+                "the hook leaked a concrete class after raising; the next "
+                "registry build would crash with an inconsistent MRO (#4668)",
+            )
+        finally:
+            module_to_models["spec_driven_model"] = saved_module_classes
+            registry.ready = ready
+            registry.__dict__.pop("_poxsd_register_hook_loaded", None)
+
     def test_registry_reload_with_extended_remaining_model(self):
         """Regression test for issue #4668.
 


### PR DESCRIPTION
Forward-port do #4907. Cherry-pick limpo, e o `spec_mixin.py` daqui continua sem o `mute_logger("odoo.tests.common")` que só existe na 18.
