### PR TITLE
[16.0][FIX] l10n_br_account: Recalcula o nome da linha de parcela quando o document_number é atribuído depois

### DIFF
--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -96,7 +96,7 @@ class AccountMoveLine(models.Model):
                 line.quantity * line.price_unit or 1
             )
 
-    @api.depends("product_id", "payment_term_number")
+    @api.depends("product_id", "payment_term_number", "move_id.document_number")
     def _compute_name(self):
         """
         Override to set 'name' with 'document_number/payment_term_number' for


### PR DESCRIPTION
## Problema

Para faturas ligadas a um documento fiscal (l10n_br_fiscal.document), a linha de parcela (account.move.line, display_type='payment_term') deveria ter o campo name no formato:

NUMERO_DO_DOCUMENTO_FISCAL/PARCELA-TOTAL_DE_PARCELAS

ex: 114549/1-1.

Na prática, algumas faturas acabam com o name da linha igual ao próprio nome/referência de pagamento da fatura (ex: SAJ/2026/04613), mesmo quando o documento fiscal vinculado já tem um document_number definido.

## Causa raiz

AccountMoveLine._compute_name() só monta o label documento/parcela quando move_id.document_number já está disponível no momento em que o cálculo roda:

```python
@api.depends("product_id", "payment_term_number")
def _compute_name(self):
    payment_term_lines = self.filtered(
        lambda line: line.display_type == "payment_term"
        and line.document_type_id
        and line.move_id.document_number
        and line.payment_term_number
    )
    for line in payment_term_lines:
        line.name = f"{line.move_id.document_number}/{line.payment_term_number}"

    other_lines = self - payment_term_lines
    if other_lines:
        return super()._compute_name()
    return True
```

Se document_number ainda não estiver preenchido nesse momento (comum em documentos eletrônicos, cujo número só é atribuído durante a confirmação/autorização do documento — o que pode acontecer depois de a fatura já ter sido postada, por exemplo via um job assíncrono), a linha cai no super()._compute_name(). O módulo core account então define o name da linha de parcela como move_id.payment_reference, que por padrão é o próprio nome da fatura.

Como document_number não estava declarado no @api.depends, isso é uma via de mão única: uma vez que o name é calculado e armazenado com o valor de fallback, ele nunca mais é recalculado, mesmo depois que o documento fiscal é confirmado/autorizado e recebe seu document_number real. O valor armazenado fica travado permanentemente.

## Correção

Adicionar move_id.document_number ao @api.depends de _compute_name(), para que o campo seja recalculado corretamente assim que o número do documento fiscal ficar disponível:

```python
@api.depends("product_id", "payment_term_number", "move_id.document_number")
def _compute_name(self):
    ...
```

## Impacto / correção de dados

Essa mudança só corrige o cálculo daqui pra frente. Os registros que já foram calculados com o valor errado (fallback) precisam de uma correção de dados única — rodamos o seguinte no nosso banco para recompor o label correto nas linhas de parcela já afetadas:

```sql
UPDATE account_move_line aml
SET name = fd.document_number || '/' || aml.payment_term_number
FROM account_move am
JOIN l10n_br_fiscal_document fd ON fd.id = am.fiscal_document_id
WHERE am.id = aml.move_id
  AND aml.display_type = 'payment_term'
  AND fd.document_number IS NOT NULL
  AND aml.payment_term_number IS NOT NULL
  AND aml.name IS DISTINCT FROM (
      fd.document_number || '/' || aml.payment_term_number
  );
```

## Teste

Validado em um banco com dados reais: antes da correção, uma linha de parcela ligada a um documento fiscal com document_number = 12345 mantinha name = <nome da fatura> (ex: SAJ/2026/00001) em vez de 12345/1-1. Depois de adicionar a dependência, o recálculo (ou a correção via SQL de backfill) define corretamente 12345/1-1. Confirmado que não restam linhas divergentes após aplicar a correção.