### PR TITLE
[16.0] l10n br fiscal, l10n_br_nfe: Suporte a configuração da Desoneração do ICMS

### DIFF
--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -328,6 +328,7 @@ class AccountMoveLine(models.Model):
         "icms_origin",
         "ind_final",
         "icms_relief_value",
+        "icms_relief_type",
     )
     def _compute_totals(self):
         """
@@ -383,11 +384,10 @@ class AccountMoveLine(models.Model):
                 line.price_total = taxes_res["total_included"]
 
                 line.price_total += (
-                    line.insurance_value
-                    + line.other_value
-                    + line.freight_value
-                    - line.icms_relief_value
+                    line.insurance_value + line.other_value + line.freight_value
                 )
+                if line.icms_relief_type == "1":
+                    line.price_total -= line.icms_relief_value
             else:
                 # If no tax, just compute the total based on price_unit and quantity
                 subtotal = line.quantity * line_discount_price_unit

--- a/l10n_br_account/tests/test_account_move_lc.py
+++ b/l10n_br_account/tests/test_account_move_lc.py
@@ -552,9 +552,11 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
         )
 
     def test_venda_with_icms_reduction_with_relief(self):
-        # Testando com Alivio do ICMS
+        # Testando com Alivio do ICMS, mas indDeduzDeson = "0"
+        # (não deduzir o alívio do total do documento).
         prod_line = self.move_out_venda_with_icms_reduction.invoice_line_ids[0]
         prod_line.icms_relief_id = self.env.ref("l10n_br_fiscal.icms_relief_1")
+        prod_line.icms_relief_type = "0"
 
         # Foi setado essa linha manualmente na criação do account.move.
         self.assertEqual(
@@ -562,9 +564,12 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "Venda com ICMS 12 e Redução de 26,57",
         )
 
-        # price_total deve ser vProd + vIPI − vICMSDeson
-        # 1000.00 + 32.50 − 36.23 = 996.27
-        price_total = 996.27
+        # O valor do alívio é calculado e fica disponível para a NFe
+        # (vICMSDeson), mas como indDeduzDeson = "0" ele não é deduzido
+        # do total do documento, então os totais ficam iguais aos de
+        # uma venda sem alívio (vProd + vIPI = 1000.00 + 32.50 = 1032.50).
+        self.assertAlmostEqual(prod_line.icms_relief_value, 31.88, places=2)
+        price_total = 1032.5
 
         product_line_vals_1 = {
             "name": self.product_a.display_name,
@@ -579,9 +584,9 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "price_total": price_total,
             "tax_line_id": False,
             "currency_id": self.company_data["currency"].id,
-            "amount_currency": -839.15,
+            "amount_currency": -875.38,
             "debit": 0.0,
-            "credit": 839.15,
+            "credit": 875.38,
             "date_maturity": False,
         }
 
@@ -747,8 +752,8 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "tax_ids": [],
             "tax_line_id": False,
             "currency_id": self.company_data["currency"].id,
-            "amount_currency": 996.27,
-            "debit": 996.27,
+            "amount_currency": 1032.5,
+            "debit": 1032.5,
             "credit": 0.0,
             "date_maturity": fields.Date.from_string("2019-01-01"),
         }
@@ -761,9 +766,258 @@ class AccountMoveLucroPresumido(AccountMoveBRCommon):
             "fiscal_position_id": False,
             "payment_reference": "",
             "invoice_payment_term_id": self.pay_terms_a.id,
-            "amount_untaxed": 963.77,
+            "amount_untaxed": 1000.0,
             "amount_tax": 32.5,
-            "amount_total": 996.27,
+            "amount_total": 1032.5,
+        }
+
+        self.assertInvoiceValues(
+            self.move_out_venda_with_icms_reduction,
+            [
+                product_line_vals_1,
+                tax_line_vals_cofins,
+                tax_line_vals_icms,
+                tax_line_vals_ipi,
+                tax_line_vals_pis,
+                term_line_vals_1,
+            ],
+            move_vals,
+        )
+
+    def test_venda_with_icms_reduction_with_relief_deduct(self):
+        # Testando com Alivio do ICMS e indDeduzDeson = "1"
+        # (deduzir o alívio do total do documento).
+        prod_line = self.move_out_venda_with_icms_reduction.invoice_line_ids[0]
+        # Written through the move (not the line) so account.move's
+        # _sync_dynamic_lines recomputes amount_currency/debit/credit
+        # from the updated fiscal totals.
+        self.move_out_venda_with_icms_reduction.write(
+            {
+                "invoice_line_ids": [
+                    Command.update(
+                        prod_line.id,
+                        {
+                            "icms_relief_id": self.env.ref(
+                                "l10n_br_fiscal.icms_relief_1"
+                            ).id,
+                            "icms_relief_type": "1",
+                        },
+                    )
+                ]
+            }
+        )
+
+        self.assertEqual(
+            prod_line.fiscal_operation_line_id.name,
+            "Venda com ICMS 12 e Redução de 26,57",
+        )
+
+        # icms_relief_value = base(reduzida) * aliquota * redução / (1 - redução)
+        # = 734.30 * 0.12 * 0.2657 / (1 - 0.2657) = 31.88
+        self.assertAlmostEqual(prod_line.icms_relief_value, 31.88, places=2)
+
+        # price_total deve ser vProd + vIPI − vICMSDeson
+        # 1000.00 + 32.50 − 31.88 = 1000.62
+        price_total = 1000.62
+
+        product_line_vals_1 = {
+            "name": self.product_a.display_name,
+            "product_id": self.product_a.id,
+            "account_id": self.product_a.property_account_income_id.id,
+            "partner_id": self.partner_a.id,
+            "product_uom_id": self.product_a.uom_id.id,
+            "quantity": 1.0,
+            "discount": 0.0,
+            "price_unit": 1000.0,
+            "price_subtotal": 1000.0,
+            "price_total": price_total,
+            "tax_line_id": False,
+            "currency_id": self.company_data["currency"].id,
+            "amount_currency": -843.5,
+            "debit": 0.0,
+            "credit": 843.5,
+            "date_maturity": False,
+        }
+
+        tax_line_vals_cofins = {
+            "name": "COFINS",
+            "product_id": False,
+            "account_id": self.env["account.account"]
+            .search(
+                [
+                    ("name", "=", "COFINS a Recolher"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
+            .id,
+            "partner_id": self.partner_a.id,
+            "product_uom_id": False,
+            "quantity": False,
+            "discount": 0.0,
+            "price_unit": 0.0,
+            "price_subtotal": 0.0,
+            "price_total": 0.0,
+            "tax_ids": [],
+            "tax_line_id": self.env["account.tax"]
+            .search(
+                [
+                    ("name", "=", "COFINS Saida"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
+            .id,
+            "currency_id": self.company_data["currency"].id,
+            "amount_currency": -30.0,
+            "debit": 0.0,
+            "credit": 30.0,
+            "date_maturity": False,
+        }
+
+        tax_line_vals_icms = {
+            "name": "ICMS",
+            "product_id": False,
+            "account_id": self.env["account.account"]
+            .search(
+                [
+                    ("name", "=", "ICMS a Recolher"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
+            .id,
+            "partner_id": self.partner_a.id,
+            "product_uom_id": False,
+            "quantity": 0.0,
+            "discount": 0.0,
+            "price_unit": 0.0,
+            "price_subtotal": 0.0,
+            "price_total": 0.0,
+            "tax_ids": [],
+            "tax_line_id": self.env["account.tax"]
+            .search(
+                [
+                    ("name", "=", "ICMS Saida"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                order="id desc",
+                limit=1,
+            )
+            .id,
+            "currency_id": self.company_data["currency"].id,
+            "amount_currency": -88.12,
+            "debit": 0.0,
+            "credit": 88.12,
+            "date_maturity": False,
+        }
+
+        tax_line_vals_ipi = {
+            "name": "IPI",
+            "product_id": False,
+            "account_id": self.env["account.account"]
+            .search(
+                [
+                    ("name", "=", "IPI a Recolher"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                order="id ASC",
+                limit=1,
+            )
+            .id,
+            "partner_id": self.partner_a.id,
+            "product_uom_id": False,
+            "quantity": 0.0,
+            "discount": 0.0,
+            "price_unit": 0.0,
+            "price_subtotal": 0.0,
+            "price_total": 0.0,
+            "tax_ids": [],
+            "tax_line_id": self.env["account.tax"]
+            .search(
+                [
+                    ("name", "=", "IPI Saída"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                order="id desc",
+                limit=1,
+            )
+            .id,
+            "currency_id": self.company_data["currency"].id,
+            "amount_currency": -32.5,
+            "debit": 0.0,
+            "credit": 32.5,
+            "date_maturity": False,
+        }
+
+        tax_line_vals_pis = {
+            "name": "PIS",
+            "product_id": False,
+            "account_id": self.env["account.account"]
+            .search(
+                [
+                    ("name", "=", "PIS a Recolher"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                limit=1,
+            )
+            .id,
+            "partner_id": self.partner_a.id,
+            "product_uom_id": False,
+            "quantity": 0.0,
+            "discount": 0.0,
+            "price_unit": 0.0,
+            "price_subtotal": 0.0,
+            "price_total": 0.0,
+            "tax_ids": [],
+            "tax_line_id": self.env["account.tax"]
+            .search(
+                [
+                    ("name", "=", "PIS Saida"),
+                    ("company_id", "=", self.company_data["company"].id),
+                ],
+                order="id desc",
+                limit=1,
+            )
+            .id,
+            "currency_id": self.company_data["currency"].id,
+            "amount_currency": -6.5,
+            "debit": 0.0,
+            "credit": 6.5,
+            "date_maturity": False,
+        }
+
+        term_line_vals_1 = {
+            "name": "",
+            "product_id": False,
+            "account_id": self.company_data["default_account_receivable"].id,
+            "partner_id": self.partner_a.id,
+            "product_uom_id": False,
+            "quantity": 0.0,
+            "discount": 0.0,
+            "price_unit": 0.0,
+            "price_subtotal": 0.0,
+            "price_total": 0.0,
+            "tax_ids": [],
+            "tax_line_id": False,
+            "currency_id": self.company_data["currency"].id,
+            "amount_currency": 1000.62,
+            "debit": 1000.62,
+            "credit": 0.0,
+            "date_maturity": fields.Date.from_string("2019-01-01"),
+        }
+
+        move_vals = {
+            "partner_id": self.partner_a.id,
+            "currency_id": self.company_data["currency"].id,
+            "journal_id": self.company_data["default_journal_sale"].id,
+            "date": fields.Date.from_string("2019-01-01"),
+            "fiscal_position_id": False,
+            "payment_reference": "",
+            "invoice_payment_term_id": self.pay_terms_a.id,
+            "amount_untaxed": 968.12,
+            "amount_tax": 32.5,
+            "amount_total": 1000.62,
         }
 
         self.assertInvoiceValues(

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -336,6 +336,8 @@ class FiscalDocumentLineMixin(models.AbstractModel):
                 line.ipi_guideline_id = mapping_result["ipi_guideline"]
                 line.tax_classification_id = mapping_result["tax_classification"]
                 line.icms_tax_benefit_id = mapping_result["icms_tax_benefit_id"]
+                line.icms_relief_id = mapping_result["icms_relief_id"]
+                line.icms_relief_type = mapping_result["icms_relief_type"]
 
                 if line._is_imported():
                     continue
@@ -717,6 +719,11 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     def _onchange_icms_fields(self):
         if self.icms_tax_benefit_id:
             self.icms_tax_id = self.icms_tax_benefit_id.tax_id
+            self.icms_relief_id = self.icms_tax_benefit_id.icms_relief_id
+            self.icms_relief_type = self.icms_tax_benefit_id.icms_relief_type
+        else:
+            self.icms_relief_id = False
+            self.icms_relief_type = "0"
 
     @api.onchange("tax_classification_id")
     def _onchange_tax_classification_id(self):
@@ -924,7 +931,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
 
     @api.model
     def _rm_fields_to_amount(self):
-        return ["icms_relief_value"]
+        fields_to_remove = []
+        if self.icms_relief_type == "1":
+            fields_to_remove.append("icms_relief_value")
+        return fields_to_remove
 
     def _is_imported(self):
         # When the mixin is used for instance
@@ -1490,7 +1500,24 @@ class FiscalDocumentLineMixin(models.AbstractModel):
 
     # motDesICMS - Motivo da desoneração do ICMS
     icms_relief_id = fields.Many2one(
-        comodel_name="l10n_br_fiscal.icms.relief", string="ICMS Relief"
+        comodel_name="l10n_br_fiscal.icms.relief",
+        string="ICMS Relief",
+        compute="_compute_fiscal_tax_ids",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
+
+    # indDeduzDeson - Indicador de dedução do valor do ICMS desonerado
+    icms_relief_type = fields.Selection(
+        selection=[
+            ("0", "0 - Do not deduct the ICMS Relief"),
+            ("1", "1 -  Deduct ICMS Relief from Product Amount"),
+        ],
+        compute="_compute_fiscal_tax_ids",
+        store=True,
+        precompute=True,
+        readonly=False,
     )
 
     # vICMSDeson - Valor do ICMS desonerado

--- a/l10n_br_fiscal/models/document_mixin.py
+++ b/l10n_br_fiscal/models/document_mixin.py
@@ -399,6 +399,12 @@ class FiscalDocumentMixin(models.AbstractModel):
         store=True,
     )
 
+    amount_icms_relief_value = fields.Monetary(
+        string="ICMS Relief Value",
+        compute="_compute_fiscal_amount",
+        store=True,
+    )
+
     amount_icmsst_base = fields.Monetary(
         string="ICMS ST Base",
         compute="_compute_fiscal_amount",

--- a/l10n_br_fiscal/models/icms_regulation.py
+++ b/l10n_br_fiscal/models/icms_regulation.py
@@ -1986,9 +1986,14 @@ class ICMSRegulation(models.Model):
 
         return domain
 
-    def _tax_definition_search(self, domain, ncm, nbm, cest, product, ind_final=None):
+    def _tax_definition_search(
+        self, domain, ncm, nbm, cest, product, ind_final=None, exclude_benefit=False
+    ):
         tax_definitions = self.env["l10n_br_fiscal.tax.definition"]
         icms_defs = tax_definitions.search(domain)
+
+        if exclude_benefit:
+            icms_defs = icms_defs.filtered(lambda d: not d.is_benefit)
 
         if len(icms_defs) == 1:
             tax_definitions |= icms_defs
@@ -2048,6 +2053,7 @@ class ICMSRegulation(models.Model):
         cest=None,
         operation_line=None,
         ind_final=None,
+        exclude_benefit=False,
     ):
         self.ensure_one()
         icms_taxes = self.env["l10n_br_fiscal.tax"]
@@ -2070,7 +2076,13 @@ class ICMSRegulation(models.Model):
             )
 
             tax_definitions = self._tax_definition_search(
-                domain, ncm, nbm, cest, product, ind_final
+                domain,
+                ncm,
+                nbm,
+                cest,
+                product,
+                ind_final,
+                exclude_benefit=exclude_benefit,
             )
         return icms_taxes, tax_definitions
 

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -215,6 +215,8 @@ class OperationLine(models.Model):
     def _build_mapping_result_icms(self, mapping_result, tax_definition):
         if tax_definition and tax_definition.is_benefit:
             mapping_result["icms_tax_benefit_id"] = tax_definition.id
+            mapping_result["icms_relief_id"] = tax_definition.icms_relief_id.id
+            mapping_result["icms_relief_type"] = tax_definition.icms_relief_type
 
     def _build_mapping_result(self, mapping_result, tax_definition):
         mapping_result["taxes"][tax_definition.tax_domain] = tax_definition.tax_id
@@ -290,6 +292,10 @@ class OperationLine(models.Model):
               (l10n_br_fiscal.tax.ipi.guideline).
             - 'icms_tax_benefit_id': The determined ICMS tax benefit record
               ID (l10n_br_fiscal.tax.definition) or False.
+            - 'icms_relief_id': The determined ICMS relief record ID
+              (l10n_br_fiscal.icms.relief) or False.
+            - 'icms_relief_type': The determined indDeduzDeson indicator
+              ('0' or '1') for the ICMS relief.
             - 'tax_classification': The determined Tax Classification record
               (l10n_br_fiscal.tax.classification).
         """
@@ -298,6 +304,8 @@ class OperationLine(models.Model):
             "cfop": False,
             "ipi_guideline": self.env.ref("l10n_br_fiscal.tax_guideline_999"),
             "icms_tax_benefit_id": False,
+            "icms_relief_id": False,
+            "icms_relief_type": "0",
             "tax_classification": False,
         }
 

--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -549,25 +549,41 @@ class Tax(models.Model):
             )
 
         if kwargs.get("icms_relief_id") and cst["code"] in ICMS_CST_RELIEF:
-            icms_base = kwargs.get("price_unit", 0.00) * kwargs.get("quantity", 0.00)
+            icms_base = tax_dict.get("base")
             icms_percent = tax_dict.get("percent_amount", 0.00) / 100
             icms_reduction = tax_dict.get("percent_reduction", 0.00) / 100
-            if cst["code"] in ["30", "40"]:
-                icms_relief = icms_base * icms_percent
-                tax_dict.update({"icms_relief": icms_relief})
-            elif cst["code"] in ["20", "70"]:
-                icms_relief = (
-                    icms_base
-                    * (1 - (icms_percent * (1 - icms_reduction)))
-                    / (1 - icms_percent)
-                    - icms_base
+            icms_relief_value = 0.0
+            if float_is_zero(tax_dict.get("base", 0.00), currency.decimal_places):
+                if not icms_percent and company.icms_regulation_id:
+                    (
+                        _standard_taxes,
+                        standard_defs,
+                    ) = company.icms_regulation_id._map_tax_def_icms(
+                        company,
+                        partner,
+                        product,
+                        ncm=ncm,
+                        nbm=nbm,
+                        cest=cest,
+                        operation_line=operation_line,
+                        ind_final=ind_final,
+                        exclude_benefit=True,
+                    )
+                    standard_tax = standard_defs.mapped("tax_id")[:1]
+                    if standard_tax:
+                        standard_tax_dict = {
+                            standard_tax.tax_domain: dict(TAX_DICT_VALUES)
+                        }
+                        standard_tax_dict = self._compute_tax(
+                            standard_tax, standard_tax_dict, **kwargs
+                        )
+                        icms_relief_value = standard_tax_dict.get("tax_value")
+            elif not float_is_zero(1 - icms_reduction, currency.decimal_places):
+                icms_relief_value = (
+                    icms_base * icms_percent * icms_reduction / (1 - icms_reduction)
                 )
-                tax_dict.update({"icms_relief": icms_relief})
-            else:
-                icms_relief = (icms_base / (1 - icms_percent)) * icms_percent
-                tax_dict.update({"icms_relief": icms_relief})
-        else:
-            tax_dict.update({"icms_relief": 0})
+
+            tax_dict.update({"icms_relief": icms_relief_value})
 
         return taxes_dict
 

--- a/l10n_br_fiscal/models/tax_definition.py
+++ b/l10n_br_fiscal/models/tax_definition.py
@@ -300,6 +300,18 @@ class TaxDefinition(models.Model):
         states={"draft": [("readonly", False)]},
     )
 
+    icms_relief_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.icms.relief", string="ICMS Relief"
+    )
+
+    icms_relief_type = fields.Selection(
+        selection=[
+            ("0", "0 - Do not deduct the ICMS Relief"),
+            ("1", "1 -  Deduct ICMS Relief from Product Amount"),
+        ],
+        default="0",
+    )
+
     def _get_search_domain(self, tax_definition):
         """Create domain to be used in contraints methods"""
         domain = [

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -8,6 +8,7 @@ from . import (
     test_fiscal_tax,
     test_tax_classification,
     test_tax_benefit,
+    test_tax_icms_relief,
     test_document_edition,
     test_ibpt_product,
     test_ibpt_service,

--- a/l10n_br_fiscal/tests/test_tax_icms_relief.py
+++ b/l10n_br_fiscal/tests/test_tax_icms_relief.py
@@ -1,0 +1,55 @@
+# Copyright 2026 Akretion - Renato Lima <renato.lima@akretion.com.br>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import Command
+from odoo.tests import TransactionCase
+
+
+class TestTaxIcmsRelief(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.nfe_tax_benefit = cls.env.ref("l10n_br_fiscal.demo_nfe_tax_benefit")
+        cls.icms_relief = cls.env.ref("l10n_br_fiscal.icms_relief_9")
+        cls.tax_benefit = cls.env["l10n_br_fiscal.tax.definition"].create(
+            {
+                "icms_regulation_id": cls.env.ref(
+                    "l10n_br_fiscal.tax_icms_regulation"
+                ).id,
+                "tax_group_id": cls.env.ref("l10n_br_fiscal.tax_group_icms").id,
+                "code": "SP810002",
+                "name": "TAX BENEFIT DEMO RELIEF",
+                "description": "TAX BENEFIT DEMO RELIEF",
+                "benefit_type": "1",
+                "is_benefit": True,
+                "is_taxed": True,
+                "is_debit_credit": True,
+                "custom_tax": True,
+                "icms_relief_id": cls.icms_relief.id,
+                "tax_id": cls.env.ref("l10n_br_fiscal.tax_icms_12_red_26_57").id,
+                "cst_id": cls.env.ref("l10n_br_fiscal.cst_icms_20").id,
+                "state_from_id": cls.env.ref("base.state_br_sp").id,
+                "state_to_ids": [Command.set(cls.env.ref("base.state_br_mg").ids)],
+                "ncms": "73269090",
+                "ncm_ids": [
+                    Command.set(cls.env.ref("l10n_br_fiscal.ncm_73269090").ids)
+                ],
+                "state": "approved",
+            }
+        )
+        # force update
+        cls.nfe_tax_benefit.fiscal_line_ids._compute_fiscal_tax_ids()
+
+    def test_nfe_tax_icms_relief(self):
+        """Test NFe document line gets icms_relief_id from the tax benefit."""
+        for line in self.nfe_tax_benefit.fiscal_line_ids:
+            self.assertEqual(
+                line.icms_tax_benefit_id,
+                self.tax_benefit,
+                "Document line must have tax benefit",
+            )
+            self.assertEqual(
+                line.icms_relief_id,
+                self.icms_relief,
+                "Document line must have ICMS relief",
+            )

--- a/l10n_br_fiscal/views/document_line_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_line_mixin_view.xml
@@ -282,7 +282,7 @@
                                 <group name="icms" string="ICMS">
                                     <field
                                         name="icms_tax_id"
-                                        attrs="{'invisible': [('tax_framework', 'in', ('1', '2'))]}"
+                                        attrs="{'invisible': [('tax_framework', 'in', ('1', '2'))], 'readonly': [('icms_tax_benefit_id', '!=', False)]}"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
                                     <field
@@ -367,6 +367,11 @@
                                         />
                                         <field
                                             name="icms_relief_id"
+                                            force_save="1"
+                                            attrs="{'readonly': [('icms_tax_id', '!=', False), ('icms_cst_code', 'not in', ('20', '30', '40', '41', '50', '70', '90'))], 'invisible': ['|', ('tax_framework', 'in', ('1', '2')), ('icms_cst_code', 'not in', ('20', '30', '40', '41', '50', '70', '90'))]}"
+                                        />
+                                        <field
+                                            name="icms_relief_type"
                                             force_save="1"
                                             attrs="{'readonly': [('icms_tax_id', '!=', False), ('icms_cst_code', 'not in', ('20', '30', '40', '41', '50', '70', '90'))], 'invisible': ['|', ('tax_framework', 'in', ('1', '2')), ('icms_cst_code', 'not in', ('20', '30', '40', '41', '50', '70', '90'))]}"
                                         />

--- a/l10n_br_fiscal/views/tax_definition_view.xml
+++ b/l10n_br_fiscal/views/tax_definition_view.xml
@@ -119,6 +119,11 @@
                             name="benefit_type"
                             attrs="{'required': [('is_benefit', '!=', False)]}"
                         />
+                        <field
+                            name="icms_relief_id"
+                            options="{'no_create': True, 'no_create_edit': True}"
+                        />
+                        <field name="icms_relief_type" />
                     </group>
                     <group name="state" string="State">
                         <field

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -503,7 +503,7 @@ class NFe(spec_models.StackedModel):
 
     nfe40_vICMS = fields.Monetary(related="amount_icms_value")
 
-    # <vICMSDeson>0.00</vICMSDeson> TODO
+    nfe40_vICMSDeson = fields.Monetary(related="amount_icms_relief_value")
 
     nfe40_vFCPUFDest = fields.Monetary(related="amount_icmsfcp_value")
 

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -770,6 +770,7 @@ class NFeLine(spec_models.StackedModel):
                     # DESONERAÇÃO DO IMCS
                     "vICMSDeson": f"{self.icms_relief_value:.2f}",
                     "motDesICMS": self.icms_relief_id.code,
+                    "indDeduzDeson": self.icms_relief_type,
                 }
             )
         return icms


### PR DESCRIPTION
## Resumo

Adiciona suporte completo à **desoneração do ICMS** (`motDesICMS`, `vICMSDeson` e `indDeduzDeson`) na localização fiscal brasileira, cobrindo configuração, propagação automática para a linha do documento fiscal e emissão da NF-e (`l10n_br_fiscal` + `l10n_br_nfe`).

Antes, a desoneração do ICMS só podia ser configurada manualmente, linha a linha, e o total do cabeçalho da NF-e (`ICMSTot/vICMSDeson`) nunca era calculado/exportado (estava como `TODO`). O próprio valor desonerado também era calculado errado nos casos de isenção e de redução de base de cálculo.

## O que há de novo

### Configuração (`l10n_br_fiscal.tax.definition`)

- Novos campos `icms_relief_id` (motivo da desoneração, `l10n_br_fiscal.icms.relief`) e `icms_relief_type` (`indDeduzDeson`: `0` - não deduz / `1` - deduz do total da nota), configuráveis na seção de benefício fiscal ("Tax Benefit") de uma Tax Definition.
- Esses campos passam a ser a fonte única de verdade para um benefício fiscal: uma vez configurados em um `tax.definition` com `is_benefit=True`, eles se propagam automaticamente — sem necessidade de seleção manual por linha.

### Propagação automática para a linha do documento fiscal

- `l10n_br_fiscal.operation.line._build_mapping_result_icms` agora copia `icms_relief_id` e `icms_relief_type` da `tax.definition` de benefício encontrada para o resultado do mapeamento de impostos, junto com o já existente `icms_tax_benefit_id`.
- `document_line_mixin._compute_fiscal_tax_ids` atribui esses valores automaticamente na linha do documento (mesmo padrão `compute`/`store`/`precompute`/`readonly=False` já usado em `icms_tax_benefit_id`), então os campos vêm pré-preenchidos mas continuam editáveis manualmente.
- `_onchange_icms_fields` foi estendido: selecionar `icms_tax_benefit_id` na linha também já preenche `icms_relief_id`/`icms_relief_type` imediatamente; ao remover o benefício, ambos voltam para vazio/`"0"` (antes ficavam presos com dados do benefício removido).

### `indDeduzDeson` — dedução do total do documento

- `_rm_fields_to_amount` agora remove `icms_relief_value` do total financeiro do documento **somente quando `icms_relief_type == "1"`** (deduzir do total), respeitando o significado real do indicador `indDeduzDeson` da SEFAZ.

### Emissão da NF-e (`l10n_br_nfe`)

- `nfe40_vICMSDeson` (total do cabeçalho `ICMSTot/vICMSDeson`) agora é calculado e exportado — antes era um `TODO`, sempre `0.00`. Baseado em um novo campo agregado `amount_icms_relief_value` em `document_mixin`, somado automaticamente a partir do `icms_relief_value` das linhas (usa o mecanismo de auto-agregação de campos `amount_*` que já existe no módulo).
- A exportação por item (`det/imposto/ICMSxx/indDeduzDeson`) já existia e agora recebe um valor calculado corretamente.

### Cálculo correto do valor desonerado (`l10n_br_fiscal.tax._compute_icms`)

O cálculo da desoneração produzia valores errados (ou zerados) em dois cenários:

1. **Isenção (CST 30/40)**: o imposto aplicado ("ICMS Isento") tem `percent_amount = 0`, então multiplicá-lo pela base sempre resultava em `icms_relief = 0`. Corrigido buscando o imposto padrão que se aplicaria sem o benefício, através de um novo parâmetro `exclude_benefit` em `icms_regulation._map_tax_def_icms` / `_tax_definition_search` (filtra as tax definitions com `is_benefit` antes da lógica de prioridade específico/genérico), calculando o `tax_value` desse imposto padrão com a própria engine `_compute_tax`.
2. **Redução de base de cálculo (CST 20/70/…)**: a base usada na fórmula (`tax_dict["base"]`) é a base **já reduzida**, mas a fórmula foi herdada de uma versão anterior que esperava a base **bruta** — produzindo um valor de desoneração errado (validado com um exemplo real: esperado R$ 17,98, calculado R$ 15,01). Corrigido com a fórmula fechada correta para uma base já reduzida:
   `icms_relief_value = icms_base * icms_percent * icms_reduction / (1 - icms_reduction)`

### Correção de UX

- `icms_tax_id` na linha do documento passa a ficar **readonly** sempre que `icms_tax_benefit_id` estiver preenchido. Antes era possível editá-lo manualmente com um benefício selecionado, e o Odoo reafirmava silenciosamente o imposto do benefício no próximo recompute — deixando `icms_base`/`icms_percent`/`icms_value` calculados para um imposto que não estava mais realmente aplicado. Agora é preciso remover o benefício primeiro para escolher outro imposto.

### Testes

- Novo `l10n_br_fiscal/tests/test_tax_icms_relief.py`: verifica que uma `tax.definition` de benefício com `icms_relief_id` preenchido propaga automaticamente tanto `icms_tax_benefit_id` quanto `icms_relief_id` para a linha do documento.

## Arquivos alterados

- `l10n_br_fiscal/models/tax_definition.py` — campos `icms_relief_id`, `icms_relief_type`
- `l10n_br_fiscal/models/operation_line.py` — mapeamento dos campos de desoneração a partir da definição de benefício
- `l10n_br_fiscal/models/document_line_mixin.py` — preenchimento/limpeza automáticos na linha, efeito do `indDeduzDeson` no total
- `l10n_br_fiscal/models/document_mixin.py` — agregado `amount_icms_relief_value`
- `l10n_br_fiscal/models/icms_regulation.py` — parâmetro `exclude_benefit` para busca da alíquota padrão
- `l10n_br_fiscal/models/tax.py` — cálculo correto da desoneração para isenção e redução de base
- `l10n_br_fiscal/views/tax_definition_view.xml` — UI de configuração
- `l10n_br_fiscal/views/document_line_mixin_view.xml` — UI da linha (`icms_relief_type`, correção do readonly)
- `l10n_br_fiscal/tests/test_tax_icms_relief.py` — novo teste
- `l10n_br_nfe/models/document.py` — campo `nfe40_vICMSDeson` do cabeçalho
- `l10n_br_nfe/models/document_line.py` — exportação por item do `indDeduzDeson`

## Plano de testes

- [x] `TestTaxIcmsRelief` / `TestTaxBenefit` — preenchimento automático de `icms_tax_benefit_id`/`icms_relief_id` a partir de uma `tax.definition` de benefício
- [x] `TestNFeExportLC` / `TestNFeExportSN` — serialização do XML da NF-e continua batendo com os fixtures (agora com `vICMSDeson` do cabeçalho preenchido)
- [x] Verificação manual: cenário de isenção (estilo SUFRAMA) e cenário de redução de base (ICMS 12% com redução de 26,57%) produzem os valores de desoneração esperados, validado contra um exemplo real
