### PR TITLE
[18.0][FIX] l10n_br_fiscal: declared II in the tax base

### DIFF
--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -219,6 +219,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         "icms_value",
         "ii_value",
         "ii_customhouse_charges",
+        "ii_declared_value",
     )
     def _compute_fiscal_amounts(self):
         for record in self:
@@ -426,6 +427,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         "insurance_value",
         "ii_customhouse_charges",
         "ii_iof_value",
+        "ii_declared_value",
         "other_value",
         "freight_value",
         "ncm_id",
@@ -480,6 +482,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
                     insurance_value=line.insurance_value,
                     ii_customhouse_charges=line.ii_customhouse_charges,
                     ii_iof_value=line.ii_iof_value,
+                    ii_declared_value=line.ii_declared_value,
                     other_value=line.other_value,
                     freight_value=line.freight_value,
                     ncm=line.ncm_id,
@@ -2080,6 +2083,15 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     ii_iof_value = fields.Monetary(string="IOF Value")
 
     ii_customhouse_charges = fields.Monetary(string="Despesas Aduaneiras")
+
+    ii_declared_value = fields.Monetary(
+        string="II charged by the declaration",
+        help="Import Tax the import declaration actually charged. It follows the "
+        "tariff classification and any tariff exception, so the product file has "
+        "no way to know it. When informed it wins over the rate of the product "
+        "file, and it is what composes the base of the IPI, of the ICMS, of the "
+        "CBS and of the IS.",
+    )
 
     # PIS/COFINS Fields
     # COFINS

--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -333,6 +333,54 @@ class Tax(models.Model):
         return tax_dict
 
     @api.model
+    def _import_tax_in_base(self, taxes_dict, **kwargs):
+        """Import Tax that composes the base of the other taxes of an import.
+
+        The amount that matters is the one the declaration charged: it follows the
+        tariff classification and any tariff exception, which the product file has
+        no way to know. Recomputing it from the rate of the product leaves the base
+        of the IPI and of the ICMS short whenever the two disagree, and the SEFAZ
+        refuses the note with 538 and with 528.
+
+        Falls back to the computed amount when no declaration was informed, which
+        is every operation that is not an import.
+        """
+        declared = kwargs.get("ii_declared_value") or 0.00
+        if declared:
+            return declared
+        return taxes_dict.get("ii", {}).get("tax_value", 0.00)
+
+    @api.model
+    def _compute_ii(self, tax, taxes_dict, **kwargs):
+        """Let the amount charged by the declaration win over the rate.
+
+        The rate follows the amount, so base times rate reproduces what was paid:
+        the SEFAZ recomputes it and refuses the note with 528 when the two do not
+        agree to the cent.
+        """
+        declared = kwargs.get("ii_declared_value") or 0.00
+        if not declared:
+            return self._compute_tax(tax, taxes_dict, **kwargs)
+
+        tax_dict = taxes_dict.get(tax.tax_domain)
+        # Seeding the rate before the base is what makes the base exist at all:
+        # a tax of zero percent and zero amount gets a base of zero, and a
+        # declaration charging over a classification the product file keeps at
+        # zero is precisely the case this method is here for.
+        gross = (kwargs.get("fiscal_price") or 0.00) * (
+            kwargs.get("fiscal_quantity") or 0.00
+        )
+        if gross and not tax_dict.get("percent_amount"):
+            tax_dict["percent_amount"] = declared / gross * 100.0
+
+        tax_dict = self._compute_tax(tax, taxes_dict, **kwargs)
+        base_amount = tax_dict.get("base") or 0.00
+        tax_dict["tax_value"] = declared
+        if base_amount:
+            tax_dict["percent_amount"] = declared / base_amount * 100.0
+        return tax_dict
+
+    @api.model
     def _compute_tax(self, tax, taxes_dict, **kwargs):
         """Generic calculation of Brazilian taxes"""
 
@@ -444,8 +492,7 @@ class Tax(models.Model):
             and cfop.destination == CFOP_DESTINATION_EXPORT
             and fiscal_operation_type == FISCAL_IN
         ):
-            tax_dict_ii = taxes_dict.get("ii", {})
-            tax_dict["add_to_base"] += tax_dict_ii.get("tax_value", 0.00)
+            tax_dict["add_to_base"] += self._import_tax_in_base(taxes_dict, **kwargs)
 
             tax_dict_pis = taxes_dict.get("pis", {})
             tax_dict["add_to_base"] += tax_dict_pis.get("tax_value", 0.00)
@@ -712,8 +759,7 @@ class Tax(models.Model):
             and cfop.destination == CFOP_DESTINATION_EXPORT
             and fiscal_operation_type == FISCAL_IN
         ):
-            tax_dict_ii = taxes_dict.get("ii", {})
-            tax_dict["add_to_base"] += tax_dict_ii.get("tax_value", 0.00)
+            tax_dict["add_to_base"] += self._import_tax_in_base(taxes_dict, **kwargs)
 
         return self._compute_tax(tax, taxes_dict, **kwargs)
 
@@ -726,7 +772,6 @@ class Tax(models.Model):
         operation_line = kwargs.get("operation_line")
         fiscal_operation_type = operation_line.fiscal_operation_type or FISCAL_OUT
         tax_dict = taxes_dict.get(tax.tax_domain)
-        tax_dict_ii = taxes_dict.get("ii", {})
         tax_dict_is = taxes_dict.get("is", {})
         tax_dict_icms = taxes_dict.get("icms", {})
         tax_dict_issqn = taxes_dict.get("issqn", {})
@@ -738,7 +783,7 @@ class Tax(models.Model):
             and fiscal_operation_type == FISCAL_IN
         ):
             tax_dict["add_to_base"] += (
-                tax_dict_ii.get("tax_value", 0.00)
+                self._import_tax_in_base(taxes_dict, **kwargs)
                 + tax_dict_is.get("tax_value", 0.00)
                 + kwargs.get("ii_customhouse_charges", 0.00)
             )
@@ -760,7 +805,6 @@ class Tax(models.Model):
         operation_line = kwargs.get("operation_line")
         fiscal_operation_type = operation_line.fiscal_operation_type or FISCAL_OUT
         tax_dict = taxes_dict.get(tax.tax_domain)
-        tax_dict_ii = taxes_dict.get("ii", {})
         tax_dict_is = taxes_dict.get("is", {})
         tax_dict_icms = taxes_dict.get("icms", {})
         tax_dict_issqn = taxes_dict.get("issqn", {})
@@ -772,7 +816,7 @@ class Tax(models.Model):
             and fiscal_operation_type == FISCAL_IN
         ):
             tax_dict["add_to_base"] += (
-                tax_dict_ii.get("tax_value", 0.00)
+                self._import_tax_in_base(taxes_dict, **kwargs)
                 + tax_dict_is.get("tax_value", 0.00)
                 + kwargs.get("ii_customhouse_charges", 0.00)
             )
@@ -794,7 +838,6 @@ class Tax(models.Model):
         operation_line = kwargs.get("operation_line")
         fiscal_operation_type = operation_line.fiscal_operation_type or FISCAL_OUT
         tax_dict = taxes_dict.get(tax.tax_domain)
-        tax_dict_ii = taxes_dict.get("ii", {})
         tax_dict_icms = taxes_dict.get("icms", {})
         tax_dict_pis = taxes_dict.get("pis", {})
         tax_dict_cofins = taxes_dict.get("cofins", {})
@@ -803,9 +846,9 @@ class Tax(models.Model):
             and cfop.destination == CFOP_DESTINATION_EXPORT
             and fiscal_operation_type == FISCAL_IN
         ):
-            tax_dict["add_to_base"] += tax_dict_ii.get("tax_value", 0.00) + kwargs.get(
-                "ii_customhouse_charges", 0.00
-            )
+            tax_dict["add_to_base"] += self._import_tax_in_base(
+                taxes_dict, **kwargs
+            ) + kwargs.get("ii_customhouse_charges", 0.00)
         else:
             tax_dict["remove_from_base"] += (
                 tax_dict_icms.get("tax_value", 0.00)
@@ -880,6 +923,10 @@ class Tax(models.Model):
         :param ii_customhouse_charges: float, customs house charges for Import Tax
             (II).
         :param ii_iof_value: float, IOF value related to Import Tax (II).
+        :param ii_declared_value: float, Import Tax the declaration charged.
+            When informed it wins over the rate of the product file, and it is
+            what composes the base of the IPI, of the ICMS, of the CBS and of
+            the IS.
         :param ncm: l10n_br_fiscal.ncm record, NCM code for the product.
         :param nbs: l10n_br_fiscal.nbs record, NBS code for the service.
         :param nbm: l10n_br_fiscal.nbm record, NBM code for the product.

--- a/l10n_br_fiscal/tests/__init__.py
+++ b/l10n_br_fiscal/tests/__init__.py
@@ -6,6 +6,7 @@ from . import (
     test_fiscal_document_generic,
     test_fiscal_document_nfse,
     test_fiscal_tax,
+    test_import_tax_base,
     test_tax_classification,
     test_tax_benefit,
     test_document_edition,

--- a/l10n_br_fiscal/tests/test_import_tax_base.py
+++ b/l10n_br_fiscal/tests/test_import_tax_base.py
@@ -1,0 +1,106 @@
+# Copyright 2026 KMEE (Ygor Carvalho <ygor.carvalho@kmee.com.br>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tests import TransactionCase
+
+from ..constants.fiscal import FINAL_CUSTOMER_NO
+from ..constants.icms import ICMS_ORIGIN_DEFAULT
+from .tools import load_fiscal_fixture_files
+
+CUSTOMS_VALUE = 101654.28
+DECLARED_II = 17999.20
+
+
+class TestImportTaxBase(TransactionCase):
+    """The Import Tax of the declaration has to compose the base of the others.
+
+    Taken from a real import: a line of NCM 8537.10.90, whose product file
+    carries II 0%, and a declaration that charged the Import Tax anyway,
+    because the tariff of the classification is not zero. The base of the IPI
+    came out as the customs value alone, the IPI was short by the tariff over
+    the Import Tax, and the ICMS followed it down, since the IPI composes its
+    base. On a note that reaches the SEFAZ this is rejection 538 and 528.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        load_fiscal_fixture_files(cls.env)
+        cls.company = cls.env.ref("l10n_br_base.empresa_lucro_presumido")
+        cls.currency = cls.company.currency_id
+        cls.taxes = cls.env.ref("l10n_br_fiscal.tax_ii_0") + cls.env.ref(
+            "l10n_br_fiscal.tax_ipi_9_75"
+        )
+
+    def _kwargs(self, **overrides):
+        values = {
+            "company": self.company,
+            "partner": self.env.ref("l10n_br_base.res_partner_cliente5_pe"),
+            "product": self.env.ref("product.product_product_12"),
+            "price_unit": CUSTOMS_VALUE,
+            "quantity": 1.000,
+            "uom_id": self.env.ref("uom.product_uom_unit"),
+            "fiscal_price": CUSTOMS_VALUE,
+            "fiscal_quantity": 1.000,
+            "uot_id": self.env.ref("uom.product_uom_unit"),
+            "discount_value": 0.00,
+            "insurance_value": 0.00,
+            "other_value": 0.00,
+            "freight_value": 0.00,
+            "ii_customhouse_charges": 0.00,
+            "ii_iof_value": 0.00,
+            "ncm": self.env.ref("l10n_br_fiscal.ncm_72132000"),
+            "nbs": False,
+            "nbm": False,
+            "cest": False,
+            "operation_line": self.env.ref("l10n_br_fiscal.fo_compras_compras"),
+            "cfop": self.env.ref("l10n_br_fiscal.cfop_3101"),
+            "icmssn_range": False,
+            "icms_origin": ICMS_ORIGIN_DEFAULT,
+            "ind_final": FINAL_CUSTOMER_NO,
+        }
+        values.update(overrides)
+        return values
+
+    def test_the_declared_import_tax_composes_the_ipi_base(self):
+        result = self.taxes.compute_taxes(**self._kwargs(ii_declared_value=DECLARED_II))
+        ipi = result["taxes"]["ipi"]
+        self.assertEqual(
+            self.currency.round(ipi["base"]),
+            self.currency.round(CUSTOMS_VALUE + DECLARED_II),
+            "the base of the IPI on an import is the customs value plus the "
+            "Import Tax the declaration charged",
+        )
+        self.assertEqual(
+            self.currency.round(ipi["tax_value"]),
+            self.currency.round((CUSTOMS_VALUE + DECLARED_II) * 0.0975),
+        )
+
+    def test_the_declared_import_tax_wins_over_the_product_rate(self):
+        result = self.taxes.compute_taxes(**self._kwargs(ii_declared_value=DECLARED_II))
+        ii = result["taxes"]["ii"]
+        self.assertEqual(self.currency.round(ii["tax_value"]), DECLARED_II)
+        self.assertAlmostEqual(
+            ii["base"] * ii["percent_amount"] / 100.0,
+            DECLARED_II,
+            places=2,
+            msg="base times rate has to reproduce the amount charged, or the "
+            "SEFAZ refuses the note with 528",
+        )
+
+    def test_without_a_declaration_the_product_rate_still_rules(self):
+        """Contraproof: nothing changes for whoever does not inform a value."""
+        result = self.taxes.compute_taxes(**self._kwargs())
+        self.assertEqual(self.currency.round(result["taxes"]["ii"]["tax_value"]), 0.00)
+        self.assertEqual(
+            self.currency.round(result["taxes"]["ipi"]["base"]),
+            self.currency.round(CUSTOMS_VALUE),
+        )
+
+    def test_a_zero_declaration_is_not_a_declaration(self):
+        """An import free of the tax keeps following the product file."""
+        result = self.taxes.compute_taxes(**self._kwargs(ii_declared_value=0.00))
+        self.assertEqual(
+            self.currency.round(result["taxes"]["ipi"]["base"]),
+            self.currency.round(CUSTOMS_VALUE),
+        )


### PR DESCRIPTION
Na importação o Imposto de Importação que vale é o que a declaração cobrou: ele segue a classificação tarifária e eventual ex-tarifário, coisa que o cadastro do produto não tem como saber. Hoje a base do IPI, do ICMS, da CBS e do IS é composta com o II recalculado pela alíquota do produto, então quando os dois divergem a nota sai com imposto a menos e a SEFAZ recusa com 538 e 528.

Peguei reproduzindo uma importação real de oito linhas contra a DI dela. Três linhas têm NCM cujo cadastro traz II 14% e cinco têm NCM com II 0%, e a declaração cobrou o imposto em todas. Medido por linha, a base do IPI da primeira soma o II do cadastro, `13.220,81 + 14% = 15.071,72`, e a base da segunda fica no bruto puro, 425.158,20, porque 0% de qualquer coisa é zero. O IPI total saiu 75.970,89 contra os 89.198,15 que a DI cobrou, e o ICMS caiu junto, porque o IPI compõe a base dele.

O `ii_value` que a linha guarda nunca chega ao cálculo: o `compute_taxes` recebe `ii_customhouse_charges` e `ii_iof_value` nos kwargs e não recebe o II declarado.

Entra o campo `ii_declared_value` na linha do documento fiscal, entrada e não calculado, do mesmo tipo do `ii_customhouse_charges` ao lado dele. A composição das quatro bases passa a usá-lo quando informado, e o `_compute_ii` deixa ele vencer a alíquota do cadastro, derivando a alíquota do valor para que base vezes alíquota reproduza o que foi pago: é esse produto que a SEFAZ refaz na 528.

Nada muda para quem não informa declaração, que é toda operação que não é importação. O fallback é o valor calculado, e declaração zerada não é declaração.

Os testes cobram os quatro casos: o valor declarado compondo a base do IPI, ele vencendo a alíquota do cadastro com base vezes alíquota reproduzindo o que foi pago, e as duas contraprovas, de ausência e de zero. Suíte do `l10n_br_fiscal` medida nas duas pontas, no mesmo ambiente: 54 testes antes, 58 depois, 0 falhas nas duas e os mesmos 5 erros de `setUpClass` que já existiam na árvore limpa.
