### PR TITLE
[18.0][FIX] l10n_br_account: remove required

### DIFF
--- a/l10n_br_account/views/account_move_view.xml
+++ b/l10n_br_account/views/account_move_view.xml
@@ -433,17 +433,14 @@
                 <field
                     name="city_taxation_code_id"
                     invisible="not document_type_id or tax_icms_or_issqn == 'icms'"
-                    required="document_type_id and tax_icms_or_issqn == 'issqn' and fiscal_operation_type == 'out'"
                 />
                 <field
                     name="national_taxation_code_id"
                     invisible="not document_type_id or tax_icms_or_issqn == 'icms'"
-                    required="document_type_id and tax_icms_or_issqn == 'issqn' and fiscal_operation_type == 'out'"
                 />
                 <field
                     name="service_type_id"
                     invisible="not document_type_id or tax_icms_or_issqn == 'icms'"
-                    required="document_type_id and tax_icms_or_issqn == 'issqn' and fiscal_operation_type == 'out'"
                 />
                 <field
                     name="cnae_id"


### PR DESCRIPTION
## Objetivo da PR

Esses campos Código de Tributação da Cidade, ISS National Taxation Code e Tipo de Serviço LC 166 quando estamos criando uma NFS-e tão ficando como obrigatório mas muita vezes nem passamos ele remover essa opção de required igual temos na V16.0

https://github.com/OCA/l10n-brazil/blob/16.0/l10n_br_account/views/account_move_view.xml#L427