### PR TITLE
[18.0][IMP] l10n_br_nfe: keep the import declaration on a round trip

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -67,6 +67,9 @@ NFE_XML_NAMESPACE = {"nfe": "http://www.portalfiscal.inf.br/nfe"}
 _logger = logging.getLogger(__name__)
 
 
+CFOP_WITHOUT_IMPORT_DECLARATION = ("3201", "3202", "3503", "3553")
+
+
 def filter_processador_edoc_nfe(record):
     if record.processador_edoc == PROCESSADOR_OCA and record.document_type_id.code in [
         MODELO_FISCAL_NFE,
@@ -1201,6 +1204,32 @@ class NFe(spec_models.StackedModel):
                     " cannot be different from what is configured "
                     f"in the company: {company_nfe_environment}"
                 )
+            )
+
+    def _document_check(self):
+        for record in self.filtered(filter_processador_edoc_nfe):
+            record._check_import_declaration()
+        return super()._document_check()
+
+    def _check_import_declaration(self):
+        self.ensure_one()
+        lines = self.fiscal_line_ids.filtered(
+            lambda line: line.cfop_id.is_import
+            and line.cfop_id.code not in CFOP_WITHOUT_IMPORT_DECLARATION
+            and not line.nfe40_DI
+        )
+        if lines:
+            raise UserError(
+                _(
+                    "The import declaration is missing on the lines %(lines)s. "
+                    "SEFAZ rejects a NF-e whose CFOP starts with 3 and carries "
+                    "no DI group (rejection 525)."
+                )
+                % {
+                    "lines": ", ".join(
+                        line.name or line.product_id.display_name for line in lines
+                    )
+                }
             )
 
     def _document_export(self, pretty_print=True):

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -939,13 +939,23 @@ class NFeLine(spec_models.StackedModel):
     # Grupo P. Imposto de Importação
     ################################
 
-    # vBC TODO
-
     nfe40_vDespAdu = fields.Monetary(related="ii_customhouse_charges")
 
     nfe40_vII = fields.Monetary(related="ii_value")
 
     nfe40_vIOF = fields.Monetary(related="ii_iof_value", string="vIOF")
+
+    def _export_fields_nfe_40_ii(self, xsd_fields, class_obj, export_dict):
+        export_dict["vBC"] = self.ii_base
+
+    def _ii_percent_from_values(self, tax_binding, odoo_attrs):
+        base = float(getattr(tax_binding, "vBC", 0.0) or 0.0)
+        if not base:
+            return None
+        value = float(getattr(tax_binding, "vII", 0.0) or 0.0)
+        percent = round(value * 100 / base, 2)
+        odoo_attrs["ii_percent"] = percent
+        return percent
 
     ###############
     # NF-e tag: PIS
@@ -1541,6 +1551,8 @@ class NFeLine(spec_models.StackedModel):
         percent = map_binding_attr(
             f"p{kind.upper().replace('ST', '')}", f"{kind}_percent"
         )
+        if kind == "ii" and not percent:
+            percent = self._ii_percent_from_values(tax_binding, odoo_attrs)
         if kind in ("icms", "icmsufdest"):
             map_binding_attr("modBC", "icms_base_type")
             icms_percent_red = map_binding_attr("pRedBC", "icms_reduction")

--- a/l10n_br_nfe/models/nfe_di.py
+++ b/l10n_br_nfe/models/nfe_di.py
@@ -1,7 +1,9 @@
 # Copyright 2021 Akretion (Renato Lima <renato.lima@akretion.com>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from erpbrasil.base.misc import punctuation_rm
+
+from odoo import api, fields, models
 
 TPVIATRANSP_DI = [
     ("1", "1 - Maritima"),
@@ -35,10 +37,27 @@ class NFeDI(models.AbstractModel):
         domain=[("country_id.code", "=", "BR")],
     )
 
-    nfe40_UFDesemb = fields.Char(
-        related="state_clearance_id.code",
+    nfe40_UFDesemb = fields.Selection(
+        compute="_compute_nfe40_UFDesemb",
+        inverse="_inverse_nfe40_UFDesemb",
         string="Customs Clearance Code",
     )
+
+    @api.depends("state_clearance_id")
+    def _compute_nfe40_UFDesemb(self):
+        for record in self:
+            record.nfe40_UFDesemb = record.state_clearance_id.code
+
+    def _inverse_nfe40_UFDesemb(self):
+        state_model = self.env["res.country.state"]
+        for record in self:
+            record.state_clearance_id = record.nfe40_UFDesemb and state_model.search(
+                [
+                    ("country_id.code", "=", "BR"),
+                    ("code", "=", record.nfe40_UFDesemb),
+                ],
+                limit=1,
+            )
 
     nfe40_tpViaTransp = fields.Selection(
         selection=TPVIATRANSP_DI,
@@ -53,9 +72,42 @@ class NFeDI(models.AbstractModel):
     )
 
     nfe40_CNPJ = fields.Char(
-        related="partner_acquirer_id.nfe40_CNPJ",
+        compute="_compute_nfe40_acquirer",
+        inverse="_inverse_nfe40_acquirer",
     )
 
-    nfe40_UFTerceiro = fields.Char(
-        related="partner_acquirer_id.state_id.code",
+    nfe40_UFTerceiro = fields.Selection(
+        compute="_compute_nfe40_acquirer",
+        inverse="_inverse_nfe40_acquirer",
     )
+
+    @api.depends("partner_acquirer_id")
+    def _compute_nfe40_acquirer(self):
+        for record in self:
+            record.nfe40_CNPJ = record.partner_acquirer_id.nfe40_CNPJ
+            record.nfe40_UFTerceiro = record.partner_acquirer_id.state_id.code
+
+    def _inverse_nfe40_acquirer(self):
+        partner_model = self.env["res.partner"]
+        state_model = self.env["res.country.state"]
+        for record in self:
+            if record.nfe40_CNPJ and not record.partner_acquirer_id:
+                stripped = punctuation_rm(record.nfe40_CNPJ)
+                record.partner_acquirer_id = partner_model.search(
+                    ["|", ("cnpj_cpf_stripped", "=", stripped), ("vat", "=", stripped)],
+                    limit=1,
+                ) or partner_model.create(
+                    {
+                        "name": f"contato CNPJ {record.nfe40_CNPJ}",
+                        "is_company": True,
+                        "vat": stripped,
+                    }
+                )
+            if record.nfe40_UFTerceiro and not record.partner_acquirer_id.state_id:
+                record.partner_acquirer_id.state_id = state_model.search(
+                    [
+                        ("country_id.code", "=", "BR"),
+                        ("code", "=", record.nfe40_UFTerceiro),
+                    ],
+                    limit=1,
+                )

--- a/l10n_br_nfe/tests/__init__.py
+++ b/l10n_br_nfe/tests/__init__.py
@@ -12,3 +12,4 @@ from . import test_nfe_dfe
 from . import test_nfe_mde
 from . import test_nfe_danfe
 from . import test_nfe_ibscbs
+from . import test_nfe_import_declaration

--- a/l10n_br_nfe/tests/test_nfe_import_declaration.py
+++ b/l10n_br_nfe/tests/test_nfe_import_declaration.py
@@ -1,0 +1,168 @@
+# Copyright 2026 KMEE
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import importlib
+
+import nfelib
+from nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00 import TnfeProc
+
+from odoo.exceptions import UserError
+from odoo.tests import TransactionCase
+
+SAMPLE = (
+    "nfe",
+    "samples",
+    "v4_0",
+    "leiauteNFe",
+    "35180834128745000152550010000474281920007498-nfe.xml",
+)
+
+DECLARATION = (
+    "<DI>"
+    "<nDI>0000001</nDI><dDI>2026-08-01</dDI>"
+    "<xLocDesemb>Santos</xLocDesemb><UFDesemb>SP</UFDesemb>"
+    "<dDesemb>2026-08-05</dDesemb><tpViaTransp>1</tpViaTransp>"
+    "<tpIntermedio>2</tpIntermedio><CNPJ>11222333000181</CNPJ>"
+    "<UFTerceiro>SP</UFTerceiro><cExportador>EXP001</cExportador>"
+    "<adi><nAdicao>1</nAdicao><nSeqAdic>1</nSeqAdic>"
+    "<cFabricante>FAB001</cFabricante></adi>"
+    "<adi><nAdicao>2</nAdicao><nSeqAdic>2</nSeqAdic>"
+    "<cFabricante>FAB002</cFabricante></adi>"
+    "</DI>"
+)
+
+IMPORT_TAX = (
+    "<II><vBC>1000.00</vBC><vDespAdu>0.00</vDespAdu>"
+    "<vII>140.00</vII><vIOF>0.00</vIOF></II>"
+)
+
+
+class TestNFeImportDeclaration(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.acquirer = cls.env["res.partner"].create(
+            {
+                "name": "Adquirente da importação",
+                "is_company": True,
+                "vat": "11222333000181",
+                "country_id": cls.env.ref("base.br").id,
+                "state_id": cls.env.ref("base.state_br_sp").id,
+            }
+        )
+
+    def _sample_xml(self):
+        resource_path = "/".join(SAMPLE)
+        stream = importlib.resources.files(nfelib.__name__).joinpath(resource_path)
+        with stream.open("rb") as handle:
+            return handle.read().decode()
+
+    def test_the_declaration_keeps_the_customs_state_and_the_acquirer(self):
+        declaration = self.env["nfe.40.di"].create(
+            {
+                "nfe40_nDI": "0000001",
+                "nfe40_dDI": "2026-08-01",
+                "nfe40_xLocDesemb": "Santos",
+                "nfe40_UFDesemb": "SP",
+                "nfe40_dDesemb": "2026-08-05",
+                "nfe40_tpViaTransp": "1",
+                "nfe40_tpIntermedio": "2",
+                "nfe40_cExportador": "EXP001",
+                "nfe40_CNPJ": "11222333000181",
+            }
+        )
+        self.assertEqual(
+            declaration.state_clearance_id, self.env.ref("base.state_br_sp")
+        )
+        self.assertEqual(declaration.nfe40_UFDesemb, "SP")
+        self.assertEqual(declaration.partner_acquirer_id, self.acquirer)
+        self.assertEqual(declaration.nfe40_CNPJ, "11222333000181")
+
+    def test_the_imported_nfe_brings_the_declaration_and_the_import_tax(self):
+        xml = self._sample_xml()
+        xml = xml.replace("</indTot>", "</indTot>" + DECLARATION, 1)
+        xml = xml.replace("<PIS>", IMPORT_TAX + "<PIS>", 1)
+
+        document = self.env["l10n_br_fiscal.document"].import_binding_nfe(
+            TnfeProc.from_xml(xml), edoc_type="in", dry_run=False
+        )
+        line = document.fiscal_line_ids[0]
+
+        self.assertEqual(len(line.nfe40_DI), 1)
+        declaration = line.nfe40_DI
+        self.assertEqual(declaration.nfe40_nDI, "0000001")
+        self.assertEqual(declaration.nfe40_xLocDesemb, "Santos")
+        self.assertEqual(
+            declaration.state_clearance_id, self.env.ref("base.state_br_sp")
+        )
+        self.assertEqual(declaration.partner_acquirer_id, self.acquirer)
+        self.assertEqual(
+            declaration.partner_acquirer_id.state_id, self.env.ref("base.state_br_sp")
+        )
+        self.assertEqual(len(declaration.nfe40_adi), 2)
+        self.assertEqual(
+            declaration.nfe40_adi.mapped("nfe40_cFabricante"), ["FAB001", "FAB002"]
+        )
+
+        self.assertEqual(line.ii_base, 1000.0)
+        self.assertEqual(line.ii_value, 140.0)
+        self.assertEqual(line.ii_percent, 14.0)
+        self.assertEqual(line.ii_tax_id.percent_amount, 14.0)
+
+    def _import_document(self, cfop_ref):
+        company = self.env.ref("l10n_br_base.empresa_lucro_presumido")
+        document = self.env["l10n_br_fiscal.document"].create(
+            {
+                "company_id": company.id,
+                "partner_id": self.env.ref("l10n_br_base.res_partner_exterior").id,
+                "document_type_id": self.env.ref("l10n_br_fiscal.document_55").id,
+                "document_serie": "1",
+                "document_number": "910001",
+                "fiscal_operation_id": self.env.ref("l10n_br_fiscal.fo_compras").id,
+                "fiscal_operation_type": "in",
+            }
+        )
+        self.env["l10n_br_fiscal.document.line"].create(
+            {
+                "document_id": document.id,
+                "name": "Mercadoria importada",
+                "product_id": self.env.ref("product.product_product_7").id,
+                "quantity": 1,
+                "price_unit": 1000.0,
+                "fiscal_operation_type": "in",
+                "fiscal_operation_id": self.env.ref("l10n_br_fiscal.fo_compras").id,
+                "fiscal_operation_line_id": self.env.ref(
+                    "l10n_br_fiscal.fo_compras_compras"
+                ).id,
+                "cfop_id": self.env.ref(cfop_ref).id,
+            }
+        )
+        return document
+
+    def test_a_line_with_an_import_cfop_needs_the_declaration(self):
+        document = self._import_document("l10n_br_fiscal.cfop_3101")
+        with self.assertRaises(UserError) as error:
+            document._document_check()
+        self.assertIn("525", str(error.exception))
+
+        document.fiscal_line_ids[0].nfe40_DI = [
+            (
+                0,
+                0,
+                {
+                    "nfe40_nDI": "0000002",
+                    "nfe40_dDI": "2026-08-01",
+                    "nfe40_xLocDesemb": "Santos",
+                    "nfe40_UFDesemb": "SP",
+                    "nfe40_dDesemb": "2026-08-05",
+                    "nfe40_tpViaTransp": "1",
+                    "nfe40_tpIntermedio": "1",
+                    "nfe40_cExportador": "EXP002",
+                },
+            )
+        ]
+        self.assertTrue(document._document_check())
+
+    def test_the_returned_import_cfops_do_not_need_the_declaration(self):
+        document = self._import_document("l10n_br_fiscal.cfop_3201")
+        self.assertTrue(document._document_check())

--- a/l10n_br_nfe/views/nfe_di_view.xml
+++ b/l10n_br_nfe/views/nfe_di_view.xml
@@ -30,6 +30,7 @@
                         <field name="nfe40_tpIntermedio" />
                         <field name="partner_acquirer_id" />
                         <field name="nfe40_CNPJ" invisible="1" />
+                        <field name="nfe40_CPF" invisible="1" />
                         <field name="nfe40_UFTerceiro" invisible="1" />
                         <field name="nfe40_cExportador" />
                         <field name="nfe40_vAFRMM" />


### PR DESCRIPTION
Importar XML de NF-e de importação perde três campos da declaração de importação sem avisar. O `nfe40_UFDesemb`, o `nfe40_CNPJ` e o `nfe40_UFTerceiro` do `nfe.40.di` são `related` sem `inverse`, e `related` sem `inverse` escreve na ponta da corrente: com `state_clearance_id` e `partner_acquirer_id` vazios, que é o estado de uma DI que acabou de nascer do arquivo, a escrita não tem onde cair e o valor simplesmente evapora. A UF de desembaraço e o CNPJ do adquirente estão no XML e não chegam ao banco. Junto vinha o `vBC` do grupo `II`, que saía zero na emissão porque o grupo não tem campo próprio pra ele: `vBC` já é nome do ICMS depois que a linha da NF-e é achatada.

Os três viraram `compute` com `inverse`, no mesmo padrão que o `res.partner` do módulo já usa pro `nfe40_CNPJ`, e mantendo o tipo do spec: o `UFDesemb` e o `UFTerceiro` são `Selection` de UF e estavam retipados pra `Char`. O inverso do CNPJ reaproveita o `match_or_create_m2o` do parceiro, que já sabe casar por CNPJ e criar quando não acha, e um inverso só atende os dois campos do adquirente pra não depender da ordem em que o `write` processa as chaves. O `vBC` do `II` sai por `_export_fields_nfe_40_ii`, no mesmo molde do IPI, e a alíquota do imposto de importação passa a ser derivada de `vII` sobre `vBC` na volta: o grupo `II` não tem `pII` no schema, então a busca de imposto casava o primeiro II do catálogo, sem olhar alíquota.

A validação que faltava é a da rejeição 525: CFOP iniciando por 3, com `idDest` 3 e `tpNF` 0, exige o grupo DI, e a regra não vale pros CFOPs 3201, 3202, 3503 e 3553. Hoje nada checa e a nota só é recusada na transmissão. Peguei isso montando entrada de mercadoria vinda do exterior. Os testes criam uma DI escrevendo a UF e o CNPJ como o importador escreve e cobram o estado e o parceiro resolvidos; importam um XML com DI de duas adições e `II` de 14% e cobram a DI, as adições, os valores e a alíquota derivada; e mandam `_document_check` num documento de CFOP 3101 sem DI, que estoura citando a 525, e num de 3201, que passa. A 16.0 e a 17.0 têm o mesmo `nfe_di.py` e o mesmo `# TODO` no grupo I01, e faço o backport se este entrar; na 19.0 o `l10n_br_nfe` ainda não foi migrado.
