### PR TITLE
[18.0][IMP] l10n_br_nfe: the import and export groups

### DIFF
--- a/l10n_br_nfe/__manifest__.py
+++ b/l10n_br_nfe/__manifest__.py
@@ -30,6 +30,7 @@
         "views/nfe_document_view.xml",
         "views/nfe_document_line_view.xml",
         "views/nfe_di_view.xml",
+        "views/nfe_detexport_view.xml",
         "views/res_config_settings_view.xml",
         "views/mde/mde_views.xml",
         "views/dfe/dfe_views.xml",

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -30,6 +30,7 @@ from odoo.addons.l10n_br_fiscal.constants.fiscal import (
     CANCELADO,
     CANCELADO_DENTRO_PRAZO,
     CANCELADO_FORA_PRAZO,
+    CFOP_DESTINATION_EXPORT,
     DENEGADO,
     DOCUMENT_ISSUER_COMPANY,
     DOCUMENT_STATE_CANCEL,
@@ -38,6 +39,7 @@ from odoo.addons.l10n_br_fiscal.constants.fiscal import (
     EVENT_ENV_HML,
     EVENT_ENV_PROD,
     EVENTO_RECEBIDO,
+    FISCAL_OUT,
     LOTE_PROCESSADO,
     MODELO_FISCAL_NFCE,
     MODELO_FISCAL_NFE,
@@ -78,6 +80,8 @@ _logger = logging.getLogger(__name__)
 
 
 CFOP_WITHOUT_IMPORT_DECLARATION = ("3201", "3202", "3503", "3553")
+
+CFOP_INDIRECT_EXPORT = ("7501", "3503")
 
 
 def filter_processador_edoc_nfe(record):
@@ -1222,6 +1226,7 @@ class NFe(spec_models.StackedModel):
     def _document_check(self):
         for record in self.filtered(filter_processador_edoc_nfe):
             record._check_import_declaration()
+            record._check_export_detail()
         return super()._document_check()
 
     def _check_import_declaration(self):
@@ -1238,12 +1243,64 @@ class NFe(spec_models.StackedModel):
                     "SEFAZ rejects a NF-e whose CFOP starts with 3 and carries "
                     "no DI group (rejection 525)."
                 )
-                % {
-                    "lines": ", ".join(
-                        line.name or line.product_id.display_name for line in lines
-                    )
-                }
+                % {"lines": self._line_names(lines)}
             )
+
+    def _export_lines(self):
+        return self.fiscal_line_ids.filtered(
+            lambda line: line.cfop_id.destination == CFOP_DESTINATION_EXPORT
+            and line.cfop_id.type_in_out == FISCAL_OUT
+        )
+
+    def _check_export_detail(self):
+        self.ensure_one()
+        export_lines = self._export_lines()
+        shipping_place = self.nfe40_UFSaidaPais or self.nfe40_xLocExporta
+
+        if export_lines and not (self.nfe40_UFSaidaPais and self.nfe40_xLocExporta):
+            raise UserError(
+                _(
+                    "An export needs the state and the place of shipment, "
+                    "because SEFAZ requires the whole exporta group."
+                )
+            )
+
+        if shipping_place and not export_lines:
+            raise UserError(
+                _(
+                    "The place of shipment is only for an export, and no line "
+                    "of this document carries an export CFOP (rejection 356)."
+                )
+            )
+
+        misplaced = self.fiscal_line_ids.filtered(
+            lambda line: line.nfe40_detExport
+            and line.cfop_id.destination != CFOP_DESTINATION_EXPORT
+        )
+        if misplaced:
+            raise UserError(
+                _(
+                    "The export detail is only for an export CFOP, and the "
+                    "lines %(lines)s carry another one (rejection 336)."
+                )
+                % {"lines": self._line_names(misplaced)}
+            )
+
+        indirect = self.fiscal_line_ids.filtered(
+            lambda line: line.cfop_id.code in CFOP_INDIRECT_EXPORT
+            and not line.nfe40_detExport.filtered("nfe40_exportInd")
+        )
+        if indirect:
+            raise UserError(
+                _(
+                    "An indirect export needs the export registration on the "
+                    "lines %(lines)s (rejection 340)."
+                )
+                % {"lines": self._line_names(indirect)}
+            )
+
+    def _line_names(self, lines):
+        return ", ".join(line.name or line.product_id.display_name for line in lines)
 
     def _document_export(self, pretty_print=True):
         result = super()._document_export()

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -77,6 +77,9 @@ NFE_XML_NAMESPACE = {"nfe": "http://www.portalfiscal.inf.br/nfe"}
 _logger = logging.getLogger(__name__)
 
 
+CFOP_WITHOUT_IMPORT_DECLARATION = ("3201", "3202", "3503", "3553")
+
+
 def filter_processador_edoc_nfe(record):
     if record.processador_edoc == PROCESSADOR_OCA and record.document_type_id.code in [
         MODELO_FISCAL_NFE,
@@ -1214,6 +1217,32 @@ class NFe(spec_models.StackedModel):
                     " cannot be different from what is configured "
                     f"in the company: {company_nfe_environment}"
                 )
+            )
+
+    def _document_check(self):
+        for record in self.filtered(filter_processador_edoc_nfe):
+            record._check_import_declaration()
+        return super()._document_check()
+
+    def _check_import_declaration(self):
+        self.ensure_one()
+        lines = self.fiscal_line_ids.filtered(
+            lambda line: line.cfop_id.is_import
+            and line.cfop_id.code not in CFOP_WITHOUT_IMPORT_DECLARATION
+            and not line.nfe40_DI
+        )
+        if lines:
+            raise UserError(
+                _(
+                    "The import declaration is missing on the lines %(lines)s. "
+                    "SEFAZ rejects a NF-e whose CFOP starts with 3 and carries "
+                    "no DI group (rejection 525)."
+                )
+                % {
+                    "lines": ", ".join(
+                        line.name or line.product_id.display_name for line in lines
+                    )
+                }
             )
 
     def _document_export(self, pretty_print=True):

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -9,6 +9,7 @@ from enum import Enum
 from nfelib.nfe.bindings.v4_0.dfe_tipos_basicos_v1_00 import Tcibs, TtribNfe
 
 from odoo import _, api, fields
+from odoo.exceptions import UserError
 
 from odoo.addons.l10n_br_fiscal.constants.fiscal import (
     CFOP_DESTINATION_EXTERNAL,
@@ -782,6 +783,19 @@ class NFeLine(spec_models.StackedModel):
         # TODO Not Implemented
         if "nfe40_ICMSST" in xsd_fields:
             xsd_fields.remove("nfe40_ICMSST")
+
+        if not self.nfe40_choice_icms:
+            raise UserError(
+                _(
+                    "The line %(line)s has no ICMS CST, so its ICMS group "
+                    "cannot be built. Review the tax definition of the fiscal "
+                    "operation for the CFOP %(cfop)s."
+                )
+                % {
+                    "line": self.name or self.product_id.display_name,
+                    "cfop": self.cfop_id.code or "",
+                }
+            )
 
         xsd_fields = [self.nfe40_choice_icms]
         icms_tag = (

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -939,13 +939,23 @@ class NFeLine(spec_models.StackedModel):
     # Grupo P. Imposto de Importação
     ################################
 
-    # vBC TODO
-
     nfe40_vDespAdu = fields.Monetary(related="ii_customhouse_charges")
 
     nfe40_vII = fields.Monetary(related="ii_value")
 
     nfe40_vIOF = fields.Monetary(related="ii_iof_value", string="vIOF")
+
+    def _export_fields_nfe_40_ii(self, xsd_fields, class_obj, export_dict):
+        export_dict["vBC"] = self.ii_base
+
+    def _ii_percent_from_values(self, tax_binding, odoo_attrs):
+        base = float(getattr(tax_binding, "vBC", 0.0) or 0.0)
+        if not base:
+            return None
+        value = float(getattr(tax_binding, "vII", 0.0) or 0.0)
+        percent = round(value * 100 / base, 2)
+        odoo_attrs["ii_percent"] = percent
+        return percent
 
     ###############
     # NF-e tag: PIS
@@ -1541,6 +1551,8 @@ class NFeLine(spec_models.StackedModel):
         percent = map_binding_attr(
             f"p{kind.upper().replace('ST', '')}", f"{kind}_percent"
         )
+        if kind == "ii" and not percent:
+            percent = self._ii_percent_from_values(tax_binding, odoo_attrs)
         if kind in ("icms", "icmsufdest"):
             map_binding_attr("modBC", "icms_base_type")
             icms_percent_red = map_binding_attr("pRedBC", "icms_reduction")

--- a/l10n_br_nfe/models/nfe_di.py
+++ b/l10n_br_nfe/models/nfe_di.py
@@ -1,7 +1,9 @@
 # Copyright 2021 Akretion (Renato Lima <renato.lima@akretion.com>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from erpbrasil.base.misc import punctuation_rm
+
+from odoo import api, fields, models
 
 TPVIATRANSP_DI = [
     ("1", "1 - Maritima"),
@@ -35,10 +37,27 @@ class NFeDI(models.AbstractModel):
         domain=[("country_id.code", "=", "BR")],
     )
 
-    nfe40_UFDesemb = fields.Char(
-        related="state_clearance_id.code",
+    nfe40_UFDesemb = fields.Selection(
+        compute="_compute_nfe40_UFDesemb",
+        inverse="_inverse_nfe40_UFDesemb",
         string="Customs Clearance Code",
     )
+
+    @api.depends("state_clearance_id")
+    def _compute_nfe40_UFDesemb(self):
+        for record in self:
+            record.nfe40_UFDesemb = record.state_clearance_id.code
+
+    def _inverse_nfe40_UFDesemb(self):
+        state_model = self.env["res.country.state"]
+        for record in self:
+            record.state_clearance_id = record.nfe40_UFDesemb and state_model.search(
+                [
+                    ("country_id.code", "=", "BR"),
+                    ("code", "=", record.nfe40_UFDesemb),
+                ],
+                limit=1,
+            )
 
     nfe40_tpViaTransp = fields.Selection(
         selection=TPVIATRANSP_DI,
@@ -53,9 +72,42 @@ class NFeDI(models.AbstractModel):
     )
 
     nfe40_CNPJ = fields.Char(
-        related="partner_acquirer_id.nfe40_CNPJ",
+        compute="_compute_nfe40_acquirer",
+        inverse="_inverse_nfe40_acquirer",
     )
 
-    nfe40_UFTerceiro = fields.Char(
-        related="partner_acquirer_id.state_id.code",
+    nfe40_UFTerceiro = fields.Selection(
+        compute="_compute_nfe40_acquirer",
+        inverse="_inverse_nfe40_acquirer",
     )
+
+    @api.depends("partner_acquirer_id")
+    def _compute_nfe40_acquirer(self):
+        for record in self:
+            record.nfe40_CNPJ = record.partner_acquirer_id.nfe40_CNPJ
+            record.nfe40_UFTerceiro = record.partner_acquirer_id.state_id.code
+
+    def _inverse_nfe40_acquirer(self):
+        partner_model = self.env["res.partner"]
+        state_model = self.env["res.country.state"]
+        for record in self:
+            if record.nfe40_CNPJ and not record.partner_acquirer_id:
+                stripped = punctuation_rm(record.nfe40_CNPJ)
+                record.partner_acquirer_id = partner_model.search(
+                    ["|", ("cnpj_cpf_stripped", "=", stripped), ("vat", "=", stripped)],
+                    limit=1,
+                ) or partner_model.create(
+                    {
+                        "name": f"contato CNPJ {record.nfe40_CNPJ}",
+                        "is_company": True,
+                        "vat": stripped,
+                    }
+                )
+            if record.nfe40_UFTerceiro and not record.partner_acquirer_id.state_id:
+                record.partner_acquirer_id.state_id = state_model.search(
+                    [
+                        ("country_id.code", "=", "BR"),
+                        ("code", "=", record.nfe40_UFTerceiro),
+                    ],
+                    limit=1,
+                )

--- a/l10n_br_nfe/tests/__init__.py
+++ b/l10n_br_nfe/tests/__init__.py
@@ -14,3 +14,4 @@ from . import test_nfe_danfe
 from . import test_nfe_ibscbs
 from . import test_nfe_workflow
 from . import test_nfe_import_declaration
+from . import test_nfe_export_detail

--- a/l10n_br_nfe/tests/__init__.py
+++ b/l10n_br_nfe/tests/__init__.py
@@ -13,3 +13,4 @@ from . import test_nfe_mde
 from . import test_nfe_danfe
 from . import test_nfe_ibscbs
 from . import test_nfe_workflow
+from . import test_nfe_import_declaration

--- a/l10n_br_nfe/tests/test_nfe_export_detail.py
+++ b/l10n_br_nfe/tests/test_nfe_export_detail.py
@@ -1,0 +1,168 @@
+# Copyright 2026 KMEE
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import base64
+
+from odoo import Command
+from odoo.exceptions import UserError
+from odoo.tests import TransactionCase
+
+
+class TestNFeExportDetail(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.company = cls.env.ref("l10n_br_base.empresa_lucro_presumido")
+        cls.env.user.company_ids += cls.company
+        cls.env.user.company_id = cls.company
+        cls.env = cls.env(
+            context=dict(cls.env.context, allowed_company_ids=[cls.company.id])
+        )
+        cls.abroad = cls.env["res.partner"].create(
+            {
+                "name": "Cliente do exterior",
+                "is_company": True,
+                "country_id": cls.env.ref("base.es").id,
+                "city": "Gijon",
+                "street_name": "Poligono de Roces",
+                "street_number": "36",
+                "district": "Roces",
+                "zip": "33211",
+            }
+        )
+        cls.inland = cls.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        cls.product = cls.env.ref("product.product_product_7")
+        cls.document_type = cls.env.ref("l10n_br_fiscal.document_55")
+        cls._define_tax("tax_group_icms", "tax_icms_nt", "cst_icms_41")
+        cls._define_tax("tax_group_ipi", "tax_ipi_nt", "cst_ipi_53")
+
+    @classmethod
+    def _define_tax(cls, tax_group, tax, cst):
+        cls.env["l10n_br_fiscal.tax.definition"].create(
+            {
+                "fiscal_operation_line_id": cls.env.ref(
+                    "l10n_br_fiscal.fo_venda_venda"
+                ).id,
+                "tax_group_id": cls.env.ref(f"l10n_br_fiscal.{tax_group}").id,
+                "custom_tax": True,
+                "tax_id": cls.env.ref(f"l10n_br_fiscal.{tax}").id,
+                "cst_id": cls.env.ref(f"l10n_br_fiscal.{cst}").id,
+                "state": "approved",
+            }
+        )
+
+    def _document(self, partner, cfop_ref, number, **values):
+        document = self.env["l10n_br_fiscal.document"].create(
+            {
+                "company_id": self.company.id,
+                "partner_id": partner.id,
+                "document_type_id": self.document_type.id,
+                "document_serie": "1",
+                "document_number": number,
+                "fiscal_operation_id": self.env.ref("l10n_br_fiscal.fo_venda").id,
+                "fiscal_operation_type": "out",
+                **values,
+            }
+        )
+        line = self.env["l10n_br_fiscal.document.line"].create(
+            {
+                "document_id": document.id,
+                "name": "Mercadoria exportada",
+                "product_id": self.product.id,
+                "quantity": 2,
+                "price_unit": 5000.0,
+                "fiscal_operation_type": "out",
+                "fiscal_operation_id": self.env.ref("l10n_br_fiscal.fo_venda").id,
+                "fiscal_operation_line_id": self.env.ref(
+                    "l10n_br_fiscal.fo_venda_venda"
+                ).id,
+                "cfop_id": self.env.ref(cfop_ref).id,
+            }
+        )
+        return document, line
+
+    def test_an_export_needs_the_place_of_shipment(self):
+        document, _line = self._document(
+            self.abroad, "l10n_br_fiscal.cfop_7101", "910001"
+        )
+        with self.assertRaises(UserError) as error:
+            document._document_check()
+        self.assertIn("place of shipment", str(error.exception))
+
+        document.write({"nfe40_UFSaidaPais": "SP", "nfe40_xLocExporta": "Santos"})
+        self.assertTrue(document._document_check())
+
+    def test_the_place_of_shipment_is_only_for_an_export(self):
+        document, _line = self._document(
+            self.inland,
+            "l10n_br_fiscal.cfop_5101",
+            "910002",
+            nfe40_UFSaidaPais="SP",
+            nfe40_xLocExporta="Santos",
+        )
+        with self.assertRaises(UserError) as error:
+            document._document_check()
+        self.assertIn("356", str(error.exception))
+
+    def test_the_export_detail_is_only_for_an_export_cfop(self):
+        document, line = self._document(
+            self.inland, "l10n_br_fiscal.cfop_5101", "910003"
+        )
+        line.nfe40_detExport = [Command.create({"nfe40_nDraw": "12345678901"})]
+        with self.assertRaises(UserError) as error:
+            document._document_check()
+        self.assertIn("336", str(error.exception))
+
+    def test_an_indirect_export_needs_the_export_registration(self):
+        document, line = self._document(
+            self.abroad,
+            "l10n_br_fiscal.cfop_7501",
+            "910004",
+            nfe40_UFSaidaPais="SP",
+            nfe40_xLocExporta="Santos",
+        )
+        with self.assertRaises(UserError) as error:
+            document._document_check()
+        self.assertIn("340", str(error.exception))
+
+        line.nfe40_detExport = [
+            Command.create(
+                {
+                    "nfe40_exportInd": self.env["nfe.40.exportind"]
+                    .create(
+                        {
+                            "nfe40_nRE": "12345678901",
+                            "nfe40_chNFe": "3" * 44,
+                            "nfe40_qExport": 2,
+                        }
+                    )
+                    .id
+                }
+            )
+        ]
+        self.assertTrue(document._document_check())
+
+    def test_the_nfe_of_an_export_carries_the_shipping_place(self):
+        document, line = self._document(
+            self.abroad,
+            "l10n_br_fiscal.cfop_7101",
+            "910005",
+            nfe40_UFSaidaPais="SP",
+            nfe40_xLocExporta="Santos",
+        )
+        line.nfe40_detExport = [Command.create({"nfe40_nDraw": "12345678901"})]
+        document.nfe40_detPag = [
+            Command.create({"nfe40_tPag": "90", "nfe40_vPag": 0.0})
+        ]
+
+        document.action_document_confirm()
+        document.with_context(force_product_lang="en_US")._document_export()
+
+        self.assertFalse(document.xml_error_message)
+        xml = base64.b64decode(document.send_file_id.datas).decode()
+        self.assertEqual(line.cfop_id.code, "7101")
+        self.assertIn("<UFSaidaPais>SP</UFSaidaPais>", xml)
+        self.assertIn("<xLocExporta>Santos</xLocExporta>", xml)
+        self.assertIn("<nDraw>12345678901</nDraw>", xml)
+        self.assertIn("<idDest>3</idDest>", xml)

--- a/l10n_br_nfe/tests/test_nfe_import_declaration.py
+++ b/l10n_br_nfe/tests/test_nfe_import_declaration.py
@@ -1,0 +1,168 @@
+# Copyright 2026 KMEE
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import importlib
+
+import nfelib
+from nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00 import TnfeProc
+
+from odoo.exceptions import UserError
+from odoo.tests import TransactionCase
+
+SAMPLE = (
+    "nfe",
+    "samples",
+    "v4_0",
+    "leiauteNFe",
+    "35180834128745000152550010000474281920007498-nfe.xml",
+)
+
+DECLARATION = (
+    "<DI>"
+    "<nDI>0000001</nDI><dDI>2026-08-01</dDI>"
+    "<xLocDesemb>Santos</xLocDesemb><UFDesemb>SP</UFDesemb>"
+    "<dDesemb>2026-08-05</dDesemb><tpViaTransp>1</tpViaTransp>"
+    "<tpIntermedio>2</tpIntermedio><CNPJ>11222333000181</CNPJ>"
+    "<UFTerceiro>SP</UFTerceiro><cExportador>EXP001</cExportador>"
+    "<adi><nAdicao>1</nAdicao><nSeqAdic>1</nSeqAdic>"
+    "<cFabricante>FAB001</cFabricante></adi>"
+    "<adi><nAdicao>2</nAdicao><nSeqAdic>2</nSeqAdic>"
+    "<cFabricante>FAB002</cFabricante></adi>"
+    "</DI>"
+)
+
+IMPORT_TAX = (
+    "<II><vBC>1000.00</vBC><vDespAdu>0.00</vDespAdu>"
+    "<vII>140.00</vII><vIOF>0.00</vIOF></II>"
+)
+
+
+class TestNFeImportDeclaration(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.acquirer = cls.env["res.partner"].create(
+            {
+                "name": "Adquirente da importação",
+                "is_company": True,
+                "vat": "11222333000181",
+                "country_id": cls.env.ref("base.br").id,
+                "state_id": cls.env.ref("base.state_br_sp").id,
+            }
+        )
+
+    def _sample_xml(self):
+        resource_path = "/".join(SAMPLE)
+        stream = importlib.resources.files(nfelib.__name__).joinpath(resource_path)
+        with stream.open("rb") as handle:
+            return handle.read().decode()
+
+    def test_the_declaration_keeps_the_customs_state_and_the_acquirer(self):
+        declaration = self.env["nfe.40.di"].create(
+            {
+                "nfe40_nDI": "0000001",
+                "nfe40_dDI": "2026-08-01",
+                "nfe40_xLocDesemb": "Santos",
+                "nfe40_UFDesemb": "SP",
+                "nfe40_dDesemb": "2026-08-05",
+                "nfe40_tpViaTransp": "1",
+                "nfe40_tpIntermedio": "2",
+                "nfe40_cExportador": "EXP001",
+                "nfe40_CNPJ": "11222333000181",
+            }
+        )
+        self.assertEqual(
+            declaration.state_clearance_id, self.env.ref("base.state_br_sp")
+        )
+        self.assertEqual(declaration.nfe40_UFDesemb, "SP")
+        self.assertEqual(declaration.partner_acquirer_id, self.acquirer)
+        self.assertEqual(declaration.nfe40_CNPJ, "11222333000181")
+
+    def test_the_imported_nfe_brings_the_declaration_and_the_import_tax(self):
+        xml = self._sample_xml()
+        xml = xml.replace("</indTot>", "</indTot>" + DECLARATION, 1)
+        xml = xml.replace("<PIS>", IMPORT_TAX + "<PIS>", 1)
+
+        document = self.env["l10n_br_fiscal.document"].import_binding_nfe(
+            TnfeProc.from_xml(xml), edoc_type="in", dry_run=False
+        )
+        line = document.fiscal_line_ids[0]
+
+        self.assertEqual(len(line.nfe40_DI), 1)
+        declaration = line.nfe40_DI
+        self.assertEqual(declaration.nfe40_nDI, "0000001")
+        self.assertEqual(declaration.nfe40_xLocDesemb, "Santos")
+        self.assertEqual(
+            declaration.state_clearance_id, self.env.ref("base.state_br_sp")
+        )
+        self.assertEqual(declaration.partner_acquirer_id, self.acquirer)
+        self.assertEqual(
+            declaration.partner_acquirer_id.state_id, self.env.ref("base.state_br_sp")
+        )
+        self.assertEqual(len(declaration.nfe40_adi), 2)
+        self.assertEqual(
+            declaration.nfe40_adi.mapped("nfe40_cFabricante"), ["FAB001", "FAB002"]
+        )
+
+        self.assertEqual(line.ii_base, 1000.0)
+        self.assertEqual(line.ii_value, 140.0)
+        self.assertEqual(line.ii_percent, 14.0)
+        self.assertEqual(line.ii_tax_id.percent_amount, 14.0)
+
+    def _import_document(self, cfop_ref):
+        company = self.env.ref("l10n_br_base.empresa_lucro_presumido")
+        document = self.env["l10n_br_fiscal.document"].create(
+            {
+                "company_id": company.id,
+                "partner_id": self.env.ref("l10n_br_base.res_partner_exterior").id,
+                "document_type_id": self.env.ref("l10n_br_fiscal.document_55").id,
+                "document_serie": "1",
+                "document_number": "910001",
+                "fiscal_operation_id": self.env.ref("l10n_br_fiscal.fo_compras").id,
+                "fiscal_operation_type": "in",
+            }
+        )
+        self.env["l10n_br_fiscal.document.line"].create(
+            {
+                "document_id": document.id,
+                "name": "Mercadoria importada",
+                "product_id": self.env.ref("product.product_product_7").id,
+                "quantity": 1,
+                "price_unit": 1000.0,
+                "fiscal_operation_type": "in",
+                "fiscal_operation_id": self.env.ref("l10n_br_fiscal.fo_compras").id,
+                "fiscal_operation_line_id": self.env.ref(
+                    "l10n_br_fiscal.fo_compras_compras"
+                ).id,
+                "cfop_id": self.env.ref(cfop_ref).id,
+            }
+        )
+        return document
+
+    def test_a_line_with_an_import_cfop_needs_the_declaration(self):
+        document = self._import_document("l10n_br_fiscal.cfop_3101")
+        with self.assertRaises(UserError) as error:
+            document._document_check()
+        self.assertIn("525", str(error.exception))
+
+        document.fiscal_line_ids[0].nfe40_DI = [
+            (
+                0,
+                0,
+                {
+                    "nfe40_nDI": "0000002",
+                    "nfe40_dDI": "2026-08-01",
+                    "nfe40_xLocDesemb": "Santos",
+                    "nfe40_UFDesemb": "SP",
+                    "nfe40_dDesemb": "2026-08-05",
+                    "nfe40_tpViaTransp": "1",
+                    "nfe40_tpIntermedio": "1",
+                    "nfe40_cExportador": "EXP002",
+                },
+            )
+        ]
+        self.assertTrue(document._document_check())
+
+    def test_the_returned_import_cfops_do_not_need_the_declaration(self):
+        document = self._import_document("l10n_br_fiscal.cfop_3201")
+        self.assertTrue(document._document_check())

--- a/l10n_br_nfe/views/nfe_detexport_view.xml
+++ b/l10n_br_nfe/views/nfe_detexport_view.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="nfe_detexport_tree" model="ir.ui.view">
+        <field name="name">nfe.40.detexport.list</field>
+        <field name="model">nfe.40.detexport</field>
+        <field name="arch" type="xml">
+            <list editable="bottom">
+                <field name="nfe40_nDraw" />
+                <field name="nfe40_exportInd" />
+            </list>
+        </field>
+    </record>
+    <record id="nfe_detexport_form" model="ir.ui.view">
+        <field name="name">nfe.40.detexport.form</field>
+        <field name="model">nfe.40.detexport</field>
+        <field name="arch" type="xml">
+            <form>
+                <group>
+                    <field name="nfe40_nDraw" />
+                    <field
+                        name="nfe40_exportInd"
+                        context="{'form_view_ref': 'l10n_br_nfe.nfe_exportind_form'}"
+                    />
+                </group>
+            </form>
+        </field>
+    </record>
+    <record id="nfe_exportind_form" model="ir.ui.view">
+        <field name="name">nfe.40.exportind.form</field>
+        <field name="model">nfe.40.exportind</field>
+        <field name="arch" type="xml">
+            <form>
+                <group>
+                    <field name="nfe40_nRE" />
+                    <field name="nfe40_chNFe" />
+                    <field name="nfe40_qExport" />
+                </group>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/l10n_br_nfe/views/nfe_di_view.xml
+++ b/l10n_br_nfe/views/nfe_di_view.xml
@@ -30,6 +30,7 @@
                         <field name="nfe40_tpIntermedio" />
                         <field name="partner_acquirer_id" />
                         <field name="nfe40_CNPJ" invisible="1" />
+                        <field name="nfe40_CPF" invisible="1" />
                         <field name="nfe40_UFTerceiro" invisible="1" />
                         <field name="nfe40_cExportador" />
                         <field name="nfe40_vAFRMM" />

--- a/l10n_br_nfe/views/nfe_document_line_view.xml
+++ b/l10n_br_nfe/views/nfe_document_line_view.xml
@@ -12,6 +12,18 @@
                     context="{'form_view_ref': 'l10n_br_nfe.nfe_di_form', 'tree_view_ref': 'l10n_br_nfe.nfe_di_tree'}"
                 />
             </page>
+            <page name="import_declaration" position="after">
+                <page
+                    name="export_detail"
+                    string="Export Detail"
+                    invisible="cfop_destination != '3' or fiscal_operation_type != 'out'"
+                >
+                    <field
+                        name="nfe40_detExport"
+                        context="{'form_view_ref': 'l10n_br_nfe.nfe_detexport_form', 'tree_view_ref': 'l10n_br_nfe.nfe_detexport_tree'}"
+                    />
+                </page>
+            </page>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
São dois commits, um para cada grupo de comércio exterior que estava em aberto no módulo: o I01, da declaração de importação, e o I03, do detalhe de exportação. Os dois eram `# TODO` no código.

Importar XML de NF-e de importação perde três campos da declaração de importação sem avisar. O `nfe40_UFDesemb`, o `nfe40_CNPJ` e o `nfe40_UFTerceiro` do `nfe.40.di` são `related` sem `inverse`, e `related` sem `inverse` escreve na ponta da corrente: com `state_clearance_id` e `partner_acquirer_id` vazios, que é o estado de uma DI que acabou de nascer do arquivo, a escrita não tem onde cair e o valor simplesmente evapora. A UF de desembaraço e o CNPJ do adquirente estão no XML e não chegam ao banco. Junto vinha o `vBC` do grupo `II`, que saía zero na emissão porque o grupo não tem campo próprio pra ele: `vBC` já é nome do ICMS depois que a linha da NF-e é achatada.

Os três viraram `compute` com `inverse`, no mesmo padrão que o `res.partner` do módulo já usa pro `nfe40_CNPJ`, e mantendo o tipo do spec: o `UFDesemb` e o `UFTerceiro` são `Selection` de UF e estavam retipados pra `Char`. O inverso do CNPJ reaproveita o `match_or_create_m2o` do parceiro, que já sabe casar por CNPJ e criar quando não acha, e um inverso só atende os dois campos do adquirente pra não depender da ordem em que o `write` processa as chaves. O `vBC` do `II` sai por `_export_fields_nfe_40_ii`, no mesmo molde do IPI, e a alíquota do imposto de importação passa a ser derivada de `vII` sobre `vBC` na volta: o grupo `II` não tem `pII` no schema, então a busca de imposto casava o primeiro II do catálogo, sem olhar alíquota. Entra também a validação da rejeição 525: CFOP iniciando por 3, com `idDest` 3 e `tpNF` 0, exige o grupo DI, e a regra não vale pros CFOPs 3201, 3202, 3503 e 3553.

Do lado da exportação, o grupo I03 existe como campo em `l10n_br_fiscal.document.line` e não tem view nenhuma, então na tela não há como preencher exportação indireta. A página `import_declaration`, onde o `nfe40_DI` mora, é `invisible` quando a operação é de saída, e exportação é saída, então pôr o `detExport` lá deixa o campo inalcançável. E o grupo `exporta` do cabeçalho sai pela metade sem reclamar: o exportador de ponto de empilhamento emite o grupo quando qualquer campo achatado está preenchido, então preencher só o `xLocDespacho`, que é opcional, produz um `exporta` sem os dois filhos obrigatórios; documento com `idDest` 3 e os três vazios não emite grupo nenhum, calado. Entra uma página própria de exportação na linha, visível quando o destino é exterior e a operação é de saída, com list e form pro `nfe.40.detexport` e pra filha `nfe.40.exportind`. E entram as validações que faltavam, todas no `_document_check`, que roda logo antes do export: exportação exige a UF e o local de embarque; local de embarque em documento sem linha de exportação é a rejeição 356; `detExport` em CFOP que não é de exportação é a 336; e CFOP 7501 ou 3503, que é exportação indireta, exige o registro de exportação, que é a 340. Junto vai uma mensagem pro caso em que a linha não tem CST de ICMS: hoje isso estoura `AttributeError` no meio da serialização, e agora diz qual linha e qual CFOP revisar.

Peguei isso montando entrada de mercadoria vinda do exterior e venda pro exterior. Os testes da DI criam uma escrevendo a UF e o CNPJ como o importador escreve e cobram o estado e o parceiro resolvidos; importam um XML com DI de duas adições e `II` de 14% e cobram a DI, as adições, os valores e a alíquota derivada; e mandam `_document_check` num documento de CFOP 3101 sem DI, que estoura citando a 525, e num de 3201, que passa. Os da exportação cobrem uma rejeição por vez, cada um com o CFOP e o parceiro que a provocam, e o último emite a nota inteira: confirma o documento, exporta, cobra `xml_error_message` vazio e procura `UFSaidaPais`, `xLocExporta`, `nDraw` e `idDest` 3 no XML que saiu. A 16.0 e a 17.0 têm o mesmo `nfe_di.py`, os mesmos dois `# TODO` e a mesma página escondida, e faço o backport se este entrar; na 19.0 o `l10n_br_nfe` ainda não foi migrado.
