### PR TITLE
[16.0][FIX] sped newline sanitize

### DIFF
--- a/l10n_br_sped_base/models/sped_declaration.py
+++ b/l10n_br_sped_base/models/sped_declaration.py
@@ -213,7 +213,11 @@ class SpedDeclaration(models.AbstractModel):
         blocos = defaultdict(list)
         current_bloco = None
         for line in sped_txt.splitlines():
-            if line.startswith(("|0", "|9")):
+            # A register line is "|REG|...". Anything else is skipped: block
+            # 0/9 summary lines, and fragments left by a field value that
+            # contained a line break. This also guarantees the split can never
+            # crash on a corrupted line.
+            if not line.startswith("|") or len(line) < 2 or line[1] in "09":
                 continue
             current_bloco = line[1]
             if current_bloco:

--- a/l10n_br_sped_base/models/sped_mixin.py
+++ b/l10n_br_sped_base/models/sped_mixin.py
@@ -566,6 +566,13 @@ class SpedMixin(models.AbstractModel):
             # em branco e o PVA recusa o registro.
             field = self._fields.get(fname) or register_spec._fields[fname]
             val = self._format_field_value(field, value)
+            if isinstance(val, str) and ("\n" in val or "\r" in val):
+                # SPED is a pipe-delimited flat file with one register per
+                # line: a line break inside a field would split the register
+                # line and corrupt the file (the PVA rejects it). This can
+                # happen with texts imported from the NFe (observations,
+                # product descriptions) that contain line breaks.
+                val = val.replace("\r\n", " ").replace("\n", " ").replace("\r", " ")
             sped.write(f"{val}|")
 
     def _format_field_value(self, field, value):


### PR DESCRIPTION
Antes desse fix eu tive um erro assim ao gerir oi SPED com decriçao de produto ou observaçao fiscal com quebra de linha:

```
2026-08-14 18:06:22,645 3098 ERROR homologação odoo.http: Exception during request handling.
Traceback (most recent call last):                                                                                 File "/odoo/src/odoo/http.py", line 2262, in __call__
    response = request._serve_db()                                                                                 File "/odoo/src/odoo/http.py", line 1849, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)                                                   File "/odoo/src/odoo/service/model.py", line 153, in retrying
    result = func()                                                                                                File "/odoo/src/odoo/http.py", line 1877, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)                                                       File "/odoo/src/odoo/http.py", line 2081, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)                                                  File "/odoo/src/odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)                                                                            File "/odoo/src/odoo/http.py", line 763, in route_wrapper
    result = endpoint(self, *args, **params_ok)                                                                    File "/odoo/src/addons/web/controllers/dataset.py", line 47, in call_button
    action = self._call_kw(model, method, args, kwargs)                                                            File "/odoo/src/addons/web/controllers/dataset.py", line 34, in _call_kw
    return call_kw(Model, method, args, kwargs)
  File "/odoo/src/odoo/api.py", line 484, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/odoo/src/odoo/api.py", line 469, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/odoo/external-src/l10n-brazil/l10n_br_sped_base/models/sped_declaration.py", line 207, in button_create_
sped_files
    attachment_vals = self._split_sped_text_by_bloco(sped_txt)
  File "/odoo/external-src/l10n-brazil/l10n_br_sped_base/models/sped_declaration.py", line 218, in _split_sped_te
xt_by_bloco
    current_bloco = line[1]
IndexError: string index out of range
```