### PR TITLE
[18.0][FIX] l10n_br_account: hide the native tax totals widget

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -244,10 +244,15 @@ class AccountMove(models.Model):
         if view_type == "form" and self.env.company.country_id.code == "BR":
             arch = self.env["l10n_br_fiscal.document.line"].inject_fiscal_fields(arch)
 
+        # The Brazilian footer already shows the document totals computed by the
+        # fiscal engine. The native widget recomputes them with its own rules and
+        # adds the price included taxes (ICMS, PIS, COFINS, IBS, CBS) on top of a
+        # subtotal that already carries them, so it must not be displayed.
+        # "attrs" was dropped in Odoo 17.0: the modifier is now a plain attribute.
         for tax_totals_node in arch.xpath(
             "//field[@name='tax_totals'][@widget='account-tax-totals-field']"
         ):
-            tax_totals_node.set("attrs", "{'invisible': True}")
+            tax_totals_node.set("invisible", "1")
 
         if view_type == "form" and (
             self.env.user.has_group("l10n_br_account.group_line_fiscal_detail")


### PR DESCRIPTION
A fatura brasileira mostra dois blocos de totais, com dois totais diferentes. O `_get_view` do `account.move` tenta esconder o widget nativo com `tax_totals_node.set("attrs", "{'invisible': True}")`, e `attrs` saiu do Odoo na 17.0: o atributo é gravado no arch, ninguém lê, e o campo continua renderizando. O módulo substitui o rodapé de subtotais nativo pelo brasileiro e reinsere o `tax_totals` logo abaixo, então os dois aparecem juntos.

O de baixo soma todo imposto em cima do valor sem impostos, e ICMS, PIS, COFINS, IBS e CBS já estão dentro do preço. Medi numa fatura de entrada importada de base real: o rodapé brasileiro fecha em 77.609,92, que é `70.715,19 + IPI 6.894,73`, o IPI sendo o único por fora; o widget mostra 93.193,77, acrescentando `ICMS 8.485,82 + PIS 1.166,80 + COFINS 5.374,35 + IBS 55,69 + CBS 501,19` por cima do que já os contém. Quem lança lê isso como a nota dobrando o imposto, e o imposto está certo: o errado é o segundo bloco existir. Pega qualquer fatura com operação fiscal, não só importada.

Peguei conferindo o rodapé de nota importada num clone de base real, e a correção é o nome do atributo. O teste renderiza o formulário com empresa brasileira e cobra que o nó traga `invisible="1"` e nenhum `attrs`; com a linha revertida fica vermelho em `AssertionError: None != '1'`.
