### PR TITLE
[18.0][FIX] l10n_br_coa: load classification from chart CSV

### DIFF
--- a/l10n_br_coa/migrations/18.0.2.1.0/post-migration.py
+++ b/l10n_br_coa/migrations/18.0.2.1.0/post-migration.py
@@ -2,52 +2,81 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 """Carry the account classification from the chart templates to live accounts.
 
-`account.account.template.tag_ids` only reaches `account.account` when the
-chart is loaded into a company. On a database that already loaded the chart,
-updating the module updates the template and not the account, and the reports
-would read zero, because they select by classification.
+As of Odoo 17.0 the CoA no longer uses ``account.account.template``. Tags
+live on the chart CSV (``tag_ids`` or the OCA ``tag_ids:id`` column) and
+only reach ``account.account`` when the chart is loaded into a company.
+Updating the module updates the template files, not the accounts already
+created, and the reports would read zero because they select by
+classification.
 
-The template to account mapping is the `ir.model.data` the chart load creates,
-named `{company_id}_{template xmlid}`. That is the same path the core uses to
-know which account came from which template, so it works for any chart, not
-only the two shipped by the OCA.
+The template to account mapping is the ``ir.model.data`` the chart load
+creates, named ``{company_id}_{template xmlid}``. That is the same path the
+core uses to know which account came from which template, so it works for any
+chart, not only the two shipped by the OCA.
 
 The migration never removes an existing classification: whoever tagged an
 account by hand keeps what they did.
 """
 
+import csv
 import logging
 
 from openupgradelib import openupgrade
 
+from odoo.tools.misc import file_open
+
 _logger = logging.getLogger(__name__)
+
+
+def _tag_xmlids_from_row(row):
+    raw = row.get("tag_ids") or row.get("tag_ids:id") or ""
+    return [xmlid.strip() for xmlid in raw.split(",") if xmlid.strip()]
+
+
+def _account_tags_from_chart(env, template_code):
+    """Return {account template xmlid: tag recordset} for a chart template."""
+    chart = env["account.chart.template"]
+    mapping = chart._get_chart_template_mapping(get_all=True)
+    tags_by_xmlid = {}
+    for code in reversed(chart._get_parent_template(template_code)):
+        template_info = mapping.get(code)
+        if not template_info:
+            continue
+        path = f"{template_info['module']}/data/template/account.account-{code}.csv"
+        try:
+            with file_open(path, mode="r") as csv_file:
+                for row in csv.DictReader(csv_file):
+                    account_xmlid = row.get("id")
+                    tag_xmlids = _tag_xmlids_from_row(row)
+                    if not account_xmlid or not tag_xmlids:
+                        continue
+                    tags = env["account.account.tag"]
+                    for tag_xmlid in tag_xmlids:
+                        tag = env.ref(tag_xmlid, raise_if_not_found=False)
+                        if tag:
+                            tags |= tag
+                    if tags:
+                        tags_by_xmlid[account_xmlid] = tags
+        except FileNotFoundError:
+            _logger.debug("No account CSV for chart template %s (%s)", code, path)
+    return tags_by_xmlid
 
 
 @openupgrade.migrate()
 def migrate(env, version):
-    templates = env["account.account.template"].search([("tag_ids", "!=", False)])
-    if not templates:
-        return
-
-    # {template id: tag ids}
-    tags_by_template = {t.id: t.tag_ids.ids for t in templates}
-
-    data = env["ir.model.data"].search(
-        [
-            ("model", "=", "account.account.template"),
-            ("res_id", "in", list(tags_by_template)),
-        ]
-    )
-    # {full template xmlid: tag ids}
-    tags_by_xmlid = {f"{d.module}.{d.name}": tags_by_template[d.res_id] for d in data}
-    if not tags_by_xmlid:
+    companies = env["res.company"].search([("chart_template", "!=", False)])
+    if not companies:
         return
 
     updated = 0
-    for company in env["res.company"].search([]):
+    for company in companies:
+        tags_by_xmlid = _account_tags_from_chart(env, company.chart_template)
+        if not tags_by_xmlid:
+            continue
+
         suffix_map = {
-            f"{company.id}_{name.split('.', 1)[1]}": tags
-            for name, tags in tags_by_xmlid.items()
+            f"{company.id}_{account_xmlid}": tags
+            for account_xmlid, tags in tags_by_xmlid.items()
         }
         account_data = env["ir.model.data"].search(
             [
@@ -55,13 +84,13 @@ def migrate(env, version):
                 ("name", "in", list(suffix_map)),
             ]
         )
-        for d in account_data:
-            account = env["account.account"].browse(d.res_id).exists()
+        for data in account_data:
+            account = env["account.account"].browse(data.res_id).exists()
             if not account:
                 continue
-            missing = set(suffix_map[d.name]) - set(account.tag_ids.ids)
+            missing = suffix_map[data.name] - account.tag_ids
             if missing:
-                account.write({"tag_ids": [(4, tag_id) for tag_id in missing]})
+                account.write({"tag_ids": [(4, tag.id) for tag in missing]})
                 updated += 1
 
     _logger.info("l10n_br_coa: classification applied to %s existing accounts", updated)


### PR DESCRIPTION
## Summary
- The `18.0.2.1.0` post-migration searched `account.account.template`, which was removed in Odoo 17 and is not in the 18.0 registry.
- That `KeyError` aborted `-u l10n_br_coa` on databases already at `18.0.2.0.0`.
- The script now reads `tag_ids` / `tag_ids:id` from the chart CSV and copies missing classification tags onto existing accounts via `{company_id}_{xmlid}`.

## Test plan
- [x] Upgrade a database with `l10n_br_coa` `18.0.2.0.0` (`-u l10n_br_coa`) and confirm the post-migration no longer raises `KeyError: 'account.account.template'`.
- [x] On a company that already loaded `br_oca_generic` or `br_oca_simple`, confirm accounts receive the missing `l10n_br_coa.account_tag_*` tags.
- [x] Confirm accounts that were tagged by hand keep their existing tags (migration only links missing ones).
- [x] Confirm companies without a Brazilian OCA chart are left unchanged.

Verified on `develbrcoa`:
- Upgrade completed without `KeyError`.
- `Empresa Lucro Real` + `br_oca_generic`: migration tagged **392/493** accounts.
- After clearing tags on 15 accounts, a second run restored them.
- A manual tag (`Manual Classification Test`) was kept; template tags were only linked.
- `generic_coa` companies (`Sua Empresa`, `Lucro Presumido`, `Simples Nacional`) stayed at **0** Brazilian classification tags.