### PR TITLE
[18.0][FIX] l10n_br_fiscal: keep the taxes of an imported line

### DIFF
--- a/l10n_br_fiscal/constants/fiscal.py
+++ b/l10n_br_fiscal/constants/fiscal.py
@@ -565,6 +565,34 @@ FISCAL_TAX_ID_FIELDS = [
     "ibs_tax_id",
 ]
 
+TAX_VALUE_FIELDS = {
+    TAX_DOMAIN_COFINS: "cofins_value",
+    TAX_DOMAIN_COFINS_WH: "cofins_wh_value",
+    TAX_DOMAIN_COFINS_ST: "cofinsst_value",
+    TAX_DOMAIN_CSLL: "csll_value",
+    TAX_DOMAIN_CSLL_WH: "csll_wh_value",
+    TAX_DOMAIN_ICMS: "icms_value",
+    TAX_DOMAIN_ICMS_FCP: "icmsfcp_value",
+    TAX_DOMAIN_ICMS_SN: "icmssn_credit_value",
+    TAX_DOMAIN_ICMS_ST: "icmsst_value",
+    TAX_DOMAIN_ICMS_FCP_ST: "icmsfcpst_value",
+    TAX_DOMAIN_II: "ii_value",
+    TAX_DOMAIN_INSS: "inss_value",
+    TAX_DOMAIN_INSS_WH: "inss_wh_value",
+    TAX_DOMAIN_IPI: "ipi_value",
+    TAX_DOMAIN_IRPJ: "irpj_value",
+    TAX_DOMAIN_IRPJ_WH: "irpj_wh_value",
+    TAX_DOMAIN_ISSQN: "issqn_value",
+    TAX_DOMAIN_ISSQN_WH: "issqn_wh_value",
+    TAX_DOMAIN_PIS: "pis_value",
+    TAX_DOMAIN_PIS_WH: "pis_wh_value",
+    TAX_DOMAIN_PIS_ST: "pisst_value",
+    TAX_DOMAIN_CBS: "cbs_value",
+    TAX_DOMAIN_IBS: "ibs_value",
+}
+
+TAX_VALUE_FIELD_NAMES = frozenset(TAX_VALUE_FIELDS.values())
+
 TAX_RATE_TYPE = [
     ("1", "1 - Fixa"),
     ("2", "2 - Padrão"),

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -42,6 +42,8 @@ from ..constants.fiscal import (
     TAX_DOMAIN_PIS_WH,
     TAX_FRAMEWORK_SIMPLES_ALL,
     TAX_ICMS_OR_ISSQN,
+    TAX_VALUE_FIELD_NAMES,
+    TAX_VALUE_FIELDS,
 )
 from ..constants.icms import (
     ICMS_BASE_TYPE,
@@ -382,6 +384,12 @@ class FiscalDocumentLineMixin(models.AbstractModel):
             # Por segurança, sempre recalcula se um campo relevante mudou.
             self._update_fiscal_tax_ids()
 
+        imported = self.filtered(lambda line: line._is_imported())
+        if imported and TAX_VALUE_FIELD_NAMES.intersection(vals):
+            tax_groups = imported._tax_groups_by_domain()
+            for line in imported:
+                line._update_imported_tax_amounts(tax_groups)
+
         return res
 
     def _update_fiscal_tax_ids(self):
@@ -441,7 +449,13 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         Compute base, percent, value... tax fields for ICMS, IPI, PIS, COFINS... taxes.
         """
         null_mask = None
-        for line in self.filtered(lambda line: not line._is_imported()):
+        tax_groups = None
+        for line in self:
+            if line._is_imported():
+                if tax_groups is None:
+                    tax_groups = line._tax_groups_by_domain()
+                line._update_imported_tax_amounts(tax_groups)
+                continue
             if null_mask is None:
                 null_mask = self._build_null_mask_dict()
             to_update = null_mask.copy()
@@ -510,6 +524,38 @@ class FiscalDocumentLineMixin(models.AbstractModel):
                 line.update(to_update)
             else:
                 line.write(to_update)
+
+    def _tax_groups_by_domain(self):
+        groups = self.env["l10n_br_fiscal.tax.group"].search([])
+        return {group.tax_domain: group for group in groups}
+
+    def _update_imported_tax_amounts(self, tax_groups):
+        self.ensure_one()
+        empty_group = self.env["l10n_br_fiscal.tax.group"]
+        amount_included = amount_not_included = amount_withholding = 0.0
+        for tax_field in FISCAL_TAX_ID_FIELDS:
+            tax_domain = tax_field[: -len("_tax_id")]
+            tax_value = self[TAX_VALUE_FIELDS[tax_domain]]
+            if not tax_value:
+                continue
+            tax_group = self[tax_field].tax_group_id or tax_groups.get(
+                tax_domain, empty_group
+            )
+            if tax_group.tax_withholding:
+                amount_withholding += tax_value
+            elif tax_group.tax_include:
+                amount_included += tax_value
+            else:
+                amount_not_included += tax_value
+        to_update = {
+            "amount_tax_included": amount_included,
+            "amount_tax_not_included": amount_not_included,
+            "amount_tax_withholding": amount_withholding,
+        }
+        if self != self._origin:
+            self.update(to_update)
+        else:
+            self.write(to_update)
 
     def _prepare_tax_fields(self, compute_result):
         self.ensure_one()

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -344,6 +344,15 @@ class FiscalDocumentLineMixin(models.AbstractModel):
                 line.icms_tax_benefit_id = mapping_result["icms_tax_benefit_id"]
 
                 if line._is_imported():
+                    # The taxes of an imported line come from the file, not from
+                    # the fiscal mapping. They are rebuilt from the tax field of
+                    # each domain because leaving fiscal_tax_ids unassigned here
+                    # empties it on every recompute, and everything downstream
+                    # (account taxes, line totals, tax lines) is computed from it.
+                    imported_taxes = line.env["l10n_br_fiscal.tax"]
+                    for fiscal_tax_field in FISCAL_TAX_ID_FIELDS:
+                        imported_taxes |= line[fiscal_tax_field]
+                    line.fiscal_tax_ids = imported_taxes
                     continue
 
                 taxes = line.env["l10n_br_fiscal.tax"]
@@ -556,6 +565,35 @@ class FiscalDocumentLineMixin(models.AbstractModel):
             self.update(to_update)
         else:
             self.write(to_update)
+
+    def _get_imported_tax_values(self):
+        """Return the tax values of the imported file, keyed by tax domain.
+
+        An imported document keeps the amounts the issuer declared, so the
+        fiscal mapping must not replace them. The result is empty when the
+        line does not belong to an imported document.
+        """
+        if not self._is_imported():
+            return {}
+        self.ensure_one()
+        imported_values = {}
+        for tax_field in FISCAL_TAX_ID_FIELDS:
+            tax_domain = tax_field[: -len("_tax_id")]
+            tax_value = self[TAX_VALUE_FIELDS[tax_domain]]
+            if not tax_value:
+                continue
+            tax = self[tax_field]
+            base_field = f"{tax_domain}_base"
+            imported_values[tax_domain] = {
+                "name": tax.name,
+                "tax_domain": tax_domain,
+                "fiscal_tax_id": tax.id,
+                "tax_include": tax.tax_group_id.tax_include,
+                "tax_withholding": tax.tax_group_id.tax_withholding,
+                "base": self[base_field] if base_field in self._fields else 0.0,
+                "tax_value": tax_value,
+            }
+        return imported_values
 
     def _prepare_tax_fields(self, compute_result):
         self.ensure_one()

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -9,6 +9,7 @@ from . import (
     test_tax_classification,
     test_tax_benefit,
     test_document_edition,
+    test_document_imported,
     test_ibpt_product,
     test_ibpt_service,
     test_icms_regulation,

--- a/l10n_br_fiscal/tests/test_document_imported.py
+++ b/l10n_br_fiscal/tests/test_document_imported.py
@@ -122,3 +122,50 @@ class TestImportedDocumentTaxAmounts(TransactionCase):
             tax_domain = tax_field[: -len("_tax_id")]
             self.assertIn(tax_domain, TAX_VALUE_FIELDS)
             self.assertIn(TAX_VALUE_FIELDS[tax_domain], line_fields)
+
+    def test_recomputing_keeps_the_taxes_of_the_file(self):
+        document = self._create_imported_document(
+            {
+                "ipi_tax_id": self.ipi_tax.id,
+                "ipi_base": 210.0,
+                "ipi_percent": 6.5,
+                "ipi_value": 13.65,
+                "icms_tax_id": self.icms_tax.id,
+                "icms_base": 210.0,
+                "icms_percent": 18.0,
+                "icms_value": 37.8,
+            }
+        )
+        line = document.fiscal_line_ids
+        self.assertEqual(line.fiscal_tax_ids, self.ipi_tax | self.icms_tax)
+
+        line._compute_fiscal_tax_ids()
+
+        self.assertEqual(line.fiscal_tax_ids, self.ipi_tax | self.icms_tax)
+
+    def test_imported_tax_values_come_from_the_file(self):
+        document = self._create_imported_document(
+            {
+                "ipi_tax_id": self.ipi_tax.id,
+                "ipi_base": 210.0,
+                "ipi_percent": 6.5,
+                "ipi_value": 13.65,
+                "icms_tax_id": self.icms_tax.id,
+                "icms_base": 210.0,
+                "icms_percent": 18.0,
+                "icms_value": 37.8,
+            }
+        )
+        imported_values = document.fiscal_line_ids._get_imported_tax_values()
+
+        self.assertEqual(sorted(imported_values), ["icms", "ipi"])
+        self.assertEqual(imported_values["ipi"]["tax_value"], 13.65)
+        self.assertFalse(imported_values["ipi"]["tax_include"])
+        self.assertEqual(imported_values["icms"]["tax_value"], 37.8)
+        self.assertTrue(imported_values["icms"]["tax_include"])
+
+    def test_a_line_that_was_not_imported_has_no_imported_tax_values(self):
+        document = self._create_imported_document({})
+        document.imported_document = False
+
+        self.assertEqual(document.fiscal_line_ids._get_imported_tax_values(), {})

--- a/l10n_br_fiscal/tests/test_document_imported.py
+++ b/l10n_br_fiscal/tests/test_document_imported.py
@@ -1,0 +1,124 @@
+# Copyright (C) 2026 - TODAY KMEE
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import Command
+from odoo.tests import TransactionCase
+
+from ..constants.fiscal import FISCAL_TAX_ID_FIELDS, TAX_VALUE_FIELDS
+from .tools import load_fiscal_fixture_files
+
+
+class TestImportedDocumentTaxAmounts(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        load_fiscal_fixture_files(cls.env)
+        cls.company = cls.env.ref("l10n_br_base.empresa_lucro_presumido")
+        cls.partner = cls.env.ref("l10n_br_base.res_partner_akretion")
+        cls.product = cls.env.ref("product.product_product_6")
+        cls.uom = cls.env.ref("uom.product_uom_unit")
+        cls.document_type = cls.env.ref("l10n_br_fiscal.document_55")
+        cls.operation = cls.env.ref("l10n_br_fiscal.fo_compras")
+        cls.operation_line = cls.env.ref("l10n_br_fiscal.fo_compras_compras")
+        cls.ipi_tax = cls.env.ref("l10n_br_fiscal.tax_ipi_6_5")
+        cls.icms_tax = cls.env.ref("l10n_br_fiscal.tax_icms_18")
+
+    def _create_imported_document(self, tax_values):
+        line_values = {
+            "name": "Imported purchase line",
+            "product_id": self.product.id,
+            "uom_id": self.uom.id,
+            "quantity": 1,
+            "price_unit": 210.0,
+            "fiscal_operation_type": "in",
+            "fiscal_operation_id": self.operation.id,
+            "fiscal_operation_line_id": self.operation_line.id,
+        }
+        line_values.update(tax_values)
+        return self.env["l10n_br_fiscal.document"].create(
+            {
+                "company_id": self.company.id,
+                "document_type_id": self.document_type.id,
+                "document_serie": "1",
+                "document_number": "4909",
+                "issuer": "partner",
+                "partner_id": self.partner.id,
+                "fiscal_operation_id": self.operation.id,
+                "fiscal_operation_type": "in",
+                "imported_document": True,
+                "fiscal_line_ids": [Command.create(line_values)],
+            }
+        )
+
+    def test_ipi_from_the_file_reaches_the_document_total(self):
+        document = self._create_imported_document(
+            {
+                "ipi_tax_id": self.ipi_tax.id,
+                "ipi_base": 210.0,
+                "ipi_percent": 6.5,
+                "ipi_value": 13.65,
+            }
+        )
+        line = document.fiscal_line_ids
+        self.assertEqual(line.ipi_value, 13.65)
+        self.assertEqual(line.amount_tax_not_included, 13.65)
+        self.assertEqual(line.amount_tax_included, 0.0)
+        self.assertEqual(line.fiscal_amount_tax, 13.65)
+        self.assertEqual(document.amount_ipi_value, 13.65)
+        self.assertEqual(document.fiscal_amount_tax, 13.65)
+        self.assertEqual(
+            document.fiscal_amount_total, document.fiscal_amount_untaxed + 13.65
+        )
+
+    def test_icms_from_the_file_stays_inside_the_price(self):
+        document = self._create_imported_document(
+            {
+                "icms_tax_id": self.icms_tax.id,
+                "icms_base": 210.0,
+                "icms_percent": 18.0,
+                "icms_value": 37.8,
+            }
+        )
+        line = document.fiscal_line_ids
+        self.assertEqual(line.amount_tax_included, 37.8)
+        self.assertEqual(line.amount_tax_not_included, 0.0)
+        self.assertEqual(line.fiscal_amount_tax, 0.0)
+        self.assertEqual(document.fiscal_amount_tax, 0.0)
+        self.assertEqual(document.fiscal_amount_total, document.fiscal_amount_untaxed)
+
+    def test_tax_values_from_the_file_are_not_recomputed(self):
+        document = self._create_imported_document(
+            {
+                "ipi_tax_id": self.ipi_tax.id,
+                "ipi_base": 210.0,
+                "ipi_percent": 9.75,
+                "ipi_value": 20.48,
+            }
+        )
+        line = document.fiscal_line_ids
+        self.assertEqual(line.ipi_percent, 9.75)
+        self.assertEqual(line.ipi_value, 20.48)
+        self.assertEqual(line.amount_tax_not_included, 20.48)
+
+    def test_editing_an_imported_tax_value_updates_the_total(self):
+        document = self._create_imported_document(
+            {
+                "ipi_tax_id": self.ipi_tax.id,
+                "ipi_base": 210.0,
+                "ipi_percent": 6.5,
+                "ipi_value": 13.65,
+            }
+        )
+        line = document.fiscal_line_ids
+        line.write({"ipi_value": 20.0})
+        self.assertEqual(line.amount_tax_not_included, 20.0)
+        self.assertEqual(line.fiscal_amount_tax, 20.0)
+        self.assertEqual(document.fiscal_amount_tax, 20.0)
+
+    def test_every_line_tax_field_has_a_value_field(self):
+        line_fields = self.env["l10n_br_fiscal.document.line"]._fields
+        for tax_field in FISCAL_TAX_ID_FIELDS:
+            tax_domain = tax_field[: -len("_tax_id")]
+            self.assertIn(tax_domain, TAX_VALUE_FIELDS)
+            self.assertIn(TAX_VALUE_FIELDS[tax_domain], line_fields)

--- a/l10n_br_nfe/tests/test_nfe_import.py
+++ b/l10n_br_nfe/tests/test_nfe_import.py
@@ -197,3 +197,31 @@ class NFeImportTest(TransactionCase):
 
     def test_import_out_nfe(self):
         "(can be useful after an ERP migration)"
+
+    def test_import_in_nfe_ipi_reaches_the_totals(self):
+        res_items = (
+            "nfe",
+            "samples",
+            "v4_0",
+            "leiauteNFe",
+            "35180834128745000152550010000474281920007498-nfe.xml",
+        )
+        resource_path = "/".join(res_items)
+        nfe_stream = pkg_resources.resource_stream(nfelib.__name__, resource_path)
+        xml = nfe_stream.read().decode()
+        ipi = (
+            "<IPI><cEnq>999</cEnq><IPITrib>"
+            "<CST>50</CST><vBC>50.60</vBC><pIPI>6.50</pIPI><vIPI>3.29</vIPI>"
+            "</IPITrib></IPI>"
+        )
+        xml = re.sub(r"<IPI>.*?</IPI>", ipi, xml, count=1, flags=re.S)
+
+        binding = TnfeProc.from_xml(xml)
+        nfe = self.env["l10n_br_fiscal.document"].import_binding_nfe(
+            binding, edoc_type="in", dry_run=False
+        )
+        line = nfe.fiscal_line_ids[0]
+        self.assertEqual(line.ipi_value, 3.29)
+        self.assertEqual(line.amount_tax_not_included, 3.29)
+        self.assertEqual(line.fiscal_amount_tax, 3.29)
+        self.assertEqual(line.amount_tax_included, 7.64)


### PR DESCRIPTION
Depende do #5005: essa branch está empilhada nele, e faço rebase quando ele entrar.

Linha de documento importado perde os impostos a cada recompute. O `_compute_fiscal_tax_ids` sai pelo `continue` quando a linha é de documento importado, e campo computado armazenado que não recebe atribuição fica vazio no cache. O `fiscal_tax_ids` é a origem de tudo que vem depois: imposto contábil, total da linha e as linhas de imposto do lançamento. O arquivo trouxe IPI e ICMS, a linha guarda `ipi_tax_id` e `icms_tax_id` certos, e o conjunto que o resto do sistema lê está vazio.

A correção reconstrói o `fiscal_tax_ids` da linha importada a partir do campo de imposto de cada domínio, em vez de deixar a atribuição de fora. O ramo do mapeamento fiscal continua intocado: importado não passa pelo motor, e não é isso que muda aqui. Entra também o `_get_imported_tax_values`, que devolve o valor de imposto do arquivo por domínio, separando incluído de retido pela mesma regra que o `compute_taxes` usa; é o que o `l10n_br_account` consome para o lançamento nascer com os valores do emitente e não com os do nosso mapeamento.

Peguei isso conferindo o contas a pagar de nota de entrada importada, que vinha menor que a duplicata. O teste importa a nota, força o recompute e cobra o conjunto de impostos igual antes e depois; outro cobra os valores por domínio vindos do arquivo, com o IPI fora do preço e o ICMS dentro; e um terceiro cobra dicionário vazio em linha que não é importada, que é a fronteira do ramo novo. A 16.0 e a 17.0 têm a mesma guarda, e faço o backport se este entrar.
