### PR TITLE
[16.0][FIX] l10n_br_account_payment_brcobranca: accept the raw JSON array from /retorno

### DIFF
--- a/l10n_br_account_payment_brcobranca/parser/cnab_file_parser.py
+++ b/l10n_br_account_payment_brcobranca/parser/cnab_file_parser.py
@@ -97,8 +97,9 @@ class CNABFileParser(FileParser):
         if res.status_code != 201:
             raise UserError(res.text)
 
-        string_result = res.json()
-        data = json.loads(string_result)
+        data = res.json()
+        if isinstance(data, str):
+            data = json.loads(data)
 
         return data
 


### PR DESCRIPTION
https://github.com/akretion/boleto_cnab_api/commit/bcc991a8b24c2a6e7a678eb59ef4b596ee06104e

## A correção

Decodifica uma segunda vez apenas quando a resposta realmente é uma string:

```python
data = res.json()
if isinstance(data, str):
    data = json.loads(data)
```

Foi escrito de forma tolerante às duas formas, em vez de simplesmente remover o
`json.loads`, para não quebrar quem ainda roda uma imagem antiga do
micro-serviço. Ambientes atualizados passam a funcionar; ambientes que ainda não
atualizaram o container continuam funcionando como antes.

Este é o único ponto do módulo com decodificação dupla — os demais usos de
`res.json()` e `json.loads` foram verificados.

cc @rvalyi @renatonlima @marcelsavegnago @mbcosta fix para destravar o CI
