### PR TITLE
[18.0][IMP] l10n_br_fiscal: enforce tax_definition date_start/date_end validity

### DIFF
--- a/l10n_br_account/tests/test_move_edition.py
+++ b/l10n_br_account/tests/test_move_edition.py
@@ -238,6 +238,7 @@ class TestMoveEdition(TransactionCase):
                 ],
                 service_type=self.env["l10n_br_fiscal.service.type"],
                 ind_final="1",
+                reference_date=False,
             )
 
             # ensure manually setting a product_uom_id is properly sync'ed:

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -335,6 +335,9 @@ class FiscalDocumentLineMixin(models.AbstractModel):
                     national_taxation_code=line.national_taxation_code_id,
                     service_type=line.service_type_id,
                     ind_final=line.ind_final,
+                    reference_date=getattr(
+                        line._get_document(), "document_date", False
+                    ),
                 )
                 line.cfop_id = mapping_result["cfop"]
                 line.ipi_guideline_id = mapping_result["ipi_guideline"]

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -244,6 +244,7 @@ class OperationLine(models.Model):
         national_taxation_code=None,
         service_type=None,
         ind_final=None,
+        reference_date=None,
     ):
         """
         Map and determine the applicable fiscal taxes, CFOP, IPI guideline,
@@ -284,6 +285,9 @@ class OperationLine(models.Model):
             (l10n_br_fiscal.service.type).
         :param ind_final: (Passed to icms_regulation_id.map_tax; not directly
             used for tax calculation here)
+        :param reference_date: Optional datetime used to check tax
+            definition date_start/date_end validity; defaults to now()
+            when not provided.
         :return: A dictionary containing:
             - 'taxes': A dictionary of applicable tax records
               (l10n_br_fiscal.tax) keyed by their tax_domain.
@@ -323,6 +327,7 @@ class OperationLine(models.Model):
             city_taxation_code=city_taxation_code,
             national_taxation_code=national_taxation_code,
             service_type=service_type,
+            reference_date=reference_date,
         ):
             self._build_mapping_result(mapping_result, tax_definition)
 
@@ -390,6 +395,7 @@ class OperationLine(models.Model):
             city_taxation_code=city_taxation_code,
             national_taxation_code=national_taxation_code,
             service_type=service_type,
+            reference_date=reference_date,
         ):
             self._build_mapping_result(mapping_result, tax_definition)
 
@@ -407,6 +413,7 @@ class OperationLine(models.Model):
             city_taxation_code=city_taxation_code,
             national_taxation_code=national_taxation_code,
             service_type=service_type,
+            reference_date=reference_date,
         ):
             self._build_mapping_result(mapping_result, tax_definition)
 
@@ -424,6 +431,7 @@ class OperationLine(models.Model):
             city_taxation_code=city_taxation_code,
             national_taxation_code=national_taxation_code,
             service_type=service_type,
+            reference_date=reference_date,
         ):
             self._build_mapping_result(mapping_result, tax_definition)
 

--- a/l10n_br_fiscal/models/tax_definition.py
+++ b/l10n_br_fiscal/models/tax_definition.py
@@ -427,6 +427,7 @@ class TaxDefinition(models.Model):
         city_taxation_code=None,
         national_taxation_code=None,
         service_type=None,
+        reference_date=None,
     ):
         """
         Filter and return tax definitions that match the given criteria.
@@ -438,6 +439,7 @@ class TaxDefinition(models.Model):
 
         The matching is based on:
         - Current record state (not 'expired').
+        - Date validity (date_start, date_end) against reference_date.
         - Originating state (state_from_id).
         - Destination states (state_to_ids), allowing for no specific destination.
         - NCM, NBM, CEST codes, allowing for no specific code.
@@ -462,12 +464,17 @@ class TaxDefinition(models.Model):
             (l10n_br_fiscal.national.taxation.code).
         :param service_type: Optional Service Type record
             (l10n_br_fiscal.service.type).
+        :param reference_date: Optional datetime used to check date_start/
+            date_end validity; defaults to now() when not provided.
         :return: A recordset of matching
             l10n_br_fiscal.tax.definition.
         """
 
         if not self:
             return self
+
+        if not reference_date:
+            reference_date = fields.Datetime.now()
 
         if not ncm:
             ncm = product.ncm_id
@@ -481,6 +488,12 @@ class TaxDefinition(models.Model):
         domain = [
             ("state", "!=", "expired"),
             ("id", "in", self.ids),
+            "|",
+            ("date_start", "=", False),
+            ("date_start", "<=", reference_date),
+            "|",
+            ("date_end", "=", False),
+            ("date_end", ">=", reference_date),
             "|",
             ("state_to_ids", "=", False),
             ("state_to_ids", "=", partner.state_id.id),

--- a/l10n_br_fiscal/tests/test_document_edition.py
+++ b/l10n_br_fiscal/tests/test_document_edition.py
@@ -102,6 +102,7 @@ class TestDocumentEdition(TransactionCase):
                 ],
                 service_type=self.env["l10n_br_fiscal.service.type"],
                 ind_final="1",
+                reference_date=False,
             )
 
             line_form.price_unit = 50

--- a/l10n_br_fiscal/views/tax_definition_view.xml
+++ b/l10n_br_fiscal/views/tax_definition_view.xml
@@ -10,6 +10,8 @@
                 <field name="is_taxed" readonly="state != 'draft'" />
                 <field name="tax_id" readonly="state != 'draft'" />
                 <field name="cst_code" readonly="state != 'draft'" />
+                <field name="date_start" optional="hide" readonly="state != 'draft'" />
+                <field name="date_end" optional="hide" readonly="state != 'draft'" />
             </list>
         </field>
     </record>
@@ -146,6 +148,10 @@
                             options="{'no_create': True}"
                             readonly="state != 'draft'"
                         />
+                    </group>
+                    <group name="validity" string="Validity">
+                        <field name="date_start" readonly="state != 'draft'" />
+                        <field name="date_end" readonly="state != 'draft'" />
                     </group>
                     <notebook>
                         <page name="ncms_page" string="NCM">


### PR DESCRIPTION
## Contexto

Com a Reforma Tributária, PIS e COFINS serão extintos em 2027, substituídos por IBS/CBS. Hoje o motor de cálculo fiscal (`map_tax_definition`) já tinha os campos `date_start`/`date_end` de vigência no modelo `l10n_br_fiscal.tax.definition`, mas eles não eram considerados na busca das regras aplicáveis — só o campo `state` (draft/review/approved/expired) filtrava.

Esta PR faz esses campos serem efetivamente respeitados no cálculo, permitindo agendar a troca de PIS/COFINS por IBS/CBS (ou qualquer outra transição de imposto) **sem precisar tirar ou adicionar regras da Operação** quando a data virar — só ajustando a vigência de cada `tax_definition` já configurada.

## O que mudou

- **`l10n_br_fiscal/models/tax_definition.py`**: `map_tax_definition` ganhou o parâmetro `reference_date` (default `now()`) e o domínio de busca passou a filtrar por `date_start`/`date_end`, no mesmo padrão já usado em `operation.py:_line_domain` para escolher a Linha de Operação vigente.
- **`l10n_br_fiscal/models/operation_line.py`**: `map_fiscal_taxes` recebe e propaga `reference_date` pelas 4 chamadas internas a `map_tax_definition` (empresa, linha de operação, CFOP, perfil fiscal do parceiro).
- **`l10n_br_fiscal/models/document_line_mixin.py`**: `_compute_fiscal_tax_ids` passa a usar a data do documento fiscal (`document_date`, já sincronizada com `invoice_date` para `account.move`) como `reference_date`. Para `sale.order.line`/`purchase.order.line`/`stock.move`, que não têm esse campo, cai no `now()` (comportamento inalterado).
- **`l10n_br_fiscal/views/tax_definition_view.xml`**: expõe `date_start`/`date_end` no formulário (novo grupo "Validity") e como colunas opcionais na lista — antes os campos existiam no modelo mas não apareciam em nenhuma tela.

## Compatibilidade

Retrocompatível: `reference_date=None` cai em `now()`, e uma `tax_definition` sem `date_start`/`date_end` preenchidos continua batendo sempre (`False` bate no `"|"` do domínio). Nenhum chamador existente precisa mudar.

## Limitação conhecida (fora do escopo desta PR)

- `_compute_fiscal_tax_ids` não recalcula automaticamente só porque a `invoice_date` mudou depois de a linha já existir — o recompute continua disparando por parceiro/produto/NCM/operação. Editar a data de uma fatura já lançada não reprocessa os impostos das linhas sozinho.
- Regras de nível **Empresa** (e CFOP/perfil fiscal) que hoje não têm `date_start`/`date_end` preenchidos continuam batendo incondicionalmente e podem "vazar" por cima de uma regra da Operação com vigência ainda não iniciada ou já encerrada. Para o corte de 2027 funcionar de ponta a ponta, os defaults de imposto no nível Empresa também precisarão ganhar vigência.

Vídeo de Demonstração:


https://github.com/user-attachments/assets/f49f4d90-1dd6-42db-9540-acf6bb74e735

cc @renatonlima @rvalyi @marcelsavegnago @antoniospneto 

