### PR TITLE
[16.0][FIX] l10n_br_fiscal_edi, l10n_br_nfe: corrige documento preso em "enviada" e retransmissão indevida

### DIFF
--- a/l10n_br_fiscal_edi/models/document.py
+++ b/l10n_br_fiscal_edi/models/document.py
@@ -351,12 +351,18 @@ class Document(models.Model):
                     "before": "_before_document_cancel",
                 },
                 # Back to Draft
-                # SENDING (enviada) is NOT a valid source: a doc being
-                # processed by SEFAZ could be edited and re-sent with the
-                # same key while the batch is in flight.  DENIED (denegada)
-                # is NOT a valid source: denial is definitive and consumes
-                # the numbering.  The SPED guard in the before callback
-                # provides an additional safety net.
+                # SENDING (enviada) is accepted as a source, but only for
+                # documents that never actually reached the tax authority:
+                # _before_document_back2draft refuses the transition as soon
+                # as the authorization event carries a batch receipt or a
+                # protocol, so a document whose batch is really in flight
+                # still cannot be edited and re-sent with the same key.
+                # Without this source a document that stopped in SENDING
+                # before any webservice call (a transmission aborted by a
+                # local error) had no way back other than a manual write.
+                # DENIED (denegada) is NOT a valid source: denial is
+                # definitive and consumes the numbering.  The SPED guard in
+                # the before callback provides an additional safety net.
                 # DRAFT self-loop is handled by an early return in
                 # action_document_back2draft for idempotency.
                 {
@@ -365,6 +371,7 @@ class Document(models.Model):
                         DOCUMENT_STATE_OPEN,
                         DOCUMENT_STATE_REJECTED,
                         DOCUMENT_STATE_CANCEL,
+                        DOCUMENT_STATE_SENDING,
                     ],
                     "dest": DOCUMENT_STATE_DRAFT,
                     "before": "_before_document_back2draft",
@@ -441,8 +448,25 @@ class Document(models.Model):
             self._document_export()
 
     def _before_document_send(self):
-        # Placeholder for pre-send checks
-        pass
+        """Veto the transition to SENDING when the XML failed schema validation.
+
+        This callback runs *before* the machine writes state_edoc (see
+        FiscalDocumentStateMachine.set_state), so raising here leaves the
+        document in its source state. Without this guard the document was
+        moved to SENDING first and only then did the transmission module skip
+        the actual send because of xml_error_message, stranding the document
+        in a state that is not a valid source for action_draft_fsm.
+        """
+        self.ensure_one()
+        if self.xml_error_message:
+            raise UserError(
+                _(
+                    "The document XML does not comply with its schema, so it "
+                    "cannot be transmitted. Set the document back to draft, "
+                    "fix the data and confirm it again.\n\n%(errors)s",
+                    errors=self.xml_error_message,
+                )
+            )
 
     def _after_document_send(self):
         # Trigger actual sending logic
@@ -466,6 +490,19 @@ class Document(models.Model):
         # and rely on it being truthy when they have nothing to do.
         return True
 
+    def _is_document_in_transit(self):
+        """Whether the document actually reached the tax authority.
+
+        A document sitting in SENDING is only really in flight when the
+        transmission left something behind: a batch receipt to consult or an
+        authorization protocol. Otherwise the send was interrupted before the
+        webservice answered and the numbering was not consumed, so the
+        document may safely go back to draft.
+        """
+        self.ensure_one()
+        event = self.authorization_event_id
+        return bool(event and (event.lot_receipt_number or event.protocol_number))
+
     def _before_document_back2draft(self):
         self.ensure_one()
         if self.state_fiscal in SITUACAO_FISCAL_SPED_CONSIDERA_CANCELADO:
@@ -475,6 +512,17 @@ class Document(models.Model):
                     "fiscal state is %(fiscal_state)s, as it has already "
                     "been recorded as cancelled for SPED purposes.",
                     fiscal_state=self.state_fiscal,
+                )
+            )
+        if self.state_edoc == DOCUMENT_STATE_SENDING and self._is_document_in_transit():
+            # state_edoc still holds the source state here: this callback runs
+            # before the machine writes the new one.
+            raise UserError(
+                _(
+                    "This document was already transmitted and is awaiting "
+                    "processing by the tax authority. Consult its status "
+                    "instead of editing it: sending the same access key "
+                    "again would be rejected as a duplicate."
                 )
             )
         self.xml_error_message = False

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -61,6 +61,7 @@ from ..constants.nfe import (
     NFCE_DANFE_LAYOUTS,
     NFE_DANFE_LAYOUTS,
     NFE_ENVIRONMENTS,
+    NFE_TRANSMISSION_DEFAULT,
     NFE_TRANSMISSIONS,
     NFE_VERSIONS,
 )
@@ -1520,9 +1521,23 @@ class NFe(spec_models.StackedModel):
                 and record.authorization_event_id.lot_receipt_number
             ):
                 record._nfe_consult_receipt()
-            else:
-                # Otherwise we send
+            elif (
+                record.state_edoc == DOCUMENT_STATE_OPEN
+                or record.nfe_transmission != NFE_TRANSMISSION_DEFAULT
+            ):
+                # Either a first transmission, or a document that fell back to
+                # a contingency mode (tpEmis != 1) because SEFAZ was down and
+                # therefore never registered it: both must be transmitted.
                 record._nfe_send_for_authorization()
+            else:
+                # Already in SENDING, with no batch receipt to consult and no
+                # contingency to justify a retransmission: the previous send
+                # left the document in an inconsistent state. Ask SEFAZ what it
+                # knows about this access key instead of transmitting the same
+                # document again -- repeated submissions of the same key are
+                # what SEFAZ punishes with the "Consumo Indevido" (656)
+                # rejection.
+                record._document_status()
 
     def _nfe_send_for_authorization(self):
         """

--- a/l10n_br_nfe/tests/test_nfe_workflow.py
+++ b/l10n_br_nfe/tests/test_nfe_workflow.py
@@ -250,6 +250,62 @@ class TestNFeWorkflowAsync(TestNFeExport):
         self.assertEqual(self.nfe.status_code, "303")
 
 
+class TestNFeWorkflowStrandedInEnviada(TestNFeExport):
+    """Documents left in 'enviada' without ever reaching SEFAZ.
+
+    A transmission aborted before the webservice answered leaves the document
+    in SENDING with no batch receipt and no protocol: nothing about its access
+    key reached SEFAZ, so it must stay both recoverable and non retransmitted.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass(nfe_list=[{"record_ref": NFE_LC_DEMO}])
+        cls.nfe = cls.nfe_list[0]["nfe"]
+
+    def _strand_in_enviada(self):
+        self.nfe.write({"state_edoc": SITUACAO_EDOC_ENVIADA})
+        self.assertFalse(self.nfe._is_document_in_transit())
+
+    def test_back2draft_from_enviada_without_protocol_is_allowed(self):
+        """Nothing reached SEFAZ, so the document must be editable again."""
+        self._strand_in_enviada()
+
+        self.nfe.action_document_back2draft()
+
+        self.assertEqual(self.nfe.state_edoc, SITUACAO_EDOC_EM_DIGITACAO)
+        self.assertFalse(self.nfe.xml_error_message)
+
+    def test_send_from_enviada_without_receipt_consults_instead_of_resending(self):
+        """The 'Consultar Recibo' button must not retransmit the same key.
+
+        Submitting the same access key over and over is what SEFAZ answers
+        with the "Consumo Indevido" (656) rejection.
+        """
+        self._strand_in_enviada()
+
+        recorder = RecordingNFeMock()
+        with recorder:
+            self.nfe.action_document_send()
+
+        self.assertNotIn("nfeAutorizacaoLote", recorder.calls)
+        self.assertIn("nfeConsultaNF", recorder.calls)
+
+    def test_back2draft_from_enviada_with_receipt_is_refused(self):
+        """A batch really in flight at SEFAZ still cannot be edited."""
+        self.env.company.nfe_separate_async_process = True
+        with nfe_mock({"nfeAutorizacaoLote": "retEnviNFe/lote_recebido.xml"}):
+            self.nfe.action_document_send()
+
+        self.assertEqual(self.nfe.state_edoc, SITUACAO_EDOC_ENVIADA)
+        self.assertTrue(self.nfe.authorization_event_id.lot_receipt_number)
+
+        with self.assertRaises(UserError):
+            self.nfe.action_document_back2draft()
+
+        self.assertEqual(self.nfe.state_edoc, SITUACAO_EDOC_ENVIADA)
+
+
 class TestNFeWorkflowXmlValidation(TransactionCase):
     """XML schema validation failure and the recovery path around it."""
 
@@ -296,21 +352,23 @@ class TestNFeWorkflowXmlValidation(TransactionCase):
         self.assertEqual(self.document.state_edoc, SITUACAO_EDOC_A_ENVIAR)
         self.assertIn("CEP", self.document.xml_error_message)
 
-    def test_invalid_xml_blocks_transmission_without_error(self):
-        """With xml_error_message set, sending is a silent no-op (no SEFAZ call)."""
+    def test_invalid_xml_blocks_transmission_and_holds_a_enviar(self):
+        """With xml_error_message set, sending is refused and the state holds."""
         self._break_partner_zip()
         self.document.action_document_confirm()
         self.assertTrue(self.document.xml_error_message)
 
         recorder = RecordingNFeMock(NFE_ASYNC_AUTHORIZED)
-        with recorder:
+        with recorder, self.assertRaises(UserError):
             self.document.action_document_send()
 
-        # FSM transitions to enviada via the Machine before the NFe
-        # _eletronic_document_send runs. The NFe module then returns
-        # early because xml_error_message is set, skipping transmission.
+        # _before_document_send vetoes the transition, so the machine never
+        # writes 'enviada'. Before this guard the document was moved to
+        # 'enviada' first and only then did _eletronic_document_send() skip
+        # the transmission, stranding it in a state that action_draft_fsm
+        # did not accept as a source.
         self.assertEqual(recorder.calls, [])
-        self.assertEqual(self.document.state_edoc, SITUACAO_EDOC_ENVIADA)
+        self.assertEqual(self.document.state_edoc, SITUACAO_EDOC_A_ENVIAR)
         self.assertIn("CEP", self.document.xml_error_message)
 
     def test_invalid_xml_recovery_via_back2draft(self):


### PR DESCRIPTION
# Em desenvolvimento

Corrige uma regressão introduzida pela #4629 que deixa documentos fiscais
presos no estado `enviada` sem terem sido transmitidos, sem caminho de volta
para digitação pela interface.

## Problema

Ao clicar em **Enviar** num documento cujo XML não passou na validação de
schema, o documento é gravado como `enviada` mesmo sem nada ter sido enviado
à SEFAZ. A partir daí o botão **Set to Draft** falha com:

> State transition failed for action 'action_draft_fsm':
> "Can't trigger event action_draft_fsm from state enviada!"

A única saída é alterar `state_edoc` manualmente no banco.

### Causa

A #4629 transformou o envio numa transição de FSM cujo callback `after` é que
dispara a transmissão. O `set_state()` da `FiscalDocumentStateMachine` grava
`state_edoc` **antes** dos callbacks `after` (como a própria docstring da
classe documenta), então a ordem real é:

```
action_send
├─ before: _before_document_send()   → pass (placeholder vazio)
├─ set_state("enviada")              → grava no banco
└─ after:  _after_document_send()
└─ _eletronic_document_send()
└─ if record.xml_error_message: return   ← só aqui verifica
```


O guard do XML em `l10n_br_nfe` roda depois da gravação e apenas retorna, sem
exceção — logo não há rollback. No workflow anterior à #4629,
`action_document_send()` chamava `_document_send()` diretamente, sem mexer no
estado, e o documento permanecia em `a_enviar`.

Como `enviada` não é origem válida de `action_draft_fsm`, o documento fica sem
saída. O `button_draft` da fatura cai no mesmo ponto via
`action_document_back2draft()`.

## Correções

**1. `_before_document_send` passa a vetar a transição** (`l10n_br_fiscal_edi`)

O placeholder vazio agora levanta `UserError` quando há `xml_error_message`.
Por ser callback `before`, roda antes de `set_state()`, então o documento
permanece em `a_enviar` e continua recuperável pelo fluxo normal.

**2. `enviada` vira origem válida de `action_draft_fsm`** (`l10n_br_fiscal_edi`)

Com guarda no `_before_document_back2draft`: o novo helper
`_is_document_in_transit()` recusa a volta assim que o evento de autorização
tiver recibo de lote ou protocolo. Documento realmente em processamento na
SEFAZ continua bloqueado; documento que parou antes de qualquer chamada ao
webservice volta para digitação sem intervenção no banco.

**3. "Consultar Recibo" deixa de retransmitir** (`l10n_br_nfe`)

A #4629 trocou o critério de decisão em `_eletronic_document_send` de *estado*
para *presença de recibo*:

```python
if record.authorization_event_id.lot_receipt_number:
    record._nfe_consult_receipt()
else:
    record._nfe_send_for_authorization()   # retransmite a mesma chave
O botão "Consultar Recibo" (visível em enviada) chama action_document_send.
Num documento sem lot_receipt_number, cada clique retransmite a NF-e inteira
— e submissão repetida da mesma chave é o que a SEFAZ rejeita com
656 – Consumo Indevido.

Agora são três ramos: consulta o recibo (assíncrono), transmite (estado
a_enviar ou contingência tpEmis != 1, que legitimamente exige reenvio),
ou consulta a chave via _document_status() em vez de retransmitir.

Os dois return dentro do laço for record in ... viraram continue — um
registro com erro abortava o processamento dos demais.