### PR TITLE
[16.0][FIX] l10n_br_account,l10n_br_account_nfe: tratar IBS/CBS como "por dentro" no vProd

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -712,20 +712,22 @@ class AccountMove(models.Model):
                 line_form.fiscal_document_line_id = line
 
                 # SEFAZ Standard: What is included in vProd?
+                # IBS/CBS are "por dentro" (tax_group tax_include=True) like
+                # ICMS/PIS/COFINS, so they belong to amt_inc, not amt_not_inc.
                 amt_inc = (
                     (line.icms_value or 0.0)
                     + (line.pis_value or 0.0)
                     + (line.cofins_value or 0.0)
                     + (line.issqn_value or 0.0)
                     + (line.icmsfcp_value or 0.0)
+                    + (line.ibs_value or 0.0)
+                    + (line.cbs_value or 0.0)
                 )
                 amt_not_inc = (
                     (line.icmsst_value or 0.0)
                     + (line.ipi_value or 0.0)
                     + (line.ii_value or 0.0)
                     + (line.icmsfcpst_value or 0.0)
-                    + (line.ibs_value or 0.0)
-                    + (line.cbs_value or 0.0)
                 )
 
                 unit_and_prices.append(

--- a/l10n_br_account_nfe/tests/nfe/35231149647316000169550010000661061151600085-nfe.xml
+++ b/l10n_br_account_nfe/tests/nfe/35231149647316000169550010000661061151600085-nfe.xml
@@ -391,7 +391,7 @@
           <vPIS>68.51</vPIS>
           <vCOFINS>316.17</vCOFINS>
           <vOutro>0.00</vOutro>
-          <vNF>12227.86</vNF>
+          <vNF>12108.10</vNF>
         </ICMSTot>
         <IBSCBSTot>
           <vBCIBSCBS>11975.96</vBCIBSCBS>
@@ -418,7 +418,7 @@
             <vCredPresCondSus>0.00</vCredPresCondSus>
           </gCBS>
         </IBSCBSTot>
-        <vNFTot>12227.86</vNFTot>
+        <vNFTot>12108.10</vNFTot>
       </total>
       <transp>
         <modFrete>1</modFrete>
@@ -441,30 +441,30 @@
       <cobr>
         <fat>
           <nFat>66106</nFat>
-          <vOrig>12227.86</vOrig>
+          <vOrig>12108.10</vOrig>
           <vDesc>0.00</vDesc>
-          <vLiq>12227.86</vLiq>
+          <vLiq>12108.10</vLiq>
         </fat>
         <dup>
           <nDup>001</nDup>
           <dVenc>2026-12-09</dVenc>
-          <vDup>4075.95</vDup>
+          <vDup>4035.63</vDup>
         </dup>
         <dup>
           <nDup>002</nDup>
           <dVenc>2026-12-24</dVenc>
-          <vDup>4075.95</vDup>
+          <vDup>4035.63</vDup>
         </dup>
         <dup>
           <nDup>003</nDup>
           <dVenc>2027-01-08</dVenc>
-          <vDup>4075.96</vDup>
+          <vDup>4036.84</vDup>
         </dup>
       </cobr>
       <pag>
         <detPag>
           <tPag>01</tPag>
-          <vPag>12227.86</vPag>
+          <vPag>12108.10</vPag>
         </detPag>
       </pag>
       <infAdic>

--- a/l10n_br_account_nfe/tests/test_nfe_import.py
+++ b/l10n_br_account_nfe/tests/test_nfe_import.py
@@ -176,8 +176,8 @@ class NFeImportTest(TransactionCase):
         self.assertAlmostEqual(move.amount_freight_value, 0, places=2)
         self.assertAlmostEqual(move.amount_insurance_value, 0, places=2)
         self.assertAlmostEqual(move.amount_other_value, 0, places=2)
-        self.assertAlmostEqual(move.amount_tax, 251.90, places=2)
-        self.assertAlmostEqual(move.amount_total, 12227.86, places=2)
+        self.assertAlmostEqual(move.amount_tax, 132.14, places=2)
+        self.assertAlmostEqual(move.amount_total, 12108.10, places=2)
 
         self.assertEqual(len(move.invoice_line_ids), 4)
 
@@ -241,9 +241,9 @@ class NFeImportTest(TransactionCase):
         )
 
         self.assertEqual(len(move.due_line_ids), 3)
-        self.assertAlmostEqual(move.due_line_ids[0].credit, 4075.95, places=2)
-        self.assertAlmostEqual(move.due_line_ids[1].credit, 4075.95, places=2)
-        self.assertAlmostEqual(move.due_line_ids[2].credit, 4075.96, places=2)
+        self.assertAlmostEqual(move.due_line_ids[0].credit, 4035.63, places=2)
+        self.assertAlmostEqual(move.due_line_ids[1].credit, 4035.63, places=2)
+        self.assertAlmostEqual(move.due_line_ids[2].credit, 4036.84, places=2)
 
     def test_import_incomplete_document_is_blocked(self):
         """A document with a line missing its product/uom/qty/price must not


### PR DESCRIPTION
Este PR foi extraído do PR #4939 (branch 16.0-nfe-import-fixes) para facilitar a revisão.
Ele contém apenas a parte de IBS/CBS "por dentro" na importação de NF-e de fornecedor.

O que faz
---------
1. No cálculo do vProd de um documento importado, os valores de IBS/CBS
   declarados no XML passam a ser tratados como já incluídos ("por dentro"):
   o vProd declarado já embute o IBS/CBS, então o fix evita que o preço seja
   recomputado como se os tributos fossem por fora (o que duplicaria o valor).

2. Alinha o teste de importação IBS/CBS do l10n_br_account_nfe com o
   comportamento "por dentro" (ajustes na fixture XML e nas expectativas do
   teste de importação).


Assisted-by AI
