### PR TITLE
[16.0][FIX] l10n_br_sped_efd_icms_ipi: Registro0150: don't blow if street_name is null

### DIFF
--- a/l10n_br_sped_efd_icms_ipi/models/sped_efd_icms_ipi.py
+++ b/l10n_br_sped_efd_icms_ipi/models/sped_efd_icms_ipi.py
@@ -328,7 +328,7 @@ class Registro0150(models.Model):
             "COD_PAIS": record.country_id.bc_code,
             "IE": misc.punctuation_rm(record.inscr_est),
             "SUFRAMA": record.l10n_br_isuf_code or "",
-            "END": record.street_name[:60],
+            "END": record.street_name[:60] if record.street_name else "",
             "NUM": misc.punctuation_rm(record.street_number),
             "COMPL": record.street2,
             "BAIRRO": record.district,


### PR DESCRIPTION
[FIX] l10n_br_sped_efd_icms_ipi: Registro0150: don't blow if street_name is null