### PR TITLE
[18.0][FIX] l10n_br_base: make vat_formatted_cnpj editable on partner/company forms

### DIFF
--- a/l10n_br_base/models/party_mixin.py
+++ b/l10n_br_base/models/party_mixin.py
@@ -27,6 +27,7 @@ class PartyMixin(models.AbstractModel):
     vat_formatted_cnpj = fields.Char(
         string="VAT Formatted (Brazil)",
         compute="_compute_vat_formatted_cnpj",
+        inverse="_inverse_vat_formatted_cnpj",
         help="CNPJ or CPF formatted with proper punctuation and special characters",
     )
 
@@ -159,6 +160,15 @@ class PartyMixin(models.AbstractModel):
             if record.vat and record.country_id and record.country_id.code == "BR":
                 vat_formatted_cnpj = cnpj_cpf.formata(record.vat)
             record.vat_formatted_cnpj = vat_formatted_cnpj
+
+    def _inverse_vat_formatted_cnpj(self):
+        """Write user edits of the formatted CNPJ/CPF back to vat, unformatted."""
+        for record in self:
+            record.vat = (
+                misc.punctuation_rm(record.vat_formatted_cnpj)
+                if record.vat_formatted_cnpj
+                else False
+            )
 
     @api.depends_context("company")
     def _compute_show_br_vat_format(self):


### PR DESCRIPTION
## Resumo

Referente issue https://github.com/OCA/l10n-brazil/issues/5132
Desde que vat_formatted_cnpj substituiu vat nos formulários de res.partner e res.company para registros brasileiros (#5030), esse campo passou a ser somente computado, sem inverse — por isso era renderizado como somente leitura, e sócios/empresas brasileiras não tinham como digitar ou editar o CNPJ/CPF pelo formulário. Só era possível definir o valor antes de escolher o país, ou via API.

## Correção
Adiciona um método inverse ao campo vat_formatted_cnpj que remove a pontuação do valor digitado pelo usuário e grava de volta em vat (que continua armazenado sem formatação, como introduzido em 3817878c36). Isso restaura a edição tanto no formulário de sócio quanto no de empresa (ambos compartilham o l10n_br_base.party.mixin), sem precisar alterar as views XML — elas já alternam entre vat e vat_formatted_cnpj conforme show_l10n_br.