### PR TITLE
[16.0][FIX] spec_driven_model: do not abort the registry load when a model has no spec module

### DIFF
--- a/spec_driven_model/models/spec_mixin.py
+++ b/spec_driven_model/models/spec_mixin.py
@@ -1,6 +1,7 @@
 # Copyright 2019-TODAY Akretion - Raphael Valyi <raphael.valyi@akretion.com>
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
 
+import logging
 from importlib import import_module
 
 from odoo import api, models
@@ -8,6 +9,8 @@ from odoo.models import is_definition_class
 from odoo.tools import mute_logger
 
 from .spec_models import SPEC_MIXIN_MAPPINGS, SpecModel, StackedModel
+
+_logger = logging.getLogger(__name__)
 
 
 class SpecMixin(models.AbstractModel):
@@ -72,7 +75,7 @@ class SpecMixin(models.AbstractModel):
                     return spec_schema, spec_version
                 return f"{spec_schema}{spec_version}"
 
-        return None, None if split else None
+        return (None, None) if split else None
 
     def _get_spec_property(self, spec_property="", fallback=None):
         """
@@ -99,6 +102,17 @@ class SpecMixin(models.AbstractModel):
         if not spec_schema:
             return
 
+        # read before the load key below, which is claimed once per schema
+        spec_module = self._get_spec_property("odoo_module")
+        if not spec_module:
+            _logger.debug(
+                "%s: no spec module for the %s schema, "
+                "skipping the remaining schema models hook",
+                self._name,
+                spec_schema,
+            )
+            return
+
         load_key = f"_{spec_schema}_register_hook_loaded"
         if hasattr(self.env.registry, load_key):  # hook already called for registry
             return
@@ -118,7 +132,6 @@ class SpecMixin(models.AbstractModel):
             if self.env.registry.get(i[0])
             and not SPEC_MIXIN_MAPPINGS[self.env.cr.dbname].get(i[0])
         }
-        spec_module = self._get_spec_property("odoo_module")
         if "_spec." in spec_module:
             odoo_module = spec_module.split("_spec.")[0].split(".")[-1]
         else:  # for tests:

--- a/spec_driven_model/tests/test_spec_model.py
+++ b/spec_driven_model/tests/test_spec_model.py
@@ -398,3 +398,24 @@ class TestSpecModel(TransactionCase, FakeModelLoader):
         finally:
             module_to_models["spec_driven_model"] = saved_module_classes
             registry.ready = ready
+
+    def test_spec_prefix_without_schema_answers_a_single_value(self):
+        """`_spec_prefix()` answers one value when asked for one."""
+        model = self.env["spec.mixin"].with_context(
+            spec_schema=False, spec_version=False
+        )
+        self.assertIsNone(model._spec_prefix())
+        self.assertEqual(model._spec_prefix(split=True), (None, None))
+
+    def test_model_without_odoo_module_does_not_break_the_registry(self):
+        """A prefix that resolves without a spec module must not abort the load."""
+        model = self.env["spec.mixin"].with_context(
+            spec_schema="nosuch", spec_version="10"
+        )
+        self.assertEqual(model._spec_prefix(), "nosuch10")
+        self.assertIsNone(model._get_spec_property("odoo_module"))
+        self.assertIsNone(model._register_remaining_schema_models_hook())
+        self.assertFalse(
+            hasattr(self.env.registry, "_nosuch_register_hook_loaded"),
+            "the model with no spec module consumed the load key of the schema",
+        )


### PR DESCRIPTION
## Resumo

O `_register_remaining_schema_models_hook` e chamado pelo `_register_hook`, ou seja,
roda dentro da carga do registry. Ele reivindicava a chave de carga do schema, depois
lia `_<prefixo>_odoo_module` e caia direto no `if "_spec." in spec_module`.

Quando esse atributo nao existe, a leitura devolve `None` e o teste de pertinencia
levanta:

```
File "spec_driven_model/models/spec_mixin.py", line 124, in _register_remaining_schema_models_hook
  if "_spec." in spec_module:
TypeError: argument of type 'NoneType' is not iterable
```

Como o hook roda durante a carga, a excecao nao reprova um addon: vem
`Failed to load registry`, depois `CRITICAL Failed to initialize database`, e o banco
nao sobe.

## Por que isso nao depende de erro no addon

O prefixo e resolvido pelo **modulo da classe**, entao toda classe de um pacote que
declara o marcador `spec_schema` responde aquele prefixo, tenha ou nao os mixins
daquele schema. Basta uma extensao de `res.company` morando ao lado dos modelos de
evento de um schema: o `res.company` concreto carrega spec mixins (da NF-e, do CT-e e
do MDF-e), logo ele chega a este hook, e nao tem atributo para responder pelo outro
schema.

Fui conferir se a 16.0 ja esta exposta hoje. Num banco com `l10n_br_nfe`,
`l10n_br_cte` e `l10n_br_mdfe` instalados, percorri todo modelo que herda `spec.mixin`
e perguntei a cada um o prefixo e o atributo correspondente. Nenhum modelo resolve um
prefixo e fica sem o atributo, ou seja, isso nao esta latente: e preciso um addon novo
para alcancar. E foi exatamente assim que apareceu. Um addon novo da EFD-Reinf declara
`spec_schema = "reinf"` no pacote de modelos, do mesmo jeito que `l10n_br_nfe`,
`l10n_br_cte` e `l10n_br_mdfe` fazem, e o banco de teste inteiro parou de subir. O lado
do addon tambem esta sendo corrigido, mantendo o marcador no pacote que de fato guarda
os modelos do schema, mas o preco desse tipo de lacuna nao deveria ser o registry.

## O que mudou

Ler o spec module antes de reivindicar a chave de carga, e sair quando nao houver, com
log de debug.

Ler antes da chave importa tanto quanto a guarda em si. A chave e o que faz o hook
rodar uma unica vez por schema e por registry, entao reivindica-la a partir de um modelo
que nao pode fazer o trabalho consumiria a unica chance daquele schema: os modelos
remanescentes nunca seriam construidos, em silencio e com CI verde. O teste cobre as
duas coisas, a ausencia do traceback e a chave continuar livre.

Tem uma segunda correcao, no `_spec_prefix`. O caminho de falha estava escrito assim:

```python
return None, None if split else None
```

O Python le isso como `(None, (None if split else None))`, entao quem pedia um valor
unico recebia uma tupla de dois elementos, e o `_get_spec_property` montava o nome do
atributo a partir de uma tupla, o que sempre cai no fallback. Agora e
`return (None, None) if split else None`.

Esse caminho nao e exotico. Na mesma varredura descrita acima, 485 modelos receberam a
tupla do `_spec_prefix()` e 47 receberam um prefixo. Os 485 sao os mixins abstratos do
schema que nao foram injetados em nenhum modelo concreto, e para eles o fallback e a
resposta certa por acidente, entao nada quebra a vista. Ainda assim, todo diagnostico
feito via `_get_spec_property` mente sobre o motivo de ter respondido o fallback, e foi
isso que deixou a guarda acima dificil de ler.

## Testes

Dois testes, um por caminho. Medido em banco descartavel: com o fix,
`0 failed, 0 error(s) of 9 tests`; revertendo o fix e mantendo os testes,
`1 failed, 1 error(s) of 9 tests`.

@rvalyi se voce preferir que a guarda logue um warning em vez de debug, ou que levante
um erro mais claro para quem escreve o addon, e so dizer e eu mudo. Fui de skip
silencioso porque realmente nao ha nada para o hook fazer nesse caso, e porque o
caminho barulhento e justamente o que derrubava o banco.
