### PR TITLE
[14.0][FIX] l10n_br_nfse_focus: codigo_nbs_unmasked

### DIFF
--- a/l10n_br_nfse_focus/models/nfse_nacional.py
+++ b/l10n_br_nfse_focus/models/nfse_nacional.py
@@ -200,9 +200,9 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
             "codigo_municipio_prestacao": int(codigo_municipio_prestacao),
             "codigo_tributacao_nacional": codigo_tributacao_nacional,
             "codigo_tributacao_municipio": codigo_tributacao_municipio,
-            "codigo_nbs": ""
+            "codigo_nbs_unmasked": ""
             if self.env.company.city_id.ibge_code == "3516200"
-            else service_info.get("codigo_nbs", ""),
+            else service_info.get("codigo_nbs_unmasked", ""),
             "descricao": service_info.get("discriminacao", ""),
             "valor": round(service_info.get("valor_servicos", 0), 2),
             "tributacao_iss": int(tributacao_iss),
@@ -384,7 +384,7 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
             "codigo_tributacao_municipal_iss": service_basic[
                 "codigo_tributacao_municipio"
             ],
-            "codigo_nbs": service_basic["codigo_nbs"],
+            "codigo_nbs": service_basic["codigo_nbs_unmasked"],
             "descricao_servico": service_basic["descricao"],
             "valor_servico": service_basic["valor"],
             "tributacao_iss": service_basic["tributacao_iss"],


### PR DESCRIPTION
## Objetivo da PR

Corrigir Codigo NBS enviar `codigo_nbs_unmasked`
<img width="661" height="227" alt="Erro usuario" src="https://github.com/user-attachments/assets/4003d43c-e6f3-469f-8bd0-aba31dff892d" />

JSON Exemplo:
```
{
  "data_emissao": "2026-01-13T11:16:06-03:00",
  "data_competencia": "2026-01-13",
  "codigo_municipio_emissora": 4314902,
  "cnpj_prestador": "00000000000000",
  "codigo_opcao_simples_nacional": 1,
  "regime_especial_tributacao": 0,
  "cnpj_tomador": "00000000000000",
  "razao_social_tomador": "RAZAO SOCIAL TOMADOR LTDA",
  "codigo_municipio_tomador": 4314902,
  "cep_tomador": "00000000",
  "logradouro_tomador": "AVENIDA EXEMPLO",
  "numero_tomador": "000",
  "complemento_tomador": "-",
  "bairro_tomador": "BAIRRO EXEMPLO",
  "telefone_tomador": "0000000000",
  "email_tomador": "contato@exemplo.org.br",
  "codigo_municipio_prestacao": 4314902,
  "codigo_tributacao_nacional_iss": "130501",
  "codigo_nbs": "121012200",
  "descricao_servico": "DESCRICAO EXEMPLO",
  "valor_servico": 60,
  "valor_iss": 1.5,
  "tributacao_iss": 1,
  "tipo_retencao_iss": 1,
  "percentual_total_tributos_federais": "10.38",
  "percentual_total_tributos_estaduais": "0.00",
  "percentual_total_tributos_municipais": "2.50",
  "situacao_tributaria_pis_cofins": "00",
  "indicador_total_tributacao": null
}
```

Documentação da Focus:
https://focusnfe.com.br/guides/nfse/municipios-integrados/municipios-da-nfse-nacional/

cc @marcelsavegnago @mileo @rvalyi 