### PR TITLE
[16.0][FIX] l10n_br_fiscal: remove dependência circular em icms_cst_id

### DIFF
--- a/l10n_br_contract/models/contract_line.py
+++ b/l10n_br_contract/models/contract_line.py
@@ -63,6 +63,7 @@ class ContractLine(models.Model):
                 "_compute_fiscal_price",
                 "_compute_fiscal_tax_ids",
                 "_compute_tax_fields",
+                "_compute_icms_cst_id",
                 "_compute_fiscal_operation_line_id",
                 "_compute_comment_ids",
             ) and getattr(mixin_field, "precompute", False):

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -424,7 +424,6 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         "cfop_id",
         "icmssn_range_id",
         "icms_origin",
-        "icms_cst_id",
         "ind_final",
         "icms_relief_id",
     )
@@ -478,7 +477,6 @@ class FiscalDocumentLineMixin(models.AbstractModel):
                     cfop=line.cfop_id,
                     icmssn_range=line.icmssn_range_id,
                     icms_origin=line.icms_origin,
-                    icms_cst_id=line.icms_cst_id,
                     ind_final=line.ind_final,
                     icms_relief_id=line.icms_relief_id,
                 )

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -13,6 +13,7 @@ from ..constants.fiscal import (
     FINAL_CUSTOMER,
     FISCAL_COMMENT_LINE,
     FISCAL_IN,
+    FISCAL_OUT,
     FISCAL_TAX_ID_FIELDS,
     PRODUCT_FISCAL_TYPE,
     TAX_BASE_TYPE,
@@ -400,6 +401,16 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     def _onchange_fiscal_taxes(self):
         self._update_fiscal_tax_ids()
 
+    @api.depends("icms_tax_id", "icmssn_tax_id", "fiscal_operation_line_id")
+    def _compute_icms_cst_id(self):
+        for line in self.filtered(lambda ln: not ln._is_imported()):
+            tax = line.icms_tax_id or line.icmssn_tax_id
+            if tax and line.fiscal_operation_line_id:
+                fiscal_operation_type = (
+                    line.fiscal_operation_line_id.fiscal_operation_type or FISCAL_OUT
+                )
+                line.icms_cst_id = tax.cst_from_tax(fiscal_operation_type)
+
     @api.depends(
         "partner_id",
         "fiscal_tax_ids",
@@ -683,9 +694,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
 
     def _prepare_fields_icms(self, tax_dict):
         self.ensure_one()
-        cst_id = tax_dict.get("cst_id").id if tax_dict.get("cst_id") else False
         return {
-            "icms_cst_id": cst_id,
             "icms_base_type": tax_dict.get("icms_base_type", ICMS_BASE_TYPE_DEFAULT),
             "icms_base": tax_dict.get("base", 0.0),
             "icms_percent": tax_dict.get("percent_amount", 0.0),
@@ -724,13 +733,11 @@ class FiscalDocumentLineMixin(models.AbstractModel):
 
     def _prepare_fields_icmssn(self, tax_dict):
         self.ensure_one()
-        cst_id = tax_dict.get("cst_id").id if tax_dict.get("cst_id") else False
         icmssn_base = tax_dict.get("base", 0.0)
         icmssn_credit_value = tax_dict.get("tax_value", 0.0)
         simple_value = icmssn_base * self.icmssn_range_id.total_tax_percent
         simple_without_icms_value = simple_value - icmssn_credit_value
         return {
-            "icms_cst_id": cst_id,
             "icmssn_base": icmssn_base,
             "icmssn_percent": tax_dict.get("percent_amount"),
             "icmssn_reduction": tax_dict.get("percent_reduction"),
@@ -1399,7 +1406,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         string="CST ICMS",
         domain="[('tax_domain', '=', {'1': 'icmssn', '2': 'icmssn', "
         "'3': 'icms'}.get(tax_framework))]",
-        compute="_compute_tax_fields",
+        compute="_compute_icms_cst_id",
         store=True,
         precompute=True,
         readonly=False,

--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -423,8 +423,6 @@ class Tax(models.Model):
         cfop = kwargs.get("cfop")
         fiscal_operation_type = operation_line.fiscal_operation_type or FISCAL_OUT
         ind_final = kwargs.get("ind_final", FINAL_CUSTOMER_NO)
-        cst = kwargs.get("icms_cst_id", self.env["l10n_br_fiscal.cst"])
-
         # Get Computed IPI Tax
         tax_dict_ipi = taxes_dict.get("ipi", {})
 
@@ -548,14 +546,15 @@ class Tax(models.Model):
                 }
             )
 
-        if kwargs.get("icms_relief_id") and cst["code"] in ICMS_CST_RELIEF:
+        cst = tax_dict.get("cst_id") or self.env["l10n_br_fiscal.cst"]
+        if kwargs.get("icms_relief_id") and cst.code in ICMS_CST_RELIEF:
             icms_base = kwargs.get("price_unit", 0.00) * kwargs.get("quantity", 0.00)
             icms_percent = tax_dict.get("percent_amount", 0.00) / 100
             icms_reduction = tax_dict.get("percent_reduction", 0.00) / 100
-            if cst["code"] in ["30", "40"]:
+            if cst.code in ["30", "40"]:
                 icms_relief = icms_base * icms_percent
                 tax_dict.update({"icms_relief": icms_relief})
-            elif cst["code"] in ["20", "70"]:
+            elif cst.code in ["20", "70"]:
                 icms_relief = (
                     icms_base
                     * (1 - (icms_percent * (1 - icms_reduction)))
@@ -577,7 +576,11 @@ class Tax(models.Model):
         tax_dict = taxes_dict.get(tax.tax_domain)
         partner = kwargs.get("partner")
         company = kwargs.get("company")
-        icms_cst_id = kwargs.get("icms_cst_id")
+        icms_cst = (
+            taxes_dict.get("icms", {}).get("cst_id")
+            or taxes_dict.get("icmssn", {}).get("cst_id")
+            or self.env["l10n_br_fiscal.cst"]
+        )
 
         if taxes_dict.get("icms"):
             if company.state_id != partner.state_id:
@@ -596,7 +599,7 @@ class Tax(models.Model):
         tax_dict["fcpst_base"] = taxes_dict.get("icmsst", {}).get("base", 0.00)
 
         # TODO Improve this condition
-        if icms_cst_id.code in ICSM_CST_CSOSN_ST_BASE:
+        if icms_cst.code in ICSM_CST_CSOSN_ST_BASE:
             tax_dict["fcpst_value"] = tax_dict["fcpst_base"] * (
                 tax_dict["percent_amount"] / 100
             )
@@ -887,7 +890,6 @@ class Tax(models.Model):
         :param icmssn_range: l10n_br_fiscal.simplified.tax.range record for
             Simples Nacional ICMS calculation.
         :param icms_origin: str, ICMS origin code for the product.
-        :param icms_cst_id: l10n_br_fiscal.cst record, the ICMS CST code.
         :param icms_relief_id: l10n_br_fiscal.icms.relief record, if ICMS relief
             applies.
         :param ind_final: str, indicates if the operation is for a final

--- a/l10n_br_purchase/models/purchase_order_line.py
+++ b/l10n_br_purchase/models/purchase_order_line.py
@@ -165,6 +165,7 @@ class PurchaseOrderLine(models.Model):
                 "_compute_fiscal_price",
                 "_compute_fiscal_tax_ids",
                 "_compute_tax_fields",
+                "_compute_icms_cst_id",
                 "_compute_fiscal_operation_line_id",
                 "_compute_comment_ids",
             ) and getattr(mixin_field, "precompute", False):

--- a/l10n_br_purchase_blanket_order/models/purchase_blanket_order_line.py
+++ b/l10n_br_purchase_blanket_order/models/purchase_blanket_order_line.py
@@ -181,7 +181,6 @@ class PurchaseBlanketOrderLine(models.Model):
         "cfop_id",
         "icmssn_range_id",
         "icms_origin",
-        "icms_cst_id",
         "ind_final",
         "icms_relief_id",
         "order_id.company_id",

--- a/l10n_br_purchase_blanket_order/models/purchase_blanket_order_line.py
+++ b/l10n_br_purchase_blanket_order/models/purchase_blanket_order_line.py
@@ -102,6 +102,7 @@ class PurchaseBlanketOrderLine(models.Model):
                 "_compute_fiscal_price",
                 "_compute_fiscal_tax_ids",
                 "_compute_tax_fields",
+                "_compute_icms_cst_id",
                 "_compute_fiscal_operation_line_id",
                 "_compute_comment_ids",
             ) and getattr(mixin_field, "precompute", False):

--- a/l10n_br_sale_blanket_order/models/sale_blanket_order_line.py
+++ b/l10n_br_sale_blanket_order/models/sale_blanket_order_line.py
@@ -115,6 +115,7 @@ class SaleBlanketOrderLine(models.Model):
                 "_compute_fiscal_price",
                 "_compute_fiscal_tax_ids",
                 "_compute_tax_fields",
+                "_compute_icms_cst_id",
                 "_compute_fiscal_operation_line_id",
                 "_compute_comment_ids",
             ) and getattr(mixin_field, "precompute", False):
@@ -187,7 +188,6 @@ class SaleBlanketOrderLine(models.Model):
         "cfop_id",
         "icmssn_range_id",
         "icms_origin",
-        "icms_cst_id",
         "ind_final",
         "icms_relief_id",
         "order_id.company_id",


### PR DESCRIPTION
same as https://github.com/Engenere/l10n-brazil/pull/62 but on a fresh 16.0