### PR TITLE
[18.0][IMP] l10n_br_fiscal: the CFOP in the tax rule

### DIFF
--- a/l10n_br_fiscal/models/cfop.py
+++ b/l10n_br_fiscal/models/cfop.py
@@ -46,6 +46,14 @@ class Cfop(models.Model):
         "ICMS Tax Substitution (Substituição Tributária).",
     )
 
+    tax_classification_id = fields.Many2one(
+        comodel_name="l10n_br_fiscal.tax.classification",
+        string="Tax Classification",
+        help="IBS/CBS tax classification of the operations of this CFOP. "
+        "Takes precedence over the one of the fiscal operation line and over "
+        "the one of the company.",
+    )
+
     cfop_inverse_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.cfop",
         string="Inverse CFOP",

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -323,6 +323,7 @@ class OperationLine(models.Model):
             city_taxation_code=city_taxation_code,
             national_taxation_code=national_taxation_code,
             service_type=service_type,
+            cfop=mapping_result["cfop"],
         ):
             self._build_mapping_result(mapping_result, tax_definition)
 
@@ -390,6 +391,7 @@ class OperationLine(models.Model):
             city_taxation_code=city_taxation_code,
             national_taxation_code=national_taxation_code,
             service_type=service_type,
+            cfop=mapping_result["cfop"],
         ):
             self._build_mapping_result(mapping_result, tax_definition)
 
@@ -407,6 +409,7 @@ class OperationLine(models.Model):
             city_taxation_code=city_taxation_code,
             national_taxation_code=national_taxation_code,
             service_type=service_type,
+            cfop=mapping_result["cfop"],
         ):
             self._build_mapping_result(mapping_result, tax_definition)
 
@@ -424,6 +427,7 @@ class OperationLine(models.Model):
             city_taxation_code=city_taxation_code,
             national_taxation_code=national_taxation_code,
             service_type=service_type,
+            cfop=mapping_result["cfop"],
         ):
             self._build_mapping_result(mapping_result, tax_definition)
 

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -203,7 +203,9 @@ class OperationLine(models.Model):
             cfop = self.cfop_export_id
         return cfop
 
-    def _get_tax_classification(self, company):
+    def _get_tax_classification(self, company, cfop=None):
+        if cfop and cfop.tax_classification_id:
+            return cfop.tax_classification_id
         if self.tax_classification_id:
             return self.tax_classification_id
         elif company.tax_classification_id:
@@ -309,7 +311,9 @@ class OperationLine(models.Model):
         mapping_result["cfop"] = self._get_cfop(company, partner)
 
         # Define Tax Classification
-        mapping_result["tax_classification"] = self._get_tax_classification(company)
+        mapping_result["tax_classification"] = self._get_tax_classification(
+            company, mapping_result["cfop"]
+        )
 
         # 1 Get Tax Defs from Company
         for tax_definition in company.tax_definition_ids.map_tax_definition(

--- a/l10n_br_fiscal/models/tax_definition.py
+++ b/l10n_br_fiscal/models/tax_definition.py
@@ -427,6 +427,7 @@ class TaxDefinition(models.Model):
         city_taxation_code=None,
         national_taxation_code=None,
         service_type=None,
+        cfop=None,
     ):
         """
         Filter and return tax definitions that match the given criteria.
@@ -444,6 +445,7 @@ class TaxDefinition(models.Model):
         - City taxation codes, allowing for no specific code.
         - Service types, allowing for no specific type.
         - Specific products, allowing for no specific product.
+        - CFOP, allowing for no specific CFOP, when the caller knows it.
 
         :param company: The company record (res.company) of the transaction.
         :param partner: The partner record (res.partner) of the transaction.
@@ -462,6 +464,9 @@ class TaxDefinition(models.Model):
             (l10n_br_fiscal.national.taxation.code).
         :param service_type: Optional Service Type record
             (l10n_br_fiscal.service.type).
+        :param cfop: Optional CFOP record (l10n_br_fiscal.cfop) of the
+            operation. When given, a definition bound to another CFOP is
+            skipped; when omitted, the CFOP is not part of the matching.
         :return: A recordset of matching
             l10n_br_fiscal.tax.definition.
         """
@@ -506,6 +511,13 @@ class TaxDefinition(models.Model):
             ("product_ids", "=", False),
             ("product_ids", "=", product.id),
         ]
+
+        if cfop:
+            domain += [
+                "|",
+                ("cfop_id", "=", False),
+                ("cfop_id", "=", cfop.id),
+            ]
 
         return self.search(domain)
 

--- a/l10n_br_fiscal/tests/test_operation.py
+++ b/l10n_br_fiscal/tests/test_operation.py
@@ -146,3 +146,76 @@ class TestOperation(TransactionCase):
         line = operation.line_definition(self.env.company, partner, product)
         self.assertTrue(line, "bonificação ficou sem linha de operação")
         self.assertEqual(line.cfop_internal_id.code, "5910")
+
+    def _map_kwargs(self, company, partner, product):
+        return {
+            "company": company,
+            "partner": partner,
+            "product": product,
+            "ncm": product.ncm_id,
+            "nbm": self.env["l10n_br_fiscal.nbm"],
+            "nbs": self.env["l10n_br_fiscal.nbs"],
+            "cest": self.env["l10n_br_fiscal.cest"],
+            "city_taxation_code": self.env["l10n_br_fiscal.city.taxation.code"],
+            "national_taxation_code": self.env["l10n_br_fiscal.national.taxation.code"],
+            "service_type": self.env["l10n_br_fiscal.service.type"],
+        }
+
+    def _tax_definition_for_cfop(self, operation_line, cfop, tax):
+        return self.env["l10n_br_fiscal.tax.definition"].create(
+            {
+                "fiscal_operation_line_id": operation_line.id,
+                "tax_group_id": tax.tax_group_id.id,
+                "custom_tax": True,
+                "tax_id": tax.id,
+                "cst_id": tax.cst_out_id.id,
+                "cfop_id": cfop.id,
+                "state": "approved",
+            }
+        )
+
+    def test_tax_definition_pinned_to_a_cfop_applies_only_there(self):
+        """A tax definition with a CFOP must not reach the other CFOPs.
+
+        The same Operation Line resolves the internal, the interstate and the
+        export CFOP, so pinning the definition to the CFOP is the only way to
+        tax an export apart from a domestic sale.
+        """
+        operation = self.env.ref("l10n_br_fiscal.fo_venda")
+        operation_line = self.env.ref("l10n_br_fiscal.fo_venda_venda")
+        company = self.env.company
+        company.country_id = self.env.ref("base.br")
+        company.state_id = self.env.ref("base.state_br_sp")
+        company.icms_regulation_id = self.env.ref("l10n_br_fiscal.tax_icms_regulation")
+        product = self.env.ref("product.product_product_1")
+        product.fiscal_type = "04"
+        product.ncm_id = self.env.ref("l10n_br_fiscal.ncm_48191000")
+
+        icms_nt = self.env.ref("l10n_br_fiscal.tax_icms_nt")
+        self._tax_definition_for_cfop(
+            operation_line, self.env.ref("l10n_br_fiscal.cfop_7101"), icms_nt
+        )
+
+        abroad = self.env.ref("l10n_br_base.res_partner_exterior")
+        abroad.ind_ie_dest = "1"
+        mapping = operation_line.map_fiscal_taxes(
+            **self._map_kwargs(company, abroad, product)
+        )
+        self.assertEqual(mapping["cfop"].code, "7101")
+        self.assertEqual(mapping["taxes"].get("icms"), icms_nt)
+
+        inland = self.env.ref("l10n_br_base.res_partner_akretion")
+        inland.state_id = self.env.ref("base.state_br_sp")
+        inland.ind_ie_dest = "1"
+        mapping = operation_line.map_fiscal_taxes(
+            **self._map_kwargs(company, inland, product)
+        )
+        self.assertEqual(mapping["cfop"].code, "5101")
+        self.assertNotEqual(
+            mapping["taxes"].get("icms"),
+            icms_nt,
+            "the definition of the export CFOP leaked into the domestic sale",
+        )
+        self.assertEqual(
+            operation.line_definition(company, abroad, product), operation_line
+        )

--- a/l10n_br_fiscal/tests/test_tax_classification.py
+++ b/l10n_br_fiscal/tests/test_tax_classification.py
@@ -109,3 +109,36 @@ class TestTaxClassification(TransactionCase):
             self.assertIn(
                 self.classification_company.tax_ibs_id, line_form.fiscal_tax_ids
             )
+
+    def test_map_fiscal_taxes_tax_classification_from_cfop(self):
+        """CFOP tax classification must override the line and the company.
+
+        The same Operation Line answers for the domestic sale and for the
+        export, and only the CFOP tells them apart: the export is immune to
+        IBS and CBS while the domestic sale is fully taxed.
+        """
+        self.company.tax_classification_id = self.classification_company
+        self.operation_line.tax_classification_id = self.classification_line
+        classification_export = self.env.ref("l10n_br_fiscal.tax_classification_410004")
+        self.env.ref(
+            "l10n_br_fiscal.cfop_7101"
+        ).tax_classification_id = classification_export
+
+        kwargs = self._map_kwargs()
+        kwargs["partner"] = self.env.ref("l10n_br_base.res_partner_exterior")
+        result = self.operation_line.map_fiscal_taxes(**kwargs)
+
+        self.assertEqual(result["cfop"].code, "7101")
+        self.assertEqual(result["tax_classification"], classification_export)
+        self.assertEqual(
+            result["taxes"][classification_export.tax_ibs_id.tax_domain],
+            classification_export.tax_ibs_id,
+        )
+        self.assertEqual(
+            result["taxes"][classification_export.tax_cbs_id.tax_domain],
+            classification_export.tax_cbs_id,
+        )
+
+        result = self.operation_line.map_fiscal_taxes(**self._map_kwargs())
+        self.assertEqual(result["cfop"].code, "5101")
+        self.assertEqual(result["tax_classification"], self.classification_line)

--- a/l10n_br_fiscal/views/cfop_view.xml
+++ b/l10n_br_fiscal/views/cfop_view.xml
@@ -109,6 +109,7 @@
                     </group>
                 </group>
                 <group name="tax_settings" string="Taxes Settings">
+                    <field name="tax_classification_id" colspan="2" />
                     <field
                         name="tax_definition_ids"
                         nolabel="1"


### PR DESCRIPTION
São dois commits e as duas metades do mesmo problema: o CFOP não pesa na regra de imposto nem na classificação tributária, e por isso uma linha de operação que atende o interno e o exterior entrega tributação de interno na exportação.

O `cfop_id` do `l10n_br_fiscal.tax.definition` só filtra em um dos quatro lugares de onde as definições vêm. O `map_fiscal_taxes` agrega definições da empresa, da linha de operação, do CFOP e do perfil do parceiro; a do CFOP funciona, porque o `tax_definition_ids` é o o2m inverso de `cfop_id` e por construção só traz as daquele CFOP. Nas outras três o `map_tax_definition` nem recebe o CFOP, então definição fixada num CFOP e pendurada na empresa, na linha de operação ou no perfil vale em todos. Medi numa base limpa com uma definição de `IPI NT` pendurada na linha de operação de venda e fixada no CFOP 7102: ela se aplicou tanto na saída interna, CFOP 5101, quanto na exportação, CFOP 7101, ou seja em dois CFOPs que não são o que ela nomeia. O docstring do modelo lista o CFOP entre as dimensões da regra e existe constraint de unicidade por CFOP, então o campo promete um filtro que não acontece.

O primeiro commit passa o CFOP que o `map_fiscal_taxes` já resolveu para dentro do `map_tax_definition` e acrescenta `('cfop_id', '=', False)` ou o CFOP da operação ao domínio, na mesma forma que `state_to_ids` e `ncm_ids` usam. Definição sem CFOP continua valendo em tudo, e o filtro só entra quando quem chama sabe o CFOP, então chamada externa sem CFOP mantém o comportamento de hoje. Base que já preenche `cfop_id` fora do o2m do CFOP muda de comportamento, e é o ponto: a definição passa a valer só no CFOP que ela nomeia.

Resolvido o imposto, sobra a classificação, e é o segundo commit. O `_get_tax_classification` cascateia da linha de operação para a empresa e nunca olha o CFOP. Como a mesma linha de operação atende o interno e o exterior, a exportação herda a classificação da empresa, na prática `000001`, tributada integralmente, e é dela que sai o `cClassTrib` do item. O resultado é a pior combinação possível a partir de 2026: com o imposto de IBS e CBS vindo imune pela definição do CFOP, o item vai pra SEFAZ com CST 410 e `cClassTrib` 000001, que é inconsistência declarada. A correção põe `tax_classification_id` no `l10n_br_fiscal.cfop` e faz a cascata ser CFOP, linha de operação e empresa, nessa ordem. Uma linha de operação só passa a resolver o interno e o exterior sem duplicar catálogo, que era a alternativa: criar operação fiscal separada de exportação e obrigar quem lança a escolher a certa. O campo fica na aba de impostos do CFOP, ao lado das definições que já moram lá.

Peguei os dois montando tributação de exportação, onde a mesma linha de operação resolve o 5101 interno e o 7101 do exterior. O teste do primeiro fixa uma definição de `ICMS NT` no 7101 pendurada na linha de operação e pede o mapeamento duas vezes: com parceiro no exterior ela casa, com parceiro em SP ela não casa, e antes da correção a segunda asserção falha. O do segundo põe `410004`, exportações de bens e serviços, no CFOP 7101, deixa `200001` na linha de operação e `000001` na empresa, e pede o mapeamento com parceiro no exterior: volta `410004` e os impostos de IBS e CBS da imunidade; repetindo com parceiro em SP volta a classificação da linha, provando que o CFOP não vazou. A 16.0, a 17.0 e a 19.0 têm o mesmo `map_tax_definition` sem o CFOP e a mesma cascata de dois níveis, e faço o backport e o forward-port se este entrar.
