### PR TITLE
[18.0][REM] l10n_br_base: remove _onchange_city_id

### DIFF
--- a/l10n_br_base/models/res_partner.py
+++ b/l10n_br_base/models/res_partner.py
@@ -235,10 +235,6 @@ class Partner(models.Model):
         fields that are synced from the parent."""
         return super()._address_fields() + ["district"]
 
-    @api.onchange("city_id")
-    def _onchange_city_id(self):
-        self.city = self.city_id.name
-
     def create_company(self):
         self.ensure_one()
         res = super(


### PR DESCRIPTION
Esse onchange já tem no mixin - https://github.com/OCA/l10n-brazil/blob/18.0/l10n_br_base/models/party_mixin.py#L183