### PR TITLE
[16.0][FIX] l10n_br_base: require erpbrasil-base>=2.4.2 for alphanumeric CNPJ

### DIFF
--- a/l10n_br_account_payment_brcobranca/__manifest__.py
+++ b/l10n_br_account_payment_brcobranca/__manifest__.py
@@ -29,7 +29,7 @@
     ],
     "external_dependencies": {
         "python": [
-            "erpbrasil.base",
+            "erpbrasil-base>=2.4.2",
         ]
     },
 }

--- a/l10n_br_account_payment_order/__manifest__.py
+++ b/l10n_br_account_payment_order/__manifest__.py
@@ -101,7 +101,7 @@
     "installable": True,
     "external_dependencies": {
         "python": [
-            "erpbrasil.base",
+            "erpbrasil-base>=2.4.2",
         ]
     },
 }

--- a/l10n_br_base/__manifest__.py
+++ b/l10n_br_base/__manifest__.py
@@ -43,7 +43,7 @@
     "external_dependencies": {
         "python": [
             "num2words",
-            "erpbrasil.base",
+            "erpbrasil-base>=2.4.2",
             "phonenumbers",
             "email-validator",
         ]

--- a/l10n_br_base/tests/test_cnpj_alfanumerico.py
+++ b/l10n_br_base/tests/test_cnpj_alfanumerico.py
@@ -97,6 +97,73 @@ class CNPJAlfanumericoTest(TransactionCase):
         )
         self.assertEqual(partner.cnpj_cpf_stripped, "A87HBZHB000161")
 
+    def test_partner_write_alphanumeric_cnpj(self):
+        """Writing an alphanumeric CNPJ on an existing partner must succeed.
+
+        Only the create path was covered before, so a formatting helper
+        that dropped the letters and validated the remaining digits as a
+        CPF went unnoticed on write.
+        """
+        partner = (
+            self.env["res.partner"]
+            .with_context(tracking_disable=True)
+            .create(
+                {
+                    "name": "Parceiro Write Alfa",
+                    "is_company": True,
+                    "cnpj_cpf": "77.889.900/0001-66",
+                    **self.base_address,
+                }
+            )
+        )
+
+        partner.write({"cnpj_cpf": "99.XYZ.888/0001-50"})
+
+        self.assertEqual(partner.cnpj_cpf, "99.XYZ.888/0001-50")
+        self.assertEqual(partner.cnpj_cpf_stripped, "99XYZ888000150")
+
+    def test_partner_write_numeric_over_alphanumeric_cnpj(self):
+        """Replacing an alphanumeric CNPJ with a numeric one must keep
+        working, so the fix does not regress the plain numeric path."""
+        partner = (
+            self.env["res.partner"]
+            .with_context(tracking_disable=True)
+            .create(
+                {
+                    "name": "Parceiro Write Numerico",
+                    "is_company": True,
+                    "cnpj_cpf": "12.ABC.345/01DE-35",
+                    **self.base_address,
+                }
+            )
+        )
+
+        partner.write({"cnpj_cpf": "44.556.677/0001-86"})
+
+        self.assertEqual(partner.cnpj_cpf, "44.556.677/0001-86")
+        self.assertEqual(partner.cnpj_cpf_stripped, "44556677000186")
+
+    def test_company_write_alphanumeric_cnpj(self):
+        """Writing an alphanumeric CNPJ on an existing company must succeed
+        and reach the delegated partner."""
+        company = (
+            self.env["res.company"]
+            .with_context(tracking_disable=True)
+            .create(
+                {
+                    "name": "Empresa Write Alfa",
+                    "legal_name": "Empresa Write Alfa Ltda",
+                    "cnpj_cpf": "11.222.333/0001-81",
+                    **self.base_address,
+                }
+            )
+        )
+
+        company.write({"cnpj_cpf": "11.AAA.222/0001-64"})
+
+        self.assertEqual(company.cnpj_cpf, "11.AAA.222/0001-64")
+        self.assertEqual(company.partner_id.cnpj_cpf, "11.AAA.222/0001-64")
+
     def test_pix_valid_alphanumeric_cnpj(self):
         """Creating a PIX key with a valid alphanumeric CNPJ must succeed."""
         pix_vals = {

--- a/l10n_br_cnpj_search/__manifest__.py
+++ b/l10n_br_cnpj_search/__manifest__.py
@@ -24,7 +24,7 @@
     ],
     "external_dependencies": {
         "python": [
-            "erpbrasil.base",
+            "erpbrasil-base>=2.4.2",
         ]
     },
 }

--- a/l10n_br_crm/__manifest__.py
+++ b/l10n_br_crm/__manifest__.py
@@ -16,7 +16,7 @@
     "auto_install": True,
     "external_dependencies": {
         "python": [
-            "erpbrasil.base",
+            "erpbrasil-base>=2.4.2",
         ]
     },
 }

--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -135,7 +135,7 @@
     "auto_install": False,
     "external_dependencies": {
         "python": [
-            "erpbrasil.base",
+            "erpbrasil-base>=2.4.2",
         ]
     },
 }

--- a/l10n_br_fiscal_closing/__manifest__.py
+++ b/l10n_br_fiscal_closing/__manifest__.py
@@ -17,7 +17,7 @@
     ],
     "external_dependencies": {
         "python": [
-            "erpbrasil.base",
+            "erpbrasil-base>=2.4.2",
         ]
     },
 }

--- a/l10n_br_hr/__manifest__.py
+++ b/l10n_br_hr/__manifest__.py
@@ -32,7 +32,7 @@
     "license": "AGPL-3",
     "external_dependencies": {
         "python": [
-            "erpbrasil.base",
+            "erpbrasil-base>=2.4.2",
         ]
     },
 }

--- a/l10n_br_hr_contract/__manifest__.py
+++ b/l10n_br_hr_contract/__manifest__.py
@@ -29,7 +29,7 @@
     "demo": [
         "demo/hr_contract_demo.xml",
     ],
-    "external_dependencies": {"python": ["erpbrasil.base"]},
+    "external_dependencies": {"python": ["erpbrasil-base>=2.4.2"]},
     "installable": True,
     "auto_install": False,
 }

--- a/l10n_br_ie_search/__manifest__.py
+++ b/l10n_br_ie_search/__manifest__.py
@@ -13,7 +13,7 @@
     "data": ["views/res_config_settings_view.xml"],
     "external_dependencies": {
         "python": [
-            "erpbrasil.base",
+            "erpbrasil-base>=2.4.2",
             "erpbrasil.transmissao",
             "erpbrasil.assinatura",
             "erpbrasil.edoc",

--- a/l10n_br_nfe/__manifest__.py
+++ b/l10n_br_nfe/__manifest__.py
@@ -59,7 +59,7 @@
             "erpbrasil.assinatura",
             "erpbrasil.transmissao",
             "erpbrasil.edoc",
-            "erpbrasil.base",
+            "erpbrasil-base>=2.4.2",
             "brazilfiscalreport",
         ],
     },

--- a/l10n_br_nfse/__manifest__.py
+++ b/l10n_br_nfse/__manifest__.py
@@ -13,7 +13,7 @@
         "python": [
             "erpbrasil.edoc",
             "erpbrasil.transmissao",
-            "erpbrasil.base",
+            "erpbrasil-base>=2.4.2",
         ],
     },
     "depends": [

--- a/l10n_br_nfse_paulistana/__manifest__.py
+++ b/l10n_br_nfse_paulistana/__manifest__.py
@@ -16,7 +16,7 @@
             "erpbrasil.edoc",
             "erpbrasil.assinatura",
             "erpbrasil.transmissao",
-            "erpbrasil.base",
+            "erpbrasil-base>=2.4.2",
             "nfselib.paulistana",
             "unidecode",
         ],

--- a/l10n_br_pos/__manifest__.py
+++ b/l10n_br_pos/__manifest__.py
@@ -61,7 +61,7 @@
     "installable": True,
     "external_dependencies": {
         "python": [
-            "erpbrasil.base",
+            "erpbrasil-base>=2.4.2",
         ]
     },
 }

--- a/l10n_br_sped_ecd/__manifest__.py
+++ b/l10n_br_sped_ecd/__manifest__.py
@@ -14,7 +14,7 @@
     "depends": ["l10n_br_sped_base", "l10n_br_account"],
     "external_dependencies": {
         "python": [
-            "erpbrasil.base",
+            "erpbrasil-base>=2.4.2",
         ]
     },
     "data": [

--- a/l10n_br_sped_efd_icms_ipi/__manifest__.py
+++ b/l10n_br_sped_efd_icms_ipi/__manifest__.py
@@ -14,7 +14,7 @@
     "depends": ["l10n_br_sped_base", "l10n_br_account", "stock_account"],
     "external_dependencies": {
         "python": [
-            "erpbrasil.base",
+            "erpbrasil-base>=2.4.2",
         ]
     },
     "data": [

--- a/l10n_br_zip/__manifest__.py
+++ b/l10n_br_zip/__manifest__.py
@@ -24,7 +24,7 @@
     "external_dependencies": {
         "python": [
             "brazilcep",
-            "erpbrasil.base",
+            "erpbrasil-base>=2.4.2",
         ]
     },
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@
 brazilcep
 brazilfiscalreport
 email-validator
+erpbrasil-base>=2.4.2
 erpbrasil.assinatura
-erpbrasil.base
 erpbrasil.edoc
 erpbrasil.transmissao
 nfelib


### PR DESCRIPTION
Corrige #4926.

## Causa

O CNPJ alfanumérico só é tratado pelo `erpbrasil.base` a partir da 2.4.2. Antes disso o `cnpj_cpf.formata()` descarta as letras `12ABC34501DE35` vira `123450135` então o `_inverse_cnpj_cpf` grava um valor mutilado em `vat` e a constraint `_check_cnpj_cpf` o valida como CPF, levantando `ValidationError`.

O suporte no módulo entrou em 8ba42f3226, no mesmo dia do release da 2.4.2, mas a dependência ficou declarada sem versão mínima.

## Por que uma versão mínima

Sem ela o pip não conserta nada: havendo qualquer versão instalada, ele trata o requisito como satisfeito e não atualiza. Um ambiente em 2.4.1 continua em 2.4.1. Só instalação limpa puxa a mais recente o caso da CI, e por isso o problema nunca apareceu lá.

`>=2.4.2` é piso, não travamento: 2.4.3 e posteriores seguem válidos.

## Por que `erpbrasil-base` e não `erpbrasil.base`

O `pkg_resources` casa requisito com distribuição pela chave normalizada (PEP 503), que é `erpbrasil-base`. Com ponto, o `Requirement.parse` só normaliza em setuptools recente; em versões anteriores o `get_distribution` levanta `DistributionNotFound` e o Odoo cai no fallback `importlib.import_module("erpbrasil.base>=2.4.2")`, que falha.

Isso passava despercebido enquanto não havia versão mínima, porque o fallback importava `erpbrasil.base` com sucesso ou seja, a versão nunca era conferida de fato. Verificado com o próprio `check_python_external_dependency` sob setuptools 59.6.0.

## O que muda

Os 17 manifests que declaram a lib passam a exigir `erpbrasil-base>=2.4.2`, com o `requirements.txt` acompanhando, para a instalação falhar com mensagem clara em vez de erro de CPF inválido em runtime.

Mais três testes de regressão no write, que não tinha cobertura: alfanumérico sobre numérico, numérico sobre alfanumérico e `res.company` chegando ao partner delegado. Vale notar que, com a lib antiga, o create também falha a issue supõe que apenas o write quebra.
