### PR TITLE
[18.0][FIX] l10n_br_nfe: IBSCBS of exempt items and totals

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -676,11 +676,12 @@ class NFe(spec_models.StackedModel):
                 record.nfe40_vCredPresCondSusCBS = 0.0
                 continue
 
-            # Calculate totals from lines
-            total_ibs_base = (
-                sum(record.fiscal_line_ids.mapped("ibs_base"))
-                or sum(record.fiscal_line_ids.mapped("cbs_base"))
-                or sum(record.fiscal_line_ids.mapped("price_gross"))
+            lines_with_base = record.fiscal_line_ids.filtered(
+                lambda line: line._has_nfe40_ibscbs_amounts()
+            )
+            total_ibs_base = sum(
+                line.ibs_base or line.cbs_base or line.price_gross
+                for line in lines_with_base
             )
 
             total_ibs_value = sum(record.fiscal_line_ids.mapped("ibs_value"))
@@ -818,12 +819,9 @@ class NFe(spec_models.StackedModel):
     ################################
 
     def _nfe_export_ibscbs_totals(self):
-        """Return True when the document has IBS/CBS values to export"""
+        """Return True when the document has to export the IBS/CBS totals"""
         self.ensure_one()
-        return bool(
-            sum(self.fiscal_line_ids.mapped("ibs_value"))
-            or sum(self.fiscal_line_ids.mapped("cbs_value"))
-        )
+        return any(line._has_nfe40_ibscbs() for line in self.fiscal_line_ids)
 
     def _export_field(self, xsd_field, class_obj, member_spec, export_value=None):
         if xsd_field == "nfe40_tpAmb":
@@ -907,9 +905,7 @@ class NFe(spec_models.StackedModel):
                 return False
 
             if field_name == "nfe40_IBSCBSTot":
-                total_ibs = sum(self.fiscal_line_ids.mapped("ibs_value"))
-                total_cbs = sum(self.fiscal_line_ids.mapped("cbs_value"))
-                if not total_ibs and not total_cbs:
+                if not self._nfe_export_ibscbs_totals():
                     return False
 
             elif (not xsd_required) and field_name not in ["nfe40_enderDest"]:

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -65,6 +65,9 @@ COFINS_SUB_TAGS = [
 
 COFINS_SELECTION = list(map(lambda tag: (f"nfe40_{tag}", tag), COFINS_SUB_TAGS))
 
+IBSCBS_CST_DEFAULT = "000"
+IBSCBS_CLASS_TRIB_DEFAULT = "000001"
+
 
 class NFeLine(spec_models.StackedModel):
     """Classe para mapear a linha do documento fiscal com a linha da NF-e
@@ -223,8 +226,95 @@ class NFeLine(spec_models.StackedModel):
     # Framework Spec model's methods
     ################################
 
+    def _nfe40_ibscbs_cst(self):
+        if self.ibs_cst_id.code:
+            return self.ibs_cst_id.code
+        if self.cbs_cst_id.code:
+            return self.cbs_cst_id.code
+        if self.tax_classification_id.code:
+            return self.tax_classification_id.code.zfill(6)[:3]
+        return IBSCBS_CST_DEFAULT
+
+    def _nfe40_ibscbs_class_trib(self):
+        if self.tax_classification_id.code:
+            return self.tax_classification_id.code.zfill(6)
+        return IBSCBS_CLASS_TRIB_DEFAULT
+
+    def _has_nfe40_ibscbs(self):
+        return bool(
+            self.ibs_value
+            or self.cbs_value
+            or self.ibs_percent
+            or self.cbs_percent
+            or self.ibs_cst_id
+            or self.cbs_cst_id
+            or self.tax_classification_id
+        )
+
+    def _has_nfe40_ibscbs_amounts(self):
+        return bool(
+            self.ibs_value or self.cbs_value or self.ibs_percent or self.cbs_percent
+        )
+
+    def _build_nfe40_gibscbs(self):
+        # Base calculation - use IBS base or CBS base, whichever is available
+        v_bc = self.ibs_base or self.cbs_base or self.price_gross
+
+        p_ibs_uf = self.ibs_percent or 0.0
+        if self.ibs_value:
+            v_ibs_uf = self.ibs_value
+        elif p_ibs_uf > 0 and v_bc > 0:
+            v_ibs_uf = v_bc * p_ibs_uf / 100
+        else:
+            v_ibs_uf = 0.0
+
+        # IBS Municipal values - not available yet, set to 0
+        p_ibs_mun = 0.0
+        v_ibs_mun = 0.0
+
+        v_ibs = self.ibs_value or (v_ibs_uf + v_ibs_mun)
+
+        p_cbs = self.cbs_percent or 0.0
+        v_cbs = self.cbs_value or (v_bc * p_cbs / 100) if p_cbs else 0.0
+
+        gibsuf = Tcibs.GIbsuf(
+            pIBSUF=f"{p_ibs_uf:.4f}",
+            vIBSUF=f"{v_ibs_uf:.2f}",
+        )
+
+        gibsmun = Tcibs.GIbsmun(
+            pIBSMun=f"{p_ibs_mun:.4f}",
+            vIBSMun=f"{v_ibs_mun:.2f}",
+        )
+
+        gcbs = Tcibs.GCbs(
+            pCBS=f"{p_cbs:.4f}",
+            vCBS=f"{v_cbs:.2f}",
+        )
+
+        return Tcibs(
+            vBC=f"{v_bc:.2f}",
+            gIBSUF=gibsuf,
+            gIBSMun=gibsmun,
+            vIBS=f"{v_ibs:.2f}",
+            gCBS=gcbs,
+        )
+
+    def _build_nfe40_ibscbs(self):
+        self.ensure_one()
+        if not self._has_nfe40_ibscbs():
+            return False
+
+        values = {
+            "CST": self._nfe40_ibscbs_cst(),
+            "cClassTrib": self._nfe40_ibscbs_class_trib(),
+        }
+        if self._has_nfe40_ibscbs_amounts():
+            values["gIBSCBS"] = self._build_nfe40_gibscbs()
+
+        return TtribNfe(**values)
+
     def _export_field(self, xsd_field, class_obj, member_spec, export_value=None):
-        """Override to handle IBSCBS field export"""
         if xsd_field == "nfe40_vItem":
             # NT 2025.002 (rules VB01/W60): vItem must be present in every
             # det when the document exports the IBS/CBS totals, and the sum
@@ -239,162 +329,13 @@ class NFeLine(spec_models.StackedModel):
             return f"{self.fiscal_amount_total:.2f}"
 
         if xsd_field == "nfe40_IBSCBS":
-            if not self.ibs_value and not self.cbs_value:
-                return False
-
-            # Get tax classification code
-            c_class_trib = "000001"
-            if self.tax_classification_id and self.tax_classification_id.code:
-                c_class_trib = self.tax_classification_id.code.zfill(6)
-
-            # Get CST code - use IBS CST if available, otherwise CBS CST
-            cst = "000"
-            if self.ibs_cst_id and self.ibs_cst_id.code:
-                cst = self.ibs_cst_id.code
-            elif self.cbs_cst_id and self.cbs_cst_id.code:
-                cst = self.cbs_cst_id.code
-
-            # Base calculation - use IBS base or CBS base, whichever is available
-            v_bc = self.ibs_base or self.cbs_base or self.price_gross
-
-            # IBS UF values - when there's only one IBS, populate IBSUF directly
-            # Use IBS percent directly for pIBSUF
-            p_ibs_uf = self.ibs_percent or 0.0
-            # Use IBS value directly for vIBSUF, or calculate from base and percent
-            if self.ibs_value:
-                v_ibs_uf = self.ibs_value
-            elif p_ibs_uf > 0 and v_bc > 0:
-                v_ibs_uf = v_bc * p_ibs_uf / 100
-            else:
-                v_ibs_uf = 0.0
-
-            # IBS Municipal values - not available yet, set to 0
-            p_ibs_mun = 0.0
-            v_ibs_mun = 0.0
-
-            # Total IBS - use IBS value directly or sum of UF + Municipal
-            v_ibs = self.ibs_value or (v_ibs_uf + v_ibs_mun)
-
-            # CBS values
-            p_cbs = self.cbs_percent or 0.0
-            v_cbs = self.cbs_value or (v_bc * p_cbs / 100) if p_cbs else 0.0
-
-            # Build gIBSUF
-            gibsuf = Tcibs.GIbsuf(
-                pIBSUF=f"{p_ibs_uf:.4f}",
-                vIBSUF=f"{v_ibs_uf:.2f}",
-            )
-
-            # Build gIBSMun
-            gibsmun = Tcibs.GIbsmun(
-                pIBSMun=f"{p_ibs_mun:.4f}",
-                vIBSMun=f"{v_ibs_mun:.2f}",
-            )
-
-            # Build gCBS
-            gcbs = Tcibs.GCbs(
-                pCBS=f"{p_cbs:.4f}",
-                vCBS=f"{v_cbs:.2f}",
-            )
-
-            # Build gIBSCBS (Tcibs)
-            gibscbs = Tcibs(
-                vBC=f"{v_bc:.2f}",
-                gIBSUF=gibsuf,
-                gIBSMun=gibsmun,
-                vIBS=f"{v_ibs:.2f}",
-                gCBS=gcbs,
-            )
-
-            # Build TtribNfe
-            ibscbs_obj = TtribNfe(
-                CST=cst,
-                cClassTrib=c_class_trib,
-                gIBSCBS=gibscbs,
-            )
-
-            return ibscbs_obj
+            return self._build_nfe40_ibscbs()
 
         return super()._export_field(xsd_field, class_obj, member_spec, export_value)
 
     def _export_many2one(self, field_name, xsd_required, class_obj=None):
-        """Override to handle IBSCBS Many2one field export"""
         if field_name == "nfe40_IBSCBS":
-            if not self.ibs_value and not self.cbs_value:
-                return False
-
-            # Get tax classification code
-            c_class_trib = "000001"
-            if self.tax_classification_id and self.tax_classification_id.code:
-                c_class_trib = self.tax_classification_id.code.zfill(6)
-
-            # Get CST code - use IBS CST if available, otherwise CBS CST
-            cst = "000"
-            if self.ibs_cst_id and self.ibs_cst_id.code:
-                cst = self.ibs_cst_id.code
-            elif self.cbs_cst_id and self.cbs_cst_id.code:
-                cst = self.cbs_cst_id.code
-
-            # Base calculation - use IBS base or CBS base, whichever is available
-            v_bc = self.ibs_base or self.cbs_base or self.price_gross
-
-            # IBS UF values - when there's only one IBS, populate IBSUF directly
-            # Use IBS percent directly for pIBSUF
-            p_ibs_uf = self.ibs_percent or 0.0
-            # Use IBS value directly for vIBSUF, or calculate from base and percent
-            if self.ibs_value:
-                v_ibs_uf = self.ibs_value
-            elif p_ibs_uf > 0 and v_bc > 0:
-                v_ibs_uf = v_bc * p_ibs_uf / 100
-            else:
-                v_ibs_uf = 0.0
-
-            # IBS Municipal values - not available yet, set to 0
-            p_ibs_mun = 0.0
-            v_ibs_mun = 0.0
-
-            # Total IBS - use IBS value directly or sum of UF + Municipal
-            v_ibs = self.ibs_value or (v_ibs_uf + v_ibs_mun)
-
-            # CBS values
-            p_cbs = self.cbs_percent or 0.0
-            v_cbs = self.cbs_value or (v_bc * p_cbs / 100) if p_cbs else 0.0
-
-            # Build gIBSUF
-            gibsuf = Tcibs.GIbsuf(
-                pIBSUF=f"{p_ibs_uf:.4f}",
-                vIBSUF=f"{v_ibs_uf:.2f}",
-            )
-
-            # Build gIBSMun
-            gibsmun = Tcibs.GIbsmun(
-                pIBSMun=f"{p_ibs_mun:.4f}",
-                vIBSMun=f"{v_ibs_mun:.2f}",
-            )
-
-            # Build gCBS
-            gcbs = Tcibs.GCbs(
-                pCBS=f"{p_cbs:.4f}",
-                vCBS=f"{v_cbs:.2f}",
-            )
-
-            # Build gIBSCBS (Tcibs)
-            gibscbs = Tcibs(
-                vBC=f"{v_bc:.2f}",
-                gIBSUF=gibsuf,
-                gIBSMun=gibsmun,
-                vIBS=f"{v_ibs:.2f}",
-                gCBS=gcbs,
-            )
-
-            # Build TtribNfe
-            ibscbs_obj = TtribNfe(
-                CST=cst,
-                cClassTrib=c_class_trib,
-                gIBSCBS=gibscbs,
-            )
-
-            return ibscbs_obj
+            return self._build_nfe40_ibscbs()
 
         return super()._export_many2one(field_name, xsd_required, class_obj)
 
@@ -543,83 +484,11 @@ class NFeLine(spec_models.StackedModel):
         if self.document_id.document_type == "65":
             xsd_fields.remove("nfe40_IPI")
 
-        # Export IBSCBS if there are values
-        if self.ibs_value or self.cbs_value:
-            # Get tax classification code
-            c_class_trib = "000001"
-            if self.tax_classification_id and self.tax_classification_id.code:
-                c_class_trib = self.tax_classification_id.code.zfill(6)
-
-            # Get CST code - use IBS CST if available, otherwise CBS CST
-            cst = "000"
-            if self.ibs_cst_id and self.ibs_cst_id.code:
-                cst = self.ibs_cst_id.code
-            elif self.cbs_cst_id and self.cbs_cst_id.code:
-                cst = self.cbs_cst_id.code
-
-            # Base calculation - use IBS base or CBS base, whichever is available
-            v_bc = self.ibs_base or self.cbs_base or self.price_gross
-
-            # IBS UF values - when there's only one IBS, populate IBSUF directly
-            # Use IBS percent directly for pIBSUF
-            p_ibs_uf = self.ibs_percent or 0.0
-            # Use IBS value directly for vIBSUF, or calculate from base and percent
-            if self.ibs_value:
-                v_ibs_uf = self.ibs_value
-            elif p_ibs_uf > 0 and v_bc > 0:
-                v_ibs_uf = v_bc * p_ibs_uf / 100
-            else:
-                v_ibs_uf = 0.0
-
-            # IBS Municipal values - not available yet, set to 0
-            p_ibs_mun = 0.0
-            v_ibs_mun = 0.0
-
-            # Total IBS - use IBS value directly or sum of UF + Municipal
-            v_ibs = self.ibs_value or (v_ibs_uf + v_ibs_mun)
-
-            # CBS values
-            p_cbs = self.cbs_percent or 0.0
-            v_cbs = self.cbs_value or (v_bc * p_cbs / 100) if p_cbs else 0.0
-
-            # Build gIBSUF
-            gibsuf = Tcibs.GIbsuf(
-                pIBSUF=f"{p_ibs_uf:.4f}",
-                vIBSUF=f"{v_ibs_uf:.2f}",
-            )
-
-            # Build gIBSMun
-            gibsmun = Tcibs.GIbsmun(
-                pIBSMun=f"{p_ibs_mun:.4f}",
-                vIBSMun=f"{v_ibs_mun:.2f}",
-            )
-
-            # Build gCBS
-            gcbs = Tcibs.GCbs(
-                pCBS=f"{p_cbs:.4f}",
-                vCBS=f"{v_cbs:.2f}",
-            )
-
-            # Build gIBSCBS (Tcibs)
-            gibscbs = Tcibs(
-                vBC=f"{v_bc:.2f}",
-                gIBSUF=gibsuf,
-                gIBSMun=gibsmun,
-                vIBS=f"{v_ibs:.2f}",
-                gCBS=gcbs,
-            )
-
-            # Build TtribNfe and add to export_dict
-            ibscbs_obj = TtribNfe(
-                CST=cst,
-                cClassTrib=c_class_trib,
-                gIBSCBS=gibscbs,
-            )
-            export_dict["IBSCBS"] = ibscbs_obj
-        else:
-            # Remove IBSCBS from xsd_fields if no values
-            if "nfe40_IBSCBS" in xsd_fields:
-                xsd_fields.remove("nfe40_IBSCBS")
+        ibscbs = self._build_nfe40_ibscbs()
+        if ibscbs:
+            export_dict["IBSCBS"] = ibscbs
+        elif "nfe40_IBSCBS" in xsd_fields:
+            xsd_fields.remove("nfe40_IBSCBS")
 
     ##################################################
     # NF-e tag: ICMS

--- a/l10n_br_nfe/tests/test_nfe_ibscbs.py
+++ b/l10n_br_nfe/tests/test_nfe_ibscbs.py
@@ -653,6 +653,53 @@ class TestNFeIBSCBS(TransactionCase):
         self.assertEqual(result.cClassTrib, "410004")
         self.assertIsNone(result.gIBSCBS)
 
+    def test_export_field_ibscbstot_exempt_document(self):
+        line = self._create_exempt_line()
+
+        self.assertEqual(sum(self.document.fiscal_line_ids.mapped("ibs_value")), 0.0)
+        self.assertEqual(sum(self.document.fiscal_line_ids.mapped("cbs_value")), 0.0)
+        self.assertTrue(line._has_nfe40_ibscbs())
+
+        result = self.document._export_field("nfe40_IBSCBSTot", None, None)
+        self.assertIsNot(result, False)
+        self.assertEqual(result.vBCIBSCBS, "0.00")
+        self.assertEqual(result.gIBS.vIBS, "0.00")
+        self.assertEqual(result.gCBS.vCBS, "0.00")
+
+    def test_export_field_ibscbstot_base_only_from_taxed_lines(self):
+        exempt = self._create_exempt_line()
+        taxed = self.env["l10n_br_fiscal.document.line"].create(
+            {
+                "document_id": self.document.id,
+                "product_id": self.product.id,
+                "quantity": 1.0,
+                "price_unit": 200.0,
+            }
+        )
+        taxed.write({"ibs_value": 10.0, "ibs_base": 0.0})
+
+        self.assertFalse(exempt._has_nfe40_ibscbs_amounts())
+        self.assertTrue(taxed._has_nfe40_ibscbs_amounts())
+        self.assertEqual(taxed._build_nfe40_gibscbs().vBC, "200.00")
+
+        result = self.document._export_field("nfe40_IBSCBSTot", None, None)
+        self.assertEqual(result.vBCIBSCBS, "200.00")
+
+    def test_export_field_ibscbstot_without_reform_taxes(self):
+        self.env["l10n_br_fiscal.document.line"].create(
+            {
+                "document_id": self.document.id,
+                "product_id": self.product.id,
+                "quantity": 1.0,
+                "price_unit": 100.0,
+                "tax_classification_id": False,
+                "ibs_cst_id": False,
+                "cbs_cst_id": False,
+            }
+        )
+
+        self.assertFalse(self.document._export_field("nfe40_IBSCBSTot", None, None))
+
 
 @tagged("post_install", "-at_install")
 class TestNFeVItemVNFTot(TransactionCase):

--- a/l10n_br_nfe/tests/test_nfe_ibscbs.py
+++ b/l10n_br_nfe/tests/test_nfe_ibscbs.py
@@ -578,6 +578,81 @@ class TestNFeIBSCBS(TransactionCase):
         self.assertEqual(result.gIBSCBS.gIBSMun.vIBSMun, "0.00")
         self.assertEqual(result.gIBSCBS.gIBSMun.pIBSMun, "0.0000")
 
+    def _create_exempt_line(self):
+        return self.env["l10n_br_fiscal.document.line"].create(
+            {
+                "document_id": self.document.id,
+                "product_id": self.product.id,
+                "quantity": 1.0,
+                "price_unit": 100.0,
+                "tax_classification_id": self.env.ref(
+                    "l10n_br_fiscal.tax_classification_400001"
+                ).id,
+                "ibs_cst_id": self.env.ref("l10n_br_fiscal.cst_ibs_400").id,
+            }
+        )
+
+    def test_export_field_ibscbs_exempt_line(self):
+        line = self._create_exempt_line()
+
+        result = line._export_field("nfe40_IBSCBS", None, None)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.CST, "400")
+        self.assertEqual(result.cClassTrib, "400001")
+        self.assertIsNone(result.gIBSCBS)
+
+    def test_export_many2one_ibscbs_exempt_line(self):
+        line = self._create_exempt_line()
+
+        result = line._export_many2one("nfe40_IBSCBS", False)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.CST, "400")
+        self.assertEqual(result.cClassTrib, "400001")
+        self.assertIsNone(result.gIBSCBS)
+
+    def test_export_fields_nfe_40_imposto_exempt_line(self):
+        line = self._create_exempt_line()
+        line.write({"tax_icms_or_issqn": "icms"})
+        line._compute_nfe40_choice_imposto()
+
+        xsd_fields = [
+            "nfe40_ICMS",
+            "nfe40_ISSQN",
+            "nfe40_II",
+            "nfe40_ICMSUFDest",
+            "nfe40_PISST",
+            "nfe40_COFINSST",
+            "nfe40_IPI",
+            "nfe40_IBSCBS",
+        ]
+        export_dict = {}
+        line._export_fields_nfe_40_imposto(xsd_fields, None, export_dict)
+
+        self.assertIn("IBSCBS", export_dict)
+        self.assertEqual(export_dict["IBSCBS"].CST, "400")
+        self.assertEqual(export_dict["IBSCBS"].cClassTrib, "400001")
+        self.assertIn("nfe40_IBSCBS", xsd_fields)
+
+    def test_export_field_ibscbs_cst_from_tax_classification(self):
+        line = self.env["l10n_br_fiscal.document.line"].create(
+            {
+                "document_id": self.document.id,
+                "product_id": self.product.id,
+                "quantity": 1.0,
+                "price_unit": 100.0,
+                "tax_classification_id": self.env.ref(
+                    "l10n_br_fiscal.tax_classification_410004"
+                ).id,
+            }
+        )
+        line.write({"ibs_cst_id": False, "cbs_cst_id": False})
+
+        result = line._export_field("nfe40_IBSCBS", None, None)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.CST, "410")
+        self.assertEqual(result.cClassTrib, "410004")
+        self.assertIsNone(result.gIBSCBS)
+
 
 @tagged("post_install", "-at_install")
 class TestNFeVItemVNFTot(TransactionCase):


### PR DESCRIPTION
São dois commits e duas camadas do mesmo defeito: linha imune sai sem o grupo `IBSCBS`, e nota imune sai sem o total `IBSCBSTot`. A segunda camada só apareceu depois de a primeira ser corrigida e a nota transmitida de novo.

Linha imune ou isenta sai sem o grupo `IBSCBS`. O exportador desiste do grupo quando `ibs_value` e `cbs_value` são zero, e é exatamente o que acontece numa exportação, numa imunidade e em qualquer não tributado: o valor é zero por definição. A partir de 2026 a SEFAZ cobra CST e `cClassTrib` em todo item, então a nota vai pra recusa 1115 mesmo com o cadastro perfeito; o `gIBSCBS`, esse sim, não é exigido com CST 410, e é o único pedaço que pode faltar. A montagem do grupo estava escrita três vezes, em `_export_field`, em `_export_many2one` e em `_export_fields_nfe_40_imposto`, com as três cópias decidindo pelo mesmo `if` de valor. Agora existe um `_build_nfe40_ibscbs` só, e ele separa as duas perguntas: se o item tem alguma coisa de IBS e CBS a declarar, e se tem valor. Sem valor sai só o CST e o `cClassTrib`; com valor sai o `gIBSCBS` também. O CST cai pro prefixo da classificação tributária quando a linha não tem CST próprio. O cálculo de valor não mudou, inclusive o `or` do `vCBS`, que devolve zero quando a alíquota é zero mesmo com valor gravado: é comportamento de hoje e não é o assunto deste PR.

Corrigido o item, a nota passou a levar a recusa 1119, total de IBS e CBS não informado, que é o mesmo defeito um nível acima: o `_nfe_export_ibscbs_totals` só libera o `IBSCBSTot` quando a soma de `ibs_value` ou de `cbs_value` dá diferente de zero, e o mesmo `if` também segura o `vNFTot`. O segundo commit reusa no total o predicado criado pro item, então os dois passam a responder a mesma pergunta, e o `_export_many2one` deixa de repetir a conta pela terceira vez.

E emitir o grupo ainda não bastava. Com ele no lugar veio a recusa 1076, total da BC do IBS e da CBS difere da soma dos itens, porque a base do total é `sum(ibs_base) or sum(cbs_base) or sum(price_gross)` e esse último `or` é um fallback que entrega o valor bruto da nota quando as duas somas dão zero. Numa nota imune o item não declara `gIBSCBS`, logo não declara base; o total dizia 42.000,00 contra itens somando zero. Agora a base do total soma só as linhas que declaram `gIBSCBS`, pelo mesmo predicado do item e com o mesmo fallback por linha, então os dois lados somam o mesmo conjunto. Com tudo zerado o grupo sai com `vBCIBSCBS`, `gIBS` e `gCBS` em `0.00`, que é o que a nota técnica pede quando o CST é de imunidade.

Peguei as três emitindo NF-e de exportação contra a SEFAZ de homologação, uma recusa de cada vez, e a nota só foi autorizada depois da última. Uma venda interna da mesma base atravessa os dois grupos sem problema, porque nela o IBS e a CBS têm valor: o defeito só aparece quando a operação é imune, e foi assim que ele passou despercebido. Os testes montam linha com classificação de isenção e CST 400 sem valor nenhum e cobram os três caminhos de export do item devolvendo o grupo com CST e `cClassTrib` e sem `gIBSCBS`; do lado do total, um documento imune precisa devolver o grupo com os valores em `0.00`, um documento cuja linha não tem CST nem classificação precisa continuar sem grupo, e um documento com uma linha imune e uma tributada sem base própria precisa somar só a segunda, pelo bruto dela. Vale dizer como foram conferidos, porque o primeiro que eu escrevi passava sem a correção: eu tinha usado `assertIsNotNone` contra um método que devolve `False`, e `False` não é `None`. Todos agora ficam vermelhos com a linha do conserto revertida. A 16.0 e a 17.0 têm o mesmo código com os mesmos `if`, e faço o backport se este entrar; na 19.0 o `l10n_br_nfe` ainda não foi migrado.
