### PR TITLE
[16.0][IMP] l10n_br_fiscal: fall back to the company PIS/COFINS regime

### DIFF
--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -343,13 +343,16 @@ class OperationLine(models.Model):
             tax_ii = ncm.tax_ii_id
             mapping_result["taxes"][TAX_DOMAIN_IPI] = tax_ipi
 
-            if len(ncm.piscofins_ids) == 1:
+            piscofins = ncm.piscofins_ids
+            if len(piscofins) != 1:
+                piscofins = company.piscofins_id
+            if piscofins:
                 mapping_result["taxes"][
-                    ncm.piscofins_ids[0].tax_pis_id.tax_domain
-                ] = ncm.piscofins_ids[0].tax_pis_id
+                    piscofins.tax_pis_id.tax_domain
+                ] = piscofins.tax_pis_id
                 mapping_result["taxes"][
-                    ncm.piscofins_ids[0].tax_cofins_id.tax_domain
-                ] = ncm.piscofins_ids[0].tax_cofins_id
+                    piscofins.tax_cofins_id.tax_domain
+                ] = piscofins.tax_cofins_id
 
             if (
                 mapping_result["cfop"].destination == CFOP_DESTINATION_EXPORT


### PR DESCRIPTION
Quando o NCM não tem exatamente uma configuração de PIS/COFINS, o mapeamento não aplica nada e não avisa. O `res.company.piscofins_id` guarda o regime que a empresa declarou, é preenchido no cadastro e não é lido em nenhum ponto do caminho de mercadoria. Passa a ser o fallback.

Anda junto com o #4954: aquele tira as duas configurações que estão coladas em toda a tabela de NCM, e este garante que NCM sem configuração nenhuma continue calculando pelo regime da empresa em vez de sair sem imposto.
