### PR TITLE
[18.0][FIX] l10n_br_nfse: the ISSQN taxation code of an exported service

### DIFF
--- a/l10n_br_nfse/constants/nfse.py
+++ b/l10n_br_nfse/constants/nfse.py
@@ -36,10 +36,10 @@ TAXATION_SPECIAL_REGIME = [
 
 ISSQN_TO_TRIBUTACAO_ISS = {
     "1": "1",  # Exigível → Operação tributável
-    "2": "4",  # Não incidência → Não Incidência
-    "3": "4",  # Isenção → Não Incidência
-    "4": "3",  # Exportação → Exportação de serviço
-    "5": "2",  # Imunidade → Imunidade
+    "2": "3",  # Não incidência → Não Incidência
+    "3": "3",  # Isenção → Não Incidência
+    "4": "2",  # Exportação → Exportação de serviço
+    "5": "4",  # Imunidade → Imunidade
     "6": "1",  # Suspensa (Judicial) → Operação tributável
     "7": "1",  # Suspensa (Administrativo) → Operação tributável
 }

--- a/l10n_br_nfse/tests/test_fiscal_document_nfse_common.py
+++ b/l10n_br_nfse/tests/test_fiscal_document_nfse_common.py
@@ -241,3 +241,32 @@ class TestFiscalDocumentNFSeCommon(TransactionCase):
             service_data["percentual_total_tributos_municipais"],
             "Should be the same as tax_estimate.municipal_taxes",
         )
+
+    def test_the_exported_service_is_not_declared_as_immune(self):
+        """``tribISSQN`` is 1 taxable, 2 export, 3 no incidence, 4 immunity.
+
+        The map sent 4 (export) as 3 and 5 (immunity) as 2, so an exported
+        service was declared as no incidence and an immune one as an export.
+        """
+        fiscal_document = self.nfse_same_state
+        fiscal_line = fiscal_document.fiscal_line_ids[0]
+
+        fiscal_line.issqn_eligibility = "4"
+        self.assertEqual(
+            fiscal_document._prepare_dados_servico()["codigo_tributacao_iss"], "2"
+        )
+
+        fiscal_line.issqn_eligibility = "5"
+        self.assertEqual(
+            fiscal_document._prepare_dados_servico()["codigo_tributacao_iss"], "4"
+        )
+
+        fiscal_line.issqn_eligibility = "2"
+        self.assertEqual(
+            fiscal_document._prepare_dados_servico()["codigo_tributacao_iss"], "3"
+        )
+
+        fiscal_line.issqn_eligibility = "1"
+        self.assertEqual(
+            fiscal_document._prepare_dados_servico()["codigo_tributacao_iss"], "1"
+        )


### PR DESCRIPTION
O mapa que traduz a exigibilidade do ISSQN pro código de tributação da NFS-e está com três entradas erradas, duas delas trocadas entre si. A tabela de destino é `1` operação tributável, `2` exportação de serviço, `3` não incidência e `4` imunidade, como o próprio schema documenta. O mapa manda exportação como `3`, que é não incidência, e imunidade como `2`, que é exportação; e manda não incidência como `4`, que é imunidade. Os comentários ao lado de cada linha descrevem o destino certo, então o defeito é só no valor.

Serviço exportado é o caso que dói: ele vai pro município declarado como não incidência, o que é errado no mérito e some com a informação de que houve exportação, que é justamente onde o `cPaisResult` seria cobrado. Imunidade vai declarada como exportação, que é pior ainda, porque afirma uma operação com o exterior que não existiu.

Peguei isso montando NFS-e de serviço de engenharia pra tomador no exterior. O teste percorre a exigibilidade no documento de demonstração e cobra o código de cada uma: exportação vira `2`, imunidade vira `4`, não incidência vira `3` e exigível continua `1`. Isenção não tem código próprio na tabela de destino e vai pra não incidência, que é o que mantém o ISS fora do cálculo sem afirmar imunidade. A 16.0 e a 17.0 têm o mesmo mapa, e faço o backport se este entrar; na 19.0 o `l10n_br_nfse` ainda não foi migrado.
