### PR TITLE
[16.0][FIX][IMP] l10n_br_sped_ecd: geração do bloco I a partir da escrituração

### DIFF
--- a/l10n_br_sped_ecd/models/sped_ecd.py
+++ b/l10n_br_sped_ecd/models/sped_ecd.py
@@ -326,17 +326,116 @@ class RegistroI050(models.Model):
     _name = "l10n_br_sped.ecd.i050"
     _inherit = "l10n_br_sped.ecd.9.i050"
 
-    # @api.model
-    # def _map_from_odoo(self, record, parent_record, declaration, index=0):
-    #     return {
-    #         "DT_ALT": 0,  # Data da inclusão/alteração.
-    #         "COD_NAT": 0,  # Código da natureza da conta/grupo de contas, conform...
-    #         "IND_CTA": 0,  # Indicador do tipo de conta: S - Sintética (grupo de ...
-    #         "NIVEL": 0,  # Nível da conta analítica/grupo de contas.
-    #         "COD_CTA": 0,  # Código da conta analítica/grupo de contas.
-    #         "COD_CTA_SUP": 0,  # Código da conta sintética /grupo de contas de ní...
-    #         "CTA": 0,  # Nome da conta analítica/grupo de contas.
-    #     }
+    # Natureza da conta, tabela 4.2.1 do leiaute. O Odoo não guarda a natureza
+    # do SPED, mas o grupo interno da conta a determina sem ambiguidade.
+    _COD_NAT_BY_GROUP = {
+        "asset": "01",
+        "liability": "02",
+        "equity": "03",
+        "income": "04",
+        "expense": "04",
+        "off_balance": "05",
+    }
+
+    @api.model
+    def _pull_records_from_odoo(
+        self, kind, level, parent_register=None, parent_record=None, log_msg=None
+    ):
+        """Declara o plano inteiro, sintéticas e analíticas.
+
+        O registro vem de DOIS modelos: o `account.group` dá as contas
+        sintéticas e o `account.account` as analíticas. O mapeamento padrão
+        percorre um modelo só, por isso a coleta é montada aqui.
+
+        A ordem é a do código da conta, e não a de criação, porque o PVA exige
+        que a conta superior apareça antes da conta que a referencia.
+        """
+        declaration = self._context["declaration"]
+        company = declaration.company_id
+        i051 = self.env["l10n_br_sped.ecd.i051"]
+
+        groups = (
+            self.env["account.group"]
+            .with_company(company)
+            .search([("company_id", "=", company.id)])
+        )
+        accounts = (
+            self.env["account.account"]
+            .with_company(company)
+            .search([("company_id", "=", company.id)])
+        )
+
+        # A natureza de um grupo é a das contas que ele reúne: o grupo em si
+        # não a declara. Herdar da primeira conta encontrada e subir a árvore
+        # evita marcar o grupo como "outras" quando ele é claramente de ativo.
+        nat_by_group = {}
+        for account in accounts:
+            group = account.group_id
+            nat = self._COD_NAT_BY_GROUP.get(account.internal_group, "09")
+            while group:
+                nat_by_group.setdefault(group.id, nat)
+                group = group.parent_id
+
+        def depth(group):
+            level_, parent = 1, group.parent_id
+            while parent:
+                level_, parent = level_ + 1, parent.parent_id
+            return level_
+
+        items = [
+            (group.code_prefix_start, "S", group)
+            for group in groups
+            if group.code_prefix_start
+        ]
+        items += [(account.code, "A", account) for account in accounts if account.code]
+        items.sort(key=lambda item: item[0])
+
+        registers = self.browse()
+        for _code, ind_cta, record in items:
+            if ind_cta == "S":
+                vals = {
+                    "COD_NAT": nat_by_group.get(record.id, "09"),
+                    "IND_CTA": "S",
+                    "NIVEL": depth(record),
+                    "COD_CTA": record.code_prefix_start,
+                    "COD_CTA_SUP": record.parent_id.code_prefix_start or "",
+                    "CTA": record.name,
+                    "res_model": "account.group",
+                    "res_id": record.id,
+                }
+            else:
+                group = record.group_id
+                vals = {
+                    "COD_NAT": self._COD_NAT_BY_GROUP.get(record.internal_group, "09"),
+                    "IND_CTA": "A",
+                    "NIVEL": (depth(group) + 1) if group else 1,
+                    "COD_CTA": record.code,
+                    "COD_CTA_SUP": group.code_prefix_start if group else "",
+                    "CTA": record.name,
+                    "res_model": "account.account",
+                    "res_id": record.id,
+                }
+            vals["DT_ALT"] = declaration.DT_INI
+            vals["declaration_id"] = declaration.id
+            if parent_register:
+                vals["reg_I050_ids_RegistroI010_id"] = parent_register.id
+            register = self.create(vals)
+            registers |= register
+
+            # I051 é o de-para para o plano referencial da Receita. Só a conta
+            # analítica mapeada gera o filho: o registro é opcional por conta.
+            if ind_cta == "A" and record.l10n_br_sped_referential_code:
+                i051.create(
+                    {
+                        "COD_CCUS": "",
+                        "COD_CTA_REF": record.l10n_br_sped_referential_code,
+                        "declaration_id": declaration.id,
+                        "reg_I051_ids_RegistroI050_id": register.id,
+                    }
+                )
+
+        if log_msg is not None:
+            self._log_chatter_sped_item(log_msg, level, registers)
 
 
 class RegistroI051(models.Model):
@@ -423,12 +522,32 @@ class RegistroI150(models.Model):
     _name = "l10n_br_sped.ecd.i150"
     _inherit = "l10n_br_sped.ecd.9.i150"
 
-    # @api.model
-    # def _map_from_odoo(self, record, parent_record, declaration, index=0):
-    #     return {
-    #         "DT_INI": 0,  # Data de início do período.
-    #         "DT_FIN": 0,  # Data de fim do período.
-    #     }
+    @api.model
+    def _odoo_query(self, parent_record, declaration):
+        """Um período por mês do intervalo da escrituração.
+
+        O balancete mensal é a periodicidade usual da ECD, e é a que permite
+        conferir a escrituração mês a mês. Os períodos precisam cobrir o
+        intervalo inteiro sem buraco, então são gerados do calendário e não
+        dos lançamentos: mês sem movimento entra com saldo repetido, que é o
+        que o leiaute espera.
+        """
+        query = """
+            SELECT mes::date AS dt_ini,
+                   (mes + INTERVAL '1 month' - INTERVAL '1 day')::date AS dt_fin
+            FROM generate_series(
+                date_trunc('month', %s::date), %s::date, INTERVAL '1 month'
+            ) AS mes
+            ORDER BY 1
+        """
+        return query, (declaration.DT_INI, declaration.DT_FIN)
+
+    @api.model
+    def _map_from_odoo(self, record, parent_record, declaration, index=0):
+        return {
+            "DT_INI": record["dt_ini"],
+            "DT_FIN": record["dt_fin"],
+        }
 
 
 class RegistroI155(models.Model):
@@ -438,24 +557,82 @@ class RegistroI155(models.Model):
     _name = "l10n_br_sped.ecd.i155"
     _inherit = "l10n_br_sped.ecd.9.i155"
 
-    # @api.model
-    # def _map_from_odoo(self, record, parent_record, declaration, index=0):
-    #     return {
-    #         "COD_CTA": 0,  # Código da conta analítica.
-    #         "COD_CCUS": 0,  # Código do centro de custos.
-    #         "VL_SLD_INI": 0,  # Valor do saldo inicial do período.
-    #         "IND_DC_INI": 0,  # Indicador da situação do saldo inicial: D - Deved...
-    #         "VL_DEB": 0,  # Valor total dos débitos do período.
-    #         "VL_CRED": 0,  # Valor total dos créditos do período.
-    #         "VL_SLD_FIN": 0,  # Valor do saldo final do período.
-    #         "IND_DC_FIN": 0,  # Indicador da situação do saldo final: D - Devedor...
-    #         "VL_SLD_INI_MF": 0,  # Valor do saldo inicial do período em moeda fun...
-    #         "IND_DC_INI_MF": 0,  # Indicador da situação do saldo inicial em moed...
-    #         "VL_DEB_MF": 0,  # Valor total dos débitos do período em moeda funcio...
-    #         "VL_CRED_MF": 0,  # Valor total dos créditos do período em moeda func...
-    #         "VL_SLD_FIN_MF": 0,  # Valor do saldo final do período em moeda funci...
-    #         "IND_DC_FIN_MF": 0,  # Indicador da situação do saldo final em moeda ...
-    #     }
+    @api.model
+    def _odoo_query(self, parent_record, declaration):
+        """Saldo inicial, movimento e saldo final de cada conta, no mês do pai.
+
+        A agregação é feita no banco porque o balancete percorre todas as
+        partidas do exercício por conta, e trazer isso para o ORM não escala
+        em escrituração de porte real.
+
+        O saldo inicial é a soma de tudo que foi lançado ANTES do mês, o que
+        é a leitura literal do razão. Vale registrar a consequência: sem
+        lançamento de encerramento do exercício, conta de resultado acumula
+        desde a abertura da escrituração, e não desde 1º de janeiro.
+
+        Só entra conta que tem movimento ou saldo, para o arquivo não carregar
+        o plano inteiro zerado em todo mês.
+        """
+        query = """
+            SELECT a.code AS cod_cta,
+                   COALESCE(SUM(
+                       CASE WHEN l.date < %(ini)s THEN l.balance ELSE 0 END
+                   ), 0) AS vl_sld_ini,
+                   COALESCE(SUM(
+                       CASE WHEN l.date BETWEEN %(ini)s AND %(fim)s
+                            THEN l.debit ELSE 0 END
+                   ), 0) AS vl_deb,
+                   COALESCE(SUM(
+                       CASE WHEN l.date BETWEEN %(ini)s AND %(fim)s
+                            THEN l.credit ELSE 0 END
+                   ), 0) AS vl_cred,
+                   COALESCE(SUM(
+                       CASE WHEN l.date <= %(fim)s THEN l.balance ELSE 0 END
+                   ), 0) AS vl_sld_fin
+            FROM account_move_line l
+            JOIN account_account a ON a.id = l.account_id
+            JOIN account_move m ON m.id = l.move_id
+            WHERE l.company_id = %(company)s
+              AND m.state = 'posted'
+              AND l.date <= %(fim)s
+            GROUP BY a.code
+            HAVING COALESCE(SUM(
+                       CASE WHEN l.date <= %(fim)s THEN l.balance ELSE 0 END
+                   ), 0) <> 0
+                OR COALESCE(SUM(
+                       CASE WHEN l.date BETWEEN %(ini)s AND %(fim)s
+                            THEN l.debit ELSE 0 END
+                   ), 0) <> 0
+                OR COALESCE(SUM(
+                       CASE WHEN l.date BETWEEN %(ini)s AND %(fim)s
+                            THEN l.credit ELSE 0 END
+                   ), 0) <> 0
+            ORDER BY a.code
+        """
+        params = {
+            "ini": parent_record["dt_ini"],
+            "fim": parent_record["dt_fin"],
+            "company": declaration.company_id.id,
+        }
+        return query, params
+
+    @api.model
+    def _map_from_odoo(self, record, parent_record, declaration, index=0):
+        # O leiaute pede valor sempre positivo, com a natureza declarada à
+        # parte: saldo devedor é "D" e credor é "C". No Odoo o saldo devedor
+        # é positivo, então o sinal decide o indicador e o valor vai em módulo.
+        sld_ini = record["vl_sld_ini"]
+        sld_fin = record["vl_sld_fin"]
+        return {
+            "COD_CTA": record["cod_cta"],
+            "COD_CCUS": "",
+            "VL_SLD_INI": abs(sld_ini),
+            "IND_DC_INI": "C" if sld_ini < 0 else "D",
+            "VL_DEB": record["vl_deb"],
+            "VL_CRED": record["vl_cred"],
+            "VL_SLD_FIN": abs(sld_fin),
+            "IND_DC_FIN": "C" if sld_fin < 0 else "D",
+        }
 
 
 class RegistroI157(models.Model):
@@ -492,21 +669,32 @@ class RegistroI200(models.Model):
         else:
             return [
                 ("company_id", "=", declaration.company_id.id),
-                ("state", "=", "open"),
-                ("date", ">", declaration.DT_INI),
-                ("date", "<", declaration.DT_FIN),
+                # "open" nao existe na 16.0: os estados sao draft, posted e
+                # cancel. Com o valor invalido o dominio nunca casava e o
+                # bloco I saia sem nenhum lancamento.
+                ("state", "=", "posted"),
+                # as datas sao inclusivas: com o operador estrito, lancamento
+                # no primeiro ou no ultimo dia do periodo ficava de fora
+                ("date", ">=", declaration.DT_INI),
+                ("date", "<=", declaration.DT_FIN),
             ]
 
     @api.model
     def _map_from_odoo(self, record, parent_record, declaration, index=0):
+        # O valor do lançamento é o total das partidas devedoras. O
+        # `fiscal_amount_total` só existe em lançamento originado de documento
+        # fiscal e vale zero em todo o resto do razão (folha, depreciação,
+        # encerramento), que sairia com valor zerado no arquivo.
+        amount = sum(record.line_ids.mapped("debit"))
         return {
             "NUM_LCTO": record.name,  # Número ou Código de identificação
-            "DT_LCTO": record.create_date,  # Data do lançamento.
-            "VL_LCTO": record.fiscal_amount_total,  # Valor do lançamento.
+            # data do lançamento é a data contábil, não a de digitação
+            "DT_LCTO": record.date,
+            "VL_LCTO": amount,  # Valor do lançamento.
             "IND_LCTO": "N",
             "DT_LCTO_EXT": record.date,  # O Data de ocorrência dos fatos
             # Valor do lançamento em moeda funcional
-            "VL_LCTO_MF": record.fiscal_amount_total,
+            "VL_LCTO_MF": amount,
         }
 
 
@@ -524,9 +712,12 @@ class RegistroI250(models.Model):
             ("company_id", "=", declaration.company_id.id),
             ("parent_state", "=", "posted"),
             ("move_id", "=", parent_record.id),
-            ("display_type", "=", False),
-            # ("date", ">", date_start),
-            # ("date", "<", date_end),
+            # Na 16.0 o `display_type` nunca é falso numa partida real: vale
+            # "product", "tax", "payment_term" e afins. Comparar com falso
+            # excluía TODAS as linhas, e o lançamento saía sem partida
+            # nenhuma. O que não se escritura são as linhas de apresentação,
+            # seção e nota, que não carregam valor.
+            ("display_type", "not in", ("line_section", "line_note")),
         ]
 
     @api.model
@@ -534,15 +725,20 @@ class RegistroI250(models.Model):
         return {
             "COD_CTA": record.account_id.code,
             # "COD_CCUS": 0,  # Código do centro de custos.
-            "VL_DC": record.amount_currency,  # Valor da partida.
+            # o valor da partida é o do lançamento, sempre positivo: a
+            # natureza vai no IND_DC. O `amount_currency` é o valor em moeda
+            # estrangeira e vale zero na escrituração em reais.
+            "VL_DC": abs(record.debit or record.credit),  # Valor da partida.
             "IND_DC": record.debit > 0
             and "D"
             or "C",  # Indicador da natureza da partida: D - Débito; C - Cré...
             # "NUM_ARQ": 0,  # Número, Código ou caminho de localização dos documen...
             # "COD_HIST_PAD": 0,  # Código do histórico padronizado, conforme tabel...
             # "HIST": 0,  # O Histórico completo da partida ou histórico complement...
-            "COD_PART": record.partner_id.id,  # ?,  # Código identificação participante
-            "VL_DC_MF": record.amount_currency,  # Valor da partida em moeda funcional
+            # o 0150 identifica o participante pelo id do parceiro; aqui se
+            # usa o mesmo, e vazio quando a partida não tem participante
+            "COD_PART": record.partner_id.id or "",
+            "VL_DC_MF": abs(record.debit or record.credit),
             # "IND_DC_MF": 0,  # Indicador da natureza da partida em moeda funciona...
         }
 

--- a/l10n_br_sped_ecd/tests/__init__.py
+++ b/l10n_br_sped_ecd/tests/__init__.py
@@ -1,3 +1,2 @@
 from . import test_sped_ecd_import
-
-# from . import test_sped_ecd_generate
+from . import test_sped_ecd_generate

--- a/l10n_br_sped_ecd/tests/test_sped_ecd_generate.py
+++ b/l10n_br_sped_ecd/tests/test_sped_ecd_generate.py
@@ -1,150 +1,207 @@
-# Copyright 2024 - TODAY, Akretion - Raphael Valyi <raphael.valyi@akretion.com>
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
+# Copyright 2026 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+"""Generation of block I from the Odoo ledger.
 
-from os import path
+These tests assert VALUES, not presence. A register full of zeros passes any
+check that only looks at whether the line was written, and is rejected by the
+PVA all the same, so every assertion here names the amount it expects.
+"""
+from io import StringIO
 
-# from odoo.addons import l10n_br_sped_ecd
-from odoo.tests.common import tagged
+from odoo.tests import tagged
 
-from odoo.addons.l10n_br_account.tests.common import AccountMoveBRCommon
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 
 @tagged("post_install", "-at_install")
-class SpedTest(AccountMoveBRCommon):
+class TestSpedEcdGenerate(AccountTestInvoicingCommon):
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
-        cls.fol_sale_with_icms_reduction = cls.env[
-            "l10n_br_fiscal.operation.line"
-        ].create(
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+        cls.company = cls.company_data["company"]
+        cls.journal = cls.company_data["default_journal_misc"]
+        # the accountant of the account test common is not a fiscal manager,
+        # and creating a declaration is a manager right
+        cls.env.user.groups_id |= cls.env.ref("l10n_br_fiscal.group_manager")
+
+        cls.group = cls.env["account.group"].create(
             {
-                "name": "Venda com ICMS 12 e Redução de 26,57",
-                "ind_ie_dest": "1",
-                "cfop_internal_id": cls.env.ref("l10n_br_fiscal.cfop_5101").id,
-                "cfop_external_id": cls.env.ref("l10n_br_fiscal.cfop_6101").id,
-                "cfop_export_id": cls.env.ref("l10n_br_fiscal.cfop_7101").id,
-                "state": "approved",
-                "product_type": "04",
-                "fiscal_operation_id": cls.env.ref("l10n_br_fiscal.fo_venda").id,
+                "name": "DISPONIVEL",
+                "code_prefix_start": "ECD1",
+                "company_id": cls.company.id,
+            }
+        )
+        cls.acc_caixa = cls.env["account.account"].create(
+            {
+                "code": "ECD10",
+                "name": "Caixa",
+                "account_type": "asset_cash",
+                "company_id": cls.company.id,
+                "group_id": cls.group.id,
+            }
+        )
+        cls.acc_receita = cls.env["account.account"].create(
+            {
+                "code": "ECD90",
+                "name": "Vendas",
+                "account_type": "income",
+                "company_id": cls.company.id,
             }
         )
 
-        cls.pis_tax_definition_empresa_lc = cls.env[
-            "l10n_br_fiscal.tax.definition"
-        ].create(
+        cls.declaration = cls.env["l10n_br_sped.ecd.0000"].create(
             {
-                "company_id": cls.company_data["company"].id,
-                "tax_group_id": cls.env.ref("l10n_br_fiscal.tax_group_pis").id,
-                "is_taxed": True,
-                "is_debit_credit": True,
-                "custom_tax": True,
-                "tax_id": cls.env.ref("l10n_br_fiscal.tax_pis_0_65").id,
-                "cst_id": cls.env.ref("l10n_br_fiscal.cst_pis_01").id,
-                "state": "approved",
+                "company_id": cls.company.id,
+                "DT_INI": "2026-01-01",
+                "DT_FIN": "2026-03-31",
+                "LECD": "LECD",
+                "NOME": cls.company.name,
+                "CNPJ": "18751708000140",
+                "UF": "SP",
+                # the header fields the layout requires; the values are the
+                # ordinary case: regular bookkeeping, not a consolidated nor a
+                # centralised one, with no change of chart in the period
+                "IND_SIT_INI_PER": "0",
+                "IND_NIRE": "0",
+                "IND_FIN_ESC": "0",
+                "IND_GRANDE_PORTE": "N",
+                "TIP_ECD": 0,
+                "IDENT_MF": "N",
+                "IND_ESC_CONS": "N",
+                "IND_CENTRALIZADA": "0",
+                "IND_MUDANC_PC": "0",
             }
-        )
-
-        cls.cofins_tax_definition_empresa_lc = cls.env[
-            "l10n_br_fiscal.tax.definition"
-        ].create(
-            {
-                "company_id": cls.company_data["company"].id,
-                "tax_group_id": cls.env.ref("l10n_br_fiscal.tax_group_cofins").id,
-                "is_taxed": True,
-                "is_debit_credit": True,
-                "custom_tax": True,
-                "tax_id": cls.env.ref("l10n_br_fiscal.tax_cofins_3").id,
-                "cst_id": cls.env.ref("l10n_br_fiscal.cst_cofins_01").id,
-                "state": "approved",
-            }
-        )
-
-        cls.cofins_tax_definition_empresa_lc_icms_reduction = cls.env[
-            "l10n_br_fiscal.tax.definition"
-        ].create(
-            {
-                "company_id": cls.company_data["company"].id,
-                "tax_group_id": cls.env.ref("l10n_br_fiscal.tax_group_icms").id,
-                "is_taxed": True,
-                "is_debit_credit": True,
-                "custom_tax": True,
-                "tax_id": cls.env.ref("l10n_br_fiscal.tax_icms_12_red_26_57").id,
-                "cst_id": cls.env.ref("l10n_br_fiscal.cst_icms_20").id,
-                "state": "approved",
-                "fiscal_operation_line_id": cls.fol_sale_with_icms_reduction.id,
-            }
-        )
-
-        cls.empresa_lc_document_55_serie_1 = cls.env[
-            "l10n_br_fiscal.document.serie"
-        ].create(
-            {
-                "code": "1",
-                "name": "Série 1",
-                "document_type_id": cls.env.ref("l10n_br_fiscal.document_55").id,
-                "active": True,
-            }
-        )
-
-        cls.move_out_venda = cls.init_invoice(
-            "out_invoice",
-            products=[cls.product_a],
-            document_type=cls.env.ref("l10n_br_fiscal.document_55"),
-            document_serie_id=cls.empresa_lc_document_55_serie_1,
-            fiscal_operation=cls.env.ref("l10n_br_fiscal.fo_venda"),
-            fiscal_operation_lines=[cls.env.ref("l10n_br_fiscal.fo_venda_venda")],
-        )
-
-        cls.env.ref("l10n_br_fiscal.fo_compras").deductible_taxes = True
-        cls.move_in_compra_para_revenda = cls.init_invoice(
-            "in_invoice",
-            products=[cls.product_a],
-            document_type=cls.env.ref("l10n_br_fiscal.document_55"),
-            fiscal_operation=cls.env.ref("l10n_br_fiscal.fo_compras"),
-            fiscal_operation_lines=[
-                cls.env.ref("l10n_br_fiscal.fo_compras_compras_comercializacao")
-            ],
-            document_serie="1",
-            document_number="42",
         )
 
     @classmethod
-    def setup_company_data(cls, company_name, chart_template=None, **kwargs):
-        if company_name == "company_1_data":
-            company_name = "empresa 1 Lucro Presumido"
-        else:
-            company_name = "empresa 2 Lucro Presumido"
-        chart_template = cls.env.ref("l10n_br_coa_generic.l10n_br_coa_generic_template")
-        res = super().setup_company_data(
-            company_name,
-            chart_template,
-            tax_framework="3",
-            is_industry=True,
-            industry_type="00",
-            profit_calculation="presumed",
-            ripi=True,
-            piscofins_id=cls.env.ref("l10n_br_fiscal.tax_pis_cofins_columativo").id,
-            icms_regulation_id=cls.env.ref("l10n_br_fiscal.tax_icms_regulation").id,
-            cnae_main_id=cls.env.ref("l10n_br_fiscal.cnae_3101200").id,
-            document_type_id=cls.env.ref("l10n_br_fiscal.document_55").id,
-            **kwargs,
+    def _post(cls, date, amount):
+        move = cls.env["account.move"].create(
+            {
+                "journal_id": cls.journal.id,
+                "company_id": cls.company.id,
+                "date": date,
+                "line_ids": [
+                    (0, 0, {"account_id": cls.acc_caixa.id, "debit": amount}),
+                    (0, 0, {"account_id": cls.acc_receita.id, "credit": amount}),
+                ],
+            }
         )
-        res["company"].partner_id.state_id = cls.env.ref("base.state_br_sp").id
-        chart_template.load_fiscal_taxes()
-        return res
+        move.action_post()
+        return move
 
-    def test_generate_sped(self):
-        self.env["l10n_br_sped.mixin"]._flush_registers("ecd")
-        file_path = path.join(self.demo_path, "demo_ecd_output.txt")
-        declaration = self.env["l10n_br_sped.declaration"].create({})
-        # sped_mixin._import_file(file_path, "ecd")
-        sped = declaration._generate_sped_text()
-        with open(file_path) as f:
-            target_content = f.read()
-            # print(sped)
-            self.assertEqual(sped.strip(), target_content.strip())
+    def _populate(self):
+        """Pull the way `button_populate_sped_from_odoo` does.
+
+        Block I hangs entirely under I010, so the pull starts there and
+        cascades: pulling a child on its own would leave its parent link null.
+        `default_declaration_id` is what ties each register created down the
+        recursion to the declaration.
+        """
+        self.env["l10n_br_sped.ecd.i010"].with_context(
+            company_id=self.company.id,
+            declaration=self.declaration,
+            default_declaration_id=self.declaration.id,
+        )._pull_records_from_odoo("ecd", 2, log_msg=StringIO())
+
+    def _registers(self, model_name):
+        return self.env[model_name].search(
+            [("declaration_id", "=", self.declaration.id)]
+        )
+
+    def test_entries_are_pulled_with_the_accounting_date_and_amount(self):
+        """The entry carries its accounting date and the total of its debits.
+
+        Two defects lived here: the domain filtered `state = "open"`, a value
+        that does not exist in this version, so nothing was ever pulled; and
+        the amount came from `fiscal_amount_total`, which is zero on every
+        entry that did not come from a fiscal document.
+        """
+        self._post("2026-02-10", 1500.0)
+        self._populate()
+        registers = self._registers("l10n_br_sped.ecd.i200")
+        self.assertEqual(len(registers), 1)
+        self.assertEqual(str(registers.DT_LCTO), "2026-02-10")
+        self.assertAlmostEqual(registers.VL_LCTO, 1500.0, places=2)
+
+    def test_entries_on_the_period_edges_are_included(self):
+        """The period bounds are inclusive.
+
+        With the strict operator an entry booked on the first or the last day
+        of the escrituracao was silently dropped.
+        """
+        self._post("2026-01-01", 100.0)
+        self._post("2026-03-31", 200.0)
+        self._populate()
+        registers = self._registers("l10n_br_sped.ecd.i200")
+        self.assertEqual(len(registers), 2)
+
+    def test_line_amount_is_the_posted_value_not_the_currency_one(self):
+        """A line carries its own amount, positive, with the nature apart."""
+        move = self._post("2026-02-10", 800.0)
+        self._populate()
+        parent = self._registers("l10n_br_sped.ecd.i200")
+        lines = self._registers("l10n_br_sped.ecd.i250")
+        self.assertEqual(len(lines), 2)
+        self.assertEqual(parent.res_id, move.id)
+        for line in lines:
+            self.assertAlmostEqual(line.VL_DC, 800.0, places=2)
+        self.assertEqual(set(lines.mapped("IND_DC")), {"D", "C"})
+
+    def test_chart_of_accounts_declares_groups_and_accounts(self):
+        """I050 carries both the synthetic groups and the analytic accounts."""
+        self._populate()
+        registers = self._registers("l10n_br_sped.ecd.i050")
+        sintetica = registers.filtered(lambda r: r.COD_CTA == "ECD1")
+        analitica = registers.filtered(lambda r: r.COD_CTA == "ECD10")
+        self.assertEqual(sintetica.IND_CTA, "S")
+        self.assertEqual(analitica.IND_CTA, "A")
+        # the analytic account hangs under its group, one level below
+        self.assertEqual(analitica.COD_CTA_SUP, "ECD1")
+        self.assertEqual(analitica.NIVEL, sintetica.NIVEL + 1)
+        # nature comes from the internal group: 01 assets, 04 result
+        self.assertEqual(analitica.COD_NAT, "01")
         self.assertEqual(
-            self.move_out_venda.invoice_line_ids[0].cfop_id.name,
-            "Venda de produção do estabelecimento",
+            registers.filtered(lambda r: r.COD_CTA == "ECD90").COD_NAT, "04"
         )
+
+    def test_trial_balance_has_one_period_per_month(self):
+        """I150 covers the escrituracao month by month, with no gap."""
+        self._populate()
+        registers = self._registers("l10n_br_sped.ecd.i150")
+        self.assertEqual(len(registers), 3)
+        self.assertEqual(
+            [str(r.DT_INI) for r in registers.sorted("DT_INI")],
+            ["2026-01-01", "2026-02-01", "2026-03-01"],
+        )
+        self.assertEqual(str(registers.sorted("DT_INI")[-1].DT_FIN), "2026-03-31")
+
+    def test_trial_balance_carries_opening_movement_and_closing(self):
+        """I155 states the opening balance, the movement and the closing one.
+
+        January books 1000 and February another 400. February therefore opens
+        at 1000, moves 400 and closes at 1400, which is what makes the trial
+        balance tie from one month to the next.
+        """
+        self._post("2026-01-15", 1000.0)
+        self._post("2026-02-15", 400.0)
+        self._populate()
+        periods = self._registers("l10n_br_sped.ecd.i150").sorted("DT_INI")
+        fevereiro = periods[1]
+        detail = fevereiro.reg_I155_ids
+        caixa = detail.filtered(lambda r: r.COD_CTA == "ECD10")
+        self.assertAlmostEqual(caixa.VL_SLD_INI, 1000.0, places=2)
+        self.assertEqual(caixa.IND_DC_INI, "D")
+        self.assertAlmostEqual(caixa.VL_DEB, 400.0, places=2)
+        self.assertAlmostEqual(caixa.VL_CRED, 0.0, places=2)
+        self.assertAlmostEqual(caixa.VL_SLD_FIN, 1400.0, places=2)
+        self.assertEqual(caixa.IND_DC_FIN, "D")
+
+    def test_credit_balance_is_reported_as_credit_not_as_a_negative(self):
+        """A credit balance goes out positive, with the nature saying credit."""
+        self._post("2026-01-15", 700.0)
+        self._populate()
+        periods = self._registers("l10n_br_sped.ecd.i150").sorted("DT_INI")
+        detail = periods[0].reg_I155_ids
+        vendas = detail.filtered(lambda r: r.COD_CTA == "ECD90")
+        self.assertAlmostEqual(vendas.VL_SLD_FIN, 700.0, places=2)
+        self.assertEqual(vendas.IND_DC_FIN, "C")


### PR DESCRIPTION
## Contexto

A geração da ECD a partir do Odoo nunca funcionou. Dois filtros que a migração
para a 16.0 deixou para trás faziam o bloco I sair vazio, e como o módulo tem um
teste de round-trip que passa (importa o arquivo de exemplo, reemite e compara),
o defeito não aparecia: o que estava provado era o serializador, não a geração.

## Correções

- **O registro I200 filtrava `state = "open"`**, valor que não existe nesta
  versão (os estados são draft, posted e cancel). Nenhum lançamento era puxado.
- **O registro I250 filtrava `display_type = False`**, e nesta versão esse campo
  nunca é falso numa partida real: vale "product", "tax", "payment_term". Numa
  base com movimento são 108 linhas "product", 24 "payment_term", 6 "tax" e
  nenhuma nula. O filtro excluía todas, e as partidas do lançamento, que são o
  miolo da escrituração contábil, nunca saíam.

Mais quatro no mesmo caminho:

- a data do lançamento vinha da data de digitação (`create_date`), não da data
  contábil;
- o valor do lançamento vinha de `fiscal_amount_total`, que é zero em todo
  lançamento que não veio de documento fiscal (folha, depreciação, encerramento);
- o valor da partida vinha de `amount_currency`, que é o valor em moeda
  estrangeira e vale zero na escrituração em reais;
- as datas do período usavam operador estrito, então lançamento no primeiro ou
  no último dia da escrituração ficava de fora.

## O que esta PR acrescenta

- **I050 e I051**, o plano de contas: as sintéticas vêm de `account.group` e as
  analíticas de `account.account`, ordenadas pelo código porque o PVA exige a
  conta superior declarada antes da que a referencia. O I051 sai para a conta
  que tem o de-para do plano referencial da Receita.
- **I150 e I155**, o balancete: um período por mês, gerado do calendário para
  não abrir buraco em mês sem movimento, com saldo inicial, débito, crédito e
  saldo final por conta. A agregação é feita no banco porque o balancete
  percorre todas as partidas do exercício. O valor sai sempre positivo, com a
  natureza no indicador, como o leiaute pede.

## Testes

O teste de geração existia mas estava **desligado no `__init__`**, e tinha sete
defeitos que o impediam de rodar (referenciava um atributo inexistente,
comparava com um arquivo que não existe no repositório e instanciava um modelo
abstrato).

Ele volta asserindo **valor, e não presença**: um registro cheio de zeros passa
em qualquer verificação que só olhe se a linha foi escrita, e é recusado pelo
PVA do mesmo jeito. O teste do balancete lança 1000 em janeiro e 400 em
fevereiro, e exige que fevereiro abra em 1000, movimente 400 e feche em 1400,
que é o que amarra um mês no outro.

São 8 testes, incluindo o de round-trip que já existia.

## Limitação conhecida

O saldo inicial soma tudo o que foi lançado antes do mês, que é a leitura
literal do razão. Sem lançamento de encerramento do exercício, conta de
resultado acumula desde a abertura da escrituração e não desde 1º de janeiro.
Está documentado no código.

## Como testar

1. Instale o módulo e crie uma escrituração (registro 0000) com o período.
2. Lance e poste algumas partidas no período.
3. Use "Puxar registros do Odoo" e confira que saem o plano de contas (I050), o
   balancete mês a mês (I150 e I155) e os lançamentos com suas partidas (I200 e
   I250).
