### PR TITLE
[16.0][IMP] better workflow integration between fiscal document and account.move

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -15,7 +15,6 @@ from odoo.addons.l10n_br_fiscal.constants.fiscal import (
     DOCUMENT_ISSUER_COMPANY,
     DOCUMENT_ISSUER_PARTNER,
     DOCUMENT_STATE_CANCEL,
-    DOCUMENT_STATE_DRAFT,
     FISCAL_IN_OUT_ALL,
     FISCAL_OUT,
     MODELO_FISCAL_NFE,
@@ -156,6 +155,28 @@ class AccountMove(models.Model):
             for line in move.invoice_line_ids:
                 docs |= line.document_id
             move.fiscal_document_ids = docs
+
+    edoc_locked_warning = fields.Char(
+        compute="_compute_edoc_locked_warning",
+    )
+
+    @api.depends("fiscal_document_ids.edoc_is_locked")
+    def _compute_edoc_locked_warning(self):
+        for move in self:
+            locked = move.fiscal_document_ids.filtered("edoc_is_locked")
+            if not locked:
+                move.edoc_locked_warning = False
+            elif locked.filtered(lambda d: d.issuer == DOCUMENT_ISSUER_COMPANY):
+                move.edoc_locked_warning = _(
+                    "This move is linked to a fiscal document already "
+                    "validated or sent (locked). Fiscal identity fields can "
+                    "only be changed from the Fiscal Document view."
+                )
+            else:
+                move.edoc_locked_warning = _(
+                    "This move is linked to a cancelled fiscal document. "
+                    "Its fiscal fields can no longer be changed."
+                )
 
     @api.depends("move_type", "fiscal_operation_id")
     def _compute_fiscal_operation_type(self):
@@ -504,20 +525,23 @@ class AccountMove(models.Model):
                         "because this document is cancelled in SEFAZ"
                     ).format(move.document_number)
                 )
-            move.fiscal_document_ids.filtered(
-                lambda d: d.state_edoc != DOCUMENT_STATE_DRAFT
-            ).action_document_back2draft()
+            # Best-effort: reset only e-docs that don't need a SEFAZ event.
+            # SEFAZ-locked docs are left as-is so the accountant can still
+            # reset the move (e.g. to fix a journal or account).
+            move.fiscal_document_ids.action_document_back2draft_from_move()
         return super().button_draft()
 
     def action_document_send(self):
-        for invoice in self.filtered(lambda d: d.document_type_id):
-            if hasattr(invoice.fiscal_document_ids, "action_document_send"):
-                invoice.fiscal_document_ids.action_document_send()
-            # FIXME: na migração para a v14 foi permitido o post antes do envio
-            #  para destravar a migração, mas poderia ser cogitado de obrigar a
-            #  transmissão antes do post novamente como na v12.
-            # for invoice in invoices:
-            #     invoice.move_id.post(invoice=invoice)
+        """Send all related electronic fiscal documents to SEFAZ.
+
+        Surfaced as a button on the move so the e-doc transmission can be
+        driven from the invoice without opening the fiscal view. Advanced
+        e-doc operations (correction, number invalidation) still require
+        the fiscal document view.
+        """
+        docs = self.fiscal_document_ids.filtered(lambda d: d.document_type_id)
+        if hasattr(docs, "action_document_send"):
+            docs.action_document_send()
 
     def action_document_cancel(self):
         for move in self.filtered(lambda d: d.document_type_id):
@@ -546,11 +570,46 @@ class AccountMove(models.Model):
             move.ensure_one_doc()
             return move.fiscal_document_id.action_view_invoice()
 
+    def _edoc_post_gate(self):
+        """Optional hard gate: block posting a move whose electronic
+        company-issued fiscal document is not yet authorized by SEFAZ.
+
+        Controlled per-company by `edoc_require_send_before_post` (off by
+        default). Billing Administrators, or the `force_edoc_post` context,
+        bypass the gate so an authorized user can still post when needed.
+        """
+        if self.env.context.get("force_edoc_post"):
+            return
+        if self.env.user.has_group("account.group_account_manager"):
+            return
+        blocking = self.env["l10n_br_fiscal.document"]
+        for doc in self.fiscal_document_ids.filtered(lambda d: d.document_type_id):
+            if not (
+                doc.company_id.edoc_require_send_before_post
+                and doc.document_electronic
+                and doc.issuer == DOCUMENT_ISSUER_COMPANY
+            ):
+                continue
+            # "authorized" is the terminal OK state; anything else means the
+            # e-doc still needs to be sent / is not cleared by SEFAZ.
+            if doc.state_edoc != "autorizada":
+                blocking |= doc
+        if blocking:
+            raise UserError(
+                _(
+                    "The following fiscal document(s) must be authorized by "
+                    "SEFAZ before posting: %(docs)s.\nUse the Send button "
+                    "first, or ask a Billing Administrator to post.",
+                    docs=", ".join(blocking.mapped("display_name")),
+                )
+            )
+
     def _post(self, soft=True):
         for move in self.with_context(skip_post=True):
             move.fiscal_document_ids.filtered(
                 lambda d: d.document_type_id
             ).action_document_confirm()
+        self._edoc_post_gate()
         return super()._post(soft=soft)
 
     def view_xml(self):
@@ -621,8 +680,12 @@ class AccountMove(models.Model):
         return new_moves
 
     def button_cancel(self):
-        for doc in self.filtered(lambda d: d.document_type_id):
-            doc.fiscal_document_id.action_document_cancel()
+        # Best-effort: cancel only the related e-docs that don't need a
+        # SEFAZ event. SEFAZ-locked docs (authorized / in transit) keep
+        # their real fiscal state and must be cancelled from the fiscal
+        # document view via the proper SEFAZ event; cancelling the move
+        # here is never blocked by them.
+        self.fiscal_document_ids.action_document_cancel_from_move()
         return super().button_cancel()
 
     def button_import_fiscal_document(self):

--- a/l10n_br_account/views/account_move_view.xml
+++ b/l10n_br_account/views/account_move_view.xml
@@ -63,6 +63,23 @@
                     <span>Fiscal Details</span>
                 </button>
             </div>
+            <xpath expr="//widget[@name='web_ribbon'][1]" position="before">
+                <widget
+                    name="web_ribbon"
+                    title="Locked e-doc"
+                    bg_color="bg-warning"
+                    attrs="{'invisible': [('edoc_locked_warning', '=', False)]}"
+                />
+            </xpath>
+            <header position="inside">
+                <button
+                    name="action_document_send"
+                    type="object"
+                    string="Send e-doc"
+                    groups="l10n_br_fiscal.group_user"
+                    attrs="{'invisible': ['|', '|', ('document_type_id', '=', False), ('issuer', '!=', 'company'), ('state_edoc', '!=', 'a_enviar')]}"
+                />
+            </header>
             <xpath expr="//form/sheet/div/h1[1]" position="attributes">
                 <attribute
                     name="attrs"
@@ -84,6 +101,8 @@
             </xpath>
             <field name="ref" position="after">
                 <field name="document_type" invisible="1" />
+                <field name="edoc_locked_warning" invisible="1" />
+                <field name="state_edoc" invisible="1" />
                 <field
                     name="document_type_id"
                     attrs="{ 'invisible': [ ('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')), ], 'readonly': [('state', '!=', 'draft')] }"

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -518,6 +518,43 @@ class Document(models.Model):
         """
         pass
 
+    def _edoc_needs_sefaz_action(self):
+        """True when cancelling/resetting the e-doc requires a SEFAZ
+        round-trip, so the driving account.move flow must NOT touch it.
+
+        Base fiscal documents have no SEFAZ lifecycle, so they never do.
+        Overridden in l10n_br_fiscal_edi for authorized/in-transit docs.
+        """
+        self.ensure_one()
+        return False
+
+    def action_document_cancel_from_move(self):
+        """Best-effort cancel triggered by cancelling the linked move.
+
+        Cancels only e-docs that do not need a SEFAZ event; SEFAZ-locked
+        ones are left untouched so the accounting user can still cancel or
+        adjust the move without being blocked.
+        """
+        for doc in self:
+            if doc.state_edoc == DOCUMENT_STATE_CANCEL:
+                continue
+            if doc._edoc_needs_sefaz_action():
+                continue
+            doc.action_document_cancel()
+
+    def action_document_back2draft_from_move(self):
+        """Best-effort reset-to-draft triggered by resetting the move.
+
+        Resets only e-docs that do not need a SEFAZ event; SEFAZ-locked
+        ones are left untouched so the move can still be reset to draft.
+        """
+        for doc in self:
+            if doc.state_edoc == DOCUMENT_STATE_DRAFT:
+                continue
+            if doc._edoc_needs_sefaz_action():
+                continue
+            doc.action_document_back2draft()
+
     @api.depends("fiscal_operation_id")
     def _compute_edoc_purpose(self):
         for record in self:

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -89,6 +89,25 @@ class Document(models.Model):
         index=True,
     )
 
+    edoc_is_locked = fields.Boolean(
+        compute="_compute_edoc_is_locked",
+        help="Technical field: True once the document leaves the draft "
+        "state, used to make identity fields readonly in the views.",
+    )
+
+    @api.depends("state_edoc", "issuer")
+    def _compute_edoc_is_locked(self):
+        for doc in self:
+            if doc.issuer == DOCUMENT_ISSUER_COMPANY:
+                # Company-issued docs lock as soon as they leave draft: the
+                # fiscal identity is committed once validated/sent.
+                doc.edoc_is_locked = doc.state_edoc != DOCUMENT_STATE_DRAFT
+            else:
+                # Partner-issued docs (e.g. supplier bills) are just local
+                # records of a third-party document; keep them editable so
+                # the user can fix data entry, except once cancelled.
+                doc.edoc_is_locked = doc.state_edoc == DOCUMENT_STATE_CANCEL
+
     state_fiscal = fields.Selection(
         selection=SITUACAO_FISCAL,
         string="Situação Fiscal",

--- a/l10n_br_fiscal/models/res_company.py
+++ b/l10n_br_fiscal/models/res_company.py
@@ -131,7 +131,7 @@ class ResCompany(models.Model):
 
     cnae_secondary_ids = fields.Many2many(
         comodel_name="l10n_br_fiscal.cnae",
-        domain="[('internal_type', '=', 'normal'), " "('id', '!=', cnae_main_id)]",
+        domain="[('internal_type', '=', 'normal'), ('id', '!=', cnae_main_id)]",
         string="Secondary CNAE",
     )
 
@@ -315,6 +315,14 @@ class ResCompany(models.Model):
         selection=PROCESSADOR,
         string="Processador documentos eletrônicos",
         default=PROCESSADOR_NENHUM,
+    )
+
+    edoc_require_send_before_post = fields.Boolean(
+        string="Require e-doc authorization before posting",
+        help="When enabled, an electronic fiscal document issued by the "
+        "company must be authorized by SEFAZ before its account move can "
+        "be posted. Users in the Billing Administrator group can bypass "
+        "this gate. Disabled by default to keep the post-then-send flow.",
     )
 
     document_type_id = fields.Many2one(

--- a/l10n_br_fiscal/models/res_config_settings.py
+++ b/l10n_br_fiscal/models/res_config_settings.py
@@ -51,3 +51,8 @@ class ResConfigSettings(models.TransientModel):
     delivery_costs = fields.Selection(
         related="company_id.delivery_costs", readonly=False
     )
+
+    edoc_require_send_before_post = fields.Boolean(
+        related="company_id.edoc_require_send_before_post",
+        readonly=False,
+    )

--- a/l10n_br_fiscal_edi/models/document.py
+++ b/l10n_br_fiscal_edi/models/document.py
@@ -743,6 +743,20 @@ class Document(models.Model):
         else:
             return super().action_document_cancel()
 
+    def _edoc_needs_sefaz_action(self):
+        """A company electronic doc needs a SEFAZ round-trip to cancel or
+        reset once it has been authorized or is awaiting a protocol
+        (sending). Such docs must not be silently cancelled/reset by the
+        driving account.move flow.
+        """
+        self.ensure_one()
+        if self.document_electronic and self.issuer == DOCUMENT_ISSUER_COMPANY:
+            return self.state_edoc in (
+                DOCUMENT_STATE_SENDING,
+                DOCUMENT_STATE_AUTHORIZED,
+            )
+        return super()._edoc_needs_sefaz_action()
+
     def action_document_correction(self):
         """Open the correction wizard for authorized company-issued documents."""
         self.ensure_one()


### PR DESCRIPTION
# Integração do fluxo de trabalho e-doc com o account.move (extraido da PR experimental https://github.com/OCA/l10n-brazil/pull/4660) - assisted by AI

Construído sobre a refatoração da FSM de EDI (já mesclada na 16.0).
Esta PR traz apenas a integração do fluxo e-doc com o `account.move`,
deixando para depois o mecanismo de bloqueio de escrita dos campos de
identidade fiscal.

## O que muda

### 1. Cancelar / voltar para rascunho sem ficar travado

`button_cancel` e `button_draft` do `account.move` passam a ser
**best-effort** em relação aos documentos fiscais:

- Cancelam/voltam para rascunho apenas os e-docs que **não exigem um
  evento na SEFAZ** (`action_document_cancel_from_move` /
  `action_document_back2draft_from_move`).
- E-docs da empresa autorizados ou em trânsito (`_edoc_needs_sefaz_action`)
  mantêm seu estado fiscal real: devem ser cancelados pelo evento correto
  na SEFAZ, pela view do documento fiscal.
- O usuário contábil nunca fica bloqueado de cancelar/ajustar o lançamento
  (ex.: corrigir um diário ou conta contábil).

### 2. Botão "Enviar e-doc" no lançamento

- Novo botão no `account.move` transmite o(s) e-doc(s) para a SEFAZ sem
  abrir a view fiscal (somente documentos emitidos pela empresa, no estado
  `a_enviar`).
- Operações avançadas de e-doc (carta de correção, inutilização de
  numeração) continuam na view do documento fiscal, por design.

### 3. Trava opcional no post

- Novo campo `res.company.edoc_require_send_before_post` (desligado por
  padrão): quando ativo, exige que os e-docs eletrônicos emitidos pela
  empresa estejam **autorizados pela SEFAZ** antes de postar o lançamento.
- Contornável por usuários do grupo "Administradores de Faturamento" ou
  pelo contexto `force_edoc_post`.
- Configurável nas configurações do módulo (res.config.settings).

### 4. Faixa de aviso nos lançamentos vinculados

- Campo computado `edoc_locked_warning` no `account.move` + ribbon de
  aviso na view da fatura, com texto ciente do emitente:
  - empresa emite → avisa que o documento já saiu do rascunho;
  - terceiro emite → avisa que o documento está cancelado.
- Para isso, adicionamos apenas o **flag computado** `edoc_is_locked` no
  documento fiscal (empresa → trava ao sair do rascunho; terceiro → trava
  apenas quando cancelado). **Ainda não há bloqueio de escrita real**: o
  guard no `write()` e as views readonly ficam para uma PR posterior.

## Detalhes técnicos

- `l10n_br_fiscal/models/document.py`: métodos
  `action_document_cancel_from_move`, `action_document_back2draft_from_move`,
  `_edoc_needs_sefaz_action` (base, sem ciclo SEFAZ) e campo
  `edoc_is_locked`.
- `l10n_br_fiscal_edi/models/document.py`: override de
  `_edoc_needs_sefaz_action` (e-doc eletrônico de empresa autorizado/em
  trânsito exige evento SEFAZ).
- `l10n_br_account/models/account_move.py`: `button_cancel`, `button_draft`,
  `action_document_send`, `_edoc_post_gate` e `_compute_edoc_locked_warning`.
- `l10n_br_fiscal/models/res_company.py` + `res_config_settings.py`: campo
  `edoc_require_send_before_post`.
- `l10n_br_account/views/account_move_view.xml`: botão "Enviar e-doc" e
  ribbon de aviso.
