### PR TITLE
[18.0][FIX] l10n_br_account: import the XML among the uploaded files

### DIFF
--- a/l10n_br_account/tests/__init__.py
+++ b/l10n_br_account/tests/__init__.py
@@ -1,5 +1,6 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+from . import test_document_import_wizard
 from . import test_tax_computation
 from . import test_account_move_sn
 from . import test_account_move_lc

--- a/l10n_br_account/tests/test_document_import_wizard.py
+++ b/l10n_br_account/tests/test_document_import_wizard.py
@@ -1,0 +1,64 @@
+# Copyright (C) 2026 - TODAY KMEE
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import base64
+from unittest.mock import patch
+
+from odoo.exceptions import UserError
+from odoo.tests import TransactionCase
+
+
+class TestDocumentImportWizardAttachments(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.wizard = cls.env["l10n_br_fiscal.document.import.wizard"]
+
+    def _attachment(self, name, mimetype):
+        return self.env["ir.attachment"].create(
+            {
+                "name": name,
+                "mimetype": mimetype,
+                "datas": base64.b64encode(b"whatever"),
+            }
+        )
+
+    def test_a_pdf_alone_is_refused_before_being_parsed(self):
+        danfe = self._attachment("Nota Fiscal Eletronica.pdf", "application/pdf")
+
+        with self.assertRaises(UserError) as error:
+            self.wizard._get_importer_action(danfe)
+
+        self.assertIn("Nota Fiscal Eletronica.pdf", str(error.exception))
+
+    def test_an_xml_is_recognized_by_its_extension(self):
+        attachment = self._attachment("nfe.XML", "application/octet-stream")
+
+        self.assertTrue(self.wizard._is_xml_attachment(attachment))
+
+    def test_an_xml_is_recognized_by_its_mimetype(self):
+        attachment = self._attachment("nfe", "text/xml")
+
+        self.assertTrue(self.wizard._is_xml_attachment(attachment))
+
+    def test_a_pdf_is_not_taken_for_an_xml(self):
+        attachment = self._attachment("danfe.pdf", "application/pdf")
+
+        self.assertFalse(self.wizard._is_xml_attachment(attachment))
+
+    def test_only_the_xml_attachments_are_linked_to_the_wizard(self):
+        """A DANFE uploaded next to the XML must not follow it into the import.
+
+        The selection of a bill often carries the PDF and the XML together, and
+        the ones that are not XML are left out of the queue the wizard walks.
+        """
+        xml = self._attachment("nfe.xml", "application/xml")
+        danfe = self._attachment("danfe.pdf", "application/pdf")
+
+        with patch.object(type(self.wizard), "_onchange_file", lambda self: None):
+            action = self.wizard._get_importer_action(xml | danfe)
+
+        self.assertEqual(action["res_model"], "l10n_br_fiscal.document.import.wizard")
+        self.assertEqual(xml.res_id, action["res_id"])
+        self.assertEqual(xml.res_model, "l10n_br_fiscal.document.import.wizard")
+        self.assertFalse(danfe.res_id)

--- a/l10n_br_account/wizards/document_import_wizard.py
+++ b/l10n_br_account/wizards/document_import_wizard.py
@@ -2,7 +2,12 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 
+import logging
+
 from odoo import fields, models
+from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
 
 
 class DocumentImportWizard(models.TransientModel):
@@ -92,20 +97,40 @@ class DocumentImportWizard(models.TransientModel):
                     "res_model": "account.move",
                 }
 
+    def _is_xml_attachment(self, attachment):
+        if attachment.mimetype in ("application/xml", "text/xml"):
+            return True
+        return (attachment.name or "").lower().endswith(".xml")
+
     def _get_importer_action(self, attachments, move_id=None):
         """
-        Try to parse the 1st file of the the attachments to
+        Try to parse the 1st XML of the attachments to
         detect its type and return the wizard import action.
-        Also mark the other attachments to be imported next.
+        Also mark the other XML attachments to be imported next.
         """
+        xml_attachments = attachments.filtered(self._is_xml_attachment)
+        if not xml_attachments:
+            raise UserError(
+                self.env._(
+                    "None of the uploaded files is an XML: %(names)s",
+                    names=", ".join(attachments.mapped("name")),
+                )
+            )
+        ignored_attachments = attachments - xml_attachments
+        if ignored_attachments:
+            _logger.info(
+                "Not importing the files that are not XML: %s",
+                ", ".join(ignored_attachments.mapped("name")),
+            )
+
         wizard = self.env["l10n_br_fiscal.document.import.wizard"].create(
             {
-                "file": attachments[0].datas,
+                "file": xml_attachments[0].datas,
                 "first_imported_move_id": self.first_imported_move_id or move_id,
             }
         )
 
-        for attachment in attachments:
+        for attachment in xml_attachments:
             # this link will allow to retrieve the next attachments to import:
             attachment.res_model = "l10n_br_fiscal.document.import.wizard"
             attachment.res_id = wizard.id


### PR DESCRIPTION
Selecionar o XML e o DANFE juntos e pedir a importação quebra quando o PDF vem primeiro. O `_get_importer_action` parseia `attachments[0]`, sem olhar o tipo, e a ordem dos anexos é a que o navegador mandou. Os outros anexos ficam marcados para importar em seguida, então o PDF também entra na fila e derruba a importação seguinte.

A correção escolhe o primeiro anexo que é XML, por `mimetype` ou pela extensão, e enfileira só os XMLs restantes. O que ficou de fora vira aviso no log com o nome de cada arquivo ignorado, em vez de erro: subir a nota e o DANFE na mesma leva é o hábito de quem recebe os dois por e-mail, e recusar a leva inteira por causa do PDF seria pior. Nenhum XML entre os anexos continua sendo erro, agora com mensagem dizendo o que se esperava.

Peguei isso importando nota de entrada com o XML e o DANFE selecionados de uma vez. O teste sobe um PDF antes do XML e cobra que a importação siga com o XML; outro sobe só PDF e cobra a mensagem. A 16.0 e a 17.0 têm o mesmo `_get_importer_action`, e faço o backport se este entrar.
