### PR TITLE
[16.0][REF] l10n_br_*: Refatoração da View Documento Fiscal

### DIFF
--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -117,7 +117,7 @@
                         string="Set to Draft"
                         groups="l10n_br_fiscal.group_user"
                         class="btn-secondary"
-                        attrs="{'invisible': [('state_edoc', '=', 'em_digitacao')]}"
+                        attrs="{'invisible': [('state_edoc', 'in', ('em_digitacao', 'autorizada'))]}"
                     />
                     <button
                         name="action_document_cancel"
@@ -161,13 +161,6 @@
                 >Fiscal Document:
                 <field name="document_type_id" readonly="1" />
                 <strong><field name="state_edoc" readonly="1" /></strong></div>
-                <div
-                    class="alert alert-success"
-                    role="alert"
-                    attrs="{'invisible': [('state_edoc','!=','a_enviar')]}"
-                >Fiscal Document:
-                <field name="document_type_id" readonly="1" />
-                <strong>Open</strong></div>
                 <div
                     class="alert alert-success"
                     role="alert"

--- a/l10n_br_fiscal_edi/views/document_view.xml
+++ b/l10n_br_fiscal_edi/views/document_view.xml
@@ -50,7 +50,7 @@
         <field name="priority">5</field>
         <field name="inherit_id" ref="l10n_br_fiscal.document_form" />
         <field name="arch" type="xml">
-            <button name="action_document_confirm" position="after">
+            <button name="action_create_return" position="before">
                 <button
                     name="action_document_correction"
                     type="object"
@@ -66,7 +66,7 @@
                     string="View PDF"
                     groups="l10n_br_fiscal.group_user"
                     class="btn-primary"
-                    attrs="{'invisible': [('state_edoc', 'in', ('em_digitacao', 'a_enviar'))]}"
+                    attrs="{'invisible': [('state_edoc', '=', 'em_digitacao')]}"
                 />
                 <button
                     name="view_xml"
@@ -74,7 +74,7 @@
                     string="View XML"
                     groups="l10n_br_fiscal.group_user"
                     class="btn-primary"
-                    attrs="{'invisible': [('state_edoc', 'in', ('em_digitacao', 'a_enviar'))]}"
+                    attrs="{'invisible': [('state_edoc', '=', 'em_digitacao')]}"
                 />
             </button>
             <field name="state_edoc" position="attributes">

--- a/l10n_br_fiscal_notification/views/document_view.xml
+++ b/l10n_br_fiscal_notification/views/document_view.xml
@@ -4,7 +4,7 @@
         <field name="model">l10n_br_fiscal.document</field>
         <field name="inherit_id" ref="l10n_br_fiscal.document_form" />
         <field name="arch" type="xml">
-            <button name="action_document_cancel" position="after">
+            <button name="action_create_return" position="after">
                 <button
                     name="action_send_email"
                     type="object"

--- a/l10n_br_nfe/views/nfe_document_view.xml
+++ b/l10n_br_nfe/views/nfe_document_view.xml
@@ -103,7 +103,7 @@
             >
                 <attribute
                     name="attrs"
-                >{'invisible': ['|', ('state_edoc', '=', 'em_digitacao'), ('imported_document', '=', True)]}</attribute>
+                >{'invisible': ['|', ('state_edoc', 'in', ('em_digitacao', 'autorizada')), ('imported_document', '=', True)]}</attribute>
             </xpath>
             <xpath
                 expr="//header/button[@name='action_document_correction']"

--- a/l10n_br_nfse_paulistana/views/document_view.xml
+++ b/l10n_br_nfse_paulistana/views/document_view.xml
@@ -15,7 +15,7 @@
                 <attribute name="attrs">
                     {'invisible': [
                         '|',
-                        ('state_edoc', 'in', ('em_digitacao', 'a_enviar')),
+                        ('state_edoc', '=', 'em_digitacao'),
                         ('is_nfse_paulistana', '=', True)
                     ]}
                 </attribute>


### PR DESCRIPTION
## Problema

Na view do documento fiscal `(l10n_br_fiscal.document)`, usada por NF-e, NFS-e e demais e-docs:

- O botão **Set to Draft** continuava visível mesmo com o documento já **Autorizado**, permitindo tentar voltar para digitação uma NF-e/NFS-e já emitida junto ao órgão fiscal.
- Os botões **Visualizar PDF** / **Visualizar XML** só apareciam depois do envio (enviada/autorizada), impedindo conferir o PDF/XML gerado enquanto o documento ainda estava **Aguardando Envio**.
- Os botões **Carta de Correção** e **Send Email** apareciam fora de ordem no cabeçalho, quebrando a sequência padrão de ações.
- Uma faixa verde **"Open"** no estado **Aguardando Envio** usava a mesma cor (`alert-success`) da faixa **"Authorized"**, gerando confusão visual entre os dois estados.

## Mudanças

- **l10n_br_fiscal**: esconde "Set to Draft" também quando `state_edoc == 'autorizada'`; remove a faixa "Open" duplicada com a cor de "Authorized".
- **l10n_br_fiscal_edi**: libera "Visualizar PDF/XML" a partir do estado `a_enviar` (só ficam ocultos em `em_digitacao`); reposiciona "Carta de Correção" para antes do botão "Devolver".
- **l10n_br_fiscal_notification**: reposiciona "Send Email" para depois do botão "Devolver".
- **l10n_br_nfe**: aplica a mesma regra de ocultar "Set to Draft" quando autorizado (override específico de NF-e).
- **l10n_br_nfse_paulistana**: mesma liberação de "Visualizar PDF" a partir de `a_enviar`.

Continuação daqui -> https://github.com/OCA/l10n-brazil/pull/5010


before
<img width="1248" height="870" alt="print_+02332" src="https://github.com/user-attachments/assets/75be1ec2-e361-47b6-ab26-d410e9d4206a" />

after
<img width="1248" height="873" alt="print_novo" src="https://github.com/user-attachments/assets/ad61a5d9-12e4-4681-bff2-d7316257b28e" />

Consegue vê o PDF e XML antes de enviar a nota:
Removi também essa parte do codigo
```
<div
                    class="alert alert-success"
                    role="alert"
                    attrs="{'invisible': [('state_edoc','!=','a_enviar')]}"
                >Fiscal Document:
                <field name="document_type_id" readonly="1" />
                <strong>Open</strong></div>
```
<img width="1248" height="910" alt="print_23232asa" src="https://github.com/user-attachments/assets/6db76b94-22d1-4241-b940-43bb0eda78ae" />

cc @renatonlima @rvalyi @marcelsavegnago @antoniospneto 
