### PR TITLE
[18.0][FIX] l10n_br_stock_account: Operação Fiscal de Devolução no stock.return.picking

### DIFF
--- a/l10n_br_stock_account/wizards/stock_return_picking.py
+++ b/l10n_br_stock_account/wizards/stock_return_picking.py
@@ -8,24 +8,15 @@ from odoo.exceptions import UserError
 class StockReturnPicking(models.TransientModel):
     _inherit = "stock.return.picking"
 
-    def _create_returns(self):
+    def _prepare_picking_default_values(self):
         """
-        Creates return picking.
-        @param self: The object pointer.
-        @return: A dictionary which of fields with values.
+        Inform the return Fiscal Operation on the new return picking.
         """
-        new_picking_id, pick_type_id = super()._create_returns()
-
-        picking_obj = self.env["stock.picking"]
-        picking = picking_obj.browse(new_picking_id)
-
-        origin_picking = self.env["stock.picking"].browse(self.env.context["active_id"])
-
-        if origin_picking.fiscal_operation_id:
+        vals = super()._prepare_picking_default_values()
+        if self.picking_id.fiscal_operation_id:
             refund_fiscal_operation = (
-                origin_picking.fiscal_operation_id.return_fiscal_operation_id
+                self.picking_id.fiscal_operation_id.return_fiscal_operation_id
             )
-
             if not refund_fiscal_operation:
                 if self.invoice_state == "2binvoiced":
                     raise UserError(
@@ -35,18 +26,25 @@ class StockReturnPicking(models.TransientModel):
                         )
                     )
             else:
-                picking.fiscal_operation_id = refund_fiscal_operation.id
-                for move in picking.move_ids:
-                    ret_move = move.origin_returned_move_id
-                    fiscal_op = ret_move.fiscal_operation_id.return_fiscal_operation_id
-                    fiscal_op_line = ret_move.fiscal_operation_line_id.line_refund_id
-                    vals = {}
-                    vals["fiscal_operation_id"] = fiscal_op.id
-                    if fiscal_op_line:
-                        # Only include fiscal_operation_line_id when the return
-                        # has a fiscal operation line otherwise, omit it so Odoo
-                        # can compute/fallback to the default value.
-                        vals["fiscal_operation_line_id"] = fiscal_op_line.id
-                    if vals:
-                        move.write(vals)
-        return new_picking_id, pick_type_id
+                vals["fiscal_operation_id"] = refund_fiscal_operation.id
+        return vals
+
+
+class StockReturnPickingLine(models.TransientModel):
+    _inherit = "stock.return.picking.line"
+
+    def _prepare_move_default_values(self, new_picking):
+        """
+        Inform the return Fiscal Operation (and its line) on the return moves.
+        """
+        vals = super()._prepare_move_default_values(new_picking)
+        if self.move_id.fiscal_operation_id:
+            fiscal_op = self.move_id.fiscal_operation_id.return_fiscal_operation_id
+            if fiscal_op:
+                vals["fiscal_operation_id"] = fiscal_op.id
+                refund_line = fiscal_op.line_definition(
+                    self.move_id.company_id, self.move_id.partner_id, self.product_id
+                )
+                if refund_line:
+                    vals["fiscal_operation_line_id"] = refund_line.id
+        return vals


### PR DESCRIPTION
Fiscal Operation in Return Picking.

PR corrige a Operação Fiscal usada no Picking criado na Devolução, objeto stock.return.picking.

Antes desse PR estava sendo usado o método **def _create_returns( ... )** mas esse método não estava sendo realmente chamado porque houve alteração no nome do método, removendo o S no final, o método é **def _create_return(** https://github.com/OCA/OCB/blob/18.0/addons/stock/wizard/stock_picking_return.py#L156 , mas pelo o que vi dentro desse método o Picking já foi criado e é possível usar os métodos que retornam o dicionário com os valores que serão usados para criar o Picking de Devolução, o que acredito ser melhor, por isso o PR altera os métodos usados tanto para o Picking quanto para as Linhas.

Os testes verificam esse processo, mas não encontravam problemas porque para criar o Picking de Devolução o core faz um **copy()** dos valores do Picking Original então a Operação Fiscal e a Linha de Operação Fiscal que eram informadas na verdade estavam erradas porque eram as mesmas do Picking Original e não a **fiscal_operation_id.return_fiscal_operation_id** e como os Testes verificavam apenas a presença dos campos e não se eles estavam corretos o problema não aparecia nos Testes, vou corrigir essa questão em outro PR que é especifico sobre os Testes:

* https://github.com/OCA/l10n-brazil/pull/5057

cc @OCA/local-brazil-maintainers 