### PR TITLE
[16.0][FIX] l10n_br_fiscal_edi: refuse to send a document with an invalid XML

### DIFF
--- a/l10n_br_fiscal_edi/models/document.py
+++ b/l10n_br_fiscal_edi/models/document.py
@@ -441,8 +441,25 @@ class Document(models.Model):
             self._document_export()
 
     def _before_document_send(self):
-        # Placeholder for pre-send checks
-        pass
+        """Veto the transition to SENDING when the XML failed schema validation.
+
+        This callback runs *before* the machine writes state_edoc (see
+        FiscalDocumentStateMachine.set_state), so raising here leaves the
+        document in its source state. Without this guard the document was
+        moved to SENDING first and only then did the transmission module skip
+        the actual send because of xml_error_message, stranding the document
+        in a state that is not a valid source for action_draft_fsm.
+        """
+        self.ensure_one()
+        if self.xml_error_message:
+            raise UserError(
+                _(
+                    "The document XML does not comply with its schema, so it "
+                    "cannot be transmitted. Set the document back to draft, "
+                    "fix the data and confirm it again.\n\n%(errors)s",
+                    errors=self.xml_error_message,
+                )
+            )
 
     def _after_document_send(self):
         # Trigger actual sending logic

--- a/l10n_br_nfe/tests/test_nfe_workflow.py
+++ b/l10n_br_nfe/tests/test_nfe_workflow.py
@@ -296,21 +296,23 @@ class TestNFeWorkflowXmlValidation(TransactionCase):
         self.assertEqual(self.document.state_edoc, SITUACAO_EDOC_A_ENVIAR)
         self.assertIn("CEP", self.document.xml_error_message)
 
-    def test_invalid_xml_blocks_transmission_without_error(self):
-        """With xml_error_message set, sending is a silent no-op (no SEFAZ call)."""
+    def test_invalid_xml_blocks_transmission_and_holds_a_enviar(self):
+        """With xml_error_message set, sending is refused and the state holds."""
         self._break_partner_zip()
         self.document.action_document_confirm()
         self.assertTrue(self.document.xml_error_message)
 
         recorder = RecordingNFeMock(NFE_ASYNC_AUTHORIZED)
-        with recorder:
+        with recorder, self.assertRaises(UserError):
             self.document.action_document_send()
 
-        # FSM transitions to enviada via the Machine before the NFe
-        # _eletronic_document_send runs. The NFe module then returns
-        # early because xml_error_message is set, skipping transmission.
+        # _before_document_send vetoes the transition, so the machine never
+        # writes 'enviada'. Before this guard the document was moved to
+        # 'enviada' first and only then did _eletronic_document_send() skip
+        # the transmission, stranding it in a state that action_draft_fsm
+        # did not accept as a source.
         self.assertEqual(recorder.calls, [])
-        self.assertEqual(self.document.state_edoc, SITUACAO_EDOC_ENVIADA)
+        self.assertEqual(self.document.state_edoc, SITUACAO_EDOC_A_ENVIAR)
         self.assertIn("CEP", self.document.xml_error_message)
 
     def test_invalid_xml_recovery_via_back2draft(self):

--- a/l10n_br_nfe/tests/test_nfe_xml_validation.py
+++ b/l10n_br_nfe/tests/test_nfe_xml_validation.py
@@ -1,9 +1,10 @@
 import logging
 
+from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
 from odoo.tools import float_compare
 
-from odoo.addons.l10n_br_fiscal.constants.fiscal import SITUACAO_EDOC_ENVIADA
+from odoo.addons.l10n_br_fiscal.constants.fiscal import SITUACAO_EDOC_A_ENVIAR
 
 _logger = logging.getLogger(__name__)
 
@@ -38,12 +39,16 @@ class TestXMLValidation(TransactionCase):
             }
         )
         document.action_document_confirm()
-        document.action_document_send()
+        # The schema errors are recorded by the confirmation, and the send is
+        # then refused by _before_document_send() so the document stays in
+        # 'a_enviar', where it can be set back to draft and fixed.
+        with self.assertRaises(UserError):
+            document.action_document_send()
         _logger.info(
             f"(Test Result) XML Validation Message: {document.xml_error_message}"
         )
         self.assertTrue("CEP" in document.xml_error_message)
-        self.assertEqual(document.state_edoc, SITUACAO_EDOC_ENVIADA)
+        self.assertEqual(document.state_edoc, SITUACAO_EDOC_A_ENVIAR)
 
     def test_xml_nfe_taxes(self):
         """This method tests multiple tax fields for NFe lines and NFe totals.
@@ -127,8 +132,11 @@ class TestXMLValidation(TransactionCase):
             }
         )
 
+        # This test only checks tax values, which are computed by the
+        # confirmation. It does not transmit: the document carries no payment
+        # details, so its XML does not validate against the schema and
+        # _before_document_send() refuses the transmission.
         document.action_document_confirm()
-        document.action_document_send()
         # This section probably indicates an error in eiter
         #   l10n_br_account or l10n_br_fiscal
         self.assertEqual(line.icms_value, 307.32)


### PR DESCRIPTION
@Escodoo HT02188
Parte de #5122, que foi quebrada em três correções independentes.

## O caso real

Numa emissão em produção, uma NF-e foi confirmada e o XML não passou na
validação de schema (o endereço da transportadora estourava o limite de 60
caracteres de `transporta/xEnder`). O usuário clicou em **Enviar** e, a partir
daí, a nota ficou presa: o documento constava como `enviada` sem nunca ter
sido transmitido à SEFAZ, e o botão **Set to Draft** respondia com

> State transition failed for action 'action_draft_fsm':
> "Can't trigger event action_draft_fsm from state enviada!"

Não havia caminho de volta pela interface. A nota só foi recuperada alterando
`state_edoc` na mão via OdooTerminal.

## Por que acontece

A #4629 transformou o envio numa transição de FSM cujo callback `after` é que
dispara a transmissão. O `set_state()` da `FiscalDocumentStateMachine` grava
`state_edoc` **antes** dos callbacks `after` — como a própria docstring da
classe documenta. E o guard do XML mora no `_eletronic_document_send()` do
`l10n_br_nfe`, que é justamente um callback `after`, e apenas retorna, sem
levantar exceção. Sem exceção, não há rollback:

```
action_send
 ├─ before: _before_document_send()   → `pass`  (placeholder vazio)
 ├─ set_state("enviada")              → gravado no banco
 └─ after:  _after_document_send()
            └─ _eletronic_document_send()
               └─ if record.xml_error_message: return   ← só aqui verifica
```

No workflow anterior à #4629, `action_document_send()` chamava
`_document_send()` diretamente, sem mexer no estado — quem mudava `state_edoc`
era o próprio código de transmissão. Com XML inválido o documento simplesmente
permanecia em `a_enviar`, e o Set to Draft funcionava.

Como `enviada` não é origem válida de `action_draft_fsm`, o documento fica sem
saída. O `button_draft` da fatura cai no mesmo ponto, via
`action_document_back2draft()`.

## A correção

Preenche o `_before_document_send()`, que estava vazio e não é sobrescrito em
lugar nenhum do repositório. Por ser callback `before`, ele roda antes da
gravação do estado: a transição é vetada, o documento permanece em `a_enviar`
e o usuário volta para digitação pelo fluxo normal, corrige e reconfirma.

A confirmação segue funcionando como antes — a nota continua sendo confirmada
com o banner de erro de schema visível, porque é dela que saem a numeração e a
chave necessárias para inspecionar o XML. O que muda é apenas o envio, que
agora recusa em vez de simular sucesso.

## Testes ajustados

Dois testes congelavam o comportamento defeituoso:

- `test_invalid_xml_blocks_transmission_without_error` (renomeado para
  `..._and_holds_a_enviar`) e `test_xml_nfe_validation` afirmavam
  `state_edoc == SITUACAO_EDOC_ENVIADA` após o envio com XML inválido. Agora
  esperam `UserError` e permanência em `a_enviar`.
- `test_xml_nfe_taxes` verifica apenas valores de imposto, calculados na
  confirmação. Seu documento não tem dados de pagamento, então o XML não valida
  e a transmissão já era um no-op — o `_eletronic_document_send()` retornava
  cedo por causa do `xml_error_message`. O envio incidental foi removido, sem
  perda de cobertura.
  
  ---

Assisted-by: Claude Opus 5