### PR TITLE
[14.0][FIX] l10n_br_nfse_focus: retencao_pis_cofins

### DIFF
--- a/l10n_br_nfse_focus/models/nfse_nacional.py
+++ b/l10n_br_nfse_focus/models/nfse_nacional.py
@@ -262,6 +262,12 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
         else:
             aliquota_pis = "0.00"
             aliquota_cofins = "0.00"
+        valor_pis_retido = round(service_info.get("valor_pis_retido", 0), 2)
+        valor_cofins_retido = round(service_info.get("valor_cofins_retido", 0), 2)
+        valor_csll_retido = round(service_info.get("valor_csll_retido", 0), 2)
+        tipo_retencao_pis_cofins = self._compute_tipo_retencao_pis_cofins(
+            bool(valor_pis_retido), bool(valor_cofins_retido), bool(valor_csll_retido)
+        )
 
         return {
             **(
@@ -274,14 +280,33 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
             "aliquota_cofins": aliquota_cofins,
             "valor_pis": valor_pis,
             "valor_cofins": valor_cofins,
-            "tipo_retencao_pis_cofins": service_info.get(
-                "tipo_retencao_pis_cofins", "2"
-            ),
+            "tipo_retencao_pis_cofins": tipo_retencao_pis_cofins,
             "valor_cp": round(service_info.get("valor_inss_retido", 0), 2),
             "valor_irrf": round(service_info.get("valor_ir_retido", 0), 2),
-            "valor_csll": round(service_info.get("valor_csll_retido", 0), 2),
+            "valor_csll": round(
+                valor_pis_retido + valor_cofins_retido + valor_csll_retido, 2
+            ),
             "valor_iss": round(service_info.get("valor_iss", 0), 2),
         }
+
+    @staticmethod
+    def _compute_tipo_retencao_pis_cofins(pis_retido, cofins_retido, csll_retido):
+        """Map PIS/COFINS/CSLL retention flags to the NT 007 tpRetPisCofins code.
+
+        Legacy codes "1" and "2" are no longer accepted by NFSe Nacional.
+        Codes "0" and "3"-"9" cover every combination of retained taxes.
+        """
+        tipo_retencao_map = {
+            (False, False, False): "0",
+            (True, True, True): "3",
+            (True, True, False): "4",
+            (True, False, False): "5",
+            (False, True, False): "6",
+            (False, True, True): "7",
+            (False, False, True): "8",
+            (True, False, True): "9",
+        }
+        return tipo_retencao_map[(pis_retido, cofins_retido, csll_retido)]
 
     def _prepare_payload_nacional(self, edoc, company):
         """Construct the NFSe Nacional payload.

--- a/l10n_br_nfse_focus/models/nfse_nacional.py
+++ b/l10n_br_nfse_focus/models/nfse_nacional.py
@@ -420,7 +420,10 @@ class FocusnfeNfseNacional(FocusnfeNfseBase):
                         "aliquota_iss"
                     ]
                 }
-                if provider_data["codigo_opcao_simples_nacional"] == 2
+                if (
+                    provider_data["codigo_opcao_simples_nacional"] == 2
+                    or provider_data["regime_especial_tributacao"] == 0
+                )
                 and service_basic["tributacao_iss"] not in (2, 3, 4)
                 else {}
             ),

--- a/l10n_br_nfse_focus/tests/test_l10n_br_nfse_focus.py
+++ b/l10n_br_nfse_focus/tests/test_l10n_br_nfse_focus.py
@@ -799,6 +799,68 @@ class TestL10nBrNfseFocus(common.TransactionCase):
         self.assertEqual(result["aliquota_pis"], "1.50")
         self.assertEqual(result["aliquota_cofins"], "3.00")
 
+    def test_compute_tipo_retencao_pis_cofins_nt007_codes(self):
+        """Tests the NT 007 tpRetPisCofins code for every retention combination.
+
+        Legacy codes "1" and "2" must never be returned; only "0" and
+        "3"-"9" are valid for NFSe Nacional after NT 007.
+        """
+        nfse_nacional = self.env["focusnfe.nfse.nacional"]
+        compute = nfse_nacional._compute_tipo_retencao_pis_cofins
+
+        self.assertEqual(compute(False, False, False), "0")
+        self.assertEqual(compute(True, False, False), "5")
+        self.assertEqual(compute(False, True, False), "6")
+        self.assertEqual(compute(False, False, True), "8")
+        self.assertEqual(compute(True, True, False), "4")
+        self.assertEqual(compute(True, False, True), "9")
+        self.assertEqual(compute(False, True, True), "7")
+        self.assertEqual(compute(True, True, True), "3")
+
+    def test_prepare_tax_data_nacional_no_retention_uses_code_zero(self):
+        """Tests that no retention maps to code "0", not the legacy code "2"."""
+        nfse_nacional = self.env["focusnfe.nfse.nacional"]
+        service_info = {
+            "valor_pis": 2.48,
+            "valor_cofins": 11.4,
+            "valor_pis_retido": 0,
+            "valor_cofins_retido": 0,
+            "valor_csll_retido": 0,
+        }
+
+        result = nfse_nacional._prepare_tax_data_nacional(service_info, 150.0)
+
+        self.assertEqual(result["tipo_retencao_pis_cofins"], "0")
+        self.assertEqual(result["valor_csll"], 0.0)
+
+    def test_prepare_tax_data_nacional_full_retention_uses_code_three(self):
+        """Tests that PIS+COFINS+CSLL retention maps to code "3".
+
+        valor_csll must carry the sum of the three retained amounts,
+        as required by NT 007.
+        """
+        nfse_nacional = self.env["focusnfe.nfse.nacional"]
+        service_info = {
+            "valor_pis_retido": 2.60,
+            "valor_cofins_retido": 12.0,
+            "valor_csll_retido": 4.0,
+        }
+
+        result = nfse_nacional._prepare_tax_data_nacional(service_info, 150.0)
+
+        self.assertEqual(result["tipo_retencao_pis_cofins"], "3")
+        self.assertEqual(result["valor_csll"], 18.6)
+
+    def test_prepare_tax_data_nacional_pis_only_retention_uses_code_five(self):
+        """Tests that PIS-only retention maps to code "5"."""
+        nfse_nacional = self.env["focusnfe.nfse.nacional"]
+        service_info = {"valor_pis_retido": 1.0}
+
+        result = nfse_nacional._prepare_tax_data_nacional(service_info, 150.0)
+
+        self.assertEqual(result["tipo_retencao_pis_cofins"], "5")
+        self.assertEqual(result["valor_csll"], 1.0)
+
     @patch(
         "odoo.addons.l10n_br_nfse_focus.models.nfse_nacional.FocusnfeNfseNacional.process_focus_nfse_nacional_document"  # noqa: B950
     )

--- a/l10n_br_nfse_focus/tests/test_l10n_br_nfse_focus.py
+++ b/l10n_br_nfse_focus/tests/test_l10n_br_nfse_focus.py
@@ -749,6 +749,59 @@ class TestL10nBrNfseFocus(common.TransactionCase):
 
         self.assertNotIn("inscricao_municipal_prestador", payload)
 
+    def test_prepare_payload_nacional_sends_aliquota_non_simples_no_special_regime(
+        self,
+    ):
+        """Tests aliquota is sent for a non-Simples provider without special regime.
+
+        Some municipalities require percentual_aliquota_relativa_municipio even
+        for providers that are not optante do Simples Nacional, as long as they
+        have no special municipal taxation regime (regime_especial_tributacao
+        == 0) and ISS is normally taxable.
+        """
+        nfse_nacional = self.env["focusnfe.nfse.nacional"]
+        edoc = {
+            "rps": dict(
+                PAYLOAD[0]["rps"],
+                optante_simples_nacional="2",
+                regime_especial_tributacao="0",
+            ),
+            "service": PAYLOAD[1]["service"],
+            "recipient": PAYLOAD[2]["recipient"],
+        }
+
+        self.company.city_id = self.env.ref("l10n_br_base.city_3550308")
+
+        payload = nfse_nacional._prepare_payload_nacional(edoc, self.company)
+
+        self.assertEqual(payload.get("codigo_opcao_simples_nacional"), 1)
+        self.assertIn("percentual_aliquota_relativa_municipio", payload)
+
+    def test_prepare_payload_nacional_suppresses_aliquota_special_regime(self):
+        """Tests aliquota is omitted for a non-Simples provider with special regime.
+
+        A provider that is neither optante do Simples Nacional nor free of a
+        special municipal taxation regime must not have the aliquota field
+        sent, matching the pre-existing behavior for that combination.
+        """
+        nfse_nacional = self.env["focusnfe.nfse.nacional"]
+        edoc = {
+            "rps": dict(
+                PAYLOAD[0]["rps"],
+                optante_simples_nacional="2",
+                regime_especial_tributacao="1",
+            ),
+            "service": PAYLOAD[1]["service"],
+            "recipient": PAYLOAD[2]["recipient"],
+        }
+
+        self.company.city_id = self.env.ref("l10n_br_base.city_3550308")
+
+        payload = nfse_nacional._prepare_payload_nacional(edoc, self.company)
+
+        self.assertEqual(payload.get("codigo_opcao_simples_nacional"), 1)
+        self.assertNotIn("percentual_aliquota_relativa_municipio", payload)
+
     def test_prepare_service_basic_nacional_tipo_retencao_iss_override(self):
         """Tests that tipo_retencao_iss is forced to '1' for tributacao_iss 2/3/4.
 


### PR DESCRIPTION
@Escodoo HT02145

A NFSe Nacional passou a rejeitar notas emitidas com os códigos 1 e 2 no campo tipo_retencao_pis_cofins (tag tpRetPisCofins), descontinuados pela **Nota Técnica SE/CGNFS-e nº 007/2026:**


```
Rejeitado pela regras municipais: Conforme estabelecido pela NT 007, os tipos de
retenção 1 e 2 para PIS/COFINS e CSLL não devem mais ser utilizados.
```
O conector sempre enviava tipo_retencao_pis_cofins fixo em "2" (ou o que viesse do documento, também nos códigos legados 1/2), independente de haver ou não retenção de fato.

A NT 007 ampliou o domínio do campo para 0 e 3–9, cobrindo todas as combinações de retenção entre PIS, COFINS e CSLL, e passou a exigir que valor_csll (vRetCSLL) carregue a soma dos três valores retidos (PIS + COFINS + CSLL), não apenas o CSLL isolado.

Correção (em `_prepare_tax_data_nacional`, `nfse_nacional.py`):

Novo método `_compute_tipo_retencao_pis_cofins`, que deriva o código correto (0, 3–9) a partir de quais impostos (PIS/COFINS/CSLL) foram efetivamente retidos no documento, em vez de usar um valor fixo/legado.
`valor_csll` no payload passa a ser `valor_pis_retido` + `valor_cofins_retido` + `valor_csll_retido`, conforme exigido pela NT 007.

cc @marcelsavegnago @rvalyi @renatonlima @mileo 