### PR TITLE
[18.0][FIX] l10n_br_account: quantity and taxes from the imported file

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -310,15 +310,21 @@ class AccountMove(models.Model):
         for move in self.filtered(
             lambda m: m.document_type_id and not m.l10n_latam_document_type_id
         ):
-            latam_doc_type = self.env["l10n_latam.document.type"].search(
-                [
-                    ("code", "=", move.document_type_id.code),
-                    ("country_id", "=", move.company_id.account_fiscal_country_id.id),
-                ],
-                limit=1,
+            latam_doc_type = self._find_latam_document_type(
+                move.document_type_id, move.company_id
             )
             if latam_doc_type:
                 move.l10n_latam_document_type_id = latam_doc_type
+
+    @api.model
+    def _find_latam_document_type(self, document_type, company):
+        return self.env["l10n_latam.document.type"].search(
+            [
+                ("code", "=", document_type.code),
+                ("country_id", "=", company.account_fiscal_country_id.id),
+            ],
+            limit=1,
+        )
 
     def _compute_imported_terms(self):
         self.ensure_one()
@@ -946,10 +952,24 @@ class AccountMove(models.Model):
             move_form.fiscal_document_id = fiscal_document
             move_form.fiscal_operation_id = fiscal_document.fiscal_operation_id
             move_form.document_serie = fiscal_document.document_serie
+            if (
+                "l10n_latam.document.type" in self.env
+                and move_form.l10n_latam_use_documents
+            ):
+                latam_doc_type = self._find_latam_document_type(
+                    fiscal_document.document_type_id, fiscal_document.company_id
+                )
+                if latam_doc_type:
+                    move_form.l10n_latam_document_type_id = latam_doc_type
+                if move_form.l10n_latam_manual_document_number:
+                    move_form.l10n_latam_document_number = (
+                        fiscal_document.document_number
+                    )
 
         unit_and_prices = []  # save units to force them later
         for line in fiscal_document.fiscal_line_ids:
             with move_form.invoice_line_ids.new() as line_form:
+                line_form.product_id = line.product_id
                 line_form.cfop_id = (
                     line.cfop_id
                 )  # required if we disable some fiscal tax updates

--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -966,7 +966,6 @@ class AccountMove(models.Model):
                         fiscal_document.document_number
                     )
 
-        unit_and_prices = []  # save units to force them later
         for line in fiscal_document.fiscal_line_ids:
             with move_form.invoice_line_ids.new() as line_form:
                 line_form.product_id = line.product_id
@@ -975,14 +974,8 @@ class AccountMove(models.Model):
                 )  # required if we disable some fiscal tax updates
                 line_form.fiscal_operation_id = self.fiscal_operation_id
                 line_form.fiscal_document_line_id = line
-                # for some reason trying to set the product_uom_id
-                # here results in strange bugs like unbalanced move
-                # so we will force product_uom_id later
-                # we also save price_unit to reset unit factor effect
-                unit_and_prices.append((line.uot_id.id, line.price_unit))
+                line_form.product_uom_id = line.uot_id
+                line_form.quantity = line.quantity
+                line_form.price_unit = line.price_unit
         move_form.save()
-        move = self.env["account.move"].browse(move_form.id)
-        for index, item in enumerate(unit_and_prices):
-            move.invoice_line_ids[index].product_uom_id = item[0]
-            move.invoice_line_ids[index].price_unit = item[1]
         return move_form

--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -259,7 +259,7 @@ class AccountMove(models.Model):
                 # fiscal documents for instance. It should be used
                 # exceptionnaly as it breaks the dependency chain and
                 # can leave fields such as payment_state inconsistent.
-                move._compute_fiscal_amount()
+                move.fiscal_document_id._compute_fiscal_amount()
 
         result = super()._compute_amount()
         for move in self.filtered(lambda m: m.fiscal_operation_id):

--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -425,6 +425,9 @@ class AccountMoveLine(models.Model):
                     icmssn_range=line.icmssn_range_id,
                     icms_origin=line.icms_origin,
                     ind_final=line.ind_final,
+                    imported_taxes=(
+                        line.fiscal_document_line_id._get_imported_tax_values()
+                    ),
                 )
 
                 line.price_subtotal = taxes_res["total_excluded"]

--- a/l10n_br_account/models/account_tax.py
+++ b/l10n_br_account/models/account_tax.py
@@ -46,6 +46,7 @@ class AccountTax(models.Model):
         icmssn_range=None,
         icms_origin=None,
         ind_final=FINAL_CUSTOMER_NO,
+        imported_taxes=None,
     ):
         """Returns all information required to apply taxes
             (in self + their children in case of a tax goup).
@@ -123,6 +124,13 @@ class AccountTax(models.Model):
             ind_final=ind_final,
         )
 
+        if imported_taxes:
+            # The document was imported: the amounts of the file replace the
+            # ones the mapping just computed, and only the taxes of the file
+            # take part in the totals.
+            fiscal_taxes_results["taxes"] = dict(imported_taxes)
+            fiscal_taxes_results.update(self._sum_imported_tax_amounts(imported_taxes))
+
         taxes_results["amount_tax_included"] = fiscal_taxes_results["amount_included"]
         taxes_results["amount_tax_not_included"] = fiscal_taxes_results[
             "amount_not_included"
@@ -191,6 +199,29 @@ class AccountTax(models.Model):
                 )
 
         return taxes_results
+
+    @api.model
+    def _sum_imported_tax_amounts(self, imported_taxes):
+        """Split the tax values of an imported file by the kind of tax group.
+
+        Follows the same rule as ``compute_taxes``: a withholding group is
+        withheld, a group flagged as included is already inside the price and
+        the remaining ones are added on top of it.
+        """
+        amount_included = amount_not_included = amount_withholding = 0.0
+        for tax_values in imported_taxes.values():
+            tax_value = tax_values.get("tax_value", 0.0)
+            if tax_values.get("tax_withholding"):
+                amount_withholding += tax_value
+            elif tax_values.get("tax_include"):
+                amount_included += tax_value
+            else:
+                amount_not_included += tax_value
+        return {
+            "amount_included": amount_included,
+            "amount_not_included": amount_not_included,
+            "amount_withholding": amount_withholding,
+        }
 
     def _add_tax_details_in_base_line(self, base_line, company, rounding_method=None):
         """Override to inject Brazilian fiscal tax computation.
@@ -262,6 +293,7 @@ class AccountTax(models.Model):
         if not tax_ids:
             super()._add_tax_details_in_base_line(base_line, company, rounding_method)
             return
+        fiscal_line = getattr(record, "fiscal_document_line_id", False)
         taxes_computation = tax_ids._origin.compute_all(
             price_unit=price_unit_after_discount,
             currency=currency,
@@ -290,6 +322,9 @@ class AccountTax(models.Model):
             icmssn_range=record.icmssn_range_id,
             icms_origin=record.icms_origin,
             ind_final=record.ind_final,
+            imported_taxes=(
+                fiscal_line._get_imported_tax_values() if fiscal_line else {}
+            ),
         )
 
         # Override totals with Brazilian computation

--- a/l10n_br_account/tests/__init__.py
+++ b/l10n_br_account/tests/__init__.py
@@ -10,3 +10,4 @@ from . import test_invoice_refund
 # from . import test_multi_localizations_invoice
 from . import test_payment_status
 from . import test_move_workflow
+from . import test_import_fiscal_document

--- a/l10n_br_account/tests/test_import_fiscal_document.py
+++ b/l10n_br_account/tests/test_import_fiscal_document.py
@@ -1,0 +1,90 @@
+# Copyright 2026 KMEE INFORMATICA LTDA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields
+from odoo.tests.common import tagged
+
+from .common import AccountMoveBRCommon
+
+
+@tagged("post_install", "-at_install")
+class TestImportFiscalDocument(AccountMoveBRCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.document_type_55 = cls.env.ref("l10n_br_fiscal.document_55")
+        if "l10n_latam.document.type" in cls.env:
+            cls._mirror_latam_document_type()
+        cls.fiscal_document_to_import = cls.env["l10n_br_fiscal.document"].create(
+            {
+                "fiscal_operation_id": cls.env.ref("l10n_br_fiscal.fo_compras").id,
+                "document_type_id": cls.document_type_55.id,
+                "document_serie": "1",
+                "document_number": "4952",
+                "document_date": fields.Date.from_string("2026-08-17"),
+                "issuer": "partner",
+                "partner_id": cls.partner_a.id,
+                "fiscal_operation_type": "in",
+            }
+        )
+        cls.env["l10n_br_fiscal.document.line"].create(
+            {
+                "document_id": cls.fiscal_document_to_import.id,
+                "name": "Purchase Test",
+                "product_id": cls.product_a.id,
+                "fiscal_operation_type": "in",
+                "fiscal_operation_id": cls.env.ref("l10n_br_fiscal.fo_compras").id,
+                "fiscal_operation_line_id": cls.env.ref(
+                    "l10n_br_fiscal.fo_compras_compras"
+                ).id,
+            }
+        )
+
+    @classmethod
+    def _mirror_latam_document_type(cls):
+        fiscal_country = cls.company_data["company"].account_fiscal_country_id
+        domain = [
+            ("code", "=", cls.document_type_55.code),
+            ("country_id", "=", fiscal_country.id),
+        ]
+        if cls.env["l10n_latam.document.type"].search_count(domain):
+            return
+        cls.env["l10n_latam.document.type"].create(
+            {
+                "name": cls.document_type_55.name,
+                "code": cls.document_type_55.code,
+                "country_id": fiscal_country.id,
+                "internal_type": "invoice",
+                "doc_code_prefix": "NFe",
+            }
+        )
+
+    def test_import_into_a_new_vendor_bill(self):
+        move_form = (
+            self.env["account.move"]
+            .sudo()
+            .import_fiscal_document(
+                self.fiscal_document_to_import, move_type="in_invoice"
+            )
+        )
+        move = self.env["account.move"].sudo().browse(move_form.id)
+
+        self.assertEqual(move.move_type, "in_invoice")
+        self.assertEqual(move.fiscal_document_id, self.fiscal_document_to_import)
+        self.assertEqual(move.partner_id, self.partner_a)
+        self.assertEqual(len(move.invoice_line_ids), 1)
+        self.assertEqual(move.invoice_line_ids.product_id, self.product_a)
+        self.assertEqual(
+            move.amount_total, self.fiscal_document_to_import.fiscal_amount_total
+        )
+
+        if "l10n_latam.document.type" in self.env:
+            self.assertTrue(move.journal_id.l10n_latam_use_documents)
+            self.assertTrue(move.l10n_latam_manual_document_number)
+            self.assertEqual(
+                move.l10n_latam_document_type_id.code, self.document_type_55.code
+            )
+            self.assertEqual(
+                move.l10n_latam_document_number,
+                self.fiscal_document_to_import.document_number,
+            )

--- a/l10n_br_account/tests/test_import_fiscal_document.py
+++ b/l10n_br_account/tests/test_import_fiscal_document.py
@@ -27,11 +27,13 @@ class TestImportFiscalDocument(AccountMoveBRCommon):
                 "fiscal_operation_type": "in",
             }
         )
-        cls.env["l10n_br_fiscal.document.line"].create(
+        cls.fiscal_line_to_import = cls.env["l10n_br_fiscal.document.line"].create(
             {
                 "document_id": cls.fiscal_document_to_import.id,
                 "name": "Purchase Test",
                 "product_id": cls.product_a.id,
+                "quantity": 10,
+                "price_unit": 38.0,
                 "fiscal_operation_type": "in",
                 "fiscal_operation_id": cls.env.ref("l10n_br_fiscal.fo_compras").id,
                 "fiscal_operation_line_id": cls.env.ref(
@@ -39,6 +41,16 @@ class TestImportFiscalDocument(AccountMoveBRCommon):
                 ).id,
             }
         )
+
+    def _import_into_new_vendor_bill(self):
+        move_form = (
+            self.env["account.move"]
+            .sudo()
+            .import_fiscal_document(
+                self.fiscal_document_to_import, move_type="in_invoice"
+            )
+        )
+        return self.env["account.move"].sudo().browse(move_form.id)
 
     @classmethod
     def _mirror_latam_document_type(cls):
@@ -60,14 +72,7 @@ class TestImportFiscalDocument(AccountMoveBRCommon):
         )
 
     def test_import_into_a_new_vendor_bill(self):
-        move_form = (
-            self.env["account.move"]
-            .sudo()
-            .import_fiscal_document(
-                self.fiscal_document_to_import, move_type="in_invoice"
-            )
-        )
-        move = self.env["account.move"].sudo().browse(move_form.id)
+        move = self._import_into_new_vendor_bill()
 
         self.assertEqual(move.move_type, "in_invoice")
         self.assertEqual(move.fiscal_document_id, self.fiscal_document_to_import)
@@ -88,3 +93,86 @@ class TestImportFiscalDocument(AccountMoveBRCommon):
                 move.l10n_latam_document_number,
                 self.fiscal_document_to_import.document_number,
             )
+
+    def test_imported_line_keeps_the_fiscal_quantity(self):
+        move = self._import_into_new_vendor_bill()
+        line = move.invoice_line_ids
+
+        self.assertEqual(line.quantity, self.fiscal_line_to_import.quantity)
+        self.assertEqual(line.price_unit, self.fiscal_line_to_import.price_unit)
+        self.assertEqual(line.price_subtotal, self.fiscal_line_to_import.price_gross)
+
+    def test_imported_payment_term_matches_the_document_total(self):
+        move = self._import_into_new_vendor_bill()
+        payment_term_lines = move.line_ids.filtered(
+            lambda line: line.display_type == "payment_term"
+        )
+
+        self.assertEqual(
+            sum(payment_term_lines.mapped("credit")),
+            self.fiscal_document_to_import.amount_financial_total,
+        )
+
+    def _import_document_with_taxes_from_a_file(self):
+        document = self.env["l10n_br_fiscal.document"].create(
+            {
+                "fiscal_operation_id": self.env.ref("l10n_br_fiscal.fo_compras").id,
+                "document_type_id": self.document_type_55.id,
+                "document_serie": "1",
+                "document_number": "4953",
+                "document_date": fields.Date.from_string("2026-08-17"),
+                "issuer": "partner",
+                "partner_id": self.partner_a.id,
+                "fiscal_operation_type": "in",
+                "imported_document": True,
+            }
+        )
+        self.env["l10n_br_fiscal.document.line"].create(
+            {
+                "document_id": document.id,
+                "name": "Imported purchase line",
+                "product_id": self.product_a.id,
+                "quantity": 39,
+                "price_unit": 100.0,
+                "fiscal_operation_type": "in",
+                "fiscal_operation_id": self.env.ref("l10n_br_fiscal.fo_compras").id,
+                "fiscal_operation_line_id": self.env.ref(
+                    "l10n_br_fiscal.fo_compras_compras"
+                ).id,
+                # The issuer charged 12% of ICMS, and the tax the import matched
+                # has no rate: only the value of the file can be trusted here.
+                "icms_tax_id": self.env.ref("l10n_br_fiscal.tax_icms_nt").id,
+                "icms_base": 3900.0,
+                "icms_percent": 12.0,
+                "icms_value": 468.0,
+                "ipi_tax_id": self.env.ref("l10n_br_fiscal.tax_ipi_6_5").id,
+                "ipi_base": 3900.0,
+                "ipi_percent": 9.75,
+                "ipi_value": 380.25,
+            }
+        )
+        move_form = (
+            self.env["account.move"]
+            .sudo()
+            .import_fiscal_document(document, move_type="in_invoice")
+        )
+        return document, self.env["account.move"].sudo().browse(move_form.id)
+
+    def test_the_tax_lines_carry_the_values_of_the_file(self):
+        _document, move = self._import_document_with_taxes_from_a_file()
+        tax_lines = move.line_ids.filtered(lambda line: line.display_type == "tax")
+        tax_amounts = {
+            line.tax_line_id.tax_group_id.fiscal_tax_group_id.tax_domain: line.debit
+            for line in tax_lines
+        }
+
+        self.assertEqual(tax_amounts, {"icms": 468.0, "ipi": 380.25})
+
+    def test_the_payment_term_of_an_imported_document_matches_the_file(self):
+        document, move = self._import_document_with_taxes_from_a_file()
+        payment_term_lines = move.line_ids.filtered(
+            lambda line: line.display_type == "payment_term"
+        )
+
+        self.assertEqual(sum(payment_term_lines.mapped("credit")), 4280.25)
+        self.assertEqual(document.amount_financial_total, 4280.25)

--- a/l10n_br_fiscal/constants/fiscal.py
+++ b/l10n_br_fiscal/constants/fiscal.py
@@ -565,6 +565,34 @@ FISCAL_TAX_ID_FIELDS = [
     "ibs_tax_id",
 ]
 
+TAX_VALUE_FIELDS = {
+    TAX_DOMAIN_COFINS: "cofins_value",
+    TAX_DOMAIN_COFINS_WH: "cofins_wh_value",
+    TAX_DOMAIN_COFINS_ST: "cofinsst_value",
+    TAX_DOMAIN_CSLL: "csll_value",
+    TAX_DOMAIN_CSLL_WH: "csll_wh_value",
+    TAX_DOMAIN_ICMS: "icms_value",
+    TAX_DOMAIN_ICMS_FCP: "icmsfcp_value",
+    TAX_DOMAIN_ICMS_SN: "icmssn_credit_value",
+    TAX_DOMAIN_ICMS_ST: "icmsst_value",
+    TAX_DOMAIN_ICMS_FCP_ST: "icmsfcpst_value",
+    TAX_DOMAIN_II: "ii_value",
+    TAX_DOMAIN_INSS: "inss_value",
+    TAX_DOMAIN_INSS_WH: "inss_wh_value",
+    TAX_DOMAIN_IPI: "ipi_value",
+    TAX_DOMAIN_IRPJ: "irpj_value",
+    TAX_DOMAIN_IRPJ_WH: "irpj_wh_value",
+    TAX_DOMAIN_ISSQN: "issqn_value",
+    TAX_DOMAIN_ISSQN_WH: "issqn_wh_value",
+    TAX_DOMAIN_PIS: "pis_value",
+    TAX_DOMAIN_PIS_WH: "pis_wh_value",
+    TAX_DOMAIN_PIS_ST: "pisst_value",
+    TAX_DOMAIN_CBS: "cbs_value",
+    TAX_DOMAIN_IBS: "ibs_value",
+}
+
+TAX_VALUE_FIELD_NAMES = frozenset(TAX_VALUE_FIELDS.values())
+
 TAX_RATE_TYPE = [
     ("1", "1 - Fixa"),
     ("2", "2 - Padrão"),

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -42,6 +42,8 @@ from ..constants.fiscal import (
     TAX_DOMAIN_PIS_WH,
     TAX_FRAMEWORK_SIMPLES_ALL,
     TAX_ICMS_OR_ISSQN,
+    TAX_VALUE_FIELD_NAMES,
+    TAX_VALUE_FIELDS,
 )
 from ..constants.icms import (
     ICMS_BASE_TYPE,
@@ -382,6 +384,12 @@ class FiscalDocumentLineMixin(models.AbstractModel):
             # Por segurança, sempre recalcula se um campo relevante mudou.
             self._update_fiscal_tax_ids()
 
+        imported = self.filtered(lambda line: line._is_imported())
+        if imported and TAX_VALUE_FIELD_NAMES.intersection(vals):
+            tax_groups = imported._tax_groups_by_domain()
+            for line in imported:
+                line._update_imported_tax_amounts(tax_groups)
+
         return res
 
     def _update_fiscal_tax_ids(self):
@@ -441,7 +449,13 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         Compute base, percent, value... tax fields for ICMS, IPI, PIS, COFINS... taxes.
         """
         null_mask = None
-        for line in self.filtered(lambda line: not line._is_imported()):
+        tax_groups = None
+        for line in self:
+            if line._is_imported():
+                if tax_groups is None:
+                    tax_groups = line._tax_groups_by_domain()
+                line._update_imported_tax_amounts(tax_groups)
+                continue
             if null_mask is None:
                 null_mask = self._build_null_mask_dict()
             to_update = null_mask.copy()
@@ -510,6 +524,38 @@ class FiscalDocumentLineMixin(models.AbstractModel):
                 line.update(to_update)
             else:
                 line.write(to_update)
+
+    def _tax_groups_by_domain(self):
+        groups = self.env["l10n_br_fiscal.tax.group"].search([])
+        return {group.tax_domain: group for group in groups}
+
+    def _update_imported_tax_amounts(self, tax_groups):
+        self.ensure_one()
+        empty_group = self.env["l10n_br_fiscal.tax.group"]
+        amount_included = amount_not_included = amount_withholding = 0.0
+        for tax_field in FISCAL_TAX_ID_FIELDS:
+            tax_domain = tax_field[: -len("_tax_id")]
+            tax_value = self[TAX_VALUE_FIELDS[tax_domain]]
+            if not tax_value:
+                continue
+            tax_group = self[tax_field].tax_group_id or tax_groups.get(
+                tax_domain, empty_group
+            )
+            if tax_group.tax_withholding:
+                amount_withholding += tax_value
+            elif tax_group.tax_include:
+                amount_included += tax_value
+            else:
+                amount_not_included += tax_value
+        to_update = {
+            "amount_tax_included": amount_included,
+            "amount_tax_not_included": amount_not_included,
+            "amount_tax_withholding": amount_withholding,
+        }
+        if self != self._origin:
+            self.update(to_update)
+        else:
+            self.write(to_update)
 
     def _prepare_tax_fields(self, compute_result):
         self.ensure_one()

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -344,6 +344,15 @@ class FiscalDocumentLineMixin(models.AbstractModel):
                 line.icms_tax_benefit_id = mapping_result["icms_tax_benefit_id"]
 
                 if line._is_imported():
+                    # The taxes of an imported line come from the file, not from
+                    # the fiscal mapping. They are rebuilt from the tax field of
+                    # each domain because leaving fiscal_tax_ids unassigned here
+                    # empties it on every recompute, and everything downstream
+                    # (account taxes, line totals, tax lines) is computed from it.
+                    imported_taxes = line.env["l10n_br_fiscal.tax"]
+                    for fiscal_tax_field in FISCAL_TAX_ID_FIELDS:
+                        imported_taxes |= line[fiscal_tax_field]
+                    line.fiscal_tax_ids = imported_taxes
                     continue
 
                 taxes = line.env["l10n_br_fiscal.tax"]
@@ -556,6 +565,35 @@ class FiscalDocumentLineMixin(models.AbstractModel):
             self.update(to_update)
         else:
             self.write(to_update)
+
+    def _get_imported_tax_values(self):
+        """Return the tax values of the imported file, keyed by tax domain.
+
+        An imported document keeps the amounts the issuer declared, so the
+        fiscal mapping must not replace them. The result is empty when the
+        line does not belong to an imported document.
+        """
+        if not self._is_imported():
+            return {}
+        self.ensure_one()
+        imported_values = {}
+        for tax_field in FISCAL_TAX_ID_FIELDS:
+            tax_domain = tax_field[: -len("_tax_id")]
+            tax_value = self[TAX_VALUE_FIELDS[tax_domain]]
+            if not tax_value:
+                continue
+            tax = self[tax_field]
+            base_field = f"{tax_domain}_base"
+            imported_values[tax_domain] = {
+                "name": tax.name,
+                "tax_domain": tax_domain,
+                "fiscal_tax_id": tax.id,
+                "tax_include": tax.tax_group_id.tax_include,
+                "tax_withholding": tax.tax_group_id.tax_withholding,
+                "base": self[base_field] if base_field in self._fields else 0.0,
+                "tax_value": tax_value,
+            }
+        return imported_values
 
     def _prepare_tax_fields(self, compute_result):
         self.ensure_one()

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -9,6 +9,7 @@ from . import (
     test_tax_classification,
     test_tax_benefit,
     test_document_edition,
+    test_document_imported,
     test_ibpt_product,
     test_ibpt_service,
     test_icms_regulation,

--- a/l10n_br_fiscal/tests/test_document_imported.py
+++ b/l10n_br_fiscal/tests/test_document_imported.py
@@ -122,3 +122,50 @@ class TestImportedDocumentTaxAmounts(TransactionCase):
             tax_domain = tax_field[: -len("_tax_id")]
             self.assertIn(tax_domain, TAX_VALUE_FIELDS)
             self.assertIn(TAX_VALUE_FIELDS[tax_domain], line_fields)
+
+    def test_recomputing_keeps_the_taxes_of_the_file(self):
+        document = self._create_imported_document(
+            {
+                "ipi_tax_id": self.ipi_tax.id,
+                "ipi_base": 210.0,
+                "ipi_percent": 6.5,
+                "ipi_value": 13.65,
+                "icms_tax_id": self.icms_tax.id,
+                "icms_base": 210.0,
+                "icms_percent": 18.0,
+                "icms_value": 37.8,
+            }
+        )
+        line = document.fiscal_line_ids
+        self.assertEqual(line.fiscal_tax_ids, self.ipi_tax | self.icms_tax)
+
+        line._compute_fiscal_tax_ids()
+
+        self.assertEqual(line.fiscal_tax_ids, self.ipi_tax | self.icms_tax)
+
+    def test_imported_tax_values_come_from_the_file(self):
+        document = self._create_imported_document(
+            {
+                "ipi_tax_id": self.ipi_tax.id,
+                "ipi_base": 210.0,
+                "ipi_percent": 6.5,
+                "ipi_value": 13.65,
+                "icms_tax_id": self.icms_tax.id,
+                "icms_base": 210.0,
+                "icms_percent": 18.0,
+                "icms_value": 37.8,
+            }
+        )
+        imported_values = document.fiscal_line_ids._get_imported_tax_values()
+
+        self.assertEqual(sorted(imported_values), ["icms", "ipi"])
+        self.assertEqual(imported_values["ipi"]["tax_value"], 13.65)
+        self.assertFalse(imported_values["ipi"]["tax_include"])
+        self.assertEqual(imported_values["icms"]["tax_value"], 37.8)
+        self.assertTrue(imported_values["icms"]["tax_include"])
+
+    def test_a_line_that_was_not_imported_has_no_imported_tax_values(self):
+        document = self._create_imported_document({})
+        document.imported_document = False
+
+        self.assertEqual(document.fiscal_line_ids._get_imported_tax_values(), {})

--- a/l10n_br_fiscal/tests/test_document_imported.py
+++ b/l10n_br_fiscal/tests/test_document_imported.py
@@ -1,0 +1,124 @@
+# Copyright (C) 2026 - TODAY KMEE
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import Command
+from odoo.tests import TransactionCase
+
+from ..constants.fiscal import FISCAL_TAX_ID_FIELDS, TAX_VALUE_FIELDS
+from .tools import load_fiscal_fixture_files
+
+
+class TestImportedDocumentTaxAmounts(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        load_fiscal_fixture_files(cls.env)
+        cls.company = cls.env.ref("l10n_br_base.empresa_lucro_presumido")
+        cls.partner = cls.env.ref("l10n_br_base.res_partner_akretion")
+        cls.product = cls.env.ref("product.product_product_6")
+        cls.uom = cls.env.ref("uom.product_uom_unit")
+        cls.document_type = cls.env.ref("l10n_br_fiscal.document_55")
+        cls.operation = cls.env.ref("l10n_br_fiscal.fo_compras")
+        cls.operation_line = cls.env.ref("l10n_br_fiscal.fo_compras_compras")
+        cls.ipi_tax = cls.env.ref("l10n_br_fiscal.tax_ipi_6_5")
+        cls.icms_tax = cls.env.ref("l10n_br_fiscal.tax_icms_18")
+
+    def _create_imported_document(self, tax_values):
+        line_values = {
+            "name": "Imported purchase line",
+            "product_id": self.product.id,
+            "uom_id": self.uom.id,
+            "quantity": 1,
+            "price_unit": 210.0,
+            "fiscal_operation_type": "in",
+            "fiscal_operation_id": self.operation.id,
+            "fiscal_operation_line_id": self.operation_line.id,
+        }
+        line_values.update(tax_values)
+        return self.env["l10n_br_fiscal.document"].create(
+            {
+                "company_id": self.company.id,
+                "document_type_id": self.document_type.id,
+                "document_serie": "1",
+                "document_number": "4909",
+                "issuer": "partner",
+                "partner_id": self.partner.id,
+                "fiscal_operation_id": self.operation.id,
+                "fiscal_operation_type": "in",
+                "imported_document": True,
+                "fiscal_line_ids": [Command.create(line_values)],
+            }
+        )
+
+    def test_ipi_from_the_file_reaches_the_document_total(self):
+        document = self._create_imported_document(
+            {
+                "ipi_tax_id": self.ipi_tax.id,
+                "ipi_base": 210.0,
+                "ipi_percent": 6.5,
+                "ipi_value": 13.65,
+            }
+        )
+        line = document.fiscal_line_ids
+        self.assertEqual(line.ipi_value, 13.65)
+        self.assertEqual(line.amount_tax_not_included, 13.65)
+        self.assertEqual(line.amount_tax_included, 0.0)
+        self.assertEqual(line.fiscal_amount_tax, 13.65)
+        self.assertEqual(document.amount_ipi_value, 13.65)
+        self.assertEqual(document.fiscal_amount_tax, 13.65)
+        self.assertEqual(
+            document.fiscal_amount_total, document.fiscal_amount_untaxed + 13.65
+        )
+
+    def test_icms_from_the_file_stays_inside_the_price(self):
+        document = self._create_imported_document(
+            {
+                "icms_tax_id": self.icms_tax.id,
+                "icms_base": 210.0,
+                "icms_percent": 18.0,
+                "icms_value": 37.8,
+            }
+        )
+        line = document.fiscal_line_ids
+        self.assertEqual(line.amount_tax_included, 37.8)
+        self.assertEqual(line.amount_tax_not_included, 0.0)
+        self.assertEqual(line.fiscal_amount_tax, 0.0)
+        self.assertEqual(document.fiscal_amount_tax, 0.0)
+        self.assertEqual(document.fiscal_amount_total, document.fiscal_amount_untaxed)
+
+    def test_tax_values_from_the_file_are_not_recomputed(self):
+        document = self._create_imported_document(
+            {
+                "ipi_tax_id": self.ipi_tax.id,
+                "ipi_base": 210.0,
+                "ipi_percent": 9.75,
+                "ipi_value": 20.48,
+            }
+        )
+        line = document.fiscal_line_ids
+        self.assertEqual(line.ipi_percent, 9.75)
+        self.assertEqual(line.ipi_value, 20.48)
+        self.assertEqual(line.amount_tax_not_included, 20.48)
+
+    def test_editing_an_imported_tax_value_updates_the_total(self):
+        document = self._create_imported_document(
+            {
+                "ipi_tax_id": self.ipi_tax.id,
+                "ipi_base": 210.0,
+                "ipi_percent": 6.5,
+                "ipi_value": 13.65,
+            }
+        )
+        line = document.fiscal_line_ids
+        line.write({"ipi_value": 20.0})
+        self.assertEqual(line.amount_tax_not_included, 20.0)
+        self.assertEqual(line.fiscal_amount_tax, 20.0)
+        self.assertEqual(document.fiscal_amount_tax, 20.0)
+
+    def test_every_line_tax_field_has_a_value_field(self):
+        line_fields = self.env["l10n_br_fiscal.document.line"]._fields
+        for tax_field in FISCAL_TAX_ID_FIELDS:
+            tax_domain = tax_field[: -len("_tax_id")]
+            self.assertIn(tax_domain, TAX_VALUE_FIELDS)
+            self.assertIn(TAX_VALUE_FIELDS[tax_domain], line_fields)

--- a/l10n_br_nfe/tests/test_nfe_import.py
+++ b/l10n_br_nfe/tests/test_nfe_import.py
@@ -197,3 +197,31 @@ class NFeImportTest(TransactionCase):
 
     def test_import_out_nfe(self):
         "(can be useful after an ERP migration)"
+
+    def test_import_in_nfe_ipi_reaches_the_totals(self):
+        res_items = (
+            "nfe",
+            "samples",
+            "v4_0",
+            "leiauteNFe",
+            "35180834128745000152550010000474281920007498-nfe.xml",
+        )
+        resource_path = "/".join(res_items)
+        nfe_stream = pkg_resources.resource_stream(nfelib.__name__, resource_path)
+        xml = nfe_stream.read().decode()
+        ipi = (
+            "<IPI><cEnq>999</cEnq><IPITrib>"
+            "<CST>50</CST><vBC>50.60</vBC><pIPI>6.50</pIPI><vIPI>3.29</vIPI>"
+            "</IPITrib></IPI>"
+        )
+        xml = re.sub(r"<IPI>.*?</IPI>", ipi, xml, count=1, flags=re.S)
+
+        binding = TnfeProc.from_xml(xml)
+        nfe = self.env["l10n_br_fiscal.document"].import_binding_nfe(
+            binding, edoc_type="in", dry_run=False
+        )
+        line = nfe.fiscal_line_ids[0]
+        self.assertEqual(line.ipi_value, 3.29)
+        self.assertEqual(line.amount_tax_not_included, 3.29)
+        self.assertEqual(line.fiscal_amount_tax, 3.29)
+        self.assertEqual(line.amount_tax_included, 7.64)


### PR DESCRIPTION
Depende do #5034, do #4981 e do #4960: essa branch está empilhada nos três, e faço rebase quando entrarem.

Fatura de fornecedor criada a partir de XML nasce com quantidade 1 em toda linha. O `import_fiscal_document` percorre as linhas fiscais e grava CFOP, operação fiscal e o vínculo com a linha fiscal, e a quantidade nunca entra: fica no default do Odoo. `quantity` é campo sombreado na linha da fatura, não vem por `_inherits`, e o `create` da linha desvia assim que enxerga `fiscal_document_line_id` nos vals, então também não sincroniza.

O efeito é o pior tipo: o cabeçalho da fatura vem do documento fiscal e continua certo, e só a parcela do contas a pagar e as linhas de imposto denunciam. Medi numa nota de duas linhas de 10 unidades: o motor recalculou todo imposto sobre R$ 56,00 em vez de R$ 560,00, e o título saiu R$ 454,86 contra os R$ 596,40 da duplicata. A aritmética fecha e é a prova: o IPI de 3,64 é 6,5% de 56,00.

Junto sai o reforço posicional que existia no lugar: as unidades e os preços eram guardados numa lista e reaplicados depois do `save` por índice de `invoice_line_ids`, assumindo que a ordem da fatura é a da linha fiscal. Agora unidade, quantidade e preço são gravados dentro do `Form`, cada um na sua linha. E o `compute_all` do `l10n_br_account` passa a receber os valores de imposto do arquivo, pelo `_get_imported_tax_values` do `l10n_br_fiscal`: sem isso o imposto sai do nosso mapeamento e não do emitente, o que dava ICMS de 107,36 contra os 100,80 do XML.

Peguei isso conferindo o contas a pagar de nota importada. O teste importa a nota e cobra a quantidade e o subtotal da linha, e depois cobra a parcela do `payment_term` igual ao total tributado do documento fiscal, que é a asserção que pega qualquer divergência entre o fiscal e o financeiro. Tem também o caso do imposto casado com alíquota zero, um `ICMS NT` diante de um XML com ICMS de 12%, em que o valor do arquivo é o que vale. A 16.0 e a 17.0 têm o mesmo `import_fiscal_document`, e faço o backport se este entrar.
