### PR TITLE
[18.0][FIX] l10n_br_nfe: fill the payment group before exporting a NF-e

### DIFF
--- a/l10n_br_nfe/__manifest__.py
+++ b/l10n_br_nfe/__manifest__.py
@@ -31,6 +31,7 @@
         "views/nfe_document_line_view.xml",
         "views/nfe_di_view.xml",
         "views/res_config_settings_view.xml",
+        "views/nfe_operation_view.xml",
         "views/mde/mde_views.xml",
         "views/dfe/dfe_views.xml",
         "views/supplier_info_view.xml",

--- a/l10n_br_nfe/constants/nfe.py
+++ b/l10n_br_nfe/constants/nfe.py
@@ -19,6 +19,36 @@ NFE_ENVIRONMENTS = [("1", "Produção"), ("2", "Homologação")]
 NFE_ENVIRONMENT_DEFAULT = "2"
 
 
+NFE_PAYMENT_TYPES = [
+    ("01", "Dinheiro"),
+    ("02", "Cheque"),
+    ("03", "Cartão de Crédito"),
+    ("04", "Cartão de Débito"),
+    ("05", "Crédito Loja"),
+    ("10", "Vale Alimentação"),
+    ("11", "Vale Refeição"),
+    ("12", "Vale Presente"),
+    ("13", "Vale Combustível"),
+    ("15", "Boleto Bancário"),
+    ("16", "Depósito Bancário"),
+    ("17", "Pagamento Instantâneo (PIX) - Dinâmico"),
+    ("18", "Transferência bancária, Carteira Digital"),
+    ("19", "Programa de fidelidade, Cashback, Crédito Virtual"),
+    ("20", "Pagamento Instantâneo (PIX) - Estático"),
+    ("21", "Crédito em Loja"),
+    ("22", "Pagamento Eletrônico não Informado"),
+    ("90", "Sem Pagamento"),
+    ("99", "Outros"),
+]
+
+
+NFE_PAYMENT_TYPE_NO_PAYMENT = "90"
+
+NFE_PAYMENT_TYPE_DEFAULT = NFE_PAYMENT_TYPE_NO_PAYMENT
+
+NFE_PAYMENT_INDICATOR_CASH = "0"
+
+
 NFE_TRANSMISSIONS = [
     ("1", "Emissão Normal"),
     ("2", "Contingência FS-IA"),

--- a/l10n_br_nfe/models/__init__.py
+++ b/l10n_br_nfe/models/__init__.py
@@ -18,6 +18,7 @@ from . import nfe_di
 from . import res_city
 from . import res_config_settings
 from . import cfop
+from . import operation
 from . import invalidate_number
 from . import dfe
 from . import mde

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -57,6 +57,8 @@ from ..constants.nfe import (
     NFCE_DANFE_LAYOUTS,
     NFE_DANFE_LAYOUTS,
     NFE_ENVIRONMENTS,
+    NFE_PAYMENT_INDICATOR_CASH,
+    NFE_PAYMENT_TYPE_NO_PAYMENT,
     NFE_TRANSMISSIONS,
     NFE_VERSIONS,
 )
@@ -89,6 +91,7 @@ class NFe(spec_models.StackedModel):
         "infnfe.exporta",
         "infnfe.cobr",
         "infnfe.cobr.fat",
+        "infnfe.pag",
     )
     _nfe_search_keys = ["nfe40_Id"]
 
@@ -1206,6 +1209,7 @@ class NFe(spec_models.StackedModel):
     def _document_export(self, pretty_print=True):
         result = super()._document_export()
         for record in self.filtered(filter_processador_edoc_nfe):
+            record._prepare_payments_for_nfe()
             edoc = record.serialize()[0]
             xml_file = edoc.to_xml()
             # Delete previous authorization events in draft
@@ -1792,6 +1796,22 @@ class NFe(spec_models.StackedModel):
             rec.nfe40_detPag.filtered(lambda p: p.nfe40_tPag == "99").write(
                 {"nfe40_xPag": "Outros"}
             )
+
+    def _prepare_payments_for_nfe(self):
+        for rec in self.filtered(
+            lambda d: d.document_type == MODELO_FISCAL_NFE and not d.nfe40_detPag
+        ):
+            payment_type = (
+                rec.fiscal_operation_id.nfe_payment_type
+                or rec.company_id.nfe_default_payment_type
+            )
+            values = {"nfe40_tPag": payment_type}
+            if payment_type == NFE_PAYMENT_TYPE_NO_PAYMENT:
+                values["nfe40_vPag"] = 0.0
+            else:
+                values["nfe40_indPag"] = NFE_PAYMENT_INDICATOR_CASH
+                values["nfe40_vPag"] = rec.amount_financial_total
+            rec.sudo().nfe40_detPag = [(0, 0, values)]
 
     def action_danfe_nfce_report(self):
         return (

--- a/l10n_br_nfe/models/operation.py
+++ b/l10n_br_nfe/models/operation.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2026 KMEE INFORMATICA LTDA
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import fields, models
+
+from ..constants.nfe import NFE_PAYMENT_TYPES
+
+
+class Operation(models.Model):
+    _inherit = "l10n_br_fiscal.operation"
+
+    nfe_payment_type = fields.Selection(
+        selection=NFE_PAYMENT_TYPES,
+        string="NFe Payment Type",
+        help=(
+            "Payment type (tPag) used to fill the payment group of a NF-e "
+            "issued under this operation. Empty falls back to the company "
+            "default."
+        ),
+    )

--- a/l10n_br_nfe/models/res_company.py
+++ b/l10n_br_nfe/models/res_company.py
@@ -15,6 +15,8 @@ from ..constants.nfe import (
     NFE_DANFE_LAYOUTS,
     NFE_ENVIRONMENT_DEFAULT,
     NFE_ENVIRONMENTS,
+    NFE_PAYMENT_TYPE_DEFAULT,
+    NFE_PAYMENT_TYPES,
     NFE_TRANSMISSION_DEFAULT,
     NFE_TRANSMISSIONS,
     NFE_VERSION_DEFAULT,
@@ -64,6 +66,18 @@ class ResCompany(spec_models.SpecModel):
         selection=NFE_ENVIRONMENTS,
         string="NFe Environment",
         default=NFE_ENVIRONMENT_DEFAULT,
+    )
+
+    nfe_default_payment_type = fields.Selection(
+        selection=NFE_PAYMENT_TYPES,
+        string="NFe Default Payment Type",
+        default=NFE_PAYMENT_TYPE_DEFAULT,
+        help=(
+            "Payment type (tPag) used to fill the payment group of a NF-e "
+            "(modelo 55) when the document has no payment line of its own. "
+            "The NF-e schema requires at least one payment line, so a document "
+            "sent without it is rejected before reaching SEFAZ."
+        ),
     )
 
     nfe_enable_sync_transmission = fields.Boolean(

--- a/l10n_br_nfe/models/res_config_settings.py
+++ b/l10n_br_nfe/models/res_config_settings.py
@@ -30,6 +30,12 @@ class ResConfigSettings(models.TransientModel):
         readonly=False,
     )
 
+    nfe_default_payment_type = fields.Selection(
+        string="NFe Default Payment Type",
+        related="company_id.nfe_default_payment_type",
+        readonly=False,
+    )
+
     nfe_danfe_layout = fields.Selection(
         string="NFe Layout",
         related="company_id.nfe_danfe_layout",

--- a/l10n_br_nfe/tests/test_nfe_xml_validation.py
+++ b/l10n_br_nfe/tests/test_nfe_xml_validation.py
@@ -128,7 +128,6 @@ class TestXMLValidation(TransactionCase):
         )
 
         document.action_document_confirm()
-        document.action_document_send()
         # This section probably indicates an error in eiter
         #   l10n_br_account or l10n_br_fiscal
         self.assertEqual(line.icms_value, 307.32)

--- a/l10n_br_nfe/views/nfe_operation_view.xml
+++ b/l10n_br_nfe/views/nfe_operation_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="nfe_operation_form" model="ir.ui.view">
+        <field name="name">l10n_br_fiscal.operation.form.nfe</field>
+        <field name="model">l10n_br_fiscal.operation</field>
+        <field name="inherit_id" ref="l10n_br_fiscal.operation_form" />
+        <field name="arch" type="xml">
+            <field name="edoc_purpose" position="after">
+                <field name="nfe_payment_type" readonly="state != 'draft'" />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/l10n_br_nfe/views/res_config_settings_view.xml
+++ b/l10n_br_nfe/views/res_config_settings_view.xml
@@ -101,6 +101,35 @@
                             </div>
                         </div>
                         <div class="col-12 col-lg-6 o_setting_box">
+                            <div class="o_setting_right_pane">
+                                <span
+                                    class="o_form_label"
+                                >NF-e Default Payment Type</span>
+                                <span
+                                    class="fa fa-lg fa-building-o"
+                                    title="Values set here are company-specific."
+                                    aria-label="Values set here are company-specific."
+                                    role="img"
+                                />
+                                <div
+                                    class="text-muted"
+                                >Payment type used when a NF-e has no payment line of its own</div>
+                                <div class="content-group">
+                                    <div class="mt16 row">
+                                        <label
+                                            for="nfe_default_payment_type"
+                                            class="col-4 col-lg-4 o_light_label"
+                                        />
+                                        <field
+                                            name="nfe_default_payment_type"
+                                            class="oe_inline"
+                                            required="1"
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-12 col-lg-6 o_setting_box">
                             <div class="o_setting_left_pane">
                                 <field name="nfe_enable_sync_transmission" />
                             </div>


### PR DESCRIPTION
O grupo `pag` da NF-e nunca é preenchido, e o XSD exige pelo menos um `detPag` dentro dele, então toda nota modelo 55 reprova na validação de schema antes de chegar na SEFAZ se ninguém digitar à mão.

O #4621 ataca o mesmo problema, mas põe a chamada no `_eletronic_document_send`. A validação acontece antes: o `_exec_before_SITUACAO_EDOC_A_ENVIAR` chama o `_document_export`, que serializa, assina e roda o `_validate_xml`. Quando o `detPag` nasce, o XML já foi montado e guardado no `send_file_id`. Rodei com o #4621 agregado na imagem de um cliente e o `detPag` continuou saindo à mão.

Aqui a chamada entra dentro do `_document_export`, antes do `serialize()`. E o `tPag` vem da operação fiscal, com o padrão da empresa como fallback, em vez de valor fixo: venda sai como boleto e remessa sai como `90 - Sem Pagamento` sem ninguém tocar. Documento que já tem `detPag` não é alterado.
