### PR TITLE
[16.0][FIX] l10n_br_mdfe: match cities by ibge_code on import

### DIFF
--- a/l10n_br_mdfe/models/__init__.py
+++ b/l10n_br_mdfe/models/__init__.py
@@ -1,6 +1,7 @@
 from . import transporte
 from . import res_company
 from . import res_country_state
+from . import res_city
 from . import document
 from . import document_related
 from . import res_partner

--- a/l10n_br_mdfe/models/res_city.py
+++ b/l10n_br_mdfe/models/res_city.py
@@ -1,0 +1,20 @@
+# Copyright 2026 Madooit
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class ResCity(models.Model):
+    _inherit = "res.city"
+    _mdfe_search_keys = ["ibge_code"]
+
+    @api.model
+    def match_or_create_m2o(self, rec_dict, parent_dict, model=None):
+        """If city not found, break hard, don't create it"""
+
+        if rec_dict.get("ibge_code"):
+            domain = [("ibge_code", "=", rec_dict.get("ibge_code"))]
+            match = self.search(domain, limit=1)
+            if match:
+                return match.id
+        return False


### PR DESCRIPTION
Fixes the MDF-e import on environments where `l10n_br_nfe` / `l10n_br_cte` are not installed.

Without this, `res.city` has no `match_or_create_m2o` override and the MDF-e import
tries to create a city with empty values, raising a `NotNullViolation` on
`country_id`. That breaks the `post_init_hook` sample import and the
`test_import_in_mdfe` test on a minimal (deps-only) OCA CI install, blocking
any PR touching `l10n_br_mdfe` (e.g. #4860).

Mirrors the existing behavior of `l10n_br_nfe`/`l10n_br_cte`: match by
`ibge_code` and never create a city on import.

Tested with a CI-faithful run (`oca_init_test_database` + `oca_run_tests`):
0 failed, 0 error(s) of 31 tests.