### PR TITLE
[16.0][IMP] l10n_br_nfe: melhorar a correspondência do produto importado com o pedido de compra

### DIFF
--- a/l10n_br_nfe/models/product_product.py
+++ b/l10n_br_nfe/models/product_product.py
@@ -50,6 +50,88 @@ class ProductProduct(models.Model):
         return rec_id
 
     @api.model
+    def _get_supplier_open_po_product_ids(self, supplier_id, company_id):
+        """Ids of products with a not-fully-billed line on the supplier's
+        confirmed/done purchase orders (soft dependency on ``purchase``)."""
+        po_line_model = self.env.get("purchase.order.line")
+        if po_line_model is None:
+            return set()
+        po_lines = po_line_model.sudo().search(
+            [
+                ("order_id.partner_id", "=", supplier_id),
+                ("order_id.company_id", "=", company_id),
+                ("order_id.state", "in", ("purchase", "done")),
+            ]
+        )
+        return set(
+            po_lines.filtered(
+                lambda line: line.product_qty > line.qty_invoiced
+            ).product_id.ids
+        )
+
+    @api.model
+    def _name_search(
+        self, name="", args=None, operator="ilike", limit=100, name_get_uid=None
+    ):
+        """Propose the NFe supplier's open purchase-order products first.
+
+        The fiscal document import wizard's product picker passes
+        ``nfe_import_supplier_id`` and ``nfe_import_company_id`` in its
+        context: the products on that supplier's confirmed purchase orders
+        with quantity still to be billed are then proposed first in the
+        many2one, while the search itself stays unrestricted so any other
+        product remains selectable (typing filters the whole catalog).
+        Without those context keys this is a plain ``super()`` pass-through.
+
+        ``qty_to_invoice`` cannot be used as the "open" criterion: with the
+        default ``purchase_method='receive'`` it is 0 until the goods are
+        received, while the supplier NF-e typically arrives together with the
+        truck. A search domain cannot compare two fields either, so the
+        not-fully-billed check is done in Python over the confirmed/done
+        order lines.
+        """
+        supplier_id = self.env.context.get("nfe_import_supplier_id")
+        company_id = self.env.context.get("nfe_import_company_id")
+        if not supplier_id or not company_id:
+            return super()._name_search(
+                name,
+                args=args,
+                operator=operator,
+                limit=limit,
+                name_get_uid=name_get_uid,
+            )
+        open_product_ids = self._get_supplier_open_po_product_ids(
+            supplier_id, company_id
+        )
+        if not open_product_ids:
+            return super()._name_search(
+                name,
+                args=args,
+                operator=operator,
+                limit=limit,
+                name_get_uid=name_get_uid,
+            )
+        priority_args = expression.AND(
+            [list(args or []), [("id", "in", list(open_product_ids))]]
+        )
+        priority_ids = super()._name_search(
+            name,
+            args=priority_args,
+            operator=operator,
+            limit=limit,
+            name_get_uid=name_get_uid,
+        )
+        ids = super()._name_search(
+            name,
+            args=args,
+            operator=operator,
+            limit=limit,
+            name_get_uid=name_get_uid,
+        )
+        merged = list(dict.fromkeys(list(priority_ids) + list(ids)))
+        return merged[:limit] if limit else merged
+
+    @api.model
     def default_get(self, default_fields):
         """
         The nfe.40.prod mixin (prod XML tag) cannot be injected in

--- a/l10n_br_nfe/models/product_product.py
+++ b/l10n_br_nfe/models/product_product.py
@@ -132,6 +132,32 @@ class ProductProduct(models.Model):
         return merged[:limit] if limit else merged
 
     @api.model
+    def name_search(self, name="", args=None, operator="ilike", limit=100):
+        """Flag the supplier's open-PO products with a leading ``*``.
+
+        ``name_search`` drives the many2one dropdown: prefixing a ``*`` marks
+        the products still awaiting billing on the NFe supplier's confirmed
+        purchase orders, so the operator can tell the proposed products apart
+        from the rest of the (still fully searchable) catalog. The decoration
+        only lives in the suggestion list — ``display_name``/``name_get`` are
+        left untouched, so the selected value and every other view stay clean.
+        """
+        result = super().name_search(name, args=args, operator=operator, limit=limit)
+        supplier_id = self.env.context.get("nfe_import_supplier_id")
+        company_id = self.env.context.get("nfe_import_company_id")
+        if not supplier_id or not company_id:
+            return result
+        open_product_ids = self._get_supplier_open_po_product_ids(
+            supplier_id, company_id
+        )
+        if not open_product_ids:
+            return result
+        return [
+            (pid, ("* " if pid in open_product_ids else "") + label)
+            for pid, label in result
+        ]
+
+    @api.model
     def default_get(self, default_fields):
         """
         The nfe.40.prod mixin (prod XML tag) cannot be injected in

--- a/l10n_br_nfe/tests/test_nfe_import_wizard.py
+++ b/l10n_br_nfe/tests/test_nfe_import_wizard.py
@@ -324,6 +324,76 @@ class NFeImportWizardTest(TransactionCase):
                 "product created during import must get the XML unit",
             )
 
+    def test_product_name_search_prioritizes_supplier_po_lines(self):
+        """The unmatched product picker proposes the products still awaiting
+        billing on the NFe supplier's confirmed POs first, without restricting
+        the search to them (parity with the legacy akretion importer)."""
+        self._prepare_wizard(self.xml_1)
+        if self.env.get("purchase.order.line") is None:
+            self.skipTest("purchase module not installed")
+
+        company = self.env.ref("base.main_company")
+        supplier = self.env["res.partner"].create({"name": "Vendor Domain"})
+        ordered = self.env["product.product"].create(
+            {"name": "ZZZ Ordered Product", "purchase_ok": True}
+        )
+        other = self.env["product.product"].create(
+            {"name": "ZZZ Other Product", "purchase_ok": True}
+        )
+        draft_product = self.env["product.product"].create(
+            {"name": "ZZZ Draft Product", "purchase_ok": True}
+        )
+        foreign_product = self.env["product.product"].create(
+            {"name": "ZZZ Foreign Product", "purchase_ok": True}
+        )
+
+        def add_line(order, product):
+            self.env["purchase.order.line"].create(
+                {
+                    "order_id": order.id,
+                    "product_id": product.id,
+                    "name": product.name,
+                    "product_qty": 1.0,
+                    "price_unit": 10.0,
+                    "date_planned": fields.Datetime.now(),
+                }
+            )
+
+        # confirmed PO line in the wizard's company -> proposed first
+        order = self.env["purchase.order"].create(
+            {"partner_id": supplier.id, "company_id": company.id}
+        )
+        add_line(order, ordered)
+        order.button_confirm()
+
+        # draft PO line in the wizard's company -> not proposed
+        draft_order = self.env["purchase.order"].create(
+            {"partner_id": supplier.id, "company_id": company.id}
+        )
+        add_line(draft_order, draft_product)
+
+        # confirmed PO line in ANOTHER company -> not proposed (multi-company)
+        other_company = self.env["res.company"].create(
+            {"name": "Other Co", "currency_id": company.currency_id.id}
+        )
+        foreign_order = self.env["purchase.order"].create(
+            {"partner_id": supplier.id, "company_id": other_company.id}
+        )
+        add_line(foreign_order, foreign_product)
+        foreign_order.button_confirm()
+
+        products = self.env["product.product"].with_context(
+            nfe_import_supplier_id=supplier.id, nfe_import_company_id=company.id
+        )
+        found = products.name_search("ZZZ")
+        found_ids = [pid for pid, _name in found]
+        # the confirmed-PO product comes first in the proposals
+        self.assertEqual(found_ids[0], ordered.id)
+        # the search is not restricted: every matching product stays reachable
+        self.assertIn(other.id, found_ids)
+        self.assertIn(draft_product.id, found_ids)
+        self.assertIn(foreign_product.id, found_ids)
+
     def test__parse_xml(self):
         self._prepare_wizard(self.xml_1)
 

--- a/l10n_br_nfe/tests/test_nfe_import_wizard.py
+++ b/l10n_br_nfe/tests/test_nfe_import_wizard.py
@@ -393,6 +393,11 @@ class NFeImportWizardTest(TransactionCase):
         self.assertIn(other.id, found_ids)
         self.assertIn(draft_product.id, found_ids)
         self.assertIn(foreign_product.id, found_ids)
+        # only the proposed (open-PO) products are flagged with a leading "*"
+        labels = dict(found)
+        self.assertTrue(labels[ordered.id].startswith("* "))
+        for pid in (other.id, draft_product.id, foreign_product.id):
+            self.assertFalse(labels[pid].startswith("* "))
 
     def test__parse_xml(self):
         self._prepare_wizard(self.xml_1)

--- a/l10n_br_nfe/tests/test_nfe_import_wizard.py
+++ b/l10n_br_nfe/tests/test_nfe_import_wizard.py
@@ -3,6 +3,7 @@ import os
 import re
 from unittest.mock import MagicMock, patch
 
+from odoo import fields
 from odoo.tests import TransactionCase
 
 from odoo.addons import l10n_br_nfe
@@ -204,26 +205,97 @@ class NFeImportWizardTest(TransactionCase):
         self.assertFalse(prod_id)
 
     def test_match_product_by_purchase(self):
-        """The purchase-order priority match is a soft dependency on
-        l10n_br_purchase (which adds partner_order/partner_order_line to
-        purchase.order.line). It must be a no-op when those fields are absent,
-        so _match_product falls back to supplierinfo/default_code/barcode."""
+        """xPed/nItemPed map to the buyer's purchase order reference and the
+        1-based line POSITION (``sequence`` defaults to 10 for every
+        interface-created line and cannot be used). When purchase is absent it
+        must no-op so _match_product falls back to
+        supplierinfo/default_code/barcode."""
         self._prepare_wizard(self.xml_1)
-        pol = self.env.get("purchase.order.line")
-        has_fields = pol is not None and "partner_order" in pol._fields
+        pol_model = self.env.get("purchase.order.line")
+
         mock = MagicMock()
         mock.xPed = "NONEXISTENT-PO-REF"
         mock.nItemPed = "999"
-        # No PO references this xPed (and/or l10n_br_purchase absent) -> no
-        # match, and crucially no crash on a missing field.
+        # No PO references this xPed (and/or purchase absent) -> no match,
+        # and crucially no crash on a missing model.
         self.assertFalse(self.wizard._match_product_by_purchase(mock))
-        if not has_fields:
+
+        if pol_model is None:
             # guard short-circuits before any purchase.order.line search
             self.assertFalse(
                 self.wizard._match_product_by_purchase(
                     self.wizard._parse_file().infNFe.det[0].prod
                 )
             )
+            return
+
+        company = self.env.ref("base.main_company")
+        partner = self.env["res.partner"].create({"name": "Vendor PO"})
+        first_product = self.env["product.product"].create({"name": "PO Product 1"})
+        second_product = self.env["product.product"].create({"name": "PO Product 2"})
+        order = self.env["purchase.order"].create(
+            {"partner_id": partner.id, "company_id": company.id}
+        )
+        for product in (first_product, second_product):
+            self.env["purchase.order.line"].create(
+                {
+                    "order_id": order.id,
+                    "product_id": product.id,
+                    "name": product.name,
+                    "product_qty": 1.0,
+                    "price_unit": 10.0,
+                    "date_planned": fields.Datetime.now(),
+                }
+            )
+        self.wizard.issuer_partner_id = partner
+        self.wizard.company_id = company
+
+        # nItemPed is the 1-based line position, not the (10, 10, ...) sequence.
+        mock = MagicMock()
+        mock.xPed = order.name
+        mock.nItemPed = "1"
+        self.assertEqual(self.wizard._match_product_by_purchase(mock), first_product)
+        mock.nItemPed = "2"
+        self.assertEqual(self.wizard._match_product_by_purchase(mock), second_product)
+
+        # the buyer's vendor reference (partner_ref) also matches xPed.
+        order.partner_ref = "SUPPLIER-PO-REF"
+        mock = MagicMock()
+        mock.xPed = "SUPPLIER-PO-REF"
+        mock.nItemPed = "2"
+        self.assertEqual(self.wizard._match_product_by_purchase(mock), second_product)
+
+        # an out-of-range nItemPed falls back to the cProd disambiguation.
+        second_product.default_code = "COD-2"
+        mock = MagicMock()
+        mock.xPed = order.name
+        mock.nItemPed = "99"
+        mock.cProd = "COD-2"
+        mock.cEANTrib = None
+        self.assertEqual(self.wizard._match_product_by_purchase(mock), second_product)
+
+        # a purchase order in another company must not match (multi-company).
+        other_company = self.env["res.company"].create(
+            {"name": "Other Co", "currency_id": company.currency_id.id}
+        )
+        foreign_order = self.env["purchase.order"].create(
+            {"partner_id": partner.id, "company_id": other_company.id}
+        )
+        self.env["purchase.order.line"].create(
+            {
+                "order_id": foreign_order.id,
+                "product_id": first_product.id,
+                "name": first_product.name,
+                "product_qty": 1.0,
+                "price_unit": 10.0,
+                "date_planned": fields.Datetime.now(),
+            }
+        )
+        foreign_order.partner_ref = "FOREIGN-COMPANY-REF"
+        mock = MagicMock()
+        mock.xPed = "FOREIGN-COMPANY-REF"
+        mock.nItemPed = "1"
+        self.assertFalse(self.wizard._match_product_by_purchase(mock))
 
     def test_import_nfe_created_product_uom_from_xml(self):
         """A product created during import gets its unit from the XML uCom.

--- a/l10n_br_nfe/wizards/document_import_wizard.py
+++ b/l10n_br_nfe/wizards/document_import_wizard.py
@@ -175,60 +175,59 @@ class DocumentImportWizard(models.TransientModel):
     def _match_product_by_purchase(self, xml_product):
         """Priority match from the referenced purchase order.
 
-        When ``l10n_br_purchase`` is installed and the XML line references the
-        buyer's purchase order (xPed / nItemPed), take the product from the
-        matching purchase order line first: it is the most authoritative match
-        since the buyer already stated which product was ordered.
+        When the XML line references the buyer's purchase order, take the
+        product from the matching purchase order line first: it is the most
+        authoritative match since the buyer already stated which product was
+        ordered.
 
-        Soft dependency: no-op unless l10n_br_purchase is installed (it adds
-        the partner_order / partner_order_line fields to purchase.order.line;
-        core ``purchase`` alone does not provide them).
+        On an inbound supplier NF-e, ``xPed`` holds the buyer's purchase order
+        reference and ``nItemPed`` the 1-based item position inside that
+        order. ``xPed`` is matched against both ``purchase.order.name`` (the
+        supplier echoes the buyer's PO number) and
+        ``purchase.order.partner_ref`` (the vendor reference the buyer fills
+        precisely to match incoming goods). ``nItemPed`` is matched by
+        POSITION: ``purchase.order.line.sequence`` defaults to 10 for every
+        line created in the interface, so it cannot be used; the order lines
+        come ordered by ``sequence, id``, so the n-th line is
+        ``order.order_line[nItemPed - 1]``.
         """
         pol_model = self.env.get("purchase.order.line")
-        if pol_model is None or "partner_order" not in pol_model._fields:
+        if pol_model is None:
             return False
         xped = (getattr(xml_product, "xPed", "") or "").strip()
         if not xped:
             return False
 
-        partner = self.partner_id.id
-        pol = pol_model.sudo()
-        nitemped = (getattr(xml_product, "nItemPed", "") or "").strip()
-
-        # 1) exact agreed reference: xPed + nItemPed on the purchase order line
-        if nitemped:
-            line = pol.search(
+        company = self.company_id or self.env.company
+        order = (
+            self.env["purchase.order"]
+            .sudo()
+            .search(
                 [
-                    ("order_id.partner_id", "=", partner),
-                    ("partner_order", "=", xped),
-                    ("partner_order_line", "=", nitemped),
+                    ("partner_id", "=", self.issuer_partner_id.id),
+                    ("company_id", "=", company.id),
+                    "|",
+                    ("name", "=", xped),
+                    ("partner_ref", "=", xped),
                 ],
                 limit=1,
             )
-            if line:
-                return line.product_id
-
-        # 2) heuristic: narrow to the referenced order (partner_order on the
-        # line, else the buyer PO name / vendor reference), then disambiguate
-        # the line by the XML product code / barcode.
-        lines = pol.search(
-            [("order_id.partner_id", "=", partner), ("partner_order", "=", xped)]
         )
-        if not lines:
-            order = (
-                self.env["purchase.order"]
-                .sudo()
-                .search(
-                    [
-                        ("partner_id", "=", partner),
-                        "|",
-                        ("partner_ref", "=", xped),
-                        ("name", "=", xped),
-                    ],
-                    limit=1,
-                )
-            )
-            lines = order.order_line
+        if not order:
+            return False
+
+        lines = order.order_line
+        nitemped = (getattr(xml_product, "nItemPed", "") or "").strip()
+        if nitemped:
+            try:
+                position = int(nitemped)
+            except ValueError:
+                position = None
+            if position is not None and 1 <= position <= len(lines):
+                return lines[position - 1].product_id
+
+        # heuristic fallback: disambiguate the referenced order's line by the
+        # XML product code / barcode when nItemPed is missing or out of range.
         if len(lines) == 1:
             return lines.product_id
         cprod = getattr(xml_product, "cProd", None)

--- a/l10n_br_nfe/wizards/document_import_wizard.xml
+++ b/l10n_br_nfe/wizards/document_import_wizard.xml
@@ -42,7 +42,7 @@
         <field name="name">l10n_br_fiscal.document.import.wizard.line.tree</field>
         <field name="model">l10n_br_fiscal.document.import.wizard.line</field>
         <field name="arch" type="xml">
-            <tree editable="top">
+            <tree editable="top" decoration-danger="not product_id">
                 <field
                     name="product_id"
                     options="{'no_quick_create': True, 'no_create': True}"

--- a/l10n_br_nfe/wizards/document_import_wizard.xml
+++ b/l10n_br_nfe/wizards/document_import_wizard.xml
@@ -10,6 +10,9 @@
             <xpath expr="//field[@name='document_serie']" position="after">
                 <field name="nat_op" readonly="1" />
             </xpath>
+            <xpath expr="//field[@name='file']" position="after">
+                <field name="company_id" invisible="1" />
+            </xpath>
             <xpath expr="//group[@id='document_info']" position="after">
                 <group
                     id="existing_document"
@@ -44,6 +47,7 @@
                     name="product_id"
                     options="{'no_quick_create': True, 'no_create': True}"
                     domain="[('purchase_ok', '=', True)]"
+                    context="{'nfe_import_supplier_id': parent.issuer_partner_id, 'nfe_import_company_id': parent.company_id}"
                 />
                 <field name="product_name" readonly="1" />
                 <field name="product_code" readonly="1" />


### PR DESCRIPTION
Este PR foi extraído do PR #4939 (branch 16.0-nfe-import-fixes) para facilitar a revisão.
Ele contém apenas a parte de correspondência de produto na importação de NF-e.

O que faz
---------
1. Mapeia xPed/nItemPed para purchase.order.name e purchase.order.line.sequence:
   em NF-e de fornecedor, o xPed é o número do pedido do COMPRADOR (não a
   referência do fornecedor), então a correspondência priorizada passa a ser
   pelo nome do PO + número do item, com fallback por código/barras.
2. Restringe a lista de produtos não correspondidos (product_domain) às linhas
   de pedidos de compra ABERTOS do fornecedor, evitando associação por engano
   com produto de outro pedido/fornecedor. A restrição é relaxada assim que o
   produto é associado.
3. Destaca em vermelho as linhas de importação ainda não correspondidas a um
   produto na árvore do wizard (feedback visual).
4. Fix nos produtos de teste (purchase_method) para o product_domain acima.

Assisted-by AI
