### PR TITLE
[16.0][FIX] l10n_br_fiscal, l10n_br_nfse, l10n_br_nfe: Correção nos Status da View

### DIFF
--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -155,18 +155,32 @@
                     <field name="xml_error_message" readonly="1" />
                 </div>
                 <div
+                    class="alert alert-danger"
+                    role="alert"
+                    attrs="{'invisible': [('state_edoc','not in',('rejeitada', 'denegada'))]}"
+                >Fiscal Document:
+                <field name="document_type_id" readonly="1" />
+                <strong><field name="state_edoc" readonly="1" /></strong></div>
+                <div
                     class="alert alert-success"
                     role="alert"
                     attrs="{'invisible': [('state_edoc','!=','a_enviar')]}"
                 >Fiscal Document:
-                <field name="document_type_id" readonly="1" />is
+                <field name="document_type_id" readonly="1" />
                 <strong>Open</strong></div>
+                <div
+                    class="alert alert-success"
+                    role="alert"
+                    attrs="{'invisible': [('state_edoc','!=','autorizada')]}"
+                >Fiscal Document:
+                <field name="document_type_id" readonly="1" />
+                <strong>Authorized</strong></div>
                 <div
                     class="alert alert-warning"
                     role="alert"
                     attrs="{'invisible': [('state_edoc','!=','cancelada')]}"
                 >Fiscal Document:
-                <field name="document_type_id" readonly="1" />is
+                <field name="document_type_id" readonly="1" />
                 <strong>Cancelled</strong></div>
                 <sheet string="Fiscal Document">
                     <div class="oe_button_box" name="button_box" />

--- a/l10n_br_nfe/views/nfe_document_view.xml
+++ b/l10n_br_nfe/views/nfe_document_view.xml
@@ -103,7 +103,31 @@
             >
                 <attribute
                     name="attrs"
-                >{'invisible': ['|', '|', ('state_edoc', '!=', 'a_enviar'), ('document_electronic', '=', False), ('imported_document', '=', True)]}</attribute>
+                >{'invisible': ['|', ('state_edoc', '=', 'em_digitacao'), ('imported_document', '=', True)]}</attribute>
+            </xpath>
+            <xpath
+                expr="//header/button[@name='action_document_correction']"
+                position="attributes"
+            >
+                <attribute
+                    name="attrs"
+                >{'invisible': ['|', ('state_edoc', '!=', 'autorizada'), ('imported_document', '=', True)]}</attribute>
+            </xpath>
+            <xpath
+                expr="//header/button[@name='action_create_return']"
+                position="attributes"
+            >
+                <attribute
+                    name="attrs"
+                >{'invisible': ['|', ('state_edoc', '!=', 'autorizada'), ('imported_document', '=', True)]}</attribute>
+            </xpath>
+            <xpath
+                expr="//header/button[@name='action_document_cancel']"
+                position="attributes"
+            >
+                <attribute
+                    name="attrs"
+                >{'invisible': ['|', ('state_edoc', '=', 'cancelada'), ('imported_document', '=', True)]}</attribute>
             </xpath>
         </field>
     </record>

--- a/l10n_br_nfse/views/document_view.xml
+++ b/l10n_br_nfse/views/document_view.xml
@@ -7,6 +7,16 @@
         <field name="model">l10n_br_fiscal.document</field>
         <field name="inherit_id" ref="l10n_br_fiscal.document_form" />
         <field name="arch" type="xml">
+            <xpath expr="//sheet" position="before">
+                <div
+                    class="alert alert-danger"
+                    role="alert"
+                    attrs="{'invisible': ['|', ('state_edoc', '!=', 'rejeitada'), ('edoc_error_message', '=', False)]}"
+                >
+                    <strong>Rejection reason:</strong>
+                    <field name="edoc_error_message" readonly="1" />
+                </div>
+            </xpath>
             <field name="status_description" position="after">
                 <field name="edoc_error_message" />
             </field>


### PR DESCRIPTION
## Problema

Depois do refactor "EDI FSM" (commits `06e2de8ab` em l10n_br_fiscal e
`cd2e306c9` em l10n_br_nfe, 2026-06-24), várias notas fiscais eletrônicas
(NF-e, NFS-e e outros documentos fiscais) ficaram com:

1. O botão "Voltar para Digitação" (Set to Draft) **sumindo** em qualquer
   estado que não fosse "Aguardando Envio" — inclusive em documentos
   Rejeitados, mesmo a máquina de estados permitindo essa transição
   normalmente.
2. Nenhum aviso visual quando o documento é **Autorizado** (o aviso verde
   existente foi silenciosamente transformado em um aviso para o estado
   "Aguardando Envio", perdendo o de "Autorizado").
3. Nenhum aviso vermelho com o motivo quando o documento é **Rejeitado** ou
   **Denegado** — o aviso genérico que mostrava isso foi removido do módulo
   base, e não existia nada equivalente pra NFS-e.
   
   cc @renatonlima @marcelsavegnago @rvalyi @kaynnan @WesleyOliveira98 

