### PR TITLE
[18.0][FIX] l10n_br_fiscal: foreign origins 6 and 7 and the is_import compute

### DIFF
--- a/l10n_br_fiscal/constants/icms.py
+++ b/l10n_br_fiscal/constants/icms.py
@@ -48,7 +48,7 @@ ICMS_ORIGIN = [
 ICMS_ORIGIN_DEFAULT = "0"
 
 
-ICMS_ORIGIN_TAX_IMPORTED = ["1", "2", "3", "8"]
+ICMS_ORIGIN_TAX_IMPORTED = ["1", "2", "3", "6", "7", "8"]
 
 
 ICMS_CST = ["00", "10", "20", "30", "40", "41", "50", "51", "60", "70", "90"]

--- a/l10n_br_fiscal/models/cfop.py
+++ b/l10n_br_fiscal/models/cfop.py
@@ -173,6 +173,7 @@ class Cfop(models.Model):
         string="Tax Definition",
     )
 
+    @api.depends("code")
     def _compute_is_import(self):
         for cfop in self:
             if cfop.code:

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -1,6 +1,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import (
+    test_cfop,
     test_cnae,
     test_fiscal_document_serie,
     test_fiscal_document_generic,

--- a/l10n_br_fiscal/tests/test_cfop.py
+++ b/l10n_br_fiscal/tests/test_cfop.py
@@ -1,0 +1,15 @@
+# Copyright 2026 KMEE
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestCfop(TransactionCase):
+    def test_is_import_follows_the_code(self):
+        """``is_import`` is a compute without depends, so it never refreshes."""
+        cfop = self.env.ref("l10n_br_fiscal.cfop_1101")
+        self.assertFalse(cfop.is_import)
+
+        cfop.invalidate_recordset()
+        cfop.code = "3101"
+        self.assertTrue(cfop.is_import)

--- a/l10n_br_fiscal/tests/test_fiscal_tax.py
+++ b/l10n_br_fiscal/tests/test_fiscal_tax.py
@@ -5,7 +5,7 @@ from odoo.tests import TransactionCase
 from odoo.tools import float_compare
 
 from ..constants.fiscal import FINAL_CUSTOMER_NO, FINAL_CUSTOMER_YES
-from ..constants.icms import ICMS_ORIGIN_DEFAULT
+from ..constants.icms import ICMS_ORIGIN_DEFAULT, ICMS_ORIGIN_TAX_IMPORTED
 from .tools import load_fiscal_fixture_files
 
 
@@ -380,3 +380,10 @@ class TestFiscalTax(TransactionCase):
         )
 
         self.assertEqual(compute_result["taxes"]["icms"]["cst_id"].code, "10")
+
+    def test_the_foreign_origins_without_similar_use_the_imported_estimate(self):
+        """Origins 6 and 7 are foreign and were missing from the list."""
+        self.assertIn("6", ICMS_ORIGIN_TAX_IMPORTED)
+        self.assertIn("7", ICMS_ORIGIN_TAX_IMPORTED)
+        self.assertNotIn("4", ICMS_ORIGIN_TAX_IMPORTED)
+        self.assertNotIn("5", ICMS_ORIGIN_TAX_IMPORTED)


### PR DESCRIPTION
Dois defeitos pequenos no mesmo assunto, origem estrangeira. O `ICMS_ORIGIN_TAX_IMPORTED` lista `1`, `2`, `3` e `8` e deixa de fora o `6` e o `7`, que também são estrangeiras: importação direta e adquirida no mercado interno, as duas sem similar nacional, constantes em lista da CAMEX. Quem vende produto de origem 6 ou 7 tem o tributo estimado calculado pela alíquota nacional do NCM em vez da de importado, e nada avisa. E o `is_import` do CFOP é compute sem `store` e sem `@api.depends`, do lado de um `_compute_destination` que tem: ele responde certo na primeira leitura e fica preso ao valor antigo quando o código do CFOP muda.

O primeiro é uma linha na lista de constantes. O segundo é o decorator que faltava, copiado do compute vizinho, que resolve o mesmo problema a partir do mesmo campo.

Peguei os dois montando nota de importação e de exportação: os produtos importados da base estão em origem 1 e 2, com uma lista de CAMEX ainda pra revisar, e mexer no código do CFOP na tela pra testar a trilha de importação não mudava o `is_import`. O teste do `is_import` troca o código do 1101 pra 3101 e cobra a resposta nova; o da lista de origens cobra o `6` e o `7` dentro dela e o `4` e o `5` fora, que são nacionais. A 16.0, a 17.0 e a 19.0 têm as duas coisas iguais, e faço o backport e o forward-port se este entrar.
