### PR TITLE
[18.0][FIX] l10n_br_fiscal: tax_classification_id view

### DIFF
--- a/l10n_br_fiscal/views/operation_view.xml
+++ b/l10n_br_fiscal/views/operation_view.xml
@@ -119,7 +119,7 @@
                             <field
                                 name="line_ids"
                                 readonly="state != 'draft'"
-                                context="{'default_fiscal_operation_id': id, 'default_fiscal_type': fiscal_type, 'default_fiscal_operation_type': fiscal_operation_type, 'form_view_ref': 'l10n_br_fiscal.operation_line_form' , 'show_code_only': 1}"
+                                context="{'default_fiscal_operation_id': id, 'default_fiscal_type': fiscal_type, 'default_fiscal_operation_type': fiscal_operation_type, 'form_view_ref': 'l10n_br_fiscal.operation_line_form'}"
                             />
                         </page>
                         <page name="operation_document_type" string="Fiscal Documents">


### PR DESCRIPTION
## Antes:
<img width="976" height="850" alt="print_01_oca" src="https://github.com/user-attachments/assets/cae10811-4989-4cad-981a-dbdc46ba6c59" />

## Depois:
<img width="977" height="850" alt="print_02_oca" src="https://github.com/user-attachments/assets/833cfec2-7d42-47ea-b950-7796d0e00aff" />
