### PR TITLE
[16.0][IMP] l10n_br_fiscal,l10n_br_nfe: opção de criar produtos não mapeados no wizard de importação

### DIFF
--- a/l10n_br_fiscal/wizards/document_import_wizard.py
+++ b/l10n_br_fiscal/wizards/document_import_wizard.py
@@ -38,6 +38,15 @@ class DocumentImportWizard(models.TransientModel):
 
     file = fields.Binary(string="File to Import")
 
+    allow_product_creation = fields.Boolean(
+        string="Create unmapped products",
+        default=False,
+        help="If enabled, products that don't match an existing record will be"
+        " automatically created during import. If disabled (default), the"
+        " import will raise an error when an unmapped product is found so you"
+        " can map it in the product lines above before importing.",
+    )
+
     date_in_out = fields.Datetime(
         default=fields.Datetime.now,
         help="Effective incoming/outgoing date of the goods (DT_E_S in the "

--- a/l10n_br_fiscal/wizards/document_import_wizard.xml
+++ b/l10n_br_fiscal/wizards/document_import_wizard.xml
@@ -17,6 +17,10 @@
                         name="date_in_out"
                         attrs="{'invisible': [('file', '=', False)]}"
                     />
+                    <field
+                        name="allow_product_creation"
+                        attrs="{'invisible': [('file', '=', False)]}"
+                    />
                 </group>
                 <separator
                     string="Preview Data"

--- a/l10n_br_nfe/tests/test_nfe_import_wizard.py
+++ b/l10n_br_nfe/tests/test_nfe_import_wizard.py
@@ -225,6 +225,33 @@ class NFeImportWizardTest(TransactionCase):
                 )
             )
 
+    def test_import_nfe_created_product_uom_from_xml(self):
+        """A product created during import gets its unit from the XML uCom.
+
+        The fiscal line's uom is computed from the product, but for a product
+        created during the import that computation runs before the product's
+        units are resolved, so the wizard must fall back to the unit it
+        matched from the XML uCom/uTrib. Otherwise ``_check_document_import``
+        rejects the document with "no unit of measure".
+        """
+        self._prepare_wizard(self.xml_1)
+        self.wizard.allow_product_creation = True
+        self.wizard.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_compras")
+        _binding, edoc = self.wizard._import_edoc()
+        if hasattr(edoc, "_check_document_import"):
+            # integrity guard lives in l10n_br_account, which l10n_br_nfe
+            # does not depend on: skip it when the module is not installed
+            edoc._check_document_import()  # must not raise
+        self.assertTrue(edoc.fiscal_line_ids)
+        for line in edoc.fiscal_line_ids:
+            self.assertTrue(
+                line.uom_id, "created-product line must get a uom from the XML"
+            )
+            self.assertTrue(
+                line.product_id.uom_id,
+                "product created during import must get the XML unit",
+            )
+
     def test__parse_xml(self):
         self._prepare_wizard(self.xml_1)
 

--- a/l10n_br_nfe/wizards/document_import_wizard.py
+++ b/l10n_br_nfe/wizards/document_import_wizard.py
@@ -275,6 +275,9 @@ class DocumentImportWizard(models.TransientModel):
             )
             edoc.document_type_id = self.env.ref("l10n_br_fiscal.document_55").id
             edoc.fiscal_operation_id = self.fiscal_operation_id
+            wizard_lines_by_code = {
+                w.product_code: w for w in self.imported_products_ids
+            }
             for line in edoc.fiscal_line_ids:
                 # Preserve the XML price_unit because setting
                 # fiscal_operation_id triggers _compute_price_unit_fiscal
@@ -284,6 +287,22 @@ class DocumentImportWizard(models.TransientModel):
                 line.fiscal_operation_id = self.fiscal_operation_id
                 line.price_unit = price_unit
                 line.uom_id = line.uot_id
+                if not line.uom_id:
+                    # When the product was created during this import its uom
+                    # was not resolved from the XML at line-creation time (the
+                    # line compute ran before the product's units were set), so
+                    # fall back to the unit the wizard matched from uCom/uTrib
+                    # and align the created product's units with it.
+                    wl = (
+                        wizard_lines_by_code.get(line.product_id.default_code)
+                        if line.product_id
+                        else None
+                    )
+                    if wl and wl.uom_internal:
+                        line.uom_id = wl.uom_internal
+                        if not wl.product_id:
+                            line.product_id.uom_id = wl.uom_internal
+                            line.product_id.uom_po_id = wl.uom_internal
 
             if not self.partner_id:
                 self.partner_id = edoc.partner_id

--- a/l10n_br_nfe/wizards/document_import_wizard.py
+++ b/l10n_br_nfe/wizards/document_import_wizard.py
@@ -265,9 +265,13 @@ class DocumentImportWizard(models.TransientModel):
     def _create_edoc_from_file(self):
         if self.document_type == MODELO_FISCAL_NFE:
             binding = self._parse_file()
-            edoc = self.env["l10n_br_fiscal.document"].import_binding_nfe(
-                binding,
-                edoc_type=self.fiscal_operation_type,
+            edoc = (
+                self.env["l10n_br_fiscal.document"]
+                .with_context(allow_product_creation=self.allow_product_creation)
+                .import_binding_nfe(
+                    binding,
+                    edoc_type=self.fiscal_operation_type,
+                )
             )
             edoc.document_type_id = self.env.ref("l10n_br_fiscal.document_55").id
             edoc.fiscal_operation_id = self.fiscal_operation_id


### PR DESCRIPTION
Este PR foi extraído do PR #4939 (branch 16.0-nfe-import-fixes) para facilitar a revisão.
Ele contém apenas a parte de criação de produtos não mapeados na importação de NF-e.

O que faz
---------
1. Novo campo booleano allow_product_creation ("Create unmapped products",
   default False) no wizard de importação (l10n_br_fiscal.document.import.wizard),
   exibido no formulário e repassado ao contexto da importação ao construir o edoc.
2. Fallback de unidade de medida para produtos criados durante a importação:
   a unidade (uom) do produto e da linha vem do XML (uCom/uTrib) — o compute
   da linha roda antes de a unidade do produto ser resolvida, então o wizard
   aplica a unidade correspondida no final do _create_edoc_from_file.

Fix de CI (herdado do #4939)
-----------------------------
O teste test_import_nfe_created_product_uom_from_xml chama o guard de
integridade _check_document_import, que só existe com o l10n_br_account
instalado (o l10n_br_nfe não depende dele). O teste agora faz o guard com
hasattr(), mantendo as asserções de uom por linha.

OBS: esse PR casa bem com esse outro https://github.com/OCA/l10n-brazil/pull/4938

Assisted-by AI