### PR TITLE
[18.0][FIX] l10n_br_account: the access rights test needs the LATAM document type

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -329,15 +329,21 @@ class AccountMove(models.Model):
         for move in self.filtered(
             lambda m: m.document_type_id and not m.l10n_latam_document_type_id
         ):
-            latam_doc_type = self.env["l10n_latam.document.type"].search(
-                [
-                    ("code", "=", move.document_type_id.code),
-                    ("country_id", "=", move.company_id.account_fiscal_country_id.id),
-                ],
-                limit=1,
+            latam_doc_type = self._find_latam_document_type(
+                move.document_type_id, move.company_id
             )
             if latam_doc_type:
                 move.l10n_latam_document_type_id = latam_doc_type
+
+    @api.model
+    def _find_latam_document_type(self, document_type, company):
+        return self.env["l10n_latam.document.type"].search(
+            [
+                ("code", "=", document_type.code),
+                ("country_id", "=", company.account_fiscal_country_id.id),
+            ],
+            limit=1,
+        )
 
     def _compute_imported_terms(self):
         self.ensure_one()
@@ -980,6 +986,19 @@ class AccountMove(models.Model):
             move_form.fiscal_document_id = fiscal_document
             move_form.fiscal_operation_id = fiscal_document.fiscal_operation_id
             move_form.document_serie = fiscal_document.document_serie
+            if (
+                "l10n_latam.document.type" in self.env
+                and move_form.l10n_latam_use_documents
+            ):
+                latam_doc_type = self._find_latam_document_type(
+                    fiscal_document.document_type_id, fiscal_document.company_id
+                )
+                if latam_doc_type:
+                    move_form.l10n_latam_document_type_id = latam_doc_type
+                if move_form.l10n_latam_manual_document_number:
+                    move_form.l10n_latam_document_number = (
+                        fiscal_document.document_number
+                    )
 
         unit_and_prices = []
         for line in fiscal_document.fiscal_line_ids:

--- a/l10n_br_account/models/ir_rule.py
+++ b/l10n_br_account/models/ir_rule.py
@@ -1,24 +1,16 @@
 # Copyright (C) 2026 - TODAY Raphaël Valyi - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import api, models, tools
-from odoo.tools import config
+from odoo import api, models
 
 
 class IrRule(models.Model):
     _inherit = "ir.rule"
 
+    def _compute_domain_keys(self):
+        return super()._compute_domain_keys() + ["allow_fiscal_access"]
+
     @api.model
-    @tools.conditional(
-        "xml" not in config["dev_mode"],
-        tools.ormcache(
-            "self.env.uid",
-            "self.env.su",
-            "model_name",
-            "mode",
-            "tuple(self._compute_domain_context_values())",
-        ),
-    )
     def _compute_domain(self, model_name, mode="read"):
         if model_name in ("account.move", "account.move.line"):
             return super(

--- a/l10n_br_account/tests/__init__.py
+++ b/l10n_br_account/tests/__init__.py
@@ -6,6 +6,7 @@ from . import test_account_move_lc
 from . import test_move_edition
 from . import test_move_document_discount
 from . import test_invoice_refund
+from . import test_import_fiscal_document_access_rights
 
 # from . import test_multi_localizations_invoice
 from . import test_payment_status

--- a/l10n_br_account/tests/__init__.py
+++ b/l10n_br_account/tests/__init__.py
@@ -10,3 +10,4 @@ from . import test_invoice_refund
 # from . import test_multi_localizations_invoice
 from . import test_payment_status
 from . import test_move_workflow
+from . import test_import_fiscal_document

--- a/l10n_br_account/tests/test_import_fiscal_document.py
+++ b/l10n_br_account/tests/test_import_fiscal_document.py
@@ -1,0 +1,90 @@
+# Copyright 2026 KMEE INFORMATICA LTDA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields
+from odoo.tests.common import tagged
+
+from .common import AccountMoveBRCommon
+
+
+@tagged("post_install", "-at_install")
+class TestImportFiscalDocument(AccountMoveBRCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.document_type_55 = cls.env.ref("l10n_br_fiscal.document_55")
+        if "l10n_latam.document.type" in cls.env:
+            cls._mirror_latam_document_type()
+        cls.fiscal_document_to_import = cls.env["l10n_br_fiscal.document"].create(
+            {
+                "fiscal_operation_id": cls.env.ref("l10n_br_fiscal.fo_compras").id,
+                "document_type_id": cls.document_type_55.id,
+                "document_serie": "1",
+                "document_number": "4952",
+                "document_date": fields.Date.from_string("2026-08-17"),
+                "issuer": "partner",
+                "partner_id": cls.partner_a.id,
+                "fiscal_operation_type": "in",
+            }
+        )
+        cls.env["l10n_br_fiscal.document.line"].create(
+            {
+                "document_id": cls.fiscal_document_to_import.id,
+                "name": "Purchase Test",
+                "product_id": cls.product_a.id,
+                "fiscal_operation_type": "in",
+                "fiscal_operation_id": cls.env.ref("l10n_br_fiscal.fo_compras").id,
+                "fiscal_operation_line_id": cls.env.ref(
+                    "l10n_br_fiscal.fo_compras_compras"
+                ).id,
+            }
+        )
+
+    @classmethod
+    def _mirror_latam_document_type(cls):
+        fiscal_country = cls.company_data["company"].account_fiscal_country_id
+        domain = [
+            ("code", "=", cls.document_type_55.code),
+            ("country_id", "=", fiscal_country.id),
+        ]
+        if cls.env["l10n_latam.document.type"].search_count(domain):
+            return
+        cls.env["l10n_latam.document.type"].create(
+            {
+                "name": cls.document_type_55.name,
+                "code": cls.document_type_55.code,
+                "country_id": fiscal_country.id,
+                "internal_type": "invoice",
+                "doc_code_prefix": "NFe",
+            }
+        )
+
+    def test_import_into_a_new_vendor_bill(self):
+        move_form = (
+            self.env["account.move"]
+            .sudo()
+            .import_fiscal_document(
+                self.fiscal_document_to_import, move_type="in_invoice"
+            )
+        )
+        move = self.env["account.move"].sudo().browse(move_form.id)
+
+        self.assertEqual(move.move_type, "in_invoice")
+        self.assertEqual(move.fiscal_document_id, self.fiscal_document_to_import)
+        self.assertEqual(move.partner_id, self.partner_a)
+        self.assertEqual(len(move.invoice_line_ids), 1)
+        self.assertEqual(move.invoice_line_ids.product_id, self.product_a)
+        self.assertEqual(
+            move.amount_total, self.fiscal_document_to_import.fiscal_amount_total
+        )
+
+        if "l10n_latam.document.type" in self.env:
+            self.assertTrue(move.journal_id.l10n_latam_use_documents)
+            self.assertTrue(move.l10n_latam_manual_document_number)
+            self.assertEqual(
+                move.l10n_latam_document_type_id.code, self.document_type_55.code
+            )
+            self.assertEqual(
+                move.l10n_latam_document_number,
+                self.fiscal_document_to_import.document_number,
+            )

--- a/l10n_br_account/tests/test_import_fiscal_document_access_rights.py
+++ b/l10n_br_account/tests/test_import_fiscal_document_access_rights.py
@@ -13,6 +13,7 @@ class TestImportFiscalDocumentAccessRights(AccountMoveBRCommon):
     def setUpClass(cls):
         super().setUpClass()
         cls.env.user.groups_id |= cls.env.ref("account.group_account_invoice")
+        cls._mirror_latam_document_type()
         cls.fiscal_document_to_import = cls.env["l10n_br_fiscal.document"].create(
             {
                 "fiscal_operation_id": cls.env.ref("l10n_br_fiscal.fo_compras").id,
@@ -35,6 +36,28 @@ class TestImportFiscalDocumentAccessRights(AccountMoveBRCommon):
                 "fiscal_operation_line_id": cls.env.ref(
                     "l10n_br_fiscal.fo_compras_compras"
                 ).id,
+            }
+        )
+
+    @classmethod
+    def _mirror_latam_document_type(cls):
+        if "l10n_latam.document.type" not in cls.env:
+            return
+        document_type = cls.env.ref("l10n_br_fiscal.document_55")
+        fiscal_country = cls.company_data["company"].account_fiscal_country_id
+        domain = [
+            ("code", "=", document_type.code),
+            ("country_id", "=", fiscal_country.id),
+        ]
+        if cls.env["l10n_latam.document.type"].search_count(domain):
+            return
+        cls.env["l10n_latam.document.type"].create(
+            {
+                "name": document_type.name,
+                "code": document_type.code,
+                "country_id": fiscal_country.id,
+                "internal_type": "invoice",
+                "doc_code_prefix": "NFe",
             }
         )
 

--- a/l10n_br_account/tests/test_import_fiscal_document_access_rights.py
+++ b/l10n_br_account/tests/test_import_fiscal_document_access_rights.py
@@ -1,0 +1,47 @@
+# Copyright 2026 KMEE INFORMATICA LTDA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields
+from odoo.tests.common import tagged
+
+from .common import AccountMoveBRCommon
+
+
+@tagged("post_install", "-at_install")
+class TestImportFiscalDocumentAccessRights(AccountMoveBRCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.user.groups_id |= cls.env.ref("account.group_account_invoice")
+        cls.fiscal_document_to_import = cls.env["l10n_br_fiscal.document"].create(
+            {
+                "fiscal_operation_id": cls.env.ref("l10n_br_fiscal.fo_compras").id,
+                "document_type_id": cls.env.ref("l10n_br_fiscal.document_55").id,
+                "document_serie": "1",
+                "document_number": "4952",
+                "document_date": fields.Date.from_string("2026-08-17"),
+                "issuer": "partner",
+                "partner_id": cls.partner_a.id,
+                "fiscal_operation_type": "in",
+            }
+        )
+        cls.env["l10n_br_fiscal.document.line"].create(
+            {
+                "document_id": cls.fiscal_document_to_import.id,
+                "name": "Purchase Test",
+                "product_id": cls.product_a.id,
+                "fiscal_operation_type": "in",
+                "fiscal_operation_id": cls.env.ref("l10n_br_fiscal.fo_compras").id,
+                "fiscal_operation_line_id": cls.env.ref(
+                    "l10n_br_fiscal.fo_compras_compras"
+                ).id,
+            }
+        )
+
+    def test_import_without_sudo(self):
+        move_form = self.env["account.move"].import_fiscal_document(
+            self.fiscal_document_to_import, move_type="in_invoice"
+        )
+        move = self.env["account.move"].sudo().browse(move_form.id)
+        self.assertEqual(move.move_type, "in_invoice")
+        self.assertEqual(move.fiscal_document_id, self.fiscal_document_to_import)


### PR DESCRIPTION
Depende do #4980 e do #4981: essa branch está empilhada nos dois, e faço rebase quando entrarem.

O `test_import_without_sudo` do #4980 falha com `AssertionError: l10n_latam_document_type_id is a required field`. O `l10n_br` oficial da Odoo depende do `l10n_latam_invoice_document` e o plano de contas marca `l10n_latam_use_documents` nos diários de compra, então o campo passa a ser obrigatório no Form; o `import_fiscal_document` preenche o tipo a partir do `l10n_latam_available_document_type_ids` do diário, que fica vazio quando não existe `l10n_latam.document.type` com o código do documento fiscal e o país da empresa.

O `test_import_fiscal_document.py` do #4981 já espelha esse tipo no `setUpClass` justamente por isso, e o teste de permissões não. Medi isolando: com só o #4980 agregado a falha aparece, e com o #4980, o #4981 e o espelhamento os três testes passam.

A correção põe o mesmo espelhamento no `setUpClass` do teste de permissões, guardado por `"l10n_latam.document.type" not in cls.env` para a base sem o módulo continuar passando. Peguei isso rodando a suíte na árvore agregada de uma imagem, onde a falha aparece no meio de 237 testes e parece regressão de outra coisa.
