### PR TITLE
[16.0][FIX] spec_driven_model: import the binding module instead of assuming it is imported

### DIFF
--- a/spec_driven_model/models/spec_export.py
+++ b/spec_driven_model/models/spec_export.py
@@ -3,7 +3,7 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
 
 import logging
-import sys
+from importlib import import_module
 
 from odoo import api, fields, models
 
@@ -20,7 +20,11 @@ class SpecMixinExport(models.AbstractModel):
         Use (_spec_prefix)_binding_type of odoo_class and its binding_module to get
         the Python binding type for export.
         """
-        binding_module = sys.modules[self._get_spec_property("binding_module")]
+        # importlib because the binding may not be imported yet: modules with
+        # an optional external dependency cannot import it at load time (any
+        # warning at loading fails the checklog), so nothing guarantees the
+        # binding is in sys.modules before the first export.
+        binding_module = import_module(self._get_spec_property("binding_module"))
         binding_type = odoo_class._get_spec_property("binding_type")
         if not binding_type and field_name:
             if field_name in odoo_class._fields and hasattr(


### PR DESCRIPTION
_get_binding_class resolves the binding module with sys.modules[], which
assumes something already imported it. NF-e, CT-e and MDF-e import their
bindings at the top of their files so they never hit this, but a module
with an optional external dependency cannot import it at load time (an
import warning at loading fails the checklog) and gets a KeyError on the
first export. Found while developing l10n_br_reinf.

The fix resolves the module with importlib.import_module, which returns the
cached module when it is already imported (no behavior change for the
existing documents).
