### PR TITLE
[14.0][FIX] l10n_br_nfse_focus: alíquota do ISSQN calculada indevidamente pelo Sistema Nacional NFS-e

### DIFF
--- a/l10n_br_nfse_focus/models/nfse_nacional.py
+++ b/l10n_br_nfse_focus/models/nfse_nacional.py
@@ -395,7 +395,7 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
                         "aliquota_iss"
                     ]
                 }
-                if regime_especial_tributacao == 0
+                if provider_data["codigo_opcao_simples_nacional"] == 2
                 and service_basic["tributacao_iss"] not in (2, 3, 4)
                 else {}
             ),


### PR DESCRIPTION
@Escodoo HT02002
## Objetivo da PR

Ao emitir NFS-e Nacional para prestadores não optantes do Simples Nacional, em municípios com status "ATIVO" no Sistema Nacional NFS-e, o campo `percentual_aliquota_relativa_municipio (pAliq)` estava sendo enviado indevidamente na DPS.

O Sistema Nacional NFS-e rejeitava o envio com o erro:

```
Código: E0617
Mensagem: Não é permitido informar alíquota quando o prestador de serviço não é
optante do simples nacional (opSimpNac = 1) na data de competência informada na
DPS, com o município de incidência do ISSQN com situação "ATIVO" no Sistema
Nacional NFS-e.
```

O `pAliq` só deve ser informado quando o prestador for optante do Simples Nacional (para o cálculo do DAS). Quando não optante e o município já é administrado pelo Sistema Nacional, é o próprio sistema quem calcula a alíquota e o valor do ISSQN aplicáveis.

A condição usada para decidir o envio desse campo estava baseada em `regime_especial_tributacao == 0`, que não reflete a regra acima — um prestador pode não ter regime especial de tributação e mesmo assim não ser optante do Simples Nacional. A condição foi corrigida para usar `codigo_opcao_simples_nacional == 2 (optante)`, que é o critério correto exigido pelo Sistema Nacional NFS-e.
