### PR TITLE
[16.0][FIX] l10n_br_account: full reversal fails with reconciled journal entry

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -569,7 +569,14 @@ class AccountMove(models.Model):
             force_fiscal_operation_id = self.env["l10n_br_fiscal.operation"].browse(
                 self.env.context.get("force_fiscal_operation_id")
             )
-        for record in new_moves.filtered(lambda i: i.document_type_id):
+        fiscal_records = new_moves.filtered(lambda i: i.document_type_id)
+        reconciled_lines = fiscal_records.line_ids.filtered(
+            lambda line: line.matched_debit_ids or line.matched_credit_ids
+        )
+        if reconciled_lines:
+            reconciled_lines.remove_move_reconcile()
+
+        for record in fiscal_records:
             if (
                 not force_fiscal_operation_id
                 and not record.fiscal_operation_id.return_fiscal_operation_id
@@ -612,6 +619,17 @@ class AccountMove(models.Model):
                     record.fiscal_document_id._document_reference(
                         record.reversed_entry_id.fiscal_document_id
                     )
+
+        if reconciled_lines:
+            accounts = reconciled_lines.account_id
+            for account in accounts:
+                account_lines = reconciled_lines.filtered(
+                    lambda line, account=account: line.account_id == account
+                )
+                for currency in account_lines.currency_id:
+                    account_lines.filtered(
+                        lambda line, currency=currency: line.currency_id == currency
+                    ).with_context(move_reverse_cancel=cancel).reconcile()
 
         return new_moves
 

--- a/l10n_br_account/tests/test_invoice_refund.py
+++ b/l10n_br_account/tests/test_invoice_refund.py
@@ -170,6 +170,55 @@ class TestInvoiceRefund(AccountMoveBRCommon):
             "The refund process was unsuccessful.",
         )
 
+    def test_refund_cancel(self):
+        """Estorno Completo (refund_method='cancel') must not fail.
+
+        With cancel=True, Odoo's core _reverse_moves() already reconciles the
+        new reversal's receivable/payable line against the original invoice
+        before this module updates fiscal_operation_id on the lines. That
+        update recomputes taxes/totals, which can rewrite the balance of the
+        line just reconciled and hit Odoo's reconciliation guard.
+        """
+        reverse_vals = dict(self.reverse_vals, refund_method="cancel")
+
+        invoice = self.invoice
+        invoice.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
+        invoice.invoice_line_ids.write(
+            {
+                "fiscal_operation_id": self.env.ref("l10n_br_fiscal.fo_venda").id,
+                "fiscal_operation_line_id": (
+                    self.env.ref("l10n_br_fiscal.fo_venda_venda").id
+                ),
+            }
+        )
+        invoice.action_post()
+
+        move_reversal = (
+            self.env["account.move.reversal"]
+            .with_context(active_model="account.move", active_ids=invoice.ids)
+            .create(reverse_vals)
+        )
+
+        reversal = move_reversal.reverse_moves()
+        reverse_move = self.env["account.move"].browse(reversal["res_id"])
+
+        self.assertTrue(reverse_move)
+        self.assertEqual(
+            reverse_move.operation_name,
+            "Devolução de Venda",
+            "The refund process was unsuccessful.",
+        )
+
+        reconcilable_lines = (invoice.line_ids + reverse_move.line_ids).filtered(
+            lambda line: line.account_id.reconcile
+        )
+        self.assertTrue(reconcilable_lines)
+        self.assertTrue(
+            all(line.reconciled for line in reconcilable_lines),
+            "The receivable/payable lines should be reconciled again after "
+            "the fiscal operation update on the reversal.",
+        )
+
     def test_refund_force_fiscal_operation(self):
         reverse_vals = self.reverse_vals
         invoice = self.invoice


### PR DESCRIPTION
@Escodoo HT02128
## Problema

Ao estornar uma fatura (Vendor Bill/Customer Invoice) usando o método **"Estorno
Completo"** (`refund_method = "cancel"` no wizard `account.move.reversal`), o
Odoo bloqueia a operação com o erro padrão:

```
Você não pode fazer essa modificação em uma entrada de diário reconciliada.
Você pode apenas alterar alguns campos não legais ou você deve desconciliar
primeiro.
Entrada de Diário (id): RCONTA/2026/08/0001 (13017)
```

A cada nova tentativa o erro se repete, sempre com um `id` de lançamento
diferente (13017, 13022, ...) mas o mesmo nome provisório — ou seja, o Odoo
cria um novo lançamento de estorno a cada tentativa e desfaz tudo (rollback)
quando o erro estoura. O estorno nunca é concluído.

Como contorno imediato, usar **"Estorno Parcial"** (`refund_method = "refund"`)
funciona normalmente — o que ajudou a confirmar que o problema está
especificamente ligado ao fluxo de reconciliação automática do "Estorno
Completo".

## Causa raiz

Em `cancel=True` (Estorno Completo), o `account.move._reverse_moves()` do
core do Odoo já **cria e reconcilia automaticamente** as linhas do novo
lançamento de estorno contra a fatura original, antes de retornar.

O `l10n_br_account` sobrescreve esse método
(`l10n_br_account/models/account_move.py`, método `_reverse_moves()`) e,
**depois** de chamar `super()`, reatribui o `fiscal_operation_id` do
lançamento e de cada linha, apontando para a Operação Fiscal de devolução
(`return_fiscal_operation_id`):

```python
def _reverse_moves(self, default_values_list=None, cancel=False):
    new_moves = super()._reverse_moves(...)  # já cria E reconcilia o estorno
    ...
    for record in new_moves.filtered(lambda i: i.document_type_id):
        record.fiscal_operation_id = (
            force_fiscal_operation_id
            or record.fiscal_operation_id.return_fiscal_operation_id
        )
        for line in record.invoice_line_ids:
            line.fiscal_operation_id = (
                force_fiscal_operation_id
                or line.fiscal_operation_id.return_fiscal_operation_id
            )
    ...
```

Só que essa reatribuição de `fiscal_operation_id` recalcula em cascata
impostos e totais da linha (CFOP, classificação tributária, `fiscal_tax_ids`
etc.), o que pode reescrever o saldo (`balance`/`amount_currency`) da linha
de contrapartida (Duplicatas a Pagar/Receber) — **que acabou de ser
reconciliada** um instante antes, pelo próprio `super()`. Essa regravação
dispara a trava padrão do Odoo (`account.move.line._check_reconciliation()`,
em `addons/account/models/account_move_line.py`), que bloqueia qualquer
alteração em linha já reconciliada. Como o erro estoura dentro da mesma
transação de criação do lançamento, tudo é revertido — daí o `id` diferente
a cada tentativa e o nome do lançamento nunca sendo efetivamente gravado.

Esse comportamento é determinístico: independe de a fatura original já
estar paga/conciliada ou não. Ele ocorre porque o problema está na
conciliação **nova**, criada pelo próprio estorno, e não em nenhum estado
pré-existente da fatura.

## Correção

Antes de reatribuir o `fiscal_operation_id`, o código agora:

1. Identifica as linhas do novo lançamento que já foram reconciliadas pelo
   `super()._reverse_moves()`.
2. Remove essa conciliação (`remove_move_reconcile()`).
3. Aplica normalmente o ajuste de `fiscal_operation_id` (impostos/totais são
   recalculados livremente, sem trava).
4. Reconcilia novamente essas linhas, agora com os valores finais e
   corretos já aplicados — reproduzindo o agrupamento por conta/moeda que o
   próprio core do Odoo usa em `_reverse_moves()`.