### PR TITLE
[16.0][FIX] l10n_br_nfe: fidelidade dos dados fiscais importados (Imposto Seletivo, ICMSSN/CSOSN, CRT)

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -105,7 +105,7 @@ class NFe(spec_models.StackedModel):
 
     # When dynamic stacking is applied the NFe structure is:
     INFNFE_TREE = """
-> <infnfe>
+    > <infnfe>
     > <ide>
         ≡ <NFref> l10n_br_fiscal.document.related
         - <gPagAntecipado>
@@ -977,8 +977,8 @@ class NFe(spec_models.StackedModel):
     @api.model
     def _build_attr(self, node, fields, vals, path, attr):
         key = f"nfe40_{attr[1].metadata.get('name', attr[0])}"
-        if key == "nfe40_IBSCBSTot":
-            # IBSCBSTot fields are computed from lines, skip importing
+        if key in ("nfe40_IBSCBSTot", "nfe40_ISTot"):
+            # IBSCBSTot/ISTot totals are computed from lines, skip importing
             return
         return super()._build_attr(node, fields, vals, path, attr)
 

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -105,7 +105,7 @@ class NFe(spec_models.StackedModel):
 
     # When dynamic stacking is applied the NFe structure is:
     INFNFE_TREE = """
-    > <infnfe>
+> <infnfe>
     > <ide>
         ≡ <NFref> l10n_br_fiscal.document.related
         - <gPagAntecipado>
@@ -1031,6 +1031,12 @@ class NFe(spec_models.StackedModel):
             if company_vat != emit_vat:
                 vals["issuer"] = "partner"
             new_value["vat"] = emit_vat
+            # Capture the emitente's tax regime (CRT) into the supplier
+            # partner's tax_framework (Simples Nacional vs Regime Normal),
+            # which drives the tax mapping and SPED reporting.
+            crt = getattr(value, "CRT", None)
+            if crt is not None:
+                new_value["tax_framework"] = str(getattr(crt, "value", crt))
             super()._build_many2one(
                 self.env["res.partner"], vals, new_value, "partner_id", value, path
             )

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -1354,6 +1354,12 @@ class NFeLine(spec_models.StackedModel):
         if key in ["nfe40_CST", "nfe40_modBC", "nfe40_CSOSN"]:
             return  # (dealt with in _build_many2one)
 
+        if key == "nfe40_IS":
+            # Imposto Seletivo (2026 reform): not imported yet, skip it instead
+            # of instantiating the nfe.40.tis concrete model (no table). Scalar
+            # is_* fields can mirror _import_ibscbs_attrs when SPED needs it.
+            return
+
         if key == "nfe40_IBSCBS":
             self._import_ibscbs_attrs(value, vals)
             return

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -1514,10 +1514,12 @@ class NFeLine(spec_models.StackedModel):
         """
         tax_binding = value
         kind = key.split("_")[1].lower()
+        found_tag = key
         if sub_tags:
             for tag in sub_tags:
                 if getattr(value, tag) is not None:
                     tax_binding = getattr(value, tag)
+                    found_tag = f"nfe40_{tag}"
 
         def map_binding_attr(attr, odoo_attr=None):
             """
@@ -1534,10 +1536,12 @@ class NFeLine(spec_models.StackedModel):
                     odoo_attrs[odoo_attr] = casted_value
                 return casted_value
 
-        # common attributes CST, VBC, p*, v*:
-        cst = map_binding_attr("CST")
+        # common attributes CST (or CSOSN for Simples Nacional), VBC, p*, v*:
+        is_icmssn = "ICMSSN" in found_tag
+        cst_kind = "icmssn" if is_icmssn else kind
+        cst = map_binding_attr("CSOSN" if is_icmssn else "CST")
         if cst:
-            cst_id = self.env.ref(f"l10n_br_fiscal.cst_{kind}_{cst}").id
+            cst_id = self.env.ref(f"l10n_br_fiscal.cst_{cst_kind}_{cst}").id
             odoo_attrs[f"{kind}_cst_id"] = cst_id
         else:
             cst_id = None
@@ -1554,7 +1558,7 @@ class NFeLine(spec_models.StackedModel):
             map_binding_attr("modBC", f"{kind}_base_type")
             icms_percent_red = None
 
-        if "ICMSSN" in key:
+        if is_icmssn:
             tax_group_kind = "icmssn"
         elif "ICMSST" in key:
             tax_group_kind = "icmsst"
@@ -1661,13 +1665,8 @@ class NFeLine(spec_models.StackedModel):
             map_binding_attr("vICMSUFRemet", "icms_origin_value")
             map_binding_attr("vICMSUFDest", "icms_destination_value")
 
-            # ICMS Simples Nacional Fields
-            # TODO map icmssn_tax_id using CSOSN
-            csosn = map_binding_attr("CSOSN")
-            if csosn:
-                odoo_attrs["icms_cst_id"] = self.env.ref(
-                    f"l10n_br_fiscal.cst_icmssn_{csosn}"
-                ).id
+            # ICMS Simples Nacional Fields (CSOSN is already mapped to
+            # icms_cst_id above via the icmssn tax group)
             map_binding_attr("pCredSN", "icmssn_percent")
             map_binding_attr("vCredICMSSN", "icmssn_credit_value")
 

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -300,6 +300,11 @@ class ResPartner(spec_models.SpecModel):
         if rec_dict.get("nfe40_CNPJ", False):
             rec_dict["cnpj_cpf"] = rec_dict["nfe40_CNPJ"]
 
+        # The emitente's tax regime (CRT) is written after create/match: the
+        # fiscal_profile_id inverse would otherwise reset tax_framework to the
+        # profile's default during create.
+        tax_framework = rec_dict.pop("tax_framework", None)
+
         if rec_dict.get("cnpj_cpf", False):
             domain_cnpj = [
                 "|",
@@ -308,6 +313,14 @@ class ResPartner(spec_models.SpecModel):
             ]
             match = self.search(domain_cnpj, limit=1)
             if match:
+                if (
+                    not self._context.get("dry_run")
+                    and tax_framework
+                    and match.tax_framework != tax_framework
+                ):
+                    # logged in the partner chatter (tax_framework is tracked)
+                    # and historicized in SPED.
+                    match.tax_framework = tax_framework
                 return match.id
 
         vals = self._prepare_import_dict(
@@ -316,7 +329,10 @@ class ResPartner(spec_models.SpecModel):
         if self._context.get("dry_run", False):
             rec_id = self.new(vals).id
         else:
-            rec_id = self.with_context(parent_dict=parent_dict).create(vals).id
+            rec = self.with_context(parent_dict=parent_dict).create(vals)
+            if tax_framework and rec.tax_framework != tax_framework:
+                rec.tax_framework = tax_framework
+            rec_id = rec.id
         return rec_id
 
     def _export_field(self, xsd_field, class_obj, member_spec, export_value=None):


### PR DESCRIPTION
Este PR foi extraído do PR #4939 (branch 16.0-nfe-import-fixes) para facilitar a revisão.
Ele contém apenas os fixes de fidelidade dos dados fiscais importados da NF-e.

O que faz
---------
1. Pula o Imposto Seletivo (IS / nfe40_ISTot) na importação: o grupo IS não é
   mais interpretado como ICMS (o tag era importado por engano como ICMS).

2. Mapeia ICMSSN/CSOSN para o grupo de imposto "icmssn" na importação, em vez
   de cair em outro grupo, corrigindo a classificação do ICMS-ST/SN das linhas.

3. Captura o CRT do emitente (<emit><CRT>) para o tax_framework do parceiro
   fornecedor: o valor é escrito APÓS o create/match, pois o inverse do
   fiscal_profile_id resetaria o tax_framework para o default do perfil
   durante o create.

Assisted-by AI