### PR TITLE
Aviso sobre a branch 17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@
 
 Odoo Brazilian localization
 
+## ⚠️ **Aviso Importante sobre a branch 17.0**
+
+A branch `17.0` é uma **transição técnica** entre as versões `16.0` e `18.0` e pode ser utilizada como **contingência** para implantações já realizadas no Odoo 17.0 no Brasil.
+
+- **Se você está migrando da versão 16.0:** recomendamos migrar **diretamente para a 18.0**, que conta com uma base de usuários mais ampla e suporte mais ativo da comunidade.
+- **Se você está iniciando um novo projeto Odoo:** opte por uma versão **superior à 17.0**, evitando começar por uma branch de transição.
+
+💡 **OpenUpgrade:** no processo de migração **versão a versão** com o OpenUpgrade, recomendamos que **ao passar pela 17.0** você **não** inclua o repositório `OCA/l10n-brazil` no seu `addons_path`.
+
 <!-- /!\ do not modify below this line -->
 
 <!-- prettier-ignore-start -->


### PR DESCRIPTION
@OCA/local-brazil-maintainers a gente usou a branch 17.0 como branch de transiçao para migrar modulos importantes como l10n_br_fiscal, l10n_br_account, l10n_br_account_nfe, spec_driven_model, l10n_br_stock_account...

Ate um tempo atras, pessoas como @antoniospneto , @felipemotter da empresa Engenere ou ate o @marcelsavegnago da Escodoo eram mais ativas no projeto e nao era tao claro ate onde a gente poderia manter a branch 17.0. Mas hoje fica claro que temos que focar nas branches 18.0 e futuramente a 20.0 usando a 19.0 como transiçao de novo para os modulos criticos. Nisso acho melhor mandar esse aviso de "se vira" para quem aposta na 17.0 hoje para nao dar falsas esperanças.

E assim, para a gente foi util ter a 17.0 como transiçao para fazer refatores importantes como https://github.com/OCA/l10n-brazil/pull/5010 ou ports importantes como https://github.com/OCA/l10n-brazil/pull/4630 mas esses entrando ja nao pretendemos manter a branch 17.0 do nosso lado da Akretion, assim como depois de um certo tempo a gente deixou de manter a branch 15.0 uns anos atras.