### PR TITLE
[18.0][FIX] l10n_br_fiscal, l10n_br_nfe: fiscal operation from issuer CFOP

### DIFF
--- a/l10n_br_fiscal/wizards/document_import_wizard.py
+++ b/l10n_br_fiscal/wizards/document_import_wizard.py
@@ -210,20 +210,40 @@ class DocumentImportWizard(models.TransientModel):
             limit=1,
         )
 
-    def _find_fiscal_operation(self, cfop, nat_op, fiscal_operation_type):
-        """try to find a matching fiscal operation via an operation line"""
+    def _counterpart_cfop_code(self, cfop, fiscal_operation_type):
+        code = str(cfop or "")
+        if fiscal_operation_type != "in":
+            return code
+        counterpart = {"5": "1", "6": "2", "7": "3"}.get(code[:1])
+        if not counterpart:
+            return ""
+        return counterpart + code[1:]
+
+    def _find_fiscal_operation_line(self, cfop, nat_op, fiscal_operation_type):
+        code = self._counterpart_cfop_code(cfop, fiscal_operation_type)
+        if not code:
+            return self.env["l10n_br_fiscal.operation.line"]
         operation_lines = self.env["l10n_br_fiscal.operation.line"].search(
             [
                 ("state", "=", "approved"),
-                ("fiscal_type", "=", fiscal_operation_type),
-                ("cfop_external_id", "=", cfop),
+                ("fiscal_operation_type", "=", fiscal_operation_type),
+                "|",
+                "|",
+                ("cfop_internal_id.code", "=", code),
+                ("cfop_external_id.code", "=", code),
+                ("cfop_export_id.code", "=", code),
             ],
         )
         for line in operation_lines:
             if line.fiscal_operation_id.name == nat_op:
-                return line.fiscal_operation_id
-        if operation_lines:
-            return operation_lines[0].fiscal_operation_id
+                return line
+        return operation_lines[:1]
+
+    def _find_fiscal_operation(self, cfop, nat_op, fiscal_operation_type):
+        """try to find a matching fiscal operation via an operation line"""
+        line = self._find_fiscal_operation_line(cfop, nat_op, fiscal_operation_type)
+        if line:
+            return line.fiscal_operation_id
 
     def _match_uom_by_code(self, *codes):
         """Match a fiscal UoM from one or more XML unit codes (uCom/uTrib).

--- a/l10n_br_nfe/models/dfe.py
+++ b/l10n_br_nfe/models/dfe.py
@@ -130,4 +130,25 @@ class DFe(models.Model):
     @api.model
     def parse_procNFe(self, xml):
         binding = TnfeProc.from_xml(xml.read().decode())
-        return self.env["l10n_br_fiscal.document"].import_binding_nfe(binding)
+        document = self.env["l10n_br_fiscal.document"].import_binding_nfe(binding)
+        self._apply_fiscal_operation(document, binding)
+        return document
+
+    @api.model
+    def _apply_fiscal_operation(self, document, binding):
+        wizard = self.env["l10n_br_fiscal.document.import.wizard"]
+        inf_nfe = binding.NFe.infNFe
+        operation_line = wizard._find_fiscal_operation_line(
+            wizard._most_common_cfop(inf_nfe), inf_nfe.ide.natOp, "in"
+        )
+        if not operation_line:
+            return
+
+        document.document_type_id = self.env.ref("l10n_br_fiscal.document_55")
+        document.fiscal_operation_id = operation_line.fiscal_operation_id
+        for line in document.fiscal_line_ids:
+            price_unit = line.price_unit
+            line.fiscal_operation_id = operation_line.fiscal_operation_id
+            line.fiscal_operation_line_id = operation_line
+            line.price_unit = price_unit
+            line.uom_id = line.uot_id

--- a/l10n_br_nfe/tests/test_nfe_dfe.py
+++ b/l10n_br_nfe/tests/test_nfe_dfe.py
@@ -22,9 +22,27 @@ class TestNFeDFe(TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dfe_id = cls.env["l10n_br_fiscal.dfe"].create(
-            {"company_id": cls.env.ref("l10n_br_base.empresa_lucro_presumido").id}
+        company = cls.env.ref("l10n_br_base.empresa_lucro_presumido")
+        cls.dfe_id = (
+            cls.env["l10n_br_fiscal.dfe"]
+            .with_company(company)
+            .create({"company_id": company.id})
         )
+
+    def test_the_document_is_left_alone_when_no_operation_answers_the_cfop(self):
+        """The imported document keeps what the file said when no fiscal operation
+        of the company covers the CFOP of the issuer."""
+        document = self.env["l10n_br_fiscal.document"].new({})
+        binding = mock.MagicMock()
+
+        with mock.patch.object(
+            type(self.env["l10n_br_fiscal.document.import.wizard"]),
+            "_find_fiscal_operation_line",
+            lambda self, *args: self.env["l10n_br_fiscal.operation.line"],
+        ):
+            self.env["l10n_br_fiscal.dfe"]._apply_fiscal_operation(document, binding)
+
+        self.assertFalse(document.fiscal_operation_id)
 
     @mock.patch.object(
         DocumentoElectronicoAdapter,
@@ -37,10 +55,13 @@ class TestNFeDFe(TransactionCase):
 
         self.dfe_id.import_documents()
         self.assertEqual(len(self.dfe_id.imported_document_ids), 1)
+        document = self.dfe_id.imported_document_ids[0]
         self.assertEqual(
-            self.dfe_id.imported_document_ids[0].document_key,
+            document.document_key,
             "35200159594315000157550010000000012062777161",
         )
+        self.assertTrue(document.fiscal_operation_id)
+        self.assertEqual(document.fiscal_line_ids.cfop_id.code, "1102")
 
     @mock.patch.object(
         DocumentoElectronicoAdapter, "_post", side_effect=mocked_post_success_multiple

--- a/l10n_br_nfe/tests/test_nfe_import_wizard.py
+++ b/l10n_br_nfe/tests/test_nfe_import_wizard.py
@@ -109,6 +109,42 @@ class NFeImportWizardTest(TransactionCase):
         self.assertEqual(first_imported_product.price_unit_trib, 14)
         self.assertEqual(first_imported_product.total, 14)
 
+    def test_fiscal_operation_from_issuer_cfop(self):
+        self._prepare_wizard(self.xml_1)
+
+        self.assertEqual(self.wizard.fiscal_operation_type, "in")
+        self.assertTrue(self.wizard.fiscal_operation_id)
+        self.assertEqual(self.wizard.fiscal_operation_id.fiscal_operation_type, "in")
+
+    def test_counterpart_cfop_code(self):
+        wizard = self.env["l10n_br_fiscal.document.import.wizard"]
+        self.assertEqual(wizard._counterpart_cfop_code("5102", "in"), "1102")
+        self.assertEqual(wizard._counterpart_cfop_code("6102", "in"), "2102")
+        self.assertEqual(wizard._counterpart_cfop_code("7102", "in"), "3102")
+        self.assertEqual(wizard._counterpart_cfop_code("5102", "out"), "5102")
+        self.assertFalse(wizard._counterpart_cfop_code("1102", "in"))
+
+    def test_an_inbound_cfop_has_no_counterpart_to_look_for(self):
+        """A note issued against us already carries our own CFOP, and there is no
+        issuer operation to translate: the search has nothing to run on."""
+        wizard = self.env["l10n_br_fiscal.document.import.wizard"]
+
+        self.assertFalse(wizard._find_fiscal_operation_line("1102", "Compra", "in"))
+
+    def test_the_operation_whose_name_matches_the_nature_wins(self):
+        """Several operations can share the CFOP, and the natureza da operacao of
+        the file is what tells them apart."""
+        wizard = self.env["l10n_br_fiscal.document.import.wizard"]
+
+        any_line = wizard._find_fiscal_operation_line("5102", False, "in")
+        self.assertTrue(any_line, "no approved operation line answers CFOP 1102")
+
+        named = wizard._find_fiscal_operation_line(
+            "5102", any_line.fiscal_operation_id.name, "in"
+        )
+
+        self.assertEqual(named.fiscal_operation_id, any_line.fiscal_operation_id)
+
     def test_create_edoc_from_xml(self):
         self._prepare_wizard(self.xml_1)
 


### PR DESCRIPTION
O `_find_fiscal_operation` compara `fiscal_type` (`purchase`/`sale`/`other`) com `in`/`out`, e o Many2one `cfop_external_id` com o código cru do XML, então nunca casa nada. O CFOP do XML é sempre o do emitente: numa entrada, `5102` vira `1102`, `6102` vira `2102`, `7102` vira `3102`. O `_counterpart_cfop_code` traduz antes da busca, que passa a comparar o `code` de `cfop_internal_id`, `cfop_external_id` e `cfop_export_id`.

Achar a operação não bastava, porque o `_select_best_line` reescolhe a linha por especificidade de campos auxiliares, sem olhar CFOP, e troca o CFOP resolvido. O `_find_fiscal_operation_line` devolve a linha exata, o `_find_fiscal_operation` virou wrapper em cima dele, e o `parse_procNFe` do DF-e, que nem tentava resolver operação, fixa as duas no documento.

Peguei importando XML num cliente, onde a operação era escolhida na mão em toda nota. Os testes cobrem a tradução dos três grupos e a captura por DF-e chegando com CFOP `1102`.
