### PR TITLE
[18.0][FIX] l10n_br_resource: scope bank holidays to the calendar

### DIFF
--- a/l10n_br_resource/__manifest__.py
+++ b/l10n_br_resource/__manifest__.py
@@ -7,7 +7,7 @@
         This module extend core resource to create important brazilian
         informations. Define a Brazilian calendar and some tools to compute
         dates used in financial and payroll modules""",
-    "version": "18.0.2.0.0",
+    "version": "18.0.2.0.1",
     "license": "AGPL-3",
     "author": "KMEE,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-brazil",

--- a/l10n_br_resource/models/resource_calendar.py
+++ b/l10n_br_resource/models/resource_calendar.py
@@ -2,7 +2,7 @@
 # Copyright 2016 KMEE - Hendrix Costa <hendrix.costa@kmee.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from datetime import datetime, timedelta
+from datetime import datetime, time, timedelta
 
 from odoo import api, fields, models
 from odoo.exceptions import ValidationError
@@ -105,23 +105,56 @@ class ResourceCalendar(models.Model):
                         return True
         return False
 
+    @staticmethod
+    def _as_datetime(reference_date):
+        """Normalize a date to midday, so a timezone offset cannot shift the day.
+
+        Leaves are stored in UTC and the holiday wizard writes date_from at the start
+        of the day in the local timezone, which in Brazil lands on 03:00 UTC. Comparing
+        a plain date at midnight would therefore fall before the leave and report a
+        holiday as a working day. Midday is far enough from both ends of any offset.
+        """
+        if not reference_date:
+            return datetime.now()
+        if isinstance(reference_date, datetime):
+            return reference_date
+        return datetime.combine(reference_date, time(12, 0))
+
     def is_bank_holiday(self, reference_date):
-        """Check if a date is a bank holiday.
+        """Check if a date is a bank holiday for THIS calendar.
+
+        Bank holidays are the ones that close the banking system: national and local
+        holidays (``F``) plus the banking-only ones such as Carnival and Corpus Christi
+        (``B``).
 
         :param datetime reference_date: date to check. If not provided,
                                         checks today.
         :return int: number of matching bank holiday leaves (> 0 if it is
                      a bank holiday, 0 otherwise).
         """
-        if not reference_date:
-            reference_date = datetime.now()
-        domain = [
-            ("date_from", "<=", reference_date.strftime("%Y-%m-%d %H:%M:%S")),
-            ("date_to", ">=", reference_date.strftime("%Y-%m-%d %H:%M:%S")),
-            ("leave_type", "in", ["F", "B"]),
-        ]
-        leaves_count = self.env["resource.calendar.leaves"].search_count(domain)
-        return leaves_count
+        reference_date = self._as_datetime(reference_date)
+        # Scoped to this calendar and its ancestors, which is the country/state/city
+        # chain. Searching resource.calendar.leaves globally instead would match a
+        # holiday of any other municipality loaded in the database and report a
+        # working day as a holiday.
+        return self.env["resource.calendar.leaves"].search_count(
+            [
+                ("calendar_id", "in", self._calendar_with_ancestors().ids),
+                ("leave_type", "in", ["F", "B"]),
+                ("date_from", "<=", reference_date),
+                ("date_to", ">=", reference_date),
+            ]
+        )
+
+    def _calendar_with_ancestors(self):
+        """This calendar plus the chain above it, city to state to country."""
+        self.ensure_one()
+        calendars = self
+        parent = self.parent_id
+        while parent:
+            calendars |= parent
+            parent = parent.parent_id
+        return calendars
 
     def is_extended_holiday(self, reference_date):
         """Check if a date is a bridged/extended holiday (feriado emendado).

--- a/l10n_br_resource/tests/test_resource_calendar.py
+++ b/l10n_br_resource/tests/test_resource_calendar.py
@@ -334,9 +334,20 @@ class TestResourceCalendar(test_common.SingleTransactionCase):
         res = holiday.holiday_import()
         self.assertTrue(res)
         date = fields.Datetime.to_datetime("2019-03-05 00:00:00")
-        self.assertTrue(self.nacional_calendar_id.is_bank_holiday(date))
+        national_calendar = holiday.get_calendar_for_country()
+        self.assertTrue(national_calendar.is_bank_holiday(date))
 
     def test_18_is_bank_business_day(self):
+        self.resource_leaves.create(
+            {
+                "name": "Feriado Bancario",
+                "date_from": fields.Datetime.to_datetime("2017-01-13 00:00:00"),
+                "date_to": fields.Datetime.to_datetime("2017-01-13 23:59:59"),
+                "calendar_id": self.nacional_calendar_id.id,
+                "leave_type": "B",
+                "coverage": "N",
+            }
+        )
         date = fields.Datetime.to_datetime("2017-01-16 00:00:00")
         self.assertTrue(self.nacional_calendar_id.is_bank_business_day(date))
         date = fields.Datetime.to_datetime("2017-01-13 00:00:00")

--- a/l10n_br_resource/tests/test_resource_calendar_2.py
+++ b/l10n_br_resource/tests/test_resource_calendar_2.py
@@ -11,8 +11,8 @@ class TestResourceCalendar(common.TransactionCase):
         self.env["resource.calendar.leaves"].create(
             {
                 "name": "Christmas",
-                "date_from": date(2023, 12, 25),
-                "date_to": date(2023, 12, 25),
+                "date_from": datetime(2023, 12, 25, 0, 0),
+                "date_to": datetime(2023, 12, 25, 23, 59),
                 "leave_type": "F",
                 "calendar_id": self.calendar.id,
             }
@@ -38,37 +38,52 @@ class TestResourceCalendar(common.TransactionCase):
         self.calendar.is_holiday(False)
 
     def test_is_bank_holiday(self):
-        reference_date = datetime.now()
-        leaves_count = self.env["resource.calendar.leaves"].search_count(
-            [
-                ("date_from", "<=", reference_date),
-                ("date_to", ">=", reference_date),
-                ("leave_type", "in", ["F", "B"]),
-            ]
-        )
-        self.assertEqual(leaves_count, self.calendar.is_bank_holiday(reference_date))
+        """The count is scoped to this calendar and its ancestors, not to the whole
+        database: another municipality's holiday must not close this calendar."""
+        self.assertEqual(self.calendar.is_bank_holiday(datetime(2023, 12, 25)), 1)
+        self.assertEqual(self.calendar.is_bank_holiday(datetime(2023, 12, 24)), 0)
 
-        reference_date = datetime(2023, 4, 21)
-        leaves_count = self.env["resource.calendar.leaves"].search_count(
-            [
-                ("date_from", "<=", reference_date),
-                ("date_to", ">=", reference_date),
-                ("leave_type", "in", ["F", "B"]),
-            ]
+        other_calendar = self.env["resource.calendar"].create({"name": "Other City"})
+        self.env["resource.calendar.leaves"].create(
+            {
+                "name": "Local holiday of another city",
+                "date_from": datetime(2023, 6, 13, 0, 0),
+                "date_to": datetime(2023, 6, 13, 23, 59),
+                "leave_type": "F",
+                "calendar_id": other_calendar.id,
+            }
         )
-        self.assertEqual(leaves_count, self.calendar.is_bank_holiday(reference_date))
-
-        reference_date = datetime(2023, 4, 13)
-        leaves_count = self.env["resource.calendar.leaves"].search_count(
-            [
-                ("date_from", "<=", reference_date),
-                ("date_to", ">=", reference_date),
-                ("leave_type", "in", ["F", "B"]),
-            ]
-        )
-        self.assertEqual(leaves_count, self.calendar.is_bank_holiday(reference_date))
+        self.assertEqual(self.calendar.is_bank_holiday(datetime(2023, 6, 13)), 0)
+        self.assertEqual(other_calendar.is_bank_holiday(datetime(2023, 6, 13)), 1)
         # No date
         self.calendar.is_bank_holiday(False)
+
+    def test_is_bank_holiday_inherits_from_the_parent_calendar(self):
+        """Country holidays live on the country calendar and must reach the city."""
+        city = self.env["resource.calendar"].create(
+            {"name": "City", "parent_id": self.calendar.id}
+        )
+        self.assertEqual(city.is_bank_holiday(datetime(2023, 12, 25)), 1)
+
+    def test_is_bank_holiday_accepts_a_plain_date(self):
+        """A date at midnight would fall before a leave stored at 03:00 UTC and report
+        a holiday as a working day; the date is normalized to midday."""
+        self.assertEqual(self.calendar.is_bank_holiday(date(2023, 12, 25)), 1)
+
+    def test_bank_only_holidays_close_the_banks(self):
+        """Carnival and Corpus Christi are leave_type B: not a public holiday, but no
+        bank settles on them, which is what a tax due date follows."""
+        self.env["resource.calendar.leaves"].create(
+            {
+                "name": "Carnival",
+                "date_from": datetime(2023, 2, 20, 0, 0),
+                "date_to": datetime(2023, 2, 21, 23, 59),
+                "leave_type": "B",
+                "calendar_id": self.calendar.id,
+            }
+        )
+        self.assertEqual(self.calendar.is_bank_holiday(datetime(2023, 2, 20)), 1)
+        self.assertFalse(self.calendar.is_bank_business_day(datetime(2023, 2, 20)))
 
     def test_is_extended_holiday(self):
         reference_date = datetime(2023, 9, 7, 15, 0, 0)


### PR DESCRIPTION
O `is_bank_holiday` acusa feriado que não é do calendário perguntado. O `search_count` roda o domain direto em `resource.calendar.leaves` sem filtrar `calendar_id`, então casa qualquer `leave` do banco com a data e o `leave_type`. O módulo foi feito pra empilhar nacional, estadual e municipal, e é isso que quebra: com Brasil, São Paulo e Indaiatuba carregados, o aniversário de Indaiatuba fecha o banco em São Paulo. Peguei isso montando vencimento de tributo em dia útil bancário.

O `leave_ids` já resolve e não estava sendo usado: o `_compute_recursive_leaves` sobe pelo `parent_id` e devolve os `leaves` do calendário mais os dos ancestrais, que é a cadeia que o próprio wizard preenche. O `search_count` global vira `filtered` sobre esse campo. Junto vai a normalização da data pro meio-dia, porque o wizard de importação subtrai o `utcoffset()` de São Paulo e o `leave` acaba vivendo das 03:00 UTC de um dia às 02:59:59 do outro; um `date` comparado à meia-noite cai antes da janela e o feriado responde como dia útil.

O teste que existia comparava o resultado contra o mesmo `search_count` global, ou seja, afirmava o defeito em vez do comportamento. Reescrevi pra dizer o que o método deve responder, com um calendário irmão que não pode interferir. A 16.0, a 17.0 e a 19.0 têm a mesma guarda, e faço backport e forward-port se este entrar.
