### PR TITLE
[16.0] l10n br fiscal: Vigência de datas nas parametrizações fiscais

### DIFF
--- a/l10n_br_fiscal/data/ir_cron.xml
+++ b/l10n_br_fiscal/data/ir_cron.xml
@@ -35,4 +35,23 @@
             <field name="code">model._scheduled_update()</field>
         </record>
 
+        <record
+        forcecreate="True"
+        id="l10n_br_fiscal_expire_parametrization_cron"
+        model="ir.cron"
+    >
+            <field name="name">Expire Fiscal Parametrization</field>
+            <field name="state">code</field>
+            <field name="user_id" ref="base.user_root" />
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="numbercall">-1</field>
+            <field name="model_id" ref="model_l10n_br_fiscal_data_abstract" />
+            <field name="code">model._cron_expire_fiscal_parametrization()</field>
+            <field
+            name="nextcall"
+            eval="(DateTime.now()).strftime('%Y-%m-%d 00:01:00')"
+        />
+        </record>
+
 </odoo>

--- a/l10n_br_fiscal/models/data_abstract.py
+++ b/l10n_br_fiscal/models/data_abstract.py
@@ -10,6 +10,8 @@ from odoo import _, api, fields, models
 from odoo.exceptions import AccessError
 from odoo.osv import expression
 
+from .. import tools
+
 
 class DataAbstract(models.AbstractModel):
     """
@@ -64,6 +66,46 @@ class DataAbstract(models.AbstractModel):
         if not self.env.user.has_group("l10n_br_fiscal.group_manager"):
             raise AccessError(_("You don't have permission to unarchive records."))
         return super().action_unarchive()
+
+    @api.model
+    def _get_invalid_records(self):
+        """Return active records whose validity window (date_start/date_end)
+        does not include today."""
+        today = fields.Date.context_today(self)
+        active_records = self.search([("active", "=", True)])
+        valid_records = self.search(
+            [("active", "=", True)] + tools.date_validity_domain(today)
+        )
+        return active_records - valid_records
+
+    @api.model
+    def _expire_invalid_records(self):
+        """Deactivate records that fell outside their date validity window."""
+        invalid_records = self._get_invalid_records()
+        if invalid_records:
+            invalid_records.write({"active": False})
+
+    @api.model
+    def _cron_expire_fiscal_parametrization(self):
+        """Daily cron entry point: deactivate fiscal master data outside
+        their validity window, and mark expired fiscal operation lines and
+        tax definitions.
+
+        Iterates every concrete model that inherits from this abstract
+        model (NCM, NBS, CFOP, CST, CEST, NBM, ...), including through the
+        intermediate `data.product.abstract` / `data.ncm.nbs.abstract`
+        abstractions.
+        """
+        abstract_class = self.pool["l10n_br_fiscal.data.abstract"]
+        for model_name, model_class in self.pool.models.items():
+            if model_class._abstract or model_class._transient:
+                continue
+            if not issubclass(model_class, abstract_class):
+                continue
+            self.env[model_name]._expire_invalid_records()
+
+        self.env["l10n_br_fiscal.operation.line"]._expire_invalid_lines()
+        self.env["l10n_br_fiscal.tax.definition"]._expire_invalid_definitions()
 
     @api.depends("code")
     def _compute_code_unmasked(self):

--- a/l10n_br_fiscal/models/icms_regulation.py
+++ b/l10n_br_fiscal/models/icms_regulation.py
@@ -5,6 +5,7 @@ from lxml import etree
 
 from odoo import api, fields, models
 
+from .. import tools
 from ..constants.fiscal import (
     FINAL_CUSTOMER_YES,
     FISCAL_IN,
@@ -1943,6 +1944,7 @@ class ICMSRegulation(models.Model):
             ("ind_final", "=", ind_final),
             ("ind_final", "=", False),
         ]
+        domain += tools.date_validity_domain(fields.Datetime.now())
 
         if tax_group_icms.tax_domain in (TAX_DOMAIN_ICMS, TAX_DOMAIN_ICMS_ST):
             domain += [

--- a/l10n_br_fiscal/models/operation.py
+++ b/l10n_br_fiscal/models/operation.py
@@ -4,6 +4,7 @@
 from odoo import _, fields, models
 from odoo.exceptions import UserError
 
+from .. import tools
 from ..constants.fiscal import (
     EDOC_PURPOSE,
     EDOC_PURPOSE_NORMAL,
@@ -230,14 +231,7 @@ class Operation(models.Model):
             ("state", "=", "approved"),
         ]
 
-        domain += [
-            "|",
-            ("date_start", "=", False),
-            ("date_start", "<=", fields.Datetime.now()),
-            "|",
-            ("date_end", "=", False),
-            ("date_end", ">=", fields.Datetime.now()),
-        ]
+        domain += tools.date_validity_domain(fields.Datetime.now())
 
         domain += [
             "|",

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -4,6 +4,7 @@
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
+from .. import tools
 from ..constants.fiscal import (
     CFOP_DESTINATION_EXPORT,
     FISCAL_COMMENT_LINE,
@@ -176,6 +177,19 @@ class OperationLine(models.Model):
                 or line.cfop_external_id.is_icmsst
                 or line.cfop_export_id.is_icmsst
             )
+
+    @api.model
+    def _expire_invalid_lines(self):
+        """Mark as 'expired' operation lines outside their date validity
+        window (date_start/date_end)."""
+        today = fields.Datetime.now()
+        candidates = self.search([("state", "!=", "expired")])
+        valid = self.search(
+            [("state", "!=", "expired")] + tools.date_validity_domain(today)
+        )
+        expired = candidates - valid
+        if expired:
+            expired.write({"state": "expired"})
 
     def get_document_type(self, company):
         self.ensure_one()

--- a/l10n_br_fiscal/models/tax_definition.py
+++ b/l10n_br_fiscal/models/tax_definition.py
@@ -348,6 +348,19 @@ class TaxDefinition(models.Model):
     def action_draft(self):
         self.write({"state": "draft"})
 
+    @api.model
+    def _expire_invalid_definitions(self):
+        """Mark as 'expired' tax definitions outside their date validity
+        window (date_start/date_end)."""
+        today = fields.Datetime.now()
+        candidates = self.search([("state", "!=", "expired")])
+        valid = self.search(
+            [("state", "!=", "expired")] + tools.date_validity_domain(today)
+        )
+        expired = candidates - valid
+        if expired:
+            expired.write({"state": "expired"})
+
     def unlink(self):
         operations = self.filtered(lambda line: line.state == "approved")
         if operations:
@@ -506,6 +519,9 @@ class TaxDefinition(models.Model):
         domain = [
             ("state", "!=", "expired"),
             ("id", "in", self.ids),
+        ]
+        domain += tools.date_validity_domain(fields.Datetime.now())
+        domain += [
             "|",
             ("state_to_ids", "=", False),
             ("state_to_ids", "=", partner.state_id.id),

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -17,4 +17,5 @@ from . import (
     test_service_type,
     test_operation,
     test_tax_framework,
+    test_fiscal_validity,
 )

--- a/l10n_br_fiscal/tests/test_fiscal_validity.py
+++ b/l10n_br_fiscal/tests/test_fiscal_validity.py
@@ -1,0 +1,135 @@
+# Copyright 2026 Akretion - Renato Lima <renato.lima@akretion.com.br>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import Command, fields
+from odoo.tests import TransactionCase
+
+
+class TestFiscalDataValidity(TransactionCase):
+    """Validity window (date_start/date_end) for `l10n_br_fiscal.data.abstract`
+    descendants, exercised through `l10n_br_fiscal.ncm`."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.Ncm = cls.env["l10n_br_fiscal.ncm"]
+        cls.today = fields.Date.context_today(cls.Ncm)
+
+    def _create_ncm(self, code, **kwargs):
+        vals = {"code": code, "name": "Test NCM %s" % code}
+        vals.update(kwargs)
+        return self.Ncm.create(vals)
+
+    def test_no_dates_stay_active(self):
+        ncm = self._create_ncm("11111111")
+        ncm._expire_invalid_records()
+        self.assertTrue(ncm.active)
+
+    def test_future_start_date_expires(self):
+        ncm = self._create_ncm(
+            "22222222", date_start=fields.Date.add(self.today, days=5)
+        )
+        ncm._expire_invalid_records()
+        self.assertFalse(ncm.active)
+
+    def test_past_end_date_expires(self):
+        ncm = self._create_ncm(
+            "33333333", date_end=fields.Date.subtract(self.today, days=1)
+        )
+        ncm._expire_invalid_records()
+        self.assertFalse(ncm.active)
+
+    def test_within_range_stays_active(self):
+        ncm = self._create_ncm(
+            "44444444",
+            date_start=fields.Date.subtract(self.today, days=1),
+            date_end=fields.Date.add(self.today, days=1),
+        )
+        ncm._expire_invalid_records()
+        self.assertTrue(ncm.active)
+
+    def test_only_start_date_in_the_past_stays_active(self):
+        ncm = self._create_ncm(
+            "55555555", date_start=fields.Date.subtract(self.today, days=1)
+        )
+        ncm._expire_invalid_records()
+        self.assertTrue(ncm.active)
+
+    def test_cron_expires_across_fiscal_data_models(self):
+        expired_ncm = self._create_ncm(
+            "66666666", date_end=fields.Date.subtract(self.today, days=1)
+        )
+        valid_ncm = self._create_ncm("77777777")
+        self.env["l10n_br_fiscal.data.abstract"]._cron_expire_fiscal_parametrization()
+        self.assertFalse(expired_ncm.active)
+        self.assertTrue(valid_ncm.active)
+
+
+class TestOperationLineValidity(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.line = self.env.ref("l10n_br_fiscal.fo_venda_venda")
+        self.today = fields.Datetime.now()
+
+    def test_expired_line_is_marked_expired(self):
+        self.line.state = "approved"
+        self.line.date_end = fields.Datetime.subtract(self.today, hours=1)
+        self.env["l10n_br_fiscal.operation.line"]._expire_invalid_lines()
+        self.assertEqual(self.line.state, "expired")
+
+    def test_valid_line_is_not_marked_expired(self):
+        self.line.state = "approved"
+        self.line.date_start = False
+        self.line.date_end = False
+        self.env["l10n_br_fiscal.operation.line"]._expire_invalid_lines()
+        self.assertEqual(self.line.state, "approved")
+
+
+class TestTaxDefinitionValidity(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.today = fields.Datetime.now()
+
+    def _create_tax_definition(self, code, **kwargs):
+        vals = {
+            "tax_group_id": self.env.ref("l10n_br_fiscal.tax_group_icms").id,
+            "code": code,
+            "name": "Test Tax Definition %s" % code,
+            "state": "approved",
+        }
+        vals.update(kwargs)
+        return self.env["l10n_br_fiscal.tax.definition"].create(vals)
+
+    def test_expired_definition_is_marked_expired(self):
+        tax_definition = self._create_tax_definition(
+            "TDV001",
+            date_end=fields.Datetime.subtract(self.today, hours=1),
+        )
+        self.env["l10n_br_fiscal.tax.definition"]._expire_invalid_definitions()
+        self.assertEqual(tax_definition.state, "expired")
+
+    def test_valid_definition_is_not_marked_expired(self):
+        tax_definition = self._create_tax_definition("TDV002")
+        self.env["l10n_br_fiscal.tax.definition"]._expire_invalid_definitions()
+        self.assertEqual(tax_definition.state, "approved")
+
+    def test_map_tax_definition_excludes_out_of_validity_records(self):
+        tax_definition = self._create_tax_definition(
+            "TDV003",
+            date_start=fields.Datetime.add(self.today, days=5),
+            state_from_id=self.env.ref("base.state_br_sp").id,
+            state_to_ids=[Command.set(self.env.ref("base.state_br_mg").ids)],
+        )
+        company = self.env.ref("l10n_br_base.empresa_lucro_presumido")
+        partner = self.env.ref("l10n_br_base.res_partner_cliente9_mg")
+        product = self.env.ref("product.product_product_7")
+        result = tax_definition.map_tax_definition(
+            company,
+            partner,
+            product,
+            city_taxation_code=self.env["l10n_br_fiscal.city.taxation.code"],
+            national_taxation_code=self.env["l10n_br_fiscal.national.taxation.code"],
+            service_type=self.env["l10n_br_fiscal.service.type"],
+        )
+        self.assertNotIn(tax_definition, result)

--- a/l10n_br_fiscal/tools.py
+++ b/l10n_br_fiscal/tools.py
@@ -53,6 +53,25 @@ def domain_field_codes(
     return domain
 
 
+def date_validity_domain(
+    reference_date, date_start_field="date_start", date_end_field="date_end"
+):
+    """Domain fragment matching records valid on `reference_date`.
+
+    A record is considered valid when it has no start date or the start
+    date is not after `reference_date`, and it has no end date or the end
+    date is not before `reference_date`.
+    """
+    return [
+        "|",
+        (date_start_field, "=", False),
+        (date_start_field, "<=", reference_date),
+        "|",
+        (date_end_field, "=", False),
+        (date_end_field, ">=", reference_date),
+    ]
+
+
 def path_edoc_company(company_id):
     db_name = company_id._cr.dbname
     filestore = tools.config.filestore(db_name)


### PR DESCRIPTION
# Vigência de datas nas parametrizações fiscais

As tabelas fiscais (`l10n_br_fiscal.ncm`, `cfop`, `cst`, `cest`, `nbm`, `nbs`, ...), as linhas de operação fiscal (`l10n_br_fiscal.operation.line`) e as definições tributárias (`l10n_br_fiscal.tax.definition`) já tinham campos `date_start`/`date_end` havia tempo, mas com usos desiguais:

- `operation.line` já respeitava essas datas na hora de escolher a linha de operação (`_line_domain`).
- `tax.definition` **nunca** checava as datas ao mapear a tributação de uma linha de documento (`map_tax_definition`, e o caminho de ICMS em `icms_regulation._build_map_tax_def_domain`) — uma definição tributária com `date_end` vencido continuava sendo aplicada normalmente.
- Não existia nenhuma rotina que marcasse um registro como "fora de vigência" — o campo só existia para consulta manual, sem nenhum efeito prático além da constraint que impede `date_end < date_start`.

## A solução

Dois mecanismos complementares, atuando em conjunto:

1. **Filtro no momento do mapeamento** — garante corretude imediata: um registro fora da janela de vigência nunca é selecionado, mesmo que o cron ainda não tenha rodado naquele dia.
2. **Cron diário (00:01)** — garante visibilidade/limpeza: desativa/expira os registros que saíram de vigência, para que apareçam corretamente no cadastro (arquivado ou com estado "Expired") em vez de ficarem silenciosamente invisíveis apenas pelo filtro de busca.

A regra de vigência é sempre a mesma, em todos os pontos:

> Um registro é válido na data de referência quando **não tem `date_start` OU `date_start` não é depois dela**, **E não tem `date_end` OU `date_end` não é antes dela**.

Isso cobre os quatro casos pedidos: sem nenhuma data, só `date_start`, só `date_end`, ou as duas.

---

## Commit 1 — `data.abstract`: métodos de expiração + orquestrador do cron

**Arquivos:** `l10n_br_fiscal/tools.py`, `l10n_br_fiscal/models/data_abstract.py`

### `tools.date_validity_domain()`

Novo helper reutilizável que constrói o fragmento de domínio da regra de vigência acima, parametrizado pelo nome dos campos de data (por padrão `date_start`/`date_end`) e pela data de referência:

```python
def date_validity_domain(reference_date, date_start_field="date_start", date_end_field="date_end"):
    return [
        "|", (date_start_field, "=", False), (date_start_field, "<=", reference_date),
        "|", (date_end_field, "=", False), (date_end_field, ">=", reference_date),
    ]
```

Esse helper é a peça central: todos os outros commits só o consomem, evitando reescrever a mesma lógica de domínio em cada modelo.

### `data.abstract._get_invalid_records()` / `_expire_invalid_records()`

Em `l10n_br_fiscal.data.abstract` — herdado por **todos** os objetos de tabela fiscal (NCM, CFOP, CST, CEST, NBM, NBS, e por tabela nova que venha a herdar desse abstrato no futuro):

- `_get_invalid_records()`: retorna os registros atualmente `active=True` cuja janela de vigência não inclui hoje (via um `search` com e sem o filtro de vigência, e subtração de recordsets).
- `_expire_invalid_records()`: chama o método acima e desativa (`active=False`) o que encontrar.

Usar o campo `active` aqui é deliberado: é o mecanismo nativo do Odoo para "esconder sem apagar" — o registro some das buscas/pickers padrão automaticamente, sem precisar adicionar filtro extra em lugar nenhum.

### `data.abstract._cron_expire_fiscal_parametrization()`

Ponto de entrada único do cron (ver commit 3). Em vez de listar manualmente cada modelo de tabela fiscal, ele **descobre dinamicamente** todos os modelos concretos que herdam de `l10n_br_fiscal.data.abstract`, percorrendo o registry de modelos do Odoo e testando `issubclass`:

```python
abstract_class = self.pool["l10n_br_fiscal.data.abstract"]
for model_name, model_class in self.pool.models.items():
    if model_class._abstract or model_class._transient:
        continue
    if not issubclass(model_class, abstract_class):
        continue
    self.env[model_name]._expire_invalid_records()
```

Como a herança Python é transitiva, isso cobre automaticamente `l10n_br_fiscal.data.product.abstract` e `l10n_br_fiscal.data.ncm.nbs.abstract` (e qualquer NCM/NBS que herde deles) sem precisar de nenhum caso especial — e continua funcionando se um módulo futuro adicionar uma nova tabela fiscal baseada no mesmo abstrato.

Em seguida, chama a expiração de `operation.line` e `tax.definition` (implementadas no commit 2), que usam `state` em vez de `active` — ver próxima seção.

---

## Commit 2 — vigência no mapeamento de `operation.line`, `tax.definition` e `icms.regulation`

**Arquivos:** `l10n_br_fiscal/models/operation.py`, `operation_line.py`, `tax_definition.py`, `icms_regulation.py`

### `operation.py` — refatoração (sem mudança de comportamento)

`_line_domain()` já filtrava por vigência, mas com a lógica escrita à mão. Trocado pelo helper novo:

```python
domain += tools.date_validity_domain(fields.Datetime.now())
```

Mesmo resultado, agora compartilhando a mesma implementação usada nos outros modelos (uma única fonte de verdade para a regra).

### `operation_line.py` — `_expire_invalid_lines()`

`operation.line` não tem campo `active` — usa `state` (`draft` / `review` / `approved` / **`expired`**, esse último já existia como opção de seleção, mas nunca era atribuído automaticamente). O novo método marca como `expired` toda linha fora da vigência:

```python
def _expire_invalid_lines(self):
    today = fields.Datetime.now()
    candidates = self.search([("state", "!=", "expired")])
    valid = self.search([("state", "!=", "expired")] + tools.date_validity_domain(today))
    expired = candidates - valid
    if expired:
        expired.write({"state": "expired"})
```

### `tax_definition.py` — `_expire_invalid_definitions()` + filtro no `map_tax_definition()`

Mesma lógica de expiração (`state = "expired"`) que em `operation_line.py`.

Além disso — e esse é o ponto que faltava — `map_tax_definition()`, usado para determinar qual definição tributária se aplica a uma linha de documento, ganhou o filtro de vigência no domínio de busca:

```python
domain = [
    ("state", "!=", "expired"),
    ("id", "in", self.ids),
]
domain += tools.date_validity_domain(fields.Datetime.now())
domain += [...]  # demais critérios (NCM, CEST, estado de destino, etc.)
```

Antes, uma `tax.definition` com `date_end` vencido continuava sendo escolhida normalmente até o cron rodar (e o cron nem existia). Agora ela é excluída da busca imediatamente, no mesmo instante em que a linha de documento é computada.

### `icms_regulation.py` — filtro em `_build_map_tax_def_domain()`

O ICMS tem um segundo caminho de busca de `tax.definition`, específico do `icms.regulation` (usado por ICMS normal, ICMS-ST, DIFAL e FCP). Recebeu o mesmo filtro:

```python
domain += tools.date_validity_domain(fields.Datetime.now())
```

Sem isso, uma definição de ICMS fora de vigência continuaria sendo aplicada por esse caminho mesmo com o filtro do `map_tax_definition()` já corrigido, já que são buscas independentes.

---

## Commit 3 — o cron e os testes

**Arquivos:** `l10n_br_fiscal/data/ir_cron.xml`, `l10n_br_fiscal/tests/__init__.py`, `l10n_br_fiscal/tests/test_fiscal_validity.py`

### O cron

Um único `ir.cron`, rodando diariamente a partir das 00:01, apontando para o modelo abstrato `l10n_br_fiscal.data.abstract` e chamando o orquestrador do commit 1:

```xml
<record forcecreate="True" id="l10n_br_fiscal_expire_parametrization_cron" model="ir.cron">
    <field name="name">Expire Fiscal Parametrization</field>
    <field name="state">code</field>
    <field name="user_id" ref="base.user_root" />
    <field name="interval_number">1</field>
    <field name="interval_type">days</field>
    <field name="numbercall">-1</field>
    <field name="model_id" ref="model_l10n_br_fiscal_data_abstract" />
    <field name="code">model._cron_expire_fiscal_parametrization()</field>
    <field name="nextcall" eval="(DateTime.now()).strftime('%Y-%m-%d 00:01:00')" />
</record>
```

Apontar para um modelo abstrato funciona normalmente no Odoo — não é possível ter registros de `data.abstract` em si, mas métodos `@api.model` podem ser chamados nele, e é exatamente esse método que faz o trabalho de descobrir e percorrer todos os modelos concretos.

### Os testes (`test_fiscal_validity.py`)

Três classes de teste, uma por família de objeto:

- **`TestFiscalDataValidity`** (via `l10n_br_fiscal.ncm`, representando qualquer tabela fiscal): sem datas permanece ativo; `date_start` no futuro expira; `date_end` no passado expira; dentro do intervalo permanece ativo; só `date_start` no passado (sem fim) permanece ativo; e um teste rodando o cron orquestrador inteiro e conferindo que ele afeta o NCM correto sem afetar um NCM válido.
- **`TestOperationLineValidity`**: linha de operação com `date_end` vencido é marcada `expired`; linha válida permanece `approved`.
- **`TestTaxDefinitionValidity`**: definição tributária vencida é marcada `expired`; definição válida permanece `approved`; e um teste chamando `map_tax_definition()` diretamente para confirmar que uma definição com `date_start` no futuro **não** é retornada pela busca (valida o filtro do commit 2, não só o cron).

---

## Resumo do fluxo completo

```
Cadastro com date_start/date_end
        │
        ├─► Busca/mapeamento (map_tax_definition, _build_map_tax_def_domain,
        │    _line_domain)  ──► já filtra por vigência a cada chamada,
        │                        efeito imediato, independe do cron
        │
        └─► Cron diário 00:01 (_cron_expire_fiscal_parametrization)
             ├─ tabelas fiscais (data.abstract e descendentes) → active = False
             ├─ operation.line fora de vigência                → state = "expired"
             └─ tax.definition fora de vigência                 → state = "expired"
```
