### PR TITLE
[18.0][FW] l10n_br_nfe: multiple ports from 16.0

### DIFF
--- a/l10n_br_account/data/template/account.tax.group-br_oca.csv
+++ b/l10n_br_account/data/template/account.tax.group-br_oca.csv
@@ -22,3 +22,5 @@
 "tax_group_inss_wh","l10n_br_fiscal.tax_group_inss_wh"
 "tax_group_simples","l10n_br_fiscal.tax_group_simples"
 "tax_group_others","l10n_br_fiscal.tax_group_others"
+"tax_group_ibs","l10n_br_fiscal.tax_group_ibs"
+"tax_group_cbs","l10n_br_fiscal.tax_group_cbs"

--- a/l10n_br_account/models/template_br_oca.py
+++ b/l10n_br_account/models/template_br_oca.py
@@ -117,10 +117,29 @@ class AccountChartTemplate(models.AbstractModel):
                 if existing_tax:
                     continue
                 existing_tax = self.env["account.tax"].search(
-                    [("name", "=", value["name"])], limit=1
+                    [
+                        ("name", "=", value["name"]),
+                        ("company_id", "=", company.id),
+                    ],
+                    limit=1,
                 )
                 if existing_tax:
-                    pass  # adjust ir.model.data ?
+                    # Ensure the XML ID mapping exists for this company/tax
+                    self.env["ir.model.data"].create(
+                        {
+                            "name": id_key,
+                            "module": "l10n_br_coa",
+                            "model": "account.tax",
+                            "res_id": existing_tax.id,
+                            "noupdate": True,
+                        }
+                    )
+                    _logger.debug(
+                        "Tax %s for company %s already exists; XML ID %s created",
+                        value["name"],
+                        company.name,
+                        id_key,
+                    )
                 else:
                     tax_vals = {
                         "name": value["name"],

--- a/l10n_br_account/tests/test_move_edition.py
+++ b/l10n_br_account/tests/test_move_edition.py
@@ -252,7 +252,7 @@ class TestMoveEdition(TransactionCase):
             line_form.price_unit = 42
             line_form.quantity = 5
 
-            self.assertEqual(len(line_form.fiscal_tax_ids), 4)
+            self.assertEqual(len(line_form.fiscal_tax_ids), 6)
             self.assertEqual(
                 line_form.icms_tax_id, self.env.ref("l10n_br_fiscal.tax_icms_7")
             )
@@ -267,7 +267,7 @@ class TestMoveEdition(TransactionCase):
             line_form.fiscal_operation_line_id = self.env.ref(
                 "l10n_br_fiscal.fo_venda_venda"
             )
-            self.assertEqual(len(line_form.fiscal_tax_ids), 4)
+            self.assertEqual(len(line_form.fiscal_tax_ids), 6)
             self.assertEqual(
                 line_form.icms_tax_id, self.env.ref("l10n_br_fiscal.tax_icms_7")
             )

--- a/l10n_br_coa/data/template/account.tax-br_oca.csv
+++ b/l10n_br_coa/data/template/account.tax-br_oca.csv
@@ -59,3 +59,7 @@
 "tax_template_in_inss_wh","INSS WH","INSS WH Entrada","INSS WH Entrada","0.00","purchase","0","0","1","tax_group_inss_wh"
 "tax_template_simples","Simples Nacional","Simples Nacional","Simples Nacional","0.00","none","0","0","0","tax_group_simples"
 "tax_template_others","Others","Others","Others","0.00","none","0","0","0","tax_group_others"
+"tax_template_out_ibs","IBS","IBS Saída","IBS Saída","0.00","sale","0","0","0","tax_group_ibs"
+"tax_template_in_ibs","IBS","IBS Entrada","IBS Entrada","0.00","purchase","0","0","0","tax_group_ibs"
+"tax_template_out_cbs","CBS","CBS Saída","CBS Saída","0.00","sale","0","0","0","tax_group_cbs"
+"tax_template_in_cbs","CBS","CBS Entrada","CBS Entrada","0.00","purchase","0","0","0","tax_group_cbs"

--- a/l10n_br_coa/data/template/account.tax.group-br_oca.csv
+++ b/l10n_br_coa/data/template/account.tax.group-br_oca.csv
@@ -23,3 +23,5 @@
 "tax_group_inss_wh","INSS WH"
 "tax_group_simples","Simples Nacional"
 "tax_group_others","Others"
+"tax_group_ibs","IBS"
+"tax_group_cbs","CBS"

--- a/l10n_br_fiscal/demo/company_demo.xml
+++ b/l10n_br_fiscal/demo/company_demo.xml
@@ -41,6 +41,10 @@
         <field name="legal_nature_id" ref="l10n_br_fiscal.legal_nature_2062" />
         <field name="cnae_main_id" ref="l10n_br_fiscal.cnae_3101200" />
         <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
+        <field
+            name="tax_classification_id"
+            ref="l10n_br_fiscal.tax_classification_000001"
+        />
     </record>
 
     <record id="icms_tax_definition_main_company" model="l10n_br_fiscal.tax.definition">
@@ -51,6 +55,28 @@
         <field name="custom_tax">True</field>
         <field name="tax_id" ref="l10n_br_fiscal.tax_icms_sn_com_credito" />
         <field name="cst_id" ref="l10n_br_fiscal.cst_icmssn_101" />
+        <field name="state">draft</field>
+    </record>
+
+    <record id="ibs_tax_definition_main_company" model="l10n_br_fiscal.tax.definition">
+        <field name="company_id" ref="base.main_company" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ibs" />
+        <field name="is_taxed">True</field>
+        <field name="is_debit_credit">True</field>
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ibs_0_1" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ibs_000" />
+        <field name="state">draft</field>
+    </record>
+
+    <record id="cbs_tax_definition_main_company" model="l10n_br_fiscal.tax.definition">
+        <field name="company_id" ref="base.main_company" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cbs" />
+        <field name="is_taxed">True</field>
+        <field name="is_debit_credit">True</field>
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cbs_0_9" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cbs_000" />
         <field name="state">draft</field>
     </record>
 
@@ -114,6 +140,10 @@
         <field name="cnae_main_id" ref="l10n_br_fiscal.cnae_3101200" />
         <field name="piscofins_id" ref="l10n_br_fiscal.tax_pis_cofins_columativo" />
         <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
+        <field
+            name="tax_classification_id"
+            ref="l10n_br_fiscal.tax_classification_000001"
+        />
     </record>
 
     <record
@@ -155,6 +185,34 @@
         <field name="custom_tax">True</field>
         <field name="tax_id" ref="l10n_br_fiscal.tax_issqn_5" />
         <field name="state">approved</field>
+    </record>
+
+    <record
+        id="ibs_tax_definition_empresa_lucro_presumido"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ibs" />
+        <field name="is_taxed">True</field>
+        <field name="is_debit_credit">True</field>
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ibs_0_1" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ibs_000" />
+        <field name="state">draft</field>
+    </record>
+
+    <record
+        id="cbs_tax_definition_empresa_lucro_presumido"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cbs" />
+        <field name="is_taxed">True</field>
+        <field name="is_debit_credit">True</field>
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cbs_0_9" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cbs_000" />
+        <field name="state">draft</field>
     </record>
 
     <record id="empresa_lc_document_55_serie_1" model="l10n_br_fiscal.document.serie">
@@ -204,6 +262,10 @@
         <field name="cnae_main_id" ref="l10n_br_fiscal.cnae_3101200" />
         <field name="document_type_id" ref="l10n_br_fiscal.document_55" />
         <field name="annual_revenue">815000.00</field>
+        <field
+            name="tax_classification_id"
+            ref="l10n_br_fiscal.tax_classification_000001"
+        />
     </record>
 
     <record id="empresa_sn_document_55_serie_1" model="l10n_br_fiscal.document.serie">
@@ -296,6 +358,34 @@
         <field name="custom_tax">True</field>
         <field name="tax_id" ref="l10n_br_fiscal.tax_ipi_outros" />
         <field name="cst_id" ref="l10n_br_fiscal.cst_ipi_99" />
+        <field name="state">draft</field>
+    </record>
+
+    <record
+        id="ibs_tax_definition_simples_nacional"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="company_id" ref="l10n_br_base.empresa_simples_nacional" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_ibs" />
+        <field name="is_taxed">True</field>
+        <field name="is_debit_credit">True</field>
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_ibs_0_1" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_ibs_000" />
+        <field name="state">draft</field>
+    </record>
+
+    <record
+        id="cbs_tax_definition_simples_nacional"
+        model="l10n_br_fiscal.tax.definition"
+    >
+        <field name="company_id" ref="l10n_br_base.empresa_simples_nacional" />
+        <field name="tax_group_id" ref="l10n_br_fiscal.tax_group_cbs" />
+        <field name="is_taxed">True</field>
+        <field name="is_debit_credit">True</field>
+        <field name="custom_tax">True</field>
+        <field name="tax_id" ref="l10n_br_fiscal.tax_cbs_0_9" />
+        <field name="cst_id" ref="l10n_br_fiscal.cst_cbs_000" />
         <field name="state">draft</field>
     </record>
 </odoo>

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -127,3 +127,72 @@ class DocumentLine(models.Model):
             line.additional_data = line.comment_ids.compute_message(
                 line.__document_comment_vals(), line.manual_additional_data
             )
+
+    @api.model
+    def _add_imported_ibscbs_vals(self, ibscbs, vals):
+        """Merge into ``vals`` the IBS/CBS values of an imported IBSCBS
+        binding node (NFe and CTe share the same DFe schema for it).
+
+        Returns the list of matched fiscal tax ids so each caller can
+        link them into ``fiscal_tax_ids`` with its own convention (the
+        NFe import framework expects raw ids, the CTe one expects
+        Command tuples).
+        """
+        tax_ids = []
+        if not (ibscbs and ibscbs.gIBSCBS):
+            return tax_ids
+
+        gibscbs = ibscbs.gIBSCBS
+        base = float(gibscbs.vBC) if gibscbs.vBC else 0.0
+
+        ibs_percent = ibs_value = 0.0
+        if gibscbs.gIBSUF:
+            ibs_percent = float(gibscbs.gIBSUF.pIBSUF) if gibscbs.gIBSUF.pIBSUF else 0.0
+            ibs_value = float(gibscbs.gIBSUF.vIBSUF) if gibscbs.gIBSUF.vIBSUF else 0.0
+        cbs_percent = cbs_value = 0.0
+        if gibscbs.gCBS:
+            cbs_percent = float(gibscbs.gCBS.pCBS) if gibscbs.gCBS.pCBS else 0.0
+            cbs_value = float(gibscbs.gCBS.vCBS) if gibscbs.gCBS.vCBS else 0.0
+
+        cst_code = ibscbs.CST if ibscbs.CST else "000"
+        cst_ibs = self.env.ref(
+            f"l10n_br_fiscal.cst_ibs_{cst_code}", raise_if_not_found=False
+        )
+        if cst_ibs:
+            vals["ibs_cst_id"] = cst_ibs.id
+        cst_cbs = self.env.ref(
+            f"l10n_br_fiscal.cst_cbs_{cst_code}", raise_if_not_found=False
+        )
+        if cst_cbs:
+            vals["cbs_cst_id"] = cst_cbs.id
+
+        vals.update(
+            ibs_base=base,
+            ibs_percent=ibs_percent,
+            ibs_value=ibs_value,
+            cbs_base=base,
+            cbs_percent=cbs_percent,
+            cbs_value=cbs_value,
+        )
+
+        ibs_tax = self.env["l10n_br_fiscal.tax"].search(
+            [
+                ("tax_group_id", "=", self.env.ref("l10n_br_fiscal.tax_group_ibs").id),
+                ("percent_amount", "=", ibs_percent),
+            ],
+            limit=1,
+        )
+        if ibs_tax:
+            vals["ibs_tax_id"] = ibs_tax.id
+            tax_ids.append(ibs_tax.id)
+        cbs_tax = self.env["l10n_br_fiscal.tax"].search(
+            [
+                ("tax_group_id", "=", self.env.ref("l10n_br_fiscal.tax_group_cbs").id),
+                ("percent_amount", "=", cbs_percent),
+            ],
+            limit=1,
+        )
+        if cbs_tax:
+            vals["cbs_tax_id"] = cbs_tax.id
+            tax_ids.append(cbs_tax.id)
+        return tax_ids

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -1098,6 +1098,14 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         string="CFOP Destination",
     )
 
+    partner_cfop_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.cfop",
+        string="Partner CFOP",
+        help="CFOP as declared by the counterparty in the imported document. "
+        "It is preserved as-is for fiscal bookkeeping / SPED (e.g. C197), "
+        "while cfop_id reflects the company's own operation after the de-para.",
+    )
+
     fiscal_price = fields.Float(
         digits="Product Price",
         compute="_compute_fiscal_price",

--- a/l10n_br_fiscal/tests/test_document_edition.py
+++ b/l10n_br_fiscal/tests/test_document_edition.py
@@ -106,7 +106,7 @@ class TestDocumentEdition(TransactionCase):
 
             line_form.price_unit = 50
             line_form.quantity = 2
-            self.assertEqual(len(line_form.fiscal_tax_ids), 4)
+            self.assertEqual(len(line_form.fiscal_tax_ids), 6)
             self.assertEqual(
                 line_form.icms_tax_id, self.env.ref("l10n_br_fiscal.tax_icms_12")
             )
@@ -146,7 +146,7 @@ class TestDocumentEdition(TransactionCase):
         self.assertEqual(line.fiscal_price, 100)
         self.assertEqual(line.quantity, 2)
         self.assertEqual(line.fiscal_quantity, 2)
-        self.assertEqual(len(line.fiscal_tax_ids), 4)
+        self.assertEqual(len(line.fiscal_tax_ids), 6)
 
         self.assertEqual(
             line.fiscal_operation_line_id,

--- a/l10n_br_fiscal/tests/test_fiscal_tax.py
+++ b/l10n_br_fiscal/tests/test_fiscal_tax.py
@@ -118,12 +118,14 @@ class TestFiscalTax(TransactionCase):
             + self.env.ref("l10n_br_fiscal.tax_ipi_15")
             + self.env.ref("l10n_br_fiscal.tax_pis_0_65")
             + self.env.ref("l10n_br_fiscal.tax_cofins_3")
+            + self.env.ref("l10n_br_fiscal.tax_ibs_0_1")
+            + self.env.ref("l10n_br_fiscal.tax_cbs_0_9")
         )
 
         compute_result = fiscal_taxes.compute_taxes(**kwargs)
 
         test_result = {
-            "amount_included": 4.04,
+            "amount_included": 4.34,
             "amount_not_included": 5.19,
             "amount_withholding": 0.0,
             "estimate_tax": 0.0,
@@ -160,6 +162,22 @@ class TestFiscalTax(TransactionCase):
                     "percent_reduction": 0.0,
                     "value_amount": 0.0,
                     "tax_value": 1.04,
+                },
+                "ibs": {
+                    "base": 30.54,
+                    "base_reduction": 0.0,
+                    "percent_amount": 0.10,
+                    "percent_reduction": 0.0,
+                    "value_amount": 0.0,
+                    "tax_value": 0.03,
+                },
+                "cbs": {
+                    "base": 30.54,
+                    "base_reduction": 0.0,
+                    "percent_amount": 0.90,
+                    "percent_reduction": 0.0,
+                    "value_amount": 0.0,
+                    "tax_value": 0.27,
                 },
             },
         }

--- a/l10n_br_fiscal/wizards/document_import_wizard.py
+++ b/l10n_br_fiscal/wizards/document_import_wizard.py
@@ -225,6 +225,22 @@ class DocumentImportWizard(models.TransientModel):
         if operation_lines:
             return operation_lines[0].fiscal_operation_id
 
+    def _match_uom_by_code(self, *codes):
+        """Match a fiscal UoM from one or more XML unit codes (uCom/uTrib).
+
+        First try the fiscal ``code`` field, then fall back to the
+        ``uom_alias`` module aliases so that supplier abbreviations
+        (e.g. ``MIL`` -> ``MILHEIRO``, ``UNID`` -> ``Units``) resolve to
+        the company's own UoM.
+        """
+        codes = [code for code in codes if code]
+        if not codes:
+            return self.env["uom.uom"]
+        uom = self.env["uom.uom"].search([("code", "in", codes)], limit=1)
+        if not uom:
+            uom = self.env["uom.uom"].search([("alias_ids.code", "in", codes)], limit=1)
+        return uom
+
     def _parse_file(self):
         return self._parse_file_data(self.file)
 

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -981,7 +981,9 @@ class NFe(spec_models.StackedModel):
         if key == "nfe40_entrega" and self.env.context.get("edoc_type") == "in":
             enderEntreg_value = self.env["res.partner"].build_attrs(value, path=path)
             new_value.update(enderEntreg_value)
-            parent_domain = [("nfe40_CNPJ", "=", new_value.get("nfe40_CNPJ"))]
+            parent_domain = [
+                ("vat", "=", new_value.get("nfe40_CNPJ"))
+            ]
             parent_partner_match = self.env["res.partner"].search(
                 parent_domain, limit=1
             )

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -817,6 +817,14 @@ class NFe(spec_models.StackedModel):
     # Framework Spec model's methods
     ################################
 
+    def _nfe_export_ibscbs_totals(self):
+        """Return True when the document has IBS/CBS values to export"""
+        self.ensure_one()
+        return bool(
+            sum(self.fiscal_line_ids.mapped("ibs_value"))
+            or sum(self.fiscal_line_ids.mapped("cbs_value"))
+        )
+
     def _export_field(self, xsd_field, class_obj, member_spec, export_value=None):
         if xsd_field == "nfe40_tpAmb":
             self.env.context = dict(self.env.context)
@@ -825,11 +833,21 @@ class NFe(spec_models.StackedModel):
                 xsd_field, class_obj, member_spec, export_value
             )
 
-        if xsd_field == "nfe40_IBSCBSTot":
-            total_ibs = sum(self.fiscal_line_ids.mapped("ibs_value"))
-            total_cbs = sum(self.fiscal_line_ids.mapped("cbs_value"))
+        if xsd_field == "nfe40_vNFTot":
+            # NT 2025.002 (rule W60): total of the NF-e considering the
+            # IBS/CBS/IS taxes. This mirrors fiscal_amount_total, which
+            # already honors each tax group's "tax_include" flag: taxes
+            # flagged as included in the price do not add to the total,
+            # taxes flagged as "outside" do. In the 2026 transition the
+            # IBS/CBS/IS groups are set as included, so vNFTot equals vNF;
+            # switching those groups to "outside" makes them compose the
+            # total automatically, with no code change.
+            if not self._nfe_export_ibscbs_totals():
+                return False
+            return f"{self.fiscal_amount_total:.2f}"
 
-            if not total_ibs and not total_cbs:
+        if xsd_field == "nfe40_IBSCBSTot":
+            if not self._nfe_export_ibscbs_totals():
                 return False
 
             # Build gIBSUF

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -13,8 +13,8 @@ from erpbrasil.base.fiscal.edoc import ChaveEdoc
 from erpbrasil.transmissao import TransmissaoSOAP
 from lxml import etree
 from nfelib.nfe.bindings.v4_0.dfe_tipos_basicos_v1_00 import TibscbsmonoTot
-from nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00 import TnfeProc
 from nfelib.nfe.bindings.v4_0.nfe_v4_00 import Nfe
+from nfelib.nfe.bindings.v4_0.proc_nfe_v4_00 import NfeProc
 from nfelib.nfe.ws.edoc_legacy import NFCeAdapter as edoc_nfce
 from nfelib.nfe.ws.edoc_legacy import NFeAdapter as edoc_nfe
 from requests import Session
@@ -94,7 +94,7 @@ class NFe(spec_models.StackedModel):
 
     # When dynamic stacking is applied the NFe structure is:
     INFNFE_TREE = """
-> <infnfe>
+    > <infnfe>
     > <ide>
         ≡ <NFref> l10n_br_fiscal.document.related
         - <gPagAntecipado>
@@ -1362,7 +1362,7 @@ class NFe(spec_models.StackedModel):
         if proc_nfe_xml:
             # it is not always possible to create nfeProc.
             parser = XmlParser()
-            nfe_proc = parser.from_string(proc_nfe_xml.decode(), TnfeProc)
+            nfe_proc = parser.from_string(proc_nfe_xml.decode(), NfeProc)
             ws_response_process.processo = nfe_proc
             ws_response_process.processo_xml = proc_nfe_xml
 

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -981,9 +981,7 @@ class NFe(spec_models.StackedModel):
         if key == "nfe40_entrega" and self.env.context.get("edoc_type") == "in":
             enderEntreg_value = self.env["res.partner"].build_attrs(value, path=path)
             new_value.update(enderEntreg_value)
-            parent_domain = [
-                ("vat", "=", new_value.get("nfe40_CNPJ"))
-            ]
+            parent_domain = [("vat", "=", new_value.get("nfe40_CNPJ"))]
             parent_partner_match = self.env["res.partner"].search(
                 parent_domain, limit=1
             )

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -94,7 +94,7 @@ class NFe(spec_models.StackedModel):
 
     # When dynamic stacking is applied the NFe structure is:
     INFNFE_TREE = """
-    > <infnfe>
+> <infnfe>
     > <ide>
         ≡ <NFref> l10n_br_fiscal.document.related
         - <gPagAntecipado>

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -984,8 +984,17 @@ class NFe(spec_models.StackedModel):
                 "company_type": "person",
             }
             new_value.update(new_vals)
+            # Store the delivery address on the stored partner_shipping_id
+            # field (like emit/dest write to partner_id). nfe40_entrega is a
+            # non-stored computed field, so writing to it would silently drop
+            # the imported delivery address.
             super()._build_many2one(
-                self.env["res.partner"], vals, new_value, key, value, path
+                self.env["res.partner"],
+                vals,
+                new_value,
+                "partner_shipping_id",
+                value,
+                path,
             )
         elif key == "nfe40_emit" and self.env.context.get("edoc_type") == "in":
             enderEmit_value = self.env["res.partner"].build_attrs(

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -969,6 +969,14 @@ class NFe(spec_models.StackedModel):
             )
         return res
 
+    @api.model
+    def _build_attr(self, node, fields, vals, path, attr):
+        key = f"nfe40_{attr[1].metadata.get('name', attr[0])}"
+        if key == "nfe40_IBSCBSTot":
+            # IBSCBSTot fields are computed from lines, skip importing
+            return
+        return super()._build_attr(node, fields, vals, path, attr)
+
     def _build_many2one(self, comodel, vals, new_value, key, value, path):
         if key == "nfe40_entrega" and self.env.context.get("edoc_type") == "in":
             enderEntreg_value = self.env["res.partner"].build_attrs(value, path=path)

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -1362,6 +1362,16 @@ class NFeLine(spec_models.StackedModel):
                 .search([("code_unmasked", "=", value)], limit=1)
                 .id
             )
+        if key == "nfe40_CFOP" and value:
+            # Preserve the CFOP declared by the counterparty. cfop_id itself is
+            # recomputed by the de-para; partner_cfop_id keeps the original for
+            # bookkeeping / SPED (C197).
+            vals["partner_cfop_id"] = (
+                self.env["l10n_br_fiscal.cfop"]
+                .search([("code", "=", value)], limit=1)
+                .id
+            )
+
         if key == "nfe40_qCom":
             vals["quantity"] = float(value)
         if key == "nfe40_qTrib":

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -2,6 +2,7 @@
 # Copyright 2020 KMEE INFORMATICA LTDA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import logging
 import sys
 from enum import Enum
 
@@ -18,6 +19,8 @@ from odoo.addons.l10n_br_fiscal.constants.fiscal import (
 from odoo.addons.l10n_br_fiscal.constants.icms import ICMS_CST, ICMS_SN_CST
 from odoo.addons.l10n_br_fiscal.tools import remove_non_ascii_characters
 from odoo.addons.spec_driven_model.models import spec_models
+
+_logger = logging.getLogger(__name__)
 
 ICMSSN_CST_CODES_USE_102 = ("102", "103", "300", "400")
 ICMSSN_CST_CODES_USE_202 = ("202", "203")
@@ -83,7 +86,7 @@ class NFeLine(spec_models.StackedModel):
 
     # When dynamic stacking is applied, the NFe line has the following structure:
     DET_TREE = """
-> <det>
+    > <det>
     > <prod>
         ≡ <gCred>
         ≡ <DI>
@@ -1633,6 +1636,57 @@ class NFeLine(spec_models.StackedModel):
         # elif kind == "cofins":  # (will also apply to cofinsst)
         #     pass
         #     # TODO  qBCProd, vAliqProd
+
+    def _create_reduced_fiscal_tax(
+        self, tax_group_id, percent, cst_id, percent_reduction
+    ):
+        """Create an ICMS fiscal tax with a base reduction when the company
+        has none configured for this rate/reduction combination.
+
+        Without this, an imported NFe line that declares an ICMS base
+        reduction (redução de base de cálculo) would fall back to a plain
+        no-reduction tax, computing a higher ICMS credit than the supplier
+        actually charged and diverging from the NFe / SPED. The created tax
+        carries the proper percent_reduction so it is reused on the next
+        import (idempotent via the earlier search on percent_reduction).
+        """
+        cst_field = "cst_{}_id".format(self.env.context.get("edoc_type", "in"))
+        vals = {
+            "name": _("ICMS %(percent)s%% Com Red. %(red)s%%")
+            % {"percent": percent, "red": percent_reduction},
+            "tax_group_id": tax_group_id,
+            "percent_amount": percent,
+            "percent_reduction": percent_reduction,
+            "percent_debit_credit": 0,
+            "value_amount": 0,
+            "icmsst_mva_percent": 0,
+            "icmsst_value": 0,
+            cst_field: cst_id,
+        }
+        tax = self.env["l10n_br_fiscal.tax"].create(vals)
+        # Master data created as an import side effect must leave a trail
+        # so the fiscal responsible can review it afterwards.
+        _logger.info(
+            "NFe import created fiscal tax '%s' (id %s) for company %s "
+            "(no existing ICMS tax with rate %s%% and base reduction %s%%)",
+            tax.name,
+            tax.id,
+            self.env.company.display_name,
+            percent,
+            percent_reduction,
+        )
+        return tax
+
+    def _import_ibscbs_attrs(self, value, odoo_attrs):
+        """Import IBSCBS tax attributes from NFe binding."""
+        tax_ids = self.env["l10n_br_fiscal.document.line"]._add_imported_ibscbs_vals(
+            value, odoo_attrs
+        )
+        if tax_ids:
+            # the NFe import framework links m2m fields with raw ids
+            if not odoo_attrs.get("fiscal_tax_ids"):
+                odoo_attrs["fiscal_tax_ids"] = []
+            odoo_attrs["fiscal_tax_ids"].extend(tax_ids)
 
     def _verify_related_many2ones(self, related_many2ones):
         if (

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -8,7 +8,7 @@ from enum import Enum
 
 from nfelib.nfe.bindings.v4_0.dfe_tipos_basicos_v1_00 import Tcibs, TtribNfe
 
-from odoo import api, fields
+from odoo import _, api, fields
 
 from odoo.addons.l10n_br_fiscal.constants.fiscal import (
     CFOP_DESTINATION_EXTERNAL,
@@ -225,6 +225,19 @@ class NFeLine(spec_models.StackedModel):
 
     def _export_field(self, xsd_field, class_obj, member_spec, export_value=None):
         """Override to handle IBSCBS field export"""
+        if xsd_field == "nfe40_vItem":
+            # NT 2025.002 (rules VB01/W60): vItem must be present in every
+            # det when the document exports the IBS/CBS totals, and the sum
+            # of all vItem must match vNFTot. This mirrors the line's
+            # fiscal_amount_total, which already honors each tax group's
+            # "tax_include" flag; in the 2026 transition IBS/CBS/IS are
+            # included in the price, so vItem is the line share of the
+            # current vNF (switching the groups to "outside" makes them
+            # compose vItem automatically, keeping sum(vItem) == vNFTot).
+            if not self.document_id._nfe_export_ibscbs_totals():
+                return False
+            return f"{self.fiscal_amount_total:.2f}"
+
         if xsd_field == "nfe40_IBSCBS":
             if not self.ibs_value and not self.cbs_value:
                 return False

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -1561,6 +1561,13 @@ class NFeLine(spec_models.StackedModel):
                 tax_domain_with_red,
                 limit=1,
             )
+            # If no fiscal tax with this base reduction exists yet, create it
+            # instead of falling back to a plain (no-reduction) tax, which
+            # would compute a wrong ICMS credit and diverge from the NFe/SPED.
+            if not fiscal_tax_id and percent:
+                fiscal_tax_id = self._create_reduced_fiscal_tax(
+                    tax_group_id, percent, cst_id, icms_percent_red
+                )
 
         if not fiscal_tax_id:
             if tax_domain_with_cst:

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -86,7 +86,7 @@ class NFeLine(spec_models.StackedModel):
 
     # When dynamic stacking is applied, the NFe line has the following structure:
     DET_TREE = """
-    > <det>
+> <det>
     > <prod>
         ≡ <gCred>
         ≡ <DI>

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -1354,6 +1354,10 @@ class NFeLine(spec_models.StackedModel):
         if key in ["nfe40_CST", "nfe40_modBC", "nfe40_CSOSN"]:
             return  # (dealt with in _build_many2one)
 
+        if key == "nfe40_IBSCBS":
+            self._import_ibscbs_attrs(value, vals)
+            return
+
         if key.startswith("nfe40_ICMS") and key not in [
             "nfe40_ICMS",
             "nfe40_ICMSTot",
@@ -1472,6 +1476,17 @@ class NFeLine(spec_models.StackedModel):
                 value,
                 new_value,
             )
+
+        elif key == "nfe40_IBSCBS":
+            self._import_ibscbs_attrs(value, new_value)
+            if (
+                self._name == "account.invoice.line"
+                and comodel._name == "l10n_br_fiscal.document.line"
+            ):
+                # TODO do not hardcode!!
+                # stacked m2o
+                vals.update(new_value)
+            return
 
         if (
             self._name == "account.invoice.line"

--- a/l10n_br_nfe/models/document_related.py
+++ b/l10n_br_nfe/models/document_related.py
@@ -111,9 +111,9 @@ class NFeRelated(spec_models.StackedModel):
                         else ""
                     )
                     if rec.cpfcnpj_type == "cpf":
-                        rec.nfe40_CPF = rec.cnpj_cpf
+                        rec.nfe40_CPF = rec.vat
                     else:
-                        rec.nfe40_CNPJ = rec.cnpj_cpf
+                        rec.nfe40_CNPJ = rec.vat
                     rec.nfe40_IE = rec.l10n_br_ie_code
                     rec.nfe40_mod = rec.document_type_id.code
                     rec.nfe40_serie = document.document_serie

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -9,11 +9,6 @@ from odoo.addons.spec_driven_model.models import spec_models
 
 
 class ResPartner(spec_models.SpecModel):
-    # NOTE TODO
-    # dest has a m2o tendereco. tlocal and tendereco are really similar...
-    # what happen to m2o to tendereco if we don't inherit from tendereco?
-    # should we stack tendereco from dest? will m2o to tendereco work?
-    # can we use related fields and context views to avoid troubles?
     _name = "res.partner"
     _inherit = [
         "res.partner",
@@ -34,8 +29,13 @@ class ResPartner(spec_models.SpecModel):
         values = super()._prepare_import_dict(
             values, model, parent_dict, defaults_model
         )
-        if not values.get("name") and values.get("legal_name"):
-            values["name"] = values["legal_name"]
+        if not values.get("name"):
+            if values.get("legal_name"):
+                values["name"] = values["legal_name"]
+            elif values.get("nfe40_CPF"):  # autXML for instance
+                values["name"] = f"contato CPF {values['nfe40_CPF']}"
+            elif values.get("nfe40_CNPJ"):
+                values["name"] = f"contato CNPJ {values['nfe40_CNPJ']}"
         return values
 
     # nfe.40.tlocal / nfe.40.enderEmit / 'nfe.40.enderDest

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000012062777161.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000012062777161.xml
@@ -110,7 +110,28 @@
                         <vCOFINS>0.00</vCOFINS>
                     </COFINSOutr>
                 </COFINS>
+                <IBSCBS>
+                    <CST>000</CST>
+                    <cClassTrib>000001</cClassTrib>
+                    <gIBSCBS>
+                        <vBC>140.00</vBC>
+                        <gIBSUF>
+                            <pIBSUF>0.1000</pIBSUF>
+                            <vIBSUF>0.14</vIBSUF>
+                        </gIBSUF>
+                        <gIBSMun>
+                            <pIBSMun>0.0000</pIBSMun>
+                            <vIBSMun>0.00</vIBSMun>
+                        </gIBSMun>
+                        <vIBS>0.14</vIBS>
+                        <gCBS>
+                            <pCBS>0.9000</pCBS>
+                            <vCBS>1.26</vCBS>
+                        </gCBS>
+                    </gIBSCBS>
+                </IBSCBS>
             </imposto>
+            <vItem>140.00</vItem>
         </det>
         <total>
             <ICMSTot>
@@ -134,6 +155,32 @@
                 <vOutro>0.00</vOutro>
                 <vNF>140.00</vNF>
             </ICMSTot>
+            <IBSCBSTot>
+                <vBCIBSCBS>140.00</vBCIBSCBS>
+                <gIBS>
+                    <gIBSUF>
+                        <vDif>0.00</vDif>
+                        <vDevTrib>0.00</vDevTrib>
+                        <vIBSUF>0.14</vIBSUF>
+                    </gIBSUF>
+                    <gIBSMun>
+                        <vDif>0.00</vDif>
+                        <vDevTrib>0.00</vDevTrib>
+                        <vIBSMun>0.00</vIBSMun>
+                    </gIBSMun>
+                    <vIBS>0.14</vIBS>
+                    <vCredPres>0.00</vCredPres>
+                    <vCredPresCondSus>0.00</vCredPresCondSus>
+                </gIBS>
+                <gCBS>
+                    <vDif>0.00</vDif>
+                    <vDevTrib>0.00</vDevTrib>
+                    <vCBS>1.26</vCBS>
+                    <vCredPres>0.00</vCredPres>
+                    <vCredPresCondSus>0.00</vCredPresCondSus>
+                </gCBS>
+            </IBSCBSTot>
+            <vNFTot>140.00</vNFTot>
         </total>
         <transp>
             <modFrete>9</modFrete>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000022062777169.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000022062777169.xml
@@ -111,7 +111,28 @@
                         <vCOFINS>58.50</vCOFINS>
                     </COFINSAliq>
                 </COFINS>
+                <IBSCBS>
+                    <CST>000</CST>
+                    <cClassTrib>000001</cClassTrib>
+                    <gIBSCBS>
+                        <vBC>1707.22</vBC>
+                        <gIBSUF>
+                            <pIBSUF>0.1000</pIBSUF>
+                            <vIBSUF>1.71</vIBSUF>
+                        </gIBSUF>
+                        <gIBSMun>
+                            <pIBSMun>0.0000</pIBSMun>
+                            <vIBSMun>0.00</vIBSMun>
+                        </gIBSMun>
+                        <vIBS>1.71</vIBS>
+                        <gCBS>
+                            <pCBS>0.9000</pCBS>
+                            <vCBS>15.36</vCBS>
+                        </gCBS>
+                    </gIBSCBS>
+                </IBSCBS>
             </imposto>
+            <vItem>1950.00</vItem>
         </det>
         <total>
             <ICMSTot>
@@ -135,6 +156,32 @@
                 <vOutro>0.00</vOutro>
                 <vNF>1950.00</vNF>
             </ICMSTot>
+            <IBSCBSTot>
+                <vBCIBSCBS>1707.22</vBCIBSCBS>
+                <gIBS>
+                    <gIBSUF>
+                        <vDif>0.00</vDif>
+                        <vDevTrib>0.00</vDevTrib>
+                        <vIBSUF>1.71</vIBSUF>
+                    </gIBSUF>
+                    <gIBSMun>
+                        <vDif>0.00</vDif>
+                        <vDevTrib>0.00</vDevTrib>
+                        <vIBSMun>0.00</vIBSMun>
+                    </gIBSMun>
+                    <vIBS>1.71</vIBS>
+                    <vCredPres>0.00</vCredPres>
+                    <vCredPresCondSus>0.00</vCredPresCondSus>
+                </gIBS>
+                <gCBS>
+                    <vDif>0.00</vDif>
+                    <vDevTrib>0.00</vDevTrib>
+                    <vCBS>15.36</vCBS>
+                    <vCredPres>0.00</vCredPres>
+                    <vCredPresCondSus>0.00</vCredPresCondSus>
+                </gCBS>
+            </IBSCBSTot>
+            <vNFTot>1950.00</vNFTot>
         </total>
         <transp>
             <modFrete>9</modFrete>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000032062777166.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200159594315000157550010000000032062777166.xml
@@ -113,7 +113,28 @@
                         <vCOFINS>2.82</vCOFINS>
                     </COFINSAliq>
                 </COFINS>
+                <IBSCBS>
+                    <CST>000</CST>
+                    <cClassTrib>000001</cClassTrib>
+                    <gIBSCBS>
+                        <vBC>86.81</vBC>
+                        <gIBSUF>
+                            <pIBSUF>0.1000</pIBSUF>
+                            <vIBSUF>0.09</vIBSUF>
+                        </gIBSUF>
+                        <gIBSMun>
+                            <pIBSMun>0.0000</pIBSMun>
+                            <vIBSMun>0.00</vIBSMun>
+                        </gIBSMun>
+                        <vIBS>0.09</vIBS>
+                        <gCBS>
+                            <pCBS>0.9000</pCBS>
+                            <vCBS>0.78</vCBS>
+                        </gCBS>
+                    </gIBSCBS>
+                </IBSCBS>
             </imposto>
+            <vItem>94.00</vItem>
         </det>
         <total>
             <ICMSTot>
@@ -137,6 +158,32 @@
                 <vOutro>0.00</vOutro>
                 <vNF>94.00</vNF>
             </ICMSTot>
+            <IBSCBSTot>
+                <vBCIBSCBS>86.81</vBCIBSCBS>
+                <gIBS>
+                    <gIBSUF>
+                        <vDif>0.00</vDif>
+                        <vDevTrib>0.00</vDevTrib>
+                        <vIBSUF>0.09</vIBSUF>
+                    </gIBSUF>
+                    <gIBSMun>
+                        <vDif>0.00</vDif>
+                        <vDevTrib>0.00</vDevTrib>
+                        <vIBSMun>0.00</vIBSMun>
+                    </gIBSMun>
+                    <vIBS>0.09</vIBS>
+                    <vCredPres>0.00</vCredPres>
+                    <vCredPresCondSus>0.00</vCredPresCondSus>
+                </gIBS>
+                <gCBS>
+                    <vDif>0.00</vDif>
+                    <vDevTrib>0.00</vDevTrib>
+                    <vCBS>0.78</vCBS>
+                    <vCredPres>0.00</vCredPres>
+                    <vCredPresCondSus>0.00</vCredPresCondSus>
+                </gCBS>
+            </IBSCBSTot>
+            <vNFTot>94.00</vNFTot>
         </total>
         <transp>
             <modFrete>9</modFrete>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200181583054000129550010000000052062777166.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200181583054000129550010000000052062777166.xml
@@ -113,6 +113,26 @@
                             <vCOFINS>0.00</vCOFINS>
                         </COFINSOutr>
                     </COFINS>
+                    <IBSCBS>
+                        <CST>000</CST>
+                        <cClassTrib>000001</cClassTrib>
+                        <gIBSCBS>
+                            <vBC>14.00</vBC>
+                            <gIBSUF>
+                                <pIBSUF>0.1000</pIBSUF>
+                                <vIBSUF>0.01</vIBSUF>
+                            </gIBSUF>
+                            <gIBSMun>
+                                <pIBSMun>0.0000</pIBSMun>
+                                <vIBSMun>0.00</vIBSMun>
+                            </gIBSMun>
+                            <vIBS>0.01</vIBS>
+                            <gCBS>
+                                <pCBS>0.9000</pCBS>
+                                <vCBS>0.13</vCBS>
+                            </gCBS>
+                        </gIBSCBS>
+                    </IBSCBS>
                 </imposto>
             </det>
             <total>
@@ -141,6 +161,31 @@
                     <vNF>14.00</vNF>
                     <vTotTrib>0.00</vTotTrib>
                 </ICMSTot>
+                <IBSCBSTot>
+                    <vBCIBSCBS>14.00</vBCIBSCBS>
+                    <gIBS>
+                        <gIBSUF>
+                            <vDif>0.00</vDif>
+                            <vDevTrib>0.00</vDevTrib>
+                            <vIBSUF>0.01</vIBSUF>
+                        </gIBSUF>
+                        <gIBSMun>
+                            <vDif>0.00</vDif>
+                            <vDevTrib>0.00</vDevTrib>
+                            <vIBSMun>0.00</vIBSMun>
+                        </gIBSMun>
+                        <vIBS>0.01</vIBS>
+                        <vCredPres>0.00</vCredPres>
+                        <vCredPresCondSus>0.00</vCredPresCondSus>
+                    </gIBS>
+                    <gCBS>
+                        <vDif>0.00</vDif>
+                        <vDevTrib>0.00</vDevTrib>
+                        <vCBS>0.13</vCBS>
+                        <vCredPres>0.00</vCredPres>
+                        <vCredPresCondSus>0.00</vCredPresCondSus>
+                    </gCBS>
+                </IBSCBSTot>
             </total>
             <transp>
                 <modFrete>9</modFrete>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200681583054000129550010000000012760018057-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200681583054000129550010000000012760018057-nf-e.xml
@@ -113,6 +113,26 @@
                         <vCOFINS>9.60</vCOFINS>
                     </COFINSAliq>
                 </COFINS>
+                <IBSCBS>
+                    <CST>000</CST>
+                    <cClassTrib>000001</cClassTrib>
+                    <gIBSCBS>
+                        <vBC>269.92</vBC>
+                        <gIBSUF>
+                            <pIBSUF>0.1000</pIBSUF>
+                            <vIBSUF>0.27</vIBSUF>
+                        </gIBSUF>
+                        <gIBSMun>
+                            <pIBSMun>0.0000</pIBSMun>
+                            <vIBSMun>0.00</vIBSMun>
+                        </gIBSMun>
+                        <vIBS>0.27</vIBS>
+                        <gCBS>
+                            <pCBS>0.9000</pCBS>
+                            <vCBS>2.43</vCBS>
+                        </gCBS>
+                    </gIBSCBS>
+                </IBSCBS>
             </imposto>
         </det>
         <det nItem="2">
@@ -169,6 +189,26 @@
                         <vCOFINS>109.35</vCOFINS>
                     </COFINSAliq>
                 </COFINS>
+                <IBSCBS>
+                    <CST>000</CST>
+                    <cClassTrib>000001</cClassTrib>
+                    <gIBSCBS>
+                        <vBC>269.92</vBC>
+                        <gIBSUF>
+                            <pIBSUF>0.1000</pIBSUF>
+                            <vIBSUF>0.27</vIBSUF>
+                        </gIBSUF>
+                        <gIBSMun>
+                            <pIBSMun>0.0000</pIBSMun>
+                            <vIBSMun>0.00</vIBSMun>
+                        </gIBSMun>
+                        <vIBS>0.27</vIBS>
+                        <gCBS>
+                            <pCBS>0.9000</pCBS>
+                            <vCBS>2.43</vCBS>
+                        </gCBS>
+                    </gIBSCBS>
+                </IBSCBS>
             </imposto>
             <infAdProd>Valor Aprox. dos Tributos: R$ 182.25</infAdProd>
         </det>
@@ -194,6 +234,31 @@
                 <vOutro>0.00</vOutro>
                 <vNF>4147.25</vNF>
             </ICMSTot>
+            <IBSCBSTot>
+                <vBCIBSCBS>539.84</vBCIBSCBS>
+                <gIBS>
+                    <gIBSUF>
+                        <vDif>0.00</vDif>
+                        <vDevTrib>0.00</vDevTrib>
+                        <vIBSUF>0.54</vIBSUF>
+                    </gIBSUF>
+                    <gIBSMun>
+                        <vDif>0.00</vDif>
+                        <vDevTrib>0.00</vDevTrib>
+                        <vIBSMun>0.00</vIBSMun>
+                    </gIBSMun>
+                    <vIBS>0.54</vIBS>
+                    <vCredPres>0.00</vCredPres>
+                    <vCredPresCondSus>0.00</vCredPresCondSus>
+                </gIBS>
+                <gCBS>
+                    <vDif>0.00</vDif>
+                    <vDevTrib>0.00</vDevTrib>
+                    <vCBS>4.86</vCBS>
+                    <vCredPres>0.00</vCredPres>
+                    <vCredPresCondSus>0.00</vCredPresCondSus>
+                </gCBS>
+            </IBSCBSTot>
         </total>
         <transp>
             <modFrete>9</modFrete>

--- a/l10n_br_nfe/tests/test_nfe_ibscbs.py
+++ b/l10n_br_nfe/tests/test_nfe_ibscbs.py
@@ -595,7 +595,7 @@ class TestNFeVItemVNFTot(TransactionCase):
             {
                 "name": "Test Partner",
                 "is_company": True,
-                "cnpj_cpf": "65910976000147",
+                "vat": "65910976000147",
             }
         )
 

--- a/l10n_br_nfe/tests/test_nfe_ibscbs.py
+++ b/l10n_br_nfe/tests/test_nfe_ibscbs.py
@@ -1,6 +1,8 @@
 # Copyright 2025
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from decimal import Decimal
+
 from odoo.tests import TransactionCase, tagged
 
 
@@ -575,3 +577,194 @@ class TestNFeIBSCBS(TransactionCase):
         # IBS Municipal should be zero
         self.assertEqual(result.gIBSCBS.gIBSMun.vIBSMun, "0.00")
         self.assertEqual(result.gIBSCBS.gIBSMun.pIBSMun, "0.0000")
+
+
+@tagged("post_install", "-at_install")
+class TestNFeVItemVNFTot(TransactionCase):
+    """Test vItem and vNFTot export in NFe documents (NT 2025.002)"""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+
+        cls.company = cls.env.ref("base.main_company")
+        cls.icms_cst_00 = cls.env.ref("l10n_br_fiscal.cst_icms_00")
+
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "Test Partner",
+                "is_company": True,
+                "cnpj_cpf": "65910976000147",
+            }
+        )
+
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Test Product",
+                "default_code": "TEST001",
+                "list_price": 100.0,
+            }
+        )
+
+        # Document with a real fiscal operation so that the document
+        # fiscal totals are computed (see l10n_br_fiscal.document.mixin)
+        cls.document = cls.env["l10n_br_fiscal.document"].create(
+            {
+                "company_id": cls.company.id,
+                "partner_id": cls.partner.id,
+                "fiscal_operation_type": "out",
+                "fiscal_operation_id": cls.env.ref("l10n_br_fiscal.fo_venda").id,
+                "document_type_id": cls.env.ref("l10n_br_fiscal.document_55").id,
+            }
+        )
+
+    def _build_det_binding(self, line):
+        """Build the real det binding for a document line"""
+        return line._build_binding(
+            spec_schema="nfe", spec_version="40", class_name="nfe.40.det"
+        )
+
+    def _build_total_binding(self):
+        """Build the real total binding for the document"""
+        return self.document._build_binding(
+            spec_schema="nfe", spec_version="40", class_name="nfe.40.total"
+        )
+
+    def test_export_det_binding_vitem_with_ibs_cbs(self):
+        """Test det binding exports vItem when the document has IBS/CBS"""
+        line = self.env["l10n_br_fiscal.document.line"].create(
+            {
+                "document_id": self.document.id,
+                "product_id": self.product.id,
+                "icms_cst_id": self.icms_cst_00.id,
+                "quantity": 1.0,
+                "price_unit": 100.0,
+            }
+        )
+        line.write({"ibs_value": 0.1, "ibs_base": 100.0, "cbs_value": 0.9})
+
+        self.assertGreater(line.fiscal_amount_total, 0.0)
+        det = self._build_det_binding(line)
+        self.assertEqual(det.vItem, f"{line.fiscal_amount_total:.2f}")
+
+    def test_export_det_binding_vitem_mixed_lines(self):
+        """Test all lines export vItem when only one line has IBS/CBS"""
+        line_with = self.env["l10n_br_fiscal.document.line"].create(
+            {
+                "document_id": self.document.id,
+                "product_id": self.product.id,
+                "icms_cst_id": self.icms_cst_00.id,
+                "quantity": 1.0,
+                "price_unit": 100.0,
+            }
+        )
+        line_without = self.env["l10n_br_fiscal.document.line"].create(
+            {
+                "document_id": self.document.id,
+                "product_id": self.product.id,
+                "icms_cst_id": self.icms_cst_00.id,
+                "quantity": 1.0,
+                "price_unit": 50.0,
+            }
+        )
+        line_with.write({"ibs_value": 0.1, "ibs_base": 100.0, "cbs_value": 0.9})
+
+        self.assertGreater(self.document.fiscal_amount_total, 0.0)
+        det_with = self._build_det_binding(line_with)
+        det_without = self._build_det_binding(line_without)
+        total = self._build_total_binding()
+
+        self.assertIsNotNone(det_with.vItem)
+        self.assertIsNotNone(det_without.vItem)
+        self.assertEqual(
+            Decimal(det_with.vItem) + Decimal(det_without.vItem),
+            Decimal(total.vNFTot),
+        )
+        self.assertEqual(
+            Decimal(total.vNFTot),
+            Decimal(total.ICMSTot.vNF),
+        )
+        self.assertEqual(
+            Decimal(total.vNFTot),
+            Decimal(f"{self.document.fiscal_amount_total:.2f}"),
+        )
+
+    def test_export_det_binding_vitem_with_discount(self):
+        """Test vItem uses the fiscal total instead of the gross price"""
+        line = self.env["l10n_br_fiscal.document.line"].create(
+            {
+                "document_id": self.document.id,
+                "product_id": self.product.id,
+                "icms_cst_id": self.icms_cst_00.id,
+                "quantity": 1.0,
+                "price_unit": 100.0,
+            }
+        )
+        line.write({"discount_value": 10.0, "ibs_value": 0.1, "ibs_base": 90.0})
+
+        self.assertNotEqual(line.price_gross, line.fiscal_amount_total)
+        det = self._build_det_binding(line)
+        self.assertEqual(det.vItem, f"{line.fiscal_amount_total:.2f}")
+
+    def test_export_total_binding_with_vnftot(self):
+        """Test total binding exports vNFTot along with IBSCBSTot"""
+        line = self.env["l10n_br_fiscal.document.line"].create(
+            {
+                "document_id": self.document.id,
+                "product_id": self.product.id,
+                "icms_cst_id": self.icms_cst_00.id,
+                "quantity": 1.0,
+                "price_unit": 100.0,
+            }
+        )
+        line.write({"ibs_value": 0.1, "ibs_base": 100.0, "cbs_value": 0.9})
+
+        self.assertGreater(self.document.fiscal_amount_total, 0.0)
+        total = self._build_total_binding()
+        self.assertIsNotNone(total.IBSCBSTot)
+        self.assertEqual(total.vNFTot, f"{self.document.fiscal_amount_total:.2f}")
+
+    def test_export_bindings_absent_without_ibs_cbs(self):
+        """Test vItem and vNFTot are absent when there is no IBS/CBS"""
+        # Regression guard for the legacy behavior: it must stay green
+        # before and after the fix (it is not red-green evidence)
+        line = self.env["l10n_br_fiscal.document.line"].create(
+            {
+                "document_id": self.document.id,
+                "product_id": self.product.id,
+                "icms_cst_id": self.icms_cst_00.id,
+                "quantity": 1.0,
+                "price_unit": 100.0,
+            }
+        )
+
+        det = self._build_det_binding(line)
+        total = self._build_total_binding()
+        self.assertIsNone(det.vItem)
+        self.assertIsNone(total.vNFTot)
+        self.assertIsNone(total.IBSCBSTot)
+
+    def test_export_field_vitem_and_vnftot_direct(self):
+        """Test direct _export_field calls for vItem and vNFTot"""
+        line = self.env["l10n_br_fiscal.document.line"].create(
+            {
+                "document_id": self.document.id,
+                "product_id": self.product.id,
+                "icms_cst_id": self.icms_cst_00.id,
+                "quantity": 1.0,
+                "price_unit": 100.0,
+            }
+        )
+        self.assertFalse(line._export_field("nfe40_vItem", None, None))
+        self.assertFalse(self.document._export_field("nfe40_vNFTot", None, None))
+
+        line.write({"ibs_value": 0.1, "ibs_base": 100.0})
+        self.assertEqual(
+            line._export_field("nfe40_vItem", None, None),
+            f"{line.fiscal_amount_total:.2f}",
+        )
+        self.assertEqual(
+            self.document._export_field("nfe40_vNFTot", None, None),
+            f"{self.document.fiscal_amount_total:.2f}",
+        )

--- a/l10n_br_nfe/tests/test_nfe_import.py
+++ b/l10n_br_nfe/tests/test_nfe_import.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import importlib
+import re
 
 import nfelib
 import pkg_resources
@@ -141,6 +142,58 @@ class NFeImportTest(TransactionCase):
         self.assertEqual(shipping.type, "delivery")
         self.assertEqual(shipping.street_name, "Rua da Entrega")
         self.assertEqual(shipping.zip, "01001-000")
+
+    def test_import_in_nfe_creates_reduced_tax(self):
+        """A purchase NFe line declaring an ICMS base reduction (CST 20 with
+        pRedBC) for which the company has no matching fiscal tax must create a
+        tax carrying that percent_reduction, instead of falling back to a
+        plain no-reduction tax (which would compute a wrong ICMS credit)."""
+        res_items = (
+            "nfe",
+            "samples",
+            "v4_0",
+            "leiauteNFe",
+            "35180834128745000152550010000474281920007498-nfe.xml",
+        )
+        resource_path = "/".join(res_items)
+        nfe_stream = pkg_resources.resource_stream(nfelib.__name__, resource_path)
+        xml = nfe_stream.read().decode()
+        # Replace the first ICMS00 node with an ICMS20 (base reduction).
+        # pICMS 7.00 + 33.33% reduction is unlikely to pre-exist -> forces
+        # the create-if-not-found branch.
+        icms20 = (
+            "<ICMS20>"
+            "<orig>0</orig><CST>20</CST><modBC>3</modBC>"
+            "<pRedBC>33.33</pRedBC><vBC>33.73</vBC>"
+            "<pICMS>7.00</pICMS><vICMS>2.36</vICMS>"
+            "</ICMS20>"
+        )
+        xml = re.sub(r"<ICMS00>.*?</ICMS00>", icms20, xml, count=1, flags=re.S)
+
+        existing = self.env["l10n_br_fiscal.tax"].search(
+            [
+                ("tax_group_id", "=", self.env.ref("l10n_br_fiscal.tax_group_icms").id),
+                ("percent_amount", "=", 7.0),
+                ("percent_reduction", "=", 33.33),
+            ]
+        )
+        self.assertFalse(existing, "test precondition: reduced tax must not exist")
+
+        binding = TnfeProc.from_xml(xml)
+        nfe = self.env["l10n_br_fiscal.document"].import_binding_nfe(
+            binding, edoc_type="in", dry_run=False
+        )
+        created = self.env["l10n_br_fiscal.tax"].search(
+            [
+                ("tax_group_id", "=", self.env.ref("l10n_br_fiscal.tax_group_icms").id),
+                ("percent_amount", "=", 7.0),
+                ("percent_reduction", "=", 33.33),
+            ]
+        )
+        self.assertTrue(created, "reduced ICMS tax was not created on import")
+        line = nfe.fiscal_line_ids[0]
+        self.assertEqual(line.icms_tax_id, created)
+        self.assertEqual(line.icms_tax_id.percent_reduction, 33.33)
 
     def test_import_out_nfe(self):
         "(can be useful after an ERP migration)"

--- a/l10n_br_nfe/tests/test_nfe_import.py
+++ b/l10n_br_nfe/tests/test_nfe_import.py
@@ -4,6 +4,7 @@
 import importlib
 
 import nfelib
+import pkg_resources
 from nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00 import TnfeProc
 
 from odoo.models import NewId
@@ -106,6 +107,40 @@ class NFeImportTest(TransactionCase):
         self.assertEqual(
             nfe.fiscal_line_ids[2].product_id.name, "QUINOA PICANTE 100G (2X50G)"
         )
+
+    def test_import_in_nfe_delivery_address(self):
+        """A purchase NFe with an <entrega> block must import the delivery
+        address into the stored partner_shipping_id (nfe40_entrega is a
+        non-stored computed field, so it cannot hold the imported value)."""
+        res_items = (
+            "nfe",
+            "samples",
+            "v4_0",
+            "leiauteNFe",
+            "35180834128745000152550010000474281920007498-nfe.xml",
+        )
+        resource_path = "/".join(res_items)
+        nfe_stream = pkg_resources.resource_stream(nfelib.__name__, resource_path)
+        xml = nfe_stream.read().decode()
+        entrega = (
+            "<entrega>"
+            "<CNPJ>34128745000152</CNPJ>"
+            "<xLgr>Rua da Entrega</xLgr><nro>999</nro><xBairro>Centro</xBairro>"
+            "<cMun>3550308</cMun><xMun>SAO PAULO</xMun><UF>SP</UF>"
+            "<CEP>01001000</CEP><cPais>1058</cPais><xPais>Brasil</xPais>"
+            "</entrega>"
+        )
+        xml = xml.replace("</dest>", "</dest>" + entrega, 1)
+        binding = TnfeProc.from_xml(xml)
+        nfe = self.env["l10n_br_fiscal.document"].import_binding_nfe(
+            binding, edoc_type="in", dry_run=False
+        )
+        shipping = nfe.partner_shipping_id
+        self.assertTrue(shipping, "delivery address was not imported")
+        self.assertNotEqual(shipping, nfe.partner_id)
+        self.assertEqual(shipping.type, "delivery")
+        self.assertEqual(shipping.street_name, "Rua da Entrega")
+        self.assertEqual(shipping.zip, "01001-000")
 
     def test_import_out_nfe(self):
         "(can be useful after an ERP migration)"

--- a/l10n_br_nfe/tests/test_nfe_import_wizard.py
+++ b/l10n_br_nfe/tests/test_nfe_import_wizard.py
@@ -206,6 +206,28 @@ class NFeImportWizardTest(TransactionCase):
         prod_id = self.wizard._match_product(MagicMock())
         self.assertFalse(prod_id)
 
+    def test_match_product_by_purchase(self):
+        """The purchase-order priority match is a soft dependency on
+        l10n_br_purchase (which adds partner_order/partner_order_line to
+        purchase.order.line). It must be a no-op when those fields are absent,
+        so _match_product falls back to supplierinfo/default_code/barcode."""
+        self._prepare_wizard(self.xml_1)
+        pol = self.env.get("purchase.order.line")
+        has_fields = pol is not None and "partner_order" in pol._fields
+        mock = MagicMock()
+        mock.xPed = "NONEXISTENT-PO-REF"
+        mock.nItemPed = "999"
+        # No PO references this xPed (and/or l10n_br_purchase absent) -> no
+        # match, and crucially no crash on a missing field.
+        self.assertFalse(self.wizard._match_product_by_purchase(mock))
+        if not has_fields:
+            # guard short-circuits before any purchase.order.line search
+            self.assertFalse(
+                self.wizard._match_product_by_purchase(
+                    self.wizard._parse_file().infNFe.det[0].prod
+                )
+            )
+
     def test__parse_xml(self):
         self._prepare_wizard(self.xml_1)
 

--- a/l10n_br_nfe/tests/test_nfe_xml_validation.py
+++ b/l10n_br_nfe/tests/test_nfe_xml_validation.py
@@ -84,7 +84,7 @@ class TestXMLValidation(TransactionCase):
                 "fiscal_quantity": 22,
             }
         )
-        self.assertEqual(len(line.fiscal_tax_ids), 4)
+        self.assertEqual(len(line.fiscal_tax_ids), 6)
         line.write(
             {
                 "icms_tax_id": self.env.ref("l10n_br_fiscal.tax_icms_12_st").id,

--- a/l10n_br_nfe/wizards/document_import_wizard.py
+++ b/l10n_br_nfe/wizards/document_import_wizard.py
@@ -111,29 +111,7 @@ class DocumentImportWizard(models.TransientModel):
         taxes = self._get_taxes_from_xml_product(product)
         supplier_id = self._search_product_supplier_by_product_code(product.prod.cProd)
         product_id = self._match_product(product.prod)
-        # if self.fiscal_operation_type == "in"
-        # and product_id and product_id.purchase_ok:
-        if False:  # seems former test is always true after you
-            # imported the product once -> it screws the UOM.
-            uom_id = product_id.uom_po_id
-        else:
-            uom_id = self.env["uom.uom"].search(
-                [
-                    "|",
-                    ("code", "=", product.prod.uCom),
-                    ("code", "=", product.prod.uTrib),
-                ],
-                limit=1,
-            )
-            if not uom_id:  # search for alias
-                uom_id = self.env["uom.uom"].search(
-                    [
-                        "|",
-                        ("name", "=", product.prod.uCom),
-                        ("name", "=", product.prod.uTrib),
-                    ],
-                    limit=1,
-                )
+        uom_id = self._match_uom_by_code(product.prod.uCom, product.prod.uTrib)
 
         return {
             "product_name": product.prod.xProd,

--- a/l10n_br_nfe/wizards/document_import_wizard.py
+++ b/l10n_br_nfe/wizards/document_import_wizard.py
@@ -5,6 +5,7 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 import base64
+from collections import Counter
 
 from erpbrasil.base.fiscal.cnpj_cpf import formata
 
@@ -44,10 +45,25 @@ class DocumentImportWizard(models.TransientModel):
             infNFe = binding.infNFe
             self.nat_op = infNFe.ide.natOp
             self.fiscal_operation_id = self._find_fiscal_operation(
-                infNFe.det[0].prod.CFOP, self.nat_op, self.fiscal_operation_type
+                self._most_common_cfop(infNFe),
+                self.nat_op,
+                self.fiscal_operation_type,
             )
             self._create_imported_products_by_xml(binding)
         return res
+
+    @api.model
+    def _most_common_cfop(self, infNFe):
+        """Return the CFOP shared by most of the NFe lines.
+
+        A single NFe can mix CFOPs (e.g. a freight or one-off line), so
+        picking the first line's CFOP is unreliable. The majority CFOP
+        better represents the document's fiscal operation.
+        """
+        cfops = [det.prod.CFOP for det in infNFe.det if det.prod.CFOP]
+        if not cfops:
+            return False
+        return Counter(cfops).most_common(1)[0][0]
 
     def _destination_partner_from_binding(self, binding):
         if self.document_type == MODELO_FISCAL_NFE:

--- a/l10n_br_nfe/wizards/document_import_wizard.py
+++ b/l10n_br_nfe/wizards/document_import_wizard.py
@@ -5,9 +5,7 @@
 # Copyright (C) 2026  Raphaël Valyi - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-import base64
 from collections import Counter
-
 from erpbrasil.base.fiscal.cnpj_cpf import formata
 
 from odoo import Command, _, api, fields, models
@@ -303,7 +301,7 @@ class DocumentImportWizard(models.TransientModel):
         return self.env["ir.attachment"].create(
             {
                 "name": f"NFe-Importada-{edoc.document_key}.xml",
-                "datas": base64.b64decode(self.file),
+                "datas": self.file,
                 "description": "XML NFe - Importada por XML",
                 "res_model": "l10n_br_fiscal.document",
                 "res_id": edoc.id,

--- a/l10n_br_nfe/wizards/document_import_wizard.py
+++ b/l10n_br_nfe/wizards/document_import_wizard.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2022  Renan Hiroki Bastos - Kmee
 # Copyright (C) 2023  Luiz Felipe do Divino - Kmee
 # Copyright (C) 2023  Felipe Zago Rodrigues - Kmee
+# Copyright (C) 2026  Raphaël Valyi - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 import base64
@@ -157,6 +158,10 @@ class DocumentImportWizard(models.TransientModel):
         return variant_ids[0]
 
     def _match_product(self, xml_product):
+        product_id = self._match_product_by_purchase(xml_product)
+        if product_id:
+            return product_id
+
         product_id = self._get_product_by_supplier(xml_product.cProd)
         if product_id:
             return product_id
@@ -173,6 +178,74 @@ class DocumentImportWizard(models.TransientModel):
             domain = expression.OR(domains)
             rec_id = self.env["product.product"].search(domain, limit=1)
         return rec_id
+
+    def _match_product_by_purchase(self, xml_product):
+        """Priority match from the referenced purchase order.
+
+        When ``l10n_br_purchase`` is installed and the XML line references the
+        buyer's purchase order (xPed / nItemPed), take the product from the
+        matching purchase order line first: it is the most authoritative match
+        since the buyer already stated which product was ordered.
+
+        Soft dependency: no-op unless l10n_br_purchase is installed (it adds
+        the partner_order / partner_order_line fields to purchase.order.line;
+        core ``purchase`` alone does not provide them).
+        """
+        pol_model = self.env.get("purchase.order.line")
+        if pol_model is None or "partner_order" not in pol_model._fields:
+            return False
+        xped = (getattr(xml_product, "xPed", "") or "").strip()
+        if not xped:
+            return False
+
+        partner = self.partner_id.id
+        pol = pol_model.sudo()
+        nitemped = (getattr(xml_product, "nItemPed", "") or "").strip()
+
+        # 1) exact agreed reference: xPed + nItemPed on the purchase order line
+        if nitemped:
+            line = pol.search(
+                [
+                    ("order_id.partner_id", "=", partner),
+                    ("partner_order", "=", xped),
+                    ("partner_order_line", "=", nitemped),
+                ],
+                limit=1,
+            )
+            if line:
+                return line.product_id
+
+        # 2) heuristic: narrow to the referenced order (partner_order on the
+        # line, else the buyer PO name / vendor reference), then disambiguate
+        # the line by the XML product code / barcode.
+        lines = pol.search(
+            [("order_id.partner_id", "=", partner), ("partner_order", "=", xped)]
+        )
+        if not lines:
+            order = (
+                self.env["purchase.order"]
+                .sudo()
+                .search(
+                    [
+                        ("partner_id", "=", partner),
+                        "|",
+                        ("partner_ref", "=", xped),
+                        ("name", "=", xped),
+                    ],
+                    limit=1,
+                )
+            )
+            lines = order.order_line
+        if len(lines) == 1:
+            return lines.product_id
+        cprod = getattr(xml_product, "cProd", None)
+        ean = getattr(xml_product, "cEANTrib", None)
+        for line in lines:
+            if cprod and line.product_id.default_code == cprod:
+                return line.product_id
+            if ean and ean != "SEM GTIN" and line.product_id.barcode == ean:
+                return line.product_id
+        return False
 
     def _get_taxes_from_xml_product(self, product):
         vICMS = 0

--- a/l10n_br_nfe/wizards/document_import_wizard.py
+++ b/l10n_br_nfe/wizards/document_import_wizard.py
@@ -6,6 +6,7 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from collections import Counter
+
 from erpbrasil.base.fiscal.cnpj_cpf import formata
 
 from odoo import Command, _, api, fields, models

--- a/l10n_br_nfe/wizards/document_import_wizard.py
+++ b/l10n_br_nfe/wizards/document_import_wizard.py
@@ -279,7 +279,13 @@ class DocumentImportWizard(models.TransientModel):
             edoc.document_type_id = self.env.ref("l10n_br_fiscal.document_55").id
             edoc.fiscal_operation_id = self.fiscal_operation_id
             for line in edoc.fiscal_line_ids:
+                # Preserve the XML price_unit because setting
+                # fiscal_operation_id triggers _compute_price_unit_fiscal
+                # which would overwrite it with the product's list/cost price
+                # (which is 0 when the product is created during import).
+                price_unit = line.price_unit
                 line.fiscal_operation_id = self.fiscal_operation_id
+                line.price_unit = price_unit
                 line.uom_id = line.uot_id
 
             if not self.partner_id:


### PR DESCRIPTION
Port from 16.0 to 18.0:
- #4494
- #4653
- #4681
- #4692
- #4789

These PRs are ported for all modules already migrated to 18.0 (l10n_br_fiscal, l10n_br_account, l10n_br_nfe). Sub-commits belonging to l10n_br_cte and l10n_br_account_nfe are NOT ported (those modules are not available on 18.0 yet).

PR #4762 (Lucro Real company demo data) is not included in this port — it requires the br_oca_generic chart template setup on 18.0 which is a separate stream.
