### PR TITLE
[16.0] spec_driven_model and l10n_br_nfe: Correções das tags referente a reforma tributária sobre o consumo

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -13,7 +13,6 @@ from erpbrasil.base.fiscal import cnpj_cpf
 from erpbrasil.base.fiscal.edoc import ChaveEdoc
 from erpbrasil.transmissao import TransmissaoSOAP
 from lxml import etree
-from nfelib.nfe.bindings.v4_0.dfe_tipos_basicos_v1_00 import TibscbsmonoTot
 from nfelib.nfe.bindings.v4_0.nfe_v4_00 import Nfe
 from nfelib.nfe.bindings.v4_0.proc_nfe_v4_00 import NfeProc
 from nfelib.nfe.ws.edoc_legacy import NFCeAdapter as edoc_nfce
@@ -682,10 +681,8 @@ class NFe(spec_models.StackedModel):
                 continue
 
             # Calculate totals from lines
-            total_ibs_base = (
-                sum(record.fiscal_line_ids.mapped("ibs_base"))
-                or sum(record.fiscal_line_ids.mapped("cbs_base"))
-                or sum(record.fiscal_line_ids.mapped("price_gross"))
+            total_ibs_base = sum(record.fiscal_line_ids.mapped("ibs_base")) or sum(
+                record.fiscal_line_ids.mapped("cbs_base")
             )
 
             total_ibs_value = sum(record.fiscal_line_ids.mapped("ibs_value"))
@@ -711,6 +708,44 @@ class NFe(spec_models.StackedModel):
             record.nfe40_vDevTribCBS = 0.0
             record.nfe40_vCredPresCBS = 0.0
             record.nfe40_vCredPresCondSusCBS = 0.0
+
+    def _export_tag_nfe_40_ibscbstot(self, xsd_fields, class_obj, export_dict):
+        """Export the IBSCBSTot group of the document (NT 2025.002).
+
+        Dispatched by the spec_driven_model per tag hooks while exporting
+        the nfe40_IBSCBSTot field of the nfe.40.total class: the comodel is
+        the reusable nfe.40.tibscbsmonotot type, so the class name dispatch
+        would not match the IBSCBSTot tag name. This method and the
+        _export_tag_nfe_40_g* ones below only populate export_dict; the
+        framework assembles the bindings.
+        """
+        # Export IBSCBSTot only when the lines export the IBSCBS group
+        if not self._nfe_export_ibscbs_totals():
+            return
+
+        export_dict["vBCIBSCBS"] = self.nfe40_vBCIBSCBS
+
+    def _export_tag_nfe_40_gibs(self, xsd_fields, class_obj, export_dict):
+        export_dict["vIBS"] = self.nfe40_vIBS
+        export_dict["vCredPres"] = self.nfe40_vCredPres
+        export_dict["vCredPresCondSus"] = self.nfe40_vCredPresCondSus
+
+    def _export_tag_nfe_40_gibsuf(self, xsd_fields, class_obj, export_dict):
+        export_dict["vDif"] = self.nfe40_vDifIBSUF
+        export_dict["vDevTrib"] = self.nfe40_vDevTribIBSUF
+        export_dict["vIBSUF"] = self.nfe40_vIBSUF
+
+    def _export_tag_nfe_40_gibsmun(self, xsd_fields, class_obj, export_dict):
+        export_dict["vDif"] = self.nfe40_vDifIBSMun
+        export_dict["vDevTrib"] = self.nfe40_vDevTribIBSMun
+        export_dict["vIBSMun"] = self.nfe40_vIBSMun
+
+    def _export_tag_nfe_40_gcbs(self, xsd_fields, class_obj, export_dict):
+        export_dict["vDif"] = self.nfe40_vDifCBS
+        export_dict["vDevTrib"] = self.nfe40_vDevTribCBS
+        export_dict["vCBS"] = self.nfe40_vCBS
+        export_dict["vCredPres"] = self.nfe40_vCredPresCBS
+        export_dict["vCredPresCondSus"] = self.nfe40_vCredPresCondSusCBS
 
     ##########################
     # NF-e tag: ISSQNtot
@@ -823,12 +858,9 @@ class NFe(spec_models.StackedModel):
     ################################
 
     def _nfe_export_ibscbs_totals(self):
-        """Return True when the document has IBS/CBS values to export"""
+        """Return True when the document lines export the IBSCBS group"""
         self.ensure_one()
-        return bool(
-            sum(self.fiscal_line_ids.mapped("ibs_value"))
-            or sum(self.fiscal_line_ids.mapped("cbs_value"))
-        )
+        return bool(self.fiscal_line_ids.filtered("tax_classification_id"))
 
     def _export_field(self, xsd_field, class_obj, member_spec, export_value=None):
         if xsd_field == "nfe40_tpAmb":
@@ -851,51 +883,6 @@ class NFe(spec_models.StackedModel):
                 return False
             return f"{self.fiscal_amount_total:.2f}"
 
-        if xsd_field == "nfe40_IBSCBSTot":
-            if not self._nfe_export_ibscbs_totals():
-                return False
-
-            # Build gIBSUF
-            gibsuf = TibscbsmonoTot.GIbs.GIbsuf(
-                vDif=f"{self.nfe40_vDifIBSUF:.2f}",
-                vDevTrib=f"{self.nfe40_vDevTribIBSUF:.2f}",
-                vIBSUF=f"{self.nfe40_vIBSUF:.2f}",
-            )
-
-            # Build gIBSMun
-            gibsmun = TibscbsmonoTot.GIbs.GIbsmun(
-                vDif=f"{self.nfe40_vDifIBSMun:.2f}",
-                vDevTrib=f"{self.nfe40_vDevTribIBSMun:.2f}",
-                vIBSMun=f"{self.nfe40_vIBSMun:.2f}",
-            )
-
-            # Build gIBS
-            gibs = TibscbsmonoTot.GIbs(
-                gIBSUF=gibsuf,
-                gIBSMun=gibsmun,
-                vIBS=f"{self.nfe40_vIBS:.2f}",
-                vCredPres=f"{self.nfe40_vCredPres:.2f}",
-                vCredPresCondSus=f"{self.nfe40_vCredPresCondSus:.2f}",
-            )
-
-            # Build gCBS
-            gcbs = TibscbsmonoTot.GCbs(
-                vDif=f"{self.nfe40_vDifCBS:.2f}",
-                vDevTrib=f"{self.nfe40_vDevTribCBS:.2f}",
-                vCBS=f"{self.nfe40_vCBS:.2f}",
-                vCredPres=f"{self.nfe40_vCredPresCBS:.2f}",
-                vCredPresCondSus=f"{self.nfe40_vCredPresCondSusCBS:.2f}",
-            )
-
-            # Build IBSCBSTot
-            ibscbs_tot = TibscbsmonoTot(
-                vBCIBSCBS=f"{self.nfe40_vBCIBSCBS:.2f}",
-                gIBS=gibs,
-                gCBS=gcbs,
-            )
-
-            return ibscbs_tot
-
         return super()._export_field(xsd_field, class_obj, member_spec, export_value)
 
     def _export_many2one(self, field_name, xsd_required, class_obj=None):
@@ -911,13 +898,7 @@ class NFe(spec_models.StackedModel):
             ):
                 return False
 
-            if field_name == "nfe40_IBSCBSTot":
-                total_ibs = sum(self.fiscal_line_ids.mapped("ibs_value"))
-                total_cbs = sum(self.fiscal_line_ids.mapped("cbs_value"))
-                if not total_ibs and not total_cbs:
-                    return False
-
-            elif (not xsd_required) and field_name not in ["nfe40_enderDest"]:
+            if (not xsd_required) and field_name not in ["nfe40_enderDest"]:
                 comodel = self.env[
                     self._get_stacking_points().get(field_name).comodel_name
                 ]

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -6,8 +6,6 @@ import logging
 import sys
 from enum import Enum
 
-from nfelib.nfe.bindings.v4_0.dfe_tipos_basicos_v1_00 import Tcibs, TtribNfe
-
 from odoo import _, api, fields
 
 from odoo.addons.l10n_br_fiscal.constants.fiscal import (
@@ -224,7 +222,7 @@ class NFeLine(spec_models.StackedModel):
     ################################
 
     def _export_field(self, xsd_field, class_obj, member_spec, export_value=None):
-        """Override to handle IBSCBS field export"""
+        """Override to handle vItem field export"""
         if xsd_field == "nfe40_vItem":
             # NT 2025.002 (rules VB01/W60): vItem must be present in every
             # det when the document exports the IBS/CBS totals, and the sum
@@ -238,165 +236,7 @@ class NFeLine(spec_models.StackedModel):
                 return False
             return f"{self.fiscal_amount_total:.2f}"
 
-        if xsd_field == "nfe40_IBSCBS":
-            if not self.ibs_value and not self.cbs_value:
-                return False
-
-            # Get tax classification code
-            c_class_trib = "000001"
-            if self.tax_classification_id and self.tax_classification_id.code:
-                c_class_trib = self.tax_classification_id.code.zfill(6)
-
-            # Get CST code - use IBS CST if available, otherwise CBS CST
-            cst = "000"
-            if self.ibs_cst_id and self.ibs_cst_id.code:
-                cst = self.ibs_cst_id.code
-            elif self.cbs_cst_id and self.cbs_cst_id.code:
-                cst = self.cbs_cst_id.code
-
-            # Base calculation - use IBS base or CBS base, whichever is available
-            v_bc = self.ibs_base or self.cbs_base or self.price_gross
-
-            # IBS UF values - when there's only one IBS, populate IBSUF directly
-            # Use IBS percent directly for pIBSUF
-            p_ibs_uf = self.ibs_percent or 0.0
-            # Use IBS value directly for vIBSUF, or calculate from base and percent
-            if self.ibs_value:
-                v_ibs_uf = self.ibs_value
-            elif p_ibs_uf > 0 and v_bc > 0:
-                v_ibs_uf = v_bc * p_ibs_uf / 100
-            else:
-                v_ibs_uf = 0.0
-
-            # IBS Municipal values - not available yet, set to 0
-            p_ibs_mun = 0.0
-            v_ibs_mun = 0.0
-
-            # Total IBS - use IBS value directly or sum of UF + Municipal
-            v_ibs = self.ibs_value or (v_ibs_uf + v_ibs_mun)
-
-            # CBS values
-            p_cbs = self.cbs_percent or 0.0
-            v_cbs = self.cbs_value or (v_bc * p_cbs / 100) if p_cbs else 0.0
-
-            # Build gIBSUF
-            gibsuf = Tcibs.GIbsuf(
-                pIBSUF=f"{p_ibs_uf:.4f}",
-                vIBSUF=f"{v_ibs_uf:.2f}",
-            )
-
-            # Build gIBSMun
-            gibsmun = Tcibs.GIbsmun(
-                pIBSMun=f"{p_ibs_mun:.4f}",
-                vIBSMun=f"{v_ibs_mun:.2f}",
-            )
-
-            # Build gCBS
-            gcbs = Tcibs.GCbs(
-                pCBS=f"{p_cbs:.4f}",
-                vCBS=f"{v_cbs:.2f}",
-            )
-
-            # Build gIBSCBS (Tcibs)
-            gibscbs = Tcibs(
-                vBC=f"{v_bc:.2f}",
-                gIBSUF=gibsuf,
-                gIBSMun=gibsmun,
-                vIBS=f"{v_ibs:.2f}",
-                gCBS=gcbs,
-            )
-
-            # Build TtribNfe
-            ibscbs_obj = TtribNfe(
-                CST=cst,
-                cClassTrib=c_class_trib,
-                gIBSCBS=gibscbs,
-            )
-
-            return ibscbs_obj
-
         return super()._export_field(xsd_field, class_obj, member_spec, export_value)
-
-    def _export_many2one(self, field_name, xsd_required, class_obj=None):
-        """Override to handle IBSCBS Many2one field export"""
-        if field_name == "nfe40_IBSCBS":
-            if not self.ibs_value and not self.cbs_value:
-                return False
-
-            # Get tax classification code
-            c_class_trib = "000001"
-            if self.tax_classification_id and self.tax_classification_id.code:
-                c_class_trib = self.tax_classification_id.code.zfill(6)
-
-            # Get CST code - use IBS CST if available, otherwise CBS CST
-            cst = "000"
-            if self.ibs_cst_id and self.ibs_cst_id.code:
-                cst = self.ibs_cst_id.code
-            elif self.cbs_cst_id and self.cbs_cst_id.code:
-                cst = self.cbs_cst_id.code
-
-            # Base calculation - use IBS base or CBS base, whichever is available
-            v_bc = self.ibs_base or self.cbs_base or self.price_gross
-
-            # IBS UF values - when there's only one IBS, populate IBSUF directly
-            # Use IBS percent directly for pIBSUF
-            p_ibs_uf = self.ibs_percent or 0.0
-            # Use IBS value directly for vIBSUF, or calculate from base and percent
-            if self.ibs_value:
-                v_ibs_uf = self.ibs_value
-            elif p_ibs_uf > 0 and v_bc > 0:
-                v_ibs_uf = v_bc * p_ibs_uf / 100
-            else:
-                v_ibs_uf = 0.0
-
-            # IBS Municipal values - not available yet, set to 0
-            p_ibs_mun = 0.0
-            v_ibs_mun = 0.0
-
-            # Total IBS - use IBS value directly or sum of UF + Municipal
-            v_ibs = self.ibs_value or (v_ibs_uf + v_ibs_mun)
-
-            # CBS values
-            p_cbs = self.cbs_percent or 0.0
-            v_cbs = self.cbs_value or (v_bc * p_cbs / 100) if p_cbs else 0.0
-
-            # Build gIBSUF
-            gibsuf = Tcibs.GIbsuf(
-                pIBSUF=f"{p_ibs_uf:.4f}",
-                vIBSUF=f"{v_ibs_uf:.2f}",
-            )
-
-            # Build gIBSMun
-            gibsmun = Tcibs.GIbsmun(
-                pIBSMun=f"{p_ibs_mun:.4f}",
-                vIBSMun=f"{v_ibs_mun:.2f}",
-            )
-
-            # Build gCBS
-            gcbs = Tcibs.GCbs(
-                pCBS=f"{p_cbs:.4f}",
-                vCBS=f"{v_cbs:.2f}",
-            )
-
-            # Build gIBSCBS (Tcibs)
-            gibscbs = Tcibs(
-                vBC=f"{v_bc:.2f}",
-                gIBSUF=gibsuf,
-                gIBSMun=gibsmun,
-                vIBS=f"{v_ibs:.2f}",
-                gCBS=gcbs,
-            )
-
-            # Build TtribNfe
-            ibscbs_obj = TtribNfe(
-                CST=cst,
-                cClassTrib=c_class_trib,
-                gIBSCBS=gibscbs,
-            )
-
-            return ibscbs_obj
-
-        return super()._export_many2one(field_name, xsd_required, class_obj)
 
     def _export_fields_nfe_40_prod(self, xsd_fields, class_obj, export_dict):
         nfe40_cProd = self.product_id.default_code or self.nfe40_cProd or ""
@@ -543,83 +383,8 @@ class NFeLine(spec_models.StackedModel):
         if self.document_id.document_type == "65":
             xsd_fields.remove("nfe40_IPI")
 
-        # Export IBSCBS if there are values
-        if self.ibs_value or self.cbs_value:
-            # Get tax classification code
-            c_class_trib = "000001"
-            if self.tax_classification_id and self.tax_classification_id.code:
-                c_class_trib = self.tax_classification_id.code.zfill(6)
-
-            # Get CST code - use IBS CST if available, otherwise CBS CST
-            cst = "000"
-            if self.ibs_cst_id and self.ibs_cst_id.code:
-                cst = self.ibs_cst_id.code
-            elif self.cbs_cst_id and self.cbs_cst_id.code:
-                cst = self.cbs_cst_id.code
-
-            # Base calculation - use IBS base or CBS base, whichever is available
-            v_bc = self.ibs_base or self.cbs_base or self.price_gross
-
-            # IBS UF values - when there's only one IBS, populate IBSUF directly
-            # Use IBS percent directly for pIBSUF
-            p_ibs_uf = self.ibs_percent or 0.0
-            # Use IBS value directly for vIBSUF, or calculate from base and percent
-            if self.ibs_value:
-                v_ibs_uf = self.ibs_value
-            elif p_ibs_uf > 0 and v_bc > 0:
-                v_ibs_uf = v_bc * p_ibs_uf / 100
-            else:
-                v_ibs_uf = 0.0
-
-            # IBS Municipal values - not available yet, set to 0
-            p_ibs_mun = 0.0
-            v_ibs_mun = 0.0
-
-            # Total IBS - use IBS value directly or sum of UF + Municipal
-            v_ibs = self.ibs_value or (v_ibs_uf + v_ibs_mun)
-
-            # CBS values
-            p_cbs = self.cbs_percent or 0.0
-            v_cbs = self.cbs_value or (v_bc * p_cbs / 100) if p_cbs else 0.0
-
-            # Build gIBSUF
-            gibsuf = Tcibs.GIbsuf(
-                pIBSUF=f"{p_ibs_uf:.4f}",
-                vIBSUF=f"{v_ibs_uf:.2f}",
-            )
-
-            # Build gIBSMun
-            gibsmun = Tcibs.GIbsmun(
-                pIBSMun=f"{p_ibs_mun:.4f}",
-                vIBSMun=f"{v_ibs_mun:.2f}",
-            )
-
-            # Build gCBS
-            gcbs = Tcibs.GCbs(
-                pCBS=f"{p_cbs:.4f}",
-                vCBS=f"{v_cbs:.2f}",
-            )
-
-            # Build gIBSCBS (Tcibs)
-            gibscbs = Tcibs(
-                vBC=f"{v_bc:.2f}",
-                gIBSUF=gibsuf,
-                gIBSMun=gibsmun,
-                vIBS=f"{v_ibs:.2f}",
-                gCBS=gcbs,
-            )
-
-            # Build TtribNfe and add to export_dict
-            ibscbs_obj = TtribNfe(
-                CST=cst,
-                cClassTrib=c_class_trib,
-                gIBSCBS=gibscbs,
-            )
-            export_dict["IBSCBS"] = ibscbs_obj
-        else:
-            # Remove IBSCBS from xsd_fields if no values
-            if "nfe40_IBSCBS" in xsd_fields:
-                xsd_fields.remove("nfe40_IBSCBS")
+        if not self.tax_classification_id:
+            xsd_fields.remove("nfe40_IBSCBS")
 
     ##################################################
     # NF-e tag: ICMS
@@ -1203,6 +968,85 @@ class NFeLine(spec_models.StackedModel):
         comodel_name="nfe.40.ttribnfe",
         string="Grupo de informações dos tributos IBS, CBS",
     )
+
+    ##########################
+    # NF-e tag: IBSCBS
+    # Inverse Methods
+    ##########################
+
+    def _export_tag_nfe_40_ibscbs(self, xsd_fields, class_obj, export_dict):
+        """Export the IBSCBS group of the line (NT 2025.002).
+
+        Dispatched by the spec_driven_model per tag hooks while exporting
+        the nfe40_IBSCBS field of the nfe.40.imposto class: the comodel is
+        the reusable nfe.40.ttribnfe type, so the class name dispatch would
+        not match the IBSCBS tag name. Like the COFINS methods, this method
+        and the _export_tag_nfe_40_g* ones below only populate export_dict;
+        the framework assembles the bindings.
+        """
+        if self.tax_classification_id:
+            export_dict["cClassTrib"] = self.tax_classification_id.code
+
+        if self.ibs_cst_id and self.ibs_cst_id.code:
+            export_dict["CST"] = self.ibs_cst_id.code
+
+        # The choice branches are exclusive: keep only the one matching the
+        # CST, defaulting to gIBSCBS for every other CST (600, 000, ...)
+        # TODO the monophase (620), credit transfer (800) and period
+        # adjustment (811) groups have no export hook yet: their branch is
+        # kept here so the XSD choice is right once they are implemented.
+        remove_tags = {
+            "620": ["nfe40_gIBSCBS", "nfe40_gTransfCred", "nfe40_gAjusteCompet"],
+            "800": ["nfe40_gIBSCBS", "nfe40_gIBSCBSMono", "nfe40_gAjusteCompet"],
+            "811": ["nfe40_gIBSCBS", "nfe40_gIBSCBSMono", "nfe40_gTransfCred"],
+        }
+        default_remove = [
+            "nfe40_gIBSCBSMono",
+            "nfe40_gTransfCred",
+            "nfe40_gAjusteCompet",
+        ]
+
+        for tag_to_remove in remove_tags.get(self.ibs_cst_id.code, default_remove):
+            if tag_to_remove in xsd_fields:
+                xsd_fields.remove(tag_to_remove)
+
+    # Export nfe40_gIBSCBS
+
+    def _export_tag_nfe_40_gibscbs(self, xsd_fields, class_obj, export_dict):
+        # vBC is the base shared by IBS and CBS: both are computed from the
+        # same cClassTrib, but fall back to the CBS base so a line set up
+        # with a CBS tax only still exports a base consistent with gCBS
+        export_dict["vBC"] = self.ibs_base or self.cbs_base
+        export_dict["vIBS"] = self.ibs_value
+
+    def _export_tag_nfe_40_gibsuf(self, xsd_fields, class_obj, export_dict):
+        export_dict["pIBSUF"] = self.ibs_percent
+        export_dict["vIBSUF"] = self.ibs_value
+
+    def _export_tag_nfe_40_gibsuf_gred(self, xsd_fields, class_obj, export_dict):
+        """gRed of the gIBSUF group (parent qualified hook: the gRed tag also
+        exists inside gCBS with the CBS reduction instead)."""
+        if self.ibs_reduction:
+            export_dict["pRedAliq"] = self.ibs_reduction
+            export_dict["pAliqEfet"] = self.ibs_percent * (1 - self.ibs_reduction / 100)
+
+    def _export_tag_nfe_40_gibsmun(self, xsd_fields, class_obj, export_dict):
+        export_dict["pIBSMun"] = "0.0000"
+        export_dict["vIBSMun"] = "0.00"
+
+    def _export_tag_nfe_40_gcbs(self, xsd_fields, class_obj, export_dict):
+        export_dict["pCBS"] = self.cbs_percent
+        export_dict["vCBS"] = self.cbs_value
+
+    def _export_tag_nfe_40_gcbs_gred(self, xsd_fields, class_obj, export_dict):
+        """gRed of the gCBS group (parent qualified hook)."""
+        if self.cbs_reduction:
+            export_dict["pRedAliq"] = self.cbs_reduction
+            export_dict["pAliqEfet"] = self.cbs_percent * (1 - self.cbs_reduction / 100)
+
+    # TODO Export nfe40_gIBSCBSMono (monophase, CST 620): it needs the
+    # ad rem rates and the monophase amounts, which the fiscal engine does
+    # not compute yet.
 
     #################
     # NF-e tag: ISSQN

--- a/l10n_br_nfe/tests/test_nfe_ibscbs.py
+++ b/l10n_br_nfe/tests/test_nfe_ibscbs.py
@@ -47,6 +47,9 @@ class TestNFeIBSCBS(TransactionCase):
             }
         )
 
+        # Tax classification (cClassTrib) required to export the IBSCBS group
+        cls.tax_classification = cls.env.ref("l10n_br_fiscal.tax_classification_000001")
+
         # Create fiscal document
         cls.document = cls.env["l10n_br_fiscal.document"].create(
             {
@@ -57,16 +60,31 @@ class TestNFeIBSCBS(TransactionCase):
             }
         )
 
-    def test_export_field_ibscbs_with_ibs_value(self):
-        """Test _export_field for IBSCBS with IBS value"""
-        line = self.env["l10n_br_fiscal.document.line"].create(
-            {
-                "document_id": self.document.id,
-                "product_id": self.product.id,
-                "quantity": 1.0,
-                "price_unit": 100.0,
-            }
-        )
+    def _create_line(self, **extra_vals):
+        vals = {
+            "document_id": self.document.id,
+            "product_id": self.product.id,
+            "quantity": 1.0,
+            "price_unit": 100.0,
+        }
+        vals.update(extra_vals)
+        return self.env["l10n_br_fiscal.document.line"].create(vals)
+
+    def _export_ibscbs(self, line):
+        """Build the IBSCBS binding through the framework per tag hooks"""
+        return line.with_context(
+            spec_schema="nfe", spec_version="40"
+        )._export_m2o_via_tag_hooks("nfe40_IBSCBS", self.env["nfe.40.imposto"])
+
+    def _export_ibscbstot(self):
+        """Build the IBSCBSTot binding through the framework per tag hooks"""
+        return self.document.with_context(
+            spec_schema="nfe", spec_version="40"
+        )._export_m2o_via_tag_hooks("nfe40_IBSCBSTot", self.env["nfe.40.total"])
+
+    def test_export_ibscbs_with_ibs_value(self):
+        """Test IBSCBS export with IBS value"""
+        line = self._create_line(tax_classification_id=self.tax_classification.id)
         # Write computed fields directly for testing
         line.write(
             {
@@ -76,25 +94,20 @@ class TestNFeIBSCBS(TransactionCase):
             }
         )
 
-        result = line._export_field("nfe40_IBSCBS", None, None)
+        result = self._export_ibscbs(line)
         self.assertIsNotNone(result)
-        self.assertEqual(result.CST, "000")
+        # CST is only exported when the line has an IBS CST
+        self.assertIsNone(result.CST)
         self.assertEqual(result.cClassTrib, "000001")
         self.assertIsNotNone(result.gIBSCBS)
         self.assertEqual(result.gIBSCBS.vBC, "100.00")
+        self.assertEqual(result.gIBSCBS.gIBSUF.pIBSUF, "10.0000")
         self.assertEqual(result.gIBSCBS.gIBSUF.vIBSUF, "10.00")
         self.assertEqual(result.gIBSCBS.vIBS, "10.00")
 
-    def test_export_field_ibscbs_with_cbs_value(self):
-        """Test _export_field for IBSCBS with CBS value"""
-        line = self.env["l10n_br_fiscal.document.line"].create(
-            {
-                "document_id": self.document.id,
-                "product_id": self.product.id,
-                "quantity": 1.0,
-                "price_unit": 100.0,
-            }
-        )
+    def test_export_ibscbs_with_cbs_value(self):
+        """Test IBSCBS export with CBS value"""
+        line = self._create_line(tax_classification_id=self.tax_classification.id)
         line.write(
             {
                 "cbs_value": 5.0,
@@ -103,20 +116,14 @@ class TestNFeIBSCBS(TransactionCase):
             }
         )
 
-        result = line._export_field("nfe40_IBSCBS", None, None)
+        result = self._export_ibscbs(line)
         self.assertIsNotNone(result)
+        self.assertEqual(result.gIBSCBS.gCBS.pCBS, "5.0000")
         self.assertEqual(result.gIBSCBS.gCBS.vCBS, "5.00")
 
-    def test_export_field_ibscbs_with_both_values(self):
-        """Test _export_field for IBSCBS with both IBS and CBS values"""
-        line = self.env["l10n_br_fiscal.document.line"].create(
-            {
-                "document_id": self.document.id,
-                "product_id": self.product.id,
-                "quantity": 1.0,
-                "price_unit": 100.0,
-            }
-        )
+    def test_export_ibscbs_with_both_values(self):
+        """Test IBSCBS export with both IBS and CBS values"""
+        line = self._create_line(tax_classification_id=self.tax_classification.id)
         line.write(
             {
                 "ibs_value": 10.0,
@@ -128,52 +135,77 @@ class TestNFeIBSCBS(TransactionCase):
             }
         )
 
-        result = line._export_field("nfe40_IBSCBS", None, None)
+        result = self._export_ibscbs(line)
         self.assertIsNotNone(result)
         self.assertEqual(result.gIBSCBS.vIBS, "10.00")
         self.assertEqual(result.gIBSCBS.gCBS.vCBS, "5.00")
 
-    def test_export_field_ibscbs_without_values(self):
-        """Test _export_field for IBSCBS without IBS or CBS values"""
-        line = self.env["l10n_br_fiscal.document.line"].create(
+    def test_export_ibscbs_gred_parent_qualified(self):
+        """Test gRed uses the parent qualified hooks (gIBSUF vs gCBS)"""
+        line = self._create_line(tax_classification_id=self.tax_classification.id)
+        line.write(
             {
-                "document_id": self.document.id,
-                "product_id": self.product.id,
-                "quantity": 1.0,
-                "price_unit": 100.0,
+                "ibs_value": 10.0,
+                "ibs_percent": 10.0,
+                "ibs_base": 100.0,
+                "ibs_reduction": 60.0,
+                "cbs_value": 5.0,
+                "cbs_percent": 5.0,
+                "cbs_base": 100.0,
+                "cbs_reduction": 30.0,
             }
         )
 
-        result = line._export_field("nfe40_IBSCBS", None, None)
+        result = self._export_ibscbs(line)
+        self.assertIsNotNone(result)
+        # each parent gets its own reduction
+        self.assertEqual(result.gIBSCBS.gIBSUF.gRed.pRedAliq, "60.0000")
+        self.assertEqual(result.gIBSCBS.gCBS.gRed.pRedAliq, "30.0000")
+        # gIBSMun has no gRed hook
+        self.assertIsNone(result.gIBSCBS.gIBSMun.gRed)
+
+    def test_export_ibscbs_gred_absent_without_reduction(self):
+        """Test gRed is omitted when there is no reduction"""
+        line = self._create_line(tax_classification_id=self.tax_classification.id)
+        line.write({"ibs_value": 10.0, "ibs_base": 100.0, "cbs_value": 5.0})
+
+        result = self._export_ibscbs(line)
+        self.assertIsNotNone(result)
+        self.assertIsNone(result.gIBSCBS.gIBSUF.gRed)
+        self.assertIsNone(result.gIBSCBS.gCBS.gRed)
+
+    def test_export_ibscbs_without_tax_classification(self):
+        """Test IBSCBS is not exported without a tax classification"""
+        line = self._create_line()
+        line.write({"ibs_value": 10.0, "ibs_base": 100.0})
+
+        result = self._export_ibscbs(line)
         self.assertFalse(result)
 
-    def test_export_field_ibscbs_with_tax_classification(self):
-        """Test _export_field for IBSCBS with tax classification"""
-        # Create tax classification
-        tax_classification = self.env["l10n_br_fiscal.tax.classification"].create(
-            {
-                "name": "Test Classification",
-                "code": "123",
-            }
-        )
+    def test_export_ibscbs_without_values(self):
+        """Test IBSCBS export with a tax classification but no values"""
+        line = self._create_line(tax_classification_id=self.tax_classification.id)
 
-        line = self.env["l10n_br_fiscal.document.line"].create(
-            {
-                "document_id": self.document.id,
-                "product_id": self.product.id,
-                "quantity": 1.0,
-                "price_unit": 100.0,
-                "tax_classification_id": tax_classification.id,
-            }
-        )
+        result = self._export_ibscbs(line)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.cClassTrib, "000001")
+        self.assertEqual(result.gIBSCBS.vBC, "0.00")
+        self.assertEqual(result.gIBSCBS.vIBS, "0.00")
+        self.assertEqual(result.gIBSCBS.gCBS.vCBS, "0.00")
+
+    def test_export_ibscbs_with_tax_classification(self):
+        """Test IBSCBS export uses the tax classification code"""
+        tax_classification = self.env.ref("l10n_br_fiscal.tax_classification_410002")
+
+        line = self._create_line(tax_classification_id=tax_classification.id)
         line.write({"ibs_value": 10.0})
 
-        result = line._export_field("nfe40_IBSCBS", None, None)
+        result = self._export_ibscbs(line)
         self.assertIsNotNone(result)
-        self.assertEqual(result.cClassTrib, "000123")
+        self.assertEqual(result.cClassTrib, "410002")
 
-    def test_export_field_ibscbs_with_ibs_cst(self):
-        """Test _export_field for IBSCBS with IBS CST"""
+    def test_export_ibscbs_with_ibs_cst(self):
+        """Test IBSCBS export with IBS CST"""
         # Get or create IBS tax group
         ibs_tax_group = self.env.ref("l10n_br_fiscal.tax_group_ibs")
         # Create IBS CST
@@ -186,23 +218,18 @@ class TestNFeIBSCBS(TransactionCase):
             }
         )
 
-        line = self.env["l10n_br_fiscal.document.line"].create(
-            {
-                "document_id": self.document.id,
-                "product_id": self.product.id,
-                "quantity": 1.0,
-                "price_unit": 100.0,
-                "ibs_cst_id": ibs_cst.id,
-            }
+        line = self._create_line(
+            tax_classification_id=self.tax_classification.id,
+            ibs_cst_id=ibs_cst.id,
         )
         line.write({"ibs_value": 10.0})
 
-        result = line._export_field("nfe40_IBSCBS", None, None)
+        result = self._export_ibscbs(line)
         self.assertIsNotNone(result)
         self.assertEqual(result.CST, "50")
 
-    def test_export_field_ibscbs_with_cbs_cst(self):
-        """Test _export_field for IBSCBS with CBS CST"""
+    def test_export_ibscbs_with_cbs_cst(self):
+        """Test IBSCBS export with CBS CST"""
         # Get or create CBS tax group
         cbs_tax_group = self.env.ref("l10n_br_fiscal.tax_group_cbs")
         # Create CBS CST
@@ -215,182 +242,67 @@ class TestNFeIBSCBS(TransactionCase):
             }
         )
 
-        line = self.env["l10n_br_fiscal.document.line"].create(
-            {
-                "document_id": self.document.id,
-                "product_id": self.product.id,
-                "quantity": 1.0,
-                "price_unit": 100.0,
-                "cbs_cst_id": cbs_cst.id,
-            }
+        line = self._create_line(
+            tax_classification_id=self.tax_classification.id,
+            cbs_cst_id=cbs_cst.id,
         )
         line.write({"cbs_value": 5.0})
 
-        result = line._export_field("nfe40_IBSCBS", None, None)
+        result = self._export_ibscbs(line)
         self.assertIsNotNone(result)
-        self.assertEqual(result.CST, "60")
+        # The CST comes only from the IBS CST, there is no CBS fallback
+        self.assertIsNone(result.CST)
 
-    def test_export_field_ibscbs_calculated_ibs_uf(self):
-        """Test _export_field for IBSCBS with calculated IBS UF value"""
-        line = self.env["l10n_br_fiscal.document.line"].create(
-            {
-                "document_id": self.document.id,
-                "product_id": self.product.id,
-                "quantity": 1.0,
-                "price_unit": 100.0,
-            }
-        )
-        # Need at least a minimal value to pass the initial check
-        # Then it will calculate from base and percent
-        line.write(
-            {
-                "ibs_value": 0.01,  # Minimal value to pass check
-                "ibs_percent": 10.0,
-                "ibs_base": 100.0,
-            }
-        )
+    def test_export_ibscbs_hook_only_populates_dict(self):
+        """Test the IBSCBS hook only populates export_dict with values"""
+        line = self._create_line(tax_classification_id=self.tax_classification.id)
 
-        result = line._export_field("nfe40_IBSCBS", None, None)
-        self.assertIsNotNone(result)
-        # vIBSUF should use ibs_value directly when available
-        self.assertEqual(result.gIBSCBS.gIBSUF.vIBSUF, "0.01")
-        self.assertEqual(result.gIBSCBS.gIBSUF.pIBSUF, "10.0000")
-
-    def test_export_field_ibscbs_calculated_cbs(self):
-        """Test _export_field for IBSCBS with calculated CBS value"""
-        line = self.env["l10n_br_fiscal.document.line"].create(
-            {
-                "document_id": self.document.id,
-                "product_id": self.product.id,
-                "quantity": 1.0,
-                "price_unit": 100.0,
-            }
-        )
-        # Need at least a minimal value to pass the initial check
-        # Then it will calculate from base and percent
-        line.write(
-            {
-                "cbs_value": 0.01,  # Minimal value to pass check
-                "cbs_percent": 5.0,
-                "cbs_base": 100.0,
-            }
-        )
-
-        result = line._export_field("nfe40_IBSCBS", None, None)
-        self.assertIsNotNone(result)
-        # vCBS should use cbs_value directly when available
-        self.assertEqual(result.gIBSCBS.gCBS.vCBS, "0.01")
-        self.assertEqual(result.gIBSCBS.gCBS.pCBS, "5.0000")
-
-    def test_export_many2one_ibscbs(self):
-        """Test _export_many2one for IBSCBS"""
-        line = self.env["l10n_br_fiscal.document.line"].create(
-            {
-                "document_id": self.document.id,
-                "product_id": self.product.id,
-                "quantity": 1.0,
-                "price_unit": 100.0,
-            }
-        )
-        line.write(
-            {
-                "ibs_value": 10.0,
-                "ibs_percent": 10.0,
-                "ibs_base": 100.0,
-            }
-        )
-
-        result = line._export_many2one("nfe40_IBSCBS", False)
-        self.assertIsNotNone(result)
-        self.assertEqual(result.CST, "000")
-        self.assertIsNotNone(result.gIBSCBS)
-
-    def test_export_many2one_ibscbs_without_values(self):
-        """Test _export_many2one for IBSCBS without values"""
-        line = self.env["l10n_br_fiscal.document.line"].create(
-            {
-                "document_id": self.document.id,
-                "product_id": self.product.id,
-                "quantity": 1.0,
-                "price_unit": 100.0,
-            }
-        )
-
-        result = line._export_many2one("nfe40_IBSCBS", False)
-        self.assertFalse(result)
-
-    def test_export_fields_nfe_40_imposto_with_ibs(self):
-        """Test _export_fields_nfe_40_imposto adds IBSCBS to export_dict"""
-        line = self.env["l10n_br_fiscal.document.line"].create(
-            {
-                "document_id": self.document.id,
-                "product_id": self.product.id,
-                "quantity": 1.0,
-                "price_unit": 100.0,
-            }
-        )
-        line.write(
-            {
-                "ibs_value": 10.0,
-                "ibs_percent": 10.0,
-                "ibs_base": 100.0,
-                "tax_icms_or_issqn": "icms",
-            }
-        )
-        # Force compute of nfe40_choice_imposto
-        line._compute_nfe40_choice_imposto()
-
-        # Include all fields that the method may try to remove
-        xsd_fields = [
-            "nfe40_ICMS",
-            "nfe40_ISSQN",
-            "nfe40_II",
-            "nfe40_ICMSUFDest",
-            "nfe40_PISST",
-            "nfe40_COFINSST",
-            "nfe40_IPI",
-            "nfe40_IBSCBS",
-        ]
         export_dict = {}
-        line._export_fields_nfe_40_imposto(xsd_fields, None, export_dict)
+        line._export_tag_nfe_40_ibscbs([], None, export_dict)
+        # CST is only set when the line has an IBS CST
+        self.assertNotIn("CST", export_dict)
+        self.assertEqual(export_dict.get("cClassTrib"), "000001")
 
-        self.assertIn("IBSCBS", export_dict)
-        self.assertIsNotNone(export_dict["IBSCBS"])
+    def test_export_ibscbs_hook_without_tax_classification(self):
+        """Test the IBSCBS hook leaves export_dict empty without classification"""
+        line = self._create_line()
 
-    def test_export_fields_nfe_40_imposto_without_ibs_cbs(self):
-        """Test _export_fields_nfe_40_imposto removes IBSCBS when no values"""
-        line = self.env["l10n_br_fiscal.document.line"].create(
-            {
-                "document_id": self.document.id,
-                "product_id": self.product.id,
-                "quantity": 1.0,
-                "price_unit": 100.0,
-            }
-        )
-        line.write(
-            {
-                "tax_icms_or_issqn": "icms",
-            }
-        )
-        # Force compute of nfe40_choice_imposto
-        line._compute_nfe40_choice_imposto()
-
-        # Include all fields that the method may try to remove
-        xsd_fields = [
-            "nfe40_ICMS",
-            "nfe40_ISSQN",
-            "nfe40_II",
-            "nfe40_ICMSUFDest",
-            "nfe40_PISST",
-            "nfe40_COFINSST",
-            "nfe40_IPI",
-            "nfe40_IBSCBS",
-        ]
         export_dict = {}
-        line._export_fields_nfe_40_imposto(xsd_fields, None, export_dict)
+        line._export_tag_nfe_40_ibscbs([], None, export_dict)
+        self.assertFalse(export_dict)
 
-        self.assertNotIn("IBSCBS", export_dict)
-        self.assertNotIn("nfe40_IBSCBS", xsd_fields)
+    def test_export_ibscbs_base_from_ibs_base(self):
+        """Test IBSCBS export takes the base from ibs_base"""
+        line = self._create_line(tax_classification_id=self.tax_classification.id)
+        line.write({"ibs_value": 10.0, "ibs_base": 100.0, "cbs_base": 100.0})
+
+        result = self._export_ibscbs(line)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.gIBSCBS.vBC, "100.00")
+        self.assertEqual(result.gIBSCBS.gIBSUF.vIBSUF, "10.00")
+
+    def test_export_ibscbs_base_falls_back_to_cbs_base(self):
+        """Test vBC falls back to cbs_base on a CBS only line"""
+        line = self._create_line(tax_classification_id=self.tax_classification.id)
+        # no IBS tax on this line, only CBS
+        line.write({"cbs_value": 5.0, "cbs_percent": 5.0, "cbs_base": 100.0})
+
+        result = self._export_ibscbs(line)
+        self.assertIsNotNone(result)
+        # vBC is the base shared by IBS and CBS, it must match gCBS
+        self.assertEqual(result.gIBSCBS.vBC, "100.00")
+        self.assertEqual(result.gIBSCBS.gCBS.vCBS, "5.00")
+
+    def test_export_ibscbs_ibs_municipal_zero(self):
+        """Test IBSCBS export sets IBS Municipal to zero"""
+        line = self._create_line(tax_classification_id=self.tax_classification.id)
+        line.write({"ibs_value": 10.0})
+
+        result = self._export_ibscbs(line)
+        self.assertIsNotNone(result)
+        # IBS Municipal should be zero
+        self.assertEqual(result.gIBSCBS.gIBSMun.vIBSMun, "0.00")
+        self.assertEqual(result.gIBSCBS.gIBSMun.pIBSMun, "0.0000")
 
     def test_compute_nfe40_ibscbstot_fields_empty(self):
         """Test _compute_nfe40_IBSCBSTot_fields with no lines"""
@@ -403,14 +315,7 @@ class TestNFeIBSCBS(TransactionCase):
 
     def test_compute_nfe40_ibscbstot_fields_with_ibs(self):
         """Test _compute_nfe40_IBSCBSTot_fields with IBS values"""
-        line = self.env["l10n_br_fiscal.document.line"].create(
-            {
-                "document_id": self.document.id,
-                "product_id": self.product.id,
-                "quantity": 1.0,
-                "price_unit": 100.0,
-            }
-        )
+        line = self._create_line()
         line.write(
             {
                 "ibs_value": 10.0,
@@ -426,14 +331,7 @@ class TestNFeIBSCBS(TransactionCase):
 
     def test_compute_nfe40_ibscbstot_fields_with_cbs(self):
         """Test _compute_nfe40_IBSCBSTot_fields with CBS values"""
-        line = self.env["l10n_br_fiscal.document.line"].create(
-            {
-                "document_id": self.document.id,
-                "product_id": self.product.id,
-                "quantity": 1.0,
-                "price_unit": 100.0,
-            }
-        )
+        line = self._create_line()
         line.write(
             {
                 "cbs_value": 5.0,
@@ -448,14 +346,7 @@ class TestNFeIBSCBS(TransactionCase):
 
     def test_compute_nfe40_ibscbstot_fields_with_multiple_lines(self):
         """Test _compute_nfe40_IBSCBSTot_fields with multiple lines"""
-        line1 = self.env["l10n_br_fiscal.document.line"].create(
-            {
-                "document_id": self.document.id,
-                "product_id": self.product.id,
-                "quantity": 1.0,
-                "price_unit": 100.0,
-            }
-        )
+        line1 = self._create_line()
         line1.write(
             {
                 "ibs_value": 10.0,
@@ -463,14 +354,7 @@ class TestNFeIBSCBS(TransactionCase):
             }
         )
 
-        line2 = self.env["l10n_br_fiscal.document.line"].create(
-            {
-                "document_id": self.document.id,
-                "product_id": self.product.id,
-                "quantity": 1.0,
-                "price_unit": 200.0,
-            }
-        )
+        line2 = self._create_line(price_unit=200.0)
         line2.write(
             {
                 "ibs_value": 20.0,
@@ -484,16 +368,9 @@ class TestNFeIBSCBS(TransactionCase):
         self.assertEqual(self.document.nfe40_vIBS, 30.0)
         self.assertEqual(self.document.nfe40_vIBSUF, 30.0)
 
-    def test_export_field_ibscbstot_with_values(self):
-        """Test _export_field for IBSCBSTot with IBS/CBS values"""
-        line = self.env["l10n_br_fiscal.document.line"].create(
-            {
-                "document_id": self.document.id,
-                "product_id": self.product.id,
-                "quantity": 1.0,
-                "price_unit": 100.0,
-            }
-        )
+    def test_export_ibscbstot_with_values(self):
+        """Test IBSCBSTot export with IBS/CBS values"""
+        line = self._create_line(tax_classification_id=self.tax_classification.id)
         line.write(
             {
                 "ibs_value": 10.0,
@@ -501,82 +378,21 @@ class TestNFeIBSCBS(TransactionCase):
             }
         )
 
-        result = self.document._export_field("nfe40_IBSCBSTot", None, None)
+        result = self._export_ibscbstot()
         self.assertIsNotNone(result)
         self.assertEqual(result.vBCIBSCBS, "100.00")
         self.assertIsNotNone(result.gIBS)
         self.assertEqual(result.gIBS.vIBS, "10.00")
+        self.assertEqual(result.gIBS.gIBSUF.vIBSUF, "10.00")
         self.assertIsNotNone(result.gCBS)
 
-    def test_export_field_ibscbstot_without_values(self):
-        """Test _export_field for IBSCBSTot without IBS/CBS values"""
-        result = self.document._export_field("nfe40_IBSCBSTot", None, None)
+    def test_export_ibscbstot_without_tax_classification(self):
+        """Test IBSCBSTot is not exported when no line has a classification"""
+        line = self._create_line()
+        line.write({"ibs_value": 10.0, "ibs_base": 100.0})
+
+        result = self._export_ibscbstot()
         self.assertFalse(result)
-
-    def test_export_many2one_ibscbstot_with_values(self):
-        """Test _export_many2one for IBSCBSTot with values"""
-        line = self.env["l10n_br_fiscal.document.line"].create(
-            {
-                "document_id": self.document.id,
-                "product_id": self.product.id,
-                "quantity": 1.0,
-                "price_unit": 100.0,
-            }
-        )
-        line.write(
-            {
-                "ibs_value": 10.0,
-                "ibs_base": 100.0,
-            }
-        )
-
-        # The method checks if there are values and returns False if not
-        # We test the logic through _export_field which is the main entry point
-        result = self.document._export_field("nfe40_IBSCBSTot", None, None)
-        # Should not return False when there are values
-        self.assertIsNotNone(result)
-
-    def test_export_many2one_ibscbstot_without_values(self):
-        """Test _export_many2one for IBSCBSTot without values"""
-        # Test through _export_field which is the main entry point
-        result = self.document._export_field("nfe40_IBSCBSTot", None, None)
-        self.assertFalse(result)
-
-    def test_export_field_ibscbs_base_fallback(self):
-        """Test _export_field for IBSCBS uses price_gross as base fallback"""
-        line = self.env["l10n_br_fiscal.document.line"].create(
-            {
-                "document_id": self.document.id,
-                "product_id": self.product.id,
-                "quantity": 1.0,
-                "price_unit": 100.0,
-            }
-        )
-        # No ibs_base or cbs_base, should use price_gross
-        line.write({"ibs_value": 10.0})
-
-        result = line._export_field("nfe40_IBSCBS", None, None)
-        self.assertIsNotNone(result)
-        # Should use price_gross (100.0) as base
-        self.assertEqual(result.gIBSCBS.vBC, "100.00")
-
-    def test_export_field_ibscbs_ibs_municipal_zero(self):
-        """Test _export_field for IBSCBS sets IBS Municipal to zero"""
-        line = self.env["l10n_br_fiscal.document.line"].create(
-            {
-                "document_id": self.document.id,
-                "product_id": self.product.id,
-                "quantity": 1.0,
-                "price_unit": 100.0,
-            }
-        )
-        line.write({"ibs_value": 10.0})
-
-        result = line._export_field("nfe40_IBSCBS", None, None)
-        self.assertIsNotNone(result)
-        # IBS Municipal should be zero
-        self.assertEqual(result.gIBSCBS.gIBSMun.vIBSMun, "0.00")
-        self.assertEqual(result.gIBSCBS.gIBSMun.pIBSMun, "0.0000")
 
 
 @tagged("post_install", "-at_install")
@@ -607,6 +423,9 @@ class TestNFeVItemVNFTot(TransactionCase):
             }
         )
 
+        # Tax classification (cClassTrib) required to export the IBSCBS group
+        cls.tax_classification = cls.env.ref("l10n_br_fiscal.tax_classification_000001")
+
         # Document with a real fiscal operation so that the document
         # fiscal totals are computed (see l10n_br_fiscal.document.mixin)
         cls.document = cls.env["l10n_br_fiscal.document"].create(
@@ -618,6 +437,17 @@ class TestNFeVItemVNFTot(TransactionCase):
                 "document_type_id": cls.env.ref("l10n_br_fiscal.document_55").id,
             }
         )
+
+    def _create_line(self, **extra_vals):
+        vals = {
+            "document_id": self.document.id,
+            "product_id": self.product.id,
+            "icms_cst_id": self.icms_cst_00.id,
+            "quantity": 1.0,
+            "price_unit": 100.0,
+        }
+        vals.update(extra_vals)
+        return self.env["l10n_br_fiscal.document.line"].create(vals)
 
     def _build_det_binding(self, line):
         """Build the real det binding for a document line"""
@@ -633,41 +463,46 @@ class TestNFeVItemVNFTot(TransactionCase):
 
     def test_export_det_binding_vitem_with_ibs_cbs(self):
         """Test det binding exports vItem when the document has IBS/CBS"""
-        line = self.env["l10n_br_fiscal.document.line"].create(
-            {
-                "document_id": self.document.id,
-                "product_id": self.product.id,
-                "icms_cst_id": self.icms_cst_00.id,
-                "quantity": 1.0,
-                "price_unit": 100.0,
-            }
-        )
+        line = self._create_line(tax_classification_id=self.tax_classification.id)
         line.write({"ibs_value": 0.1, "ibs_base": 100.0, "cbs_value": 0.9})
 
         self.assertGreater(line.fiscal_amount_total, 0.0)
         det = self._build_det_binding(line)
         self.assertEqual(det.vItem, f"{line.fiscal_amount_total:.2f}")
 
+    def test_export_det_binding_ibscbs_group(self):
+        """Test the det binding exports IBSCBS via the per tag hooks"""
+        line = self._create_line(tax_classification_id=self.tax_classification.id)
+        line.write(
+            {
+                "ibs_value": 10.0,
+                "ibs_percent": 10.0,
+                "ibs_base": 100.0,
+                "cbs_value": 5.0,
+                "cbs_percent": 5.0,
+                "cbs_base": 100.0,
+            }
+        )
+
+        det = self._build_det_binding(line)
+        self.assertIsNotNone(det.imposto.IBSCBS)
+        self.assertEqual(det.imposto.IBSCBS.cClassTrib, "000001")
+        self.assertEqual(det.imposto.IBSCBS.gIBSCBS.vBC, "100.00")
+        self.assertEqual(det.imposto.IBSCBS.gIBSCBS.vIBS, "10.00")
+        self.assertEqual(det.imposto.IBSCBS.gIBSCBS.gIBSUF.vIBSUF, "10.00")
+        self.assertEqual(det.imposto.IBSCBS.gIBSCBS.gCBS.vCBS, "5.00")
+
+    def test_export_det_binding_no_ibscbs_group(self):
+        """Test the det binding does not export IBSCBS without classification"""
+        line = self._create_line()
+
+        det = self._build_det_binding(line)
+        self.assertIsNone(det.imposto.IBSCBS)
+
     def test_export_det_binding_vitem_mixed_lines(self):
         """Test all lines export vItem when only one line has IBS/CBS"""
-        line_with = self.env["l10n_br_fiscal.document.line"].create(
-            {
-                "document_id": self.document.id,
-                "product_id": self.product.id,
-                "icms_cst_id": self.icms_cst_00.id,
-                "quantity": 1.0,
-                "price_unit": 100.0,
-            }
-        )
-        line_without = self.env["l10n_br_fiscal.document.line"].create(
-            {
-                "document_id": self.document.id,
-                "product_id": self.product.id,
-                "icms_cst_id": self.icms_cst_00.id,
-                "quantity": 1.0,
-                "price_unit": 50.0,
-            }
-        )
+        line_with = self._create_line(tax_classification_id=self.tax_classification.id)
+        line_without = self._create_line(price_unit=50.0)
         line_with.write({"ibs_value": 0.1, "ibs_base": 100.0, "cbs_value": 0.9})
 
         self.assertGreater(self.document.fiscal_amount_total, 0.0)
@@ -692,15 +527,7 @@ class TestNFeVItemVNFTot(TransactionCase):
 
     def test_export_det_binding_vitem_with_discount(self):
         """Test vItem uses the fiscal total instead of the gross price"""
-        line = self.env["l10n_br_fiscal.document.line"].create(
-            {
-                "document_id": self.document.id,
-                "product_id": self.product.id,
-                "icms_cst_id": self.icms_cst_00.id,
-                "quantity": 1.0,
-                "price_unit": 100.0,
-            }
-        )
+        line = self._create_line(tax_classification_id=self.tax_classification.id)
         line.write({"discount_value": 10.0, "ibs_value": 0.1, "ibs_base": 90.0})
 
         self.assertNotEqual(line.price_gross, line.fiscal_amount_total)
@@ -709,15 +536,7 @@ class TestNFeVItemVNFTot(TransactionCase):
 
     def test_export_total_binding_with_vnftot(self):
         """Test total binding exports vNFTot along with IBSCBSTot"""
-        line = self.env["l10n_br_fiscal.document.line"].create(
-            {
-                "document_id": self.document.id,
-                "product_id": self.product.id,
-                "icms_cst_id": self.icms_cst_00.id,
-                "quantity": 1.0,
-                "price_unit": 100.0,
-            }
-        )
+        line = self._create_line(tax_classification_id=self.tax_classification.id)
         line.write({"ibs_value": 0.1, "ibs_base": 100.0, "cbs_value": 0.9})
 
         self.assertGreater(self.document.fiscal_amount_total, 0.0)
@@ -729,15 +548,7 @@ class TestNFeVItemVNFTot(TransactionCase):
         """Test vItem and vNFTot are absent when there is no IBS/CBS"""
         # Regression guard for the legacy behavior: it must stay green
         # before and after the fix (it is not red-green evidence)
-        line = self.env["l10n_br_fiscal.document.line"].create(
-            {
-                "document_id": self.document.id,
-                "product_id": self.product.id,
-                "icms_cst_id": self.icms_cst_00.id,
-                "quantity": 1.0,
-                "price_unit": 100.0,
-            }
-        )
+        line = self._create_line()
 
         det = self._build_det_binding(line)
         total = self._build_total_binding()
@@ -747,19 +558,17 @@ class TestNFeVItemVNFTot(TransactionCase):
 
     def test_export_field_vitem_and_vnftot_direct(self):
         """Test direct _export_field calls for vItem and vNFTot"""
-        line = self.env["l10n_br_fiscal.document.line"].create(
-            {
-                "document_id": self.document.id,
-                "product_id": self.product.id,
-                "icms_cst_id": self.icms_cst_00.id,
-                "quantity": 1.0,
-                "price_unit": 100.0,
-            }
-        )
+        line = self._create_line()
         self.assertFalse(line._export_field("nfe40_vItem", None, None))
         self.assertFalse(self.document._export_field("nfe40_vNFTot", None, None))
 
-        line.write({"ibs_value": 0.1, "ibs_base": 100.0})
+        line.write(
+            {
+                "tax_classification_id": self.tax_classification.id,
+                "ibs_value": 0.1,
+                "ibs_base": 100.0,
+            }
+        )
         self.assertEqual(
             line._export_field("nfe40_vItem", None, None),
             f"{line.fiscal_amount_total:.2f}",
@@ -768,3 +577,110 @@ class TestNFeVItemVNFTot(TransactionCase):
             self.document._export_field("nfe40_vNFTot", None, None),
             f"{self.document.fiscal_amount_total:.2f}",
         )
+
+
+@tagged("post_install", "-at_install")
+class TestNFeIBSCBSFiscalOperation(TransactionCase):
+    """Test IBSCBS export with the tax classification coming from the
+    fiscal operation line instead of being written on the line"""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+
+        cls.company = cls.env.ref("base.main_company")
+        cls.fiscal_operation = cls.env.ref("l10n_br_fiscal.fo_transferencia")
+        cls.fiscal_operation_line = cls.env.ref(
+            "l10n_br_fiscal.fol_manifesto_mercadoria"
+        )
+        cls.tax_classification = cls.env.ref("l10n_br_fiscal.tax_classification_410002")
+
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "Test Partner",
+                "is_company": True,
+                "cnpj_cpf": "65910976000147",
+            }
+        )
+
+        # fiscal_type 00 (goods for resale) so the fiscal operation line
+        # matched is fol_manifesto_mercadoria, the one carrying the
+        # 410002 tax classification
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Test Product",
+                "default_code": "TEST001",
+                "list_price": 100.0,
+                "fiscal_type": "00",
+            }
+        )
+
+        cls.document = cls.env["l10n_br_fiscal.document"].create(
+            {
+                "company_id": cls.company.id,
+                "partner_id": cls.partner.id,
+                "fiscal_operation_type": "out",
+                "fiscal_operation_id": cls.fiscal_operation.id,
+                "document_type_id": cls.env.ref("l10n_br_fiscal.document_55").id,
+            }
+        )
+        cls.line = cls.env["l10n_br_fiscal.document.line"].create(
+            {
+                "document_id": cls.document.id,
+                "product_id": cls.product.id,
+                "fiscal_operation_id": cls.fiscal_operation.id,
+                "icms_cst_id": cls.env.ref("l10n_br_fiscal.cst_icms_00").id,
+                "quantity": 1.0,
+                "price_unit": 100.0,
+            }
+        )
+
+    def _build_det_binding(self):
+        return self.line._build_binding(
+            spec_schema="nfe", spec_version="40", class_name="nfe.40.det"
+        )
+
+    def test_tax_classification_from_fiscal_operation_line(self):
+        """Test the line takes the tax classification from the operation line"""
+        self.assertEqual(self.line.fiscal_operation_line_id, self.fiscal_operation_line)
+        self.assertEqual(self.line.tax_classification_id, self.tax_classification)
+        self.assertEqual(self.line.tax_classification_id.code, "410002")
+        # 410002 maps the IBS/CBS immunity taxes (CST 410, zero rate)
+        self.assertEqual(self.line.ibs_cst_id.code, "410")
+        self.assertEqual(self.line.cbs_cst_id.code, "410")
+
+    def test_export_det_binding_ibscbs_group(self):
+        """Test the det binding exports IBSCBS from the operation line data"""
+        det = self._build_det_binding()
+
+        self.assertIsNotNone(det.imposto.IBSCBS)
+        self.assertEqual(det.imposto.IBSCBS.CST, "410")
+        self.assertEqual(det.imposto.IBSCBS.cClassTrib, "410002")
+        # immunity: the group is exported with zero values
+        self.assertEqual(det.imposto.IBSCBS.gIBSCBS.vBC, "0.00")
+        self.assertEqual(det.imposto.IBSCBS.gIBSCBS.vIBS, "0.00")
+        self.assertEqual(det.imposto.IBSCBS.gIBSCBS.gIBSUF.pIBSUF, "0.0000")
+        self.assertEqual(det.imposto.IBSCBS.gIBSCBS.gCBS.vCBS, "0.00")
+        # no reduction configured, so no gRed
+        self.assertIsNone(det.imposto.IBSCBS.gIBSCBS.gIBSUF.gRed)
+        self.assertIsNone(det.imposto.IBSCBS.gIBSCBS.gCBS.gRed)
+        # CST 410 keeps the gIBSCBS choice branch
+        self.assertIsNone(det.imposto.IBSCBS.gIBSCBSMono)
+
+    def test_export_total_binding_ibscbstot(self):
+        """Test the totals are exported for a document with a classification"""
+        total = self.document._build_binding(
+            spec_schema="nfe", spec_version="40", class_name="nfe.40.total"
+        )
+
+        self.assertIsNotNone(total.IBSCBSTot)
+        self.assertEqual(total.IBSCBSTot.vBCIBSCBS, "0.00")
+        self.assertEqual(total.IBSCBSTot.gIBS.vIBS, "0.00")
+        self.assertEqual(total.IBSCBSTot.gCBS.vCBS, "0.00")
+        self.assertEqual(total.vNFTot, f"{self.document.fiscal_amount_total:.2f}")
+
+    def test_export_det_binding_vitem(self):
+        """Test vItem is exported for every line of such a document"""
+        det = self._build_det_binding()
+        self.assertEqual(det.vItem, f"{self.line.fiscal_amount_total:.2f}")

--- a/spec_driven_model/models/spec_export.py
+++ b/spec_driven_model/models/spec_export.py
@@ -3,6 +3,7 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
 
 import logging
+import sys
 from importlib import import_module
 
 from odoo import api, fields, models
@@ -122,10 +123,10 @@ class SpecMixinExport(models.AbstractModel):
         binding_class = self._get_binding_class(class_obj, field_name=field_name)
         binding_class_spec = binding_class.__dataclass_fields__
 
+        xsd_fields = [i for i in xsd_fields]
         class_name = class_obj._name.replace(".", "_")
         export_method_name = f"_export_fields_{class_name}"
         if hasattr(self, export_method_name):
-            xsd_fields = [i for i in xsd_fields]
             export_method = getattr(self, export_method_name)
             export_method(xsd_fields, class_obj, export_dict)
 
@@ -163,6 +164,127 @@ class SpecMixinExport(models.AbstractModel):
 
             export_dict[field_spec_name] = field_data
 
+    def _get_tag_export_hook(self, xsd_field, parent_tag=None):
+        """
+        Return the per tag export hook for a field, if any.
+
+        The hook is a method named _export_tag_SCHEMA_VERSION_TAG_NAME
+        (e.g. _export_tag_nfe_40_ibscbs for the nfe40_IBSCBS field). The
+        _export_tag_ prefix keeps this family apart from the per class
+        _export_fields_CLASS_NAME hooks: tag names and spec class names
+        share the same shape (the gMonoPadrao tag and the
+        nfe.40.gmonopadrao class would both yield
+        _export_fields_nfe_40_gmonopadrao), so a common prefix would make
+        the two dispatches silently collide.
+
+        When the same tag appears under different parent tags with different
+        values (e.g. gRed inside both gIBSUF and gCBS), a hook qualified by
+        the parent tag takes precedence over the generic one:
+        _export_tag_nfe_40_gibsuf_gred and _export_tag_nfe_40_gcbs_gred
+        are looked up before _export_tag_nfe_40_gred.
+
+        Stacking points never get a per tag hook: they are exported through
+        their own class and already get the _export_fields_CLASS_NAME
+        dispatch.
+        """
+        schema, version = self._spec_prefix(split=True)
+        if not schema or xsd_field in self._get_stacking_points():
+            return None
+        tag = xsd_field.split("_", 1)[-1].lower()
+        if parent_tag:
+            qualified_method = getattr(
+                self,
+                f"_export_tag_{schema}_{version}_{parent_tag.lower()}_{tag}",
+                None,
+            )
+            if qualified_method is not None:
+                return qualified_method
+        return getattr(self, f"_export_tag_{schema}_{version}_{tag}", None)
+
+    def _get_hook_binding_class(self, child_class, parent_binding_class=None):
+        """
+        Resolve the binding class of a spec model exported via per tag hooks.
+
+        Falls back to the parent binding class module when the type is not
+        reachable from the schema binding module (e.g. Tcibs lives in
+        nfelib dfe_tipos_basicos, not in leiaute_nfe).
+        """
+        try:
+            return self._get_binding_class(child_class)
+        except AttributeError:
+            if parent_binding_class is None:
+                raise
+            binding = sys.modules[parent_binding_class.__module__]
+            for attr in child_class._binding_type.split("."):
+                binding = getattr(binding, attr)
+            return binding
+
+    def _export_m2o_via_tag_hooks(
+        self, xsd_field, class_obj, parent_binding_class=None, parent_tag=None
+    ):
+        """
+        Build the binding of a many2one field through per tag export hooks.
+
+        Used for fields whose comodel is a reusable schema type that is
+        neither stacked in self nor mapped to a related record (e.g. the
+        nfe40_IBSCBS field pointing to nfe.40.ttribnfe): the class name
+        dispatch would not match the tag name and the field values are not
+        denormalized in self. The hook of each (sub) tag only populates
+        export_dict with simple values (numeric values are formatted here
+        according to the field xsd_type); this method assembles the
+        bindings, recursing into the child many2one fields that have their
+        own hook (e.g. nfe40_gIBSUF -> _export_tag_nfe_40_gibsuf, and
+        nfe40_gRed inside gIBSUF -> _export_tag_nfe_40_gibsuf_gred or
+        _export_tag_nfe_40_gred, see _get_tag_export_hook).
+
+        Returns False when the hook leaves export_dict empty, so the tag
+        is omitted.
+        """
+        hook = self._get_tag_export_hook(xsd_field, parent_tag=parent_tag)
+        if hook is None:
+            return False
+        # "is not None": an empty recordset is falsy but still holds _fields
+        field = (
+            class_obj._fields.get(xsd_field) if class_obj is not None else None
+        ) or self._fields.get(xsd_field)
+        child_class = self.env[field.comodel_name]
+        binding_class = self._get_hook_binding_class(child_class, parent_binding_class)
+        prefix = f"{self._spec_prefix()}_"
+        xsd_fields = [
+            f
+            for f in child_class._fields
+            if f.startswith(prefix) and "_choice" not in f
+        ]
+        export_dict = {}
+        hook(xsd_fields, child_class, export_dict)
+        if not export_dict:
+            return False
+        tag = xsd_field.split("_", 1)[-1]
+        for child_field in xsd_fields:
+            tag_name = child_field.split("_", 1)[-1]
+            if child_class._fields[child_field].type == "many2one":
+                if export_dict.get(tag_name) is None:
+                    sub_data = self._export_m2o_via_tag_hooks(
+                        child_field, child_class, binding_class, parent_tag=tag
+                    )
+                    if sub_data:
+                        export_dict[tag_name] = sub_data
+                continue
+            # format the raw numeric values set by the hooks according
+            # to the decimal places of the field xsd_type
+            value = export_dict.get(tag_name)
+            if isinstance(value, bool) or not isinstance(value, int | float):
+                continue
+            export_dict[tag_name] = self._format_float_xsd(
+                value, getattr(child_class._fields[child_field], "xsd_type", None)
+            )
+        sliced_dict = {
+            key: value
+            for key, value in export_dict.items()
+            if key in binding_class.__dataclass_fields__ and value is not None
+        }
+        return binding_class(**sliced_dict)
+
     def _export_field(self, xsd_field, class_obj, field_spec, export_value=None):
         """
         Map a single Odoo field to a python binding value according to the
@@ -179,7 +301,13 @@ class SpecMixinExport(models.AbstractModel):
             if (not self._get_stacking_points().get(xsd_field)) and (
                 not self[xsd_field] and not xsd_required
             ):
-                if field.comodel_name not in self._get_spec_classes():
+                # a per tag hook can export a field with no record behind
+                # it, so let it reach _export_many2one, the single m2o
+                # entry point, which dispatches to the hooks
+                if (
+                    field.comodel_name not in self._get_spec_classes()
+                    and self._get_tag_export_hook(xsd_field) is None
+                ):
                     return False
             if hasattr(field, "xsd_choice_required"):
                 xsd_required = True
@@ -210,6 +338,9 @@ class SpecMixinExport(models.AbstractModel):
             return self._build_binding(
                 class_name=self._get_stacking_points()[field_name].comodel_name
             )
+        elif not self[field_name] and self._get_tag_export_hook(field_name):
+            # no record behind the m2o: the tag is built from its hooks
+            return self._export_m2o_via_tag_hooks(field_name, class_obj)
         else:
             return (self[field_name] or self)._build_binding(
                 field_name=field_name,
@@ -226,6 +357,18 @@ class SpecMixinExport(models.AbstractModel):
             relational_data.append(field_data)
         return relational_data
 
+    @api.model
+    def _format_float_xsd(self, value, xsd_type):
+        """
+        Format a float according to the decimal places of its xsd_type
+        (e.g. TDec1302 -> 2 decimals, TDec_0302_04RTC -> 4 decimals).
+        """
+        if xsd_type and xsd_type.startswith("TDec"):
+            tdec = "".join(filter(lambda x: x.isdigit(), xsd_type))[-2:]
+        else:
+            tdec = ""
+        return str(f"%.{tdec}f" % value)
+
     def _export_float_monetary(
         self, field_name, xsd_type, class_obj, xsd_required, export_value=None
     ):
@@ -234,12 +377,7 @@ class SpecMixinExport(models.AbstractModel):
         # TODO check xsd_required for all fields to export?
         if not field_data and not xsd_required:
             return False
-        if xsd_type and xsd_type.startswith("TDec"):
-            tdec = "".join(filter(lambda x: x.isdigit(), xsd_type))[-2:]
-        else:
-            tdec = ""
-        my_format = f"%.{tdec}f"
-        return str(my_format % field_data)
+        return self._format_float_xsd(field_data, xsd_type)
 
     def _export_date(self, field_name):
         self.ensure_one()


### PR DESCRIPTION
# Refatoração do export das tags IBS/CBS (NT 2025.002) — hooks por tag no `spec_driven_model`

Branch: `16.0-l10n_br_fiscal-cbs-ibs-tag` · Repositório: OCA/l10n-brazil (16.0)

Arquivos alterados:

| Arquivo | Mudança |
|---|---|
| `spec_driven_model/models/spec_export.py` | Novo mecanismo genérico de export por *hooks de tag* |
| `l10n_br_nfe/models/document_line.py` | Hooks da tag `IBSCBS` do `det` (linha do documento fiscal) |
| `l10n_br_nfe/models/document.py` | Hooks da tag `IBSCBSTot` do `total` + guard `_nfe_export_ibscbs_totals` |
| `l10n_br_nfe/tests/test_nfe_ibscbs.py` | Testes adaptados ao novo mecanismo + novos casos |

---

## 1. O problema

A NT 2025.002 introduziu na NF-e os grupos `IBSCBS` (por item, dentro de `imposto`) e `IBSCBSTot` (no `total`). Diferentemente dos demais impostos (ICMS, PIS, COFINS…), essas tags **não seguem o padrão de dispatch do `spec_driven_model`**:

- Para o COFINS, a tag `COFINS` e suas sub-tags (`COFINSAliq`, `COFINSOutr`…) são classes *stacked* na linha do documento, cujo nome de modelo coincide com o nome da tag (`nfe.40.cofins`). O framework constrói cada classe recursivamente e despacha `_export_fields_nfe_40_cofins`, `_export_fields_nfe_40_cofinsaliq` etc., em que cada método **apenas popula o `export_dict`** com valores simples.
- Já o campo `nfe40_IBSCBS` aponta para o tipo **reutilizável** `nfe.40.ttribnfe` (`TTribNFe`), que não é *stacked* na linha (o tipo é tornado concreto pelo `_register_hook`). Consequência: nem o dispatch por classe nem o export genérico de m2o alcançavam a tag, e a implementação original duplicava a construção manual dos bindings `TtribNfe`/`Tcibs` em **três lugares** (`_export_field`, `_export_many2one` e `_export_fields_nfe_40_imposto`) — o mesmo valendo para o `IBSCBSTot` no documento.

## 2. Solução: dispatch por nome de tag no `spec_driven_model`

O `spec_export.py` ganhou um mecanismo genérico e *opt-in* para exportar campos m2o cujo comodel é um tipo de schema reutilizável, mantendo o estilo "hooks que só populam dict" do restante do módulo:

### `_get_field_export_hook(xsd_field, parent_tag=None)`

Resolve o hook de um campo pelo **nome da tag**:
`_export_fields_{schema}_{versão}_{tag}` — ex.: `nfe40_IBSCBS` → `_export_fields_nfe_40_ibscbs`; `nfe40_gIBSUF` → `_export_fields_nfe_40_gibsuf`.

**Qualificação pelo pai**: quando a mesma sub-tag existe sob pais diferentes com conteúdo diferente (ex.: `gRed` dentro de `gIBSUF` **e** de `gCBS`), o hook qualificado pelo pai tem precedência sobre o genérico:

1. `_export_fields_nfe_40_gibsuf_gred` / `_export_fields_nfe_40_gcbs_gred` (específicos)
2. `_export_fields_nfe_40_gred` (fallback genérico)

*Stacking points* nunca recebem hook por tag — eles já são exportados pela própria classe com o dispatch `_export_fields_{CLASSE}` existente. Isso evita dupla chamada dos hooks legados (`_export_fields_nfe_40_cofins` etc.), verificado em NFe, CTe e MDFe.

### `_export_m2o_via_field_hooks(xsd_field, class_obj, parent_binding_class, parent_tag)`

Monta o binding de um m2o via hooks de tag, recursivamente:

- chama o hook da tag, que popula um `export_dict` novo **apenas com valores simples** (strings ou números crus dos campos do Odoo);
- **dict vazio → tag omitida** (retorna `False`) — é assim que um hook "se guarda" (ex.: sem `tax_classification_id`, nada é populado e a `IBSCBS` não sai no XML);
- **formata valores numéricos pelo `xsd_type` do campo spec** (mesma convenção do `_export_float_monetary`): `TDec1302RTC` → 2 casas, `TDec_0302_04RTC` → 4 casas. Os hooks não precisam mais de `f"{...:.2f}"`;
- recursa nas sub-tags m2o **que têm hook definido** (opt-in) — sub-tags de *choice* sem hook (ex.: `gTransfCred`) ficam naturalmente de fora;
- o hook também recebe a lista `xsd_fields` da classe filha e pode removê-la condicionalmente (usado para o *choice* por CST, ver §3).

### `_get_hook_binding_class(child_class, parent_binding_class)`

Resolve a classe de binding do nfelib. Quando o tipo não é alcançável a partir do módulo de binding do schema (ex.: `Tcibs` vive em `dfe_tipos_basicos_v1_00`, não em `leiaute_nfe_v4_00`), faz fallback para o módulo da binding class do **pai**, seguindo o `_binding_type` do modelo spec (`"Tcibs"`, `"Tcibs.GIbsuf"`, …).

### Integração

`_export_field` (branch m2o) desvia para o builder quando o campo está vazio e existe
hook para a tag. Nenhum comportamento muda para quem não define hooks — a extensão é
totalmente retrocompatível (suíte do `spec_driven_model` e das demais localizações
inalterada).

## 3. `l10n_br_nfe` — linha do documento (`document_line.py`)

Toda a construção manual de bindings foi substituída por hooks curtos (~60 linhas no
lugar de 3 blocos de ~70):

- `_export_fields_nfe_40_ibscbs` — popula `cClassTrib` (da
  `tax_classification_id`) e `CST` (do `ibs_cst_id`); sem classificação/CST o dict
  fica vazio e a tag é omitida. Também resolve o **choice** do `TTribNFe` removendo
  de `xsd_fields` os ramos que não correspondem ao CST:
  - `620` → mantém `gIBSCBSMono`
  - `800` → mantém `gTransfCred`
  - `811` → mantém `gAjusteCompet`
  - default (qualquer outro CST) → mantém `gIBSCBS`
  > O default é obrigatório: sem ele, linhas com CST fora dos casos especiais
  > exportavam `gIBSCBS` **e** `gIBSCBSMono` juntos, violando o choice do XSD e
  > bloqueando a transmissão (regressão detectada nos testes da NFCe).
- `_export_fields_nfe_40_gibscbs` — `vBC` (`ibs_base`), `vIBS` (`ibs_value`).
- `_export_fields_nfe_40_gibsuf` — `pIBSUF`, `vIBSUF`.
- `_export_fields_nfe_40_gibsuf_gred` — `gRed` do IBS UF: `pRedAliq` (`ibs_reduction`) e `pAliqEfet` (`ibs_percent × (1 − redução/100)`), só quando há redução.
- `_export_fields_nfe_40_gibsmun` — zeros (IBS municipal ainda não disponível).
- `_export_fields_nfe_40_gcbs` — `pCBS`, `vCBS`.
- `_export_fields_nfe_40_gcbs_gred` — `gRed` da CBS com `cbs_reduction` (hook qualificado pelo pai — demonstra a resolução de colisão de sub-tags homônimas).
- `_export_fields_nfe_40_gibscbsmono` / `_export_fields_nfe_40_gmonopadrao` — grupo da monofasia (CST 620).

Também foram removidos: os overrides de `_export_field`/`_export_many2one` para a IBSCBS (permanece só o tratamento de `vItem` da NT 2025.002), o bloco IBSCBS do `_export_fields_nfe_40_imposto` e os imports diretos de `Tcibs`/`TtribNfe` do nfelib.

## 4. `l10n_br_nfe` — documento (`document.py`)

Mesmo padrão para o `IBSCBSTot` (comodel reutilizável `nfe.40.tibscbsmonotot`):

- `_export_fields_nfe_40_ibscbstot` — guard + `vBCIBSCBS`;
- `_export_fields_nfe_40_gibs` / `_gibsuf` / `_gibsmun` / `_gcbs` — totais computados (`nfe40_vIBS`, `nfe40_vIBSUF`, `nfe40_vDif*`, `nfe40_vDevTrib*`, `nfe40_vCredPres*`, `nfe40_vCBS`), valores crus formatados pelo framework. (Não há colisão com os hooks homônimos da linha — são modelos diferentes.)
- `_nfe_export_ibscbs_totals()` — o guard de `vItem`/`vNFTot`/`IBSCBSTot` passou de "soma de `ibs_value`/`cbs_value`" para **"alguma linha tem `tax_classification_id`"**, mantendo os totais consistentes com a presença da `IBSCBS` nas linhas.
- Removidos o bloco de construção manual do `TibscbsmonoTot` em `_export_field`, o branch morto do `_export_many2one` e o import do binding.

## 5. Testes (`test_nfe_ibscbs.py`)

- Testes unitários passam a exercitar o caminho real do framework (`_export_m2o_via_field_hooks` com `nfe.40.imposto`/`nfe.40.total`), não mais os overrides removidos.
- Testes de integração via `_build_binding` real do `det` e do `total` validam o dispatch de ponta a ponta (`det.imposto.IBSCBS`, `total.IBSCBSTot`, `vItem`, `vNFTot`).
- Novos casos: guard por `tax_classification_id` (com e sem), CST por `ibs_cst_id`, `gRed` qualificado por pai com reduções distintas de IBS (60%) e CBS (30%), ausência de `gRed` sem redução, `gIBSMun` zerado.

## 6. Validação executada

- `spec_driven_model`: 11/11 testes ✅
- `TestNFeIBSCBS` + `TestNFeVItemVNFTot` + `TestNFCe`: 0 falhas ✅
- Suíte completa `l10n_br_nfe` (76 testes): **idêntica à baseline** do branch (1 falha + 25 erros pré-existentes e ambientais: certificado A1 fake/OpenSSL local e serviço `brcobranca` ausente) ✅
- XML real gerado via `odoo shell` (binding do `det`/`total` da demo) confere com a estrutura esperada da NT 2025.002: `<IBSCBS><CST><cClassTrib><gIBSCBS><vBC> <gIBSUF><gRed>…`, `<IBSCBSTot>`, `<vItem>`, `<vNFTot>` ✅
- `pre-commit` (ruff, ruff-format, pylint-odoo) ✅

## 7. Como estender

Para exportar uma nova tag de tipo reutilizável em qualquer schema baseado no `spec_driven_model`, basta definir hooks nomeados pela tag:

```python
def _export_fields_nfe_40_minhatag(self, xsd_fields, class_obj, export_dict):
    export_dict["campoX"] = self.valor_x        # cru; framework formata pelo xsd_type

def _export_fields_nfe_40_pai_subtag(self, xsd_fields, class_obj, export_dict):
    ...  # variante qualificada pelo pai, quando a sub-tag se repete em pais distintos
```

Sem hook definido, nada muda no comportamento do framework.
