### PR TITLE
[18.0][FIX] l10n_br_stock_account: Método _get_price_unit no stock.move na v18 retorna um dicionário e não um Float

### DIFF
--- a/l10n_br_stock_account/models/stock_move.py
+++ b/l10n_br_stock_account/models/stock_move.py
@@ -280,7 +280,11 @@ class StockMove(models.Model):
         #  Quant deve ser registrado o preço padrão como era feito antes
         #  e continua sendo feito abaixo?
         if self.fiscal_operation_id.fiscal_operation_type == "out":
-            result = self.product_id.with_company(self.company_id).standard_price
+            result = {
+                self.env["stock.lot"]: self.product_id.with_company(
+                    self.company_id
+                ).standard_price
+            }
 
         return result
 


### PR DESCRIPTION
Method _get_price now return dict not a Float.

O método [_get_price_unit no objeto stock.move](https://github.com/OCA/OCB/blob/18.0/addons/stock_account/models/stock_move.py#L44) deve retornar um dicionário e não um Float como nas versões anteriores 

https://github.com/OCA/OCB/blob/18.0/addons/stock_account/models/stock_move.py#L66
```bash
                prices = {self.env['stock.lot']: sum(layers.mapped("value")) / quantity if not float_is_zero(quantity, precision_rounding=layers.uom_id.rounding) else 0}
            return prices

        if not float_is_zero(price_unit, precision) or self._should_force_price_unit():
            if self.product_id.lot_valuated:
                return dict.fromkeys(self.lot_ids, price_unit)
            else:
                return {self.env['stock.lot']: price_unit}
        else:
            if self.product_id.lot_valuated:
                return {lot: lot.standard_price or self.product_id.with_company(self.company_id).standard_price for lot in self.lot_ids}
            else:
                return {self.env['stock.lot']: self.product_id.with_company(self.company_id).standard_price}
```

Complementa a migração

* https://github.com/OCA/l10n-brazil/pull/4590

cc @OCA/local-brazil-maintainers 