### PR TITLE
[18.0][FIX] l10n_br_account: call _compute_fiscal_amount on the document

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -259,7 +259,7 @@ class AccountMove(models.Model):
                 # fiscal documents for instance. It should be used
                 # exceptionnaly as it breaks the dependency chain and
                 # can leave fields such as payment_state inconsistent.
-                move._compute_fiscal_amount()
+                move.fiscal_document_id._compute_fiscal_amount()
 
         result = super()._compute_amount()
         for move in self.filtered(lambda m: m.fiscal_operation_id):


### PR DESCRIPTION
Importar documento fiscal com o `force_fiscal_amount_recompute` no contexto estoura em `account_move.py:262` com `AttributeError: 'account.move' object has no attribute '_compute_fiscal_amount'`.

O método é do mixin do documento fiscal, e quem herda o mixin é o `l10n_br_fiscal.document`. O `account.move` chega nos campos do documento por `_inherits`, e delegação carrega campo, não método.

Só o caminho de importação põe esse contexto, então emissão e faturamento normal nunca passam por aqui. A 16.0 e a 17.0 não têm essa chamada.
