### PR TITLE
[16.0][REM] l10n_br_contract: remove contract_recalculate_taxes_before_invoice

### DIFF
--- a/l10n_br_contract/models/contract_contract.py
+++ b/l10n_br_contract/models/contract_contract.py
@@ -16,11 +16,6 @@ class ContractContract(models.Model):
     )
     country_id = fields.Many2one(related="company_id.country_id", store=True)
 
-    contract_recalculate_taxes_before_invoice = fields.Boolean(
-        string="Recalculate taxes before invoicing",
-        default="company.contract_recalculate_taxes_before_invoice",
-    )
-
     @api.model
     def _fiscal_operation_domain(self):
         domain = [("state", "=", "approved")]

--- a/l10n_br_contract/models/res_company.py
+++ b/l10n_br_contract/models/res_company.py
@@ -18,7 +18,3 @@ class ResCompany(models.Model):
         string="Default Contract Purchase Fiscal Operation",
         required=False,
     )
-
-    contract_recalculate_taxes_before_invoice = fields.Boolean(
-        string="Dafault recalculate taxes before invoicing", default=True
-    )

--- a/l10n_br_contract/views/contract_view.xml
+++ b/l10n_br_contract/views/contract_view.xml
@@ -21,10 +21,6 @@
                     options="{'no_create': True}"
                     attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
                 />
-                <field
-                    name="contract_recalculate_taxes_before_invoice"
-                    attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"
-                />
             </field>
             <xpath
                 expr="//field[@name='contract_line_fixed_ids']"

--- a/l10n_br_contract/views/res_company.xml
+++ b/l10n_br_contract/views/res_company.xml
@@ -13,7 +13,6 @@
                         <group>
                             <field name="contract_sale_fiscal_operation_id" />
                             <field name="contract_purchase_fiscal_operation_id" />
-                            <field name="contract_recalculate_taxes_before_invoice" />
                         </group>
                     </group>
                 </page>


### PR DESCRIPTION
No commit https://github.com/OCA/l10n-brazil/pull/4072/changes/345be7680c77d384aaa5e935ddbe249b22cc77d0 foi removido 
```
-        if contract.contract_recalculate_taxes_before_invoice:
-            self._onchange_fiscal_operation_id()
```
a partir disso o campo contract_recalculate_taxes_before_invoice não foi mais usado