### PR TITLE
[16.0][FIX] l10n_br_nfe: accept field_name in _export_fields

### DIFF
--- a/l10n_br_nfe/models/document_related.py
+++ b/l10n_br_nfe/models/document_related.py
@@ -134,7 +134,7 @@ class NFeRelated(spec_models.StackedModel):
             if record.nfe40_refCTe:
                 record.document_key = record.nfe40_refCTe
 
-    def _export_fields(self, xsd_fields, class_obj, export_dict):
+    def _export_fields(self, xsd_fields, class_obj, export_dict, field_name=None):
         if class_obj._name == "nfe.40.nfref":
             xsd_fields = [
                 f
@@ -142,4 +142,6 @@ class NFeRelated(spec_models.StackedModel):
                 if f not in [i[0] for i in self._fields["nfe40_choice_nfref"].selection]
             ]
             xsd_fields += [self.nfe40_choice_nfref]
-        return super()._export_fields(xsd_fields, class_obj, export_dict)
+        return super()._export_fields(
+            xsd_fields, class_obj, export_dict, field_name=field_name
+        )


### PR DESCRIPTION
`spec_driven_model` `_build_binding` calls `_export_fields` with the
`field_name` keyword argument since db9fff8d6c, but the `NFeRelated` override
still used the old signature, raising:

```
TypeError: NFeRelated._export_fields() got an unexpected keyword argument 'field_name'
```

when serializing related documents (e.g. MDF-e `infNFe`) in environments
where `l10n_br_nfe` is installed.