### PR TITLE
[16.0][IMP] l10n_br_nfse_focus: Concatenação do Serviços 

### DIFF
--- a/l10n_br_nfse_focus/models/document.py
+++ b/l10n_br_nfse_focus/models/document.py
@@ -37,6 +37,7 @@ from .constants import (
 )
 from .helpers import (
     _is_valid_pdf,
+    concat_lines_discriminacao,
     filter_focusnfe,
     filter_focusnfe_municipal,
     filter_focusnfe_nacional,
@@ -100,6 +101,10 @@ class Document(models.Model):
                 "service": record._prepare_dados_servico(),
                 "recipient": record._prepare_dados_tomador(),
             }
+            if record.company_id.focusnfe_nfse_nacional_concat_lines_discriminacao:
+                edoc["service"]["discriminacao"] = concat_lines_discriminacao(
+                    record.fiscal_line_ids
+                )
             edocs.append(edoc)
         # Handle NFSe Municipal (original)
         for record in self.filtered(filter_processador_edoc_nfse).filtered(

--- a/l10n_br_nfse_focus/models/helpers.py
+++ b/l10n_br_nfse_focus/models/helpers.py
@@ -58,6 +58,23 @@ def _identify_cpf_cnpj(cpf, cnpj):
     return is_cpf, is_cnpj, cleaned_cpf, cleaned_cnpj
 
 
+def concat_lines_discriminacao(fiscal_line_ids, max_length=2000):
+    """Concatenate the description of every fiscal line into a single text.
+
+    Args:
+        fiscal_line_ids: recordset of l10n_br_fiscal.document.line.
+        max_length (int): maximum length allowed for the resulting text.
+
+    Returns:
+        str: descriptions of every line with a product, joined by newline
+        and truncated to max_length.
+    """
+    descricoes = [
+        line.name for line in fiscal_line_ids if line.product_id and line.name
+    ]
+    return "\n".join(descricoes)[:max_length]
+
+
 def _is_valid_pdf(content):
     """Check if content is a valid PDF.
 

--- a/l10n_br_nfse_focus/models/res_company.py
+++ b/l10n_br_nfse_focus/models/res_company.py
@@ -76,6 +76,14 @@ class ResCompany(models.Model):
         default=True,
     )
 
+    focusnfe_nfse_nacional_concat_lines_discriminacao = fields.Boolean(
+        string="Concatenate All Lines in Discriminação (NFSe Nacional)",
+        default=False,
+        help="If checked, the Discriminação do Serviço sent to NFSe Nacional will "
+        "concatenate the description of every fiscal line in the document, instead "
+        "of using only the description of the first line.",
+    )
+
     def get_focusnfe_token(self):
         """
         Retrieve the appropriate FocusNFe API token based on the current NFSe

--- a/l10n_br_nfse_focus/tests/test_l10n_br_nfse_focus.py
+++ b/l10n_br_nfse_focus/tests/test_l10n_br_nfse_focus.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import os
+from collections import namedtuple
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
@@ -30,6 +31,7 @@ from ... import l10n_br_nfse_focus
 from ..models.constants import API_ENDPOINT, NFSE_URL
 from ..models.document import Document
 from ..models.helpers import (
+    concat_lines_discriminacao,
     filter_focusnfe,
     filter_focusnfe_municipal,
     filter_focusnfe_nacional,
@@ -1329,6 +1331,73 @@ class TestL10nBrNfseFocus(common.TransactionCase):
                     mock_rps.assert_called_once()
                     mock_service.assert_called_once()
                     mock_recipient.assert_called_once()
+
+    def test_concat_lines_discriminacao_helper(self):
+        """Tests the pure helper that concatenates fiscal line descriptions."""
+        SimpleLine = namedtuple("SimpleLine", ["name", "product_id"])
+        lines = [
+            SimpleLine(name="Linha 1", product_id=True),
+            SimpleLine(name="Linha 2", product_id=True),
+            SimpleLine(name="Sem produto", product_id=False),
+            SimpleLine(name="", product_id=True),
+        ]
+
+        result = concat_lines_discriminacao(lines)
+
+        self.assertEqual(result, "Linha 1\nLinha 2")
+
+    def test_concat_lines_discriminacao_helper_truncates(self):
+        """Tests that the helper truncates the result to max_length."""
+        SimpleLine = namedtuple("SimpleLine", ["name", "product_id"])
+        lines = [SimpleLine(name="A" * 3000, product_id=True)]
+
+        result = concat_lines_discriminacao(lines, max_length=2000)
+
+        self.assertEqual(len(result), 2000)
+
+    def test_serialize_nacional_concat_lines_discriminacao_enabled(self):
+        """Tests discriminacao concatenation when the company flag is enabled."""
+        document = self.nfse_demo
+        document.processador_edoc = PROCESSADOR_OCA
+        document.document_type_id.code = MODELO_FISCAL_NFSE
+        document.company_id.provedor_nfse = "focusnfe"
+        document.company_id.focusnfe_nfse_type = "nfse_nacional"
+        document.company_id.focusnfe_nfse_nacional_concat_lines_discriminacao = True
+        document.document_date = datetime.now()
+        document.date_in_out = datetime.now()
+
+        first_line = document.fiscal_line_ids[0]
+        first_line.name = "Linha 1 descricao"
+        first_line.copy({"name": "Linha 2 descricao"})
+
+        edocs = document._serialize([])
+
+        self.assertEqual(
+            edocs[-1]["service"]["discriminacao"],
+            "Linha 1 descricao\nLinha 2 descricao",
+        )
+
+    def test_serialize_nacional_concat_lines_discriminacao_disabled(self):
+        """Tests discriminacao keeps only the first line when the flag is disabled."""
+        document = self.nfse_demo
+        document.processador_edoc = PROCESSADOR_OCA
+        document.document_type_id.code = MODELO_FISCAL_NFSE
+        document.company_id.provedor_nfse = "focusnfe"
+        document.company_id.focusnfe_nfse_type = "nfse_nacional"
+        document.company_id.focusnfe_nfse_nacional_concat_lines_discriminacao = False
+        document.document_date = datetime.now()
+        document.date_in_out = datetime.now()
+
+        first_line = document.fiscal_line_ids[0]
+        first_line.name = "Linha 1 descricao"
+        first_line.copy({"name": "Linha 2 descricao"})
+
+        edocs = document._serialize([])
+
+        self.assertEqual(
+            edocs[-1]["service"]["discriminacao"],
+            "Linha 1 descricao",
+        )
 
     def test_serialize_municipal(self):
         """Tests serialization for NFSe Municipal."""

--- a/l10n_br_nfse_focus/views/res_company.xml
+++ b/l10n_br_nfse_focus/views/res_company.xml
@@ -49,6 +49,10 @@
                     name="focusnfe_nfse_nacional_send_im_prestador"
                     attrs="{'invisible': ['|',('provedor_nfse','!=', 'focusnfe'),('focusnfe_nfse_type', '!=', 'nfse_nacional')]}"
                 />
+                <field
+                    name="focusnfe_nfse_nacional_concat_lines_discriminacao"
+                    attrs="{'invisible': ['|',('provedor_nfse','!=', 'focusnfe'),('focusnfe_nfse_type', '!=', 'nfse_nacional')]}"
+                />
             </field>
             <xpath expr="//field[@name='nfse_ssl_verify']" position="attributes">
                 <attribute name="invisible">0</attribute>


### PR DESCRIPTION
## Objetivo da PR

Concatenação de todas as linhas dos Serviços na Fatura para a NFS-e

Configuração dentro da configuração da empresa Fiscal -> NFS-e
<img width="384" height="84" alt="image" src="https://github.com/user-attachments/assets/6447fd48-0a7f-45d3-9655-4e690ea5787b" />

Linhas da Fatura:
<img width="1169" height="455" alt="image" src="https://github.com/user-attachments/assets/a9ede327-f5de-4080-a40c-ca2eec09c68f" />

NFS-e:
<img width="1238" height="160" alt="image" src="https://github.com/user-attachments/assets/37bc2530-6056-4a39-9ce9-d53bbaec47f8" />

cc @marcelsavegnago @WesleyOliveira98 @renatonlima @rvalyi 