### PR TITLE
[16.0][FIX] l10n_br_nfe: deduplicar parceiros autorizados (autXML) na importação

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -22,7 +22,7 @@ from requests import Session
 from xsdata.formats.dataclass.parsers import XmlParser
 from xsdata.models.datatype import XmlDateTime
 
-from odoo import _, api, fields
+from odoo import Command, _, api, fields
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
 
@@ -979,6 +979,27 @@ class NFe(spec_models.StackedModel):
         key = f"nfe40_{attr[1].metadata.get('name', attr[0])}"
         if key == "nfe40_IBSCBSTot":
             # IBSCBSTot fields are computed from lines, skip importing
+            return
+        if attr[0] == "autXML":
+            # <autXML> is imported as a one2many of res.partner "contato
+            # CNPJ/CPF X" records. Deduplicate them by CNPJ/CPF through the
+            # res.partner match_or_create_m2o override instead of always
+            # creating a fresh partner, otherwise importing two NF-e sharing
+            # the same autXML CNPJ/CPF (e.g. the supplier's accountant) raises
+            # the l10n_br_fiscal CNPJ/CPF uniqueness constraint.
+            value = getattr(node, attr[0])
+            if value is None or value == []:
+                return
+            partner_model = self.env["res.partner"]
+            partner_ids = []
+            for autxml_line in value:
+                if autxml_line is None:
+                    continue
+                line_vals = partner_model.build_attrs(
+                    autxml_line, path=f"{path}.{key}", defaults_model=partner_model
+                )
+                partner_ids.append(partner_model.match_or_create_m2o(line_vals, vals))
+            vals[key] = [Command.set(partner_ids)]
             return
         return super()._build_attr(node, fields, vals, path, attr)
 

--- a/l10n_br_nfe/tests/test_nfe_import.py
+++ b/l10n_br_nfe/tests/test_nfe_import.py
@@ -48,6 +48,55 @@ class NFeImportTest(TransactionCase):
         assert isinstance(nfe.id, int)
         self._check_nfe(nfe)
 
+    def test_import_nfe_autxml_dedup(self):
+        """autXML "contato" partners are deduplicated by CNPJ.
+
+        An inbound NFe carrying the same CNPJ in both ``<autXML>`` and
+        ``<infRespTec>`` (typical: the software house is both the authorized
+        XML downloader and the technical responsible) must import a single
+        partner instead of raising the l10n_br_base CNPJ uniqueness
+        constraint.
+
+        Regression test: the ``_build_attr`` autXML shortcut MUST return
+        after setting the deduplicated ``Command.set`` values, otherwise the
+        generic o2m path overwrites them with ``Command.create`` entries and
+        the same partners are created a second time at document create (a
+        merge resolution once dropped that return and broke supplier NFe
+        imports carrying an autXML section).
+        """
+        res_items = (
+            "nfe",
+            "samples",
+            "v4_0",
+            "leiauteNFe",
+            "35180834128745000152550010000474281920007498-nfe.xml",
+        )
+        resource_path = "/".join(res_items)
+        nfe_stream = pkg_resources.resource_stream(nfelib.__name__, resource_path)
+        xml = nfe_stream.read().decode()
+
+        # the sample has <infRespTec> with Akretion's CNPJ; use the same
+        # fresh CNPJ for both <infRespTec> and a new <autXML> entry
+        cnpj = "12345678000195"
+        assert "<autXML>" not in xml
+        xml = xml.replace("<CNPJ>11034414000158</CNPJ>", f"<CNPJ>{cnpj}</CNPJ>")
+        xml = xml.replace("</infNFe>", f"<autXML><CNPJ>{cnpj}</CNPJ></autXML></infNFe>")
+        binding = TnfeProc.from_xml(xml)
+
+        before = self.env["res.partner"].search_count(
+            [("cnpj_cpf_stripped", "=", cnpj)]
+        )
+        nfe = (
+            self.env["l10n_br_fiscal.document"]
+            .with_context(allow_product_creation=True)
+            .import_binding_nfe(binding, edoc_type="in", dry_run=False)
+        )
+        after = self.env["res.partner"].search_count([("cnpj_cpf_stripped", "=", cnpj)])
+
+        # exactly one "contato" partner for the autXML/infRespTec CNPJ
+        self.assertEqual(after - before, 1)
+        self.assertEqual(len(nfe.nfe40_autXML), 1)
+
     def _check_nfe(self, nfe):
         self.assertEqual(type(nfe)._name, "l10n_br_fiscal.document")
         self.assertEqual(


### PR DESCRIPTION
Este PR foi extraído do PR #4939 (branch 16.0-nfe-import-fixes) para facilitar a revisão.
Ele contém apenas a parte de deduplicação de parceiros <autXML> na importação de NF-e.

Problema
--------
O tag <autXML> é importado como um one2many de res.partner ("contato CNPJ/CPF X").
O caminho de importação criava um parceiro novo para cada NF-e em vez de
reaproveitar um existente: ao importar duas NF-e com o mesmo CNPJ/CPF no
autXML (ex.: o contador do fornecedor), a constraint de unicidade CNPJ/CPF
do l10n_br_fiscal era violada.

Solução
-------
Cada entrada <autXML> agora passa por res.partner.match_or_create_m2o, que
deduplica por cnpj_cpf_stripped/vat, e os parceiros resolvidos são ligados
com Command.set.
