### PR TITLE
[18.0][FIX] l10n_br_nfe: match the imported product only on informed keys

### DIFF
--- a/l10n_br_nfe/models/product_product.py
+++ b/l10n_br_nfe/models/product_product.py
@@ -38,10 +38,15 @@ class ProductProduct(models.Model):
             rec_dict["default_code"] = parent_dict["nfe40_cProd"]
             domain_default_code = [("default_code", "=", rec_dict.get("default_code"))]
 
-        domain = expression.OR([domain_name, domain_barcode, domain_default_code])
-        match = self.search(domain, limit=1)
-        if match:
-            return match.id
+        informed_domains = [
+            domain
+            for domain in (domain_name, domain_barcode, domain_default_code)
+            if domain
+        ]
+        if informed_domains:
+            match = self.search(expression.OR(informed_domains), limit=1)
+            if match:
+                return match.id
 
         if self._context.get("dry_run"):
             rec_id = self.new(rec_dict).id

--- a/l10n_br_nfe/tests/test_nfe_import.py
+++ b/l10n_br_nfe/tests/test_nfe_import.py
@@ -51,6 +51,35 @@ class NFeImportTest(TransactionCase):
         assert isinstance(nfe.id, int)
         self._check_nfe(nfe)
 
+    def test_items_without_gtin_do_not_all_match_the_same_product(self):
+        res_items = (
+            "nfe",
+            "samples",
+            "v4_0",
+            "leiauteNFe",
+            "35180834128745000152550010000474281920007498-nfe.xml",
+        )
+        resource_path = "/".join(res_items)
+        nfe_stream = pkg_resources.resource_stream(nfelib.__name__, resource_path)
+        xml = nfe_stream.read().decode()
+        xml = re.sub(r"<cEAN>[^<]*</cEAN>", "<cEAN>SEM GTIN</cEAN>", xml)
+        xml = re.sub(
+            r"<cEANTrib>[^<]*</cEANTrib>", "<cEANTrib>SEM GTIN</cEANTrib>", xml
+        )
+
+        binding = TnfeProc.from_xml(xml)
+        nfe = self.env["l10n_br_fiscal.document"].import_binding_nfe(
+            binding, edoc_type="in", dry_run=False
+        )
+
+        codes = [line.nfe40_cProd for line in nfe.fiscal_line_ids]
+        self.assertEqual(len(set(codes)), len(codes))
+        self.assertEqual(
+            [line.product_id.default_code for line in nfe.fiscal_line_ids], codes
+        )
+        products = nfe.fiscal_line_ids.mapped("product_id")
+        self.assertEqual(len(products), len(nfe.fiscal_line_ids))
+
     def _check_nfe(self, nfe):
         self.assertEqual(type(nfe)._name, "l10n_br_fiscal.document")
         self.assertEqual(


### PR DESCRIPTION
Importar XML cujos itens não têm GTIN casa todas as linhas no mesmo produto, que não tem relação nenhuma com o arquivo. O casamento monta três domínios, um de nome, um de código de barras e um de referência interna, e junta os três com `expression.OR`. Quando o `cEANTrib` é `SEM GTIN` o domínio do código de barras fica vazio, e `expression.OR` com operando vazio não restringe nada: o `search` vira `search([], limit=1)` e devolve o primeiro produto da tabela. Toda linha de todo fornecedor cai nele.

O que arrasta atrás é pior que o produto errado: o NCM da linha é recomputado a partir do produto, e o `nfe40_NCM` é `related`, então a tela mostra o NCM do produto errado como se tivesse vindo do arquivo. O mapeamento fiscal depende do NCM, então a linha inteira é tributada pelo item errado. Medi numa base real: três linhas de dois fornecedores diferentes, todas no produto de `default_code` `134`, com o NCM dele e não o do XML.

A correção é montar o `OR` só com os domínios informados e não pesquisar quando nenhum deles informa nada. Nesse caso a importação cai no ramo que cria o produto, que é o comportamento certo pra item que o cadastro não conhece. Peguei isso conferindo nota de entrada importada. O teste troca todo `cEAN` e `cEANTrib` do XML de exemplo por `SEM GTIN` e cobra que as seis linhas fiquem em seis produtos distintos, cada um com o `default_code` do seu próprio `cProd`; antes da correção as seis apontam pro mesmo produto. A 16.0 e a 17.0 têm o mesmo `expression.OR`, e faço o backport se este entrar; na 19.0 o `l10n_br_nfe` ainda não foi migrado.
