### PR TITLE
[18.0][REM] l10n_br_stock_account: Método '_prepare_extra_move_vals' foi removido na v17.3

### DIFF
--- a/l10n_br_stock_account/models/stock_move.py
+++ b/l10n_br_stock_account/models/stock_move.py
@@ -228,14 +228,6 @@ class StockMove(models.Model):
         keys_sorted += [move.fiscal_operation_id.id, move.fiscal_operation_line_id.id]
         return keys_sorted
 
-    def _prepare_extra_move_vals(self, qty):
-        values = {}
-        if self.fiscal_operation_id:
-            # Caso Brasil se caracteriza por ter Operação Fiscal
-            values = self._prepare_br_fiscal_dict()
-        values.update(super()._prepare_extra_move_vals(qty))
-        return values
-
     def _prepare_move_split_vals(self, uom_qty):
         values = {}
         if self.fiscal_operation_id:


### PR DESCRIPTION
There is no more '_prepare_extra_move_vals' method in stock.move, removed in v17.3.

Método '_prepare_extra_move_vals' do objeto **stock.move** foi removido na v17.3

* https://github.com/odoo/odoo/pull/162244

Já removido no módulo **stock_picking_invoicing**

* https://github.com/OCA/account-invoicing/pull/2301

Complementa a migração

* https://github.com/OCA/l10n-brazil/pull/4590

cc @OCA/local-brazil-maintainers 