### PR TITLE
[18.0][FIX] l10n_br_fiscal: operation_indicator_id view product_product

### DIFF
--- a/l10n_br_fiscal/views/product_product_view.xml
+++ b/l10n_br_fiscal/views/product_product_view.xml
@@ -119,6 +119,11 @@
                                 options="{'no_create': True, 'no_create_edit': True}"
                             />
                             <field
+                                name="operation_indicator_id"
+                                invisible="fiscal_type != '09'"
+                                options="{'no_create': True, 'no_create_edit': True}"
+                            />
+                            <field
                                 name="ipi_guideline_class_id"
                                 invisible="fiscal_type == '09'"
                                 options="{'no_create': True, 'no_create_edit': True}"


### PR DESCRIPTION
## Objetivo da PR

Correção do campo INDOP na view do product.product

Ao abrir um produto pelo Form normalmente o campo INDOP (Operation Indicator) aparece normalmente

<img width="1919" height="911" alt="image" src="https://github.com/user-attachments/assets/42021d50-d61f-4360-9b68-539935e1c7cc" />

Ao abrir essa produto pela fatura o campo não aparece na view essa PR faz a correção disso

<img width="1919" height="912" alt="image" src="https://github.com/user-attachments/assets/7fc54507-4fff-44dc-bf56-5266fb3adefa" />

cc @renatonlima @marcelsavegnago @rvalyi 

