### PR TITLE
[16.0][FIX] l10n_br_account: account_taxes respeita a empresa recebida

### DIFF
--- a/l10n_br_account/models/fiscal_tax.py
+++ b/l10n_br_account/models/fiscal_tax.py
@@ -9,6 +9,14 @@ class FiscalTax(models.Model):
 
     def account_taxes(self, user_type="sale", fiscal_operation=False, company=False):
         account_taxes = self.env["account.tax"]
+        # `deductible_taxes` is company dependent, so reading it off the record
+        # as it comes answers for whatever company sits in the environment, not
+        # for the one the caller asked about. Every caller passes the company of
+        # its own document, and the answer has to follow that company: otherwise
+        # the same purchase line takes the deductible taxes or not depending on
+        # which company the user happens to have selected.
+        if fiscal_operation and company:
+            fiscal_operation = fiscal_operation.with_company(company)
         for fiscal_tax in self:
             taxes = fiscal_tax._account_taxes(company)
             # Atualiza os impostos contábeis relacionados aos impostos fiscais

--- a/l10n_br_account/tests/__init__.py
+++ b/l10n_br_account/tests/__init__.py
@@ -9,3 +9,4 @@ from . import test_payment_status
 from . import test_move_workflow
 from . import test_cancel_move_ids
 from . import test_document_import_check
+from . import test_fiscal_tax_deductible

--- a/l10n_br_account/tests/__init__.py
+++ b/l10n_br_account/tests/__init__.py
@@ -10,3 +10,4 @@ from . import test_move_workflow
 from . import test_cancel_move_ids
 from . import test_document_import_check
 from . import test_fiscal_tax_deductible
+from . import test_deductible_balance

--- a/l10n_br_account/tests/test_deductible_balance.py
+++ b/l10n_br_account/tests/test_deductible_balance.py
@@ -1,0 +1,82 @@
+# Copyright 2026 KMEE
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo.tests import tagged
+
+from .common import AccountMoveBRCommon
+
+
+@tagged("post_install", "-at_install")
+class TestDeductibleBalance(AccountMoveBRCommon):
+    """The balance of a move cannot follow the company in the environment.
+
+    `deductible_taxes` is company dependent, and `_sync_invoice` reads it to
+    decide whether the product line takes the full document total or the total
+    minus the taxes. Reading it in the environment company instead of the
+    company of the line makes the same move balance differently depending on
+    which company the user happens to have selected on screen.
+    """
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+        cls.operation = cls.env.ref("l10n_br_fiscal.fo_compras")
+        cls.other_company = cls.env["res.company"].create(
+            {"name": "Empresa que nao deduz"}
+        )
+        cls.env.user.company_ids += cls.other_company
+        # Deducts in the company of the invoice, does not deduct in the other.
+        cls.operation.with_company(cls.env.company).deductible_taxes = True
+        cls.operation.with_company(cls.other_company).deductible_taxes = False
+
+    def _purchase_move(self):
+        return self.init_invoice(
+            "in_invoice",
+            products=[self.product_a],
+            document_type=self.env.ref("l10n_br_fiscal.document_55"),
+            fiscal_operation=self.operation,
+            fiscal_operation_lines=[
+                self.env.ref("l10n_br_fiscal.fo_compras_compras_comercializacao")
+            ],
+            document_serie="1",
+            document_number="4996",
+        )
+
+    def _product_line(self, move):
+        return move.invoice_line_ids.filtered(lambda line: line.product_id)[:1]
+
+    def test_the_flag_is_read_per_company(self):
+        """Guard of the scenario: the two companies really disagree.
+
+        Without this the next test could pass for the wrong reason, with both
+        readings landing on the same value.
+        """
+        self.assertTrue(self.operation.with_company(self.env.company).deductible_taxes)
+        self.assertFalse(
+            self.operation.with_company(self.other_company).deductible_taxes
+        )
+
+    def test_the_balance_does_not_follow_the_environment_company(self):
+        """Re-syncing from another company must not move the balance."""
+        move = self._purchase_move()
+        line = self._product_line(move)
+        self.assertTrue(line, "the purchase move has a product line")
+        before = line.balance
+
+        # Touch the line from an environment sitting on the other company, so
+        # `_sync_invoice` runs again there. Both companies stay allowed, which
+        # is the real scenario: one user, two companies, and the selector on
+        # the wrong one. `with_company` alone would drop the company of the
+        # line from `allowed_company_ids` and the record rule would make
+        # it unreadable, which is a different failure.
+        other_env = line.with_context(
+            allowed_company_ids=[self.other_company.id, self.env.company.id]
+        )
+        self.assertEqual(other_env.env.company, self.other_company)
+        other_env.write({"quantity": line.quantity})
+
+        self.assertEqual(
+            line.balance,
+            before,
+            "the balance followed the company in the environment",
+        )

--- a/l10n_br_account/tests/test_fiscal_tax_deductible.py
+++ b/l10n_br_account/tests/test_fiscal_tax_deductible.py
@@ -1,0 +1,101 @@
+# Copyright 2026 KMEE
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo.tests import TransactionCase
+
+
+class TestFiscalTaxDeductible(TransactionCase):
+    """`account_taxes` has to answer for the company it was asked about.
+
+    `l10n_br_fiscal.operation.deductible_taxes` is company dependent, so
+    reading it depends on the company in the environment unless somebody says
+    otherwise. Every caller of `account_taxes` passes the company of its own
+    document, and the answer has to follow that company: a purchase line of
+    company A cannot take the deductible taxes just because the user happened
+    to have company B selected.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.company_a = cls.env["res.company"].create({"name": "Deductible on"})
+        cls.company_b = cls.env["res.company"].create({"name": "Deductible off"})
+        cls.env.user.company_ids += cls.company_a + cls.company_b
+        cls.operation = cls.env.ref("l10n_br_fiscal.fo_compras")
+        # The key is company dependent: switch company to write each value.
+        cls.operation.with_company(cls.company_a).deductible_taxes = True
+        cls.operation.with_company(cls.company_b).deductible_taxes = False
+
+        cls.fiscal_tax = cls.env.ref("l10n_br_fiscal.tax_pis_0_65")
+        group = cls.fiscal_tax.tax_group_id.account_tax_group()
+        # One plain tax and one deductible tax in company A, so the answer can
+        # actually differ. Without the deductible one there would be nothing to
+        # tell apart and the test would pass for the wrong reason.
+        cls.plain_tax = cls.env["account.tax"].create(
+            {
+                "name": "PIS purchase",
+                "amount_type": "percent",
+                "amount": 0.65,
+                "type_tax_use": "purchase",
+                "tax_group_id": group.id,
+                "company_id": cls.company_a.id,
+                "deductible": False,
+            }
+        )
+        cls.deductible_tax = cls.env["account.tax"].create(
+            {
+                "name": "PIS purchase deductible",
+                "amount_type": "percent",
+                "amount": 0.65,
+                "type_tax_use": "purchase",
+                "tax_group_id": group.id,
+                "company_id": cls.company_a.id,
+                "deductible": True,
+            }
+        )
+
+    def _account_taxes_for(self, company, env_company):
+        """Ask about `company` from an environment sitting on `env_company`."""
+        fiscal_tax = self.fiscal_tax.with_company(env_company)
+        return fiscal_tax.account_taxes(
+            user_type="purchase",
+            fiscal_operation=self.operation,
+            company=company,
+        )
+
+    def test_the_company_asked_about_decides_the_deductible_tax(self):
+        """Company A deducts, so asking about A brings the deductible tax."""
+        taxes = self._account_taxes_for(self.company_a, self.company_a)
+        self.assertIn(self.plain_tax, taxes)
+        self.assertIn(self.deductible_tax, taxes)
+
+    def test_the_environment_company_does_not_decide_it(self):
+        """This is the regression: same question, different environment.
+
+        Asking about company A from an environment on company B used to drop
+        the deductible tax, because the company dependent key was read for B.
+        """
+        from_a = self._account_taxes_for(self.company_a, self.company_a)
+        from_b = self._account_taxes_for(self.company_a, self.company_b)
+        self.assertEqual(from_a, from_b)
+        self.assertIn(self.deductible_tax, from_b)
+
+    def test_a_company_that_does_not_deduct_never_takes_the_deductible_tax(self):
+        """The fix must not turn the flag on for everybody."""
+        self.operation.with_company(self.company_a).deductible_taxes = False
+        taxes = self._account_taxes_for(self.company_a, self.company_a)
+        self.assertIn(self.plain_tax, taxes)
+        self.assertNotIn(self.deductible_tax, taxes)
+
+    def test_without_a_company_the_operation_answers_for_its_own_company(self):
+        """Caller that passes no company keeps the old behaviour.
+
+        With no company to follow, the answer comes from the company the
+        operation record itself is in, which is what it did before.
+        """
+        taxes = self.fiscal_tax.with_company(self.company_a).account_taxes(
+            user_type="purchase",
+            fiscal_operation=self.operation.with_company(self.company_a),
+        )
+        self.assertIn(self.deductible_tax, taxes)


### PR DESCRIPTION
`l10n_br_fiscal.operation.deductible_taxes` e `company_dependent`, e o
`account_taxes` le essa chave no registro como ele chega, sem considerar a empresa
que recebeu por parametro. Resultado: a resposta depende da empresa que esta no
ambiente do usuario, nao da empresa do documento.

```python
def account_taxes(self, user_type="sale", fiscal_operation=False, company=False):
    account_taxes = self.env["account.tax"]
    for fiscal_tax in self:
        taxes = fiscal_tax._account_taxes(company)          # respeita company
        ...
        if fiscal_operation and fiscal_operation.deductible_taxes:   # nao respeita
```

O `_account_taxes` logo acima respeita o parametro. A leitura da chave dedutivel
ficou de fora, e e ela que decide se os impostos dedutiveis entram na linha.

## Por que importa

Os dez chamadores em producao passam a empresa do proprio documento:
`l10n_br_purchase`, `l10n_br_sale`, `l10n_br_account` (account.move.line),
`l10n_br_stock_account`, `l10n_br_contract`, `l10n_br_purchase_blanket_order` e
`l10n_br_sale_blanket_order`. Todos pedem a resposta para uma empresa e recebem a
resposta da empresa do ambiente.

Num banco multi-empresa em que uma empresa deduz e a outra nao, a mesma linha de
compra recebe ou nao os impostos dedutiveis conforme a empresa que o usuario tem
selecionada no momento. O valor contabilizado muda sem nada no documento mudar, e
o `taxes_id` gravado depende de quem salvou.

## O que muda

Uma linha: quando o chamador diz de qual empresa esta falando, a operacao fiscal
e lida naquela empresa. Chamador que nao passa empresa continua como antes, lendo
do ambiente.

## Testes

`l10n_br_account/tests/test_fiscal_tax_deductible.py`, quatro casos, com duas
empresas, uma que deduz e outra que nao, e um imposto dedutivel de verdade no banco
(sem ele o teste passaria por nao ter o que diferenciar):

- a empresa perguntada decide o imposto dedutivel;
- a empresa do ambiente nao decide: perguntar pela empresa A a partir de um ambiente
  na empresa B da o mesmo resultado que perguntar de dentro de A (e a regressao, e
  falha sem esta correcao);
- empresa que nao deduz nunca recebe o imposto dedutivel, para o fix nao ligar a
  chave para todo mundo;
- sem empresa no parametro, a operacao responde pela empresa em que ela esta.

`l10n_br_account/tests/test_deductible_balance.py` cobre o **outro lado da mesma
raiz**, que o #4997 do @DiegoParadeda corrigiu no `_sync_invoice` e entrou sem
teste. O cenario: duas empresas, a chave ligada so na empresa da nota, e uma escrita
na linha com o ambiente apontando para a outra empresa, com as duas permitidas (um
usuario, duas empresas, seletor na errada).

O que esse teste mostra sem a correcao do #4997 nao e um valor diferente, e o Odoo
recusando a gravacao: o `_check_balanced` levanta erro porque as duas metades do
calculo discordam sobre a mesma flag e o lancamento sai desbalanceado. Medido em
banco descartavel: sem o fix `1 error of 2`, com o fix `0 failed of 2`.

## Relacao com outros PRs

O #4997 (mesclado) corrigiu o `_sync_invoice`. Este PR corrige o `account_taxes` e
traz os testes dos dois lados.

O #4717 reescreve o `account_taxes` inteiro e ja carrega esta correcao dentro da
reescrita, para que a ordem de merge entre os dois nao apague o fix em silencio,
com CI verde, porque nenhum teste daquele PR cobre leitura por empresa.

Vale registrar o contexto que explica por que isso passou tanto tempo invisivel: a
branch 16.0 nao roda CI de push desde 16/07, com mais de 320 commits desde entao.
Uma regressao mesclada na base so aparece no CI dos PRs novos, e cada autor a recebe
como se fosse dele. Foi assim que o teste
`l10n_br_purchase_blanket_order.test_confirm_and_process_blanket_order` passou a
reprovar todo PR novo aberto contra a 16.0.
