### PR TITLE
[17.0][FW] l10n_br_account: port from 16.0 - #322

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -439,18 +439,21 @@ class AccountMove(models.Model):
         self.update_payment_term_number()
 
     def update_payment_term_number(self):
-        payment_term_lines = self.line_ids.filtered(
-            lambda line: line.display_type == "payment_term"
-        )
-        payment_term_lines_sorted = payment_term_lines.sorted(
-            key=lambda line: line.date_maturity
-        )
-        for idx, line in enumerate(payment_term_lines_sorted, start=1):
-            line.with_context(skip_invoice_sync=True).write(
-                {
-                    "payment_term_number": f"{idx}-{len(payment_term_lines_sorted)}",
-                }
-            )
+        for move in self.filtered(
+            lambda m: m.fiscal_operation_id and m.is_invoice(include_receipts=True)
+        ):
+            payment_term_lines_sorted = move.line_ids.filtered(
+                lambda line: line.display_type == "payment_term"
+            ).sorted(key=lambda line: line.date_maturity)
+            total = len(payment_term_lines_sorted)
+            for idx, line in enumerate(payment_term_lines_sorted, start=1):
+                number = f"{idx}-{total}"
+                # payment_term_number feeds the stored _compute_name of the aml;
+                # only write (and re-trigger the rename) when it actually changes.
+                if line.payment_term_number != number:
+                    line.with_context(skip_invoice_sync=True).write(
+                        {"payment_term_number": number}
+                    )
 
     def unlink(self):
         """Allow to delete draft or cancelled invoices"""


### PR DESCRIPTION
Port from 16.0 to 17.0:
- #4711 (guard update_payment_term_number writes)

The rest of the PR #311 port set (#4653, #4692, #4494, and the other #4711 commits) already landed on 17.0 via merged PR #4920; this is the single remaining missing commit.