### PR TITLE
[16.0][FIX] l10n_br_account_withholding: amount_currency/balance zerados na fatura de retenção

### DIFF
--- a/l10n_br_account_withholding/models/account_move.py
+++ b/l10n_br_account_withholding/models/account_move.py
@@ -103,7 +103,11 @@ class AccountMove(models.Model):
                 Command.create(
                     {
                         "name": move_line.name,
+                        "display_type": "product",
+                        "quantity": 1.0,
                         "price_unit": abs(move_line.balance),
+                        "amount_currency": abs(move_line.balance),
+                        "balance": abs(move_line.balance),
                         "account_id": move_line.account_id.id,
                         "wh_move_line_id": move_line.id,
                         "analytic_distribution": move_line.analytic_distribution,
@@ -155,6 +159,26 @@ class AccountMove(models.Model):
                             subtype_id=self.env.ref("mail.mt_note").id,
                         )
                         wh_invoice.action_post()
+                        product_line = wh_invoice.line_ids.filtered(
+                            lambda line: line.display_type == "product"
+                        )
+                        product_line.write(
+                            {
+                                "amount_currency": abs(line.balance),
+                                "balance": abs(line.balance),
+                            }
+                        )
+                        for fname in (
+                            "amount_untaxed",
+                            "amount_tax",
+                            "amount_total",
+                            "amount_untaxed_signed",
+                            "amount_tax_signed",
+                            "amount_total_signed",
+                        ):
+                            self.env.add_to_compute(
+                                self.env["account.move"]._fields[fname], wh_invoice
+                            )
 
     def _withholding_validate(self):
         """


### PR DESCRIPTION
@Escodoo HT02135

## Problema

Faturas de retenção (RET/...) geradas automaticamente por `create_wh_invoices()`
eram lançadas com `amount_currency`, `balance`, `debit`/`credit` e os totais do
cabeçalho (`amount_total`, `amount_untaxed`) todos zerados — mesmo com
`price_unit`/`price_subtotal` corretos na linha. O lançamento contábil ficava
sem efeito financeiro real, apesar de aparecer como "Lançado"/"Pago".

Referência: HT02135

## Causa raiz

Não é um erro de cálculo — os valores corretos existem em `price_subtotal`
o tempo todo. O problema é de sincronização/timing no próprio `create()` e
`action_post()` do Odoo:

- O núcleo do `account` sincroniza `partner_id`/`account_id` das linhas em
  vários pontos durante a criação e a confirmação da fatura (o mecanismo
  `_sync_dynamic_lines`/`_sync_invoice`).
- Cada uma dessas sincronizações recalcula `amount_currency`/`balance` a
  partir de `price_subtotal` — e, para linhas sem `tax_ids` (como as de
  retenção, que só têm `price_unit` + conta, sem imposto), esse recálculo
  específico devolve 0.
- Qualquer valor definido antes ou durante esse processo (inclusive
  explicitamente no `create()`) é sobrescrito por essa sincronização
  posterior, disparada por outras escritas na mesma fatura (ex.: mudar a
  conta da linha de contrapartida para a conta de retenção).

Reproduzido isoladamente **fora** do módulo de retenção: qualquer fatura de
fornecedor criada via `env["account.move"].create()` (sem passar pela tela/
onchange do usuário) sofre do mesmo problema, com ou sem imposto na linha.
Isso indica uma fragilidade mais ampla do `l10n_br_account` para faturas
criadas via código, mas o escopo deste fix é apenas a retenção.

## Correção

Em `create_wh_invoices()`:

1. Mantido o `display_type`/`quantity`/`amount_currency`/`balance` explícitos
   no `Command.create` de `_prepare_wh_invoice` (necessário, mas insuficiente
   sozinho).
2. Após `wh_invoice.action_post()` ter terminado completamente (único ponto em
   que a sincronização do Odoo para de sobrescrever o valor), a linha de
   produto tem `amount_currency`/`balance` reafirmados.
3. Como os totais do cabeçalho já haviam sido computados e persistidos com o
   valor zerado, e escrever na linha não propaga automaticamente para eles
   numa fatura já lançada, os campos `amount_total`, `amount_untaxed`,
   `amount_tax` (e as versões `_signed`) são marcados para recomputar.
