### PR TITLE
[18.0][REF]l10n_br_stock_account: Separação dos Dados usados nos Testes dos Dados de Demonstração

### DIFF
--- a/l10n_br_stock_account/tests/common.py
+++ b/l10n_br_stock_account/tests/common.py
@@ -1,5 +1,7 @@
+# Copyright (C) 2023-Today - Akretion (<http://www.akretion.com>).
 # @author Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
 
 from odoo.addons.stock_picking_invoicing.tests.common import (
     TestStockPickingInvoicingCommon,
@@ -10,6 +12,13 @@ from odoo.addons.stock_picking_invoicing.tests.tools import (
     create_with_form_return_picking,
 )
 
+from .tools import (
+    create_and_configure_br_company,
+    create_br_journal_and_set_fiscal_ops,
+    create_with_form_br_res_partner,
+    create_with_form_br_stock_picking,
+)
+
 
 class TestBrPickingInvoicingCommon(TestStockPickingInvoicingCommon):
     chart_template = "generic_coa"
@@ -18,8 +27,271 @@ class TestBrPickingInvoicingCommon(TestStockPickingInvoicingCommon):
     def setUpClass(cls):
         super().setUpClass()
         # Add main company to test user to access demo data from other modules
-        main_company = cls.env.ref("base.main_company")
-        cls.env.user.company_ids |= main_company
+        cls.env.user.company_ids |= cls.env.ref("base.main_company")
+        cls.get_default_groups()
+
+        # Operação Fiscais comuns em todas as empresas
+        cls.op_simples_remessa = cls.env["l10n_br_fiscal.operation"].search(
+            [("name", "=", "Simples Remessa")]
+        )
+        cls.op_bonificacao = cls.env["l10n_br_fiscal.operation"].search(
+            [("name", "=", "Bonificação")]
+        )
+        cls.op_entrada_remessa = cls.env["l10n_br_fiscal.operation"].search(
+            [("name", "=", "Entrada de Remessa")]
+        )
+
+        # Configuração da empresa company_1_data, é a empresa padrão que vem no teste
+        # automaticamente, necessário para validar o campo fiscal_tax_ids.
+        cls.company_test = cls.env.company
+        cls.env.company.write(
+            {
+                "tax_framework": "1",
+                "is_industry": "True",
+                "ripi": "True",
+                "piscofins_id": cls.env.ref(
+                    "l10n_br_fiscal.tax_pis_cofins_simples_nacional"
+                ).id,
+                "tax_ipi_id": cls.env.ref("l10n_br_fiscal.tax_ipi_outros").id,
+                "tax_icms_id": cls.env.ref("l10n_br_fiscal.tax_icms_sn_com_credito").id,
+                "legal_nature_id": cls.env.ref("l10n_br_fiscal.legal_nature_2062").id,
+                "cnae_main_id": cls.env.ref("l10n_br_fiscal.cnae_3101200").id,
+                "document_type_id": cls.env.ref("l10n_br_fiscal.document_55").id,
+                "tax_classification_id": cls.env.ref(
+                    "l10n_br_fiscal.tax_classification_000001"
+                ).id,
+            }
+        )
+        cls.fiscal_ops = (
+            cls.op_simples_remessa | cls.op_bonificacao | cls.op_entrada_remessa
+        )
+        create_br_journal_and_set_fiscal_ops(cls.env, cls.env.company, cls.fiscal_ops)
+
+        # Partners usados nos testes, um principal e outro Endereço de Entrega
+        data_res_partner = {
+            "name": "Cliente 2 -SP - Simples Nacional",
+            "legal_name": "Cliente 2 SN - SP",
+            "country_id": cls.env.ref("base.br"),
+            "state_id": cls.env.ref("base.state_br_sp"),
+            "city_id": cls.env.ref("l10n_br_base.city_3550308"),
+            "zip": "18125-000",
+            "street_name": "Rua A",
+            "street_number": "1",
+            "district": "Bela Vista",
+            "vat": "12.046.835/0001-61",
+            "l10n_br_ie_code": "887.273.429.152",
+            "fiscal_profile_id": cls.env.ref(
+                "l10n_br_fiscal.partner_fiscal_profile_snc"
+            ),
+        }
+        cls.partner_br_stock_1 = create_with_form_br_res_partner(
+            cls.env, data_res_partner
+        )
+
+        data_res_partner_delivery_address = {
+            "name": "Cliente 2 - SP - Endereço Entrega",
+            "legal_name": "Cliente 2 - SP - Endereço Entrega",
+            "country_id": cls.env.ref("base.br"),
+            "state_id": cls.env.ref("base.state_br_sp"),
+            "city_id": cls.env.ref("l10n_br_base.city_3550308"),
+            "zip": "04583-120",
+            "street_name": "Rua B",
+            "street_number": "1",
+            "district": "Bela Vista",
+            "vat": "96.660.336/0001-50",
+            "l10n_br_ie_code": "811.510.100.755",
+            "fiscal_profile_id": cls.env.ref(
+                "l10n_br_fiscal.partner_fiscal_profile_snc"
+            ),
+            # Informações dos Contatos
+            "company_type": "person",
+            "type": "delivery",
+            "parent_id": cls.partner_br_stock_1,
+        }
+        cls.partner_br_stock_1_delivery_address = create_with_form_br_res_partner(
+            cls.env, data_res_partner_delivery_address
+        )
+        cls.partner_br_stock_1_delivery_address.type = "delivery"
+
+        # Dados comuns usados nos Pickings
+        picking_out_vals = {
+            "partner_id": cls.partner_br_stock_1,
+            "picking_type_id": cls.picking_type_out,
+            "fiscal_operation_id": cls.op_simples_remessa,
+            "company_id": cls.env.company,
+        }
+
+        picking_out_vals_delivery_address = picking_out_vals | {
+            "partner_id": cls.partner_br_stock_1_delivery_address
+        }
+
+        move_vals_1 = [
+            {
+                "product_id": cls.product_storable_1,
+                "product_uom_qty": 2,
+                "fiscal_operation_id": cls.op_simples_remessa,
+            }
+        ]
+        move_vals_2 = [
+            {
+                "product_id": cls.product_storable_2,
+                "product_uom_qty": 2,
+            }
+        ]
+        move_vals_3 = [
+            {
+                "product_id": cls.product_storable_1,
+                "product_uom_qty": 2,
+                "fiscal_operation_id": cls.op_bonificacao,
+            }
+        ]
+
+        # Picking Out Empresa principal do testes company_1_data
+        cls.picking_out_br_1 = create_with_form_br_stock_picking(
+            cls.env, picking_out_vals, move_vals_1 + move_vals_2 + move_vals_3
+        )
+        # No Form não está sendo possível incluir a OP Bonificação
+        cls.picking_out_br_1.move_ids[2].fiscal_operation_id = cls.op_bonificacao
+
+        cls.picking_out_br_2 = create_with_form_br_stock_picking(
+            cls.env,
+            picking_out_vals,
+            move_vals_1 + move_vals_2 + move_vals_3,
+        )
+        cls.picking_out_br_2.move_ids[2].fiscal_operation_id = cls.op_bonificacao
+
+        cls.picking_out_br_3 = create_with_form_br_stock_picking(
+            cls.env,
+            picking_out_vals_delivery_address,
+            move_vals_1 + move_vals_2 + move_vals_3,
+        )
+        cls.picking_out_br_3.move_ids[2].fiscal_operation_id = cls.op_bonificacao
+
+        cls.picking_out_br_4 = create_with_form_br_stock_picking(
+            cls.env,
+            picking_out_vals,
+            move_vals_1 + move_vals_2 + move_vals_3,
+        )
+        cls.picking_out_br_4.move_ids[2].fiscal_operation_id = cls.op_bonificacao
+
+        cls.picking_out_br_5 = create_with_form_br_stock_picking(
+            cls.env,
+            picking_out_vals_delivery_address,
+            move_vals_1 + move_vals_2 + move_vals_3,
+        )
+        cls.picking_out_br_5.move_ids[2].fiscal_operation_id = cls.op_bonificacao
+
+        cls.picking_out_br_6 = create_with_form_br_stock_picking(
+            cls.env,
+            picking_out_vals,
+            move_vals_1 + move_vals_2 + move_vals_3,
+        )
+        cls.picking_out_br_6.move_ids[2].fiscal_operation_id = cls.op_bonificacao
+
+        # Empresa Lucro Real
+        legal_nature_2062 = cls.env["l10n_br_fiscal.legal.nature"].search(
+            [("code", "=", "206-2")]
+        )
+        fiscal_cnae_3101200 = cls.env["l10n_br_fiscal.cnae"].search(
+            [("code", "=", "3101-2/00")]
+        )
+        data_company_lp = {
+            "name": "Empresa Lucro Presumido 1",
+            "legal_name": "Empresa Lucro Presumido 1",
+            "country_id": cls.env.ref("base.br").id,
+            "state_id": cls.env.ref("base.state_br_sp").id,
+            "city_id": cls.env.ref("l10n_br_base.city_3550308").id,
+            "zip": "01311-000",
+            "street_name": "Avenida Paulista",
+            "street_number": "1",
+            "district": "Bela Vista",
+            "vat": "37.402.925/0001-79",
+            "l10n_br_ie_code": "078.016.350.838",
+            "tax_framework": "3",
+            "profit_calculation": "presumed",
+            "is_industry": True,
+            "ripi": True,
+            "icms_regulation_id": cls.env.ref("l10n_br_fiscal.tax_icms_regulation").id,
+            "legal_nature_id": legal_nature_2062.id,
+            "cnae_main_id": fiscal_cnae_3101200.id,
+            "piscofins_id": cls.env.ref("l10n_br_fiscal.tax_pis_cofins_columativo").id,
+            "document_type_id": cls.env.ref("l10n_br_fiscal.document_55").id,
+            "tax_classification_id": cls.env.ref(
+                "l10n_br_fiscal.tax_classification_000001"
+            ).id,
+        }
+        cls.company_lp = create_and_configure_br_company(
+            cls.env, data_company_lp, cls.fiscal_ops
+        )
+
+        cls.picking_type_out_lp = cls.env["stock.picking.type"].search(
+            [
+                ("company_id", "=", cls.company_lp.id),
+                ("code", "=", "outgoing"),
+            ],
+            limit=1,
+        )
+        picking_out_vals_lp = picking_out_vals | {
+            "company_id": cls.company_lp,
+            "picking_type_id": cls.picking_type_out_lp,
+        }
+        cls.picking_out_br_lp_1 = create_with_form_br_stock_picking(
+            cls.env,
+            picking_out_vals_lp,
+            move_vals_1 + move_vals_2 + move_vals_3,
+        )
+        cls.picking_out_br_lp_1.move_ids[2].fiscal_operation_id = cls.op_bonificacao
+
+        # Empresa Simples Nacional
+        tax_classification_000001 = cls.env["l10n_br_fiscal.tax.classification"].search(
+            [("code", "=", "000001")]
+        )
+        data_company_sn = {
+            "name": "Empresa Simples Nacional 1",
+            "legal_name": "Empresa Simples Nacional 1",
+            "country_id": cls.env.ref("base.br").id,
+            "state_id": cls.env.ref("base.state_br_sp").id,
+            "city_id": cls.env.ref("l10n_br_base.city_3550308").id,
+            "zip": "18125-000",
+            "street_name": "Rua A",
+            "street_number": "1",
+            "district": "Bela Vista",
+            "vat": "69.330.888/0001-27",
+            "l10n_br_ie_code": "755.338.250.133",
+            "tax_framework": "1",
+            "legal_nature_id": legal_nature_2062.id,
+            "cnae_main_id": fiscal_cnae_3101200.id,
+            "piscofins_id": cls.env.ref(
+                "l10n_br_fiscal.tax_pis_cofins_simples_nacional"
+            ).id,
+            "document_type_id": cls.env.ref("l10n_br_fiscal.document_55").id,
+            # Simples Nacional
+            "tax_ipi_id": cls.env.ref("l10n_br_fiscal.tax_ipi_outros").id,
+            "tax_icms_id": cls.env.ref("l10n_br_fiscal.tax_icms_sn_com_credito").id,
+            "annual_revenue": "815000.00",
+            "tax_classification_id": tax_classification_000001.id,
+        }
+        cls.company_sn = create_and_configure_br_company(
+            cls.env, data_company_sn, cls.fiscal_ops
+        )
+
+        cls.picking_type_out_sn = cls.env["stock.picking.type"].search(
+            [
+                ("company_id", "=", cls.company_sn.id),
+                ("code", "=", "outgoing"),
+            ],
+            limit=1,
+        )
+        picking_out_vals_sn = picking_out_vals | {
+            "company_id": cls.company_sn,
+            "picking_type_id": cls.picking_type_out_sn,
+        }
+        cls.picking_out_br_sn_1 = create_with_form_br_stock_picking(
+            cls.env,
+            picking_out_vals_sn,
+            move_vals_1 + move_vals_2 + move_vals_3,
+        )
+        cls.picking_out_br_sn_1.move_ids[2].fiscal_operation_id = cls.op_bonificacao
 
     @classmethod
     def get_default_groups(cls):
@@ -42,10 +314,6 @@ class TestBrPickingInvoicingCommon(TestStockPickingInvoicingCommon):
         self.env.user.company_ids += company
         self.env.user.company_id = company
 
-    def _run_picking_onchanges(self, record):
-        """Run picking onchanges (compatibility with 17.0 tests)."""
-        record._onchange_invoice_state()
-
     def create_invoice_wizard(self, pickings):
         return create_with_form_inv_onshipping(self.env, pickings)
 
@@ -54,3 +322,126 @@ class TestBrPickingInvoicingCommon(TestStockPickingInvoicingCommon):
 
     def create_backorder_wizard(self, picking):
         return create_with_form_pck_backorder(self.env, picking)
+
+    def check_br_invoice_created(self, invoices, pickings):
+        for picking in pickings:
+            self.assertEqual(picking.state, "done")
+            self.assertEqual(picking.invoice_state, "invoiced")
+            # Verificar os Valores de Preço pois isso é usado na Valorização do
+            # Estoque, o metodo do core é chamado pelo botão Validate
+            for pck_line in picking.move_ids:
+                # No Brasil o caso de Ordens de Entrega que não tem ligação com
+                # Pedido de Venda por padrão deve trazer o valor o Preço de Custo
+                # e não o de Venda, ex.: Simples Remessa, Remessa p/
+                # Industrialiazação e etc, mas o valor informado pelo usuário deve
+                # ter prioridade.
+                # Os metodos do stock/core alteram o valor p/
+                # negativo por isso o abs
+                if pck_line.fiscal_operation_id != self.op_entrada_remessa:
+                    self.assertEqual(
+                        abs(pck_line.price_unit),
+                        pck_line.product_id.with_company(
+                            pck_line.company_id
+                        ).standard_price,
+                    )
+                # O Campo fiscal_price precisa ser um espelho do price_unit,
+                # apesar do onchange p/ preenche-lo sem incluir o compute no campo
+                # ele traz o valor do lst_price e falha no teste abaixo
+                # TODO - o fiscal_price aqui tbm deve ter um valor negativo ?
+
+            for invoice in invoices:
+                self.assertTrue(invoice, "Invoice is not created.")
+                self.assertEqual(picking.invoice_state, "invoiced")
+                self.assertIn(invoice, picking.invoice_ids)
+                self.assertIn(picking, invoice.picking_ids)
+                self.assertEqual(invoice.partner_id, picking.partner_id)
+                self.assertTrue(
+                    invoice.fiscal_operation_id,
+                    "Mapping fiscal operation on wizard to create invoice fail.",
+                )
+                self.assertTrue(
+                    invoice.fiscal_document_id,
+                    "Mapping Fiscal Documentation_id on wizard to create invoice fail.",
+                )
+                assert invoice.invoice_line_ids, "Error to create invoice line."
+                for line in invoice.invoice_line_ids:
+                    # Valida presença dos campos principais para o mapeamento Fiscal
+                    self.assertTrue(
+                        line.fiscal_operation_id, "Missing Fiscal Operation."
+                    )
+                    self.assertTrue(
+                        line.fiscal_operation_line_id, "Missing Fiscal Operation Line."
+                    )
+
+                    # Price Unit e Fiscal Price devem ser positivos
+                    price_unit_mv_line = picking.move_ids.filtered(
+                        lambda mv, line=line: mv.product_id == line.product_id
+                    ).mapped("price_unit")[0]
+                    if line.fiscal_operation_id != self.op_entrada_remessa:
+                        self.assertEqual(
+                            line.price_unit,
+                            price_unit_mv_line,
+                        )
+                        self.assertEqual(
+                            line.fiscal_price,
+                            price_unit_mv_line,
+                        )
+                    # TODO: No travis falha o browse aqui
+                    #  l10n_br_stock_account/models/stock_invoice_onshipping.py:105
+                    #  isso não acontece no caso da empresa de Lucro Presumido
+                    #  ou quando é feito o teste apenas instalando os modulos
+                    #  l10n_br_account e em seguida o l10n_br_stock_account
+                    # self.assertTrue(inv_line.tax_ids,
+                    # "Error to map Sale Tax in invoice.line.")
+                    self.assertTrue(
+                        line.fiscal_tax_ids,
+                        "Error to map fiscal_tax_ids in invoice line.",
+                    )
+                    assert (
+                        line.ind_final
+                    ), "Error field ind_final in Invoice Line not None"
+                    # Verifica se o campo tax_ids da Fatura esta igual ao da Separação
+                    mv_line = picking.move_ids.filtered(
+                        lambda ln, line=line: (
+                            ln.product_id == line.product_id
+                            and ln.fiscal_operation_id == line.fiscal_operation_id
+                        )
+                    )
+                    self.assertEqual(
+                        line.tax_ids,
+                        mv_line.tax_ids,
+                        "Taxes in invoice lines are different from move lines.",
+                    )
+
+    def run_picking_devolution(self, picking):
+        picking_devolution = create_with_form_return_picking(self.env, picking)
+        return_fiscal_op = picking.fiscal_operation_id.return_fiscal_operation_id
+        self.assertEqual(picking_devolution.invoice_state, "2binvoiced")
+        self.assertTrue(
+            picking_devolution.fiscal_operation_id, "Missing Fiscal Operation."
+        )
+        self.assertEqual(
+            picking_devolution.fiscal_operation_id,
+            return_fiscal_op,
+            "Wrong Return Fiscal Operation in the Devolution Picking.",
+        )
+        for line in picking_devolution.move_ids:
+            self.assertEqual(line.invoice_state, "2binvoiced")
+            # Valida presença dos campos principais para o mapeamento Fiscal
+            self.assertTrue(line.fiscal_operation_id, "Missing Fiscal Operation.")
+            self.assertEqual(
+                line.fiscal_operation_id,
+                return_fiscal_op,
+                "Wrong Return Fiscal Operation the Devolution Picking.",
+            )
+            self.assertTrue(
+                line.fiscal_operation_line_id, "Missing Fiscal Operation Line."
+            )
+            self.assertIn(
+                return_fiscal_op.line_ids,
+                line.fiscal_operation_line_id,
+                "Wrong Return Line Fiscal Operation the Devolution Picking.",
+            )
+        self.picking_move_state(picking_devolution)
+        self.assertEqual(picking_devolution.state, "done", "Change state fail.")
+        return picking_devolution

--- a/l10n_br_stock_account/tests/test_invoicing_picking.py
+++ b/l10n_br_stock_account/tests/test_invoicing_picking.py
@@ -4,6 +4,11 @@
 
 from odoo.tests import Form
 
+from odoo.addons.stock_picking_invoicing.tests.tools import (
+    create_with_form_inv_onshipping,
+    create_with_form_pck_backorder,
+)
+
 from .common import TestBrPickingInvoicingCommon
 
 
@@ -14,102 +19,24 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
     def setUpClass(cls):
         super().setUpClass()
 
-    def test_invoicing_picking(self):
+    def test_01_invoicing_picking(self):
         """Test Invoicing Picking"""
-        self._change_user_company(self.env.ref("base.main_company"))
-        picking = self.env.ref("l10n_br_stock_account.main_company-picking_1")
-        for line in picking.move_ids:
-            line.price_unit = 100
-
+        picking = self.picking_out_br_1
         # Testa os Impostos Dedutiveis
         picking.fiscal_operation_id.deductible_taxes = True
         nb_invoice_before = self.env["account.move"].search_count([])
         self.picking_move_state(picking)
-        # Verificar os Valores de Preço pois isso é usado na Valorização do
-        # Estoque, o metodo do core é chamado pelo botão Validate
-
-        for line in picking.move_ids:
-            # No Brasil o caso de Ordens de Entrega que não tem ligação com
-            # Pedido de Venda por padrão deve trazer o valor o Preço de Custo
-            # e não o de Venda, ex.: Simples Remessa, Remessa p/
-            # Industrialiazação e etc, mas o valor informado pelo usuário deve
-            # ter prioridade.
-            # Os metodos do stock/core alteram o valor p/
-            # negativo por isso o abs
-
-            self.assertEqual(
-                abs(line.price_unit),
-                line.product_id.with_company(line.company_id).standard_price,
-            )
-            # O Campo fiscal_price precisa ser um espelho do price_unit,
-            # apesar do onchange p/ preenche-lo sem incluir o compute no campo
-            # ele traz o valor do lst_price e falha no teste abaixo
-            # TODO - o fiscal_price aqui tbm deve ter um valor negativo ?
-
-        invoice = self.create_invoice_wizard(picking)
-        self.assertTrue(invoice, "Invoice is not created.")
-        self.assertEqual(picking.invoice_state, "invoiced")
-        self.assertEqual(
-            invoice.partner_id, self.env.ref("l10n_br_base.res_partner_cliente1_sp")
-        )
-        self.assertIn(invoice, picking.invoice_ids)
-        self.assertIn(picking, invoice.picking_ids)
+        invoice = create_with_form_inv_onshipping(self.env, picking)
+        self.check_br_invoice_created(invoice, picking)
         nb_invoice_after = self.env["account.move"].search_count([])
         self.assertEqual(nb_invoice_before, nb_invoice_after - len(invoice))
-        assert invoice.invoice_line_ids, "Error to create invoice line."
-        for line in invoice.picking_ids:
-            self.assertEqual(
-                line.id,
-                picking.id,
-                "Relation between invoice and picking are missing.",
-            )
-        for line in invoice.invoice_line_ids:
-            # TODO: No travis falha o browse aqui
-            #  l10n_br_stock_account/models/stock_invoice_onshipping.py:105
-            #  isso não acontece no caso da empresa de Lucro Presumido
-            #  ou quando é feito o teste apenas instalando os modulos
-            #  l10n_br_account e em seguida o l10n_br_stock_account
-            # self.assertTrue(line.tax_ids, "Taxes in invoice lines are missing.")
-
-            # No Brasil o caso de Ordens de Entrega que não tem ligação com
-            # Pedido de Venda precisam informar o Preço de Custo e não o de
-            # Venda, ex.: Simples Remessa, Remessa p/ Industrialiazação e etc.
-            # Aqui o campo não pode ser negativo
-            self.assertEqual(
-                line.price_unit,
-                line.product_id.with_company(line.company_id).standard_price,
-            )
-            # Valida presença dos campos principais para o mapeamento Fiscal
-            self.assertTrue(line.fiscal_operation_id, "Missing Fiscal Operation.")
-            self.assertTrue(
-                line.fiscal_operation_line_id, "Missing Fiscal Operation Line."
-            )
-
-        self.assertTrue(
-            invoice.fiscal_operation_id,
-            "Mapping fiscal operation on wizard to create invoice fail.",
+        picking_devolution = self.run_picking_devolution(picking)
+        invoice_devolution = create_with_form_inv_onshipping(
+            self.env, picking_devolution
         )
-        self.assertTrue(
-            invoice.fiscal_document_id,
-            "Mapping Fiscal Documentation_id on wizard to create invoice fail.",
-        )
+        self.check_br_invoice_created(invoice_devolution, picking_devolution)
 
-        picking_devolution = self.return_picking_wizard(picking)
-        self.assertEqual(picking_devolution.invoice_state, "2binvoiced")
-        self.assertTrue(
-            picking_devolution.fiscal_operation_id, "Missing Fiscal Operation."
-        )
-        for line in picking_devolution.move_ids:
-            self.assertEqual(line.invoice_state, "2binvoiced")
-            # Valida presença dos campos principais para o mapeamento Fiscal
-            self.assertTrue(line.fiscal_operation_id, "Missing Fiscal Operation.")
-            self.assertTrue(
-                line.fiscal_operation_line_id, "Missing Fiscal Operation Line."
-            )
-        self.picking_move_state(picking_devolution)
-        self.assertEqual(picking_devolution.state, "done", "Change state fail.")
-
-    def test_picking_invoicing_by_product2(self):
+    def test_02_picking_invoicing_by_product2(self):
         """
         Test the invoice generation grouped by partner/product with 2
         picking and 3 moves per picking.
@@ -118,60 +45,30 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
         :return:
         """
         nb_invoice_before = self.env["account.move"].search_count([])
-        self._change_user_company(self.env.ref("base.main_company"))
         self.env["account.move"].search_count([])
-        self.env.ref("l10n_br_base.res_partner_cliente1_sp").write({"type": "invoice"})
-        picking = self.env.ref("l10n_br_stock_account.main_company-picking_1")
-        self.picking_move_state(picking)
-        picking2 = self.env.ref("l10n_br_stock_account.main_company-picking_2")
-        self.picking_move_state(picking2)
-        self.assertEqual(picking.state, "done")
-        self.assertEqual(picking2.state, "done")
-        pickings = picking | picking2
-        invoice = self.create_invoice_wizard(pickings)
+        picking_1 = self.picking_out_br_1
+        self.picking_move_state(picking_1)
+        picking_2 = self.picking_out_br_2
+        self.picking_move_state(picking_2)
+        self.assertEqual(picking_1.state, "done")
+        self.assertEqual(picking_2.state, "done")
+        invoice = create_with_form_inv_onshipping(self.env, picking_1 | picking_2)
         self.assertEqual(len(invoice), 1)
-        self.assertEqual(picking.invoice_state, "invoiced")
-        self.assertEqual(picking2.invoice_state, "invoiced")
-        self.assertEqual(
-            invoice.partner_id, self.env.ref("l10n_br_base.res_partner_cliente1_sp")
-        )
-        self.assertIn(invoice, picking.invoice_ids)
-        self.assertIn(invoice, picking2.invoice_ids)
-        self.assertIn(picking, invoice.picking_ids)
-        self.assertIn(picking2, invoice.picking_ids)
+        self.check_br_invoice_created(invoice, picking_1 | picking_2)
         for inv_line in invoice.invoice_line_ids:
             # qty = 4 because 2 for each stock.move
             self.assertEqual(inv_line.quantity, 4)
-            # Price Unit e Fiscal Price devem ser positivos
-            price_unit_mv_line = picking.move_ids.filtered(
-                lambda mv, inv_line=inv_line: mv.product_id == inv_line.product_id
-            ).mapped("price_unit")[0]
-            self.assertEqual(
-                inv_line.price_unit,
-                price_unit_mv_line,
-            )
-            self.assertEqual(
-                inv_line.fiscal_price,
-                price_unit_mv_line,
-            )
-
-            # TODO: No travis falha o browse aqui
-            #  l10n_br_stock_account/models/stock_invoice_onshipping.py:105
-            #  isso não acontece no caso da empresa de Lucro Presumido
-            #  ou quando é feito o teste apenas instalando os modulos
-            #  l10n_br_account e em seguida o l10n_br_stock_account
-            # self.assertTrue(inv_line.tax_ids,
-            # "Error to map Sale Tax in invoice.line.")
 
         # Now test behaviour if the invoice is delete
         invoice.unlink()
+        pickings = picking_1 | picking_2
         for picking in pickings:
             self.assertEqual(picking.invoice_state, "2binvoiced")
         nb_invoice_after = self.env["account.move"].search_count([])
         # Should be equals because we delete the invoice
         self.assertEqual(nb_invoice_before, nb_invoice_after)
 
-    def test_picking_invoicing_by_product3(self):
+    def test_03_picking_invoicing_by_product3(self):
         """
         Test the invoice generation grouped by partner/product with 2
         picking and 3 moves per picking, but 1 picking are the one
@@ -179,22 +76,19 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
         with 3 lines (and qty 2)
         :return:
         """
-        self._change_user_company(self.env.ref("base.main_company"))
         self.env["account.move"].search_count([])
-        self.env.ref("l10n_br_base.res_partner_cliente1_sp").write({"type": "invoice"})
-        picking = self.env.ref("l10n_br_stock_account.main_company-picking_3")
-        self.picking_move_state(picking)
-        picking2 = self.env.ref("l10n_br_stock_account.main_company-picking_4")
-        self.picking_move_state(picking2)
-        self.assertEqual(picking.state, "done")
-        self.assertEqual(picking2.state, "done")
-        pickings = picking | picking2
-        invoicies = self.create_invoice_wizard(pickings)
+        picking_1 = self.picking_out_br_3
+        self.picking_move_state(picking_1)
+        picking_2 = self.picking_out_br_4
+        self.picking_move_state(picking_2)
+        self.assertEqual(picking_1.state, "done")
+        self.assertEqual(picking_2.state, "done")
+        invoicies = create_with_form_inv_onshipping(self.env, picking_1 | picking_2)
         self.assertEqual(len(invoicies), 2)
-        self.assertEqual(picking.invoice_state, "invoiced")
-        self.assertEqual(picking2.invoice_state, "invoiced")
+        self.assertEqual(picking_1.invoice_state, "invoiced")
+        self.assertEqual(picking_2.invoice_state, "invoiced")
         invoice_pick_1 = invoicies.filtered(
-            lambda t: t.partner_id == picking.partner_id
+            lambda t: t.partner_shipping_id == picking_1.partner_id
         )
         #  Nesse caso está trazendo o mesmo Partner apesar de ser um endereço
         #  de outro principal, isso acontece porque o metodo address_get chamado
@@ -205,16 +99,15 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
         #  Person/Pessoa e não Company/Empresa.
         #  TODO: A localização BR deveria sobreescrever o metodo address_get
         #   para ignorar o company_type?
-        self.assertEqual(invoice_pick_1.partner_id, picking.partner_id)
-        self.assertIn(invoice_pick_1, picking.invoice_ids)
-        self.assertIn(picking, invoice_pick_1.picking_ids)
+        self.assertEqual(invoice_pick_1.partner_shipping_id, picking_1.partner_id)
+        self.assertIn(invoice_pick_1, picking_1.invoice_ids)
+        self.assertIn(picking_1, invoice_pick_1.picking_ids)
 
         invoice_pick_2 = invoicies.filtered(
-            lambda t: t.partner_id == picking2.partner_id
+            lambda t: t.partner_shipping_id == picking_2.partner_id
         )
-        self.assertIn(invoice_pick_2, picking2.invoice_ids)
-
-        self.assertIn(picking2, invoice_pick_2.picking_ids)
+        self.assertIn(invoice_pick_2, picking_2.invoice_ids)
+        self.assertIn(picking_2, invoice_pick_2.picking_ids)
 
         # Not grouping products with different Operation Fiscal Line
         self.assertEqual(len(invoice_pick_1.invoice_line_ids), 3)
@@ -228,6 +121,7 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
 
         invoice_pick_1.unlink()
         invoice_pick_2.unlink()
+        pickings = picking_1 | picking_2
         for picking in pickings:
             self.assertEqual(picking.invoice_state, "2binvoiced")
         # Check that invoices for our pickings were deleted
@@ -257,12 +151,11 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
         #  stock_picking_invoicing/wizards/stock_invoice_onshipping.py#L316
         #  é preciso avaliar se deve ser alterado na localização ou mesmo
         #  no modulo stock_picking_invoicing
-        picking_3 = self.env.ref("l10n_br_stock_account.main_company-picking_5")
+        picking_3 = self.picking_out_br_5
         self.picking_move_state(picking_3)
-        picking_4 = self.env.ref("l10n_br_stock_account.main_company-picking_6")
+        picking_4 = self.picking_out_br_6
         self.picking_move_state(picking_4)
-        pickings = picking_3 | picking_4
-        invoices = self.create_invoice_wizard(pickings)
+        invoices = create_with_form_inv_onshipping(self.env, picking_3 | picking_4)
         self.assertEqual(len(invoices), 2)
         self.assertEqual(picking_3.invoice_state, "invoiced")
         self.assertEqual(picking_4.invoice_state, "invoiced")
@@ -271,20 +164,18 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
         self.assertIn(picking_3.invoice_ids, invoices)
         self.assertIn(picking_4.invoice_ids, invoices)
 
-    def test_picking_split(self):
+    def test_04_picking_split(self):
         """Test Picking Split created with Fiscal Values."""
-        self._change_user_company(self.env.ref("base.main_company"))
-        picking2 = self.env.ref("l10n_br_stock_account.main_company-picking_2")
+        picking = self.picking_out_br_2
+        picking.action_confirm()
+        picking.action_assign()
 
-        picking2.action_confirm()
-        picking2.action_assign()
-
-        for move in picking2.move_ids_without_package:
+        for move in picking.move_ids_without_package:
             # Force Split
             move.quantity = 1
 
         # Return Wizard
-        backorder = self.create_backorder_wizard(picking2)
+        backorder = create_with_form_pck_backorder(self.env, picking)
         self.assertEqual(backorder.invoice_state, "2binvoiced")
         self.assertTrue(backorder.fiscal_operation_id)
 
@@ -297,11 +188,10 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
         self.picking_move_state(backorder)
 
     # Testando o Lucro Presumido
-    def test_invoicing_picking_lucro_presumido(self):
+    def test_05_invoicing_picking_lucro_presumido(self):
         """Test Invoicing Picking - Lucro Presumido"""
-
-        self._change_user_company(self.env.ref("l10n_br_base.empresa_lucro_presumido"))
-        picking = self.env.ref("l10n_br_stock_account.lucro_presumido-picking_1")
+        self._change_user_company(self.company_lp)
+        picking = self.picking_out_br_lp_1
         nb_invoice_before = self.env["account.move"].search_count([])
 
         self.picking_move_state(picking)
@@ -320,93 +210,26 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
             line.product_id.standard_price = 0.0
             line.price_unit = 0.0
 
-        invoice = self.create_invoice_wizard(picking)
-        self.assertTrue(invoice, "Invoice is not created.")
-        self.assertEqual(picking.invoice_state, "invoiced")
-        self.assertEqual(
-            invoice.partner_id, self.env.ref("l10n_br_base.res_partner_cliente1_sp")
-        )
-        # Campo 'Consumidor Final' deve ser igual ao do picking
-        self.assertEqual(invoice.ind_final, picking.ind_final)
-        self.assertIn(invoice, picking.invoice_ids)
-        self.assertIn(picking, invoice.picking_ids)
+        invoice = create_with_form_inv_onshipping(self.env, picking)
+        self.check_br_invoice_created(invoice, picking)
         nb_invoice_after = self.env["account.move"].search_count([])
         self.assertEqual(nb_invoice_before, nb_invoice_after - len(invoice))
-        assert invoice.invoice_line_ids, "Error to create invoice line."
-        for line in invoice.picking_ids:
-            self.assertEqual(
-                line.id,
-                picking.id,
-                "Relation between invoice and picking are missing.",
-            )
-        for line in invoice.invoice_line_ids:
-            # No Brasil o caso de Ordens de Entrega que não tem ligação com
-            # Pedido de Venda precisam informar o Preço de Custo e não o de
-            # Venda, ex.: Simples Remessa, Remessa p/ Industrialiazação e etc.
-            # Aqui o campo não pode ser negativo
-            # self.assertEqual(line.price_unit, line.product_id.standard_price)
-            # Valida presença dos campos principais para o mapeamento Fiscal
-            self.assertTrue(line.fiscal_operation_id, "Missing Fiscal Operation.")
-            self.assertTrue(
-                line.fiscal_operation_line_id, "Missing Fiscal Operation Line."
-            )
-            self.assertTrue(
-                line.fiscal_tax_ids, "Error to map fiscal_tax_ids in invoice line."
-            )
-            assert line.ind_final, "Error field ind_final in Invoice Line not None"
-            # Verifica se o campo tax_ids da Fatura esta igual ao da Separação
-            mv_line = picking.move_ids.filtered(
-                lambda ln, line=line: (
-                    ln.product_id == line.product_id
-                    and ln.fiscal_operation_id == line.fiscal_operation_id
-                )
-            )
-            self.assertEqual(
-                line.tax_ids,
-                mv_line.tax_ids,
-                "Taxes in invoice lines are different from move lines.",
-            )
 
-        self.assertTrue(
-            invoice.fiscal_operation_id,
-            "Mapping fiscal operation on wizard to create invoice fail.",
-        )
-        self.assertTrue(
-            invoice.fiscal_document_id,
-            "Mapping Fiscal Documentation_id on wizard to create invoice fail.",
-        )
-
-        picking_devolution = self.return_picking_wizard(picking)
-        self.assertEqual(picking_devolution.invoice_state, "2binvoiced")
-        self.assertTrue(
-            picking_devolution.fiscal_operation_id, "Missing Fiscal Operation."
-        )
-        for line in picking_devolution.move_ids:
-            self.assertEqual(line.invoice_state, "2binvoiced")
-            # Valida presença dos campos principais para o mapeamento Fiscal
-            self.assertTrue(line.fiscal_operation_id, "Missing Fiscal Operation.")
-            self.assertTrue(
-                line.fiscal_operation_line_id, "Missing Fiscal Operation Line."
-            )
-        self.picking_move_state(picking_devolution)
-        self.assertEqual(picking_devolution.state, "done", "Change state fail.")
+        self.run_picking_devolution(picking)
 
         # Now test behaviour if the invoice is delete
         invoice.unlink()
-
         self.assertEqual(picking.invoice_state, "2binvoiced")
         nb_invoice_after = self.env["account.move"].search_count([])
         # Should be equals because we delete the invoice
         self.assertEqual(nb_invoice_before, nb_invoice_after)
 
-    def test_fields_freight_insurance_other_costs(self):
+    def test_06_fields_freight_insurance_other_costs(self):
         """Test fields Freight, Insurance and Other Costs when
         defined or By Line or By Total in Stock Picking.
         """
-
-        self._change_user_company(self.env.ref("base.main_company"))
+        picking = self.picking_out_br_1
         # Por padrão a definição dos campos está por Linha
-        picking = self.env.ref("l10n_br_stock_account.main_company-picking_1")
         picking.company_id.delivery_costs = "line"
         # Teste definindo os valores Por Linha
         for line in picking.move_ids_without_package:
@@ -496,7 +319,7 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
                 "Unexpected value for the field Other Values in Move line.",
             )
 
-        invoice = self.create_invoice_wizard(picking)
+        invoice = create_with_form_inv_onshipping(self.env, picking)
         # Confirm Invoice
         invoice.action_post()
         self.assertEqual(invoice.state, "posted", "Invoice should be in state Posted")
@@ -505,11 +328,12 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
             "Freight, Insurance and Other Costs case should has Fiscal Document.",
         )
 
-    def test_compatible_with_international_case(self):
+    def test_07_compatible_with_international_case(self):
         """
         Test of compatible with international case, create Invoice but not for Brazil.
         """
-        picking = self.env.ref("stock_picking_invoicing.stock_picking_invoicing_2")
+        picking = self.picking_out_1
+        picking.set_to_be_invoiced()
         picking.fiscal_operation_id = False
         # Force product availability
         for move in picking.move_ids_without_package:
@@ -517,7 +341,7 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
             move.product_uom_qty = 2
             move.quantity = 1
         # Return Wizard
-        backorder = self.create_backorder_wizard(picking)
+        backorder = create_with_form_pck_backorder(self.env, picking)
         self.assertEqual(backorder.invoice_state, "2binvoiced")
         self.assertFalse(backorder.fiscal_operation_id)
 
@@ -531,7 +355,7 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
         self.assertEqual(picking.state, "done")
         # Switch to picking company for invoice creation
         self._change_user_company(picking.company_id)
-        invoice = self.create_invoice_wizard(picking)
+        invoice = create_with_form_inv_onshipping(self.env, picking)
         # Confirm Invoice
         invoice.action_post()
         self.assertEqual(invoice.state, "posted", "Invoice should be in state Posted")
@@ -545,10 +369,9 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
             "International case should not has Fiscal Document.",
         )
 
-    def test_picking_extra_vals(self):
+    def test_08_picking_extra_vals(self):
         """Test Picking Extra Vals created with Fiscal Values."""
-        self._change_user_company(self.env.ref("base.main_company"))
-        picking = self.env.ref("l10n_br_stock_account.main_company-picking_2")
+        picking = self.picking_out_br_2
 
         for line in picking.move_ids:
             # Force Split
@@ -556,167 +379,36 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
 
         picking.button_validate()
 
-    def test_form_stock_picking(self):
+    def test_09_form_stock_picking(self):
         """Test Stock Picking with Form"""
-
-        picking_form = Form(
-            self.env.ref("l10n_br_stock_account.main_company-picking_2")
-        )
+        picking_form = Form(self.picking_out_br_2)
         picking_form.save()
-        stock_move_form = Form(
-            self.env.ref("l10n_br_stock_account.main_company-move_2_1")
-        )
+        stock_move_form = Form(self.picking_out_br_2.move_ids[0])
         stock_move_form.product_uom_qty = 10
         # Testa o _onchange_product_quantity
         stock_move_form.price_unit = 0.0
         stock_move_form.save()
 
-    def test_simples_nacional(self):
+    def test_10_simples_nacional(self):
         """Test case of Simples Nacional"""
-        company_sn = self.env.ref("l10n_br_base.empresa_simples_nacional")
-        self._change_user_company(company_sn)
-        # Load chart template for Simples Nacional company if not already loaded
-        has_receivable = (
-            self.env["account.account"]
-            .with_company(company_sn)
-            .search_count([("account_type", "=", "asset_receivable")])
-        )
-        if not has_receivable:
-            # Create minimal chart accounts for Simples Nacional company
-            # to avoid depending on l10n_br chart template
-            account_vals = [
-                {
-                    "name": "Receivable",
-                    "code": "1.1.1.01",
-                    "account_type": "asset_receivable",
-                    "company_ids": [(4, company_sn.id)],
-                    "reconcile": True,
-                },
-                {
-                    "name": "Payable",
-                    "code": "2.1.1.01",
-                    "account_type": "liability_payable",
-                    "company_ids": [(4, company_sn.id)],
-                    "reconcile": True,
-                },
-                {
-                    "name": "Income",
-                    "code": "3.1.1.01",
-                    "account_type": "income",
-                    "company_ids": [(4, company_sn.id)],
-                },
-                {
-                    "name": "Expense",
-                    "code": "4.1.1.01",
-                    "account_type": "expense",
-                    "company_ids": [(4, company_sn.id)],
-                },
-            ]
-            accounts = self.env["account.account"].create(account_vals)
-            receivable_account = accounts.filtered(
-                lambda a: a.account_type == "asset_receivable"
-            )
-            payable_account = accounts.filtered(
-                lambda a: a.account_type == "liability_payable"
-            )
-            income_account = accounts.filtered(lambda a: a.account_type == "income")
-            expense_account = accounts.filtered(lambda a: a.account_type == "expense")
-            # Set default company accounts
-            company_sn.account_journal_suspense_account_id = receivable_account.id
-            # Set product category accounts for this company
-            product_category = self.env.ref("product.product_category_all")
-            product_category.with_company(
-                company_sn
-            ).property_account_income_categ_id = income_account
-            product_category.with_company(
-                company_sn
-            ).property_account_expense_categ_id = expense_account
-            # Load fiscal taxes for the company
-            self.env["account.chart.template"].load_fiscal_taxes(companies=[company_sn])
-        # Ensure partner has property accounts for this company
-        partner = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
-        receivable_account = (
-            self.env["account.account"]
-            .with_company(company_sn)
-            .search(
-                [
-                    ("account_type", "=", "asset_receivable"),
-                    ("company_ids", "in", [company_sn.id]),
-                ],
-                limit=1,
-            )
-        )
-        payable_account = (
-            self.env["account.account"]
-            .with_company(company_sn)
-            .search(
-                [
-                    ("account_type", "=", "liability_payable"),
-                    ("company_ids", "in", [company_sn.id]),
-                ],
-                limit=1,
-            )
-        )
-        if receivable_account:
-            partner.with_company(
-                company_sn
-            ).property_account_receivable_id = receivable_account
-        if payable_account:
-            partner.with_company(
-                company_sn
-            ).property_account_payable_id = payable_account
-        picking = self.env.ref("l10n_br_stock_account.simples_nacional-picking_1")
+        self._change_user_company(self.company_sn)
+        picking = self.picking_out_br_sn_1
         for line in picking.move_ids:
             # Testa _get_price_unit
             line.price_unit = 0.0
         self.picking_move_state(picking)
         self.assertEqual(picking.state, "done", "Change state fail.")
-        # Testes falhando apenas no CI, a Operação Fiscal por algum motivo
-        # tem o campo journal_id preenchida com o Diário Miscelanios o que
-        # causa o erro abaixo
-        # File "/opt/odoo/addons/account/models/account_move.py", line 1931,
-        #  in _check_journal_type
-        # raise ValidationError(_("The chosen journal has a type that is
-        # not compatible with your invoice type. Sales operations should go
-        # to 'sale' journals, and purchase operations to 'purchase' ones."))
-        # odoo.exceptions.ValidationError: The chosen journal has a type that
-        # is not compatible with your invoice type. Sales operations should go
-        #  to 'sale' journals, and purchase operations to 'purchase' ones.
-        # TODO: teria alguma forma de corrigir? Por enquanto está sendo
-        # preciso preenche o campo com o Diário correto para evitar o erro
-        journal = self.env.ref(
-            "l10n_br_stock_account.simples_remessa_journal_simples_nacional"
-        )
-        of_simples_remessa = self.env.ref("l10n_br_fiscal.fo_simples_remessa")
-        of_simples_remessa.journal_id = journal
-
-        invoice = self.create_invoice_wizard(picking)
-        # Confirm Invoice
-        # TODO: O método abaixo retorna erro de Permissão de Acesso ao
-        #  'account.move.line', mas não parece ser esse realmente o problema,
-        #  porque os testes, logo abaixo, e o fato do erro não acontecer em
-        #  outras Empresas sugere que existe algum outro erro, por enquanto
-        #  o método esta sendo chamado com o sudo.
-        # invoice.action_post()
-        self.assertTrue(self.env.user.has_group("l10n_br_fiscal.group_manager"))
-        self.assertTrue(self.env.user.has_group("account.group_account_manager"))
-        self.assertEqual(self.env.user, invoice.user_id)
-        for ln in invoice.invoice_line_ids:
-            ln.name = "Teste de Permissão de Acesso no account.move.line"
-
-        invoice.sudo().action_post()
-
+        invoice = create_with_form_inv_onshipping(self.env, picking)
+        invoice.action_post()
         self.assertEqual(invoice.state, "posted", "Invoice should be in state Posted")
         self.assertTrue(
             invoice.fiscal_document_id,
             "Simples Nacional case should has Fiscal Document.",
         )
 
-    def test_generate_document_number_on_packing(self):
+    def test_11_generate_document_number_on_packing(self):
         """Test Invoicing Picking"""
-        self._change_user_company(self.env.ref("base.main_company"))
-        picking = self.env.ref("l10n_br_stock_account.main_company-picking_1")
-        # self._run_fiscal_onchanges(picking)
+        picking = self.picking_out_br_1
         # Testa os Impostos Dedutiveis
         picking.fiscal_operation_id.deductible_taxes = True
         nb_invoice_before = self.env["account.move"].search_count([])
@@ -725,170 +417,61 @@ class InvoicingPickingTest(TestBrPickingInvoicingCommon):
         picking.action_assign()
         for move in picking.move_ids_without_package:
             move.quantity = move.product_uom_qty
-        for line in picking.move_ids:
-            line.price_unit = 100
-
         picking.action_put_in_pack()
         picking.button_validate()
         picking.set_to_be_invoiced()
         self.assertTrue(picking.document_number)
 
-        invoice = self.create_invoice_wizard(picking)
-        self.assertTrue(invoice, "Invoice is not created.")
-        self.assertEqual(picking.invoice_state, "invoiced")
-        self.assertEqual(
-            invoice.partner_id, self.env.ref("l10n_br_base.res_partner_cliente1_sp")
-        )
-        self.assertIn(invoice, picking.invoice_ids)
-        self.assertIn(picking, invoice.picking_ids)
+        invoice = create_with_form_inv_onshipping(self.env, picking)
+        self.check_br_invoice_created(invoice, picking)
 
         nb_invoice_after = self.env["account.move"].search_count([])
         self.assertEqual(nb_invoice_before, nb_invoice_after - len(invoice))
-        assert invoice.invoice_line_ids, "Error to create invoice line."
-        for line in invoice.picking_ids:
-            self.assertEqual(
-                line.id,
-                picking.id,
-                "Relation between invoice and picking are missing.",
-            )
-        for line in invoice.invoice_line_ids:
-            self.assertEqual(
-                line.price_unit,
-                line.product_id.with_company(line.company_id).standard_price,
-            )
-            # Valida presença dos campos principais para o mapeamento Fiscal
-            self.assertTrue(line.fiscal_operation_id, "Missing Fiscal Operation.")
-            self.assertTrue(
-                line.fiscal_operation_line_id, "Missing Fiscal Operation Line."
-            )
-
-        self.assertTrue(
-            invoice.fiscal_operation_id,
-            "Mapping fiscal operation on wizard to create invoice fail.",
-        )
-        self.assertTrue(
-            invoice.fiscal_document_id,
-            "Mapping Fiscal Documentation_id on wizard to create invoice fail.",
-        )
 
         self.assertEqual(picking.document_number, invoice.document_number)
         self.assertEqual(
             picking.document_number, invoice.fiscal_document_id.document_number
         )
 
-    def test_generate_document_number_on_validating(self):
+    def test_12_generate_document_number_on_validating(self):
         """Test Invoicing Picking"""
-        self._change_user_company(self.env.ref("base.main_company"))
-        picking = self.env.ref("l10n_br_stock_account.main_company-picking_1")
-        # self._run_fiscal_onchanges(picking)
+        picking = self.picking_out_br_1
         # Testa os Impostos Dedutiveis
         picking.fiscal_operation_id.deductible_taxes = True
         nb_invoice_before = self.env["account.move"].search_count([])
         picking.picking_type_id.pre_generate_fiscal_document_number = "validate"
-        for line in picking.move_ids:
-            line.price_unit = 100
 
         self.picking_move_state(picking)
-
         picking.set_to_be_invoiced()
         self.assertTrue(picking.document_number)
 
-        invoice = self.create_invoice_wizard(picking)
-        self.assertTrue(invoice, "Invoice is not created.")
-        self.assertEqual(picking.invoice_state, "invoiced")
-        self.assertEqual(
-            invoice.partner_id, self.env.ref("l10n_br_base.res_partner_cliente1_sp")
-        )
-        self.assertIn(invoice, picking.invoice_ids)
-        self.assertIn(picking, invoice.picking_ids)
-
+        invoice = create_with_form_inv_onshipping(self.env, picking)
+        self.check_br_invoice_created(invoice, picking)
         nb_invoice_after = self.env["account.move"].search_count([])
         self.assertEqual(nb_invoice_before, nb_invoice_after - len(invoice))
-        assert invoice.invoice_line_ids, "Error to create invoice line."
-        for line in invoice.picking_ids:
-            self.assertEqual(
-                line.id,
-                picking.id,
-                "Relation between invoice and picking are missing.",
-            )
-        for line in invoice.invoice_line_ids:
-            self.assertEqual(
-                line.price_unit,
-                line.product_id.with_company(line.company_id).standard_price,
-            )
-            # Valida presença dos campos principais para o mapeamento Fiscal
-            self.assertTrue(line.fiscal_operation_id, "Missing Fiscal Operation.")
-            self.assertTrue(
-                line.fiscal_operation_line_id, "Missing Fiscal Operation Line."
-            )
-
-        self.assertTrue(
-            invoice.fiscal_operation_id,
-            "Mapping fiscal operation on wizard to create invoice fail.",
-        )
-        self.assertTrue(
-            invoice.fiscal_document_id,
-            "Mapping Fiscal Documentation_id on wizard to create invoice fail.",
-        )
 
         self.assertEqual(picking.document_number, invoice.document_number)
         self.assertEqual(
             picking.document_number, invoice.fiscal_document_id.document_number
         )
 
-    def test_generate_document_number_on_invoice_create_wizard(self):
+    def test_13_generate_document_number_on_invoice_create_wizard(self):
         """Test Invoicing Picking"""
-        self._change_user_company(self.env.ref("base.main_company"))
-        picking = self.env.ref("l10n_br_stock_account.main_company-picking_1")
+        picking = self.picking_out_br_1
         # Testa os Impostos Dedutiveis
         picking.fiscal_operation_id.deductible_taxes = True
         nb_invoice_before = self.env["account.move"].search_count([])
         picking.picking_type_id.pre_generate_fiscal_document_number = "validate"
-        for line in picking.move_ids:
-            line.price_unit = 100
 
         self.picking_move_state(picking)
         picking.set_to_be_invoiced()
         self.assertTrue(picking.document_number)
 
-        invoice = self.create_invoice_wizard(picking)
-        self.assertTrue(invoice, "Invoice is not created.")
-        self.assertEqual(picking.invoice_state, "invoiced")
-        self.assertEqual(
-            invoice.partner_id, self.env.ref("l10n_br_base.res_partner_cliente1_sp")
-        )
-        self.assertIn(invoice, picking.invoice_ids)
-        self.assertIn(picking, invoice.picking_ids)
+        invoice = create_with_form_inv_onshipping(self.env, picking)
+        self.check_br_invoice_created(invoice, picking)
 
         nb_invoice_after = self.env["account.move"].search_count([])
         self.assertEqual(nb_invoice_before, nb_invoice_after - len(invoice))
-        assert invoice.invoice_line_ids, "Error to create invoice line."
-        for line in invoice.picking_ids:
-            self.assertEqual(
-                line.id,
-                picking.id,
-                "Relation between invoice and picking are missing.",
-            )
-        for line in invoice.invoice_line_ids:
-            self.assertEqual(
-                line.price_unit,
-                line.product_id.with_company(line.company_id).standard_price,
-            )
-            # Valida presença dos campos principais para o mapeamento Fiscal
-            self.assertTrue(line.fiscal_operation_id, "Missing Fiscal Operation.")
-            self.assertTrue(
-                line.fiscal_operation_line_id, "Missing Fiscal Operation Line."
-            )
-
-        self.assertTrue(
-            invoice.fiscal_operation_id,
-            "Mapping fiscal operation on wizard to create invoice fail.",
-        )
-        self.assertTrue(
-            invoice.fiscal_document_id,
-            "Mapping Fiscal Documentation_id on wizard to create invoice fail.",
-        )
-
         self.assertEqual(picking.document_number, invoice.document_number)
         self.assertEqual(
             picking.document_number, invoice.fiscal_document_id.document_number

--- a/l10n_br_stock_account/tests/tools.py
+++ b/l10n_br_stock_account/tests/tools.py
@@ -1,0 +1,155 @@
+# Copyright (C) 2026-Today - Akretion (<http://www.akretion.com>).
+# @author Magno Costa <magno.costa@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import Form
+
+
+def create_with_form_br_stock_picking(env, values, line_values=False):
+    with Form(env["stock.picking"].with_company(values.get("company_id"))) as picking:
+        picking.partner_id = values.get("partner_id")
+        picking.picking_type_id = values.get("picking_type_id")
+        picking.invoice_state = "2binvoiced"
+        picking.fiscal_operation_id = values.get("fiscal_operation_id")
+        for value in line_values:
+            with picking.move_ids_without_package.new() as line:
+                line.product_id = value.get("product_id")
+                line.product_uom_qty = value.get("product_uom_qty")
+
+    return picking.save()
+
+
+def create_with_form_br_account_journal(env, values):
+    with Form(env["account.journal"].with_company(values.get("company_id"))) as journal:
+        journal.name = values.get("name")
+        journal.code = values.get("code")
+        journal.type = values.get("type")
+        journal.default_account_id = values.get("default_account_id")
+    return journal.save()
+
+
+def create_with_form_br_res_partner(env, values):
+    with Form(env["res.partner"]) as partner:
+        partner.name = values.get("name")
+        partner.country_id = values.get("country_id")
+        partner.state_id = values.get("state_id")
+        partner.city_id = values.get("city_id")
+        partner.zip = values.get("zip")
+        partner.street_name = values.get("street_name")
+        partner.street_number = values.get("street_number")
+        partner.l10n_br_ie_code = values.get("l10n_br_ie_code")
+        partner.fiscal_profile_id = values.get("fiscal_profile_id")
+        if values.get("company_type"):
+            partner.company_type = values.get("company_type")
+            partner.parent_id = values.get("parent_id")
+    return partner.save()
+
+
+def create_and_configure_br_company(env, company_values, fiscal_ops):
+    company = env["res.company"].create(company_values)
+    env.user.company_ids |= company
+    create_br_minimal_chart(env, company)
+    create_br_journal_and_set_fiscal_ops(env, company, fiscal_ops)
+    return company
+
+
+def create_br_minimal_chart(env, company):
+    # Load chart template company if not already loaded
+    has_receivable = (
+        env["account.account"]
+        .with_company(company)
+        .search_count([("account_type", "=", "asset_receivable")])
+    )
+
+    if not has_receivable:
+        # Create minimal chart accounts for company
+        # to avoid depending on l10n_br chart template
+        account_vals = [
+            {
+                "name": "Receivable",
+                "code": "1.1.1.01",
+                "account_type": "asset_receivable",
+                "company_ids": [(4, company.id)],
+                "reconcile": True,
+            },
+            {
+                "name": "Payable",
+                "code": "2.1.1.01",
+                "account_type": "liability_payable",
+                "company_ids": [(4, company.id)],
+                "reconcile": True,
+            },
+            {
+                "name": "Income",
+                "code": "3.1.1.01",
+                "account_type": "income",
+                "company_ids": [(4, company.id)],
+            },
+            {
+                "name": "Expense",
+                "code": "4.1.1.01",
+                "account_type": "expense",
+                "company_ids": [(4, company.id)],
+            },
+            {
+                "name": "EXpense Direct Cost",
+                "code": "4.1.1.10",
+                "account_type": "expense_direct_cost",
+                "company_ids": [(4, company.id)],
+            },
+        ]
+        accounts = env["account.account"].create(account_vals)
+        receivable_account = accounts.filtered(
+            lambda a: a.account_type == "asset_receivable"
+        )
+        income_account = accounts.filtered(lambda a: a.account_type == "income")
+        expense_account = accounts.filtered(lambda a: a.account_type == "expense")
+        # Set default company accounts
+        company.account_journal_suspense_account_id = receivable_account.id
+        # Set product category accounts for this company
+        product_category = env.ref("product.product_category_all")
+        product_category.with_company(
+            company
+        ).property_account_income_categ_id = income_account
+        product_category.with_company(
+            company
+        ).property_account_expense_categ_id = expense_account
+        # Load fiscal taxes for the company
+        if not company.chart_template:
+            chart_template = env["account.chart.template"]
+            chart_template.try_loading("generic_coa", company, install_demo=True)
+        env["account.chart.template"].load_fiscal_taxes(companies=[company])
+
+
+def create_br_journal_and_set_fiscal_ops(env, company, fiscal_ops):
+    doc_type_55 = env["l10n_br_fiscal.document.type"].search([("code", "=", "55")])
+    company.document_type_id = doc_type_55
+    env["l10n_br_fiscal.document.serie"].create(
+        {
+            "code": "1",
+            "name": "Série 1",
+            "document_type_id": doc_type_55.id,
+            "company_id": company.id,
+            "active": True,
+        }
+    )
+
+    account_revenue = env["account.account"].search(
+        [
+            ("account_type", "=", "expense_direct_cost"),
+            ("company_ids", "in", (company.id)),
+        ],
+        limit=1,
+    )
+    data_journal_base = {
+        "type": "sale",
+        "default_account_id": account_revenue,
+        "company_id": company,
+    }
+    for fiscal_op in fiscal_ops:
+        data_journal = data_journal_base | {
+            "name": "Diário" + fiscal_op.name,
+            "code": fiscal_op.name[:3],
+        }
+        journal = create_with_form_br_account_journal(env, data_journal)
+        fiscal_op.with_company(company).journal_id = journal


### PR DESCRIPTION
Tests without Demo Data.

Separação dos Dados usados nos Testes dos Dados de Demonstração, alguns detalhes:

- Incluído um arquivo tools.py com a criação de de alguns objetos com o Form, para simular o uso da tela e chamar automaticamente o preenchimento de campos default e onchanges; também foi incluído um método para criar um um conjunto de Contas Contábeis minimo, extraído do teste da Empresa Simples Nacional.
- Incluído no common.py dois métodos para configurar a parte Fiscal/Contábil nas Empresas para os testes e um método para verificar a Invoice e o Picking que foram criados, isso remove verificações repetitivas que eram feitas nos Testes.
- O teste passou a criar as Empresas do Regime Tributário Lucro Presumido e Simples Nacional ao invés de buscar as  empresas no banco de dados o motivo é que ao criar uma Empresa será criado automaticamente o Armazém e o Picking Type
- Com os dois items acima o teste do Simples Nacional deixou de precisar dos patchs que existem hoje https://github.com/OCA/l10n-brazil/blob/18.0/l10n_br_stock_account/tests/test_invoicing_picking.py#L559
-  Mantido no arquivo common.py por enquanto os métodos **create_invoice_wizard, return_picking_wizard e create_backorder_wizard** o motivo é manter compatibilidade com os testes do módulo **l10n_br_sale_stock**, como esse PR tem um Diff grande acredito que será melhor fazer a remoção dos métodos ao refatorar os testes do **l10n_br_sale_stock**.

Complementa a migração e estava pendente da minha parte essa refatoração

* https://github.com/OCA/l10n-brazil/pull/4590

cc @OCA/local-brazil-maintainers 

 
