### PR TITLE
[16.0][FIX] l10n_br_hr: mostrar o employee_relationship_type no formulário do funcionário

### DIFF
--- a/l10n_br_hr/views/hr_employee_view.xml
+++ b/l10n_br_hr/views/hr_employee_view.xml
@@ -124,6 +124,12 @@
             <xpath expr="//field[@name='country_id']" position="replace">
                 <field name="country_id" invisible="1" />
             </xpath>
+            <xpath
+                expr="//page[@name='hr_settings']//field[@name='employee_type']"
+                position="after"
+            >
+                <field name="employee_relationship_type" />
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
O employee_relationship_type é required e tem default, mas não aparece em view nenhuma. Quem grava ele é só o default_employee_relationship_type no context das ações de Funcionários, Autônomos e Terceirizados, e isso só vale na criação.

Resultado: não dá pra reclassificar quem já existe. Na prática o pessoal cria um segundo cadastro pelo menu do tipo certo, e os apontamentos, contratos e anexos ficam todos no cadastro velho.

Aqui eu ponho o campo na aba Configurações de RH, do lado do employee_type, na view herdada que o módulo já tem.

O xpath está ancorado na página hr_settings de propósito. O hr_contract põe um segundo employee_type invisível no button box, e //field[@name='employee_type'] solto casa com esse primeiro.

Mesma coisa na 17.0 e na 18.0, se entrar eu faço o forward port.
