### PR TITLE
[19.0][FIX] l10n_br_fiscal: fix tax framework domains

### DIFF
--- a/l10n_br_fiscal/views/res_company_view.xml
+++ b/l10n_br_fiscal/views/res_company_view.xml
@@ -85,7 +85,7 @@
                                     <field
                                         name="piscofins_id"
                                         required="1"
-                                        domain="[ ('piscofins_type', '=', 'company'), '|', '&amp;', ('parent.tax_framework', '=', 3), ('id', '!=', %(l10n_br_fiscal.tax_pis_cofins_simples_nacional)d), '&amp;', ('parent.tax_framework', '!=', 3), ('id', '=', %(l10n_br_fiscal.tax_pis_cofins_simples_nacional)d) ]"
+                                        domain="[('piscofins_type', '=', 'company'), ('id', '!=', %(l10n_br_fiscal.tax_pis_cofins_simples_nacional)d)] if tax_framework == '3' else [('piscofins_type', '=', 'company'), ('id', '=', %(l10n_br_fiscal.tax_pis_cofins_simples_nacional)d)]"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
                                     <field name="tax_pis_wh_id" />
@@ -100,7 +100,7 @@
                                         name="tax_ipi_id"
                                         invisible="tax_framework == '3' and ripi"
                                         required="tax_framework != '3'"
-                                        domain="['|', '&amp;', ('parent.tax_framework', '=', 3), '&amp;', ('id', '!=', %(l10n_br_fiscal.tax_ipi_outros)d), ('tax_group_id', '=', %(l10n_br_fiscal.tax_group_ipi)d), '&amp;', ('parent.tax_framework', '!=', 3), ('id', '=', %(l10n_br_fiscal.tax_ipi_outros)d) ]"
+                                        domain="[('id', '!=', %(l10n_br_fiscal.tax_ipi_outros)d), ('tax_group_id', '=', %(l10n_br_fiscal.tax_group_ipi)d)] if tax_framework == '3' else [('id', '=', %(l10n_br_fiscal.tax_ipi_outros)d)]"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
                                     <div
@@ -114,7 +114,7 @@
                                         name="tax_icms_id"
                                         invisible="tax_framework == '3'"
                                         required="tax_framework in ('1', '2')"
-                                        domain="['|', '&amp;', ('parent.tax_framework', '=', 3), ('tax_group_id', '=', %(l10n_br_fiscal.tax_group_icms)d), '&amp;', ('parent.tax_framework', '!=', 3), ('tax_group_id', '=', %(l10n_br_fiscal.tax_group_icmssn)d) ]"
+                                        domain="[('tax_group_id', '=', %(l10n_br_fiscal.tax_group_icms)d)] if tax_framework == '3' else [('tax_group_id', '=', %(l10n_br_fiscal.tax_group_icmssn)d)]"
                                         options="{'no_create': True, 'no_create_edit': True}"
                                     />
                                     <field


### PR DESCRIPTION
## Description

This PR fixes invalid domains in the `l10n_br_fiscal` company fiscal configuration view on Odoo 19.0.

The affected fields are:

- `piscofins_id`
- `tax_ipi_id`
- `tax_icms_id`

The current domains reference `parent.tax_framework`. However, the models used by these Many2one fields do not provide a `parent` field that can be resolved by the Odoo 19 domain engine.

As a result, searching some fiscal configuration fields in the company form can raise an exception such as:

> `ValueError: Invalid field l10n_br_fiscal.tax.pis.cofins.parent in condition ('parent.tax_framework', '=', 3)`

This prevents users from properly selecting the Brazilian fiscal configuration of a company.

## Problem

The current `res_company_view.xml` uses domains that try to access the company's tax framework through:

    ('parent.tax_framework', '=', 3)

When Odoo performs a `name_search` for the corresponding Many2one field, this domain is evaluated against the target model.

For `piscofins_id`, for example, the target model is:

    l10n_br_fiscal.tax.pis.cofins

The Odoo 19 domain optimizer therefore tries to resolve `parent` as a field of `l10n_br_fiscal.tax.pis.cofins`.

Since this field does not exist, domain optimization fails with:

    KeyError: 'parent'

followed by:

    ValueError: Invalid field l10n_br_fiscal.tax.pis.cofins.parent
    in condition ('parent.tax_framework', '=', 3)

The error happens during `web_name_search`, before the actual search can be completed.

## Root cause

The domain mixes two different contexts:

1. Fields belonging to the target Many2one model, such as `id`, `piscofins_type`, and `tax_group_id`.
2. `tax_framework`, which belongs to the current company form.

The company's `tax_framework` should be evaluated by the view expression instead of being referenced as a field path inside the domain evaluated against the target model.

In Odoo 19, keeping `parent.tax_framework` inside this domain makes the domain optimizer interpret `parent` as a field of the target model.

## Proposed solution

Replace the domains depending on `parent.tax_framework` with conditional domain expressions based directly on the current company's `tax_framework`.

The view already has access to `tax_framework`, so it can select the appropriate domain before the domain is evaluated against the target model.

This preserves the intended filtering while ensuring that the target model receives a domain containing only fields belonging to that model.

## Changes

### PIS/COFINS

The previous domain included conditions based on:

    ('parent.tax_framework', '=', 3)

The new expression selects the domain according to the current company's `tax_framework`.

For tax framework `3`, it applies:

    [
        ('piscofins_type', '=', 'company'),
        ('id', '!=', tax_pis_cofins_simples_nacional),
    ]

Otherwise:

    [
        ('piscofins_type', '=', 'company'),
        ('id', '=', tax_pis_cofins_simples_nacional),
    ]

### IPI

The same approach is applied to `tax_ipi_id`.

For tax framework `3`, the domain filters the corresponding IPI tax group while excluding `tax_ipi_outros`.

Otherwise, it selects the corresponding `tax_ipi_outros` record.

This removes the dependency on `parent.tax_framework` from the target model domain.

### ICMS

The `tax_icms_id` domain is also selected according to the current company's `tax_framework`.

The appropriate tax group is selected between:

- `tax_group_icms`
- `tax_group_icmssn`

without attempting to resolve `parent.tax_framework` on the target tax model.

## Before

Searching the PIS/COFINS field from the company fiscal configuration could result in:

    KeyError: 'parent'

followed by:

    ValueError: Invalid field l10n_br_fiscal.tax.pis.cofins.parent
    in condition ('parent.tax_framework', '=', 3)

The request fails while Odoo is optimizing the domain used by `web_name_search` on:

    l10n_br_fiscal.tax.pis.cofins

## After

The domain is selected using the company's `tax_framework` available in the view.

The target model therefore receives conditions containing only fields applicable to that model, such as:

- `piscofins_type`
- `id`
- `tax_group_id`

No lookup of `parent.tax_framework` is required.

## Steps to reproduce

1. Run Odoo 19.0 with the OCA `l10n-brazil` 19.0 branch.
2. Install `l10n_br_fiscal`.
3. Configure a Brazilian company.
4. Open the company's fiscal configuration.
5. Try to search/select the PIS/COFINS fiscal configuration.
6. Odoo executes `web_name_search` on `l10n_br_fiscal.tax.pis.cofins`.
7. The domain optimizer attempts to resolve `parent.tax_framework`.
8. The request fails because `parent` is not a field of the target model.

## Environment used to reproduce

- Odoo 19.0
- OCA `l10n-brazil` branch `19.0`
- `l10n_br_fiscal` version `19.0.1.0.0`
- PostgreSQL
- Self-hosted Docker environment

## Validation

The issue was reproduced on Odoo 19.0 using the original domain.

After applying this change:

- `parent.tax_framework` is no longer included in these target model domains.
- The domain is selected according to the current company's `tax_framework`.
- The original `Invalid field l10n_br_fiscal.tax.pis.cofins.parent` exception is avoided.
- PIS/COFINS domain evaluation no longer attempts to resolve `parent` on `l10n_br_fiscal.tax.pis.cofins`.
- The same invalid domain pattern was removed from the IPI and ICMS fields.

## Scope

This PR intentionally contains only the fix for the invalid `tax_framework` domain handling in:

    l10n_br_fiscal/views/res_company_view.xml

No unrelated changes are included.

The goal is to keep the patch small and focused on the Odoo 19 domain compatibility issue.