### PR TITLE
[16.0][FIX] l10n_br_fiscal: PIS/COFINS setup without its own NCM list

### DIFF
--- a/l10n_br_fiscal/models/tax_pis_cofins.py
+++ b/l10n_br_fiscal/models/tax_pis_cofins.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2019  Renato Lima - Akretion <renato.lima@akretion.com.br>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+import logging
+
 from odoo import _, api, fields, models
 
 from .. import tools
@@ -10,6 +12,8 @@ from ..constants.fiscal import (
     TAX_DOMAIN_PIS,
     TAX_DOMAIN_PIS_ST,
 )
+
+_logger = logging.getLogger(__name__)
 
 
 class TaxPisCofins(models.Model):
@@ -81,8 +85,17 @@ class TaxPisCofins(models.Model):
 
             # Clear Field to recompute
             r.ncm_ids = False
-            if r.ncms:
-                domain = tools.domain_field_codes(r.ncms)
+            if not r.ncms:
+                if r.not_in_ncms or r.ncm_exception:
+                    _logger.info(
+                        "PIS/COFINS setup %s (%s) declares exclusions without "
+                        "any NCM of its own and was not applied to any NCM.",
+                        r.code,
+                        r.name,
+                    )
+                continue
+
+            domain = tools.domain_field_codes(r.ncms)
 
             if r.not_in_ncms:
                 domain += tools.domain_field_codes(


### PR DESCRIPTION
O `_compute_ncms` monta o domínio só com as exclusões quando o `ncms` está vazio, e aí o `search` devolve a tabela inteira menos os códigos excluídos. Duas linhas do `l10n_br_fiscal.tax.pis.cofins.csv` caem nesse caso, a `tax_piscofins_4316_201` e a `tax_piscofins_4316_202`, os insumos de alimentação: `ncms` vazio e `not_in_ncms` com onze códigos do capítulo 2. Cada uma casa 11.498 NCMs.

O efeito é o mapeamento por NCM parar de valer para quase tudo, porque ele só entra quando o NCM tem exatamente uma configuração. Medindo com o próprio `l10n_br_fiscal.ncm.csv`, hoje são 10.934 NCMs com configuração e 45 com exatamente uma. Nada avisa: a nota sai sem CST de PIS/COFINS e o XSD reprova na hora de emitir. Peguei emitindo NF-e num cliente de Lucro Presumido.

A guarda faz a configuração sem lista positiva não casar NCM nenhum e registra no log qual está mal preenchida. Depois dela são 776 NCMs com configuração e 661 com exatamente uma. Preencher o `ncms` dessas duas linhas com os capítulos que a descrição enumera é dado, e vai em PR separado.
