### PR TITLE
[18.0][IMP] l10n_br_cnpj_search: cpfcnpj.com.br CNPJ lookup provider

### DIFF
--- a/l10n_br_cnpj_search/__manifest__.py
+++ b/l10n_br_cnpj_search/__manifest__.py
@@ -4,8 +4,8 @@
 {
     "name": "Brazilian Localization CNPJ Search",
     "summary": """
-        Integração com os Webservices da ReceitaWS e SerPro""",
-    "version": "18.0.1.2.0",
+        Integração com os Webservices da ReceitaWS, SerPro e cpfcnpj.com.br""",
+    "version": "18.0.1.3.0",
     "license": "AGPL-3",
     "development_status": "Production/Stable",
     "author": "KMEE,Odoo Community Association (OCA)",

--- a/l10n_br_cnpj_search/models/cnpj_webservice.py
+++ b/l10n_br_cnpj_search/models/cnpj_webservice.py
@@ -3,6 +3,7 @@
 
 import csv
 import logging
+from datetime import datetime
 from os.path import dirname
 
 from erpbrasil.base.misc import punctuation_rm
@@ -10,12 +11,23 @@ from erpbrasil.base.misc import punctuation_rm
 from odoo import Command, api, models
 from odoo.exceptions import UserError, ValidationError
 
+from odoo.addons.l10n_br_fiscal.constants.fiscal import (
+    TAX_FRAMEWORK_NORMAL,
+    TAX_FRAMEWORK_SIMPLES,
+)
+
 _logger = logging.getLogger(__name__)
 
 RECEITAWS_URL = "https://www.receitaws.com.br/v1/cnpj/"
 
 SERPRO_URL = "https://gateway.apiserpro.serpro.gov.br"
 QUALIFICACAO_CSV = dirname(__file__) + "/../data/serpro_qualificacao.csv"
+
+CPFCNPJ_URL = "https://api.cpfcnpj.com.br"
+CPFCNPJ_DEFAULT_PACKAGE = "6"
+# The Simples Nacional - Microempreendedor Individual (MEI) code from
+# l10n_br_fiscal has no named constant, so it is declared here.
+TAX_FRAMEWORK_MEI = "4"
 
 
 class CNPJWebservice(models.AbstractModel):
@@ -97,10 +109,11 @@ class CNPJWebservice(models.AbstractModel):
         name_str = data.get(name)
         if name_str:
             value = name_str
-            if lower:
-                value = value.lower()
-            elif title:
-                value = value.title()
+            if isinstance(value, str):
+                if lower:
+                    value = value.lower()
+                elif title:
+                    value = value.title()
 
         return value
 
@@ -423,3 +436,471 @@ class CNPJWebservice(models.AbstractModel):
         cnae_main = data.get("cnaePrincipal")
         cnae_code = self.get_data(cnae_main, "codigo")
         return self._get_cnae(cnae_code)
+
+    #
+    # CPFCNPJ (cpfcnpj.com.br)
+    #
+
+    @api.model
+    def cpfcnpj_get_api_url(self, cnpj, package=None):
+        """Build the provider endpoint.
+
+        The optional package argument overrides the configured package, which is
+        used to reach the state registration package (16) without changing the
+        configured default. When omitted, the configured package is used.
+        """
+        token = self._get_cnpj_param("cpfcnpj_token")
+        if not package:
+            package = self._get_cnpj_param("cpfcnpj_package") or CPFCNPJ_DEFAULT_PACKAGE
+        return f"{CPFCNPJ_URL}/{token}/{package}/{cnpj}"
+
+    @api.model
+    def cpfcnpj_get_headers(self):
+        return {"Accept": "application/json"}
+
+    @api.model
+    def cpfcnpj_validate(self, response):
+        self._validate(response)
+        data = response.json()
+        if not data.get("status"):
+            raise ValidationError(
+                self.env._("%(reason)s", reason=data.get("erro") or "")
+            )
+        return data
+
+    @api.model
+    def _cpfcnpj_import_data(self, data):
+        legal_name = self.get_data(data, "razao", title=True)
+        fantasy_name = self.get_data(data, "fantasia", title=True)
+        address = data.get("matrizEndereco") or {}
+        phone, mobile = self._cpfcnpj_get_phones(data)
+        state_id, city_id = self._cpfcnpj_get_state_city(data, address)
+
+        res = {
+            "legal_name": legal_name,
+            "name": fantasy_name if fantasy_name else legal_name,
+            "email": self.get_data(data, "email", lower=True),
+            "street_name": self.get_data(address, "logradouro", title=True),
+            "street2": self.get_data(address, "complemento", title=True),
+            "district": self.get_data(address, "bairro", title=True),
+            "street_number": self.get_data(address, "numero"),
+            "zip": self.get_data(address, "cep"),
+            "legal_nature_id": self._cpfcnpj_get_legal_nature(data),
+            "phone": phone,
+            "mobile": mobile,
+            "state_id": state_id,
+            "city_id": city_id,
+            "equity_capital": self.get_data(data, "capitalSocial"),
+            "cnae_main_id": self._cpfcnpj_get_cnae(data),
+            "cnae_secondary_ids": self._cpfcnpj_get_secondary_cnae(data),
+        }
+
+        tax_framework = self._cpfcnpj_get_tax_framework(data)
+        if tax_framework:
+            res["tax_framework"] = tax_framework
+
+        res.update(self._cpfcnpj_get_registry_fields(data))
+        res.update(self._cpfcnpj_import_partners(data))
+        res.update(self._cpfcnpj_get_card_pdf(data))
+
+        return res
+
+    @api.model
+    def _cpfcnpj_parse_date(self, value):
+        """Parse a provider date string into a date object.
+
+        The provider returns dates either as "YYYY-MM-DD" or as "DD/MM/YYYY".
+        Anything that does not match one of these formats returns False.
+        """
+        if not value or not isinstance(value, str):
+            return False
+        value = value.strip()
+        for date_format in ("%Y-%m-%d", "%d/%m/%Y"):
+            try:
+                return datetime.strptime(value, date_format).date()
+            except ValueError:
+                continue
+        return False
+
+    @api.model
+    def _cpfcnpj_get_bool_param(self, param_name, default=False):
+        """Read a boolean config parameter tolerating the several ways it may be
+        stored ("True"/"False", "1"/"0") and falling back to the given default
+        when the parameter is unset or empty.
+        """
+        raw = self._get_cnpj_param(param_name)
+        if raw is False or raw is None or str(raw).strip() == "":
+            return default
+        return str(raw).strip().lower() not in ("0", "false", "no", "off", "f")
+
+    @api.model
+    def _cpfcnpj_get_status_reason(self, situacao):
+        """Normalize the registration status reason.
+
+        The provider may return the reason as a plain string, as a list (empty
+        for active companies, one item otherwise) or as an object carrying a
+        "descricao" key. All three shapes are handled here.
+        """
+        motivo = situacao.get("motivo")
+        if not motivo:
+            return False
+        if isinstance(motivo, str):
+            return motivo
+        if isinstance(motivo, list):
+            for item in motivo:
+                if isinstance(item, str) and item:
+                    return item
+                if isinstance(item, dict):
+                    reason = self.get_data(item, "descricao")
+                    if reason:
+                        return reason
+            return False
+        if isinstance(motivo, dict):
+            return self.get_data(motivo, "descricao")
+        return False
+
+    @api.model
+    def _cpfcnpj_get_branch_type(self, data):
+        """Map the head office / branch indicator to the Odoo selection value.
+
+        The information comes from "matrizfilial.tipo" or, as a fallback, from
+        the top level "tipo" key. Both carry "Matriz" or "Filial".
+        """
+        matrizfilial = data.get("matrizfilial") or {}
+        tipo = matrizfilial.get("tipo") or data.get("tipo")
+        if not tipo:
+            return False
+        normalized = str(tipo).strip().lower()
+        if normalized.startswith("matriz"):
+            return "head_office"
+        if normalized.startswith("filial"):
+            return "branch"
+        return False
+
+    @api.model
+    def _cpfcnpj_get_registry_fields(self, data):
+        """Map the registry cadastral fields returned by package 6.
+
+        Every value is optional and tolerant of missing keys.
+        """
+        situacao = data.get("situacao") or {}
+        simples = data.get("simplesNacional") or {}
+        responsavel_qualificacao = data.get("responsavelQualificacao") or {}
+
+        return {
+            "company_size": self.get_data(data.get("porte") or {}, "descricao"),
+            "cnpj_status": self.get_data(situacao, "nome"),
+            "cnpj_status_date": self._cpfcnpj_parse_date(situacao.get("data")),
+            "cnpj_status_reason": self._cpfcnpj_get_status_reason(situacao),
+            "opening_date": self._cpfcnpj_parse_date(data.get("inicioAtividade")),
+            "cnpj_branch_type": self._cpfcnpj_get_branch_type(data),
+            "simples_option_date": self._cpfcnpj_parse_date(simples.get("inicio")),
+            "legal_responsible_name": self.get_data(data, "responsavel", title=True),
+            "legal_responsible_function": self.get_data(
+                responsavel_qualificacao, "descricao"
+            ),
+        }
+
+    @api.model
+    def _cpfcnpj_import_partners(self, data):
+        """Materialize the QSA (company partners) as child res.partner records.
+
+        This mirrors the SERPRO behaviour (see _import_additional_info): the
+        partners are created inside import_data and linked to the target partner
+        later, in the wizard, through child_ids. As in the SERPRO case, the
+        parent is unknown at this point, so no de-duplication against existing
+        children is attempted here.
+        """
+        if self._cpfcnpj_get_bool_param("cpfcnpj_skip_partners"):
+            return {}
+
+        socios = data.get("socios")
+        if not isinstance(socios, list) or not socios:
+            return {}
+
+        child_ids = []
+        for socio in socios:
+            if not isinstance(socio, dict):
+                continue
+            name = self.get_data(socio, "nome", title=True)
+            if not name:
+                continue
+
+            values = {"name": name}
+
+            function = self.get_data(socio.get("qualificacao_socio") or {}, "descricao")
+            if function:
+                values["function"] = function
+
+            doc = socio.get("cpf_cnpj_socio")
+            doc_digits = (
+                "".join(char for char in str(doc) if char.isalnum()) if doc else ""
+            )
+            tipo = str(socio.get("tipo") or "").strip().lower()
+            is_person = "fisica" in tipo or len(doc_digits) == 11
+            values["company_type"] = "person" if is_person else "company"
+
+            # Only a full CPF (11) or CNPJ (14) becomes a vat. The 8 digit CNPJ
+            # root of a company partner is not a valid vat and is skipped.
+            if len(doc_digits) in (11, 14):
+                values["vat"] = doc_digits
+
+            comment = self._cpfcnpj_partner_comment(socio)
+            if comment:
+                values["comment"] = comment
+
+            existing = self._cpfcnpj_find_existing_partner(values.get("vat"), name)
+            if existing is None:
+                # The document belongs to a contact of another company: leave
+                # it alone instead of moving it under this partner.
+                continue
+            if existing:
+                update = {
+                    key: values[key] for key in ("function", "comment") if key in values
+                }
+                existing.write(update)
+                child_ids.append(existing.id)
+            else:
+                child_ids.append(self.env["res.partner"].create(values).id)
+
+        if not child_ids:
+            return {}
+
+        return {"child_ids": [Command.set(child_ids)]}
+
+    @api.model
+    def _cpfcnpj_find_existing_partner(self, vat, name):
+        """Find the partner to reuse for a QSA entry so that running the
+        wizard again does not create duplicates (l10n_br_base enforces a
+        unique CPF/CNPJ per partner).
+
+        A partner with the same vat is reused wherever it is; when it already
+        belongs to another company, None is returned so the entry is skipped.
+        Without a vat, only a child of the partner being updated (taken from
+        the wizard context) with the same name is reused. Returns an empty
+        recordset when nothing matches.
+        """
+        partner_model = self.env["res.partner"]
+        parent_id = self.env.context.get("default_partner_id")
+        if vat:
+            existing = partner_model.search([("vat", "=", vat)], limit=1)
+            if existing and existing.parent_id and existing.parent_id.id != parent_id:
+                return None
+            return existing
+        if parent_id:
+            return partner_model.search(
+                [
+                    ("parent_id", "=", parent_id),
+                    ("name", "=", name),
+                    ("vat", "=", False),
+                ],
+                limit=1,
+            )
+        return partner_model
+
+    @api.model
+    def _cpfcnpj_partner_comment(self, socio):
+        """Build an optional note with the entry date and the legal
+        representative (name and qualification) when they are present.
+        """
+        parts = []
+        entry_date = self.get_data(socio, "data_entrada")
+        if entry_date:
+            parts.append(self.env._("Entry date: %(date)s", date=entry_date))
+
+        representative = self.get_data(socio, "nome_representante", title=True)
+        if representative:
+            qualification = self.get_data(socio, "qualificacao_representante")
+            if qualification:
+                parts.append(
+                    self.env._(
+                        "Legal representative: %(name)s (%(function)s)",
+                        name=representative,
+                        function=qualification,
+                    )
+                )
+            else:
+                parts.append(
+                    self.env._("Legal representative: %(name)s", name=representative)
+                )
+
+        return "\n".join(parts) if parts else False
+
+    @api.model
+    def _cpfcnpj_get_card_pdf(self, data):
+        """Return the base64 CNPJ card PDF when enabled and present.
+
+        The value is later turned into an ir.attachment by the wizard, so it is
+        deliberately kept out of the res.partner write values.
+        """
+        if self._cpfcnpj_get_bool_param("cpfcnpj_skip_card"):
+            return {}
+        pdf = data.get("comprovantePdfBase64")
+        if not pdf:
+            return {}
+        return {"cnpj_card_pdf": pdf}
+
+    @api.model
+    def _cpfcnpj_select_ie(self, data, uf):
+        """Pick the state registration (package 16) to use.
+
+        The active registration whose state matches the establishment UF is
+        preferred; otherwise the first active one is used. Returns only the
+        digits of the registration, or False when there is no active one.
+        """
+        if not isinstance(data, dict):
+            return False
+        registrations = data.get("inscricoesEstaduais") or []
+        active = [
+            reg for reg in registrations if isinstance(reg, dict) and reg.get("ativo")
+        ]
+        if not active:
+            return False
+
+        chosen = False
+        if uf:
+            for reg in active:
+                estado = reg.get("estado") or {}
+                if str(estado.get("sigla") or "").upper() == str(uf).upper():
+                    chosen = reg
+                    break
+        if not chosen:
+            chosen = active[0]
+
+        ie_code = chosen.get("inscricao_estadual")
+        if not ie_code:
+            return False
+        return "".join(char for char in str(ie_code) if char.isdigit()) or False
+
+    @api.model
+    def _cpfcnpj_format_phone(self, item):
+        """Format a phone item as "(ddd) numero".
+
+        Returns False when ddd or numero is missing, so an incomplete item is
+        never rendered as "(None) None".
+        """
+        if not isinstance(item, dict):
+            return False
+        ddd = item.get("ddd")
+        numero = item.get("numero")
+        if not ddd or not numero:
+            return False
+        return f"({ddd}) {numero}"
+
+    @api.model
+    def _cpfcnpj_get_phones(self, data):
+        """Return the first two complete phone numbers found in the response.
+
+        Items missing ddd or numero are skipped. The first valid number is
+        assigned to phone and the second, if any, to mobile. The remaining
+        numbers are ignored.
+        """
+        phones = []
+        for item in data.get("telefones") or []:
+            formatted = self._cpfcnpj_format_phone(item)
+            if formatted:
+                phones.append(formatted)
+            if len(phones) == 2:
+                break
+        phone = phones[0] if phones else False
+        mobile = phones[1] if len(phones) > 1 else False
+        return phone, mobile
+
+    @api.model
+    def _cpfcnpj_get_state_city(self, data, address):
+        """Resolve state and city.
+
+        The city is matched by its IBGE code (the most reliable key) and falls
+        back to a case-insensitive name match within the state.
+        """
+        state_id = False
+        city_id = False
+
+        uf = self.get_data(address, "uf")
+        if uf:
+            state = self.env["res.country.state"].search(
+                [("code", "=", uf), ("country_id.code", "=", "BR")],
+                limit=1,
+            )
+            state_id = state.id
+
+        ibge = data.get("ibge") or {}
+        ibge_city = ibge.get("cidade") or {}
+        ibge_code = ibge_city.get("ibge_id")
+        if ibge_code:
+            city = self.env["res.city"].search(
+                [("ibge_code", "=", str(ibge_code))], limit=1
+            )
+            city_id = city.id
+        elif state_id:
+            city_name = self.get_data(address, "cidade", title=True)
+            if city_name:
+                city = self.env["res.city"].search(
+                    [
+                        ("name", "=ilike", city_name),
+                        ("state_id", "=", state_id),
+                    ],
+                    limit=1,
+                )
+                city_id = city.id
+
+        return [state_id, city_id]
+
+    @api.model
+    def _cpfcnpj_get_legal_nature(self, data):
+        legal_nature = data.get("naturezaJuridica") or {}
+        return self._get_legal_nature(self.get_data(legal_nature, "codigo"))
+
+    @api.model
+    def _cpfcnpj_get_cnae(self, data):
+        cnae = data.get("cnae") or {}
+        return self._get_cnae(self.get_data(cnae, "fiscal"))
+
+    @api.model
+    def _cpfcnpj_get_secondary_cnae(self, data):
+        """Resolve the secondary CNAEs.
+
+        The API returns the secondary CNAE id as a number, so it is converted
+        to a string before being normalized.
+        """
+        cnae = data.get("cnae") or {}
+        secondary = []
+        for item in cnae.get("secundarias") or []:
+            if not isinstance(item, dict):
+                continue
+            code = item.get("id")
+            if code is None or code == "":
+                continue
+            cnae_id = self._get_cnae(str(code))
+            if cnae_id:
+                secondary.append(cnae_id)
+        return [Command.set(secondary)]
+
+    @api.model
+    def _cpfcnpj_get_tax_framework(self, data):
+        """Derive the Odoo fiscal tax framework from the Simples Nacional and
+        SIMEI information returned by the provider.
+
+        No other CNPJ provider fills res.partner.tax_framework today, so this
+        mapping is the main fiscal value added by this backend. The rules are:
+
+            SIMEI optante                -> Microempreendedor Individual (MEI)
+            Simples Nacional optante     -> Simples Nacional
+            otherwise                    -> Regime Normal
+
+        Package 5 does not carry tax regime data, so the field is left untouched
+        in that case.
+        """
+        simples = data.get("simplesNacional")
+        simei = data.get("simei")
+        if simples is None and simei is None:
+            return False
+        if self._cpfcnpj_is_optante(simei or {}):
+            return TAX_FRAMEWORK_MEI
+        if self._cpfcnpj_is_optante(simples or {}):
+            return TAX_FRAMEWORK_SIMPLES
+        return TAX_FRAMEWORK_NORMAL
+
+    @api.model
+    def _cpfcnpj_is_optante(self, info):
+        return str(info.get("optante", "")).strip().lower() in ("sim", "true", "1")

--- a/l10n_br_cnpj_search/models/l10n_br_base_party_mixin.py
+++ b/l10n_br_cnpj_search/models/l10n_br_base_party_mixin.py
@@ -6,11 +6,59 @@
 from odoo import api, fields, models
 from odoo.exceptions import UserError
 
+CNPJ_BRANCH_TYPE_SELECTION = [
+    ("head_office", "Head Office"),
+    ("branch", "Branch"),
+]
+
 
 class PartyMixin(models.AbstractModel):
     _inherit = "l10n_br_base.party.mixin"
 
     equity_capital = fields.Monetary(currency_field="br_currency_id")
+
+    company_size = fields.Char(
+        help="Company size classification (e.g. Small Business).",
+    )
+
+    cnpj_status = fields.Char(
+        string="CNPJ Status",
+        help="Registration status of the CNPJ (e.g. Active).",
+    )
+
+    cnpj_status_date = fields.Date(
+        string="CNPJ Status Date",
+        help="Date of the current registration status.",
+    )
+
+    cnpj_status_reason = fields.Char(
+        string="CNPJ Status Reason",
+        help="Reason for the current registration status.",
+    )
+
+    opening_date = fields.Date(
+        help="Date the company started its activities.",
+    )
+
+    cnpj_branch_type = fields.Selection(
+        selection=CNPJ_BRANCH_TYPE_SELECTION,
+        string="Head Office / Branch",
+        help="Whether the establishment is the head office or a branch.",
+    )
+
+    simples_option_date = fields.Date(
+        string="Simples Nacional Option Date",
+        help="Date the company opted for the Simples Nacional regime.",
+    )
+
+    legal_responsible_name = fields.Char(
+        string="Legal Responsible",
+        help="Name of the legal responsible for the company.",
+    )
+
+    legal_responsible_function = fields.Char(
+        help="Function of the legal responsible for the company.",
+    )
 
     cnae_main_id = fields.Many2one(comodel_name="l10n_br_fiscal.cnae")
 

--- a/l10n_br_cnpj_search/models/res_config_settings.py
+++ b/l10n_br_cnpj_search/models/res_config_settings.py
@@ -11,6 +11,7 @@ class ResConfigSettings(models.TransientModel):
         selection=[
             ("receitaws", "ReceitaWS"),
             ("serpro", "SERPRO"),
+            ("cpfcnpj", "CPF.CNPJ"),
         ],
         string="CNPJ Search Provider",
         required=True,
@@ -36,4 +37,39 @@ class ResConfigSettings(models.TransientModel):
         ],
         string="SERPRO Schema",
         config_parameter="l10n_br_cnpj_search.serpro_schema",
+    )
+
+    cpfcnpj_token = fields.Char(
+        string="CPF.CNPJ Token",
+        config_parameter="l10n_br_cnpj_search.cpfcnpj_token",
+    )
+
+    cpfcnpj_package = fields.Selection(
+        selection=[
+            ("5", "5 - Cadastro e endereço"),
+            ("6", "6 - Cadastro completo (Simples Nacional, porte e situação)"),
+        ],
+        string="CPF.CNPJ Package",
+        default="6",
+        config_parameter="l10n_br_cnpj_search.cpfcnpj_package",
+    )
+
+    cpfcnpj_skip_partners = fields.Boolean(
+        string="CPF.CNPJ: do not import partners (QSA)",
+        help="By default each partner from the QSA becomes a child contact. "
+        "Enable this to skip that step.",
+        config_parameter="l10n_br_cnpj_search.cpfcnpj_skip_partners",
+    )
+
+    cpfcnpj_skip_card = fields.Boolean(
+        string="CPF.CNPJ: do not attach the CNPJ card PDF",
+        help="By default the CNPJ card PDF returned by package 6 is attached "
+        "to the partner. Enable this to skip that step.",
+        config_parameter="l10n_br_cnpj_search.cpfcnpj_skip_card",
+    )
+
+    cpfcnpj_fetch_ie = fields.Boolean(
+        string="CPF.CNPJ: fetch state registration (package 16)",
+        default=False,
+        config_parameter="l10n_br_cnpj_search.cpfcnpj_fetch_ie",
     )

--- a/l10n_br_cnpj_search/readme/CONFIGURE.md
+++ b/l10n_br_cnpj_search/readme/CONFIGURE.md
@@ -3,3 +3,34 @@ provedor configurado na aba de configurações, vale ressaltar que o
 provedor receitaws permite a realização de três consultas por minuto,
 enquanto que o SERPRO é pago e permite consultas ilimitadas em seus
 planos.
+
+O provedor cpfcnpj.com.br é comercial, com dados em tempo real (D+0),
+sem o limite de três consultas por minuto do receitaws. Os dados vêm
+diretamente da Receita Federal no momento da consulta. Para utilizá-lo,
+selecione "CPF.CNPJ" no campo provedor e informe o token de acesso
+e o pacote desejado. O pacote 5 (CNPJ B) é a opção mais leve (cadastro e
+endereço, sem sócios e sem PDF), enquanto o pacote 6 (CNPJ D) é o
+cadastro completo (porte, situação cadastral, Simples Nacional, Quadro
+de Sócios e Administradores e Cartão CNPJ em PDF). O token é gravado em
+`ir.config_parameter` e nunca fica no código. Com o pacote 6, o módulo
+também preenche o regime tributário (`tax_framework`) do partner.
+
+Ao selecionar o provedor CPF.CNPJ, ficam visíveis em Configurações >
+Contatos as opções a seguir:
+
+- "CPF.CNPJ: do not import partners (QSA)" (padrão desligado): por padrão
+  cada sócio do Quadro de Sócios e Administradores vira um contato filho,
+  com nome, qualificação e CPF/CNPJ. Marque esta opção para pular esse
+  passo.
+- "CPF.CNPJ: do not attach the CNPJ card PDF" (padrão desligado): por
+  padrão o Cartão CNPJ em PDF emitido pela Receita Federal, retornado pela
+  API no mesmo request, é anexado ao parceiro. Marque esta opção para não
+  anexar.
+- "CPF.CNPJ: fetch state registration (package 16)" (padrão desligado):
+  faz uma segunda consulta ao pacote 16 (CNPJ H) para preencher a
+  Inscrição Estadual da UF do endereço. O pacote 16 tem custo próprio por
+  consulta, por isso a opção vem desligada.
+
+O provedor é auditado sob as normas ISO/IEC 27001, ISO/IEC 27701 e ISO
+37301. Consulte a documentação da API, os pacotes disponíveis e as
+credenciais em https://www.cpfcnpj.com.br/dev/.

--- a/l10n_br_cnpj_search/readme/CONTRIBUTORS.md
+++ b/l10n_br_cnpj_search/readme/CONTRIBUTORS.md
@@ -1,2 +1,4 @@
 - [KMEE](https://www.kmee.com.br):
   - Breno Oliveira Dias \<<breno.dias@kmee.com.br>\>
+- [ALAS Tecnologia](https://www.cpfcnpj.com.br):
+  - Alisson Linneker \<<hi@alas.technology>\>

--- a/l10n_br_cnpj_search/readme/DESCRIPTION.md
+++ b/l10n_br_cnpj_search/readme/DESCRIPTION.md
@@ -16,3 +16,30 @@ partir do CNPJ:
 ![](../static/description/serpro.png)
 
 ![](../static/description/serpro1.png)
+
+## CPF.CNPJ (cpfcnpj.com.br)
+
+Provedor comercial com dados em tempo real, vindos da Receita Federal no
+momento da consulta (D+0). O pacote 5 (CNPJ B) é a opção mais leve
+(cadastro e endereço, sem sócios e sem PDF), enquanto o pacote 6 (CNPJ D)
+traz o cadastro completo.
+
+Do pacote 6, o módulo preenche no partner: razão social, nome fantasia,
+endereço completo, telefones, e-mail, natureza jurídica, capital social,
+CNAE principal e secundários, porte da empresa, situação cadastral (com
+data e motivo), data de abertura, matriz ou filial, data de opção pelo
+Simples Nacional e responsável perante a Receita (nome e qualificação). A
+partir do Simples Nacional, SIMEI e porte, o módulo também alimenta o
+`tax_framework` (regime tributário) do partner, campo que os demais
+provedores não preenchem hoje.
+
+Cada sócio do Quadro de Sócios e Administradores vira um contato filho e
+o Cartão CNPJ em PDF da Receita Federal fica anexado ao parceiro; as
+opções "CPF.CNPJ: do not import partners (QSA)" e "CPF.CNPJ: do not attach
+the CNPJ card PDF" desligam cada um desses passos. A opção "CPF.CNPJ: fetch state registration (package
+16)" (desligada por padrão) faz uma consulta ao pacote 16 (CNPJ H) para
+trazer a Inscrição Estadual da UF do endereço.
+
+O provedor mantém as certificações ISO/IEC 27001, ISO/IEC 27701 e ISO
+37301. A documentação da API está disponível em
+https://www.cpfcnpj.com.br/dev/.

--- a/l10n_br_cnpj_search/readme/HISTORY.md
+++ b/l10n_br_cnpj_search/readme/HISTORY.md
@@ -1,1 +1,18 @@
+## 18.0.1.3.0
 
+- Adiciona o provedor de consulta cpfcnpj.com.br (dados em tempo real, D+0),
+  com token e pacote (5 ou 6) configuráveis.
+- Preenche o regime tributário (`tax_framework`) do partner a partir do
+  Simples Nacional, SIMEI e porte retornados no pacote 6.
+- Amplia o pacote 6 (CNPJ D): preenche porte da empresa, situação
+  cadastral (com data e motivo), data de abertura, matriz ou filial, data
+  de opção pelo Simples Nacional e responsável perante a Receita (nome e
+  qualificação).
+- Cada sócio do Quadro de Sócios e Administradores vira um contato filho,
+  com nome, qualificação e CPF/CNPJ. A opção "CPF.CNPJ: do not import
+  partners (QSA)" desliga esse passo.
+- O Cartão CNPJ em PDF emitido pela Receita Federal é anexado ao parceiro.
+  A opção "CPF.CNPJ: do not attach the CNPJ card PDF" desliga esse passo.
+- Nova opção "CPF.CNPJ: fetch state registration (package 16)" (padrão
+  desligado): consulta o pacote 16 (CNPJ H) para preencher a Inscrição
+  Estadual da UF do endereço. O pacote 16 tem custo próprio por consulta.

--- a/l10n_br_cnpj_search/readme/USAGE.md
+++ b/l10n_br_cnpj_search/readme/USAGE.md
@@ -5,3 +5,9 @@
 4.  Preencha os campos obrigatórios, insira no campo de CNPJ o CNPJ que
     deseja buscar e clique na lupa ao lado do campo para buscar
 5.  O mesmo procedimento pode ser feito editando alguma empresa.
+
+Com o provedor CPF.CNPJ, o botão de busca no parceiro (a lupa ao lado do
+campo de CNPJ) abre um wizard que exibe os campos retornados. Ao
+confirmar, o módulo grava os dados no parceiro, cria um contato filho por
+sócio do Quadro de Sócios e Administradores (opção QSA) e anexa o Cartão
+CNPJ em PDF na aba "Anexos".

--- a/l10n_br_cnpj_search/tests/__init__.py
+++ b/l10n_br_cnpj_search/tests/__init__.py
@@ -3,3 +3,4 @@
 
 from . import test_receitaws
 from . import test_serpro
+from . import test_cpfcnpj

--- a/l10n_br_cnpj_search/tests/common.py
+++ b/l10n_br_cnpj_search/tests/common.py
@@ -7,6 +7,21 @@ MOCK_REQUESTS_GET = (
     "odoo.addons.l10n_br_cnpj_search.wizard.partner_cnpj_search_wizard.requests.get"
 )
 
+# Minimal valid single page PDF (593 bytes), base64. Reused by the mocks.
+_PDF_MINIMO_B64 = (
+    "JVBERi0xLjQKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5kb2Jq"
+    "CjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9LaWRzIFszIDAgUl0gL0NvdW50IDEgPj4KZW5kb2Jq"
+    "CjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgL1BhcmVudCAyIDAgUiAvTWVkaWFCb3ggWzAgMCA1OTUg"
+    "ODQyXSAvUmVzb3VyY2VzIDw8IC9Gb250IDw8IC9GMSA1IDAgUiA+PiA+PiAvQ29udGVudHMgNCAw"
+    "IFIgPj4KZW5kb2JqCjQgMCBvYmoKPDwgL0xlbmd0aCA2MiA+PgpzdHJlYW0KQlQgL0YxIDE4IFRm"
+    "IDYwIDc4MCBUZCAoQ29tcHJvdmFudGUgRXhlbXBsbykgVGogRVQKZW5kc3RyZWFtCmVuZG9iago1"
+    "IDAgb2JqCjw8IC9UeXBlIC9Gb250IC9TdWJ0eXBlIC9UeXBlMSAvQmFzZUZvbnQgL0hlbHZldGlj"
+    "YSA+PgplbmRvYmoKeHJlZgowIDYKMDAwMDAwMDAwMCA2NTUzNSBmIAowMDAwMDAwMDA5IDAwMDAw"
+    "IG4gCjAwMDAwMDAwNTggMDAwMDAgbiAKMDAwMDAwMDExNSAwMDAwMCBuIAowMDAwMDAwMjQxIDAw"
+    "MDAwIG4gCjAwMDAwMDAzNDEgMDAwMDAgbiAKdHJhaWxlcgo8PCAvU2l6ZSA2IC9Sb290IDEgMCBS"
+    "ID4+CnN0YXJ0eHJlZgo0MTEKJSVFT0Y="
+)
+
 
 class TestCnpjCommon(TransactionCase):
     @classmethod
@@ -330,6 +345,513 @@ class TestCnpjCommon(TransactionCase):
                 "codigo": "6204000",
                 "descricao": "Consultoria em tecnologia da informação",
             },
+        }
+
+        # cpfcnpj.com.br - package 6 payload of a Simples Nacional company.
+        cls.mocked_response_cpfcnpj_simples = {
+            "status": 1,
+            "cnpj": "34.238.864/0001-68",
+            "tipo": "Matriz",
+            "razao": "TOKEN TEST LTDA",
+            "fantasia": "TOKEN TEST",
+            "capitalSocial": 95000,
+            "email": "contato@empresa.com",
+            "simplesNacional": {"optante": "Sim", "inicio": "17/01/2020"},
+            "simei": {"optante": "Não"},
+            "porte": {"id": "03", "descricao": "Empresa de Pequeno Porte"},
+            "matrizEndereco": {
+                "cep": "39400-000",
+                "tipo": "Rua",
+                "logradouro": "Rua A",
+                "numero": "1",
+                "complemento": "Sala 1",
+                "bairro": "Centro",
+                "cidade": "Montes Claros",
+                "uf": "MG",
+            },
+            "ibge": {
+                "estado": {"sigla": "MG", "ibge_id": 31},
+                "cidade": {"nome": "Montes Claros", "ibge_id": 3143302},
+            },
+            "telefones": [
+                {"ddd": "11", "numero": "22334454"},
+                {"ddd": "11", "numero": "22334455"},
+            ],
+            "naturezaJuridica": {
+                "codigo": "2062",
+                "descricao": "Sociedade Empresaria Limitada",
+            },
+            "cnae": {
+                "fiscal": "6202300",
+                "descricao": "Desenvolvimento e licenciamento de programas "
+                "de computador customizaveis",
+                "secundarias": [
+                    {"id": "6201501"},
+                    {"id": "6204000"},
+                ],
+            },
+        }
+
+        # cpfcnpj.com.br - package 6 payload of an MEI company.
+        cls.mocked_response_cpfcnpj_mei = {
+            "status": 1,
+            "cnpj": "44.356.113/0001-08",
+            "tipo": "Matriz",
+            "razao": "JOAO DA SILVA 12345678900",
+            "fantasia": "",
+            "capitalSocial": 5000,
+            "email": "mei@empresa.com",
+            "simplesNacional": {"optante": "Sim"},
+            "simei": {"optante": "Sim", "inicio": "17/01/2023"},
+            "porte": {"id": "01", "descricao": "Microempresa"},
+            "matrizEndereco": {
+                "cep": "39400-000",
+                "logradouro": "Rua B",
+                "numero": "10",
+                "bairro": "Centro",
+                "cidade": "Montes Claros",
+                "uf": "MG",
+            },
+            "ibge": {
+                "cidade": {"nome": "Montes Claros", "ibge_id": 3143302},
+            },
+            "telefones": [{"ddd": "38", "numero": "999998888"}],
+            "naturezaJuridica": {
+                "codigo": "2135",
+                "descricao": "Empresario (Individual)",
+            },
+            "cnae": {"fiscal": "6202300"},
+        }
+
+        # cpfcnpj.com.br - package 6 payload of a company under the normal
+        # regime (neither Simples nor SIMEI), without an IBGE code (so the city
+        # is resolved by name) and without phone numbers.
+        cls.mocked_response_cpfcnpj_normal = {
+            "status": 1,
+            "cnpj": "34.238.864/0001-68",
+            "tipo": "Matriz",
+            "razao": "REGIME NORMAL LTDA",
+            "fantasia": "Normal Test",
+            "capitalSocial": 500000,
+            "email": "normal@empresa.com",
+            "simplesNacional": {"optante": "Não"},
+            "simei": {"optante": "Não"},
+            "porte": {"id": "05", "descricao": "Demais"},
+            "matrizEndereco": {
+                "cep": "39400-000",
+                "tipo": "Rua",
+                "logradouro": "Rua C",
+                "numero": "20",
+                "bairro": "Centro",
+                "cidade": "Montes Claros",
+                "uf": "MG",
+            },
+            "naturezaJuridica": {
+                "codigo": "2062",
+                "descricao": "Sociedade Empresaria Limitada",
+            },
+            "cnae": {"fiscal": "6202300"},
+        }
+
+        # cpfcnpj.com.br - package 5 payload, which carries no tax regime data,
+        # so tax_framework must be left untouched.
+        cls.mocked_response_cpfcnpj_package5 = {
+            "status": 1,
+            "cnpj": "34.238.864/0001-68",
+            "tipo": "Matriz",
+            "razao": "PACOTE CINCO LTDA",
+            "fantasia": "Pacote 5",
+            "capitalSocial": 12000,
+            "email": "p5@empresa.com",
+            "matrizEndereco": {
+                "cep": "39400-000",
+                "logradouro": "Rua D",
+                "numero": "5",
+                "bairro": "Centro",
+                "cidade": "Montes Claros",
+                "uf": "MG",
+            },
+            "ibge": {"cidade": {"ibge_id": 3143302}},
+            "naturezaJuridica": {"codigo": "2062"},
+            "cnae": {"fiscal": "6202300"},
+        }
+
+        # cpfcnpj.com.br - package 6 payload of an active head office with a
+        # full QSA: three partners, one of them a foreign company partner with a
+        # legal representative. Values are fictitious.
+        cls.mocked_response_cpfcnpj_qsa = {
+            "status": 1,
+            "cnpj": "13347016000117",
+            "cnpj_raiz": "13347016",
+            "tipo": "Matriz",
+            "razao": "Empresa Exemplo Comercio e Servicos Ltda",
+            "fantasia": "Exemplo Servicos",
+            "capitalSocial": 3631639.0,
+            "inicioAtividade": "14/02/2011",
+            "email": "contato@exemplo.com.br",
+            "responsavel": None,
+            "responsavelCpf": None,
+            "responsavelQualificacao": {"id": 16, "descricao": "Presidente"},
+            "responsavelFederativo": None,
+            "simplesNacional": {
+                "optante": "Nao",
+                "inicio": None,
+                "fim": None,
+                "anteriores": [],
+                "mei": "Nao",
+                "data_opcao_mei": None,
+                "data_exclusao_mei": None,
+                "atualizado_em": None,
+            },
+            "matrizEndereco": {
+                "cep": "01310100",
+                "tipo": "Avenida",
+                "logradouro": "das Nacoes",
+                "numero": "1000",
+                "complemento": "Sala 12",
+                "bairro": "Centro",
+                "cidade": "Sao Paulo",
+                "uf": "SP",
+            },
+            "ibge": {
+                "pais": {
+                    "id": "1058",
+                    "iso2": "BR",
+                    "iso3": "BRA",
+                    "nome": "Brasil",
+                    "comex_id": "105",
+                },
+                "estado": {"id": 26, "nome": "Sao Paulo", "sigla": "SP", "ibge_id": 35},
+                "cidade": {
+                    "id": 9668,
+                    "nome": "Sao Paulo",
+                    "ibge_id": 3550308,
+                    "siafi_id": "7107",
+                },
+            },
+            "matrizfilial": {"id": 1, "tipo": "Matriz"},
+            "telefones": [{"ddd": "11", "numero": "40041005"}],
+            "fax": {"ddd": None, "numero": None},
+            "situacao": {"id": 2, "nome": "Ativa", "data": "14/02/2011", "motivo": []},
+            "naturezaJuridica": {
+                "codigo": "2062",
+                "descricao": "Sociedade Empresaria Limitada",
+            },
+            "cnae": {
+                "fiscal": "7312200",
+                "secao": "M",
+                "divisao": "73",
+                "grupo": "731",
+                "classe": "73122",
+                "subClasse": "7312200",
+                "descricao": "Agenciamento de espacos para publicidade",
+                "secundarias": [
+                    {
+                        "id": 7311400,
+                        "descricao": "Servicos de publicidade",
+                        "secao": "M",
+                        "divisao": "73",
+                        "grupo": "731",
+                        "classe": "73114",
+                        "subclasse": "7311400",
+                    }
+                ],
+            },
+            "porte": {"id": "05", "descricao": "Demais"},
+            "regimesTributarios": [
+                {
+                    "ano": 2023,
+                    "regime_tributario": "LUCRO PRESUMIDO",
+                    "forma_de_tributacao": "Normal",
+                    "atualizado_em": "2024-09-01T03:00:00.000Z",
+                }
+            ],
+            "comprovantePdfBase64": _PDF_MINIMO_B64,
+            "dispensa": {
+                "estabelecimento": None,
+                "uf_municipio": None,
+                "condicoes": [],
+            },
+            "socios": [
+                {
+                    "cpf_cnpj_socio": "111.444.777-35",
+                    "nome": "Maria Socia Exemplo",
+                    "tipo": "Pessoa Fisica",
+                    "data_entrada": "14/02/2011",
+                    "cpf_representante_legal": None,
+                    "nome_representante": None,
+                    "faixa_etaria": "41 a 50 anos",
+                    "atualizado_em": "2024-09-01T03:00:00.000Z",
+                    "pais_id": "1058",
+                    "qualificacao_socio": {"id": 49, "descricao": "Administrador"},
+                    "qualificacao_representante": None,
+                    "pais": {"id": "1058", "nome": "Brasil"},
+                },
+                {
+                    "cpf_cnpj_socio": "12345678",
+                    "nome": "Exemplo Holdings LLC",
+                    "tipo": "Pessoa Juridica",
+                    "data_entrada": "14/02/2011",
+                    "cpf_representante_legal": "222.555.888-46",
+                    "nome_representante": "Joao Representante Exemplo",
+                    "faixa_etaria": None,
+                    "atualizado_em": "2024-09-01T03:00:00.000Z",
+                    "pais_id": "249",
+                    "qualificacao_socio": {
+                        "id": 37,
+                        "descricao": "Socio Pessoa Juridica Domiciliado no Exterior",
+                    },
+                    "qualificacao_representante": "Representante",
+                    "pais": {"id": "249", "nome": "ESTADOS UNIDOS"},
+                },
+                {
+                    "cpf_cnpj_socio": "333.666.999-57",
+                    "nome": "Carlos Socio Exemplo",
+                    "tipo": "Pessoa Fisica",
+                    "data_entrada": "14/02/2011",
+                    "cpf_representante_legal": None,
+                    "nome_representante": None,
+                    "faixa_etaria": "51 a 60 anos",
+                    "atualizado_em": "2024-09-01T03:00:00.000Z",
+                    "pais_id": "1058",
+                    "qualificacao_socio": {"id": 49, "descricao": "Administrador"},
+                    "qualificacao_representante": None,
+                    "pais": {"id": "1058", "nome": "Brasil"},
+                },
+            ],
+            "filiais": [
+                {
+                    "cnpj": "13347016000200",
+                    "tipo": "Filial",
+                    "nome_fantasia": None,
+                    "situacao_cadastral": "Ativa",
+                    "data_inicio_atividade": "10/03/2015",
+                }
+            ],
+            "qsaObservacao": None,
+            "pacoteUsado": 6,
+            "saldo": 100.0,
+            "consultaID": "0000000000000000000000000000000a",
+            "delay": 0.42,
+        }
+
+        # cpfcnpj.com.br - package 6 payload of a closed company, with a status
+        # reason and status date.
+        cls.mocked_response_cpfcnpj_baixada = {
+            "status": 1,
+            "cnpj": "47427653007390",
+            "cnpj_raiz": "47427653",
+            "tipo": "Matriz",
+            "razao": "Empresa Encerrada Exemplo S.A.",
+            "fantasia": None,
+            "capitalSocial": 500000.0,
+            "inicioAtividade": "25/10/2006",
+            "email": "financeiro@encerrada-exemplo.com.br",
+            "responsavel": None,
+            "responsavelCpf": None,
+            "responsavelQualificacao": {"id": 10, "descricao": "Diretor"},
+            "responsavelFederativo": None,
+            "simplesNacional": {
+                "optante": "Nao",
+                "inicio": None,
+                "fim": None,
+                "anteriores": [],
+                "mei": "Nao",
+                "data_opcao_mei": None,
+                "data_exclusao_mei": None,
+                "atualizado_em": None,
+            },
+            "matrizEndereco": {
+                "cep": "20040002",
+                "tipo": "Rua",
+                "logradouro": "do Comercio",
+                "numero": "200",
+                "complemento": None,
+                "bairro": "Centro",
+                "cidade": "Rio de Janeiro",
+                "uf": "RJ",
+            },
+            "ibge": {
+                "estado": {"id": 19, "nome": "Rio de Janeiro", "sigla": "RJ"},
+                "cidade": {"nome": "Rio de Janeiro", "ibge_id": 3304557},
+            },
+            "matrizfilial": {"id": 1, "tipo": "Matriz"},
+            "telefones": [{"ddd": "21", "numero": "30030003"}],
+            "fax": {"ddd": None, "numero": None},
+            "situacao": {
+                "id": 8,
+                "nome": "Baixada",
+                "data": "01/03/2021",
+                "motivo": ["Extincao Por Encerramento Liquidacao Voluntaria"],
+            },
+            "naturezaJuridica": {
+                "codigo": "2054",
+                "descricao": "Sociedade Anonima Fechada",
+            },
+            "cnae": {
+                "fiscal": "4693100",
+                "descricao": "Comercio atacadista de mercadorias em geral",
+                "secundarias": [],
+            },
+            "porte": {"id": "05", "descricao": "Demais"},
+            "regimesTributarios": [],
+            "comprovantePdfBase64": _PDF_MINIMO_B64,
+            "dispensa": {
+                "estabelecimento": None,
+                "uf_municipio": None,
+                "condicoes": [],
+            },
+            "socios": [
+                {
+                    "cpf_cnpj_socio": "123.456.780-62",
+                    "nome": "Ana Diretora Exemplo",
+                    "tipo": "Pessoa Fisica",
+                    "data_entrada": "25/10/2006",
+                    "cpf_representante_legal": None,
+                    "nome_representante": None,
+                    "faixa_etaria": "61 a 70 anos",
+                    "atualizado_em": "2021-03-01T03:00:00.000Z",
+                    "pais_id": "1058",
+                    "qualificacao_socio": {"id": 10, "descricao": "Diretor"},
+                    "qualificacao_representante": None,
+                    "pais": {"id": "1058", "nome": "Brasil"},
+                }
+            ],
+            "filiais": [],
+            "qsaObservacao": None,
+            "pacoteUsado": 6,
+            "saldo": 100.0,
+            "consultaID": "0000000000000000000000000000000b",
+            "delay": 0.31,
+        }
+
+        # cpfcnpj.com.br - package 6 payload of a branch establishment, in the
+        # short form (no cnpj_raiz, no filiais).
+        cls.mocked_response_cpfcnpj_filial = {
+            "status": 1,
+            "cnpj": "48412392000203",
+            "tipo": "Filial",
+            "razao": "Empresa Exemplo Unidade Filial Ltda",
+            "fantasia": "Exemplo Filial",
+            "capitalSocial": 150000.0,
+            "inicioAtividade": "02/09/2020",
+            "email": "filial@exemplo.com.br",
+            "responsavel": None,
+            "responsavelCpf": None,
+            "responsavelQualificacao": None,
+            "responsavelFederativo": "",
+            "simplesNacional": {"optante": "Nao", "inicio": None, "fim": None},
+            "matrizEndereco": {
+                "cep": "30140071",
+                "tipo": "Rua",
+                "logradouro": "dos Andradas",
+                "numero": "50",
+                "complemento": "Loja 2",
+                "bairro": "Centro",
+                "cidade": "Belo Horizonte",
+                "uf": "MG",
+            },
+            "ibge": {
+                "pais": {"id": "1058", "iso2": "BR", "iso3": "BRA", "nome": "Brasil"},
+                "estado": {"sigla": "MG"},
+                "cidade": {"nome": "Belo Horizonte"},
+            },
+            "matrizfilial": {"id": 2, "tipo": "Filial"},
+            "telefones": [{"ddd": "31", "numero": "40421005"}],
+            "fax": {"ddd": None, "numero": None},
+            "situacao": {"id": 2, "nome": "Ativa", "data": "02/09/2020", "motivo": []},
+            "naturezaJuridica": {
+                "codigo": "2062",
+                "descricao": "Sociedade Empresaria Limitada",
+            },
+            "cnae": {
+                "fiscal": "9313100",
+                "secao": None,
+                "divisao": None,
+                "grupo": None,
+                "classe": None,
+                "subClasse": None,
+                "descricao": "Atividades de condicionamento fisico",
+                "secundarias": [],
+            },
+            "porte": {"id": "", "descricao": "Micro Empresa"},
+            "regimesTributarios": [],
+            "comprovantePdfBase64": _PDF_MINIMO_B64,
+            "dispensa": {
+                "estabelecimento": None,
+                "uf_municipio": None,
+                "condicoes": [],
+            },
+            "socios": [
+                {
+                    "cpf_cnpj_socio": None,
+                    "nome": "Maria Socia Exemplo",
+                    "tipo": "Pessoa Fisica",
+                    "data_entrada": None,
+                    "cpf_representante_legal": None,
+                    "nome_representante": None,
+                    "faixa_etaria": None,
+                    "atualizado_em": None,
+                    "pais_id": None,
+                    "qualificacao_socio": {
+                        "id": 49,
+                        "descricao": "Socio-Administrador",
+                    },
+                    "qualificacao_representante": None,
+                    "pais": {"nome": "Brasil"},
+                }
+            ],
+            "qsaObservacao": None,
+            "pacoteUsado": 6,
+            "saldo": 100.0,
+            "consultaID": "0000000000000000000000000000000c",
+            "delay": 0.28,
+        }
+
+        # cpfcnpj.com.br - package 16 payload (state registration): one active
+        # (SP) and one inactive (MG).
+        cls.mocked_response_cpfcnpj_ie = {
+            "status": 1,
+            "cnpj": "13347016000117",
+            "razao": "Empresa Exemplo Comercio e Servicos Ltda",
+            "inscricoesEstaduais": [
+                {
+                    "inscricao_estadual": "123456789",
+                    "ativo": True,
+                    "atualizado_em": "2026-09-05T00:00:00.000Z",
+                    "estado": {
+                        "id": 26,
+                        "nome": "Sao Paulo",
+                        "sigla": "SP",
+                        "ibge_id": 35,
+                    },
+                },
+                {
+                    "inscricao_estadual": "0987654321012",
+                    "ativo": False,
+                    "atualizado_em": "2025-11-02T04:44:52.850Z",
+                    "estado": {
+                        "id": 11,
+                        "nome": "Minas Gerais",
+                        "sigla": "MG",
+                        "ibge_id": 31,
+                    },
+                },
+            ],
+            "pacoteUsado": 16,
+            "saldo": 100.0,
+            "consultaID": "0000000000000000000000000000000d",
+            "delay": 0.30,
+        }
+
+        # cpfcnpj.com.br - error payload (HTTP 400) for an invalid CNPJ.
+        cls.mocked_response_cpfcnpj_erro = {
+            "status": 0,
+            "cnpj": "",
+            "razao": "",
+            "erro": "CNPJ invalido!",
+            "pacoteUsado": 6,
+            "erroCodigo": 200,
         }
 
     @classmethod

--- a/l10n_br_cnpj_search/tests/test_cpfcnpj.py
+++ b/l10n_br_cnpj_search/tests/test_cpfcnpj.py
@@ -1,0 +1,491 @@
+# Copyright 2015-2026 CPF.CNPJ | ALAS Tecnologia LTDA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+from datetime import date
+from unittest import mock
+
+import requests
+from erpbrasil.base.misc import punctuation_rm
+
+from odoo import Command
+from odoo.exceptions import UserError, ValidationError
+from odoo.tests import tagged
+from odoo.tools import mute_logger
+
+from odoo.addons.l10n_br_fiscal.constants.fiscal import TAX_FRAMEWORK_NORMAL
+
+from .common import MOCK_REQUESTS_GET, TestCnpjCommon
+
+_logger = logging.getLogger(__name__)
+
+MOCK_VALIDATE = (
+    "odoo.addons.l10n_br_cnpj_search.models.cnpj_webservice.CNPJWebservice.validate"
+)
+
+
+@tagged("post_install", "-at_install")
+class TestCpfCnpj(TestCnpjCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.set_param("cnpj_provider", "cpfcnpj")
+        cls.set_param("cpfcnpj_token", "dummy-token")
+        cls.set_param("cpfcnpj_package", "6")
+
+    def _run_wizard(self, partner):
+        action_wizard = partner.action_open_cnpj_search_wizard()
+        wizard_context = action_wizard.get("context")
+        wizard_context["active_model"] = "res.partner"
+        wizard = (
+            self.env["partner.search.wizard"].with_context(**wizard_context).create({})
+        )
+        wizard.action_update_partner()
+
+    def test_cpfcnpj_simples(self):
+        """A Simples Nacional company must fill tax_framework as Simples."""
+        with (
+            mock.patch(MOCK_REQUESTS_GET, return_value=mock.Mock(status_code=200)),
+            mock.patch(
+                MOCK_VALIDATE, return_value=self.mocked_response_cpfcnpj_simples
+            ),
+        ):
+            partner = self.model.create(
+                {"name": "Dummy Simples", "vat": "34.238.864/0001-68"}
+            )
+            partner._onchange_vat()
+            self._run_wizard(partner)
+
+        self.assertEqual(partner.company_type, "company")
+        self.assertEqual(partner.legal_name, "Token Test Ltda")
+        self.assertEqual(partner.name, "Token Test")
+        self.assertEqual(partner.email, "contato@empresa.com")
+        self.assertEqual(partner.street_name, "Rua A")
+        self.assertEqual(partner.street_number, "1")
+        self.assertEqual(partner.street2, "Sala 1")
+        self.assertEqual(partner.district, "Centro")
+        self.assertEqual(partner.phone, "(11) 22334454")
+        self.assertEqual(partner.mobile, "(11) 22334455")
+        self.assertEqual(partner.state_id.code, "MG")
+        self.assertEqual(partner.equity_capital, 95000)
+        self.assertEqual(partner.cnae_main_id.code, "6202-3/00")
+        # Differential: no other provider fills tax_framework today.
+        self.assertEqual(partner.tax_framework, "1")
+
+    def test_cpfcnpj_mei(self):
+        """An MEI company must fill tax_framework as MEI."""
+        with (
+            mock.patch(MOCK_REQUESTS_GET, return_value=mock.Mock(status_code=200)),
+            mock.patch(MOCK_VALIDATE, return_value=self.mocked_response_cpfcnpj_mei),
+        ):
+            partner = self.model.create(
+                {"name": "Dummy MEI", "vat": "44.356.113/0001-08"}
+            )
+            partner._onchange_vat()
+            self._run_wizard(partner)
+
+        self.assertEqual(partner.company_type, "company")
+        self.assertEqual(partner.legal_name, "Joao Da Silva 12345678900")
+        # No fantasy name, so name falls back to the legal name.
+        self.assertEqual(partner.name, "Joao Da Silva 12345678900")
+        self.assertEqual(partner.state_id.code, "MG")
+        self.assertEqual(partner.tax_framework, "4")
+
+    def test_cpfcnpj_regime_normal(self):
+        """A company that is neither Simples nor SIMEI must fill tax_framework
+        as Regime Normal. This payload also has no IBGE code (city resolved by
+        name) and no phone numbers.
+        """
+        with (
+            mock.patch(MOCK_REQUESTS_GET, return_value=mock.Mock(status_code=200)),
+            mock.patch(MOCK_VALIDATE, return_value=self.mocked_response_cpfcnpj_normal),
+        ):
+            partner = self.model.create(
+                {"name": "Dummy Normal", "vat": "34.238.864/0001-68"}
+            )
+            partner._onchange_vat()
+            self._run_wizard(partner)
+
+        self.assertEqual(partner.legal_name, "Regime Normal Ltda")
+        self.assertEqual(partner.state_id.code, "MG")
+        self.assertFalse(partner.phone)
+        self.assertFalse(partner.mobile)
+        self.assertEqual(partner.tax_framework, TAX_FRAMEWORK_NORMAL)
+
+    def test_cpfcnpj_package_5(self):
+        """A package 5 payload has no tax regime data, so tax_framework must be
+        left untouched.
+        """
+        with (
+            mock.patch(MOCK_REQUESTS_GET, return_value=mock.Mock(status_code=200)),
+            mock.patch(
+                MOCK_VALIDATE, return_value=self.mocked_response_cpfcnpj_package5
+            ),
+        ):
+            partner = self.model.create(
+                {"name": "Dummy Package 5", "vat": "34.238.864/0001-68"}
+            )
+            tax_framework_before = partner.tax_framework
+            partner._onchange_vat()
+            self._run_wizard(partner)
+
+        self.assertEqual(partner.legal_name, "Pacote Cinco Ltda")
+        self.assertEqual(partner.tax_framework, tax_framework_before)
+
+    @property
+    def _webservice(self):
+        return self.env["l10n_br_cnpj_search.webservice.abstract"]
+
+    def test_cpfcnpj_api_url_default_package(self):
+        """Without an explicit package the default (6) is used in the URL."""
+        self.set_param("cpfcnpj_package", "")
+        url = self._webservice.cpfcnpj_get_api_url("12345678000199")
+        self.assertTrue(url.endswith("/6/12345678000199"))
+
+    def test_cpfcnpj_state_city_without_uf(self):
+        """With no UF and no IBGE code, state and city stay empty."""
+        state_id, city_id = self._webservice._cpfcnpj_get_state_city({}, {})
+        self.assertFalse(state_id)
+        self.assertFalse(city_id)
+
+    def test_cpfcnpj_state_city_without_city_name(self):
+        """With a UF but no IBGE code and no city name, only the state resolves."""
+        state_id, city_id = self._webservice._cpfcnpj_get_state_city({}, {"uf": "MG"})
+        self.assertTrue(state_id)
+        self.assertFalse(city_id)
+
+    def test_cpfcnpj_phones_missing_fields(self):
+        """Items missing ddd or numero are skipped instead of producing
+        "(None) None"; the first complete item goes to phone.
+        """
+        phone, mobile = self._webservice._cpfcnpj_get_phones(
+            {
+                "telefones": [
+                    {"ddd": None, "numero": "22334454"},
+                    {"ddd": "11", "numero": None},
+                    {"numero": "22334455"},
+                    {"ddd": "11", "numero": "22334456"},
+                ]
+            }
+        )
+        self.assertEqual(phone, "(11) 22334456")
+        self.assertFalse(mobile)
+
+    def test_cpfcnpj_phones_all_incomplete(self):
+        """When no item is complete, phone and mobile stay False."""
+        phone, mobile = self._webservice._cpfcnpj_get_phones(
+            {"telefones": [{"ddd": None, "numero": None}, {}, "invalid"]}
+        )
+        self.assertFalse(phone)
+        self.assertFalse(mobile)
+
+    def test_cpfcnpj_phones_without_list(self):
+        """A payload without telefones (or with null) yields False for both."""
+        self.assertEqual(self._webservice._cpfcnpj_get_phones({}), (False, False))
+        self.assertEqual(
+            self._webservice._cpfcnpj_get_phones({"telefones": None}), (False, False)
+        )
+
+    def test_cpfcnpj_secondary_cnae_unresolved(self):
+        """A secondary CNAE that does not resolve is skipped."""
+        result = self._webservice._cpfcnpj_get_secondary_cnae(
+            {"cnae": {"secundarias": [{"id": "0000000"}]}}
+        )
+        self.assertEqual(result, [Command.set([])])
+
+    def test_cpfcnpj_validate_error_without_message(self):
+        """A status 0 without an error message still raises ValidationError."""
+        response = mock.Mock(status_code=200)
+        response.json.return_value = {"status": 0}
+        with self.assertRaises(ValidationError):
+            self._webservice.cpfcnpj_validate(response)
+
+    def test_cpfcnpj_invalid(self):
+        """An error payload (status 0) must raise a ValidationError."""
+        with (
+            mock.patch(
+                MOCK_REQUESTS_GET,
+                return_value=mock.Mock(
+                    status_code=200,
+                    **{
+                        "json.return_value": {
+                            "status": 0,
+                            "erro": "CNPJ inválido!",
+                            "erroCodigo": 100,
+                        }
+                    },
+                ),
+            ),
+            self.assertRaises(ValidationError),
+        ):
+            invalid = self.model.create(
+                {"name": "invalid", "vat": "00.000.000/0000-00"}
+            )
+            invalid._onchange_vat()
+            action_wizard = invalid.action_open_cnpj_search_wizard()
+            wizard_context = action_wizard.get("context")
+            wizard_context["active_model"] = "res.partner"
+            self.env["partner.search.wizard"].with_context(**wizard_context).create({})
+
+    @mute_logger("odoo.addons.l10n_br_cnpj_search.wizard.partner_cnpj_search_wizard")
+    def test_cpfcnpj_timeout(self):
+        """A request timeout must raise a friendly UserError."""
+        with (
+            mock.patch(MOCK_REQUESTS_GET, side_effect=requests.exceptions.Timeout),
+            self.assertRaises(UserError),
+        ):
+            partner = self.model.create(
+                {"name": "Dummy Timeout", "vat": "34.238.864/0001-68"}
+            )
+            partner._onchange_vat()
+            action_wizard = partner.action_open_cnpj_search_wizard()
+            wizard_context = action_wizard.get("context")
+            wizard_context["active_model"] = "res.partner"
+            self.env["partner.search.wizard"].with_context(**wizard_context).create({})
+
+    def _card_attachments(self, partner, cnpj_digits):
+        return self.env["ir.attachment"].search(
+            [
+                ("res_model", "=", "res.partner"),
+                ("res_id", "=", partner.id),
+                ("name", "=", f"Cartao_CNPJ_{cnpj_digits}.pdf"),
+            ]
+        )
+
+    def test_cpfcnpj_qsa_creates_children(self):
+        """The QSA import creates one child partner per socio, with the right
+        function and vat. A company partner identified only by its 8 digit CNPJ
+        root gets no vat.
+        """
+        with (
+            mock.patch(MOCK_REQUESTS_GET, return_value=mock.Mock(status_code=200)),
+            mock.patch(MOCK_VALIDATE, return_value=self.mocked_response_cpfcnpj_qsa),
+        ):
+            partner = self.model.create(
+                {"name": "Dummy QSA", "vat": "13.347.016/0001-17"}
+            )
+            partner._onchange_vat()
+            self._run_wizard(partner)
+
+        children = partner.child_ids
+        self.assertEqual(len(children), 3)
+
+        maria = children.filtered(lambda c: c.name == "Maria Socia Exemplo")
+        carlos = children.filtered(lambda c: c.name == "Carlos Socio Exemplo")
+        holdings = children.filtered(lambda c: c.name == "Exemplo Holdings Llc")
+        self.assertTrue(maria)
+        self.assertTrue(carlos)
+        self.assertTrue(holdings)
+
+        self.assertEqual(maria.function, "Administrador")
+        self.assertEqual(maria.company_type, "person")
+        self.assertEqual(punctuation_rm(maria.vat or ""), "11144477735")
+        self.assertEqual(punctuation_rm(carlos.vat or ""), "33366699957")
+
+        # Company partner: only the 8 digit CNPJ root, so no vat, typed company.
+        self.assertEqual(holdings.company_type, "company")
+        self.assertFalse(holdings.vat)
+
+    def test_cpfcnpj_qsa_rerun_reuses_partners(self):
+        """Running the wizard again for the same company must not duplicate
+        the QSA partners: the ones with a vat are found by vat and the one
+        without a vat is found by name among the current children.
+        """
+        with (
+            mock.patch(MOCK_REQUESTS_GET, return_value=mock.Mock(status_code=200)),
+            mock.patch(MOCK_VALIDATE, return_value=self.mocked_response_cpfcnpj_qsa),
+        ):
+            partner = self.model.create(
+                {"name": "Dummy QSA Rerun", "vat": "13.347.016/0001-17"}
+            )
+            partner._onchange_vat()
+            self._run_wizard(partner)
+            first_ids = set(partner.child_ids.ids)
+            self._run_wizard(partner)
+
+        self.assertEqual(len(partner.child_ids), 3)
+        self.assertEqual(set(partner.child_ids.ids), first_ids)
+        self.assertEqual(
+            self.model.search_count([("name", "=", "Maria Socia Exemplo")]), 1
+        )
+        self.assertEqual(
+            self.model.search_count([("name", "=", "Exemplo Holdings Llc")]), 1
+        )
+
+    def test_cpfcnpj_qsa_skips_contact_of_other_company(self):
+        """A QSA entry whose CPF already belongs to a contact of another
+        company is skipped instead of being moved.
+        """
+        other = self.model.create({"name": "Outra Empresa", "company_type": "company"})
+        self.model.create(
+            {
+                "name": "Maria Socia Exemplo",
+                "vat": "11144477735",
+                "company_type": "person",
+                "parent_id": other.id,
+            }
+        )
+        with (
+            mock.patch(MOCK_REQUESTS_GET, return_value=mock.Mock(status_code=200)),
+            mock.patch(MOCK_VALIDATE, return_value=self.mocked_response_cpfcnpj_qsa),
+        ):
+            partner = self.model.create(
+                {"name": "Dummy QSA Skip", "vat": "13.347.016/0001-17"}
+            )
+            partner._onchange_vat()
+            self._run_wizard(partner)
+
+        self.assertEqual(len(partner.child_ids), 2)
+        self.assertNotIn("Maria Socia Exemplo", partner.child_ids.mapped("name"))
+        self.assertEqual(other.child_ids.mapped("name"), ["Maria Socia Exemplo"])
+
+    def test_cpfcnpj_qsa_disabled(self):
+        """With cpfcnpj_skip_partners enabled, no child partner is created."""
+        self.set_param("cpfcnpj_skip_partners", "True")
+        with (
+            mock.patch(MOCK_REQUESTS_GET, return_value=mock.Mock(status_code=200)),
+            mock.patch(MOCK_VALIDATE, return_value=self.mocked_response_cpfcnpj_qsa),
+        ):
+            partner = self.model.create(
+                {"name": "Dummy QSA Off", "vat": "13.347.016/0001-17"}
+            )
+            partner._onchange_vat()
+            self._run_wizard(partner)
+
+        self.assertFalse(partner.child_ids)
+
+    def test_cpfcnpj_card_attachment(self):
+        """The CNPJ card PDF is stored as a pdf attachment on the partner and a
+        second run replaces it instead of duplicating.
+        """
+        with (
+            mock.patch(MOCK_REQUESTS_GET, return_value=mock.Mock(status_code=200)),
+            mock.patch(MOCK_VALIDATE, return_value=self.mocked_response_cpfcnpj_qsa),
+        ):
+            partner = self.model.create(
+                {"name": "Dummy Card", "vat": "13.347.016/0001-17"}
+            )
+            partner._onchange_vat()
+            self._run_wizard(partner)
+
+        attachments = self._card_attachments(partner, "13347016000117")
+        self.assertEqual(len(attachments), 1)
+        self.assertEqual(attachments.mimetype, "application/pdf")
+
+        with (
+            mock.patch(MOCK_REQUESTS_GET, return_value=mock.Mock(status_code=200)),
+            mock.patch(MOCK_VALIDATE, return_value=self.mocked_response_cpfcnpj_qsa),
+        ):
+            self._run_wizard(partner)
+
+        self.assertEqual(len(self._card_attachments(partner, "13347016000117")), 1)
+
+    def test_cpfcnpj_card_disabled(self):
+        """With cpfcnpj_skip_card enabled, no card attachment is created."""
+        self.set_param("cpfcnpj_skip_card", "True")
+        with (
+            mock.patch(MOCK_REQUESTS_GET, return_value=mock.Mock(status_code=200)),
+            mock.patch(MOCK_VALIDATE, return_value=self.mocked_response_cpfcnpj_qsa),
+        ):
+            partner = self.model.create(
+                {"name": "Dummy Card Off", "vat": "13.347.016/0001-17"}
+            )
+            partner._onchange_vat()
+            self._run_wizard(partner)
+
+        self.assertFalse(self._card_attachments(partner, "13347016000117"))
+
+    def test_cpfcnpj_status_baixada(self):
+        """A closed company fills the registration status, date and reason."""
+        with (
+            mock.patch(MOCK_REQUESTS_GET, return_value=mock.Mock(status_code=200)),
+            mock.patch(
+                MOCK_VALIDATE, return_value=self.mocked_response_cpfcnpj_baixada
+            ),
+        ):
+            partner = self.model.create(
+                {"name": "Dummy Baixada", "vat": "47.427.653/0073-90"}
+            )
+            partner._onchange_vat()
+            self._run_wizard(partner)
+
+        self.assertEqual(partner.cnpj_status, "Baixada")
+        self.assertEqual(partner.cnpj_status_date, date(2021, 3, 1))
+        self.assertEqual(
+            partner.cnpj_status_reason,
+            "Extincao Por Encerramento Liquidacao Voluntaria",
+        )
+        self.assertEqual(partner.opening_date, date(2006, 10, 25))
+        self.assertEqual(partner.company_size, "Demais")
+        self.assertEqual(partner.cnpj_branch_type, "head_office")
+
+    def test_cpfcnpj_branch_filial(self):
+        """A branch establishment fills cnpj_branch_type as branch."""
+        with (
+            mock.patch(MOCK_REQUESTS_GET, return_value=mock.Mock(status_code=200)),
+            mock.patch(MOCK_VALIDATE, return_value=self.mocked_response_cpfcnpj_filial),
+        ):
+            partner = self.model.create(
+                {"name": "Dummy Filial", "vat": "48.412.392/0002-03"}
+            )
+            partner._onchange_vat()
+            self._run_wizard(partner)
+
+        self.assertEqual(partner.cnpj_branch_type, "branch")
+        self.assertEqual(partner.company_size, "Micro Empresa")
+
+    def test_cpfcnpj_ie_second_call(self):
+        """With cpfcnpj_fetch_ie enabled a second request (package 16) fills
+        l10n_br_ie_code with the active registration of the establishment UF.
+        """
+        self.set_param("cpfcnpj_fetch_ie", "1")
+        # Isolate the feature under test from l10n_br_base IE format validation.
+        self.env["ir.config_parameter"].sudo().set_param(
+            "l10n_br_base.disable_ie_validation", "True"
+        )
+        main_response = mock.Mock(status_code=200)
+        ie_response = mock.Mock(status_code=200)
+        ie_response.json.return_value = self.mocked_response_cpfcnpj_ie
+        with (
+            mock.patch(MOCK_REQUESTS_GET, side_effect=[main_response, ie_response]),
+            mock.patch(MOCK_VALIDATE, return_value=self.mocked_response_cpfcnpj_qsa),
+        ):
+            partner = self.model.create(
+                {"name": "Dummy IE", "vat": "13.347.016/0001-17"}
+            )
+            partner._onchange_vat()
+            self._run_wizard(partner)
+
+        self.assertEqual(punctuation_rm(partner.l10n_br_ie_code or ""), "123456789")
+
+    @mute_logger("odoo.addons.l10n_br_cnpj_search.wizard.partner_cnpj_search_wizard")
+    def test_cpfcnpj_ie_second_call_failure(self):
+        """A failure on the state registration request must not break the main
+        lookup; l10n_br_ie_code simply stays empty.
+        """
+        self.set_param("cpfcnpj_fetch_ie", "1")
+        main_response = mock.Mock(status_code=200)
+        with (
+            mock.patch(
+                MOCK_REQUESTS_GET,
+                side_effect=[main_response, requests.exceptions.ConnectionError()],
+            ),
+            mock.patch(MOCK_VALIDATE, return_value=self.mocked_response_cpfcnpj_qsa),
+        ):
+            partner = self.model.create(
+                {"name": "Dummy IE Fail", "vat": "13.347.016/0001-17"}
+            )
+            partner._onchange_vat()
+            self._run_wizard(partner)
+
+        self.assertFalse(partner.l10n_br_ie_code)
+
+    def test_cpfcnpj_parse_date(self):
+        """The date helper accepts both provider formats and rejects garbage."""
+        parse = self._webservice._cpfcnpj_parse_date
+        self.assertEqual(parse("2020-01-17"), date(2020, 1, 17))
+        self.assertEqual(parse("17/01/2020"), date(2020, 1, 17))
+        self.assertFalse(parse("not-a-date"))
+        self.assertFalse(parse("31/02/2020"))
+        self.assertFalse(parse(None))
+        self.assertFalse(parse(""))

--- a/l10n_br_cnpj_search/views/res_config_settings_view.xml
+++ b/l10n_br_cnpj_search/views/res_config_settings_view.xml
@@ -56,6 +56,48 @@
                                 required="cnpj_provider == 'serpro'"
                             />
                         </div>
+                        <div
+                            class="content-group mt16"
+                            invisible="cnpj_provider != 'cpfcnpj'"
+                        >
+                            <label for="cpfcnpj_token" class="o_light_label" />
+                            <field
+                                name="cpfcnpj_token"
+                                required="cnpj_provider == 'cpfcnpj'"
+                                widget="password"
+                            />
+                        </div>
+                        <div
+                            class="content-group mt16"
+                            invisible="cnpj_provider != 'cpfcnpj'"
+                        >
+                            <label for="cpfcnpj_package" class="o_light_label" />
+                            <field
+                                name="cpfcnpj_package"
+                                required="cnpj_provider == 'cpfcnpj'"
+                            />
+                        </div>
+                        <div
+                            class="content-group mt16"
+                            invisible="cnpj_provider != 'cpfcnpj'"
+                        >
+                            <field name="cpfcnpj_skip_partners" />
+                            <label for="cpfcnpj_skip_partners" class="o_light_label" />
+                        </div>
+                        <div
+                            class="content-group mt16"
+                            invisible="cnpj_provider != 'cpfcnpj'"
+                        >
+                            <field name="cpfcnpj_skip_card" />
+                            <label for="cpfcnpj_skip_card" class="o_light_label" />
+                        </div>
+                        <div
+                            class="content-group mt16"
+                            invisible="cnpj_provider != 'cpfcnpj'"
+                        >
+                            <field name="cpfcnpj_fetch_ie" />
+                            <label for="cpfcnpj_fetch_ie" class="o_light_label" />
+                        </div>
                     </div>
                 </div>
             </xpath>

--- a/l10n_br_cnpj_search/views/res_partner_view.xml
+++ b/l10n_br_cnpj_search/views/res_partner_view.xml
@@ -10,6 +10,15 @@
         <field name="arch" type="xml">
             <field name="cnae_secondary_ids" position="after">
                 <field name="equity_capital" widget="monetary" />
+                <field name="company_size" readonly="False" />
+                <field name="cnpj_status" readonly="False" />
+                <field name="cnpj_status_date" readonly="False" />
+                <field name="cnpj_status_reason" readonly="False" />
+                <field name="opening_date" readonly="False" />
+                <field name="cnpj_branch_type" readonly="False" />
+                <field name="simples_option_date" readonly="False" />
+                <field name="legal_responsible_name" readonly="False" />
+                <field name="legal_responsible_function" readonly="False" />
             </field>
             <field name="vat" position="replace">
                 <div class="o_row" colspan="4">

--- a/l10n_br_cnpj_search/wizard/partner_cnpj_search_wizard.py
+++ b/l10n_br_cnpj_search/wizard/partner_cnpj_search_wizard.py
@@ -11,6 +11,10 @@ from erpbrasil.base.misc import punctuation_rm
 from odoo import Command, api, fields, models
 from odoo.exceptions import UserError
 
+from odoo.addons.l10n_br_fiscal.constants.fiscal import TAX_FRAMEWORK
+
+from ..models.l10n_br_base_party_mixin import CNPJ_BRANCH_TYPE_SELECTION
+
 _logger = logging.getLogger(__name__)
 # This is the original 'send' method from the requests library that
 # Odoo's test suite patches over.
@@ -48,6 +52,7 @@ class PartnerCnpjSearchWizard(models.TransientModel):
     )
     equity_capital = fields.Monetary(currency_field="currency_id")
     cnae_main_id = fields.Many2one(comodel_name="l10n_br_fiscal.cnae")
+    tax_framework = fields.Selection(selection=TAX_FRAMEWORK)
     cnae_secondary_ids = fields.Many2many(
         comodel_name="l10n_br_fiscal.cnae",
         relation="wizard_fiscal_cnae_rel",
@@ -60,6 +65,16 @@ class PartnerCnpjSearchWizard(models.TransientModel):
         column1="parent_id",
         column2="wizard_id",
     )
+    company_size = fields.Char()
+    cnpj_status = fields.Char()
+    cnpj_status_date = fields.Date()
+    cnpj_status_reason = fields.Char()
+    opening_date = fields.Date()
+    cnpj_branch_type = fields.Selection(selection=CNPJ_BRANCH_TYPE_SELECTION)
+    simples_option_date = fields.Date()
+    legal_responsible_name = fields.Char()
+    legal_responsible_function = fields.Char()
+    cnpj_card_pdf = fields.Binary(attachment=False)
 
     @api.onchange("zip")
     def _onchange_zip(self):
@@ -93,7 +108,39 @@ class PartnerCnpjSearchWizard(models.TransientModel):
         values = webservice.import_data(data)
         values["provider_name"] = provider_name
         values["vat"] = vat
+
+        if provider_name == "cpfcnpj" and webservice._cpfcnpj_get_bool_param(
+            "cpfcnpj_fetch_ie", default=False
+        ):
+            ie_code = self._fetch_cpfcnpj_ie(webservice, vat, data)
+            if ie_code:
+                values["l10n_br_ie_code"] = ie_code
+
         return values
+
+    def _fetch_cpfcnpj_ie(self, webservice, vat, main_data):
+        """Fetch the state registration (package 16) with a second request.
+
+        This is best effort: any failure is logged and swallowed so it never
+        breaks the main lookup. The active registration matching the
+        establishment UF is preferred.
+        """
+        try:
+            url = webservice.cpfcnpj_get_api_url(vat, package="16")
+            with patch("requests.Session.send", _original_send):
+                response = requests.get(
+                    url,
+                    headers=webservice.get_headers(),
+                    timeout=5,
+                )
+            if response.status_code != 200:
+                return False
+            ie_data = response.json()
+            uf = (main_data.get("matrizEndereco") or {}).get("uf")
+            return webservice._cpfcnpj_select_ie(ie_data, uf)
+        except (requests.RequestException, ValueError):
+            _logger.warning("CPF.CNPJ state registration lookup failed", exc_info=True)
+            return False
 
     def default_get(self, fields):
         res = super().default_get(fields)
@@ -126,6 +173,16 @@ class PartnerCnpjSearchWizard(models.TransientModel):
             "equity_capital": self.equity_capital,
             "cnae_main_id": self.cnae_main_id,
             "cnae_secondary_ids": self.cnae_secondary_ids,
+            "tax_framework": self.tax_framework,
+            "company_size": self.company_size,
+            "cnpj_status": self.cnpj_status,
+            "cnpj_status_date": self.cnpj_status_date,
+            "cnpj_status_reason": self.cnpj_status_reason,
+            "opening_date": self.opening_date,
+            "cnpj_branch_type": self.cnpj_branch_type,
+            "simples_option_date": self.simples_option_date,
+            "legal_responsible_name": self.legal_responsible_name,
+            "legal_responsible_function": self.legal_responsible_function,
             "company_type": "company",
         }
         if self.vat:
@@ -139,4 +196,39 @@ class PartnerCnpjSearchWizard(models.TransientModel):
         if non_empty_values:
             # Update partner only if there are non-empty values
             self.partner_id.write(non_empty_values)
+
+        if self.cnpj_card_pdf:
+            self._attach_cnpj_card()
         return {"type": "ir.actions.act_window_close"}
+
+    def _attach_cnpj_card(self):
+        """Store the CNPJ card PDF as an attachment on the partner.
+
+        A previous card with the same name is replaced in place instead of
+        being duplicated.
+        """
+        self.ensure_one()
+        partner = self.partner_id
+        cnpj_digits = punctuation_rm(self.vat) if self.vat else ""
+        name = f"Cartao_CNPJ_{cnpj_digits}.pdf"
+        attachment = self.env["ir.attachment"].search(
+            [
+                ("res_model", "=", "res.partner"),
+                ("res_id", "=", partner.id),
+                ("name", "=", name),
+            ],
+            limit=1,
+        )
+        if attachment:
+            attachment.write({"datas": self.cnpj_card_pdf})
+        else:
+            self.env["ir.attachment"].create(
+                {
+                    "name": name,
+                    "res_model": "res.partner",
+                    "res_id": partner.id,
+                    "mimetype": "application/pdf",
+                    "datas": self.cnpj_card_pdf,
+                    "type": "binary",
+                }
+            )

--- a/l10n_br_cnpj_search/wizard/partner_cnpj_search_wizard.xml
+++ b/l10n_br_cnpj_search/wizard/partner_cnpj_search_wizard.xml
@@ -41,6 +41,7 @@
 
                     <group name="Other Information" string="Other Information">
                         <field name="legal_nature_id" />
+                        <field name="tax_framework" />
                         <field name="equity_capital" widget="monetary" />
                         <field name="cnae_main_id" string="Main CNAE" />
                         <field
@@ -51,6 +52,22 @@
                         <field name="currency_id" invisible="1" />
                     </group>
                 </group>
+
+                <group>
+                    <group name="federal_revenue" string="Federal Revenue">
+                        <field name="company_size" />
+                        <field name="cnpj_status" />
+                        <field name="cnpj_status_date" />
+                        <field name="cnpj_status_reason" />
+                        <field name="opening_date" />
+                        <field name="cnpj_branch_type" />
+                        <field name="simples_option_date" />
+                        <field name="legal_responsible_name" />
+                        <field name="legal_responsible_function" />
+                    </group>
+                </group>
+
+                <field name="cnpj_card_pdf" invisible="1" />
 
                 <footer>
                     <button


### PR DESCRIPTION
## Summary

Adds cpfcnpj.com.br as a third CNPJ lookup provider in `l10n_br_cnpj_search`,
alongside ReceitaWS and SERPRO. The change is additive: the existing providers
are untouched (175 lines added, zero removed in `cnpj_webservice.py`).

## Differentiator: filling tax_framework

The main fiscal value of this backend is that it fills the partner
`tax_framework` (tax regime), a field that none of the current providers
populate. The derivation uses the Simples Nacional, SIMEI and company size
returned in package 6:

- SIMEI opted in: Microempreendedor Individual (MEI), code 4.
- Simples Nacional opted in: Simples Nacional, code 1.
- Otherwise: Normal regime, code 3.
- Package 5 does not return regime data, so the field is left untouched.

## Other points

- Real time data (D+0), without the ReceitaWS limit of three lookups per minute.
- Four methods mirroring SERPRO: `cpfcnpj_get_api_url`, `cpfcnpj_get_headers`,
  `cpfcnpj_validate` and `_cpfcnpj_import_data`.
- Full `res.partner` mapping: legal name, trade name, address (with `state_id`
  and `city_id` resolved by IBGE code with a name fallback), primary and
  secondary CNAE, share capital, phone numbers and email.
- Token and package stored in `ir.config_parameter`, never in the code.
- Handling of status 0, error payload and timeout, with a user friendly message.
- Scope limited to legal entities (CNPJ) in this first step. Individual (CPF)
  support is left for a later step.

## Tests

- New tests mocking `requests.get`, covering Simples, MEI, error payload
  (status 0) and timeout.
- `pre-commit` clean (ruff, ruff-format, pylint-odoo, oca-gen-addon-readme,
  prettier, check-xml).

## Documentation

API documentation, packages and provider credentials:
https://www.cpfcnpj.com.br/dev/

The provider holds the ISO/IEC 27001, ISO/IEC 27701 and ISO 37301
certifications.

## Checklist

- [x] Additive change, does not break ReceitaWS or SERPRO
- [x] README generated from the fragments under `readme/`
- [x] Tests covering the new paths
- [x] Target series confirmed as 18.0 by the maintainers (see #5124)
