### PR TITLE
[18.0][UPD] l10n_br_nfe: Biblioteca pkg_resources obsoleta/deprecated 

### DIFF
--- a/l10n_br_nfe/hooks.py
+++ b/l10n_br_nfe/hooks.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2019-2020 - Raphael Valyi Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
-import importlib
+import importlib.resources
 import logging
 
 import nfelib
@@ -20,10 +20,12 @@ def post_init_hook(env):
             "leiauteNFe",
             "35180834128745000152550010000474491454651420-nfe.xml",
         )
-        resource_path = "/".join(res_items)
-        nfe_stream = importlib.resources.files(nfelib.__name__).joinpath(resource_path)
-        with nfe_stream.open("rb") as fp:
-            binding = TnfeProc.from_xml(fp.read().decode())
+        binding = TnfeProc.from_xml(
+            importlib.resources.files(nfelib.__name__)
+            .joinpath(*res_items)
+            .read_bytes()
+            .decode()
+        )
         document_number = binding.NFe.infNFe.ide.nNF
         existing_nfes = env["l10n_br_fiscal.document"].search(
             [("document_number", "=", document_number)]

--- a/l10n_br_nfe/tests/test_nfe_import.py
+++ b/l10n_br_nfe/tests/test_nfe_import.py
@@ -1,11 +1,10 @@
 # Copyright 2021 - TODAY Akretion - Raphael Valyi <raphael.valyi@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-import importlib
+import importlib.resources
 import re
 
 import nfelib
-import pkg_resources
 from nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00 import TnfeProc
 
 from odoo.models import NewId
@@ -22,10 +21,12 @@ class NFeImportTest(TransactionCase):
             "35180834128745000152550010000474281920007498-nfe.xml",
         )
 
-        resource_path = "/".join(res_items)
-        nfe_stream = importlib.resources.files(nfelib.__name__).joinpath(resource_path)
-        with nfe_stream.open("rb") as fp:
-            binding = TnfeProc.from_xml(fp.read().decode())
+        binding = TnfeProc.from_xml(
+            importlib.resources.files(nfelib.__name__)
+            .joinpath(*res_items)
+            .read_bytes()
+            .decode()
+        )
         nfe = self.env["l10n_br_fiscal.document"].import_binding_nfe(
             binding, edoc_type="in", dry_run=True
         )
@@ -40,10 +41,12 @@ class NFeImportTest(TransactionCase):
             "leiauteNFe",
             "35180834128745000152550010000474281920007498-nfe.xml",
         )
-        resource_path = "/".join(res_items)
-        nfe_stream = importlib.resources.files(nfelib.__name__).joinpath(resource_path)
-        with nfe_stream.open("rb") as fp:
-            binding = TnfeProc.from_xml(fp.read().decode())
+        binding = TnfeProc.from_xml(
+            importlib.resources.files(nfelib.__name__)
+            .joinpath(*res_items)
+            .read_bytes()
+            .decode()
+        )
         nfe = self.env["l10n_br_fiscal.document"].import_binding_nfe(
             binding, edoc_type="in", dry_run=False
         )
@@ -120,9 +123,12 @@ class NFeImportTest(TransactionCase):
             "leiauteNFe",
             "35180834128745000152550010000474281920007498-nfe.xml",
         )
-        resource_path = "/".join(res_items)
-        nfe_stream = pkg_resources.resource_stream(nfelib.__name__, resource_path)
-        xml = nfe_stream.read().decode()
+        xml = (
+            importlib.resources.files(nfelib.__name__)
+            .joinpath(*res_items)
+            .read_bytes()
+            .decode()
+        )
         entrega = (
             "<entrega>"
             "<CNPJ>34128745000152</CNPJ>"
@@ -155,9 +161,12 @@ class NFeImportTest(TransactionCase):
             "leiauteNFe",
             "35180834128745000152550010000474281920007498-nfe.xml",
         )
-        resource_path = "/".join(res_items)
-        nfe_stream = pkg_resources.resource_stream(nfelib.__name__, resource_path)
-        xml = nfe_stream.read().decode()
+        xml = (
+            importlib.resources.files(nfelib.__name__)
+            .joinpath(*res_items)
+            .read_bytes()
+            .decode()
+        )
         # Replace the first ICMS00 node with an ICMS20 (base reduction).
         # pICMS 7.00 + 33.33% reduction is unlikely to pre-exist -> forces
         # the create-if-not-found branch.

--- a/l10n_br_nfe/tests/test_nfe_workflow.py
+++ b/l10n_br_nfe/tests/test_nfe_workflow.py
@@ -18,11 +18,11 @@ No network access: every SEFAZ round trip goes through the XML fixtures under
 ``tests/mocks`` via the shared ``nfe_mock`` helper.
 """
 
+import importlib.resources
 from types import SimpleNamespace
 from unittest import mock
 
 import nfelib
-import pkg_resources
 from erpbrasil.assinatura import misc
 from nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00 import TnfeProc
 
@@ -399,10 +399,12 @@ class TestNFeWorkflowImportedDocument(TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
-        nfe_stream = pkg_resources.resource_stream(
-            nfelib.__name__, "/".join(NFELIB_SAMPLE)
+        binding = TnfeProc.from_xml(
+            importlib.resources.files(nfelib.__name__)
+            .joinpath(*NFELIB_SAMPLE)
+            .read_bytes()
+            .decode()
         )
-        binding = TnfeProc.from_xml(nfe_stream.read().decode())
         cls.imported = cls.env["l10n_br_fiscal.document"].import_binding_nfe(
             binding, edoc_type="in", dry_run=False
         )


### PR DESCRIPTION
Setuptools 82.0.0 deprecated pkg_resources.

A bilbioteca pkg_resources vai se tornar obsoleta no Setuptools **82.0.0**, eu já havia criado um PR semelhante no passado:

* https://github.com/OCA/l10n-brazil/pull/4475 tem mais detalhes no PR

Por isso foi removido o uso no arquivo **l10n_br_nfe/tests/test_nfe_workflow.py** e está sendo atualizada a forma como o arquivo é importado em um único comando, eu estive testando isso junto com um programa de IA até por isso a diferença entre a forma que o comando era feito no primeiro PR e a forma que está sendo feito aqui, alguns detalhes sobre as alterações e justificativas feitas pela IA (vou colocar o texto dentro de um bloco de código para assim poder ser identificado):


```bash
2. l10n_br_nfe/tests/test_nfe_import.py (4 blocos)
   - Removeu pkg_resources.resource_stream(nfelib.name, path) e trocou por:
     importlib.resources.files(nfelib.name).joinpath(*res_items).read_bytes().decode()
   - De quebra corrigiu o join de caminho: "/".join(res_items) passado como string única virou joinpath(*res_items) — segmentos separados, correto em qualquer SO (o "/" hardcoded quebraria no Windows) e à prova de itens com separador.

3. l10n_br_nfe/tests/test_nfe_workflow.py (1 bloco)
   - Mesma substituição, agora em setUpClass; o with open("rb") + read() manual virou read_bytes() (fecha o stream sozinho, menos boilerplate).
```

Eu não sabia desse problema do SO Windows com o "/".join(res_items), não uso esse SO e não recomendo para rodar o Odoo mas é um problema a menos; sobre o 3 é referente ao código que eu havia feito e também não sabia sobre o problema com "with open("rb") + read() manual virou read_bytes()" e que agora "fecha o stream sozinho, menos boilerplate".

Também tem um outro ponto que eu inicialmente não entendia que era a substituição de um "import importlib" para um "import importlib.resources", porque ambos funcionam, segue a explicação completa:

```bash
POR QUE 'import importlib.resources' É MELHOR QUE 'import importlib'

importlib é um PACOTE, não um módulo simples. A linha import importlib apenas executa o init.py do pacote — e esse init não importa o submódulo resources. O atributo importlib.resources só passa a existir depois que ALGUÉM executa a importação do submódulo. Provei no seu próprio ambiente:

  $ python3 -c "import importlib; print(importlib.resources)"
  AttributeError: module 'importlib' has no attribute 'resources'   (3.9)

  $ ~/.local/bin/python3.11 -c "import importlib; print(importlib.resources)"
  AttributeError: module 'importlib' has no attribute 'resources'   (3.11)

  $ ~/.local/bin/python3.11 -c "import importlib.resources; print(importlib.resources)"
  <module 'importlib.resources' from '.../importlib/resources/init.py'>

Ou seja, o diff em hooks.py não é cosmético: é correção de um bug latente. Antes, import importlib + uso de importlib.resources.files() só funcionava por efeito colateral — se qualquer outro módulo carregado antes (Odoo, nfelib, libs de terceiros) já tivesse importado importlib.resources, o atributo existia e rodava; se a ordem de importação mudasse, o hook estouraria AttributeError em plena instalação do módulo. Esse é o padrão clássico de "funciona na minha máquina / funciona hoje".

Benefícios do import explícito do submódulo:
- Determinístico: import importlib.resources carrega o submódulo e o registra como atributo do pacote na hora. O acesso funciona em qualquer ordem de imports, em qualquer interpreter limpo.
- Autodocumentado: a linha de import declara exatamente o que o código consome (importlib.resources.files). Quem lê hooks.py entende a dependência sem caçar o uso.
- Amigável a linters/ferramentas: sem ele, ferramentas de análise não conseguem ligar o atributo ao import e o código fica "magicamente dependente" de estado global.

Obs.: a documentação oficial (docs.python.org/3/library/importlib.resources.html) sempre usa import importlib.resources — exatamente por essa razão.
```

O código roda sem erros no ambiente local e deve acontecer o mesmo aqui, as alterações são até simples e não é nenhuma nova funcionalidade ou uma grande refatoração feita por uma IA, mas se tiver faltando alguma informação devido as politicas sobre o uso de IA é só avisar que vejo de corrigir algo nesse sentido.

cc @OCA/local-brazil-maintainers 