### PR TITLE
[18.0][FIX] l10n_br_fiscal: a comment that renders to nothing

### DIFF
--- a/l10n_br_fiscal/models/comment.py
+++ b/l10n_br_fiscal/models/comment.py
@@ -151,7 +151,13 @@ class Comment(models.Model):
         comments = [manual_comment] if manual_comment else []
         for record in self:
             template = mako_safe_env.from_string(record.comment)
-            comments.append(template.render(vals))
+            # A comment can be conditional on the document, so it renders to
+            # nothing for the documents it does not apply to. Joining an empty
+            # render leaves a dangling separator in the additional data, which
+            # reaches the DANFE.
+            rendered = template.render(vals).strip()
+            if rendered:
+                comments.append(rendered)
         return " - ".join(comments)
 
     def action_test_message(self):

--- a/l10n_br_fiscal/models/comment.py
+++ b/l10n_br_fiscal/models/comment.py
@@ -148,17 +148,14 @@ class Comment(models.Model):
         mako_safe_env = copy.copy(mako_template_env)
         mako_safe_env.autoescape = False
 
-        comments = [manual_comment] if manual_comment else []
-        for record in self:
-            template = mako_safe_env.from_string(record.comment)
-            # A comment can be conditional on the document, so it renders to
-            # nothing for the documents it does not apply to. Joining an empty
-            # render leaves a dangling separator in the additional data, which
-            # reaches the DANFE.
-            rendered = template.render(vals).strip()
-            if rendered:
-                comments.append(rendered)
-        return " - ".join(comments)
+        # A comment can be conditional on the document, so it renders to
+        # nothing for the documents it does not apply to; joining an empty
+        # or blank candidate leaves a dangling separator in the DANFE.
+        candidates = [manual_comment or ""]
+        candidates += [
+            mako_safe_env.from_string(record.comment).render(vals) for record in self
+        ]
+        return " - ".join(c for c in (c.strip() for c in candidates) if c)
 
     def action_test_message(self):
         vals = {"user": self.env.user, "ctx": self._context, "doc": self.object_id}

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -17,4 +17,5 @@ from . import (
     test_service_type,
     test_operation,
     test_company_tax_domain,
+    test_comment,
 )

--- a/l10n_br_fiscal/tests/test_comment.py
+++ b/l10n_br_fiscal/tests/test_comment.py
@@ -1,0 +1,43 @@
+# Copyright 2026 KMEE (Ygor Carvalho <ygor.carvalho@kmee.com.br>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests.common import TransactionCase
+
+FIXO = "ISENCAO DO ICMS, REGIME ESPECIAL 91092 2020, CONTRATO A-005446"
+
+
+class TestComment(TransactionCase):
+    def _comment(self, comment):
+        return self.env["l10n_br_fiscal.comment"].create(
+            {
+                "name": "comment test",
+                "comment": comment,
+                "comment_type": "commercial",
+                "object": "l10n_br_fiscal.document.mixin",
+            }
+        )
+
+    def test_a_comment_that_does_not_apply_leaves_no_separator(self):
+        """A comment that renders to nothing must not join the message.
+
+        A benefit legend tied to a contract belongs to the notes of that
+        customer only, so the comment is written conditional on the document.
+        For every other document it renders to nothing, and joining that empty
+        render used to leave the manual text ending in " - " on the DANFE.
+        """
+        comment = self._comment(f"% if doc.applies:\n{FIXO}\n% endif")
+
+        message = comment.compute_message(
+            {"doc": type("Doc", (), {"applies": False})()}, "ITEM 01.05"
+        )
+
+        self.assertEqual(message, "ITEM 01.05")
+
+    def test_a_comment_that_applies_comes_after_the_manual_text(self):
+        comment = self._comment(f"% if doc.applies:\n{FIXO}\n% endif")
+
+        message = comment.compute_message(
+            {"doc": type("Doc", (), {"applies": True})()}, "ITEM 01.05"
+        )
+
+        self.assertEqual(message, f"ITEM 01.05 - {FIXO}")

--- a/l10n_br_fiscal/tests/test_comment.py
+++ b/l10n_br_fiscal/tests/test_comment.py
@@ -18,13 +18,7 @@ class TestComment(TransactionCase):
         )
 
     def test_a_comment_that_does_not_apply_leaves_no_separator(self):
-        """A comment that renders to nothing must not join the message.
-
-        A benefit legend tied to a contract belongs to the notes of that
-        customer only, so the comment is written conditional on the document.
-        For every other document it renders to nothing, and joining that empty
-        render used to leave the manual text ending in " - " on the DANFE.
-        """
+        """A comment that renders to nothing must not join the message."""
         comment = self._comment(f"% if doc.applies:\n{FIXO}\n% endif")
 
         message = comment.compute_message(
@@ -41,3 +35,22 @@ class TestComment(TransactionCase):
         )
 
         self.assertEqual(message, f"ITEM 01.05 - {FIXO}")
+
+    def test_a_blank_manual_comment_leaves_no_separator(self):
+        comment = self._comment(FIXO)
+
+        message = comment.compute_message({}, "   ")
+
+        self.assertEqual(message, FIXO)
+
+    def test_a_comment_that_does_not_apply_in_the_middle_is_skipped(self):
+        first = self._comment("A")
+        middle = self._comment(f"% if doc.applies:\n{FIXO}\n% endif")
+        last = self._comment("B")
+        comments = first + middle + last
+
+        message = comments.compute_message(
+            {"doc": type("Doc", (), {"applies": False})()}
+        )
+
+        self.assertEqual(message, "A - B")


### PR DESCRIPTION
Comentário fiscal condicional deixa separador solto no fim das informações adicionais, e isso chega ao DANFE. Legenda de benefício amarrada a contrato vale para as notas de um destinatário só, então o jeito de escrever isso é um comentário condicional no documento, ligado na operação fiscal: a mesma operação de venda serve o cliente do contrato e os outros 404 da carteira, e declarar isenção de contrato em nota de terceiro seria falso.

O `compute_message` monta a mensagem com `" - ".join(comments)` e dá `append` no render de todo comentário, inclusive no que devolve string vazia. Numa nota fora da condição, com o operador tendo digitado o texto manual, o resultado é `ITEM 01.05 - `, com o separador pendurado. E o render que passa vem com `\n` no fim, do `% endif`, que também entra na mensagem.

A correção é fazer `strip` no render e só juntar o que sobrou. Peguei configurando a legenda de isenção de um contrato de obra num cliente, onde o texto precisa sair fixo no fim das Informações Complementares e o item e a localização continuam digitados por nota na frente dele.

Os testes cobram os dois lados do condicional: fora da condição a mensagem é só o texto manual, dentro dela é o manual mais o fixo separados por um único `-`. Sem a correção o primeiro fica vermelho em `'ITEM 01.05 - ' != 'ITEM 01.05'` e o segundo no `\n` sobrando.
