### PR TITLE
[16.0][FIX] l10n_br_account: read deductible_taxes for the company of the move

### DIFF
--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -235,14 +235,22 @@ class AccountMoveLine(models.Model):
                 and not self.env.is_protected(self._fields["amount_currency"], line)
                 and (not changed("amount_currency") or line not in before)
             ):
-                if not line.move_id.fiscal_operation_id:
+                # `deductible_taxes` is company dependent, so reading it off the
+                # operation as it comes answers for whatever company sits in the
+                # environment. The answer has to follow the company of the move:
+                # otherwise the same line takes the deductible taxes out of its
+                # base or not depending on which company the user has selected.
+                fiscal_operation = line.move_id.fiscal_operation_id.with_company(
+                    line.company_id
+                )
+                if not fiscal_operation:
                     unsigned_amount_currency = line.currency_id.round(
                         line.price_subtotal
                     )
                 else:  # BRAZIL CASE:
                     if line.cfop_id and not line.cfop_id.finance_move:
                         unsigned_amount_currency = 0
-                        if not line.move_id.fiscal_operation_id.deductible_taxes:
+                        if not fiscal_operation.deductible_taxes:
                             # When there is no financial amount but there are non
                             # dectutible taxes, then we should take the total tax
                             # amount into account here to keep the move balanced.
@@ -253,7 +261,7 @@ class AccountMoveLine(models.Model):
                                 - line.amount_tax_withholding
                             )
                     else:
-                        if line.move_id.fiscal_operation_id.deductible_taxes:
+                        if fiscal_operation.deductible_taxes:
                             unsigned_amount_currency = (
                                 line.fiscal_amount_total + line.amount_tax_withholding
                             )


### PR DESCRIPTION
`l10n_br_fiscal.operation.deductible_taxes` is company dependent. In `_sync_invoice` it was read off the fiscal operation without scoping the company, so the base of a product line followed the company selected in the environment instead of the company of the move: the same invoice produced R$ 100,00 or R$ 83,51 as the payable amount depending on the company selector.

Same surgery as #4996, on the other side of the same flag: `with_company(line.company_id)` on the operation before both reads.

The two fixes are independent in code, but they should land together. Until this one is in, correcting only `account_taxes` makes the two halves of a move disagree about the same flag — the line takes the deductible taxes for the company of the document while the base is reduced for the company of the environment. Details and the numbers that surfaced it: https://github.com/OCA/l10n-brazil/pull/4996#issuecomment-5360716790

@mileo
