### PR TITLE
[19.0][FIX] l10n_br_base: preserve company address with IE and IM

### DIFF
--- a/l10n_br_base/models/res_company.py
+++ b/l10n_br_base/models/res_company.py
@@ -12,7 +12,8 @@ class Company(models.Model):
 
     def _get_company_address_field_names(self):
         partner_fields = super()._get_company_address_field_names()
-        return partner_fields + [
+
+        brazilian_fields = [
             "legal_name",
             "l10n_br_ie_code",
             "l10n_br_im_code",
@@ -23,6 +24,16 @@ class Company(models.Model):
             "street_number",
             "street_name",
         ]
+
+        # Odoo's official l10n_br module defines IE and IM on res.company
+        # as related fields to partner_id. In that case, including them in
+        # _compute_address() breaks the computation of the standard company
+        # address fields on Odoo 19.
+        for field_name in ("l10n_br_ie_code", "l10n_br_im_code"):
+            if self._fields[field_name].related:
+                brazilian_fields.remove(field_name)
+
+        return partner_fields + brazilian_fields
 
     def _inverse_legal_name(self):
         for company in self:

--- a/l10n_br_base/tests/test_base_onchange.py
+++ b/l10n_br_base/tests/test_base_onchange.py
@@ -127,3 +127,41 @@ class L10nBrBaseOnchangeTest(TransactionCase):
             "Avenida Paulista, 807 CJ 2315\nCentro\n01311-915 - São Paulo-SP\nBrazil",
             "The function _display_address with parameter without_company failed.",
         )
+
+    def test_company_address_fields(self):
+        """Address fields should be computed from the company's partner."""
+        company = self.company_01
+        partner = company.partner_id
+        city = self.env.ref("l10n_br_base.city_3205002")
+
+        partner.write(
+            {
+                "street": "Rua Teste, 123",
+                "city": city.name,
+                "zip": "29161-695",
+                "state_id": city.state_id.id,
+                "country_id": city.state_id.country_id.id,
+                "l10n_br_im_code": "692015742119",
+            }
+        )
+
+        company.invalidate_recordset(
+            [
+                "street",
+                "city",
+                "zip",
+                "state_id",
+                "country_id",
+            ]
+        )
+
+        self.assertEqual(company.street, "Rua Teste, 123")
+        self.assertEqual(company.city, city.name)
+        self.assertEqual(company.zip, "29161-695")
+        self.assertEqual(company.state_id, city.state_id)
+        self.assertEqual(company.country_id, city.state_id.country_id)
+
+        self.assertEqual(
+            company.l10n_br_im_code,
+            partner.l10n_br_im_code,
+        )


### PR DESCRIPTION
## Description

This PR fixes an address synchronization issue on `res.company` when using Odoo 19 together with `l10n_br_base`.

The issue is caused by adding the following fields to `_get_company_address_field_names()`:

- `l10n_br_ie_code`
- `l10n_br_im_code`

On Odoo 19, both fields are already related to their corresponding fields on `partner_id`.

Including them again in the address computation field list causes the standard company address fields to be incorrectly computed as empty.

Affected standard fields include:

- `street`
- `city`
- `zip`
- `state_id`
- `country_id`

This also breaks features that depend on `res.company.zip`, such as the ZIP search provided by `l10n_br_zip`.

## Problem

A company can have a fully populated address on its related partner:

    partner.zip = "30350-490"
    partner.city = "Belo Horizonte"
    partner.state_id = MG
    partner.country_id = Brazil

while the corresponding computed fields on `res.company` return empty values:

    company.zip = False
    company.city = False
    company.state_id = False
    company.country_id = False

The problem persists even after explicitly recomputing the address:

    company._compute_address()

## Root cause

Odoo's standard `res.company._compute_address()` uses:

    _get_company_address_field_names()

to determine which fields should be copied from the company's related partner.

`l10n_br_base` extends this list with Brazilian-specific fields, including:

    l10n_br_ie_code
    l10n_br_im_code

However, on Odoo 19 these two `res.company` fields are already related fields:

    res.company.l10n_br_ie_code
        -> partner_id.l10n_br_ie_code

    res.company.l10n_br_im_code
        -> partner_id.l10n_br_im_code

They therefore do not need to participate in `_compute_address()`.

When these fields are included in `_get_company_address_field_names()`, Odoo's company address computation ends up clearing the standard address fields.

## Investigation

The issue was isolated by testing each extra field added to `_get_company_address_field_names()` individually.

Results:

    legal_name             -> OK
    l10n_br_ie_code        -> FAIL
    l10n_br_im_code        -> FAIL
    l10n_br_isuf_code      -> OK
    state_tax_number_ids   -> OK
    tax_framework          -> OK
    legal_nature_id        -> OK
    cnae_main_id           -> OK

Using only the standard Odoo address fields plus the Brazilian address-specific fields correctly computes the company address.

Example after excluding `l10n_br_ie_code` and `l10n_br_im_code`:

    company.zip        = "30350-490"
    company.city       = "Belo Horizonte"
    company.state_id   = MG
    company.country_id = Brazil

The ZIP search also works again:

    company.zip_search()
    -> True

## Fix

Remove:

    l10n_br_ie_code
    l10n_br_im_code

from `l10n_br_base.models.res_company._get_company_address_field_names()`.

The fields remain synchronized with the related partner because they are already related fields on `res.company`.

## Regression test

A regression test was added to `test_base_onchange.py`.

The test:

1. Configures address information on the company's related partner.
2. Includes a municipal tax number.
3. Invalidates the computed company address fields.
4. Verifies that the standard company address fields are correctly computed.
5. Verifies that the municipal tax number remains synchronized with the related partner.

The tested fields include:

- `street`
- `city`
- `zip`
- `state_id`
- `country_id`
- `l10n_br_im_code`

## Behavior after the fix

After applying the change:

- company ZIP is correctly computed from `partner_id`;
- city is correctly computed;
- state is correctly computed;
- country is correctly computed;
- IE/IM synchronization is preserved;
- ZIP lookup using `l10n_br_zip` works again.

## Scope

This PR intentionally only addresses the interaction between IE/IM fields and the company address computation.

It does not include unrelated changes to ZIP providers or address formatting.